### PR TITLE
sstable: genericize sstable iterators by data block iterator

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -89,6 +89,45 @@ func (c *Checksummer) Checksum(block []byte, blockType []byte) (checksum uint32)
 	return checksum
 }
 
+// DataBlockIterator is a type constraint for implementations of block iterators
+// over data blocks. It's currently satisifed by the *rowblk.Iter type.
+//
+// DataBlockIterator requires that the type be a pointer to its type parameter,
+// D, to allow sstable iterators embed the block iterator within its struct. See
+// this example from the Go generics proposal:
+// https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#pointer-method-example
+type DataBlockIterator[D any] interface {
+	base.InternalIterator
+
+	// Handle returns the handle to the block.
+	Handle() BufferHandle
+	// InitHandle initializes the block from the provided buffer handle.
+	InitHandle(base.Compare, base.Split, BufferHandle, IterTransforms) error
+	// Valid returns true if the iterator is currently positioned at a valid KV.
+	Valid() bool
+	// KV returns the key-value pair at the current iterator position. The
+	// iterator must be Valid().
+	KV() *base.InternalKV
+	// ResetForReuse resets the iterator so that it may be used for iteration
+	// over a new block. It returns the non-pointer D type to allow resetting
+	// while initializing the containing struct, eg::
+	//   iter = sstableIter{dataBlockIter: iter.dataBlockIter.ResetForReuse()}
+	ResetForReuse() D
+	// FirstUserKey returns the first user key contained within the data block.
+	FirstUserKey() []byte
+	// Invalidate invalidates the block iterator, removing references to the block
+	// it was initialized with.
+	Invalidate()
+	// IsDataInvalidated returns true when the iterator has been invalidated
+	// using an Invalidate call.
+	//
+	// NB: this is different from Valid which indicates whether the current *KV*
+	// is valid.
+	IsDataInvalidated() bool
+
+	*D // non-interface type constraint element
+}
+
 // IterTransforms allow on-the-fly transformation of data at iteration time.
 //
 // These transformations could in principle be implemented as block transforms

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -427,8 +428,8 @@ func runIterCmd(
 			continue
 		case "internal-iter-state":
 			fmt.Fprintf(&b, "| %T:\n", origIter)
-			si, _ := origIter.(*singleLevelIterator)
-			if twoLevelIter, ok := origIter.(*twoLevelIterator); ok {
+			si, _ := origIter.(*singleLevelIterator[rowblk.Iter, *rowblk.Iter])
+			if twoLevelIter, ok := origIter.(*twoLevelIterator[rowblk.Iter, *rowblk.Iter]); ok {
 				si = &twoLevelIter.secondLevel
 				if twoLevelIter.topLevelIndex.Valid() {
 					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", twoLevelIter.topLevelIndex.Key())

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -207,10 +207,11 @@ func (r *Reader) newPointIter(
 	var res Iterator
 	var err error
 	if r.Properties.IndexType == twoLevelIndex {
-		res, err = newTwoLevelIterator(ctx, r, vState, transforms, lower, upper, filterer, filterBlockSizeLimit,
+		res, err = newRowBlockTwoLevelIterator(
+			ctx, r, vState, transforms, lower, upper, filterer, filterBlockSizeLimit,
 			stats, categoryAndQoS, statsCollector, rp, nil /* bufferPool */)
 	} else {
-		res, err = newSingleLevelIterator(
+		res, err = newRowBlockSingleLevelIterator(
 			ctx, r, vState, transforms, lower, upper, filterer, filterBlockSizeLimit,
 			stats, categoryAndQoS, statsCollector, rp, nil /* bufferPool */)
 	}
@@ -261,7 +262,7 @@ func (r *Reader) newCompactionIter(
 		transforms.HideObsoletePoints = true
 	}
 	if r.Properties.IndexType == twoLevelIndex {
-		i, err := newTwoLevelIterator(
+		i, err := newRowBlockTwoLevelIterator(
 			context.Background(),
 			r, vState, transforms, nil /* lower */, nil /* upper */, nil,
 			NeverUseFilterBlock, nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
@@ -272,7 +273,7 @@ func (r *Reader) newCompactionIter(
 		i.SetupForCompaction()
 		return i, nil
 	}
-	i, err := newSingleLevelIterator(
+	i, err := newRowBlockSingleLevelIterator(
 		context.Background(), r, vState, transforms, nil /* lower */, nil, /* upper */
 		nil, NeverUseFilterBlock, nil /* stats */, categoryAndQoS, statsCollector, rp, bufferPool,
 	)

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -55,7 +55,7 @@ func TestIteratorErrorOnInit(t *testing.T) {
 	var stats base.InternalIteratorStats
 	for k := 0; k < 20; k++ {
 		if rand.Intn(2) == 0 {
-			_, err := newSingleLevelIterator(
+			_, err := newRowBlockSingleLevelIterator(
 				context.Background(),
 				r,
 				nil, /* v */
@@ -70,7 +70,7 @@ func TestIteratorErrorOnInit(t *testing.T) {
 			)
 			require.Error(t, err)
 		} else {
-			_, err := newTwoLevelIterator(
+			_, err := newRowBlockTwoLevelIterator(
 				context.Background(),
 				r,
 				nil, /* v */

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -976,12 +976,12 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 					NoTransforms, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r), &pool)
 				require.NoError(t, err)
 				switch i := citer.(type) {
-				case *singleLevelIterator:
+				case *singleLevelIterator[rowblk.Iter, *rowblk.Iter]:
 					require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 					// Each key has one version, so no value block, regardless of
 					// sstable version.
 					require.Nil(t, i.vbRH)
-				case *twoLevelIterator:
+				case *twoLevelIterator[rowblk.Iter, *rowblk.Iter]:
 					require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.secondLevel.dataRH))
 					// Each key has one version, so no value block, regardless of
 					// sstable version.
@@ -1033,7 +1033,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 			NoTransforms, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r), &pool)
 		require.NoError(t, err)
 		defer citer.Close()
-		i := citer.(*singleLevelIterator)
+		i := citer.(*singleLevelIterator[rowblk.Iter, *rowblk.Iter])
 		require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 		require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.vbRH))
 	}
@@ -1041,7 +1041,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 		iter, err := r.NewIter(NoTransforms, nil, nil)
 		require.NoError(t, err)
 		defer iter.Close()
-		i := iter.(*singleLevelIterator)
+		i := iter.(*singleLevelIterator[rowblk.Iter, *rowblk.Iter])
 		require.False(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 		require.False(t, objstorageprovider.TestingCheckMaxReadahead(i.vbRH))
 	}

--- a/sstable/testdata/reader_bpf/Pebblev3/iter
+++ b/sstable/testdata/reader_bpf/Pebblev3/iter
@@ -94,7 +94,7 @@ next
 ----
 .
 .
-| *sstable.twoLevelIterator:
+| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "x#inf,SEPARATOR"
 |  topLevelIndex.InPlaceValue() = (Offset: 193, Length: 26, Props: 00020801)
 |  topLevelIndex.isDataInvalidated()=false
@@ -107,7 +107,7 @@ next
 |  (boundsCmp,positionedUsingLatestBounds) = (0,true)
 |  exhaustedBounds = 1
 .
-| *sstable.twoLevelIterator:
+| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "wc#inf,SEPARATOR"
 |  topLevelIndex.InPlaceValue() = (Offset: 161, Length: 27, Props: 00020201)
 |  topLevelIndex.isDataInvalidated()=false
@@ -119,7 +119,7 @@ next
 |  (boundsCmp,positionedUsingLatestBounds) = (0,true)
 |  exhaustedBounds = 1
 .
-| *sstable.twoLevelIterator:
+| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "wc#inf,SEPARATOR"
 |  topLevelIndex.InPlaceValue() = (Offset: 161, Length: 27, Props: 00020201)
 |  topLevelIndex.isDataInvalidated()=false
@@ -131,7 +131,7 @@ next
 |  (boundsCmp,positionedUsingLatestBounds) = (1,false)
 |  exhaustedBounds = 1
 <wz@8:8>
-| *sstable.twoLevelIterator:
+| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "x#inf,SEPARATOR"
 |  topLevelIndex.InPlaceValue() = (Offset: 193, Length: 26, Props: 00020801)
 |  topLevelIndex.isDataInvalidated()=false

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -331,15 +331,15 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			forceIgnoreValueBlocks := func(i *singleLevelIterator) {
+			forceIgnoreValueBlocks := func(i *singleLevelIterator[rowblk.Iter, *rowblk.Iter]) {
 				i.vbReader = nil
 				i.data.SetGetLazyValuer(nil)
 				i.data.SetHasValuePrefix(false)
 			}
 			switch i := origIter.(type) {
-			case *twoLevelIterator:
+			case *twoLevelIterator[rowblk.Iter, *rowblk.Iter]:
 				forceIgnoreValueBlocks(&i.secondLevel)
-			case *singleLevelIterator:
+			case *singleLevelIterator[rowblk.Iter, *rowblk.Iter]:
 				forceIgnoreValueBlocks(i)
 			}
 			iter := newIterAdapter(origIter)


### PR DESCRIPTION
In preparation for columnar blocks, this commit introduces type parameters to the {single,two}LevelIterator types. Parameterizing the sstable iterator ensures we pay the cost of dynamic dispatch only when entering the sstable iterator (as we do today).

In order to continue to allocate the data block iterator struct within the single-level iterator, this commit introduces two type paramters: one for the non-pointer iterator type, and one for the pointer type on which iteration methods are defined. This adds some slightly cumbersome ergonomics to data block iterator usage sites.