### PR TITLE
internal/keyspan: export Truncate in keyspan.Fragmenter.

### DIFF
--- a/internal/keyspan/fragmenter.go
+++ b/internal/keyspan/fragmenter.go
@@ -244,6 +244,14 @@ func (f *Fragmenter) Start() []byte {
 	return nil
 }
 
+// Truncates all pending spans up to key (exclusive), flushes them, and retains
+// any spans that continue onward for future flushes.
+func (f *Fragmenter) Truncate(key []byte) {
+	if len(f.pending) > 0 {
+		f.truncateAndFlush(key)
+	}
+}
+
 // Flushes all pending spans up to key (exclusive).
 //
 // WARNING: The specified key is stored without making a copy, so all callers


### PR DESCRIPTION
This change exports the truncateAndFlush method in keyspan.Fragmenter.

Necessary to unblock https://github.com/cockroachdb/cockroach/issues/67284 .