### PR TITLE
colblk: add UnsafeIntegerSlice microbenchmark

### DIFF
--- a/sstable/colblk/unsafe_slice_test.go
+++ b/sstable/colblk/unsafe_slice_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package colblk
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/internal/aligned"
+	"golang.org/x/exp/rand"
+)
+
+func BenchmarkUnsafeIntegerSlice(b *testing.B) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 8, math.MaxUint64)
+	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 4, math.MaxUint32)
+	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 2, math.MaxUint16)
+	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 1, math.MaxUint8)
+	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 0, 1)
+	benchmarkUnsafeIntegerSlice[uint32](b, rng, 1000, 4, math.MaxUint32)
+	benchmarkUnsafeIntegerSlice[uint32](b, rng, 1000, 2, math.MaxUint16)
+	benchmarkUnsafeIntegerSlice[uint32](b, rng, 1000, 1, math.MaxUint8)
+	benchmarkUnsafeIntegerSlice[uint32](b, rng, 1000, 0, 1)
+	benchmarkUnsafeIntegerSlice[uint16](b, rng, 1000, 2, math.MaxUint16)
+	benchmarkUnsafeIntegerSlice[uint16](b, rng, 1000, 1, math.MaxUint8)
+	benchmarkUnsafeIntegerSlice[uint16](b, rng, 1000, 0, 1)
+	benchmarkUnsafeIntegerSlice[uint8](b, rng, 1000, 1, math.MaxUint8)
+	benchmarkUnsafeIntegerSlice[uint8](b, rng, 1000, 0, 1)
+}
+
+func benchmarkUnsafeIntegerSlice[U Uint](
+	b *testing.B, rng *rand.Rand, rows, expectedWidth int, max uint64,
+) {
+	b.Run(fmt.Sprintf("%T,delta%d", U(0), expectedWidth), func(b *testing.B) {
+		var ub UintBuilder[U]
+		ub.Init()
+		for i := 0; i < rows; i++ {
+			ub.Set(i, U(rng.Uint64n(max)))
+		}
+
+		sz := ub.Size(rows, 0)
+		buf := aligned.ByteSlice(int(sz) + 1 /* trailing padding byte */)
+		_ = ub.Finish(0, rows, 0, buf)
+		s, _ := DecodeUnsafeIntegerSlice[U](buf, 0, rows)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = s.At(rng.Intn(rows))
+		}
+	})
+}


### PR DESCRIPTION
Add a microbenchmark for the UnsafeIntegerSlice.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble/sstable/colblk
                                    │   old.txt   │
                                    │   sec/op    │
UnsafeIntegerSlice/uint64,delta8-10   3.651n ± 0%
UnsafeIntegerSlice/uint64,delta4-10   3.557n ± 3%
UnsafeIntegerSlice/uint64,delta2-10   3.468n ± 1%
UnsafeIntegerSlice/uint64,delta1-10   3.418n ± 2%
UnsafeIntegerSlice/uint64,delta0-10   3.397n ± 0%
UnsafeIntegerSlice/uint32,delta4-10   3.542n ± 6%
UnsafeIntegerSlice/uint32,delta2-10   3.530n ± 3%
UnsafeIntegerSlice/uint32,delta1-10   3.496n ± 4%
UnsafeIntegerSlice/uint32,delta0-10   3.448n ± 2%
UnsafeIntegerSlice/uint16,delta2-10   3.512n ± 2%
UnsafeIntegerSlice/uint16,delta1-10   3.483n ± 2%
UnsafeIntegerSlice/uint16,delta0-10   3.536n ± 3%
UnsafeIntegerSlice/uint8,delta1-10    3.405n ± 1%
UnsafeIntegerSlice/uint8,delta0-10    3.421n ± 3%
geomean                               3.490n
```

I experimented with using generics over the delta type too, relying on runtime dynamic dispatch and it was ~20% slower.