### PR TITLE
base: add a Comparer checker

### DIFF
--- a/internal/base/comparer_test.go
+++ b/internal/base/comparer_test.go
@@ -55,6 +55,12 @@ func TestDefAppendSeparator(t *testing.T) {
 	}
 }
 
+func TestDefaultComparer(t *testing.T) {
+	if err := CheckComparer(DefaultComparer, [][]byte{{}, []byte("abc"), []byte("d"), []byte("ef")}, [][]byte{{}}); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestAbbreviatedKey(t *testing.T) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 	randBytes := func(size int) []byte {

--- a/internal/crdbtest/crdbtest.go
+++ b/internal/crdbtest/crdbtest.go
@@ -91,9 +91,7 @@ var Comparer = base.Comparer{
 // EncodeMVCCKey encodes a MVCC key into dst, growing dst as necessary.
 func EncodeMVCCKey(dst []byte, key []byte, walltime uint64, logical uint32) []byte {
 	if cap(dst) < len(key)+withSynthetic {
-		newKey := make([]byte, len(key), len(key)+withSynthetic)
-		copy(newKey, key)
-		key = newKey
+		dst = make([]byte, 0, len(key)+withSynthetic)
 	}
 	dst = append(dst[:0], key...)
 	return EncodeTimestamp(dst, walltime, logical)

--- a/internal/crdbtest/crdbtest_test.go
+++ b/internal/crdbtest/crdbtest_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package crdbtest
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+func TestComparer(t *testing.T) {
+	t.Skipf("TODO(radu): the crdb comparer is currently broken")
+	prefixes := [][]byte{
+		{},
+		EncodeMVCCKey(nil, []byte("abc"), 0, 0),
+		EncodeMVCCKey(nil, []byte("d"), 0, 0),
+		EncodeMVCCKey(nil, []byte("ef"), 0, 0),
+	}
+
+	suffixes := [][]byte{{}}
+	for walltime := 3; walltime > 0; walltime-- {
+		for logical := 2; logical >= 0; logical-- {
+			key := EncodeMVCCKey(nil, []byte("foo"), uint64(walltime), uint32(logical))
+			suffix := key[Comparer.Split(key):]
+			suffixes = append(suffixes, suffix)
+		}
+	}
+	if err := base.CheckComparer(&Comparer, prefixes, suffixes); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/testkeys/testkeys_test.go
+++ b/internal/testkeys/testkeys_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
@@ -289,4 +290,12 @@ func TestOverflowPanic(t *testing.T) {
 		}
 	}()
 	keyCount(6, len(alpha))
+}
+
+func TestComparer(t *testing.T) {
+	if err := base.CheckComparer(Comparer,
+		[][]byte{{}, []byte("abc"), []byte("d"), []byte("ef")},
+		[][]byte{{}, []byte("@3"), []byte("@2"), []byte("@1")}); err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
We add a `CheckComparer` function which tests the `Compare` and
`Split` functions on combinations of prefixes and suffixes.

The cockroach comparer currently fails this test, as `Split()` on a
suffix incorrectly returns the suffix length instead of 0.