### PR TITLE
sstable: clean up use-filter-block logic

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -417,7 +417,7 @@ func runIterCmd(
 			fmt.Fprintf(&b, "| %T:\n", origIter)
 			si, _ := origIter.(*singleLevelIterator)
 			if twoLevelIter, ok := origIter.(*twoLevelIterator); ok {
-				si = &twoLevelIter.singleLevelIterator
+				si = &twoLevelIter.secondLevel
 				if twoLevelIter.topLevelIndex.Valid() {
 					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", twoLevelIter.topLevelIndex.Key())
 					v := twoLevelIter.topLevelIndex.Value()

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -268,7 +268,7 @@ func (r *Reader) newCompactionIter(
 		if err != nil {
 			return nil, err
 		}
-		i.setupForCompaction()
+		i.SetupForCompaction()
 		return i, nil
 	}
 	i, err := newSingleLevelIterator(
@@ -278,7 +278,7 @@ func (r *Reader) newCompactionIter(
 	if err != nil {
 		return nil, err
 	}
-	i.setupForCompaction()
+	i.SetupForCompaction()
 	return i, nil
 }
 

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -140,11 +140,11 @@ func checkSingleLevelIterator(obj interface{}) {
 
 func checkTwoLevelIterator(obj interface{}) {
 	i := obj.(*twoLevelIterator)
-	if p := i.data.Handle().Get(); p != nil {
+	if p := i.secondLevel.data.Handle().Get(); p != nil {
 		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.handle is not nil: %p\n", p)
 		os.Exit(1)
 	}
-	if p := i.index.Handle().Get(); p != nil {
+	if p := i.secondLevel.index.Handle().Get(); p != nil {
 		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.handle is not nil: %p\n", p)
 		os.Exit(1)
 	}

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -18,35 +17,34 @@ import (
 )
 
 type twoLevelIterator struct {
-	singleLevelIterator
+	secondLevel   singleLevelIterator
 	topLevelIndex rowblk.Iter
 }
 
-// twoLevelIterator implements the base.InternalIterator interface.
-var _ base.InternalIterator = (*twoLevelIterator)(nil)
+var _ Iterator = (*twoLevelIterator)(nil)
 
 // loadIndex loads the index block at the current top level index position and
-// leaves i.index unpositioned. If unsuccessful, it gets i.err to any error
+// leaves i.index unpositioned. If unsuccessful, it gets i.secondLevel.err to any error
 // encountered, which may be nil if we have simply exhausted the entire table.
 // This is used for two level indexes.
 func (i *twoLevelIterator) loadIndex(dir int8) loadBlockResult {
 	// Ensure the index data block iterators are invalidated even if loading of
 	// the index fails.
-	i.data.Invalidate()
-	i.index.Invalidate()
+	i.secondLevel.data.Invalidate()
+	i.secondLevel.index.Invalidate()
 	if !i.topLevelIndex.Valid() {
 		return loadBlockFailed
 	}
 	v := i.topLevelIndex.Value()
 	bhp, err := decodeBlockHandleWithProperties(v.InPlaceValue())
 	if err != nil {
-		i.err = base.CorruptionErrorf("pebble/table: corrupt top level index entry (%v)", err)
+		i.secondLevel.err = base.CorruptionErrorf("pebble/table: corrupt top level index entry (%v)", err)
 		return loadBlockFailed
 	}
-	if i.bpfs != nil {
-		intersects, err := i.bpfs.intersects(bhp.Props)
+	if i.secondLevel.bpfs != nil {
+		intersects, err := i.secondLevel.bpfs.intersects(bhp.Props)
 		if err != nil {
-			i.err = errCorruptIndexEntry(err)
+			i.secondLevel.err = errCorruptIndexEntry(err)
 			return loadBlockFailed
 		}
 		if intersects == blockMaybeExcluded {
@@ -57,14 +55,14 @@ func (i *twoLevelIterator) loadIndex(dir int8) loadBlockResult {
 		}
 		// blockIntersects
 	}
-	ctx := objiotracing.WithBlockType(i.ctx, objiotracing.MetadataBlock)
-	indexBlock, err := i.reader.readBlock(
-		ctx, bhp.Handle, nil /* transform */, i.indexFilterRH, i.stats, &i.iterStats, i.bufferPool)
+	ctx := objiotracing.WithBlockType(i.secondLevel.ctx, objiotracing.MetadataBlock)
+	indexBlock, err := i.secondLevel.reader.readBlock(
+		ctx, bhp.Handle, nil /* transform */, i.secondLevel.indexFilterRH, i.secondLevel.stats, &i.secondLevel.iterStats, i.secondLevel.bufferPool)
 	if err == nil {
-		err = i.index.InitHandle(i.cmp, i.reader.Split, indexBlock, i.transforms)
+		err = i.secondLevel.index.InitHandle(i.secondLevel.cmp, i.secondLevel.reader.Split, indexBlock, i.secondLevel.transforms)
 	}
 	if err != nil {
-		i.err = err
+		i.secondLevel.err = err
 		return loadBlockFailed
 	}
 	return loadBlockOK
@@ -92,7 +90,7 @@ func (i *twoLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 	// are ≤ topLevelIndex.Key(). For forward iteration, this is all we need.
 	if dir > 0 {
 		// Forward iteration.
-		if i.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(i.topLevelIndex.Key().UserKey) {
+		if i.secondLevel.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(i.topLevelIndex.Key().UserKey) {
 			return blockExcluded
 		}
 		return blockIntersects
@@ -121,7 +119,7 @@ func (i *twoLevelIterator) resolveMaybeExcluded(dir int8) intersectsResult {
 		// we knew the lower bound for the entire table, it could provide a
 		// lower bound, but the code refactoring necessary to read it doesn't
 		// seem worth the payoff. We fall through to loading the block.
-	} else if i.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(peekKey.K.UserKey) {
+	} else if i.secondLevel.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(peekKey.K.UserKey) {
 		// The lower-bound on the original index block falls within the filter's
 		// bounds, and we can skip the block (after restoring our current
 		// top-level index position).
@@ -156,12 +154,12 @@ func newTwoLevelIterator(
 		return nil, r.err
 	}
 	i := twoLevelIterPool.Get().(*twoLevelIterator)
-	i.singleLevelIterator.init(ctx, r, v, transforms, lower, upper, filterer, filterBlockSizeLimit,
+	i.secondLevel.init(ctx, r, v, transforms, lower, upper, filterer, filterBlockSizeLimit,
 		stats, categoryAndQoS, statsCollector, rp, bufferPool)
 
-	topLevelIndexH, err := r.readIndex(ctx, i.indexFilterRH, stats, &i.iterStats)
+	topLevelIndexH, err := r.readIndex(ctx, i.secondLevel.indexFilterRH, stats, &i.secondLevel.iterStats)
 	if err == nil {
-		err = i.topLevelIndex.InitHandle(i.cmp, i.reader.Split, topLevelIndexH, transforms)
+		err = i.topLevelIndex.InitHandle(i.secondLevel.cmp, i.secondLevel.reader.Split, topLevelIndexH, transforms)
 	}
 	if err != nil {
 		_ = i.Close()
@@ -171,7 +169,7 @@ func newTwoLevelIterator(
 }
 
 func (i *twoLevelIterator) String() string {
-	return i.singleLevelIterator.String()
+	return i.secondLevel.String()
 }
 
 // DebugTree is part of the InternalIterator interface.
@@ -183,25 +181,25 @@ func (i *twoLevelIterator) DebugTree(tp treeprinter.Node) {
 // package. Note that SeekGE only checks the upper bound. It is up to the
 // caller to ensure that key is greater than or equal to the lower bound.
 func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
-	if i.vState != nil {
+	if i.secondLevel.vState != nil {
 		// Callers of SeekGE don't know about virtual sstable bounds, so we may
 		// have to internally restrict the bounds.
 		//
 		// TODO(bananabrick): We can optimize away this check for the level iter
 		// if necessary.
-		if i.cmp(key, i.lower) < 0 {
-			key = i.lower
+		if i.secondLevel.cmp(key, i.secondLevel.lower) < 0 {
+			key = i.secondLevel.lower
 		}
 	}
 
-	err := i.err
-	i.err = nil // clear cached iteration error
+	err := i.secondLevel.err
+	i.secondLevel.err = nil // clear cached iteration error
 
 	// The twoLevelIterator could be already exhausted. Utilize that when
 	// trySeekUsingNext is true. See the comment about data-exhausted, PGDE, and
 	// bounds-exhausted near the top of the file.
 	if flags.TrySeekUsingNext() &&
-		(i.exhaustedBounds == +1 || (i.data.IsDataInvalidated() && i.index.IsDataInvalidated())) &&
+		(i.secondLevel.exhaustedBounds == +1 || (i.secondLevel.data.IsDataInvalidated() && i.secondLevel.index.IsDataInvalidated())) &&
 		err == nil {
 		// Already exhausted, so return nil.
 		return nil
@@ -219,24 +217,24 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.Inte
 	// block load.
 
 	var dontSeekWithinSingleLevelIter bool
-	if i.topLevelIndex.IsDataInvalidated() || !i.topLevelIndex.Valid() || i.index.IsDataInvalidated() || err != nil ||
-		(i.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || i.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
+	if i.topLevelIndex.IsDataInvalidated() || !i.topLevelIndex.Valid() || i.secondLevel.index.IsDataInvalidated() || err != nil ||
+		(i.secondLevel.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || i.secondLevel.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
 		// Slow-path: need to position the topLevelIndex.
 
 		// The previous exhausted state of singleLevelIterator is no longer
 		// relevant, since we may be moving to a different index block.
-		i.exhaustedBounds = 0
+		i.secondLevel.exhaustedBounds = 0
 		flags = flags.DisableTrySeekUsingNext()
 		var ikv *base.InternalKV
 		if ikv = i.topLevelIndex.SeekGE(key, flags); ikv == nil {
-			i.data.Invalidate()
-			i.index.Invalidate()
+			i.secondLevel.data.Invalidate()
+			i.secondLevel.index.Invalidate()
 			return nil
 		}
 
 		result := i.loadIndex(+1)
 		if result == loadBlockFailed {
-			i.boundsCmp = 0
+			i.secondLevel.boundsCmp = 0
 			return nil
 		}
 		if result == loadBlockIrrelevant {
@@ -246,10 +244,10 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.Inte
 			// ikey.InternalKey.UserKey since even though this is the block separator, the
 			// same user key can span multiple index blocks. If upper is
 			// exclusive we use >= below, else we use >.
-			if i.upper != nil {
-				cmp := i.cmp(ikv.K.UserKey, i.upper)
-				if (!i.endKeyInclusive && cmp >= 0) || cmp > 0 {
-					i.exhaustedBounds = +1
+			if i.secondLevel.upper != nil {
+				cmp := i.secondLevel.cmp(ikv.K.UserKey, i.secondLevel.upper)
+				if (!i.secondLevel.endKeyInclusive && cmp >= 0) || cmp > 0 {
+					i.secondLevel.exhaustedBounds = +1
 				}
 			}
 			// Fall through to skipForward.
@@ -262,7 +260,7 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.Inte
 			// we never seek on the single-level iterator. This call will fall
 			// through to skipForward, which may improperly leave boundsCmp=+1
 			// unless we clear it here.
-			i.boundsCmp = 0
+			i.secondLevel.boundsCmp = 0
 		}
 	} else {
 		// INVARIANT: err == nil.
@@ -287,9 +285,9 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.Inte
 		// Note that cases 1 and 2 never overlap, and one of them must be true.
 		// This invariant checking is important enough that we do not gate it
 		// behind invariants.Enabled.
-		if i.boundsCmp > 0 == flags.TrySeekUsingNext() {
+		if i.secondLevel.boundsCmp > 0 == flags.TrySeekUsingNext() {
 			panic(fmt.Sprintf("inconsistency in optimization case 1 %t and case 2 %t",
-				i.boundsCmp > 0, flags.TrySeekUsingNext()))
+				i.secondLevel.boundsCmp > 0, flags.TrySeekUsingNext()))
 		}
 
 		if !flags.TrySeekUsingNext() {
@@ -300,7 +298,7 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.Inte
 			// worked with data-exhausted, we have made it unclear whether
 			// data-exhausted is actually true. See the comment at the top of the
 			// file.
-			i.exhaustedBounds = 0
+			i.secondLevel.exhaustedBounds = 0
 		}
 		// Else flags.TrySeekUsingNext(). The i.exhaustedBounds is important to
 		// preserve for singleLevelIterator, and twoLevelIterator.skipForward. See
@@ -310,7 +308,7 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.Inte
 	if !dontSeekWithinSingleLevelIter {
 		// Note that while trySeekUsingNext could be false here, singleLevelIterator
 		// could do its own boundsCmp-based optimization to seek using next.
-		if ikv := i.singleLevelIterator.SeekGE(key, flags); ikv != nil {
+		if ikv := i.secondLevel.SeekGE(key, flags); ikv != nil {
 			return ikv
 		}
 	}
@@ -323,14 +321,14 @@ func (i *twoLevelIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.Inte
 func (i *twoLevelIterator) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
 ) *base.InternalKV {
-	if i.vState != nil {
+	if i.secondLevel.vState != nil {
 		// Callers of SeekGE don't know about virtual sstable bounds, so we may
 		// have to internally restrict the bounds.
 		//
 		// TODO(bananabrick): We can optimize away this check for the level iter
 		// if necessary.
-		if i.cmp(key, i.lower) < 0 {
-			key = i.lower
+		if i.secondLevel.cmp(key, i.secondLevel.lower) < 0 {
+			key = i.secondLevel.lower
 		}
 	}
 
@@ -338,16 +336,16 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	// this method. Hence, we can use the existing iterator position if the last
 	// SeekPrefixGE did not fail bloom filter matching.
 
-	err := i.err
-	i.err = nil // clear cached iteration error
+	err := i.secondLevel.err
+	i.secondLevel.err = nil // clear cached iteration error
 
-	useFilter := shouldUseFilterBlock(i.reader, i.filterBlockSizeLimit)
+	useFilter := shouldUseFilterBlock(i.secondLevel.reader, i.secondLevel.filterBlockSizeLimit)
 	// The twoLevelIterator could be already exhausted. Utilize that when
 	// trySeekUsingNext is true. See the comment about data-exhausted, PGDE, and
 	// bounds-exhausted near the top of the file.
-	filterUsedAndDidNotMatch := useFilter && !i.lastBloomFilterMatched
+	filterUsedAndDidNotMatch := useFilter && !i.secondLevel.lastBloomFilterMatched
 	if flags.TrySeekUsingNext() && !filterUsedAndDidNotMatch &&
-		(i.exhaustedBounds == +1 || (i.data.IsDataInvalidated() && i.index.IsDataInvalidated())) &&
+		(i.secondLevel.exhaustedBounds == +1 || (i.secondLevel.data.IsDataInvalidated() && i.secondLevel.index.IsDataInvalidated())) &&
 		err == nil {
 		// Already exhausted, so return nil.
 		return nil
@@ -355,23 +353,23 @@ func (i *twoLevelIterator) SeekPrefixGE(
 
 	// Check prefix bloom filter.
 	if useFilter {
-		if !i.lastBloomFilterMatched {
+		if !i.secondLevel.lastBloomFilterMatched {
 			// Iterator is not positioned based on last seek.
 			flags = flags.DisableTrySeekUsingNext()
 		}
-		i.lastBloomFilterMatched = false
+		i.secondLevel.lastBloomFilterMatched = false
 		var mayContain bool
-		mayContain, i.err = i.bloomFilterMayContain(prefix)
-		if i.err != nil || !mayContain {
-			// In the i.err == nil case, this invalidation may not be necessary for
+		mayContain, i.secondLevel.err = i.secondLevel.bloomFilterMayContain(prefix)
+		if i.secondLevel.err != nil || !mayContain {
+			// In the i.secondLevel.err == nil case, this invalidation may not be necessary for
 			// correctness, and may be a place to optimize later by reusing the
 			// already loaded block. It was necessary in earlier versions of the code
 			// since the caller was allowed to call Next when SeekPrefixGE returned
 			// nil. This is no longer allowed.
-			i.data.Invalidate()
+			i.secondLevel.data.Invalidate()
 			return nil
 		}
-		i.lastBloomFilterMatched = true
+		i.secondLevel.lastBloomFilterMatched = true
 	}
 
 	// Bloom filter matches.
@@ -389,24 +387,24 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	// block load.
 
 	var dontSeekWithinSingleLevelIter bool
-	if i.topLevelIndex.IsDataInvalidated() || !i.topLevelIndex.Valid() || i.index.IsDataInvalidated() || err != nil ||
-		(i.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || i.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
+	if i.topLevelIndex.IsDataInvalidated() || !i.topLevelIndex.Valid() || i.secondLevel.index.IsDataInvalidated() || err != nil ||
+		(i.secondLevel.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || i.secondLevel.cmp(key, i.topLevelIndex.Key().UserKey) > 0 {
 		// Slow-path: need to position the topLevelIndex.
 
 		// The previous exhausted state of singleLevelIterator is no longer
 		// relevant, since we may be moving to a different index block.
-		i.exhaustedBounds = 0
+		i.secondLevel.exhaustedBounds = 0
 		flags = flags.DisableTrySeekUsingNext()
 		var ikv *base.InternalKV
 		if ikv = i.topLevelIndex.SeekGE(key, flags); ikv == nil {
-			i.data.Invalidate()
-			i.index.Invalidate()
+			i.secondLevel.data.Invalidate()
+			i.secondLevel.index.Invalidate()
 			return nil
 		}
 
 		result := i.loadIndex(+1)
 		if result == loadBlockFailed {
-			i.boundsCmp = 0
+			i.secondLevel.boundsCmp = 0
 			return nil
 		}
 		if result == loadBlockIrrelevant {
@@ -416,10 +414,10 @@ func (i *twoLevelIterator) SeekPrefixGE(
 			// ikey.InternalKey.UserKey since even though this is the block separator, the
 			// same user key can span multiple index blocks. If upper is
 			// exclusive we use >= below, else we use >.
-			if i.upper != nil {
-				cmp := i.cmp(ikv.K.UserKey, i.upper)
-				if (!i.endKeyInclusive && cmp >= 0) || cmp > 0 {
-					i.exhaustedBounds = +1
+			if i.secondLevel.upper != nil {
+				cmp := i.secondLevel.cmp(ikv.K.UserKey, i.secondLevel.upper)
+				if (!i.secondLevel.endKeyInclusive && cmp >= 0) || cmp > 0 {
+					i.secondLevel.exhaustedBounds = +1
 				}
 			}
 			// Fall through to skipForward.
@@ -432,7 +430,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 			// we never seek on the single-level iterator. This call will fall
 			// through to skipForward, which may improperly leave boundsCmp=+1
 			// unless we clear it here.
-			i.boundsCmp = 0
+			i.secondLevel.boundsCmp = 0
 		}
 	} else {
 		// INVARIANT: err == nil.
@@ -457,9 +455,9 @@ func (i *twoLevelIterator) SeekPrefixGE(
 		// Note that cases 1 and 2 never overlap, and one of them must be true.
 		// This invariant checking is important enough that we do not gate it
 		// behind invariants.Enabled.
-		if i.boundsCmp > 0 == flags.TrySeekUsingNext() {
+		if i.secondLevel.boundsCmp > 0 == flags.TrySeekUsingNext() {
 			panic(fmt.Sprintf("inconsistency in optimization case 1 %t and case 2 %t",
-				i.boundsCmp > 0, flags.TrySeekUsingNext()))
+				i.secondLevel.boundsCmp > 0, flags.TrySeekUsingNext()))
 		}
 
 		if !flags.TrySeekUsingNext() {
@@ -470,7 +468,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 			// worked with data-exhausted, we have made it unclear whether
 			// data-exhausted is actually true. See the comment at the top of the
 			// file.
-			i.exhaustedBounds = 0
+			i.secondLevel.exhaustedBounds = 0
 		}
 		// Else flags.TrySeekUsingNext(). The i.exhaustedBounds is important to
 		// preserve for singleLevelIterator, and twoLevelIterator.skipForward. See
@@ -478,7 +476,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	}
 
 	if !dontSeekWithinSingleLevelIter {
-		if ikv := i.singleLevelIterator.seekPrefixGE(
+		if ikv := i.secondLevel.seekPrefixGE(
 			prefix, key, flags, NeverUseFilterBlock); ikv != nil {
 			return ikv
 		}
@@ -489,12 +487,12 @@ func (i *twoLevelIterator) SeekPrefixGE(
 
 // virtualLast should only be called if i.vReader != nil.
 func (i *twoLevelIterator) virtualLast() *base.InternalKV {
-	if i.vState == nil {
+	if i.secondLevel.vState == nil {
 		panic("pebble: invalid call to virtualLast")
 	}
-	if !i.endKeyInclusive {
+	if !i.secondLevel.endKeyInclusive {
 		// Trivial case.
-		return i.SeekLT(i.upper, base.SeekLTFlagsNone)
+		return i.SeekLT(i.secondLevel.upper, base.SeekLTFlagsNone)
 	}
 	return i.virtualLastSeekLE()
 }
@@ -508,18 +506,18 @@ func (i *twoLevelIterator) virtualLastSeekLE() *base.InternalKV {
 	//
 	// TODO(bananabrick): We can optimize this check away for the level iter
 	// if necessary.
-	if !i.endKeyInclusive {
+	if !i.secondLevel.endKeyInclusive {
 		panic("unexpected virtualLastSeekLE with exclusive upper bounds")
 	}
-	key := i.upper
+	key := i.secondLevel.upper
 	// Need to position the topLevelIndex.
 	//
 	// The previous exhausted state of singleLevelIterator is no longer
 	// relevant, since we may be moving to a different index block.
-	i.exhaustedBounds = 0
+	i.secondLevel.exhaustedBounds = 0
 	// Seek optimization only applies until iterator is first positioned with a
 	// SeekGE or SeekLT after SetBounds.
-	i.boundsCmp = 0
+	i.secondLevel.boundsCmp = 0
 	ikv := i.topLevelIndex.SeekGE(key, base.SeekGEFlagsNone)
 	// We can have multiple internal keys with the same user key as the seek
 	// key. In that case, we want the last (greatest) internal key.
@@ -531,14 +529,14 @@ func (i *twoLevelIterator) virtualLastSeekLE() *base.InternalKV {
 	}
 	result := i.loadIndex(-1)
 	if result == loadBlockFailed {
-		i.boundsCmp = 0
+		i.secondLevel.boundsCmp = 0
 		return nil
 	}
 	if result == loadBlockIrrelevant {
 		// Load the previous block.
 		return i.skipBackward()
 	}
-	if ikv := i.singleLevelIterator.virtualLastSeekLE(); ikv != nil {
+	if ikv := i.secondLevel.virtualLastSeekLE(); ikv != nil {
 		return ikv
 	}
 	return i.skipBackward()
@@ -548,24 +546,24 @@ func (i *twoLevelIterator) virtualLastSeekLE() *base.InternalKV {
 // package. Note that SeekLT only checks the lower bound. It is up to the
 // caller to ensure that key is less than the upper bound.
 func (i *twoLevelIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
-	if i.vState != nil {
+	if i.secondLevel.vState != nil {
 		// Might have to fix upper bound since virtual sstable bounds are not
 		// known to callers of SeekLT.
 		//
 		// TODO(bananabrick): We can optimize away this check for the level iter
 		// if necessary.
-		cmp := i.cmp(key, i.upper)
-		// key == i.upper is fine. We'll do the right thing and return the
+		cmp := i.secondLevel.cmp(key, i.secondLevel.upper)
+		// key == i.secondLevel.upper is fine. We'll do the right thing and return the
 		// first internal key with user key < key.
 		if cmp > 0 {
 			return i.virtualLast()
 		}
 	}
 
-	i.exhaustedBounds = 0
-	i.err = nil // clear cached iteration error
+	i.secondLevel.exhaustedBounds = 0
+	i.secondLevel.err = nil // clear cached iteration error
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
-	i.boundsCmp = 0
+	i.secondLevel.boundsCmp = 0
 
 	var result loadBlockResult
 	var ikv *base.InternalKV
@@ -578,8 +576,8 @@ func (i *twoLevelIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.Inte
 	// Intersects=false irrespective of the block props provided) during seeks.
 	if ikv = i.topLevelIndex.SeekGE(key, base.SeekGEFlagsNone); ikv == nil {
 		if ikv = i.topLevelIndex.Last(); ikv == nil {
-			i.data.Invalidate()
-			i.index.Invalidate()
+			i.secondLevel.data.Invalidate()
+			i.secondLevel.index.Invalidate()
 			return nil
 		}
 
@@ -588,8 +586,8 @@ func (i *twoLevelIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.Inte
 			return nil
 		}
 		if result == loadBlockOK {
-			if ikv := i.singleLevelIterator.lastInternal(); ikv != nil {
-				return i.maybeVerifyKey(ikv)
+			if ikv := i.secondLevel.lastInternal(); ikv != nil {
+				return i.secondLevel.maybeVerifyKey(ikv)
 			}
 			// Fall through to skipBackward since the singleLevelIterator did
 			// not have any blocks that satisfy the block interval
@@ -602,8 +600,8 @@ func (i *twoLevelIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.Inte
 			return nil
 		}
 		if result == loadBlockOK {
-			if ikv := i.singleLevelIterator.SeekLT(key, flags); ikv != nil {
-				return i.maybeVerifyKey(ikv)
+			if ikv := i.secondLevel.SeekLT(key, flags); ikv != nil {
+				return i.secondLevel.maybeVerifyKey(ikv)
 			}
 			// Fall through to skipBackward since the singleLevelIterator did
 			// not have any blocks that satisfy the block interval
@@ -617,8 +615,8 @@ func (i *twoLevelIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.Inte
 		// exceeded. Note that the previous entry starts with keys <=
 		// ikey.InternalKey.UserKey since even though this is the current block's
 		// separator, the same user key can span multiple index blocks.
-		if i.lower != nil && i.cmp(ikv.K.UserKey, i.lower) < 0 {
-			i.exhaustedBounds = -1
+		if i.secondLevel.lower != nil && i.secondLevel.cmp(ikv.K.UserKey, i.secondLevel.lower) < 0 {
+			i.secondLevel.exhaustedBounds = -1
 		}
 	}
 	// NB: skipBackward checks whether exhaustedBounds is already -1.
@@ -633,13 +631,13 @@ func (i *twoLevelIterator) First() *base.InternalKV {
 	// If we have a lower bound, use SeekGE. Note that in general this is not
 	// supported usage, except when the lower bound is there because the table is
 	// virtual.
-	if i.lower != nil {
-		return i.SeekGE(i.lower, base.SeekGEFlagsNone)
+	if i.secondLevel.lower != nil {
+		return i.SeekGE(i.secondLevel.lower, base.SeekGEFlagsNone)
 	}
-	i.exhaustedBounds = 0
-	i.err = nil // clear cached iteration error
+	i.secondLevel.exhaustedBounds = 0
+	i.secondLevel.err = nil // clear cached iteration error
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
-	i.boundsCmp = 0
+	i.secondLevel.boundsCmp = 0
 
 	var ikv *base.InternalKV
 	if ikv = i.topLevelIndex.First(); ikv == nil {
@@ -651,7 +649,7 @@ func (i *twoLevelIterator) First() *base.InternalKV {
 		return nil
 	}
 	if result == loadBlockOK {
-		if ikv := i.singleLevelIterator.First(); ikv != nil {
+		if ikv := i.secondLevel.First(); ikv != nil {
 			return ikv
 		}
 		// Else fall through to skipForward.
@@ -662,10 +660,10 @@ func (i *twoLevelIterator) First() *base.InternalKV {
 		// starts with keys >= ikv.InternalKey.UserKey since even though this is the
 		// block separator, the same user key can span multiple index blocks.
 		// If upper is exclusive we use >= below, else we use >.
-		if i.upper != nil {
-			cmp := i.cmp(ikv.K.UserKey, i.upper)
-			if (!i.endKeyInclusive && cmp >= 0) || cmp > 0 {
-				i.exhaustedBounds = +1
+		if i.secondLevel.upper != nil {
+			cmp := i.secondLevel.cmp(ikv.K.UserKey, i.secondLevel.upper)
+			if (!i.secondLevel.endKeyInclusive && cmp >= 0) || cmp > 0 {
+				i.secondLevel.exhaustedBounds = +1
 			}
 		}
 	}
@@ -678,20 +676,20 @@ func (i *twoLevelIterator) First() *base.InternalKV {
 // to ensure that key is less than the upper bound (e.g. via a call to
 // SeekLT(upper))
 func (i *twoLevelIterator) Last() *base.InternalKV {
-	if i.vState != nil {
-		if i.endKeyInclusive {
+	if i.secondLevel.vState != nil {
+		if i.secondLevel.endKeyInclusive {
 			return i.virtualLast()
 		}
-		return i.SeekLT(i.upper, base.SeekLTFlagsNone)
+		return i.SeekLT(i.secondLevel.upper, base.SeekLTFlagsNone)
 	}
 
-	if i.upper != nil {
+	if i.secondLevel.upper != nil {
 		panic("twoLevelIterator.Last() used despite upper bound")
 	}
-	i.exhaustedBounds = 0
-	i.err = nil // clear cached iteration error
+	i.secondLevel.exhaustedBounds = 0
+	i.secondLevel.err = nil // clear cached iteration error
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
-	i.boundsCmp = 0
+	i.secondLevel.boundsCmp = 0
 
 	var ikv *base.InternalKV
 	if ikv = i.topLevelIndex.Last(); ikv == nil {
@@ -703,7 +701,7 @@ func (i *twoLevelIterator) Last() *base.InternalKV {
 		return nil
 	}
 	if result == loadBlockOK {
-		if ikv := i.singleLevelIterator.Last(); ikv != nil {
+		if ikv := i.secondLevel.Last(); ikv != nil {
 			return ikv
 		}
 		// Else fall through to skipBackward.
@@ -714,8 +712,8 @@ func (i *twoLevelIterator) Last() *base.InternalKV {
 		// entry starts with keys <= ikv.InternalKey.UserKey since even though
 		// this is the current block's separator, the same user key can span
 		// multiple index blocks.
-		if i.lower != nil && i.cmp(ikv.K.UserKey, i.lower) < 0 {
-			i.exhaustedBounds = -1
+		if i.secondLevel.lower != nil && i.secondLevel.cmp(ikv.K.UserKey, i.secondLevel.lower) < 0 {
+			i.secondLevel.exhaustedBounds = -1
 		}
 	}
 	// NB: skipBackward checks whether exhaustedBounds is already -1.
@@ -728,13 +726,13 @@ func (i *twoLevelIterator) Last() *base.InternalKV {
 // twoLevelIterator.Next due to performance. Keep the two in sync.
 func (i *twoLevelIterator) Next() *base.InternalKV {
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
-	i.boundsCmp = 0
-	if i.err != nil {
+	i.secondLevel.boundsCmp = 0
+	if i.secondLevel.err != nil {
 		// TODO(jackson): Can this case be turned into a panic? Once an error is
 		// encountered, the iterator must be re-seeked.
 		return nil
 	}
-	if ikv := i.singleLevelIterator.Next(); ikv != nil {
+	if ikv := i.secondLevel.Next(); ikv != nil {
 		return ikv
 	}
 	return i.skipForward()
@@ -742,21 +740,21 @@ func (i *twoLevelIterator) Next() *base.InternalKV {
 
 // NextPrefix implements (base.InternalIterator).NextPrefix.
 func (i *twoLevelIterator) NextPrefix(succKey []byte) *base.InternalKV {
-	if i.exhaustedBounds == +1 {
+	if i.secondLevel.exhaustedBounds == +1 {
 		panic("Next called even though exhausted upper bound")
 	}
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
-	i.boundsCmp = 0
-	if i.err != nil {
+	i.secondLevel.boundsCmp = 0
+	if i.secondLevel.err != nil {
 		// TODO(jackson): Can this case be turned into a panic? Once an error is
 		// encountered, the iterator must be re-seeked.
 		return nil
 	}
-	if ikv := i.singleLevelIterator.NextPrefix(succKey); ikv != nil {
+	if ikv := i.secondLevel.NextPrefix(succKey); ikv != nil {
 		return ikv
 	}
 	// key == nil
-	if i.err != nil {
+	if i.secondLevel.err != nil {
 		return nil
 	}
 
@@ -764,8 +762,8 @@ func (i *twoLevelIterator) NextPrefix(succKey []byte) *base.InternalKV {
 	// slow-path where we seek the iterator.
 	var ikv *base.InternalKV
 	if ikv = i.topLevelIndex.SeekGE(succKey, base.SeekGEFlagsNone); ikv == nil {
-		i.data.Invalidate()
-		i.index.Invalidate()
+		i.secondLevel.data.Invalidate()
+		i.secondLevel.index.Invalidate()
 		return nil
 	}
 	result := i.loadIndex(+1)
@@ -779,14 +777,14 @@ func (i *twoLevelIterator) NextPrefix(succKey []byte) *base.InternalKV {
 		// since even though this is the block separator, the same user key can
 		// span multiple index blocks. If upper is exclusive we use >= below,
 		// else we use >.
-		if i.upper != nil {
-			cmp := i.cmp(ikv.K.UserKey, i.upper)
-			if (!i.endKeyInclusive && cmp >= 0) || cmp > 0 {
-				i.exhaustedBounds = +1
+		if i.secondLevel.upper != nil {
+			cmp := i.secondLevel.cmp(ikv.K.UserKey, i.secondLevel.upper)
+			if (!i.secondLevel.endKeyInclusive && cmp >= 0) || cmp > 0 {
+				i.secondLevel.exhaustedBounds = +1
 			}
 		}
-	} else if kv := i.singleLevelIterator.SeekGE(succKey, base.SeekGEFlagsNone); kv != nil {
-		return i.maybeVerifyKey(kv)
+	} else if kv := i.secondLevel.SeekGE(succKey, base.SeekGEFlagsNone); kv != nil {
+		return i.secondLevel.maybeVerifyKey(kv)
 	}
 	return i.skipForward()
 }
@@ -795,11 +793,11 @@ func (i *twoLevelIterator) NextPrefix(succKey []byte) *base.InternalKV {
 // package.
 func (i *twoLevelIterator) Prev() *base.InternalKV {
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
-	i.boundsCmp = 0
-	if i.err != nil {
+	i.secondLevel.boundsCmp = 0
+	if i.secondLevel.err != nil {
 		return nil
 	}
-	if kv := i.singleLevelIterator.Prev(); kv != nil {
+	if kv := i.secondLevel.Prev(); kv != nil {
 		return kv
 	}
 	return i.skipBackward()
@@ -807,7 +805,7 @@ func (i *twoLevelIterator) Prev() *base.InternalKV {
 
 func (i *twoLevelIterator) skipForward() *base.InternalKV {
 	for {
-		if i.err != nil || i.exhaustedBounds > 0 {
+		if i.secondLevel.err != nil || i.secondLevel.exhaustedBounds > 0 {
 			return nil
 		}
 
@@ -840,14 +838,14 @@ func (i *twoLevelIterator) skipForward() *base.InternalKV {
 		// Note that this is only a problem with virtual tables; we make no
 		// guarantees wrt an iterator lower bound when we iterate forward. But we
 		// must never return keys that are not inside the virtual table.
-		useSeek := i.vState != nil &&
-			(!i.topLevelIndex.Valid() || base.InternalCompare(i.cmp, *i.topLevelIndex.Key(), i.vState.lower) < 0)
+		useSeek := i.secondLevel.vState != nil &&
+			(!i.topLevelIndex.Valid() || base.InternalCompare(i.secondLevel.cmp, *i.topLevelIndex.Key(), i.secondLevel.vState.lower) < 0)
 
-		i.exhaustedBounds = 0
+		i.secondLevel.exhaustedBounds = 0
 		topLevelKey := i.topLevelIndex.Next()
 		if topLevelKey == nil {
-			i.data.Invalidate()
-			i.index.Invalidate()
+			i.secondLevel.data.Invalidate()
+			i.secondLevel.index.Invalidate()
 			return nil
 		}
 		result := i.loadIndex(+1)
@@ -857,12 +855,12 @@ func (i *twoLevelIterator) skipForward() *base.InternalKV {
 		if result == loadBlockOK {
 			var ikv *base.InternalKV
 			if useSeek {
-				ikv = i.singleLevelIterator.SeekGE(i.lower, base.SeekGEFlagsNone)
+				ikv = i.secondLevel.SeekGE(i.secondLevel.lower, base.SeekGEFlagsNone)
 			} else {
-				ikv = i.singleLevelIterator.firstInternal()
+				ikv = i.secondLevel.firstInternal()
 			}
 			if ikv != nil {
-				return i.maybeVerifyKey(ikv)
+				return i.secondLevel.maybeVerifyKey(ikv)
 			}
 			// Next iteration will return if singleLevelIterator set
 			// exhaustedBounds = +1.
@@ -874,10 +872,10 @@ func (i *twoLevelIterator) skipForward() *base.InternalKV {
 			// though this is the block separator, the same user key can span
 			// multiple index blocks. If upper is exclusive we use >= below,
 			// else we use >.
-			if i.upper != nil {
-				cmp := i.cmp(topLevelKey.K.UserKey, i.upper)
-				if (!i.endKeyInclusive && cmp >= 0) || cmp > 0 {
-					i.exhaustedBounds = +1
+			if i.secondLevel.upper != nil {
+				cmp := i.secondLevel.cmp(topLevelKey.K.UserKey, i.secondLevel.upper)
+				if (!i.secondLevel.endKeyInclusive && cmp >= 0) || cmp > 0 {
+					i.secondLevel.exhaustedBounds = +1
 					// Next iteration will return.
 				}
 			}
@@ -887,14 +885,14 @@ func (i *twoLevelIterator) skipForward() *base.InternalKV {
 
 func (i *twoLevelIterator) skipBackward() *base.InternalKV {
 	for {
-		if i.err != nil || i.exhaustedBounds < 0 {
+		if i.secondLevel.err != nil || i.secondLevel.exhaustedBounds < 0 {
 			return nil
 		}
-		i.exhaustedBounds = 0
+		i.secondLevel.exhaustedBounds = 0
 		topLevelKey := i.topLevelIndex.Prev()
 		if topLevelKey == nil {
-			i.data.Invalidate()
-			i.index.Invalidate()
+			i.secondLevel.data.Invalidate()
+			i.secondLevel.index.Invalidate()
 			return nil
 		}
 		result := i.loadIndex(-1)
@@ -902,9 +900,9 @@ func (i *twoLevelIterator) skipBackward() *base.InternalKV {
 			return nil
 		}
 		if result == loadBlockOK {
-			ikv := i.singleLevelIterator.lastInternal()
+			ikv := i.secondLevel.lastInternal()
 			if ikv != nil {
-				return i.maybeVerifyKey(ikv)
+				return i.secondLevel.maybeVerifyKey(ikv)
 			}
 
 			// Next iteration will return if singleLevelIterator set
@@ -916,50 +914,42 @@ func (i *twoLevelIterator) skipBackward() *base.InternalKV {
 			// previous entry starts with keys <= ikv.InternalKey.UserKey since
 			// even though this is the current block's separator, the same user
 			// key can span multiple index blocks.
-			if i.lower != nil && i.cmp(topLevelKey.K.UserKey, i.lower) < 0 {
-				i.exhaustedBounds = -1
+			if i.secondLevel.lower != nil && i.secondLevel.cmp(topLevelKey.K.UserKey, i.secondLevel.lower) < 0 {
+				i.secondLevel.exhaustedBounds = -1
 				// Next iteration will return.
 			}
 		}
 	}
 }
 
+func (i *twoLevelIterator) Error() error {
+	return i.secondLevel.Error()
+}
+
+func (i *twoLevelIterator) SetBounds(lower, upper []byte) {
+	i.secondLevel.SetBounds(lower, upper)
+}
+
+func (i *twoLevelIterator) SetContext(ctx context.Context) {
+	i.secondLevel.SetContext(ctx)
+}
+
+func (i *twoLevelIterator) SetCloseHook(fn func(i Iterator) error) {
+	i.secondLevel.SetCloseHook(fn)
+}
+
+func (i *twoLevelIterator) SetupForCompaction() {
+	i.secondLevel.SetupForCompaction()
+}
+
 // Close implements internalIterator.Close, as documented in the pebble
 // package.
 func (i *twoLevelIterator) Close() error {
-	if invariants.Enabled && i.inPool {
-		panic("Close called on interator in pool")
-	}
-	i.iterStats.close()
-	var err error
-	if i.closeHook != nil {
-		err = firstError(err, i.closeHook(i))
-	}
-	err = firstError(err, i.data.Close())
-	err = firstError(err, i.index.Close())
+	err := i.secondLevel.closeInternal()
 	err = firstError(err, i.topLevelIndex.Close())
-	if i.indexFilterRH != nil {
-		err = firstError(err, i.indexFilterRH.Close())
-		i.indexFilterRH = nil
-	}
-	if i.dataRH != nil {
-		err = firstError(err, i.dataRH.Close())
-		i.dataRH = nil
-	}
-	err = firstError(err, i.err)
-	if i.bpfs != nil {
-		releaseBlockPropertiesFilterer(i.bpfs)
-	}
-	if i.vbReader != nil {
-		i.vbReader.close()
-	}
-	if i.vbRH != nil {
-		err = firstError(err, i.vbRH.Close())
-		i.vbRH = nil
-	}
 	*i = twoLevelIterator{
-		singleLevelIterator: i.singleLevelIterator.resetForReuse(),
-		topLevelIndex:       i.topLevelIndex.ResetForReuse(),
+		secondLevel:   i.secondLevel.resetForReuse(),
+		topLevelIndex: i.topLevelIndex.ResetForReuse(),
 	}
 	twoLevelIterPool.Put(i)
 	return err

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -19,6 +19,12 @@ import (
 type twoLevelIterator struct {
 	secondLevel   singleLevelIterator
 	topLevelIndex rowblk.Iter
+
+	// useFilterBlock controls whether we consult the bloom filter in the
+	// twoLevelIterator code. Note that secondLevel.useFilterBlock is always
+	// false - any filtering happens at the top level.
+	useFilterBlock         bool
+	lastBloomFilterMatched bool
 }
 
 var _ Iterator = (*twoLevelIterator)(nil)
@@ -154,8 +160,10 @@ func newTwoLevelIterator(
 		return nil, r.err
 	}
 	i := twoLevelIterPool.Get().(*twoLevelIterator)
-	i.secondLevel.init(ctx, r, v, transforms, lower, upper, filterer, filterBlockSizeLimit,
+	i.secondLevel.init(ctx, r, v, transforms, lower, upper, filterer,
+		false, // Disable the use of the filter block in the second level.
 		stats, categoryAndQoS, statsCollector, rp, bufferPool)
+	i.useFilterBlock = shouldUseFilterBlock(r, filterBlockSizeLimit)
 
 	topLevelIndexH, err := r.readIndex(ctx, i.secondLevel.indexFilterRH, stats, &i.secondLevel.iterStats)
 	if err == nil {
@@ -339,11 +347,10 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	err := i.secondLevel.err
 	i.secondLevel.err = nil // clear cached iteration error
 
-	useFilter := shouldUseFilterBlock(i.secondLevel.reader, i.secondLevel.filterBlockSizeLimit)
 	// The twoLevelIterator could be already exhausted. Utilize that when
 	// trySeekUsingNext is true. See the comment about data-exhausted, PGDE, and
 	// bounds-exhausted near the top of the file.
-	filterUsedAndDidNotMatch := useFilter && !i.secondLevel.lastBloomFilterMatched
+	filterUsedAndDidNotMatch := i.useFilterBlock && !i.lastBloomFilterMatched
 	if flags.TrySeekUsingNext() && !filterUsedAndDidNotMatch &&
 		(i.secondLevel.exhaustedBounds == +1 || (i.secondLevel.data.IsDataInvalidated() && i.secondLevel.index.IsDataInvalidated())) &&
 		err == nil {
@@ -352,12 +359,12 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	}
 
 	// Check prefix bloom filter.
-	if useFilter {
-		if !i.secondLevel.lastBloomFilterMatched {
+	if i.useFilterBlock {
+		if !i.lastBloomFilterMatched {
 			// Iterator is not positioned based on last seek.
 			flags = flags.DisableTrySeekUsingNext()
 		}
-		i.secondLevel.lastBloomFilterMatched = false
+		i.lastBloomFilterMatched = false
 		var mayContain bool
 		mayContain, i.secondLevel.err = i.secondLevel.bloomFilterMayContain(prefix)
 		if i.secondLevel.err != nil || !mayContain {
@@ -369,7 +376,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 			i.secondLevel.data.Invalidate()
 			return nil
 		}
-		i.secondLevel.lastBloomFilterMatched = true
+		i.lastBloomFilterMatched = true
 	}
 
 	// Bloom filter matches.
@@ -476,8 +483,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 	}
 
 	if !dontSeekWithinSingleLevelIter {
-		if ikv := i.secondLevel.seekPrefixGE(
-			prefix, key, flags, NeverUseFilterBlock); ikv != nil {
+		if ikv := i.secondLevel.seekPrefixGE(prefix, key, flags); ikv != nil {
 			return ikv
 		}
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -986,10 +986,10 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 					// sstable version.
 					require.Nil(t, i.vbRH)
 				case *twoLevelIterator:
-					require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
+					require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.secondLevel.dataRH))
 					// Each key has one version, so no value block, regardless of
 					// sstable version.
-					require.Nil(t, i.vbRH)
+					require.Nil(t, i.secondLevel.vbRH)
 				default:
 					require.Failf(t, fmt.Sprintf("unknown compaction iterator type: %T", citer), "")
 				}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -333,7 +333,7 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			}
 			switch i := origIter.(type) {
 			case *twoLevelIterator:
-				forceIgnoreValueBlocks(&i.singleLevelIterator)
+				forceIgnoreValueBlocks(&i.secondLevel)
 			case *singleLevelIterator:
 				forceIgnoreValueBlocks(i)
 			}


### PR DESCRIPTION
#### sstable: twoLevelIterator: unembed singleLevelIterator


#### sstable: clean up use-filter-block logic

We now store `useFilterBlock` in both the single level and the two
level iterators. When the single level iterator is part of a two-level
iterator, the "inner" `useFilterBlock` is always false.