### PR TITLE
db: fix mkdirAllAndSyncParents edge case

### DIFF
--- a/open_test.go
+++ b/open_test.go
@@ -1478,3 +1478,43 @@ func TestOpenRatchetsNextFileNum(t *testing.T) {
 	require.NoError(t, d.Compact([]byte("a"), []byte("z"), false))
 
 }
+
+func TestMkdirAllAndSyncParents(t *testing.T) {
+	filesystems := map[string]vfs.FS{}
+	rootPaths := map[string]string{}
+	var buf bytes.Buffer
+	datadriven.RunTest(t, "testdata/mkdir_all_and_sync_parents", func(t *testing.T, td *datadriven.TestData) string {
+		buf.Reset()
+		switch td.Cmd {
+		case "mkfs":
+			var fsName string
+			td.ScanArgs(t, "fs", &fsName)
+			if td.HasArg("memfs") {
+				filesystems[fsName] = vfs.NewMem()
+				return "new memfs"
+			}
+			filesystems[fsName] = vfs.Default
+			rootPaths[fsName] = t.TempDir()
+			return "new default fs"
+		case "mkdir-all-and-sync-parents":
+			var fsName, path string
+			td.ScanArgs(t, "fs", &fsName)
+			td.ScanArgs(t, "path", &path)
+			if p, ok := rootPaths[fsName]; ok {
+				require.NoError(t, os.Chdir(p))
+			}
+			fs := vfs.WithLogging(filesystems[fsName], func(format string, args ...interface{}) {
+				fmt.Fprintf(&buf, format+"\n", args...)
+			})
+			f, err := mkdirAllAndSyncParents(fs, path)
+			if err != nil {
+				return err.Error()
+			}
+			require.NoError(t, f.Close())
+			return buf.String()
+		default:
+			return fmt.Sprintf("unrecognized command %q", td.Cmd)
+		}
+	})
+
+}

--- a/testdata/mkdir_all_and_sync_parents
+++ b/testdata/mkdir_all_and_sync_parents
@@ -1,0 +1,69 @@
+mkfs memfs fs=mem1
+----
+new memfs
+
+mkdir-all-and-sync-parents fs=mem1 path=foo/bar/baz/bax
+----
+mkdir-all: foo/bar/baz/bax 0755
+open-dir: foo/bar/baz
+sync: foo/bar/baz
+close: foo/bar/baz
+open-dir: foo/bar
+sync: foo/bar
+close: foo/bar
+open-dir: foo
+sync: foo
+close: foo
+open-dir: 
+sync: 
+close: 
+open-dir: .
+open-dir: foo/bar/baz/bax
+close: foo/bar/baz/bax
+
+# Repeating the same command should only sync the parent, and then the new data
+# directory itself.
+
+mkdir-all-and-sync-parents fs=mem1 path=foo/bar/baz/bax
+----
+mkdir-all: foo/bar/baz/bax 0755
+open-dir: foo/bar/baz
+sync: foo/bar/baz
+close: foo/bar/baz
+open-dir: foo/bar/baz/bax
+close: foo/bar/baz/bax
+
+mkfs fs=default1
+----
+new default fs
+
+mkdir-all-and-sync-parents fs=default1 path=foo/bar/baz/bax
+----
+mkdir-all: foo/bar/baz/bax 0755
+open-dir: foo/bar/baz
+sync: foo/bar/baz
+close: foo/bar/baz
+open-dir: foo/bar
+sync: foo/bar
+close: foo/bar
+open-dir: foo
+sync: foo
+close: foo
+open-dir: 
+open-dir: .
+sync: .
+close: .
+open-dir: foo/bar/baz/bax
+close: foo/bar/baz/bax
+
+# Repeating the same command should only sync the parent, and then the new data
+# directory itself.
+
+mkdir-all-and-sync-parents fs=default1 path=foo/bar/baz/bax
+----
+mkdir-all: foo/bar/baz/bax 0755
+open-dir: foo/bar/baz
+sync: foo/bar/baz
+close: foo/bar/baz
+open-dir: foo/bar/baz/bax
+close: foo/bar/baz/bax


### PR DESCRIPTION
On real filesystems, relative paths were not handled correctly, sometimes attempting to sync the empty path "".