### PR TITLE
colblk: add PrefixBytesIter for stateful key synthesis

### DIFF
--- a/sstable/colblk/base.go
+++ b/sstable/colblk/base.go
@@ -4,7 +4,11 @@
 
 package colblk
 
-import "golang.org/x/exp/constraints"
+import (
+	"unsafe"
+
+	"golang.org/x/exp/constraints"
+)
 
 // align returns the next value greater than or equal to offset that's divisible
 // by val.
@@ -42,3 +46,15 @@ const (
 	align32Shift = 2
 	align64Shift = 3
 )
+
+// TODO(jackson): A subsequent Go release will remove the ability to call these
+// runtime functions. We should consider asm implementations that we maintain
+// within the crlib repo.
+//
+// See https://github.com/golang/go/issues/67401
+
+//go:linkname memmove runtime.memmove
+func memmove(to, from unsafe.Pointer, n uintptr)
+
+//go:linkname mallocgc runtime.mallocgc
+func mallocgc(size uintptr, typ unsafe.Pointer, needzero bool) unsafe.Pointer

--- a/sstable/colblk/prefix_bytes_test.go
+++ b/sstable/colblk/prefix_bytes_test.go
@@ -274,17 +274,17 @@ func BenchmarkPrefixBytes(b *testing.B) {
 			buf = build(n)
 			pb, _ := DecodePrefixBytes(buf, 0, n)
 			b.ResetTimer()
-			var k []byte
+			var pbi PrefixBytesIter
 			for i := 0; i < b.N; i++ {
 				j := i % n
 				if j == 0 {
-					k = pb.AppendAt(k[:0], j)
+					pb.SetAt(&pbi, j)
 				} else {
-					k = pb.SetNextAt(k, j)
+					pb.SetNext(&pbi)
 				}
-				if invariants.Enabled && !bytes.Equal(k, userKeys[j]) {
+				if invariants.Enabled && !bytes.Equal(pbi.UnsafeSlice(), userKeys[j]) {
 					b.Fatalf("Constructed key %q (%q, %q, %q) for index %d; expected %q",
-						k, pb.SharedPrefix(), pb.RowBundlePrefix(j), pb.RowSuffix(j), j, userKeys[j])
+						pbi.UnsafeSlice(), pb.SharedPrefix(), pb.RowBundlePrefix(j), pb.RowSuffix(j), j, userKeys[j])
 				}
 			}
 		})

--- a/sstable/colblk/unsafe_slice.go
+++ b/sstable/colblk/unsafe_slice.go
@@ -134,3 +134,16 @@ func (s UnsafeIntegerSlice[T]) At(i int) T {
 		panic("unreachable")
 	}
 }
+
+// UnsafeBuf provides a buffer without bounds checking. Every buf has a len and
+// capacity.
+type UnsafeBuf struct {
+	ptr unsafe.Pointer
+	len int
+	cap int
+}
+
+// UnsafeSlice returns the current contents of the buf.
+func (b *UnsafeBuf) UnsafeSlice() []byte {
+	return unsafe.Slice((*byte)(b.ptr), b.len)
+}


### PR DESCRIPTION
Replace PrefixBytes.{AppendAt,SetNextAt} with a new PrefixBytes.{SetAt,SetNext} API that uses a PrefixBytesIter type to hold the key buffer and metadata that can be used to more cheaply perform SetNext operations. Subsequent work will also extend the API to support a SetPrev method.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble/sstable/colblk
                                     │   old.txt   │               new.txt               │
                                     │   sec/op    │   sec/op     vs base                │
PrefixBytes/alphaLen=2/iteration-10    7.799n ± 4%   5.600n ± 1%  -28.20% (p=0.000 n=20)
PrefixBytes/alphaLen=5/iteration-10    7.741n ± 1%   5.590n ± 1%  -27.78% (p=0.000 n=20)
PrefixBytes/alphaLen=26/iteration-10   7.655n ± 0%   5.616n ± 1%  -26.63% (p=0.000 n=20)
geomean                                7.732n        5.602n       -27.54%
```