### PR TITLE
db: export MakeTrailer

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -44,6 +44,12 @@ func MakeInternalKey(userKey []byte, seqNum SeqNum, kind InternalKeyKind) Intern
 	return base.MakeInternalKey(userKey, seqNum, kind)
 }
 
+// MakeInternalKeyTrailer constructs a trailer from a specified sequence number
+// and kind.
+func MakeInternalKeyTrailer(seqNum SeqNum, kind InternalKeyKind) InternalKeyTrailer {
+	return base.MakeTrailer(seqNum, kind)
+}
+
 type internalIterator = base.InternalIterator
 
 type topLevelIterator = base.TopLevelIterator


### PR DESCRIPTION
Currently, we export MakeInternalKey but not MakeTrailer. This change exports MakeTrailer so we can use it directly in https://github.com/cockroachdb/cockroach/pull/127997 .