### PR TITLE
sstable: fix value block closure allocation

### DIFF
--- a/sstable/block/kv.go
+++ b/sstable/block/kv.go
@@ -68,3 +68,9 @@ func InPlaceValuePrefix(setHasSameKeyPrefix bool) ValuePrefix {
 	}
 	return prefix
 }
+
+// GetLazyValueForPrefixAndValueHandler is an interface for getting a LazyValue
+// from a value prefix and value.
+type GetLazyValueForPrefixAndValueHandler interface {
+	GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue
+}

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -269,7 +269,7 @@ func (i *singleLevelIterator) init(
 				vbih:   r.valueBIH,
 				stats:  stats,
 			}
-			i.data.SetGetLazyValue(i.vbReader.getLazyValueForPrefixAndValueHandle)
+			i.data.SetGetLazyValuer(i.vbReader)
 			i.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.vbRHPrealloc)
 		}
 		i.data.SetHasValuePrefix(true)

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -2153,7 +2153,7 @@ func BenchmarkIteratorScanManyVersions(b *testing.B) {
 		require.NoError(b, err)
 		return r
 	}
-	for _, format := range []TableFormat{TableFormatPebblev2, TableFormatPebblev3} {
+	for _, format := range []TableFormat{TableFormatPebblev2, TableFormatPebblev3, TableFormatPebblev4} {
 		b.Run(fmt.Sprintf("format=%s", format.String()), func(b *testing.B) {
 			// 150MiB results in a high cache hit rate for both formats. 20MiB
 			// results in a high cache hit rate for the data blocks in
@@ -2165,6 +2165,13 @@ func BenchmarkIteratorScanManyVersions(b *testing.B) {
 						defer func() {
 							require.NoError(b, r.Close())
 						}()
+						b.Run("NewIter", func(b *testing.B) {
+							for i := 0; i < b.N; i++ {
+								iter, err := r.NewIter(NoTransforms, nil, nil)
+								require.NoError(b, err)
+								require.NoError(b, iter.Close())
+							}
+						})
 						for _, readValue := range []bool{false, true} {
 							b.Run(fmt.Sprintf("read-value=%t", readValue), func(b *testing.B) {
 								iter, err := r.NewIter(NoTransforms, nil, nil)

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -751,7 +751,7 @@ type valueBlockReader struct {
 	bufToMangle   []byte
 }
 
-func (r *valueBlockReader) getLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue {
+func (r *valueBlockReader) GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue {
 	fetcher := &r.lazyFetcher
 	valLen, h := decodeLenFromValueHandle(handle[1:])
 	*fetcher = base.LazyFetcher{

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -333,7 +333,7 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			}
 			forceIgnoreValueBlocks := func(i *singleLevelIterator) {
 				i.vbReader = nil
-				i.data.SetGetLazyValue(nil)
+				i.data.SetGetLazyValuer(nil)
 				i.data.SetHasValuePrefix(false)
 			}
 			switch i := origIter.(type) {


### PR DESCRIPTION
Fix an allocation introduced when intializing a rowblk.Iter over a table that contains value blocks.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble/sstable
                                                                       │   old.txt   │              new.txt               │
                                                                       │   sec/op    │   sec/op     vs base               │
IteratorScanManyVersions/format=(Pebble,v4)/cache-size=20MB/NewIter-10   681.8n ± 2%   659.0n ± 1%  -3.35% (p=0.000 n=20)

                                                                       │  old.txt   │              new.txt              │
                                                                       │    B/op    │    B/op     vs base               │
IteratorScanManyVersions/format=(Pebble,v4)/cache-size=20MB/NewIter-10   304.0 ± 0%   288.0 ± 0%  -5.26% (p=0.000 n=20)

                                                                       │  old.txt   │              new.txt               │
                                                                       │ allocs/op  │ allocs/op   vs base                │
IteratorScanManyVersions/format=(Pebble,v4)/cache-size=20MB/NewIter-10   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=20)
```