### PR TITLE
db: remove IterOptions.TableFilter

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -108,8 +108,6 @@ func NewExternalIterWithContext(
 
 func validateExternalIterOpts(iterOpts *IterOptions) error {
 	switch {
-	case iterOpts.TableFilter != nil:
-		return errors.Errorf("pebble: external iterator: TableFilter unsupported")
 	case iterOpts.PointKeyFilters != nil:
 		return errors.Errorf("pebble: external iterator: PointKeyFilters unsupported")
 	case iterOpts.RangeKeyFilters != nil:

--- a/iterator.go
+++ b/iterator.go
@@ -2579,14 +2579,8 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 	// If OnlyReadGuaranteedDurable changed, the iterator stacks are incorrect,
 	// improperly including or excluding memtables. Invalidate them so that
 	// finishInitializingIter will reconstruct them.
-	//
-	// If either the original options or the new options specify a table filter,
-	// we need to reconstruct the iterator stacks. If they both supply a table
-	// filter, we can't be certain that it's the same filter since we have no
-	// mechanism to compare the filter closures.
 	closeBoth := i.err != nil ||
-		o.OnlyReadGuaranteedDurable != i.opts.OnlyReadGuaranteedDurable ||
-		o.TableFilter != nil || i.opts.TableFilter != nil
+		o.OnlyReadGuaranteedDurable != i.opts.OnlyReadGuaranteedDurable
 
 	// If either options specify block property filters for an iterator stack,
 	// reconstruct it.

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1292,13 +1292,9 @@ func TestIteratorBoundsLifetimes(t *testing.T) {
 			return buf.String()
 		case "set-options":
 			var label string
-			var tableFilter bool
 			td.ScanArgs(t, "label", &label)
 			opts := iterators[label].opts
 			for _, arg := range td.CmdArgs {
-				if arg.Key == "table-filter" {
-					tableFilter = true
-				}
 				if arg.Key == "key-types" {
 					switch arg.Vals[0] {
 					case "points-only":
@@ -1313,9 +1309,6 @@ func TestIteratorBoundsLifetimes(t *testing.T) {
 				}
 			}
 			opts.LowerBound, opts.UpperBound = parseBounds(td)
-			if tableFilter {
-				opts.TableFilter = func(userProps map[string]string) bool { return false }
-			}
 			iterators[label].SetOptions(&opts)
 			trashBounds(opts.LowerBound, opts.UpperBound)
 			buf.Reset()
@@ -1542,9 +1535,6 @@ func iterOptionsString(o *IterOptions) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "key-types=%s, lower=%q, upper=%q",
 		o.KeyTypes, o.LowerBound, o.UpperBound)
-	if o.TableFilter != nil {
-		fmt.Fprintf(&buf, ", table-filter")
-	}
 	if o.OnlyReadGuaranteedDurable {
 		fmt.Fprintf(&buf, ", only-durable")
 	}

--- a/level_iter.go
+++ b/level_iter.go
@@ -157,7 +157,6 @@ func (l *levelIter) init(
 	l.prefix = nil
 	l.lower = opts.LowerBound
 	l.upper = opts.UpperBound
-	l.tableOpts.TableFilter = opts.TableFilter
 	l.tableOpts.PointKeyFilters = opts.PointKeyFilters
 	if len(opts.PointKeyFilters) == 0 {
 		l.tableOpts.PointKeyFilters = l.filtersBuf[:0:1]

--- a/options.go
+++ b/options.go
@@ -115,11 +115,6 @@ type IterOptions struct {
 	// boundary the iterator will return Valid()==false. Setting UpperBound
 	// effectively truncates the key space visible to the iterator.
 	UpperBound []byte
-	// TableFilter can be used to filter the tables that are scanned during
-	// iteration based on the user properties. Return true to scan the table and
-	// false to skip scanning. This function must be thread-safe since the same
-	// function can be used by multiple iterators, if the iterator is cloned.
-	TableFilter func(userProps map[string]string) bool
 	// SkipPoint may be used to skip over point keys that don't match an
 	// arbitrary predicate during iteration. If set, the Iterator invokes
 	// SkipPoint for keys encountered. If SkipPoint returns true, the iterator


### PR DESCRIPTION
Remove support for IterOptions.TableFilter. The earliest supported format major version (FormatFlushableIngest introduced in v23.1) guarantees that all sstables that predate the introduction of block-property filters have already been compacted.