### PR TITLE
sstable: add leaktest to sstable tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/cespare/xxhash/v2 v2.2.0
+	github.com/cockroachdb/crlib v0.0.0-20240729155931-991150b7e290
 	github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056
 	github.com/cockroachdb/errors v1.11.3
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cockroachdb/crlib v0.0.0-20240729155931-991150b7e290 h1:oJGWhlrgtcPSzJEgFHo6VIQW2TCFR/OiByQr6yzjDkU=
+github.com/cockroachdb/crlib v0.0.0-20240729155931-991150b7e290/go.mod h1:Gq51ZeKaFCXk6QwuGM0w1dnaOqc/F5zKT2zA9D6Xeac=
 github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056 h1:slXychO2uDM6hYRu4c0pD0udNI8uObfeKN6UInWViS8=
 github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/cockroachdb/errors v1.11.3 h1:5bA+k2Y6r+oz/6Z/RFlNeVCesGARKuC6YymtcDrbC/I=

--- a/sstable/block/compression_test.go
+++ b/sstable/block/compression_test.go
@@ -10,11 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCompressionRoundtrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	seed := time.Now().UnixNano()
 	t.Logf("seed %d", seed)
 	rng := rand.New(rand.NewSource(seed))
@@ -43,6 +46,7 @@ func TestCompressionRoundtrip(t *testing.T) {
 // TestDecompressionError tests that a decompressing a value that does not
 // decompress returns an error.
 func TestDecompressionError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	rng := rand.New(rand.NewSource(1 /* fixed seed */))
 
 	// Create a buffer to represent a faux zstd compressed block. It's prefixed

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -28,6 +29,7 @@ import (
 )
 
 func TestIntervalEncodeDecode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		name  string
 		lower uint64
@@ -90,6 +92,7 @@ func decodeAndCheck(t *testing.T, buf []byte, expected BlockInterval) {
 }
 
 func TestIntervalUnionIntersects(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		name       string
 		i1         BlockInterval
@@ -218,6 +221,7 @@ func addTestRangeKeys(t *testing.T, bic BlockPropertyCollector, suffixes ...int)
 }
 
 func TestBlockIntervalCollector(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	bic := NewBlockIntervalCollector("foo", testIntervalMapper{}, nil /* suffixReplacer */)
 	require.Equal(t, "foo", bic.Name())
 
@@ -271,6 +275,7 @@ func TestBlockIntervalCollector(t *testing.T) {
 }
 
 func TestBlockIntervalFilter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		name       string
 		filter     BlockInterval
@@ -312,6 +317,7 @@ func TestBlockIntervalFilter(t *testing.T) {
 }
 
 func TestBlockPropertiesEncoderDecoder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	var encoder blockPropertiesEncoder
 	scratch := encoder.getScratchForProp()
 	scratch = append(scratch, []byte("foo")...)
@@ -385,6 +391,7 @@ func (b filterWithTrueForEmptyProp) SyntheticSuffixIntersects(
 }
 
 func TestBlockPropertiesFilterer_IntersectsUserPropsAndFinishInit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// props with id=0, interval [10, 20); id=10, interval [110, 120).
 	bic0 := NewBlockIntervalCollector("p0", testIntervalMapper{}, nil)
 	bic0Id := byte(0)
@@ -528,6 +535,7 @@ func TestBlockPropertiesFilterer_IntersectsUserPropsAndFinishInit(t *testing.T) 
 }
 
 func TestBlockPropertiesFilterer_Intersects(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// Setup two different properties values to filter against.
 	var emptyProps []byte
 	// props with id=0, interval [10, 20); id=10, interval [110, 120).
@@ -822,6 +830,8 @@ func (c *valueCharIntervalMapper) MapRangeKeys(span Span) (BlockInterval, error)
 }
 
 func TestBlockProperties(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	var r *Reader
 	defer func() {
 		if r != nil {
@@ -987,6 +997,7 @@ func TestBlockProperties(t *testing.T) {
 }
 
 func TestBlockProperties_BoundLimited(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	var r *Reader
 	defer func() {
 		if r != nil {

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -74,6 +74,11 @@ func runBuildCmd(
 	}
 
 	w := NewWriter(f0, *writerOpts)
+	defer func() {
+		if w != nil {
+			_ = w.Close()
+		}
+	}()
 	var rangeDels []keyspan.Span
 	rangeDelFrag := keyspan.Fragmenter{
 		Cmp:    DefaultComparer.Compare,
@@ -161,6 +166,7 @@ func runBuildCmd(
 		return nil, nil, err
 	}
 	meta, err := w.Raw().Metadata()
+	w = nil
 	if err != nil {
 		return nil, nil, err
 	}
@@ -203,6 +209,11 @@ func runBuildRawCmd(
 	}
 
 	w := NewWriter(f0, *opts)
+	defer func() {
+		if w != nil {
+			_ = w.Close()
+		}
+	}()
 	for _, data := range strings.Split(td.Input, "\n") {
 		if strings.HasPrefix(data, "rangekey:") {
 			data = strings.TrimPrefix(data, "rangekey:")
@@ -235,6 +246,7 @@ func runBuildRawCmd(
 		return nil, nil, err
 	}
 	meta, err := w.Raw().Metadata()
+	w = nil
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sstable/format_test.go
+++ b/sstable/format_test.go
@@ -7,10 +7,12 @@ package sstable
 import (
 	"testing"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTableFormat_RoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		name    string
 		magic   string

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -14,12 +14,14 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPropertiesLoad(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	expected := Properties{
 		CommonProperties: CommonProperties{
 			NumEntries:         1727,
@@ -91,6 +93,7 @@ var testProps = Properties{
 }
 
 func TestPropertiesSave(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	expected := &Properties{}
 	*expected = testProps
 

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/metamorphic"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -30,6 +31,7 @@ import (
 // an error is injected during an operation, operation surfaces the error to the
 // caller.
 func TestIterator_RandomErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	root := time.Now().UnixNano()
 	// Run the test a few times with various seeds for more consistent code
 	// coverage.

--- a/sstable/raw_writer.go
+++ b/sstable/raw_writer.go
@@ -1922,6 +1922,13 @@ func NewRawWriter(writable objstorage.Writable, o WriterOptions) *RawWriter {
 	}
 
 	w.coordination.init(o.Parallelism, w)
+	defer func() {
+		if r := recover(); r != nil {
+			// Don't leak a goroutine if we hit a panic.
+			_ = w.coordination.writeQueue.finish()
+			panic(r)
+		}
+	}()
 
 	if writable == nil {
 		w.err = errors.New("pebble: nil writable")

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
@@ -20,6 +21,7 @@ import (
 // TestIteratorErrorOnInit tests the path where creation of an iterator fails
 // when reading the index block.
 func TestIteratorErrorOnInit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	mem := vfs.NewMem()
 
 	f0, err := mem.Create("test.sst", vfs.WriteCategoryUnspecified)

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/bloom"
@@ -185,6 +186,7 @@ func (i *iterAdapter) SetContext(ctx context.Context) {
 }
 
 func TestVirtualReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	t.Run("props", func(t *testing.T) {
 		runVirtualReaderTest(t, "testdata/virtual_reader_props", 0 /* blockSize */, 0 /* indexBlockSize */)
 	})
@@ -463,6 +465,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 }
 
 func TestReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	writerOpts := map[string]WriterOptions{
 		// No bloom filters.
 		"default": {},
@@ -526,6 +529,7 @@ func TestReader(t *testing.T) {
 }
 
 func TestReaderHideObsolete(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	blockSizes := map[string]int{
 		"1bytes":   1,
 		"5bytes":   5,
@@ -560,6 +564,7 @@ func TestReaderHideObsolete(t *testing.T) {
 }
 
 func TestHamletReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	for _, fixture := range TestFixtures {
 		f, err := os.Open(filepath.Join("testdata", fixture.Filename))
 		require.NoError(t, err)
@@ -588,6 +593,7 @@ func forEveryTableFormat[I any](
 }
 
 func TestReaderStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	forEveryTableFormat[string](t,
 		[NumTableFormats]string{
 			TableFormatUnspecified: "",
@@ -612,6 +618,7 @@ func TestReaderStats(t *testing.T) {
 }
 
 func TestReaderWithBlockPropertyFilter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// Some of these tests examine internal iterator state, so they require
 	// determinism. When the invariants tag is set, disableBoundsOpt may disable
 	// the bounds optimization depending on the iterator pointer address. This
@@ -643,6 +650,7 @@ func TestReaderWithBlockPropertyFilter(t *testing.T) {
 }
 
 func TestInjectedErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	for _, fixture := range TestFixtures {
 		run := func(i int) (reterr error) {
 			f, err := vfs.Default.Open(filepath.Join("testdata", fixture.Filename))
@@ -695,6 +703,7 @@ func TestInjectedErrors(t *testing.T) {
 }
 
 func TestInvalidReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	invalid, err := NewSimpleReadable(vfs.NewMemFile([]byte("invalid sst bytes")))
 	if err != nil {
 		t.Fatal(err)
@@ -863,6 +872,7 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, printVa
 }
 
 func TestReaderCheckComparerMerger(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	const testTable = "test"
 
 	testComparer := &base.Comparer{
@@ -965,6 +975,7 @@ func checkValidPrefix(prefix, key []byte) bool {
 }
 
 func TestCompactionIteratorSetupForCompaction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tmpDir := path.Join(t.TempDir())
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
@@ -1002,6 +1013,7 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 }
 
 func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tmpDir := path.Join(t.TempDir())
 	provider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(vfs.Default, tmpDir))
 	require.NoError(t, err)
@@ -1286,6 +1298,7 @@ func createReadWorkload(
 // will contain all keys with that prefix. In other words, this is a randomized
 // version of TestBlockSyntheticSuffix and TestBlockSyntheticPrefix.
 func TestRandomizedPrefixSuffixRewriter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ks := testkeys.Alpha(3)
 
 	callCount := 500
@@ -1467,6 +1480,7 @@ func (c *checker) check(eKV *base.InternalKV) func(*base.InternalKV) {
 }
 
 func TestReaderChecksumErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	for _, checksumType := range []block.ChecksumType{block.ChecksumTypeCRC32c, block.ChecksumTypeXXHash64} {
 		t.Run(fmt.Sprintf("checksum-type=%d", checksumType), func(t *testing.T) {
 			for _, twoLevelIndex := range []bool{false, true} {
@@ -1558,6 +1572,7 @@ func TestReaderChecksumErrors(t *testing.T) {
 }
 
 func TestValidateBlockChecksums(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	seed := uint64(time.Now().UnixNano())
 	rng := rand.New(rand.NewSource(seed))
 	t.Logf("using seed = %d", seed)
@@ -1750,6 +1765,7 @@ func TestValidateBlockChecksums(t *testing.T) {
 }
 
 func TestReader_TableFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	test := func(t *testing.T, want TableFormat) {
 		fs := vfs.NewMem()
 		f, err := fs.Create("test", vfs.WriteCategoryUnspecified)

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
@@ -15,6 +16,7 @@ import (
 )
 
 func TestRewriteSuffixProps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	from, to := []byte("_212"), []byte("_646")
 	for format := TableFormatPebblev2; format <= TableFormatMax; format++ {
 		t.Run(format.String(), func(t *testing.T) {

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -258,13 +259,23 @@ func testReader(t *testing.T, filename string, comparer *Comparer, fp FilterPoli
 	}
 }
 
-func TestReaderDefaultCompression(t *testing.T) { testReader(t, "h.sst", nil, nil) }
-func TestReaderNoCompression(t *testing.T)      { testReader(t, "h.no-compression.sst", nil, nil) }
+func TestReaderDefaultCompression(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testReader(t, "h.sst", nil, nil)
+}
+
+func TestReaderNoCompression(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testReader(t, "h.no-compression.sst", nil, nil)
+}
+
 func TestReaderTableBloom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testReader(t, "h.table-bloom.no-compression.sst", nil, nil)
 }
 
 func TestReaderBloomUsed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	wordCount := hamletWordCount()
 	words := wordCount.SortedKeys()
 
@@ -324,6 +335,7 @@ func TestReaderBloomUsed(t *testing.T) {
 }
 
 func TestBloomFilterFalsePositiveRate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	f, err := os.Open(filepath.FromSlash("testdata/h.table-bloom.no-compression.sst"))
 	require.NoError(t, err)
 
@@ -409,6 +421,7 @@ func (c *countingFilterPolicy) MayContain(ftype FilterType, filter, key []byte) 
 }
 
 func TestWriterRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	blockSizes := []int{100, 1000, 2048, 4096, math.MaxInt32}
 	for _, blockSize := range blockSizes {
 		for _, indexBlockSize := range blockSizes {
@@ -432,6 +445,7 @@ func TestWriterRoundTrip(t *testing.T) {
 }
 
 func TestFinalBlockIsWritten(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	keys := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}
 	valueLengths := []int{0, 1, 22, 28, 33, 40, 50, 61, 87, 100, 143, 200}
 	xxx := bytes.Repeat([]byte("x"), valueLengths[len(valueLengths)-1])
@@ -497,6 +511,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 }
 
 func TestReaderSymtheticSeqNum(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	f, err := os.Open(filepath.FromSlash("testdata/h.sst"))
 	require.NoError(t, err)
 
@@ -519,6 +534,7 @@ func TestReaderSymtheticSeqNum(t *testing.T) {
 }
 
 func TestMetaIndexEntriesSorted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	fs := vfs.NewMem()
 	err := buildHamletTestSST(fs, "test.sst", block.DefaultCompression, nil, /* filter policy */
 		TableFilter, nil, 4096, 4096)
@@ -550,6 +566,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 }
 
 func TestFooterRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	buf := make([]byte, 100+maxFooterLen)
 	for format := TableFormatLevelDB; format < TableFormatMax; format++ {
 		t.Run(fmt.Sprintf("format=%s", format), func(t *testing.T) {
@@ -605,6 +622,7 @@ func TestFooterRoundTrip(t *testing.T) {
 }
 
 func TestReadFooter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	encode := func(format TableFormat, checksum block.ChecksumType) string {
 		f := footer{
 			format:   format,

--- a/sstable/unsafe_test.go
+++ b/sstable/unsafe_test.go
@@ -12,11 +12,13 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
 
 func TestGetBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	const size = (1 << 31) - 1
 	// No need to actually allocate a huge slice, which can cause OOM on small
 	// machines (like the GitHub CI runners).
@@ -26,6 +28,7 @@ func TestGetBytes(t *testing.T) {
 }
 
 func TestDecodeVarint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	vals := []uint32{
 		0,
 		1,

--- a/sstable/value_block_test.go
+++ b/sstable/value_block_test.go
@@ -10,11 +10,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValueHandleEncodeDecode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []valueHandle{
 		{valueLen: 23, blockNum: 100003, offsetInBlock: 2300},
 		{valueLen: math.MaxUint32 - 1, blockNum: math.MaxUint32 / 2, offsetInBlock: math.MaxUint32 - 2},
@@ -30,6 +32,7 @@ func TestValueHandleEncodeDecode(t *testing.T) {
 }
 
 func TestValueBlocksIndexHandleEncodeDecode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []valueBlocksIndexHandle{
 		{
 			h: block.Handle{
@@ -54,6 +57,7 @@ func TestValueBlocksIndexHandleEncodeDecode(t *testing.T) {
 }
 
 func TestLittleEndianGetPut(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []uint64{
 		0, (1 << 10) - 1, (1 << 25) + 1, math.MaxUint32, math.MaxUint64, uint64(rand.Int63())}
 	var buf [8]byte

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -228,11 +228,10 @@ func (w *Writer) tempRangeKeyCopy(k []byte) []byte {
 // Close finishes writing the table and closes the underlying file that the
 // table was written to.
 func (w *Writer) Close() (err error) {
-	if w.rw.err != nil {
-		return w.rw.err
+	if w.rw.err == nil {
+		// Write the range-key block, flushing any remaining spans from the
+		// fragmenter first.
+		w.fragmenter.Finish()
 	}
-	// Write the range-key block, flushing any remaining spans from the
-	// fragmenter first.
-	w.fragmenter.Finish()
 	return w.rw.Close()
 }

--- a/sstable/writer_fixture_test.go
+++ b/sstable/writer_fixture_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
@@ -73,6 +74,7 @@ func runTestFixtureOutput(fixture TestFixtureInfo) error {
 }
 
 func TestFixtureOutput(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	for _, fixture := range TestFixtures {
 		// Note: we disabled the zstd fixture test when CGO_ENABLED=0, because the
 		// implementation between DataDog/zstd and klauspost/compress are


### PR DESCRIPTION
This commit adds a `leaktest` check to all sstable tests and fixes
goroutine leaks in some error paths.