### PR TITLE
sstable/block: refactor CompressAndChecksum

### DIFF
--- a/sstable/block/compression_test.go
+++ b/sstable/block/compression_test.go
@@ -27,7 +27,7 @@ func TestCompressionRoundtrip(t *testing.T) {
 			// not sufficient, Compress should allocate one that is.
 			compressedBuf := make([]byte, rng.Intn(1<<10 /* 1 KiB */))
 
-			btyp, compressed := Compress(compression, payload, compressedBuf)
+			btyp, compressed := compress(compression, payload, compressedBuf)
 			v, err := Decompress(btyp, compressed)
 			require.NoError(t, err)
 			got := payload

--- a/sstable/raw_writer.go
+++ b/sstable/raw_writer.go
@@ -575,13 +575,12 @@ type dataBlockBuf struct {
 	// next byte slice to be compressed. The uncompressed byte slice will be backed by the
 	// dataBlock.buf.
 	uncompressed []byte
-	// compressed is a reference to a byte slice which is owned by the dataBlockBuf. It is the
-	// compressed byte slice which must be written to disk. The compressed byte slice may be
-	// backed by the dataBlock.buf, or the dataBlockBuf.compressedBuf, depending on whether
-	// we use the result of the compression.
-	compressed []byte
-	// trailer is the block trailer encoding the compression type and checksum.
-	trailer block.Trailer
+
+	// physical holds the (possibly) compressed block and its trailer. The
+	// underlying block data's byte slice is owned by the dataBlockBuf. It  may
+	// be backed by the dataBlock.buf, or the dataBlockBuf.compressedBuf,
+	// depending on whether we use the result of the compression.
+	physical block.PhysicalBlock
 
 	// We're making calls to BlockPropertyCollectors from the Writer client goroutine. We need to
 	// pass the encoded block properties over to the write queue. To prevent copies, and allocations,
@@ -600,7 +599,7 @@ func (d *dataBlockBuf) clear() {
 	d.dataBlock.Reset()
 
 	d.uncompressed = nil
-	d.compressed = nil
+	d.physical = block.PhysicalBlock{}
 	d.dataBlockProps = nil
 	d.sepScratch = d.sepScratch[:0]
 }
@@ -623,7 +622,7 @@ func (d *dataBlockBuf) finish() {
 }
 
 func (d *dataBlockBuf) compressAndChecksum(c block.Compression) {
-	d.compressed, d.trailer = compressAndChecksum(d.uncompressed, c, &d.blockBuf)
+	d.physical = block.CompressAndChecksum(&d.compressedBuf, d.uncompressed, c, &d.checksummer)
 }
 
 func (d *dataBlockBuf) shouldFlush(
@@ -1149,7 +1148,7 @@ func (w *RawWriter) flush(key InternalKey) error {
 	w.dataBlockBuf.compressAndChecksum(w.compression)
 	// Since dataBlockEstimates.addInflightDataBlock was never called, the
 	// inflightSize is set to 0.
-	w.coordination.sizeEstimate.dataBlockCompressed(len(w.dataBlockBuf.compressed), 0)
+	w.coordination.sizeEstimate.dataBlockCompressed(w.dataBlockBuf.physical.LengthWithoutTrailer(), 0)
 
 	// Determine if the index block should be flushed. Since we're accessing the
 	// dataBlockBuf.dataBlock.curKey here, we have to make sure that once we start
@@ -1581,27 +1580,6 @@ func (w *RawWriter) writeTwoLevelIndex() (block.Handle, error) {
 	w.props.TopLevelIndexSize = uint64(w.topLevelIndexBlock.EstimatedSize())
 	w.props.IndexSize += w.props.TopLevelIndexSize + block.TrailerLen
 	return w.layout.WriteIndexBlock(w.topLevelIndexBlock.Finish())
-}
-
-func compressAndChecksum(
-	b []byte, compression block.Compression, blockBuf *blockBuf,
-) (compressed []byte, trailer block.Trailer) {
-	// Compress the buffer, discarding the result if the improvement isn't at
-	// least 12.5%.
-	algo, compressed := block.Compress(compression, b, blockBuf.compressedBuf)
-	if algo != block.NoCompressionIndicator && cap(compressed) > cap(blockBuf.compressedBuf) {
-		blockBuf.compressedBuf = compressed[:cap(compressed)]
-	}
-	if len(compressed) < len(b)-len(b)/8 {
-		b = compressed
-	} else {
-		algo = block.NoCompressionIndicator
-	}
-
-	// Calculate the checksum.
-	trailer[0] = byte(algo)
-	checksum := blockBuf.checksummer.Checksum(b, trailer[:1])
-	return b, block.MakeTrailer(byte(algo), checksum)
 }
 
 // assertFormatCompatibility ensures that the features present on the table are

--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -61,7 +61,7 @@ func newWriteQueue(size int, writer *RawWriter) *writeQueue {
 func (w *writeQueue) performWrite(task *writeTask) error {
 	var bhp BlockHandleWithProperties
 	var err error
-	if bhp.Handle, err = w.writer.layout.WritePrecompressedDataBlock(task.buf.compressed, task.buf.trailer); err != nil {
+	if bhp.Handle, err = w.writer.layout.WritePrecompressedDataBlock(task.buf.physical); err != nil {
 		return err
 	}
 	bhp = BlockHandleWithProperties{Handle: bhp.Handle, Props: task.buf.dataBlockProps}


### PR DESCRIPTION
This commit moves logic around finishing a block (compressing and checksumming) into the block package. The logic is refactored to use a PhysicalBlock type that distinguishes a finished block from an unfinished, trailer-less block.