### PR TITLE
sstable: remove WriterOption

### DIFF
--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -27,9 +27,9 @@ type Writer struct {
 // writer will close the file.
 //
 // Internal clients should generally prefer NewRawWriter.
-func NewWriter(writable objstorage.Writable, o WriterOptions, extraOpts ...WriterOption) *Writer {
+func NewWriter(writable objstorage.Writable, o WriterOptions) *Writer {
 	o = o.ensureDefaults()
-	rw := NewRawWriter(writable, o, extraOpts...)
+	rw := NewRawWriter(writable, o)
 	return &Writer{
 		rw: rw,
 		fragmenter: keyspan.Fragmenter{


### PR DESCRIPTION
Remove the WriterOption type and associated extraOpts variadic parameter to New[Raw]Writer. There are no existing implementations of the WriterOption interface since #3736.