### PR TITLE
db: various DB.SSTables improvements

### DIFF
--- a/db.go
+++ b/db.go
@@ -2098,7 +2098,20 @@ const (
 	// or lifecycle management. An example of an external file is a file restored
 	// from a backup.
 	BackingTypeExternal
+	backingTypeCount
 )
+
+var backingTypeToString = [backingTypeCount]string{
+	BackingTypeLocal:         "local",
+	BackingTypeShared:        "shared",
+	BackingTypeSharedForeign: "shared-foreign",
+	BackingTypeExternal:      "external",
+}
+
+// String implements fmt.Stringer.
+func (b BackingType) String() string {
+	return backingTypeToString[b]
+}
 
 // SSTableInfo export manifest.TableInfo with sstable.Properties alongside
 // other file backing info.

--- a/db_test.go
+++ b/db_test.go
@@ -1294,10 +1294,6 @@ func TestSSTablesWithApproximateSpanBytes(t *testing.T) {
 	require.NoError(t, d.Set([]byte("g"), nil, nil))
 	require.NoError(t, d.Flush())
 
-	// cannot use WithApproximateSpanBytes without WithProperties.
-	_, err = d.SSTables(WithKeyRangeFilter([]byte("a"), []byte("e")), WithApproximateSpanBytes())
-	require.Error(t, err)
-
 	// cannot use WithApproximateSpanBytes without WithKeyRangeFilter.
 	_, err = d.SSTables(WithProperties(), WithApproximateSpanBytes())
 	require.Error(t, err)
@@ -1307,13 +1303,11 @@ func TestSSTablesWithApproximateSpanBytes(t *testing.T) {
 
 	for _, levelTables := range tableInfos {
 		for _, table := range levelTables {
-			approximateSpanBytes, err := strconv.ParseInt(table.Properties.UserProperties["approximate-span-bytes"], 10, 64)
-			require.NoError(t, err)
 			if table.FileNum == 5 {
-				require.Equal(t, uint64(approximateSpanBytes), table.Size)
+				require.Equal(t, table.ApproximateSpanBytes, table.Size)
 			}
 			if table.FileNum == 7 {
-				require.Less(t, uint64(approximateSpanBytes), table.Size)
+				require.Less(t, table.ApproximateSpanBytes, table.Size)
 			}
 		}
 	}


### PR DESCRIPTION
Add a couple improvements to the DB.SSTables method that powers the crdb_internal.sstable_metrics builtin in Cockroach. Subsequent work up in Cockroach will adopt a custom JSON serialization to improve the ergonomics of working with the builtin