### PR TITLE
crl-release-24.2: export Fragmenter.Truncate, MakeInternalKeyTrailer

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -44,6 +44,12 @@ func MakeInternalKey(userKey []byte, seqNum SeqNum, kind InternalKeyKind) Intern
 	return base.MakeInternalKey(userKey, seqNum, kind)
 }
 
+// MakeInternalKeyTrailer constructs a trailer from a specified sequence number
+// and kind.
+func MakeInternalKeyTrailer(seqNum SeqNum, kind InternalKeyKind) InternalKeyTrailer {
+	return base.MakeTrailer(seqNum, kind)
+}
+
 type internalIterator = base.InternalIterator
 
 type topLevelIterator = base.TopLevelIterator

--- a/internal/keyspan/fragmenter.go
+++ b/internal/keyspan/fragmenter.go
@@ -244,6 +244,14 @@ func (f *Fragmenter) Start() []byte {
 	return nil
 }
 
+// Truncate truncates all pending spans up to key (exclusive), flushes them, and
+// retains any spans that continue onward for future flushes.
+func (f *Fragmenter) Truncate(key []byte) {
+	if len(f.pending) > 0 {
+		f.truncateAndFlush(key)
+	}
+}
+
 // Flushes all pending spans up to key (exclusive).
 //
 // WARNING: The specified key is stored without making a copy, so all callers


### PR DESCRIPTION
This change exports these two methods to unblock https://github.com/cockroachdb/cockroach/pull/128997.