### PR TITLE
vfs: add FileInfo, DeviceID

### DIFF
--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -6,7 +6,6 @@ package sstable
 
 import (
 	"math/rand"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +42,7 @@ func TestPropertiesLoad(t *testing.T) {
 
 	{
 		// Check that we can read properties from a table.
-		f, err := os.Open(filepath.FromSlash("testdata/h.sst"))
+		f, err := vfs.Default.Open(filepath.FromSlash("testdata/h.sst"))
 		require.NoError(t, err)
 
 		r, err := newReader(f, ReaderOptions{})

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
-	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -31,6 +30,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
+	"github.com/cockroachdb/pebble/vfs"
 )
 
 var errReaderClosed = errors.New("pebble/table: reader is closed")
@@ -1019,7 +1019,7 @@ func NewReader(ctx context.Context, f objstorage.Readable, o ReaderOptions) (*Re
 type ReadableFile interface {
 	io.ReaderAt
 	io.Closer
-	Stat() (os.FileInfo, error)
+	Stat() (vfs.FileInfo, error)
 }
 
 // NewSimpleReadable wraps a ReadableFile in a objstorage.Readable

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -551,7 +551,7 @@ func TestReaderHideObsolete(t *testing.T) {
 func TestHamletReader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	for _, fixture := range TestFixtures {
-		f, err := os.Open(filepath.Join("testdata", fixture.Filename))
+		f, err := vfs.Default.Open(filepath.Join("testdata", fixture.Filename))
 		require.NoError(t, err)
 
 		r, err := newReader(f, ReaderOptions{})
@@ -1655,7 +1655,7 @@ func TestValidateBlockChecksums(t *testing.T) {
 		require.NoError(t, err)
 
 		pathCopy := path.Join(t.TempDir(), path.Base(file))
-		fCopy, err := os.OpenFile(pathCopy, os.O_CREATE|os.O_RDWR, 0600)
+		fCopy, err := vfs.Default.OpenReadWrite(pathCopy, vfs.WriteCategoryUnspecified)
 		require.NoError(t, err)
 		defer fCopy.Close()
 

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -336,7 +335,7 @@ func TestReaderBloomUsed(t *testing.T) {
 
 func TestBloomFilterFalsePositiveRate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	f, err := os.Open(filepath.FromSlash("testdata/h.table-bloom.no-compression.sst"))
+	f, err := vfs.Default.Open(filepath.FromSlash("testdata/h.table-bloom.no-compression.sst"))
 	require.NoError(t, err)
 
 	c := &countingFilterPolicy{
@@ -512,7 +511,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 
 func TestReaderSymtheticSeqNum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	f, err := os.Open(filepath.FromSlash("testdata/h.sst"))
+	f, err := vfs.Default.Open(filepath.FromSlash("testdata/h.sst"))
 	require.NoError(t, err)
 
 	r, err := newReader(f, ReaderOptions{})

--- a/vfs/default_linux.go
+++ b/vfs/default_linux.go
@@ -43,6 +43,7 @@ type linuxDir struct {
 
 func (d *linuxDir) Prefetch(offset int64, length int64) error      { return nil }
 func (d *linuxDir) Preallocate(offset, length int64) error         { return nil }
+func (d *linuxDir) Stat() (FileInfo, error)                        { return d.File.Stat() }
 func (d *linuxDir) SyncData() error                                { return d.Sync() }
 func (d *linuxDir) SyncTo(offset int64) (fullSync bool, err error) { return false, nil }
 
@@ -59,6 +60,10 @@ func (f *linuxFile) Prefetch(offset int64, length int64) error {
 
 func (f *linuxFile) Preallocate(offset, length int64) error {
 	return unix.Fallocate(int(f.fd), unix.FALLOC_FL_KEEP_SIZE, offset, length)
+}
+
+func (f *linuxFile) Stat() (FileInfo, error) {
+	return f.File.Stat()
 }
 
 func (f *linuxFile) SyncData() error {

--- a/vfs/default_unix.go
+++ b/vfs/default_unix.go
@@ -34,6 +34,7 @@ type unixFile struct {
 	fd uintptr
 }
 
+func (f *unixFile) Stat() (FileInfo, error)                 { return f.File.Stat() }
 func (*unixFile) Prefetch(offset int64, length int64) error { return nil }
 func (*unixFile) Preallocate(offset, length int64) error    { return nil }
 

--- a/vfs/default_windows.go
+++ b/vfs/default_windows.go
@@ -36,6 +36,7 @@ type windowsDir struct {
 	*os.File
 }
 
+func (d *windowsDir) Stat() (FileInfo, error)                 { return d.File.Stat() }
 func (*windowsDir) Prefetch(offset int64, length int64) error { return nil }
 func (*windowsDir) Preallocate(off, length int64) error       { return nil }
 
@@ -52,7 +53,8 @@ type windowsFile struct {
 func (*windowsFile) Prefetch(offset int64, length int64) error { return nil }
 func (*windowsFile) Preallocate(offset, length int64) error    { return nil }
 
-func (f *windowsFile) SyncData() error { return f.Sync() }
+func (f *windowsFile) Stat() (FileInfo, error) { return f.File.Stat() }
+func (f *windowsFile) SyncData() error         { return f.Sync() }
 func (f *windowsFile) SyncTo(length int64) (fullSync bool, err error) {
 	if err = f.Sync(); err != nil {
 		return false, err

--- a/vfs/default_windows.go
+++ b/vfs/default_windows.go
@@ -8,6 +8,7 @@
 package vfs
 
 import (
+	"io/fs"
 	"os"
 	"syscall"
 
@@ -36,7 +37,7 @@ type windowsDir struct {
 	*os.File
 }
 
-func (d *windowsDir) Stat() (FileInfo, error)                 { return d.File.Stat() }
+func (d *windowsDir) Stat() (FileInfo, error)                 { return maybeWrapFileInfo(d.File.Stat()) }
 func (*windowsDir) Prefetch(offset int64, length int64) error { return nil }
 func (*windowsDir) Preallocate(off, length int64) error       { return nil }
 
@@ -53,11 +54,16 @@ type windowsFile struct {
 func (*windowsFile) Prefetch(offset int64, length int64) error { return nil }
 func (*windowsFile) Preallocate(offset, length int64) error    { return nil }
 
-func (f *windowsFile) Stat() (FileInfo, error) { return f.File.Stat() }
+func (f *windowsFile) Stat() (FileInfo, error) { return maybeWrapFileInfo(f.File.Stat()) }
 func (f *windowsFile) SyncData() error         { return f.Sync() }
 func (f *windowsFile) SyncTo(length int64) (fullSync bool, err error) {
 	if err = f.Sync(); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func deviceIDFromFileInfo(finfo fs.FileInfo) DeviceID {
+	// Unsupported.
+	return DeviceID{}
 }

--- a/vfs/disk_full.go
+++ b/vfs/disk_full.go
@@ -337,7 +337,7 @@ func (fs *enospcFS) List(dir string) ([]string, error) {
 	return fs.inner.List(dir)
 }
 
-func (fs *enospcFS) Stat(name string) (os.FileInfo, error) {
+func (fs *enospcFS) Stat(name string) (FileInfo, error) {
 	return fs.inner.Stat(name)
 }
 
@@ -412,7 +412,7 @@ func (f *enospcFile) Preallocate(offset, length int64) error {
 	return f.inner.Preallocate(offset, length)
 }
 
-func (f *enospcFile) Stat() (os.FileInfo, error) {
+func (f *enospcFile) Stat() (FileInfo, error) {
 	return f.inner.Stat()
 }
 

--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -330,7 +330,7 @@ func (d *diskHealthCheckingFile) Preallocate(off, n int64) (err error) {
 }
 
 // Stat implements (vfs.File).Stat.
-func (d *diskHealthCheckingFile) Stat() (os.FileInfo, error) {
+func (d *diskHealthCheckingFile) Stat() (FileInfo, error) {
 	return d.file.Stat()
 }
 
@@ -896,7 +896,7 @@ func (d *diskHealthCheckingFS) ReuseForWrite(
 }
 
 // Stat implements the FS interface.
-func (d *diskHealthCheckingFS) Stat(name string) (os.FileInfo, error) {
+func (d *diskHealthCheckingFS) Stat(name string) (FileInfo, error) {
 	return d.fs.Stat(name)
 }
 

--- a/vfs/disk_health_test.go
+++ b/vfs/disk_health_test.go
@@ -53,7 +53,7 @@ func (m mockFile) Preallocate(int64, int64) error {
 	return nil
 }
 
-func (m mockFile) Stat() (os.FileInfo, error) {
+func (m mockFile) Stat() (FileInfo, error) {
 	panic("unimplemented")
 }
 
@@ -180,7 +180,7 @@ func (m mockFS) List(dir string) ([]string, error) {
 	return m.list(dir)
 }
 
-func (m mockFS) Stat(name string) (os.FileInfo, error) {
+func (m mockFS) Stat(name string) (FileInfo, error) {
 	if m.stat == nil {
 		panic("unimplemented")
 	}

--- a/vfs/disk_health_test.go
+++ b/vfs/disk_health_test.go
@@ -93,7 +93,7 @@ type mockFS struct {
 	removeAll     func(string) error
 	rename        func(string, string) error
 	reuseForWrite func(string, string, DiskWriteCategory) (File, error)
-	stat          func(string) (os.FileInfo, error)
+	stat          func(string) (FileInfo, error)
 	getDiskUsage  func(string) (DiskUsage, error)
 }
 

--- a/vfs/errorfs/errorfs.go
+++ b/vfs/errorfs/errorfs.go
@@ -450,7 +450,7 @@ func (fs *FS) List(dir string) ([]string, error) {
 }
 
 // Stat implements FS.Stat.
-func (fs *FS) Stat(name string) (os.FileInfo, error) {
+func (fs *FS) Stat(name string) (vfs.FileInfo, error) {
 	if err := fs.inj.MaybeError(Op{Kind: OpStat, Path: name}); err != nil {
 		return nil, err
 	}
@@ -507,7 +507,7 @@ func (f *errorFile) WriteAt(p []byte, off int64) (int, error) {
 	return f.file.WriteAt(p, off)
 }
 
-func (f *errorFile) Stat() (os.FileInfo, error) {
+func (f *errorFile) Stat() (vfs.FileInfo, error) {
 	if err := f.inj.MaybeError(Op{Kind: OpFileStat, Path: f.path}); err != nil {
 		return nil, err
 	}

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -526,7 +526,7 @@ func (y *MemFS) List(dirname string) ([]string, error) {
 }
 
 // Stat implements FS.Stat.
-func (y *MemFS) Stat(name string) (os.FileInfo, error) {
+func (y *MemFS) Stat(name string) (FileInfo, error) {
 	f, err := y.Open(name)
 	if err != nil {
 		if pe, ok := err.(*os.PathError); ok {
@@ -761,7 +761,7 @@ func (f *memFile) WriteAt(p []byte, ofs int64) (int, error) {
 func (f *memFile) Prefetch(offset int64, length int64) error { return nil }
 func (f *memFile) Preallocate(offset, length int64) error    { return nil }
 
-func (f *memFile) Stat() (os.FileInfo, error) {
+func (f *memFile) Stat() (FileInfo, error) {
 	f.n.mu.Lock()
 	defer f.n.mu.Unlock()
 	return &memFileInfo{

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -830,6 +830,10 @@ func (f *memFileInfo) Name() string {
 	return f.name
 }
 
+func (f *memFileInfo) DeviceID() DeviceID {
+	return DeviceID{}
+}
+
 func (f *memFileInfo) Size() int64 {
 	return f.size
 }

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -35,7 +35,7 @@ type File interface {
 	// Preallocate optionally preallocates storage for `length` at `offset`
 	// within the file. Implementations may choose to do nothing.
 	Preallocate(offset, length int64) error
-	Stat() (os.FileInfo, error)
+	Stat() (FileInfo, error)
 	Sync() error
 
 	// SyncTo requests that a prefix of the file's data be synced to stable
@@ -156,8 +156,8 @@ type FS interface {
 	// relative to dir.
 	List(dir string) ([]string, error)
 
-	// Stat returns an os.FileInfo describing the named file.
-	Stat(name string) (os.FileInfo, error)
+	// Stat returns an FileInfo describing the named file.
+	Stat(name string) (FileInfo, error)
 
 	// PathBase returns the last element of path. Trailing path separators are
 	// removed before extracting the last element. If the path is empty, PathBase
@@ -175,6 +175,11 @@ type FS interface {
 	// GetDiskUsage returns disk space statistics for the filesystem where
 	// path is any file or directory within that filesystem.
 	GetDiskUsage(path string) (DiskUsage, error)
+}
+
+// FileInfo describes a file.
+type FileInfo interface {
+	os.FileInfo
 }
 
 // DiskUsage summarizes disk space usage on a filesystem.
@@ -288,9 +293,12 @@ func (defaultFS) List(dir string) ([]string, error) {
 	return dirnames, errors.WithStack(err)
 }
 
-func (defaultFS) Stat(name string) (os.FileInfo, error) {
+func (defaultFS) Stat(name string) (FileInfo, error) {
 	finfo, err := os.Stat(name)
-	return finfo, errors.WithStack(err)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return finfo, nil
 }
 
 func (defaultFS) PathBase(path string) string {

--- a/vfs/vfstest/open_files.go
+++ b/vfs/vfstest/open_files.go
@@ -99,7 +99,7 @@ func (fs *openFilesFS) List(dir string) ([]string, error) {
 	return fs.inner.List(dir)
 }
 
-func (fs *openFilesFS) Stat(name string) (os.FileInfo, error) {
+func (fs *openFilesFS) Stat(name string) (vfs.FileInfo, error) {
 	return fs.inner.Stat(name)
 }
 

--- a/vfs/vfstest/vfstest.go
+++ b/vfs/vfstest/vfstest.go
@@ -6,11 +6,7 @@
 // filesystems during tests and benchmarks.
 package vfstest
 
-import (
-	"os"
-
-	"github.com/cockroachdb/pebble/vfs"
-)
+import "github.com/cockroachdb/pebble/vfs"
 
 // DiscardFile implements vfs.File but discards all written data and reads
 // without mutating input buffers.
@@ -24,7 +20,7 @@ func (*discardFile) ReadAt(p []byte, off int64) (int, error)        { return len
 func (*discardFile) Write(p []byte) (int, error)                    { return len(p), nil }
 func (*discardFile) WriteAt(p []byte, ofs int64) (int, error)       { return len(p), nil }
 func (*discardFile) Preallocate(offset, length int64) error         { return nil }
-func (*discardFile) Stat() (os.FileInfo, error)                     { return nil, nil }
+func (*discardFile) Stat() (vfs.FileInfo, error)                    { return nil, nil }
 func (*discardFile) Sync() error                                    { return nil }
 func (*discardFile) SyncTo(length int64) (fullSync bool, err error) { return false, nil }
 func (*discardFile) SyncData() error                                { return nil }


### PR DESCRIPTION
Define a new vfs.FileInfo interface to serve as the return value of Stat calls. Currently, this simply embeds os.FileInfo but future work will extend the interface with better ergonomics for information contained within the platform-depedent FileInfo.Sys().