### PR TITLE
sstable: use block cache / readhandle for downloads

### DIFF
--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -375,9 +375,7 @@ type RemoteObjectToAttach struct {
 }
 
 // Copy copies the specified range from the input to the output.
-func Copy(ctx context.Context, in Readable, out Writable, offset, length uint64) error {
-	r := in.NewReadHandle(NoReadBefore)
-	r.SetupForCompaction()
+func Copy(ctx context.Context, r ReadHandle, out Writable, offset, length uint64) error {
 	buf := make([]byte, 256<<10)
 	end := offset + length
 	for offset < end {

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -209,6 +209,11 @@ func (v *VirtualReader) NewRawRangeKeyIter(
 	), nil
 }
 
+// UnsafeReader returns the underlying *sstable.Reader behind a VirtualReader.
+func (v *VirtualReader) UnsafeReader() *Reader {
+	return v.reader
+}
+
 // Constrain bounds will narrow the start, end bounds if they do not fit within
 // the virtual sstable. The function will return if the new end key is
 // inclusive.


### PR DESCRIPTION
Previously, if we had some blocks in the block cache at the time of starting a download, we would still read all blocks from object storage. This was pretty wasteful, especially for index/footer/etc blocks that are more likely to be in cache.

This change threads through the appropriate Reader through sstable.CopySpan, so that the cached blocks can be appropriately used. Data blocks are also read through the cache if they exist in the cache; if not, we fall back to the old sequence of reading and writing bytes blindly from object storage to local disk as fast as IO allows us to.

Fixes #3758.