### PR TITLE
colblk: rework Uint encodings

### DIFF
--- a/internal/binfmt/binfmt.go
+++ b/internal/binfmt/binfmt.go
@@ -18,7 +18,7 @@ import (
 
 // New constructs a new binary formatter.
 func New(data []byte) *Formatter {
-	offsetWidth := strconv.Itoa(int(math.Log10(float64(len(data)-1))) + 1)
+	offsetWidth := strconv.Itoa(max(int(math.Log10(float64(len(data)-1)))+1, 1))
 	return &Formatter{
 		data:            data,
 		lineWidth:       40,

--- a/sstable/colblk/block.go
+++ b/sstable/colblk/block.go
@@ -352,28 +352,10 @@ func (r *BlockReader) PrefixBytes(col int) PrefixBytes {
 	return DecodeColumn(r, col, int(r.header.Rows), DataTypePrefixBytes, DecodePrefixBytes)
 }
 
-// Uint8s retrieves the col'th column as a column of uint8s. The column must be
-// of type DataTypeUint8.
-func (r *BlockReader) Uint8s(col int) UnsafeUint8s {
-	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint8, DecodeUnsafeIntegerSlice[uint8])
-}
-
-// Uint16s retrieves the col'th column as a column of uint8s. The column must be
-// of type DataTypeUint16.
-func (r *BlockReader) Uint16s(col int) UnsafeUint16s {
-	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint16, DecodeUnsafeIntegerSlice[uint16])
-}
-
-// Uint32s retrieves the col'th column as a column of uint32s. The column must be
-// of type DataTypeUint32.
-func (r *BlockReader) Uint32s(col int) UnsafeUint32s {
-	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint32, DecodeUnsafeIntegerSlice[uint32])
-}
-
-// Uint64s retrieves the col'th column as a column of uint64s. The column must be
-// of type DataTypeUint64.
-func (r *BlockReader) Uint64s(col int) UnsafeUint64s {
-	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint64, DecodeUnsafeIntegerSlice[uint64])
+// Uints retrieves the col'th column as a column of uints. The column must be
+// of type DataTypeUint.
+func (r *BlockReader) Uints(col int) UnsafeUints {
+	return DecodeColumn(r, col, int(r.header.Rows), DataTypeUint, DecodeUnsafeUints)
 }
 
 func (r *BlockReader) pageStart(col int) uint32 {
@@ -382,7 +364,7 @@ func (r *BlockReader) pageStart(col int) uint32 {
 		return uint32(len(r.data) - 1)
 	}
 	return binary.LittleEndian.Uint32(
-		unsafe.Slice((*byte)(unsafe.Pointer(r.pointer(r.customHeaderSize+uint32(blockHeaderBaseSize+columnHeaderSize*col+1)))), 4))
+		unsafe.Slice((*byte)(r.pointer(r.customHeaderSize+uint32(blockHeaderBaseSize+columnHeaderSize*col+1))), 4))
 }
 
 func (r *BlockReader) pointer(offset uint32) unsafe.Pointer {
@@ -421,7 +403,7 @@ func (r *BlockReader) columnToBinFormatter(f *binfmt.Formatter, col, rows int) {
 	switch dataType {
 	case DataTypeBool:
 		bitmapToBinFormatter(f, rows)
-	case DataTypeUint8, DataTypeUint16, DataTypeUint32, DataTypeUint64:
+	case DataTypeUint:
 		uintsToBinFormatter(f, rows, dataType, nil)
 	case DataTypeBytes:
 		rawBytesToBinFormatter(f, rows, nil)

--- a/sstable/colblk/column.go
+++ b/sstable/colblk/column.go
@@ -17,31 +17,22 @@ const (
 	DataTypeInvalid DataType = 0
 	// DataTypeBool is a data type encoding a bool per row.
 	DataTypeBool DataType = 1
-	// DataTypeUint8 is a data type encoding a fixed 8 bits per row.
-	DataTypeUint8 DataType = 2
-	// DataTypeUint16 is a data type encoding a fixed 16 bits per row.
-	DataTypeUint16 DataType = 3
-	// DataTypeUint32 is a data type encoding a fixed 32 bits per row.
-	DataTypeUint32 DataType = 4
-	// DataTypeUint64 is a data type encoding a fixed 64 bits per row.
-	DataTypeUint64 DataType = 5
+	// DataTypeUint is a data type encoding a fixed 8 bits per row.
+	DataTypeUint DataType = 2
 	// DataTypeBytes is a data type encoding a variable-length byte string per
 	// row.
-	DataTypeBytes DataType = 6
+	DataTypeBytes DataType = 3
 	// DataTypePrefixBytes is a data type encoding variable-length,
 	// lexicographically-sorted byte strings, with prefix compression.
-	DataTypePrefixBytes DataType = 7
+	DataTypePrefixBytes DataType = 4
 
-	dataTypesCount DataType = 8
+	dataTypesCount DataType = 5
 )
 
 var dataTypeName [dataTypesCount]string = [dataTypesCount]string{
 	DataTypeInvalid:     "invalid",
 	DataTypeBool:        "bool",
-	DataTypeUint8:       "uint8",
-	DataTypeUint16:      "uint16",
-	DataTypeUint32:      "uint32",
-	DataTypeUint64:      "uint64",
+	DataTypeUint:        "uint",
 	DataTypeBytes:       "bytes",
 	DataTypePrefixBytes: "prefixbytes",
 }
@@ -49,17 +40,6 @@ var dataTypeName [dataTypesCount]string = [dataTypesCount]string{
 // String returns a human-readable string representation of the data type.
 func (t DataType) String() string {
 	return dataTypeName[t]
-}
-
-func (t DataType) uintWidth() uint32 {
-	if t >= DataTypeUint8 && t <= DataTypeUint64 {
-		rv := 1 << (t - DataTypeUint8)
-		if rv > 8 {
-			panic("width greater than 8 bytes")
-		}
-		return uint32(rv)
-	}
-	panic("not a unit")
 }
 
 // ColumnWriter is an interface implemented by column encoders that accumulate a

--- a/sstable/colblk/testdata/block_writer
+++ b/sstable/colblk/testdata/block_writer
@@ -1,4 +1,4 @@
-init schema=(uint64)
+init schema=(uint)
 ----
 
 write
@@ -17,20 +17,19 @@ write
 finish
 ----
 # columnar block header
-00-01: x 01               # version 1
-01-03: x 0100             # 1 columns
-03-07: x 0a000000         # 10 rows
+00-01: x 01       # version 1
+01-03: x 0100     # 1 columns
+03-07: x 0a000000 # 10 rows
 # column 0
-07-08: b 00000101         # uint64
-08-12: x 0c000000         # page start 12
+07-08: b 00000010 # uint
+08-12: x 0c000000 # page start 12
 # data for column 0
-12-13: x 01               # delta encoding: const
-13-21: x 0000000000000000 # 64-bit constant: 0
-21-22: x 00               # block trailer padding
+12-13: x 00       # encoding: zero
+13-14: x 00       # block trailer padding
 
-# Test a uint64 column with all values equal but non-zero.
+# Test a uint column with all values equal but non-zero.
 
-init schema=(uint64)
+init schema=(uint)
 ----
 
 write
@@ -55,17 +54,17 @@ finish
 01-03: x 0100             # 1 columns
 03-07: x 0c000000         # 12 rows
 # column 0
-07-08: b 00000101         # uint64
+07-08: b 00000010         # uint
 08-12: x 0c000000         # page start 12
 # data for column 0
-12-13: x 01               # delta encoding: const
+12-13: x 80               # encoding: const
 13-21: x ffffffffffffff7f # 64-bit constant: 9223372036854775807
 21-22: x 00               # block trailer padding
 
-# Test a uint64 column with a mix of values, but all values less than 256
+# Test a uint column with a mix of values, but all values less than 256
 # greater than 4149660732785475243. It should use the delta8 encoding.
 
-init schema=(uint64)
+init schema=(uint)
 ----
 
 write
@@ -83,10 +82,10 @@ finish
 01-03: x 0100             # 1 columns
 03-07: x 05000000         # 5 rows
 # column 0
-07-08: b 00000101         # uint64
+07-08: b 00000010         # uint
 08-12: x 0c000000         # page start 12
 # data for column 0
-12-13: x 02               # delta encoding: delta8
+12-13: x 81               # encoding: 1b,delta
 13-21: x abbe105c738e9639 # 64-bit constant: 4149660732785475243
 21-22: x 01               # data[0] = 1 + 4149660732785475243 = 4149660732785475244
 22-23: x 00               # data[1] = 0 + 4149660732785475243 = 4149660732785475243
@@ -98,7 +97,7 @@ finish
 # Test the same case, but this time with a value that is exactly 256 greater
 # than the lowest value. The column should use the delta16 encoding.
 
-init schema=(uint64)
+init schema=(uint)
 ----
 
 write
@@ -117,13 +116,12 @@ finish
 01-03: x 0100             # 1 columns
 03-07: x 06000000         # 6 rows
 # column 0
-07-08: b 00000101         # uint64
+07-08: b 00000010         # uint
 08-12: x 0c000000         # page start 12
 # data for column 0
-12-13: x 03               # delta encoding: delta16
+12-13: x 82               # encoding: 2b,delta
 13-21: x abbe105c738e9639 # 64-bit constant: 4149660732785475243
-# padding
-21-22: x 00               # aligning to 16-bit boundary
+21-22: x 00               # padding (aligning to 16-bit boundary)
 22-24: x 0100             # data[0] = 1 + 4149660732785475243 = 4149660732785475244
 24-26: x 0000             # data[1] = 0 + 4149660732785475243 = 4149660732785475243
 26-28: x 3300             # data[2] = 51 + 4149660732785475243 = 4149660732785475294
@@ -132,7 +130,7 @@ finish
 32-34: x 9300             # data[5] = 147 + 4149660732785475243 = 4149660732785475390
 34-35: x 00               # block trailer padding
 
-init schema=(uint64)
+init schema=(uint)
 ----
 
 write
@@ -150,31 +148,29 @@ write
 finish
 ----
 # columnar block header
-00-01: x 01               # version 1
-01-03: x 0100             # 1 columns
-03-07: x 09000000         # 9 rows
+00-01: x 01       # version 1
+01-03: x 0100     # 1 columns
+03-07: x 09000000 # 9 rows
 # column 0
-07-08: b 00000101         # uint64
-08-12: x 0c000000         # page start 12
+07-08: b 00000010 # uint
+08-12: x 0c000000 # page start 12
 # data for column 0
-12-13: x 04               # delta encoding: delta32
-13-21: x 0000000000000000 # 64-bit constant: 0
-# padding
-21-24: x 000000           # aligning to 32-bit boundary
-24-28: x 00000000         # data[0] = 0
-28-32: x 01000000         # data[1] = 1
-32-36: x 02000000         # data[2] = 2
-36-40: x 03000000         # data[3] = 3
-40-44: x 04000000         # data[4] = 4
-44-48: x 05000000         # data[5] = 5
-48-52: x 06000000         # data[6] = 6
-52-56: x ffffff7f         # data[7] = 2147483647
-56-60: x 00000100         # data[8] = 65536
-60-61: x 00               # block trailer padding
+12-13: x 04       # encoding: 4b
+13-16: x 000000   # padding (aligning to 32-bit boundary)
+16-20: x 00000000 # data[0] = 0
+20-24: x 01000000 # data[1] = 1
+24-28: x 02000000 # data[2] = 2
+28-32: x 03000000 # data[3] = 3
+32-36: x 04000000 # data[4] = 4
+36-40: x 05000000 # data[5] = 5
+40-44: x 06000000 # data[6] = 6
+44-48: x ffffff7f # data[7] = 2147483647
+48-52: x 00000100 # data[8] = 65536
+52-53: x 00       # block trailer padding
 
 # Test two columns: a uint32 and a uint64.
 
-init schema=(uint32,uint64)
+init schema=(uint)
 ----
 
 write
@@ -193,44 +189,27 @@ write
 finish
 ----
 # columnar block header
-00-01: x 01               # version 1
-01-03: x 0200             # 2 columns
-03-07: x 0a000000         # 10 rows
+00-01: x 01       # version 1
+01-03: x 0100     # 1 columns
+03-07: x 0a000000 # 10 rows
 # column 0
-07-08: b 00000100         # uint32
-08-12: x 11000000         # page start 17
-# column 1
-12-13: b 00000101         # uint64
-13-17: x 20000000         # page start 32
+07-08: b 00000010 # uint
+08-12: x 0c000000 # page start 12
 # data for column 0
-17-18: x 02               # delta encoding: delta8
-18-22: x 00000000         # 32-bit constant: 0
-22-23: x 00               # data[0] = 0
-23-24: x 01               # data[1] = 1
-24-25: x 02               # data[2] = 2
-25-26: x 03               # data[3] = 3
-26-27: x 04               # data[4] = 4
-27-28: x 05               # data[5] = 5
-28-29: x 06               # data[6] = 6
-29-30: x 07               # data[7] = 7
-30-31: x 08               # data[8] = 8
-31-32: x 09               # data[9] = 9
-# data for column 1
-32-33: x 02               # delta encoding: delta8
-33-41: x 0000000000000000 # 64-bit constant: 0
-41-42: x 00               # data[0] = 0
-42-43: x 01               # data[1] = 1
-43-44: x 02               # data[2] = 2
-44-45: x 03               # data[3] = 3
-45-46: x 04               # data[4] = 4
-46-47: x 05               # data[5] = 5
-47-48: x 06               # data[6] = 6
-48-49: x 07               # data[7] = 7
-49-50: x 08               # data[8] = 8
-50-51: x 09               # data[9] = 9
-51-52: x 00               # block trailer padding
+12-13: x 01       # encoding: 1b
+13-14: x 00       # data[0] = 0
+14-15: x 01       # data[1] = 1
+15-16: x 02       # data[2] = 2
+16-17: x 03       # data[3] = 3
+17-18: x 04       # data[4] = 4
+18-19: x 05       # data[5] = 5
+19-20: x 06       # data[6] = 6
+20-21: x 07       # data[7] = 7
+21-22: x 08       # data[8] = 8
+22-23: x 09       # data[9] = 9
+23-24: x 00       # block trailer padding
 
-init schema=(uint32,uint64)
+init schema=(uint)
 ----
 
 write
@@ -241,27 +220,18 @@ write
 finish
 ----
 # columnar block header
-00-01: x 01               # version 1
-01-03: x 0200             # 2 columns
-03-07: x 02000000         # 2 rows
+00-01: x 01       # version 1
+01-03: x 0100     # 1 columns
+03-07: x 02000000 # 2 rows
 # column 0
-07-08: b 00000100         # uint32
-08-12: x 11000000         # page start 17
-# column 1
-12-13: b 00000101         # uint64
-13-17: x 1a000000         # page start 26
+07-08: b 00000010 # uint
+08-12: x 0c000000 # page start 12
 # data for column 0
-17-18: x 03               # delta encoding: delta16
-18-22: x 01000000         # 32-bit constant: 1
-22-24: x 0630             # data[0] = 12294 + 1 = 12295
-24-26: x 0000             # data[1] = 0 + 1 = 1
-# data for column 1
-26-27: x 00               # delta encoding: none
-# padding
-27-32: x 0000000000       # aligning to 64-bit boundary
-32-40: x b2b4949e5b020000 # data[0] = 2592525825202
-40-48: x 0100000000000000 # data[1] = 1
-48-49: x 00               # block trailer padding
+12-13: x 02       # encoding: 2b
+13-14: x 00       # padding (aligning to 16-bit boundary)
+14-16: x 0730     # data[0] = 12295
+16-18: x 0100     # data[1] = 1
+18-19: x 00       # block trailer padding
 
 init schema=(bool)
 ----
@@ -308,7 +278,7 @@ finish
 24-32: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 32-33: x 00                                                               # block trailer padding
 
-init schema=(bytes,uint64)
+init schema=(bytes,uint)
 ----
 
 write
@@ -330,46 +300,44 @@ finish
 001-003: x 0200                   # 2 columns
 003-007: x 09000000               # 9 rows
 # column 0
-007-008: b 00000110               # bytes
+007-008: b 00000011               # bytes
 008-012: x 11000000               # page start 17
 # column 1
-012-013: b 00000101               # uint64
-013-017: x 5e000000               # page start 94
+012-013: b 00000010               # uint
+013-017: x 5a000000               # page start 90
 # data for column 0
 # rawbytes
 # offsets table
-017-018: x 02                     # delta encoding: delta8
-018-022: x 00000000               # 32-bit constant: 0
-022-023: x 00                     # data[0] = 0 [32 overall]
-023-024: x 05                     # data[1] = 5 [37 overall]
-024-025: x 0b                     # data[2] = 11 [43 overall]
-025-026: x 12                     # data[3] = 18 [50 overall]
-026-027: x 1d                     # data[4] = 29 [61 overall]
-027-028: x 27                     # data[5] = 39 [71 overall]
-028-029: x 2d                     # data[6] = 45 [77 overall]
-029-030: x 31                     # data[7] = 49 [81 overall]
-030-031: x 3a                     # data[8] = 58 [90 overall]
-031-032: x 3e                     # data[9] = 62 [94 overall]
+017-018: x 01                     # encoding: 1b
+018-019: x 00                     # data[0] = 0 [28 overall]
+019-020: x 05                     # data[1] = 5 [33 overall]
+020-021: x 0b                     # data[2] = 11 [39 overall]
+021-022: x 12                     # data[3] = 18 [46 overall]
+022-023: x 1d                     # data[4] = 29 [57 overall]
+023-024: x 27                     # data[5] = 39 [67 overall]
+024-025: x 2d                     # data[6] = 45 [73 overall]
+025-026: x 31                     # data[7] = 49 [77 overall]
+026-027: x 3a                     # data[8] = 58 [86 overall]
+027-028: x 3e                     # data[9] = 62 [90 overall]
 # data
-032-037: x 6170706c65             # data[0]: apple
-037-043: x 62616e616e61           # data[1]: banana
-043-050: x 636f636f6e7574         # data[2]: coconut
-050-061: x 647261676f6e6672756974 # data[3]: dragonfruit
-061-071: x 656c6465726265727279   # data[4]: elderberry
-071-077: x 667261697365           # data[5]: fraise
-077-081: x 676f6a69               # data[6]: goji
-081-090: x 6a61636b6672756974     # data[7]: jackfruit
-090-094: x 6b697769               # data[8]: kiwi
+028-033: x 6170706c65             # data[0]: apple
+033-039: x 62616e616e61           # data[1]: banana
+039-046: x 636f636f6e7574         # data[2]: coconut
+046-057: x 647261676f6e6672756974 # data[3]: dragonfruit
+057-067: x 656c6465726265727279   # data[4]: elderberry
+067-073: x 667261697365           # data[5]: fraise
+073-077: x 676f6a69               # data[6]: goji
+077-086: x 6a61636b6672756974     # data[7]: jackfruit
+086-090: x 6b697769               # data[8]: kiwi
 # data for column 1
-094-095: x 02                     # delta encoding: delta8
-095-103: x 0a00000000000000       # 64-bit constant: 10
-103-104: x 0a                     # data[0] = 10 + 10 = 20
-104-105: x 14                     # data[1] = 20 + 10 = 30
-105-106: x 00                     # data[2] = 0 + 10 = 10
-106-107: x 3c                     # data[3] = 60 + 10 = 70
-107-108: x 28                     # data[4] = 40 + 10 = 50
-108-109: x 32                     # data[5] = 50 + 10 = 60
-109-110: x 46                     # data[6] = 70 + 10 = 80
-110-111: x 50                     # data[7] = 80 + 10 = 90
-111-112: x 5a                     # data[8] = 90 + 10 = 100
-112-113: x 00                     # block trailer padding
+090-091: x 01                     # encoding: 1b
+091-092: x 14                     # data[0] = 20
+092-093: x 1e                     # data[1] = 30
+093-094: x 0a                     # data[2] = 10
+094-095: x 46                     # data[3] = 70
+095-096: x 32                     # data[4] = 50
+096-097: x 3c                     # data[5] = 60
+097-098: x 50                     # data[6] = 80
+098-099: x 5a                     # data[7] = 90
+099-100: x 64                     # data[8] = 100
+100-101: x 00                     # block trailer padding

--- a/sstable/colblk/testdata/keyspan_block
+++ b/sstable/colblk/testdata/keyspan_block
@@ -2,137 +2,131 @@ init
 ----
 size=1:
 0: user keys:      bytes: 0 rows set; 0 bytes in data
-1: start indices:  uint32: 0 rows
-2: trailers:       uint64: 0 rows
+1: start indices:  uint: 0 rows
+2: trailers:       uint: 0 rows
 3: suffixes:       bytes: 0 rows set; 0 bytes in data
 4: values:         bytes: 0 rows set; 0 bytes in data
 
 add
 a-b:{(#0,RANGEDEL)}
 ----
-size=73:
+size=57:
 0: user keys:      bytes: 2 rows set; 2 bytes in data
-1: start indices:  uint32: 2 rows
-2: trailers:       uint64: 1 rows
+1: start indices:  uint: 2 rows
+2: trailers:       uint: 1 rows
 3: suffixes:       bytes: 1 rows set; 0 bytes in data
 4: values:         bytes: 1 rows set; 0 bytes in data
 
 add
 b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
 ----
-size=85:
+size=61:
 0: user keys:      bytes: 3 rows set; 3 bytes in data
-1: start indices:  uint32: 3 rows
-2: trailers:       uint64: 4 rows
+1: start indices:  uint: 3 rows
+2: trailers:       uint: 4 rows
 3: suffixes:       bytes: 4 rows set; 0 bytes in data
 4: values:         bytes: 4 rows set; 0 bytes in data
 
 add
 c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
 ----
-size=91:
+size=67:
 0: user keys:      bytes: 4 rows set; 4 bytes in data
-1: start indices:  uint32: 4 rows
-2: trailers:       uint64: 6 rows
+1: start indices:  uint: 4 rows
+2: trailers:       uint: 6 rows
 3: suffixes:       bytes: 6 rows set; 0 bytes in data
 4: values:         bytes: 6 rows set; 0 bytes in data
 
 add
 d-e:{(#0,RANGEDEL)}
 ----
-size=97:
+size=73:
 0: user keys:      bytes: 5 rows set; 5 bytes in data
-1: start indices:  uint32: 5 rows
-2: trailers:       uint64: 7 rows
+1: start indices:  uint: 5 rows
+2: trailers:       uint: 7 rows
 3: suffixes:       bytes: 7 rows set; 0 bytes in data
 4: values:         bytes: 7 rows set; 0 bytes in data
 
 finish
 ----
 # keyspan block header
-00-04: x 05000000         # user key count: 5
+00-04: x 05000000 # user key count: 5
 # columnar block header
-04-05: x 01               # version 1
-05-07: x 0500             # 5 columns
-07-11: x 07000000         # 7 rows
+04-05: x 01       # version 1
+05-07: x 0500     # 5 columns
+07-11: x 07000000 # 7 rows
 # column 0
-11-12: b 00000110         # bytes
-12-16: x 24000000         # page start 36
+11-12: b 00000011 # bytes
+12-16: x 24000000 # page start 36
 # column 1
-16-17: b 00000100         # uint32
-17-21: x 34000000         # page start 52
+16-17: b 00000010 # uint
+17-21: x 30000000 # page start 48
 # column 2
-21-22: b 00000101         # uint64
-22-26: x 3e000000         # page start 62
+21-22: b 00000010 # uint
+22-26: x 36000000 # page start 54
 # column 3
-26-27: b 00000110         # bytes
-27-31: x 56000000         # page start 86
+26-27: b 00000011 # bytes
+27-31: x 46000000 # page start 70
 # column 4
-31-32: b 00000110         # bytes
-32-36: x 5b000000         # page start 91
+31-32: b 00000011 # bytes
+32-36: x 47000000 # page start 71
 # data for column 0
 # rawbytes
 # offsets table
-36-37: x 02               # delta encoding: delta8
-37-41: x 00000000         # 32-bit constant: 0
-41-42: x 00               # data[0] = 0 [47 overall]
-42-43: x 01               # data[1] = 1 [48 overall]
-43-44: x 02               # data[2] = 2 [49 overall]
-44-45: x 03               # data[3] = 3 [50 overall]
-45-46: x 04               # data[4] = 4 [51 overall]
-46-47: x 05               # data[5] = 5 [52 overall]
+36-37: x 01       # encoding: 1b
+37-38: x 00       # data[0] = 0 [43 overall]
+38-39: x 01       # data[1] = 1 [44 overall]
+39-40: x 02       # data[2] = 2 [45 overall]
+40-41: x 03       # data[3] = 3 [46 overall]
+41-42: x 04       # data[4] = 4 [47 overall]
+42-43: x 05       # data[5] = 5 [48 overall]
 # data
-47-48: x 61               # data[0]: a
-48-49: x 62               # data[1]: b
-49-50: x 63               # data[2]: c
-50-51: x 64               # data[3]: d
-51-52: x 65               # data[4]: e
+43-44: x 61       # data[0]: a
+44-45: x 62       # data[1]: b
+45-46: x 63       # data[2]: c
+46-47: x 64       # data[3]: d
+47-48: x 65       # data[4]: e
 # data for column 1
-52-53: x 02               # delta encoding: delta8
-53-57: x 00000000         # 32-bit constant: 0
-57-58: x 00               # data[0] = 0
-58-59: x 01               # data[1] = 1
-59-60: x 04               # data[2] = 4
-60-61: x 06               # data[3] = 6
-61-62: x 07               # data[4] = 7
+48-49: x 01       # encoding: 1b
+49-50: x 00       # data[0] = 0
+50-51: x 01       # data[1] = 1
+51-52: x 04       # data[2] = 4
+52-53: x 06       # data[3] = 6
+53-54: x 07       # data[4] = 7
 # data for column 2
-62-63: x 03               # delta encoding: delta16
-63-71: x 0f00000000000000 # 64-bit constant: 15
-# padding
-71-72: x 00               # aligning to 16-bit boundary
-72-74: x 0000             # data[0] = 0 + 15 = 15
-74-76: x 0064             # data[1] = 25600 + 15 = 25615
-76-78: x 0014             # data[2] = 5120 + 15 = 5135
-78-80: x 0000             # data[3] = 0 + 15 = 15
-80-82: x 0064             # data[4] = 25600 + 15 = 25615
-82-84: x 0000             # data[5] = 0 + 15 = 15
-84-86: x 0000             # data[6] = 0 + 15 = 15
+54-55: x 02       # encoding: 2b
+55-56: x 00       # padding (aligning to 16-bit boundary)
+56-58: x 0f00     # data[0] = 15
+58-60: x 0f64     # data[1] = 25615
+60-62: x 0f14     # data[2] = 5135
+62-64: x 0f00     # data[3] = 15
+64-66: x 0f64     # data[4] = 25615
+66-68: x 0f00     # data[5] = 15
+68-70: x 0f00     # data[6] = 15
 # data for column 3
 # rawbytes
 # offsets table
-86-87: x 01               # delta encoding: const
-87-91: x 00000000         # 32-bit constant: 0
+70-71: x 00       # encoding: zero
 # data
-91-91: x                  # data[0]:
-91-91: x                  # data[1]:
-91-91: x                  # data[2]:
-91-91: x                  # data[3]:
-91-91: x                  # data[4]:
-91-91: x                  # data[5]:
-91-91: x                  # data[6]:
+71-71: x          # data[0]:
+71-71: x          # data[1]:
+71-71: x          # data[2]:
+71-71: x          # data[3]:
+71-71: x          # data[4]:
+71-71: x          # data[5]:
+71-71: x          # data[6]:
 # data for column 4
 # rawbytes
 # offsets table
-91-92: x 01               # delta encoding: const
-92-96: x 00000000         # 32-bit constant: 0
+71-72: x 00       # encoding: zero
 # data
-96-96: x                  # data[0]:
-96-96: x                  # data[1]:
-96-96: x                  # data[2]:
-96-96: x                  # data[3]:
-96-96: x                  # data[4]:
-96-96: x                  # data[5]:
-96-96: x                  # data[6]:
+72-72: x          # data[0]:
+72-72: x          # data[1]:
+72-72: x          # data[2]:
+72-72: x          # data[3]:
+72-72: x          # data[4]:
+72-72: x          # data[5]:
+72-72: x          # data[6]:
 
 # Test iterating over the block's spans.
 
@@ -220,18 +214,18 @@ init
 ----
 size=1:
 0: user keys:      bytes: 0 rows set; 0 bytes in data
-1: start indices:  uint32: 0 rows
-2: trailers:       uint64: 0 rows
+1: start indices:  uint: 0 rows
+2: trailers:       uint: 0 rows
 3: suffixes:       bytes: 0 rows set; 0 bytes in data
 4: values:         bytes: 0 rows set; 0 bytes in data
 
 add
 b-d:{(#4,RANGEKEYSET,@3,coconut)}
 ----
-size=86:
+size=70:
 0: user keys:      bytes: 2 rows set; 2 bytes in data
-1: start indices:  uint32: 2 rows
-2: trailers:       uint64: 1 rows
+1: start indices:  uint: 2 rows
+2: trailers:       uint: 1 rows
 3: suffixes:       bytes: 1 rows set; 2 bytes in data
 4: values:         bytes: 1 rows set; 7 bytes in data
 
@@ -244,57 +238,53 @@ finish
 05-07: x 0500             # 5 columns
 07-11: x 01000000         # 1 rows
 # column 0
-11-12: b 00000110         # bytes
+11-12: b 00000011         # bytes
 12-16: x 24000000         # page start 36
 # column 1
-16-17: b 00000100         # uint32
-17-21: x 2e000000         # page start 46
+16-17: b 00000010         # uint
+17-21: x 2a000000         # page start 42
 # column 2
-21-22: b 00000101         # uint64
-22-26: x 35000000         # page start 53
+21-22: b 00000010         # uint
+22-26: x 2d000000         # page start 45
 # column 3
-26-27: b 00000110         # bytes
-27-31: x 3e000000         # page start 62
+26-27: b 00000011         # bytes
+27-31: x 36000000         # page start 54
 # column 4
-31-32: b 00000110         # bytes
-32-36: x 47000000         # page start 71
+31-32: b 00000011         # bytes
+32-36: x 3b000000         # page start 59
 # data for column 0
 # rawbytes
 # offsets table
-36-37: x 02               # delta encoding: delta8
-37-41: x 00000000         # 32-bit constant: 0
-41-42: x 00               # data[0] = 0 [44 overall]
-42-43: x 01               # data[1] = 1 [45 overall]
-43-44: x 02               # data[2] = 2 [46 overall]
+36-37: x 01               # encoding: 1b
+37-38: x 00               # data[0] = 0 [40 overall]
+38-39: x 01               # data[1] = 1 [41 overall]
+39-40: x 02               # data[2] = 2 [42 overall]
 # data
-44-45: x 62               # data[0]: b
-45-46: x 64               # data[1]: d
+40-41: x 62               # data[0]: b
+41-42: x 64               # data[1]: d
 # data for column 1
-46-47: x 02               # delta encoding: delta8
-47-51: x 00000000         # 32-bit constant: 0
-51-52: x 00               # data[0] = 0
-52-53: x 01               # data[1] = 1
+42-43: x 01               # encoding: 1b
+43-44: x 00               # data[0] = 0
+44-45: x 01               # data[1] = 1
 # data for column 2
-53-54: x 01               # delta encoding: const
-54-62: x 1504000000000000 # 64-bit constant: 1045
+45-46: x 80               # encoding: const
+46-54: x 1504000000000000 # 64-bit constant: 1045
 # data for column 3
 # rawbytes
 # offsets table
-62-63: x 02               # delta encoding: delta8
-63-67: x 00000000         # 32-bit constant: 0
-67-68: x 00               # data[0] = 0 [69 overall]
-68-69: x 02               # data[1] = 2 [71 overall]
+54-55: x 01               # encoding: 1b
+55-56: x 00               # data[0] = 0 [57 overall]
+56-57: x 02               # data[1] = 2 [59 overall]
 # data
-69-71: x 4033             # data[0]: @3
+57-59: x 4033             # data[0]: @3
 # data for column 4
 # rawbytes
 # offsets table
-71-72: x 02               # delta encoding: delta8
-72-76: x 00000000         # 32-bit constant: 0
-76-77: x 00               # data[0] = 0 [78 overall]
-77-78: x 07               # data[1] = 7 [85 overall]
+59-60: x 01               # encoding: 1b
+60-61: x 00               # data[0] = 0 [62 overall]
+61-62: x 07               # data[1] = 7 [69 overall]
 # data
-78-85: x 636f636f6e7574   # data[0]: coconut
+62-69: x 636f636f6e7574   # data[0]: coconut
 
 iter
 seek-ge a
@@ -313,8 +303,8 @@ reset
 ----
 size=1:
 0: user keys:      bytes: 0 rows set; 0 bytes in data
-1: start indices:  uint32: 0 rows
-2: trailers:       uint64: 0 rows
+1: start indices:  uint: 0 rows
+2: trailers:       uint: 0 rows
 3: suffixes:       bytes: 0 rows set; 0 bytes in data
 4: values:         bytes: 0 rows set; 0 bytes in data
 
@@ -322,85 +312,80 @@ add
 b-d:{(#4,RANGEKEYSET,@3,coconut)}
 e-g:{(#5,RANGEKEYSET,@1,tree)}
 ----
-size=104:
+size=80:
 0: user keys:      bytes: 4 rows set; 4 bytes in data
-1: start indices:  uint32: 4 rows
-2: trailers:       uint64: 2 rows
+1: start indices:  uint: 4 rows
+2: trailers:       uint: 2 rows
 3: suffixes:       bytes: 2 rows set; 4 bytes in data
 4: values:         bytes: 2 rows set; 11 bytes in data
 
 finish
 ----
 # keyspan block header
-000-004: x 04000000         # user key count: 4
+00-04: x 04000000       # user key count: 4
 # columnar block header
-004-005: x 01               # version 1
-005-007: x 0500             # 5 columns
-007-011: x 02000000         # 2 rows
+04-05: x 01             # version 1
+05-07: x 0500           # 5 columns
+07-11: x 02000000       # 2 rows
 # column 0
-011-012: b 00000110         # bytes
-012-016: x 24000000         # page start 36
+11-12: b 00000011       # bytes
+12-16: x 24000000       # page start 36
 # column 1
-016-017: b 00000100         # uint32
-017-021: x 32000000         # page start 50
+16-17: b 00000010       # uint
+17-21: x 2e000000       # page start 46
 # column 2
-021-022: b 00000101         # uint64
-022-026: x 3b000000         # page start 59
+21-22: b 00000010       # uint
+22-26: x 33000000       # page start 51
 # column 3
-026-027: b 00000110         # bytes
-027-031: x 48000000         # page start 72
+26-27: b 00000011       # bytes
+27-31: x 38000000       # page start 56
 # column 4
-031-032: b 00000110         # bytes
-032-036: x 54000000         # page start 84
+31-32: b 00000011       # bytes
+32-36: x 40000000       # page start 64
 # data for column 0
 # rawbytes
 # offsets table
-036-037: x 02               # delta encoding: delta8
-037-041: x 00000000         # 32-bit constant: 0
-041-042: x 00               # data[0] = 0 [46 overall]
-042-043: x 01               # data[1] = 1 [47 overall]
-043-044: x 02               # data[2] = 2 [48 overall]
-044-045: x 03               # data[3] = 3 [49 overall]
-045-046: x 04               # data[4] = 4 [50 overall]
+36-37: x 01             # encoding: 1b
+37-38: x 00             # data[0] = 0 [42 overall]
+38-39: x 01             # data[1] = 1 [43 overall]
+39-40: x 02             # data[2] = 2 [44 overall]
+40-41: x 03             # data[3] = 3 [45 overall]
+41-42: x 04             # data[4] = 4 [46 overall]
 # data
-046-047: x 62               # data[0]: b
-047-048: x 64               # data[1]: d
-048-049: x 65               # data[2]: e
-049-050: x 67               # data[3]: g
+42-43: x 62             # data[0]: b
+43-44: x 64             # data[1]: d
+44-45: x 65             # data[2]: e
+45-46: x 67             # data[3]: g
 # data for column 1
-050-051: x 02               # delta encoding: delta8
-051-055: x 00000000         # 32-bit constant: 0
-055-056: x 00               # data[0] = 0
-056-057: x 01               # data[1] = 1
-057-058: x 01               # data[2] = 1
-058-059: x 02               # data[3] = 2
+46-47: x 01             # encoding: 1b
+47-48: x 00             # data[0] = 0
+48-49: x 01             # data[1] = 1
+49-50: x 01             # data[2] = 1
+50-51: x 02             # data[3] = 2
 # data for column 2
-059-060: x 03               # delta encoding: delta16
-060-068: x 1504000000000000 # 64-bit constant: 1045
-068-070: x 0000             # data[0] = 0 + 1045 = 1045
-070-072: x 0001             # data[1] = 256 + 1045 = 1301
+51-52: x 02             # encoding: 2b
+52-54: x 1504           # data[0] = 1045
+54-56: x 1505           # data[1] = 1301
 # data for column 3
 # rawbytes
 # offsets table
-072-073: x 02               # delta encoding: delta8
-073-077: x 00000000         # 32-bit constant: 0
-077-078: x 00               # data[0] = 0 [80 overall]
-078-079: x 02               # data[1] = 2 [82 overall]
-079-080: x 04               # data[2] = 4 [84 overall]
+56-57: x 01             # encoding: 1b
+57-58: x 00             # data[0] = 0 [60 overall]
+58-59: x 02             # data[1] = 2 [62 overall]
+59-60: x 04             # data[2] = 4 [64 overall]
 # data
-080-082: x 4033             # data[0]: @3
-082-084: x 4031             # data[1]: @1
+60-62: x 4033           # data[0]: @3
+62-64: x 4031           # data[1]: @1
 # data for column 4
 # rawbytes
 # offsets table
-084-085: x 02               # delta encoding: delta8
-085-089: x 00000000         # 32-bit constant: 0
-089-090: x 00               # data[0] = 0 [92 overall]
-090-091: x 07               # data[1] = 7 [99 overall]
-091-092: x 0b               # data[2] = 11 [103 overall]
+64-65: x 01             # encoding: 1b
+65-66: x 00             # data[0] = 0 [68 overall]
+66-67: x 07             # data[1] = 7 [75 overall]
+67-68: x 0b             # data[2] = 11 [79 overall]
 # data
-092-099: x 636f636f6e7574   # data[0]: coconut
-099-103: x 74726565         # data[1]: tree
+68-75: x 636f636f6e7574 # data[0]: coconut
+75-79: x 74726565       # data[1]: tree
 
 iter
 seek-ge dog

--- a/sstable/colblk/testdata/prefix_bytes
+++ b/sstable/colblk/testdata/prefix_bytes
@@ -5,7 +5,7 @@ Size: 0
 put
 abc
 ----
-Size: 12
+Size: 8
 nKeys=1; bundleSize=4
 blockPrefixLen=3; currentBundleLen=3; currentBundleKeys=1
 Offsets:
@@ -16,17 +16,16 @@ abc
 finish rows=1
 ----
 # PrefixBytes
-00-01: x 02       # bundleSize: 4
+0-1: x 02     # bundleSize: 4
 # Offsets table
-01-02: x 02       # delta encoding: delta8
-02-06: x 00000000 # 32-bit constant: 0
-06-07: x 03       # data[0] = 3 [12 overall]
-07-08: x 03       # data[1] = 3 [12 overall]
-08-09: x 03       # data[2] = 3 [12 overall]
+1-2: x 01     # encoding: 1b
+2-3: x 03     # data[0] = 3 [8 overall]
+3-4: x 03     # data[1] = 3 [8 overall]
+4-5: x 03     # data[2] = 3 [8 overall]
 # Data
-09-12: x 616263   # data[00]: abc (block prefix)
-12-12: x          # data[01]: ... (bundle prefix)
-12-12: x          # data[02]: ...
+5-8: x 616263 # data[00]: abc (block prefix)
+8-8: x        # data[01]: ... (bundle prefix)
+8-8: x        # data[02]: ...
 
 init bundle-size=4
 ----
@@ -35,7 +34,7 @@ Size: 0
 put
 abc
 ----
-Size: 12
+Size: 8
 nKeys=1; bundleSize=4
 blockPrefixLen=3; currentBundleLen=3; currentBundleKeys=1
 Offsets:
@@ -46,7 +45,7 @@ abc
 put
 abcd
 ----
-Size: 14
+Size: 10
 nKeys=2; bundleSize=4
 blockPrefixLen=3; currentBundleLen=7; currentBundleKeys=2
 Offsets:
@@ -57,7 +56,7 @@ abcabcd
 put
 abce
 ----
-Size: 16
+Size: 12
 nKeys=3; bundleSize=4
 blockPrefixLen=3; currentBundleLen=11; currentBundleKeys=3
 Offsets:
@@ -68,7 +67,7 @@ abcabcdabce
 put
 abdd
 ----
-Size: 21
+Size: 17
 nKeys=4; bundleSize=4
 blockPrefixLen=2; currentBundleLen=15; currentBundleKeys=4
 Offsets:
@@ -79,7 +78,7 @@ abcabcdabceabdd
 put
 abde
 ----
-Size: 25
+Size: 21
 nKeys=5; bundleSize=4
 blockPrefixLen=2; currentBundleLen=4; currentBundleKeys=1
 Offsets:
@@ -92,50 +91,48 @@ abcabcdabceabddabde
 finish rows=4
 ----
 # PrefixBytes
-00-01: x 02       # bundleSize: 4
+00-01: x 02   # bundleSize: 4
 # Offsets table
-01-02: x 02       # delta encoding: delta8
-02-06: x 00000000 # 32-bit constant: 0
-06-07: x 02       # data[0] = 2 [14 overall]
-07-08: x 02       # data[1] = 2 [14 overall]
-08-09: x 03       # data[2] = 3 [15 overall]
-09-10: x 05       # data[3] = 5 [17 overall]
-10-11: x 07       # data[4] = 7 [19 overall]
-11-12: x 09       # data[5] = 9 [21 overall]
+01-02: x 01   # encoding: 1b
+02-03: x 02   # data[0] = 2 [10 overall]
+03-04: x 02   # data[1] = 2 [10 overall]
+04-05: x 03   # data[2] = 3 [11 overall]
+05-06: x 05   # data[3] = 5 [13 overall]
+06-07: x 07   # data[4] = 7 [15 overall]
+07-08: x 09   # data[5] = 9 [17 overall]
 # Data
-12-14: x 6162     # data[00]: ab (block prefix)
-14-14: x          # data[01]: .. (bundle prefix)
-14-15: x 63       # data[02]: ..c
-15-17: x 6364     # data[03]: ..cd
-17-19: x 6365     # data[04]: ..ce
-19-21: x 6464     # data[05]: ..dd
+08-10: x 6162 # data[00]: ab (block prefix)
+10-10: x      # data[01]: .. (bundle prefix)
+10-11: x 63   # data[02]: ..c
+11-13: x 6364 # data[03]: ..cd
+13-15: x 6365 # data[04]: ..ce
+15-17: x 6464 # data[05]: ..dd
 
 # Finish the entirety of all put rows.
 
 finish rows=5
 ----
 # PrefixBytes
-00-01: x 02       # bundleSize: 4
+00-01: x 02   # bundleSize: 4
 # Offsets table
-01-02: x 02       # delta encoding: delta8
-02-06: x 00000000 # 32-bit constant: 0
-06-07: x 02       # data[0] = 2 [16 overall]
-07-08: x 02       # data[1] = 2 [16 overall]
-08-09: x 03       # data[2] = 3 [17 overall]
-09-10: x 05       # data[3] = 5 [19 overall]
-10-11: x 07       # data[4] = 7 [21 overall]
-11-12: x 09       # data[5] = 9 [23 overall]
-12-13: x 0b       # data[6] = 11 [25 overall]
-13-14: x 0b       # data[7] = 11 [25 overall]
+01-02: x 01   # encoding: 1b
+02-03: x 02   # data[0] = 2 [12 overall]
+03-04: x 02   # data[1] = 2 [12 overall]
+04-05: x 03   # data[2] = 3 [13 overall]
+05-06: x 05   # data[3] = 5 [15 overall]
+06-07: x 07   # data[4] = 7 [17 overall]
+07-08: x 09   # data[5] = 9 [19 overall]
+08-09: x 0b   # data[6] = 11 [21 overall]
+09-10: x 0b   # data[7] = 11 [21 overall]
 # Data
-14-16: x 6162     # data[00]: ab (block prefix)
-16-16: x          # data[01]: .. (bundle prefix)
-16-17: x 63       # data[02]: ..c
-17-19: x 6364     # data[03]: ..cd
-19-21: x 6365     # data[04]: ..ce
-21-23: x 6464     # data[05]: ..dd
-23-25: x 6465     # data[06]: ..de (bundle prefix)
-25-25: x          # data[07]: ....
+10-12: x 6162 # data[00]: ab (block prefix)
+12-12: x      # data[01]: .. (bundle prefix)
+12-13: x 63   # data[02]: ..c
+13-15: x 6364 # data[03]: ..cd
+15-17: x 6365 # data[04]: ..ce
+17-19: x 6464 # data[05]: ..dd
+19-21: x 6465 # data[06]: ..de (bundle prefix)
+21-21: x      # data[07]: ....
 
 get indices=(0, 1, 2, 3, 4)
 ----
@@ -184,7 +181,7 @@ Size: 0
 put
 aaabbbc
 ----
-Size: 16
+Size: 12
 nKeys=1; bundleSize=4
 blockPrefixLen=7; currentBundleLen=7; currentBundleKeys=1
 Offsets:
@@ -195,7 +192,7 @@ aaabbbc
 put
 aaabbbcc
 ----
-Size: 18
+Size: 14
 nKeys=2; bundleSize=4
 blockPrefixLen=7; currentBundleLen=15; currentBundleKeys=2
 Offsets:
@@ -206,7 +203,7 @@ aaabbbcaaabbbcc
 put
 aaabbbcde
 ----
-Size: 21
+Size: 17
 nKeys=3; bundleSize=4
 blockPrefixLen=7; currentBundleLen=24; currentBundleKeys=3
 Offsets:
@@ -217,7 +214,7 @@ aaabbbcaaabbbccaaabbbcde
 put
 aaabbbce
 ----
-Size: 23
+Size: 19
 nKeys=4; bundleSize=4
 blockPrefixLen=7; currentBundleLen=32; currentBundleKeys=4
 Offsets:
@@ -228,7 +225,7 @@ aaabbbcaaabbbccaaabbbcdeaaabbbce
 put
 aaabbbdee*
 ----
-Size: 29
+Size: 25
 nKeys=5; bundleSize=4
 blockPrefixLen=6; currentBundleLen=10; currentBundleKeys=1
 Offsets:
@@ -239,7 +236,7 @@ aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*
 put
 aaabbbdee*
 ----
-Size: 30
+Size: 26
 nKeys=6; bundleSize=4
 blockPrefixLen=6; currentBundleLen=10; currentBundleKeys=1
 Offsets:
@@ -250,7 +247,7 @@ aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*
 put
 aaabbbdee*
 ----
-Size: 31
+Size: 27
 nKeys=7; bundleSize=4
 blockPrefixLen=6; currentBundleLen=10; currentBundleKeys=1
 Offsets:
@@ -261,7 +258,7 @@ aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*
 put
 aaabbbeff
 ----
-Size: 35
+Size: 31
 nKeys=8; bundleSize=4
 blockPrefixLen=6; currentBundleLen=19; currentBundleKeys=2
 Offsets:
@@ -273,7 +270,7 @@ aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeff
 put
 aaabbe
 ----
-Size: 39
+Size: 35
 nKeys=9; bundleSize=4
 blockPrefixLen=5; currentBundleLen=6; currentBundleKeys=1
 Offsets:
@@ -285,7 +282,7 @@ aaabbbcaaabbbccaaabbbcdeaaabbbceaaabbbdee*aaabbbeffaaabbe
 put
 aaabbeef*
 ----
-Size: 43
+Size: 39
 nKeys=10; bundleSize=4
 blockPrefixLen=5; currentBundleLen=15; currentBundleKeys=2
 Offsets:
@@ -298,7 +295,7 @@ bbeef*
 put
 aaabbeef*
 ----
-Size: 44
+Size: 40
 nKeys=11; bundleSize=4
 blockPrefixLen=5; currentBundleLen=15; currentBundleKeys=2
 Offsets:
@@ -311,7 +308,7 @@ bbeef*
 put
 aaabc
 ----
-Size: 50
+Size: 46
 nKeys=12; bundleSize=4
 blockPrefixLen=4; currentBundleLen=20; currentBundleKeys=3
 Offsets:
@@ -325,7 +322,7 @@ put
 aabcceef*
 aabcceef*
 ----
-Size: 64
+Size: 60
 nKeys=14; bundleSize=4
 blockPrefixLen=2; currentBundleLen=9; currentBundleKeys=1
 Offsets:
@@ -340,7 +337,7 @@ bbeef*aaabcaabcceef*
 put
 aabcceegggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
 ----
-Size: 339
+Size: 335
 nKeys=15; bundleSize=4
 blockPrefixLen=2; currentBundleLen=270; currentBundleKeys=2
 Offsets:
@@ -361,47 +358,46 @@ finish rows=14
 # PrefixBytes
 00-01: x 02             # bundleSize: 4
 # Offsets table
-01-02: x 02             # delta encoding: delta8
-02-06: x 00000000       # 32-bit constant: 0
-06-07: x 02             # data[0] = 2 [27 overall]
-07-08: x 07             # data[1] = 7 [32 overall]
-08-09: x 07             # data[2] = 7 [32 overall]
-09-10: x 08             # data[3] = 8 [33 overall]
-10-11: x 0a             # data[4] = 10 [35 overall]
-11-12: x 0b             # data[5] = 11 [36 overall]
-12-13: x 0f             # data[6] = 15 [40 overall]
-13-14: x 13             # data[7] = 19 [44 overall]
-14-15: x 13             # data[8] = 19 [44 overall]
-15-16: x 13             # data[9] = 19 [44 overall]
-16-17: x 16             # data[10] = 22 [47 overall]
-17-18: x 18             # data[11] = 24 [49 overall]
-18-19: x 1a             # data[12] = 26 [51 overall]
-19-20: x 1f             # data[13] = 31 [56 overall]
-20-21: x 1f             # data[14] = 31 [56 overall]
-21-22: x 20             # data[15] = 32 [57 overall]
-22-23: x 27             # data[16] = 39 [64 overall]
-23-24: x 27             # data[17] = 39 [64 overall]
-24-25: x 27             # data[18] = 39 [64 overall]
+01-02: x 01             # encoding: 1b
+02-03: x 02             # data[0] = 2 [23 overall]
+03-04: x 07             # data[1] = 7 [28 overall]
+04-05: x 07             # data[2] = 7 [28 overall]
+05-06: x 08             # data[3] = 8 [29 overall]
+06-07: x 0a             # data[4] = 10 [31 overall]
+07-08: x 0b             # data[5] = 11 [32 overall]
+08-09: x 0f             # data[6] = 15 [36 overall]
+09-10: x 13             # data[7] = 19 [40 overall]
+10-11: x 13             # data[8] = 19 [40 overall]
+11-12: x 13             # data[9] = 19 [40 overall]
+12-13: x 16             # data[10] = 22 [43 overall]
+13-14: x 18             # data[11] = 24 [45 overall]
+14-15: x 1a             # data[12] = 26 [47 overall]
+15-16: x 1f             # data[13] = 31 [52 overall]
+16-17: x 1f             # data[14] = 31 [52 overall]
+17-18: x 20             # data[15] = 32 [53 overall]
+18-19: x 27             # data[16] = 39 [60 overall]
+19-20: x 27             # data[17] = 39 [60 overall]
+20-21: x 27             # data[18] = 39 [60 overall]
 # Data
-25-27: x 6161           # data[00]: aa (block prefix)
-27-32: x 6162626263     # data[01]: ..abbbc (bundle prefix)
-32-32: x                # data[02]: .......
-32-33: x 63             # data[03]: .......c
-33-35: x 6465           # data[04]: .......de
-35-36: x 65             # data[05]: .......e
-36-40: x 61626262       # data[06]: ..abbb (bundle prefix)
-40-44: x 6465652a       # data[07]: ......dee*
-44-44: x                # data[08]: ..........
-44-44: x                # data[09]: ..........
-44-47: x 656666         # data[10]: ......eff
-47-49: x 6162           # data[11]: ..ab (bundle prefix)
-49-51: x 6265           # data[12]: ....be
-51-56: x 626565662a     # data[13]: ....beef*
-56-56: x                # data[14]: .........
-56-57: x 63             # data[15]: ....c
-57-64: x 6263636565662a # data[16]: ..bcceef* (bundle prefix)
-64-64: x                # data[17]: .........
-64-64: x                # data[18]: .........
+21-23: x 6161           # data[00]: aa (block prefix)
+23-28: x 6162626263     # data[01]: ..abbbc (bundle prefix)
+28-28: x                # data[02]: .......
+28-29: x 63             # data[03]: .......c
+29-31: x 6465           # data[04]: .......de
+31-32: x 65             # data[05]: .......e
+32-36: x 61626262       # data[06]: ..abbb (bundle prefix)
+36-40: x 6465652a       # data[07]: ......dee*
+40-40: x                # data[08]: ..........
+40-40: x                # data[09]: ..........
+40-43: x 656666         # data[10]: ......eff
+43-45: x 6162           # data[11]: ..ab (bundle prefix)
+45-47: x 6265           # data[12]: ....be
+47-52: x 626565662a     # data[13]: ....beef*
+52-52: x                # data[14]: .........
+52-53: x 63             # data[15]: ....c
+53-60: x 6263636565662a # data[16]: ..bcceef* (bundle prefix)
+60-60: x                # data[17]: .........
+60-60: x                # data[18]: .........
 
 
 get indices=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
@@ -469,61 +465,60 @@ finish rows=15
 # PrefixBytes
 000-001: x 02                                       # bundleSize: 4
 # Offsets table
-001-002: x 03                                       # delta encoding: delta16
-002-006: x 00000000                                 # 32-bit constant: 0
-006-008: x 0200                                     # data[0] = 2 [48 overall]
-008-010: x 0700                                     # data[1] = 7 [53 overall]
-010-012: x 0700                                     # data[2] = 7 [53 overall]
-012-014: x 0800                                     # data[3] = 8 [54 overall]
-014-016: x 0a00                                     # data[4] = 10 [56 overall]
-016-018: x 0b00                                     # data[5] = 11 [57 overall]
-018-020: x 0f00                                     # data[6] = 15 [61 overall]
-020-022: x 1300                                     # data[7] = 19 [65 overall]
-022-024: x 1300                                     # data[8] = 19 [65 overall]
-024-026: x 1300                                     # data[9] = 19 [65 overall]
-026-028: x 1600                                     # data[10] = 22 [68 overall]
-028-030: x 1800                                     # data[11] = 24 [70 overall]
-030-032: x 1a00                                     # data[12] = 26 [72 overall]
-032-034: x 1f00                                     # data[13] = 31 [77 overall]
-034-036: x 1f00                                     # data[14] = 31 [77 overall]
-036-038: x 2000                                     # data[15] = 32 [78 overall]
-038-040: x 2500                                     # data[16] = 37 [83 overall]
-040-042: x 2700                                     # data[17] = 39 [85 overall]
-042-044: x 2700                                     # data[18] = 39 [85 overall]
-044-046: x 2501                                     # data[19] = 293 [339 overall]
+001-002: x 02                                       # encoding: 2b
+002-004: x 0200                                     # data[0] = 2 [44 overall]
+004-006: x 0700                                     # data[1] = 7 [49 overall]
+006-008: x 0700                                     # data[2] = 7 [49 overall]
+008-010: x 0800                                     # data[3] = 8 [50 overall]
+010-012: x 0a00                                     # data[4] = 10 [52 overall]
+012-014: x 0b00                                     # data[5] = 11 [53 overall]
+014-016: x 0f00                                     # data[6] = 15 [57 overall]
+016-018: x 1300                                     # data[7] = 19 [61 overall]
+018-020: x 1300                                     # data[8] = 19 [61 overall]
+020-022: x 1300                                     # data[9] = 19 [61 overall]
+022-024: x 1600                                     # data[10] = 22 [64 overall]
+024-026: x 1800                                     # data[11] = 24 [66 overall]
+026-028: x 1a00                                     # data[12] = 26 [68 overall]
+028-030: x 1f00                                     # data[13] = 31 [73 overall]
+030-032: x 1f00                                     # data[14] = 31 [73 overall]
+032-034: x 2000                                     # data[15] = 32 [74 overall]
+034-036: x 2500                                     # data[16] = 37 [79 overall]
+036-038: x 2700                                     # data[17] = 39 [81 overall]
+038-040: x 2700                                     # data[18] = 39 [81 overall]
+040-042: x 2501                                     # data[19] = 293 [335 overall]
 # Data
-046-048: x 6161                                     # data[00]: aa (block prefix)
-048-053: x 6162626263                               # data[01]: ..abbbc (bundle prefix)
-053-053: x                                          # data[02]: .......
-053-054: x 63                                       # data[03]: .......c
-054-056: x 6465                                     # data[04]: .......de
-056-057: x 65                                       # data[05]: .......e
-057-061: x 61626262                                 # data[06]: ..abbb (bundle prefix)
-061-065: x 6465652a                                 # data[07]: ......dee*
-065-065: x                                          # data[08]: ..........
-065-065: x                                          # data[09]: ..........
-065-068: x 656666                                   # data[10]: ......eff
-068-070: x 6162                                     # data[11]: ..ab (bundle prefix)
-070-072: x 6265                                     # data[12]: ....be
-072-077: x 626565662a                               # data[13]: ....beef*
-077-077: x                                          # data[14]: .........
-077-078: x 63                                       # data[15]: ....c
-078-083: x 6263636565                               # data[16]: ..bccee (bundle prefix)
-083-085: x 662a                                     # data[17]: .......f*
-085-085: x                                          # data[18]: .........
-085-105: x 6767676767676767676767676767676767676767 # data[19]: .......gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-105-125: x 6767676767676767676767676767676767676767 # (continued...)
-125-145: x 6767676767676767676767676767676767676767 # (continued...)
-145-165: x 6767676767676767676767676767676767676767 # (continued...)
-165-185: x 6767676767676767676767676767676767676767 # (continued...)
-185-205: x 6767676767676767676767676767676767676767 # (continued...)
-205-225: x 6767676767676767676767676767676767676767 # (continued...)
-225-245: x 6767676767676767676767676767676767676767 # (continued...)
-245-265: x 6767676767676767676767676767676767676767 # (continued...)
-265-285: x 6767676767676767676767676767676767676767 # (continued...)
-285-305: x 6767676767676767676767676767676767676767 # (continued...)
-305-325: x 6767676767676767676767676767676767676767 # (continued...)
-325-339: x 6767676767676767676767676767             # (continued...)
+042-044: x 6161                                     # data[00]: aa (block prefix)
+044-049: x 6162626263                               # data[01]: ..abbbc (bundle prefix)
+049-049: x                                          # data[02]: .......
+049-050: x 63                                       # data[03]: .......c
+050-052: x 6465                                     # data[04]: .......de
+052-053: x 65                                       # data[05]: .......e
+053-057: x 61626262                                 # data[06]: ..abbb (bundle prefix)
+057-061: x 6465652a                                 # data[07]: ......dee*
+061-061: x                                          # data[08]: ..........
+061-061: x                                          # data[09]: ..........
+061-064: x 656666                                   # data[10]: ......eff
+064-066: x 6162                                     # data[11]: ..ab (bundle prefix)
+066-068: x 6265                                     # data[12]: ....be
+068-073: x 626565662a                               # data[13]: ....beef*
+073-073: x                                          # data[14]: .........
+073-074: x 63                                       # data[15]: ....c
+074-079: x 6263636565                               # data[16]: ..bccee (bundle prefix)
+079-081: x 662a                                     # data[17]: .......f*
+081-081: x                                          # data[18]: .........
+081-101: x 6767676767676767676767676767676767676767 # data[19]: .......gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+101-121: x 6767676767676767676767676767676767676767 # (continued...)
+121-141: x 6767676767676767676767676767676767676767 # (continued...)
+141-161: x 6767676767676767676767676767676767676767 # (continued...)
+161-181: x 6767676767676767676767676767676767676767 # (continued...)
+181-201: x 6767676767676767676767676767676767676767 # (continued...)
+201-221: x 6767676767676767676767676767676767676767 # (continued...)
+221-241: x 6767676767676767676767676767676767676767 # (continued...)
+241-261: x 6767676767676767676767676767676767676767 # (continued...)
+261-281: x 6767676767676767676767676767676767676767 # (continued...)
+281-301: x 6767676767676767676767676767676767676767 # (continued...)
+301-321: x 6767676767676767676767676767676767676767 # (continued...)
+321-335: x 6767676767676767676767676767             # (continued...)
 
 init bundle-size=2
 ----
@@ -546,7 +541,7 @@ aabcceef*
 aabcceef*
 aabcceef*
 ----
-Size: 94
+Size: 90
 nKeys=15; bundleSize=2
 blockPrefixLen=2; currentBundleLen=9; currentBundleKeys=1
 Offsets:
@@ -562,110 +557,108 @@ finish rows=14
 # PrefixBytes
 00-01: x 01               # bundleSize: 2
 # Offsets table
-01-02: x 02               # delta encoding: delta8
-02-06: x 00000000         # 32-bit constant: 0
-06-07: x 02               # data[0] = 2 [30 overall]
-07-08: x 07               # data[1] = 7 [35 overall]
-08-09: x 07               # data[2] = 7 [35 overall]
-09-10: x 08               # data[3] = 8 [36 overall]
-10-11: x 0d               # data[4] = 13 [41 overall]
-11-12: x 0f               # data[5] = 15 [43 overall]
-12-13: x 10               # data[6] = 16 [44 overall]
-13-14: x 18               # data[7] = 24 [52 overall]
-14-15: x 18               # data[8] = 24 [52 overall]
-15-16: x 18               # data[9] = 24 [52 overall]
-16-17: x 1c               # data[10] = 28 [56 overall]
-17-18: x 20               # data[11] = 32 [60 overall]
-18-19: x 23               # data[12] = 35 [63 overall]
-19-20: x 27               # data[13] = 39 [67 overall]
-20-21: x 27               # data[14] = 39 [67 overall]
-21-22: x 2a               # data[15] = 42 [70 overall]
-22-23: x 2c               # data[16] = 44 [72 overall]
-23-24: x 31               # data[17] = 49 [77 overall]
-24-25: x 32               # data[18] = 50 [78 overall]
-25-26: x 39               # data[19] = 57 [85 overall]
-26-27: x 39               # data[20] = 57 [85 overall]
-27-28: x 39               # data[21] = 57 [85 overall]
+01-02: x 01               # encoding: 1b
+02-03: x 02               # data[0] = 2 [26 overall]
+03-04: x 07               # data[1] = 7 [31 overall]
+04-05: x 07               # data[2] = 7 [31 overall]
+05-06: x 08               # data[3] = 8 [32 overall]
+06-07: x 0d               # data[4] = 13 [37 overall]
+07-08: x 0f               # data[5] = 15 [39 overall]
+08-09: x 10               # data[6] = 16 [40 overall]
+09-10: x 18               # data[7] = 24 [48 overall]
+10-11: x 18               # data[8] = 24 [48 overall]
+11-12: x 18               # data[9] = 24 [48 overall]
+12-13: x 1c               # data[10] = 28 [52 overall]
+13-14: x 20               # data[11] = 32 [56 overall]
+14-15: x 23               # data[12] = 35 [59 overall]
+15-16: x 27               # data[13] = 39 [63 overall]
+16-17: x 27               # data[14] = 39 [63 overall]
+17-18: x 2a               # data[15] = 42 [66 overall]
+18-19: x 2c               # data[16] = 44 [68 overall]
+19-20: x 31               # data[17] = 49 [73 overall]
+20-21: x 32               # data[18] = 50 [74 overall]
+21-22: x 39               # data[19] = 57 [81 overall]
+22-23: x 39               # data[20] = 57 [81 overall]
+23-24: x 39               # data[21] = 57 [81 overall]
 # Data
-28-30: x 6161             # data[00]: aa (block prefix)
-30-35: x 6162626263       # data[01]: ..abbbc (bundle prefix)
-35-35: x                  # data[02]: .......
-35-36: x 63               # data[03]: .......c
-36-41: x 6162626263       # data[04]: ..abbbc (bundle prefix)
-41-43: x 6465             # data[05]: .......de
-43-44: x 65               # data[06]: .......e
-44-52: x 616262626465652a # data[07]: ..abbbdee* (bundle prefix)
-52-52: x                  # data[08]: ..........
-52-52: x                  # data[09]: ..........
-52-56: x 61626262         # data[10]: ..abbb (bundle prefix)
-56-60: x 6465652a         # data[11]: ......dee*
-60-63: x 656666           # data[12]: ......eff
-63-67: x 61626265         # data[13]: ..abbe (bundle prefix)
-67-67: x                  # data[14]: ......
-67-70: x 65662a           # data[15]: ......ef*
-70-72: x 6162             # data[16]: ..ab (bundle prefix)
-72-77: x 626565662a       # data[17]: ....beef*
-77-78: x 63               # data[18]: ....c
-78-85: x 6263636565662a   # data[19]: ..bcceef* (bundle prefix)
-85-85: x                  # data[20]: .........
-85-85: x                  # data[21]: .........
+24-26: x 6161             # data[00]: aa (block prefix)
+26-31: x 6162626263       # data[01]: ..abbbc (bundle prefix)
+31-31: x                  # data[02]: .......
+31-32: x 63               # data[03]: .......c
+32-37: x 6162626263       # data[04]: ..abbbc (bundle prefix)
+37-39: x 6465             # data[05]: .......de
+39-40: x 65               # data[06]: .......e
+40-48: x 616262626465652a # data[07]: ..abbbdee* (bundle prefix)
+48-48: x                  # data[08]: ..........
+48-48: x                  # data[09]: ..........
+48-52: x 61626262         # data[10]: ..abbb (bundle prefix)
+52-56: x 6465652a         # data[11]: ......dee*
+56-59: x 656666           # data[12]: ......eff
+59-63: x 61626265         # data[13]: ..abbe (bundle prefix)
+63-63: x                  # data[14]: ......
+63-66: x 65662a           # data[15]: ......ef*
+66-68: x 6162             # data[16]: ..ab (bundle prefix)
+68-73: x 626565662a       # data[17]: ....beef*
+73-74: x 63               # data[18]: ....c
+74-81: x 6263636565662a   # data[19]: ..bcceef* (bundle prefix)
+81-81: x                  # data[20]: .........
+81-81: x                  # data[21]: .........
 
 finish rows=15
 ----
 # PrefixBytes
 00-01: x 01               # bundleSize: 2
 # Offsets table
-01-02: x 02               # delta encoding: delta8
-02-06: x 00000000         # 32-bit constant: 0
-06-07: x 02               # data[0] = 2 [32 overall]
-07-08: x 07               # data[1] = 7 [37 overall]
-08-09: x 07               # data[2] = 7 [37 overall]
-09-10: x 08               # data[3] = 8 [38 overall]
-10-11: x 0d               # data[4] = 13 [43 overall]
-11-12: x 0f               # data[5] = 15 [45 overall]
-12-13: x 10               # data[6] = 16 [46 overall]
-13-14: x 18               # data[7] = 24 [54 overall]
-14-15: x 18               # data[8] = 24 [54 overall]
-15-16: x 18               # data[9] = 24 [54 overall]
-16-17: x 1c               # data[10] = 28 [58 overall]
-17-18: x 20               # data[11] = 32 [62 overall]
-18-19: x 23               # data[12] = 35 [65 overall]
-19-20: x 27               # data[13] = 39 [69 overall]
-20-21: x 27               # data[14] = 39 [69 overall]
-21-22: x 2a               # data[15] = 42 [72 overall]
-22-23: x 2c               # data[16] = 44 [74 overall]
-23-24: x 31               # data[17] = 49 [79 overall]
-24-25: x 32               # data[18] = 50 [80 overall]
-25-26: x 39               # data[19] = 57 [87 overall]
-26-27: x 39               # data[20] = 57 [87 overall]
-27-28: x 39               # data[21] = 57 [87 overall]
-28-29: x 40               # data[22] = 64 [94 overall]
-29-30: x 40               # data[23] = 64 [94 overall]
+01-02: x 01               # encoding: 1b
+02-03: x 02               # data[0] = 2 [28 overall]
+03-04: x 07               # data[1] = 7 [33 overall]
+04-05: x 07               # data[2] = 7 [33 overall]
+05-06: x 08               # data[3] = 8 [34 overall]
+06-07: x 0d               # data[4] = 13 [39 overall]
+07-08: x 0f               # data[5] = 15 [41 overall]
+08-09: x 10               # data[6] = 16 [42 overall]
+09-10: x 18               # data[7] = 24 [50 overall]
+10-11: x 18               # data[8] = 24 [50 overall]
+11-12: x 18               # data[9] = 24 [50 overall]
+12-13: x 1c               # data[10] = 28 [54 overall]
+13-14: x 20               # data[11] = 32 [58 overall]
+14-15: x 23               # data[12] = 35 [61 overall]
+15-16: x 27               # data[13] = 39 [65 overall]
+16-17: x 27               # data[14] = 39 [65 overall]
+17-18: x 2a               # data[15] = 42 [68 overall]
+18-19: x 2c               # data[16] = 44 [70 overall]
+19-20: x 31               # data[17] = 49 [75 overall]
+20-21: x 32               # data[18] = 50 [76 overall]
+21-22: x 39               # data[19] = 57 [83 overall]
+22-23: x 39               # data[20] = 57 [83 overall]
+23-24: x 39               # data[21] = 57 [83 overall]
+24-25: x 40               # data[22] = 64 [90 overall]
+25-26: x 40               # data[23] = 64 [90 overall]
 # Data
-30-32: x 6161             # data[00]: aa (block prefix)
-32-37: x 6162626263       # data[01]: ..abbbc (bundle prefix)
-37-37: x                  # data[02]: .......
-37-38: x 63               # data[03]: .......c
-38-43: x 6162626263       # data[04]: ..abbbc (bundle prefix)
-43-45: x 6465             # data[05]: .......de
-45-46: x 65               # data[06]: .......e
-46-54: x 616262626465652a # data[07]: ..abbbdee* (bundle prefix)
-54-54: x                  # data[08]: ..........
-54-54: x                  # data[09]: ..........
-54-58: x 61626262         # data[10]: ..abbb (bundle prefix)
-58-62: x 6465652a         # data[11]: ......dee*
-62-65: x 656666           # data[12]: ......eff
-65-69: x 61626265         # data[13]: ..abbe (bundle prefix)
-69-69: x                  # data[14]: ......
-69-72: x 65662a           # data[15]: ......ef*
-72-74: x 6162             # data[16]: ..ab (bundle prefix)
-74-79: x 626565662a       # data[17]: ....beef*
-79-80: x 63               # data[18]: ....c
-80-87: x 6263636565662a   # data[19]: ..bcceef* (bundle prefix)
-87-87: x                  # data[20]: .........
-87-87: x                  # data[21]: .........
-87-94: x 6263636565662a   # data[22]: ..bcceef* (bundle prefix)
-94-94: x                  # data[23]: .........
+26-28: x 6161             # data[00]: aa (block prefix)
+28-33: x 6162626263       # data[01]: ..abbbc (bundle prefix)
+33-33: x                  # data[02]: .......
+33-34: x 63               # data[03]: .......c
+34-39: x 6162626263       # data[04]: ..abbbc (bundle prefix)
+39-41: x 6465             # data[05]: .......de
+41-42: x 65               # data[06]: .......e
+42-50: x 616262626465652a # data[07]: ..abbbdee* (bundle prefix)
+50-50: x                  # data[08]: ..........
+50-50: x                  # data[09]: ..........
+50-54: x 61626262         # data[10]: ..abbb (bundle prefix)
+54-58: x 6465652a         # data[11]: ......dee*
+58-61: x 656666           # data[12]: ......eff
+61-65: x 61626265         # data[13]: ..abbe (bundle prefix)
+65-65: x                  # data[14]: ......
+65-68: x 65662a           # data[15]: ......ef*
+68-70: x 6162             # data[16]: ..ab (bundle prefix)
+70-75: x 626565662a       # data[17]: ....beef*
+75-76: x 63               # data[18]: ....c
+76-83: x 6263636565662a   # data[19]: ..bcceef* (bundle prefix)
+83-83: x                  # data[20]: .........
+83-83: x                  # data[21]: .........
+83-90: x 6263636565662a   # data[22]: ..bcceef* (bundle prefix)
+90-90: x                  # data[23]: .........
 
 get indices=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
 ----
@@ -697,7 +690,7 @@ abce
 abcf
 abg
 ----
-Size: 21
+Size: 17
 nKeys=4; bundleSize=4
 blockPrefixLen=2; currentBundleLen=15; currentBundleKeys=4
 Offsets:
@@ -708,21 +701,20 @@ abcdabceabcfabg
 finish rows=3
 ----
 # PrefixBytes
-00-01: x 02       # bundleSize: 4
+00-01: x 02     # bundleSize: 4
 # Offsets table
-01-02: x 02       # delta encoding: delta8
-02-06: x 00000000 # 32-bit constant: 0
-06-07: x 03       # data[0] = 3 [14 overall]
-07-08: x 03       # data[1] = 3 [14 overall]
-08-09: x 04       # data[2] = 4 [15 overall]
-09-10: x 05       # data[3] = 5 [16 overall]
-10-11: x 06       # data[4] = 6 [17 overall]
+01-02: x 01     # encoding: 1b
+02-03: x 03     # data[0] = 3 [10 overall]
+03-04: x 03     # data[1] = 3 [10 overall]
+04-05: x 04     # data[2] = 4 [11 overall]
+05-06: x 05     # data[3] = 5 [12 overall]
+06-07: x 06     # data[4] = 6 [13 overall]
 # Data
-11-14: x 616263   # data[00]: abc (block prefix)
-14-14: x          # data[01]: ... (bundle prefix)
-14-15: x 64       # data[02]: ...d
-15-16: x 65       # data[03]: ...e
-16-17: x 66       # data[04]: ...f
+07-10: x 616263 # data[00]: abc (block prefix)
+10-10: x        # data[01]: ... (bundle prefix)
+10-11: x 64     # data[02]: ...d
+11-12: x 65     # data[03]: ...e
+12-13: x 66     # data[04]: ...f
 
 # Try finishing without the last key which forces a shorter bundle prefix only.
 
@@ -736,7 +728,7 @@ abae
 abbf
 abc
 ----
-Size: 21
+Size: 17
 nKeys=4; bundleSize=2
 blockPrefixLen=2; currentBundleLen=7; currentBundleKeys=2
 Offsets:
@@ -747,23 +739,22 @@ abadabaeabbfabc
 finish rows=3
 ----
 # PrefixBytes
-00-01: x 01       # bundleSize: 2
+00-01: x 01   # bundleSize: 2
 # Offsets table
-01-02: x 02       # delta encoding: delta8
-02-06: x 00000000 # 32-bit constant: 0
-06-07: x 02       # data[0] = 2 [14 overall]
-07-08: x 03       # data[1] = 3 [15 overall]
-08-09: x 04       # data[2] = 4 [16 overall]
-09-10: x 05       # data[3] = 5 [17 overall]
-10-11: x 07       # data[4] = 7 [19 overall]
-11-12: x 07       # data[5] = 7 [19 overall]
+01-02: x 01   # encoding: 1b
+02-03: x 02   # data[0] = 2 [10 overall]
+03-04: x 03   # data[1] = 3 [11 overall]
+04-05: x 04   # data[2] = 4 [12 overall]
+05-06: x 05   # data[3] = 5 [13 overall]
+06-07: x 07   # data[4] = 7 [15 overall]
+07-08: x 07   # data[5] = 7 [15 overall]
 # Data
-12-14: x 6162     # data[00]: ab (block prefix)
-14-15: x 61       # data[01]: ..a (bundle prefix)
-15-16: x 64       # data[02]: ...d
-16-17: x 65       # data[03]: ...e
-17-19: x 6266     # data[04]: ..bf (bundle prefix)
-19-19: x          # data[05]: ....
+08-10: x 6162 # data[00]: ab (block prefix)
+10-11: x 61   # data[01]: ..a (bundle prefix)
+11-12: x 64   # data[02]: ...d
+12-13: x 65   # data[03]: ...e
+13-15: x 6266 # data[04]: ..bf (bundle prefix)
+15-15: x      # data[05]: ....
 
 # Test strings long enough to force 16-bit offsets, and have zero-length block
 # and bundle prefixes.
@@ -780,7 +771,7 @@ dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ----
-Size: 686
+Size: 682
 nKeys=6; bundleSize=2
 blockPrefixLen=0; currentBundleLen=220; currentBundleKeys=2
 Offsets:
@@ -803,59 +794,58 @@ finish rows=6
 # PrefixBytes
 000-001: x 01                                       # bundleSize: 2
 # Offsets table
-001-002: x 03                                       # delta encoding: delta16
-002-006: x 00000000                                 # 32-bit constant: 0
-006-008: x 0000                                     # data[0] = 0 [26 overall]
-008-010: x 0000                                     # data[1] = 0 [26 overall]
-010-012: x 6e00                                     # data[2] = 110 [136 overall]
-012-014: x dc00                                     # data[3] = 220 [246 overall]
-014-016: x dc00                                     # data[4] = 220 [246 overall]
-016-018: x 4a01                                     # data[5] = 330 [356 overall]
-018-020: x b801                                     # data[6] = 440 [466 overall]
-020-022: x b801                                     # data[7] = 440 [466 overall]
-022-024: x 2602                                     # data[8] = 550 [576 overall]
-024-026: x 9402                                     # data[9] = 660 [686 overall]
+001-002: x 02                                       # encoding: 2b
+002-004: x 0000                                     # data[0] = 0 [22 overall]
+004-006: x 0000                                     # data[1] = 0 [22 overall]
+006-008: x 6e00                                     # data[2] = 110 [132 overall]
+008-010: x dc00                                     # data[3] = 220 [242 overall]
+010-012: x dc00                                     # data[4] = 220 [242 overall]
+012-014: x 4a01                                     # data[5] = 330 [352 overall]
+014-016: x b801                                     # data[6] = 440 [462 overall]
+016-018: x b801                                     # data[7] = 440 [462 overall]
+018-020: x 2602                                     # data[8] = 550 [572 overall]
+020-022: x 9402                                     # data[9] = 660 [682 overall]
 # Data
-026-026: x                                          # data[00]:  (block prefix)
-026-026: x                                          # data[01]:  (bundle prefix)
-026-046: x 6161616161616161616161616161616161616161 # data[02]: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-046-066: x 6161616161616161616161616161616161616161 # (continued...)
-066-086: x 6161616161616161616161616161616161616161 # (continued...)
-086-106: x 6161616161616161616161616161616161616161 # (continued...)
-106-126: x 6161616161616161616161616161616161616161 # (continued...)
-126-136: x 61616161616161616161                     # (continued...)
-136-156: x 6262626262626262626262626262626262626262 # data[03]: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-156-176: x 6262626262626262626262626262626262626262 # (continued...)
-176-196: x 6262626262626262626262626262626262626262 # (continued...)
-196-216: x 6262626262626262626262626262626262626262 # (continued...)
-216-236: x 6262626262626262626262626262626262626262 # (continued...)
-236-246: x 62626262626262626262                     # (continued...)
-246-246: x                                          # data[04]:  (bundle prefix)
-246-266: x 6363636363636363636363636363636363636363 # data[05]: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-266-286: x 6363636363636363636363636363636363636363 # (continued...)
-286-306: x 6363636363636363636363636363636363636363 # (continued...)
-306-326: x 6363636363636363636363636363636363636363 # (continued...)
-326-346: x 6363636363636363636363636363636363636363 # (continued...)
-346-356: x 63636363636363636363                     # (continued...)
-356-376: x 6464646464646464646464646464646464646464 # data[06]: dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
-376-396: x 6464646464646464646464646464646464646464 # (continued...)
-396-416: x 6464646464646464646464646464646464646464 # (continued...)
-416-436: x 6464646464646464646464646464646464646464 # (continued...)
-436-456: x 6464646464646464646464646464646464646464 # (continued...)
-456-466: x 64646464646464646464                     # (continued...)
-466-466: x                                          # data[07]:  (bundle prefix)
-466-486: x 6565656565656565656565656565656565656565 # data[08]: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-486-506: x 6565656565656565656565656565656565656565 # (continued...)
-506-526: x 6565656565656565656565656565656565656565 # (continued...)
-526-546: x 6565656565656565656565656565656565656565 # (continued...)
-546-566: x 6565656565656565656565656565656565656565 # (continued...)
-566-576: x 65656565656565656565                     # (continued...)
-576-596: x 6666666666666666666666666666666666666666 # data[09]: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-596-616: x 6666666666666666666666666666666666666666 # (continued...)
-616-636: x 6666666666666666666666666666666666666666 # (continued...)
-636-656: x 6666666666666666666666666666666666666666 # (continued...)
-656-676: x 6666666666666666666666666666666666666666 # (continued...)
-676-686: x 66666666666666666666                     # (continued...)
+022-022: x                                          # data[00]:  (block prefix)
+022-022: x                                          # data[01]:  (bundle prefix)
+022-042: x 6161616161616161616161616161616161616161 # data[02]: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+042-062: x 6161616161616161616161616161616161616161 # (continued...)
+062-082: x 6161616161616161616161616161616161616161 # (continued...)
+082-102: x 6161616161616161616161616161616161616161 # (continued...)
+102-122: x 6161616161616161616161616161616161616161 # (continued...)
+122-132: x 61616161616161616161                     # (continued...)
+132-152: x 6262626262626262626262626262626262626262 # data[03]: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+152-172: x 6262626262626262626262626262626262626262 # (continued...)
+172-192: x 6262626262626262626262626262626262626262 # (continued...)
+192-212: x 6262626262626262626262626262626262626262 # (continued...)
+212-232: x 6262626262626262626262626262626262626262 # (continued...)
+232-242: x 62626262626262626262                     # (continued...)
+242-242: x                                          # data[04]:  (bundle prefix)
+242-262: x 6363636363636363636363636363636363636363 # data[05]: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+262-282: x 6363636363636363636363636363636363636363 # (continued...)
+282-302: x 6363636363636363636363636363636363636363 # (continued...)
+302-322: x 6363636363636363636363636363636363636363 # (continued...)
+322-342: x 6363636363636363636363636363636363636363 # (continued...)
+342-352: x 63636363636363636363                     # (continued...)
+352-372: x 6464646464646464646464646464646464646464 # data[06]: dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+372-392: x 6464646464646464646464646464646464646464 # (continued...)
+392-412: x 6464646464646464646464646464646464646464 # (continued...)
+412-432: x 6464646464646464646464646464646464646464 # (continued...)
+432-452: x 6464646464646464646464646464646464646464 # (continued...)
+452-462: x 64646464646464646464                     # (continued...)
+462-462: x                                          # data[07]:  (bundle prefix)
+462-482: x 6565656565656565656565656565656565656565 # data[08]: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+482-502: x 6565656565656565656565656565656565656565 # (continued...)
+502-522: x 6565656565656565656565656565656565656565 # (continued...)
+522-542: x 6565656565656565656565656565656565656565 # (continued...)
+542-562: x 6565656565656565656565656565656565656565 # (continued...)
+562-572: x 65656565656565656565                     # (continued...)
+572-592: x 6666666666666666666666666666666666666666 # data[09]: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+592-612: x 6666666666666666666666666666666666666666 # (continued...)
+612-632: x 6666666666666666666666666666666666666666 # (continued...)
+632-652: x 6666666666666666666666666666666666666666 # (continued...)
+652-672: x 6666666666666666666666666666666666666666 # (continued...)
+672-682: x 66666666666666666666                     # (continued...)
 
 get indices=(0, 1, 2, 3, 4, 5)
 ----
@@ -878,7 +868,7 @@ aaaab
 aaaac
 aaaad
 ----
-Size: 20
+Size: 16
 nKeys=4; bundleSize=4
 blockPrefixLen=4; currentBundleLen=20; currentBundleKeys=4
 Offsets:
@@ -890,7 +880,7 @@ put
 aaaae
 aab
 ----
-Size: 27
+Size: 23
 nKeys=6; bundleSize=4
 blockPrefixLen=2; currentBundleLen=8; currentBundleKeys=2
 Offsets:
@@ -903,22 +893,21 @@ finish rows=5
 # PrefixBytes
 00-01: x 02       # bundleSize: 4
 # Offsets table
-01-02: x 02       # delta encoding: delta8
-02-06: x 00000000 # 32-bit constant: 0
-06-07: x 04       # data[0] = 4 [18 overall]
-07-08: x 04       # data[1] = 4 [18 overall]
-08-09: x 05       # data[2] = 5 [19 overall]
-09-10: x 06       # data[3] = 6 [20 overall]
-10-11: x 07       # data[4] = 7 [21 overall]
-11-12: x 08       # data[5] = 8 [22 overall]
-12-13: x 09       # data[6] = 9 [23 overall]
-13-14: x 09       # data[7] = 9 [23 overall]
+01-02: x 01       # encoding: 1b
+02-03: x 04       # data[0] = 4 [14 overall]
+03-04: x 04       # data[1] = 4 [14 overall]
+04-05: x 05       # data[2] = 5 [15 overall]
+05-06: x 06       # data[3] = 6 [16 overall]
+06-07: x 07       # data[4] = 7 [17 overall]
+07-08: x 08       # data[5] = 8 [18 overall]
+08-09: x 09       # data[6] = 9 [19 overall]
+09-10: x 09       # data[7] = 9 [19 overall]
 # Data
-14-18: x 61616161 # data[00]: aaaa (block prefix)
-18-18: x          # data[01]: .... (bundle prefix)
-18-19: x 61       # data[02]: ....a
-19-20: x 62       # data[03]: ....b
-20-21: x 63       # data[04]: ....c
-21-22: x 64       # data[05]: ....d
-22-23: x 65       # data[06]: ....e (bundle prefix)
-23-23: x          # data[07]: .....
+10-14: x 61616161 # data[00]: aaaa (block prefix)
+14-14: x          # data[01]: .... (bundle prefix)
+14-15: x 61       # data[02]: ....a
+15-16: x 62       # data[03]: ....b
+16-17: x 63       # data[04]: ....c
+17-18: x 64       # data[05]: ....d
+18-19: x 65       # data[06]: ....e (bundle prefix)
+19-19: x          # data[07]: .....

--- a/sstable/colblk/testdata/raw_bytes
+++ b/sstable/colblk/testdata/raw_bytes
@@ -5,53 +5,49 @@ a
 ----
 # rawbytes
 # offsets table
-0-1: x 02       # delta encoding: delta8
-1-5: x 00000000 # 32-bit constant: 0
-5-6: x 00       # data[0] = 0 [7 overall]
-6-7: x 01       # data[1] = 1 [8 overall]
+0-1: x 01 # encoding: 1b
+1-2: x 00 # data[0] = 0 [3 overall]
+2-3: x 01 # data[1] = 1 [4 overall]
 # data
-7-8: x 61       # data[0]: a
+3-4: x 61 # data[0]: a
 
 # Try the same thing, but with offsets 1, 2, 3, 4.
 
 build offset=1
 a
 ----
-0-1: x 00       # start offset
+0-1: x 00 # start offset
 # rawbytes
 # offsets table
-1-2: x 02       # delta encoding: delta8
-2-6: x 00000000 # 32-bit constant: 0
-6-7: x 00       # data[0] = 0 [8 overall]
-7-8: x 01       # data[1] = 1 [9 overall]
+1-2: x 01 # encoding: 1b
+2-3: x 00 # data[0] = 0 [4 overall]
+3-4: x 01 # data[1] = 1 [5 overall]
 # data
-8-9: x 61       # data[0]: a
+4-5: x 61 # data[0]: a
 
 build offset=2
 a
 ----
-00-02: x 0000     # start offset
+0-2: x 0000 # start offset
 # rawbytes
 # offsets table
-02-03: x 02       # delta encoding: delta8
-03-07: x 00000000 # 32-bit constant: 0
-07-08: x 00       # data[0] = 0 [9 overall]
-08-09: x 01       # data[1] = 1 [10 overall]
+2-3: x 01   # encoding: 1b
+3-4: x 00   # data[0] = 0 [5 overall]
+4-5: x 01   # data[1] = 1 [6 overall]
 # data
-09-10: x 61       # data[0]: a
+5-6: x 61   # data[0]: a
 
 build offset=3
 a
 ----
-00-03: x 000000   # start offset
+0-3: x 000000 # start offset
 # rawbytes
 # offsets table
-03-04: x 02       # delta encoding: delta8
-04-08: x 00000000 # 32-bit constant: 0
-08-09: x 00       # data[0] = 0 [10 overall]
-09-10: x 01       # data[1] = 1 [11 overall]
+3-4: x 01     # encoding: 1b
+4-5: x 00     # data[0] = 0 [6 overall]
+5-6: x 01     # data[1] = 1 [7 overall]
 # data
-10-11: x 61       # data[0]: a
+6-7: x 61     # data[0]: a
 
 build offset=4
 a
@@ -59,12 +55,11 @@ a
 00-04: x 00000000 # start offset
 # rawbytes
 # offsets table
-04-05: x 02       # delta encoding: delta8
-05-09: x 00000000 # 32-bit constant: 0
-09-10: x 00       # data[0] = 0 [11 overall]
-10-11: x 01       # data[1] = 1 [12 overall]
+04-05: x 01       # encoding: 1b
+05-06: x 00       # data[0] = 0 [7 overall]
+06-07: x 01       # data[1] = 1 [8 overall]
 # data
-11-12: x 61       # data[0]: a
+07-08: x 61       # data[0]: a
 
 # Create a RawBytes with two byte slices: 'a' and 'b'.
 
@@ -74,14 +69,13 @@ b
 ----
 # rawbytes
 # offsets table
-0-1: x 02       # delta encoding: delta8
-1-5: x 00000000 # 32-bit constant: 0
-5-6: x 00       # data[0] = 0 [8 overall]
-6-7: x 01       # data[1] = 1 [9 overall]
-7-8: x 02       # data[2] = 2 [10 overall]
+0-1: x 01 # encoding: 1b
+1-2: x 00 # data[0] = 0 [4 overall]
+2-3: x 01 # data[1] = 1 [5 overall]
+3-4: x 02 # data[2] = 2 [6 overall]
 # data
-8-9: x 61       # data[0]: a
-9-10: x 62      # data[1]: b
+4-5: x 61 # data[0]: a
+5-6: x 62 # data[1]: b
 
 build offset=0
 a
@@ -90,28 +84,26 @@ abc
 ----
 # rawbytes
 # offsets table
-00-01: x 02       # delta encoding: delta8
-01-05: x 00000000 # 32-bit constant: 0
-05-06: x 00       # data[0] = 0 [9 overall]
-06-07: x 01       # data[1] = 1 [10 overall]
-07-08: x 03       # data[2] = 3 [12 overall]
-08-09: x 06       # data[3] = 6 [15 overall]
+00-01: x 01     # encoding: 1b
+01-02: x 00     # data[0] = 0 [5 overall]
+02-03: x 01     # data[1] = 1 [6 overall]
+03-04: x 03     # data[2] = 3 [8 overall]
+04-05: x 06     # data[3] = 6 [11 overall]
 # data
-09-10: x 61       # data[0]: a
-10-12: x 6162     # data[1]: ab
-12-15: x 616263   # data[2]: abc
+05-06: x 61     # data[0]: a
+06-08: x 6162   # data[1]: ab
+08-11: x 616263 # data[2]: abc
 
 build offset=0
 aaabbbc
 ----
 # rawbytes
 # offsets table
-00-01: x 02             # delta encoding: delta8
-01-05: x 00000000       # 32-bit constant: 0
-05-06: x 00             # data[0] = 0 [7 overall]
-06-07: x 07             # data[1] = 7 [14 overall]
+0-1: x 01              # encoding: 1b
+1-2: x 00              # data[0] = 0 [3 overall]
+2-3: x 07              # data[1] = 7 [10 overall]
 # data
-07-14: x 61616162626263 # data[0]: aaabbbc
+3-10: x 61616162626263 # data[0]: aaabbbc
 
 build offset=0
 a
@@ -120,16 +112,15 @@ abc
 ----
 # rawbytes
 # offsets table
-00-01: x 02       # delta encoding: delta8
-01-05: x 00000000 # 32-bit constant: 0
-05-06: x 00       # data[0] = 0 [9 overall]
-06-07: x 01       # data[1] = 1 [10 overall]
-07-08: x 03       # data[2] = 3 [12 overall]
-08-09: x 06       # data[3] = 6 [15 overall]
+00-01: x 01     # encoding: 1b
+01-02: x 00     # data[0] = 0 [5 overall]
+02-03: x 01     # data[1] = 1 [6 overall]
+03-04: x 03     # data[2] = 3 [8 overall]
+04-05: x 06     # data[3] = 6 [11 overall]
 # data
-09-10: x 61       # data[0]: a
-10-12: x 6162     # data[1]: ab
-12-15: x 616263   # data[2]: abc
+05-06: x 61     # data[0]: a
+06-08: x 6162   # data[1]: ab
+08-11: x 616263 # data[2]: abc
 
 at indices=(0, 1, 2)
 ----
@@ -150,28 +141,27 @@ kale
 ----
 # rawbytes
 # offsets table
-00-01: x 02                 # delta encoding: delta8
-01-05: x 00000000           # 32-bit constant: 0
-05-06: x 00                 # data[0] = 0 [15 overall]
-06-07: x 03                 # data[1] = 3 [18 overall]
-07-08: x 09                 # data[2] = 9 [24 overall]
-08-09: x 11                 # data[3] = 17 [32 overall]
-09-10: x 16                 # data[4] = 22 [37 overall]
-10-11: x 1b                 # data[5] = 27 [42 overall]
-11-12: x 21                 # data[6] = 33 [48 overall]
-12-13: x 2a                 # data[7] = 42 [57 overall]
-13-14: x 31                 # data[8] = 49 [64 overall]
-14-15: x 35                 # data[9] = 53 [68 overall]
+00-01: x 01                 # encoding: 1b
+01-02: x 00                 # data[0] = 0 [11 overall]
+02-03: x 03                 # data[1] = 3 [14 overall]
+03-04: x 09                 # data[2] = 9 [20 overall]
+04-05: x 11                 # data[3] = 17 [28 overall]
+05-06: x 16                 # data[4] = 22 [33 overall]
+06-07: x 1b                 # data[5] = 27 [38 overall]
+07-08: x 21                 # data[6] = 33 [44 overall]
+08-09: x 2a                 # data[7] = 42 [53 overall]
+09-10: x 31                 # data[8] = 49 [60 overall]
+10-11: x 35                 # data[9] = 53 [64 overall]
 # data
-15-18: x 636174             # data[0]: cat
-18-24: x 6f72616e6765       # data[1]: orange
-24-32: x 7a75636368696e69   # data[2]: zucchini
-32-37: x 6c656d6f6e         # data[3]: lemon
-37-42: x 6170706c65         # data[4]: apple
-42-48: x 62616e616e61       # data[5]: banana
-48-57: x 63616e74656c6f7065 # data[6]: cantelope
-57-64: x 6c657474756365     # data[7]: lettuce
-64-68: x 6b616c65           # data[8]: kale
+11-14: x 636174             # data[0]: cat
+14-20: x 6f72616e6765       # data[1]: orange
+20-28: x 7a75636368696e69   # data[2]: zucchini
+28-33: x 6c656d6f6e         # data[3]: lemon
+33-38: x 6170706c65         # data[4]: apple
+38-44: x 62616e616e61       # data[5]: banana
+44-53: x 63616e74656c6f7065 # data[6]: cantelope
+53-60: x 6c657474756365     # data[7]: lettuce
+60-64: x 6b616c65           # data[8]: kale
 
 at indices=(0, 1, 2, 3, 4, 5, 6, 7, 8)
 ----
@@ -200,18 +190,17 @@ kale
 ----
 # rawbytes
 # offsets table
-00-01: x 02               # delta encoding: delta8
-01-05: x 00000000         # 32-bit constant: 0
-05-06: x 00               # data[0] = 0 [10 overall]
-06-07: x 03               # data[1] = 3 [13 overall]
-07-08: x 09               # data[2] = 9 [19 overall]
-08-09: x 11               # data[3] = 17 [27 overall]
-09-10: x 16               # data[4] = 22 [32 overall]
+00-01: x 01               # encoding: 1b
+01-02: x 00               # data[0] = 0 [6 overall]
+02-03: x 03               # data[1] = 3 [9 overall]
+03-04: x 09               # data[2] = 9 [15 overall]
+04-05: x 11               # data[3] = 17 [23 overall]
+05-06: x 16               # data[4] = 22 [28 overall]
 # data
-10-13: x 636174           # data[0]: cat
-13-19: x 6f72616e6765     # data[1]: orange
-19-27: x 7a75636368696e69 # data[2]: zucchini
-27-32: x 6c656d6f6e       # data[3]: lemon
+06-09: x 636174           # data[0]: cat
+09-15: x 6f72616e6765     # data[1]: orange
+15-23: x 7a75636368696e69 # data[2]: zucchini
+23-28: x 6c656d6f6e       # data[3]: lemon
 
 at indices=(0, 1, 2, 3)
 ----

--- a/sstable/colblk/testdata/uints
+++ b/sstable/colblk/testdata/uints
@@ -6,29 +6,23 @@
 
 # Test a default-zero builder that only contains zeros.
 
-init widths=(32) default-zero
+init default-zero
 ----
-b32
 
 size rows=(100)
 ----
-b32:
-  32: *colblk.UintBuilder[uint32].Size(100, 0) = 5
+Size(100, 0) = 1
 
-finish widths=(32) rows=100
+finish rows=100
 ----
-b32: *colblk.UintBuilder[uint32]:
-0-1: x 01       # delta encoding: const
-1-5: x 00000000 # 32-bit constant: 0
+0-1: x 00 # encoding: zero
 
-# Initialize all four writers.
-
-init widths=(8, 16, 32, 64)
+finish rows=10
 ----
-b8
-b16
-b32
-b64
+0-1: x 00 # encoding: zero
+
+init
+----
 
 # Write a few zero values at index [0,4].
 
@@ -41,38 +35,20 @@ write
 
 size rows=(5, 4, 3, 2, 1, 0)
 ----
-b8:
-  8: *colblk.UintBuilder[uint8].Size(5, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(4, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(3, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(2, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(1, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(0, 0) = 0
-b16:
-  16: *colblk.UintBuilder[uint16].Size(5, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(4, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(3, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(2, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(1, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(0, 0) = 0
-b32:
-  32: *colblk.UintBuilder[uint32].Size(5, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(4, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(3, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(2, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(1, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(0, 0) = 0
-b64:
-  64: *colblk.UintBuilder[uint64].Size(5, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(4, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(3, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(2, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(1, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(0, 0) = 0
+Size(5, 0) = 1
+Size(4, 0) = 1
+Size(3, 0) = 1
+Size(2, 0) = 1
+Size(1, 0) = 1
+Size(0, 0) = 0
 
 # Add a nonzero value. Size calls that include the new row count should
 # increase, but the size calls that don't include the new row count should not.
 # The increased sizes should reflect use of a uint8 delta encoding.
+
+finish rows=8
+----
+0-1: x 00 # encoding: zero
 
 write
 5:10
@@ -82,52 +58,20 @@ write
 
 size rows=(8, 7, 6, 5, 4, 3, 2, 1, 0)
 ----
-b8:
-  8: *colblk.UintBuilder[uint8].Size(8, 0) = 9
-  8: *colblk.UintBuilder[uint8].Size(7, 0) = 8
-  8: *colblk.UintBuilder[uint8].Size(6, 0) = 7
-  8: *colblk.UintBuilder[uint8].Size(5, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(4, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(3, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(2, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(1, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(0, 0) = 0
-b16:
-  16: *colblk.UintBuilder[uint16].Size(8, 0) = 11
-  16: *colblk.UintBuilder[uint16].Size(7, 0) = 10
-  16: *colblk.UintBuilder[uint16].Size(6, 0) = 9
-  16: *colblk.UintBuilder[uint16].Size(5, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(4, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(3, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(2, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(1, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(0, 0) = 0
-b32:
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-  32: *colblk.UintBuilder[uint32].Size(7, 0) = 12
-  32: *colblk.UintBuilder[uint32].Size(6, 0) = 11
-  32: *colblk.UintBuilder[uint32].Size(5, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(4, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(3, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(2, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(1, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(0, 0) = 0
-b64:
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
-  64: *colblk.UintBuilder[uint64].Size(7, 0) = 16
-  64: *colblk.UintBuilder[uint64].Size(6, 0) = 15
-  64: *colblk.UintBuilder[uint64].Size(5, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(4, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(3, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(2, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(1, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(0, 0) = 0
+Size(8, 0) = 9
+Size(7, 0) = 8
+Size(6, 0) = 7
+Size(5, 0) = 1
+Size(4, 0) = 1
+Size(3, 0) = 1
+Size(2, 0) = 1
+Size(1, 0) = 1
+Size(0, 0) = 0
 
-# Finish the b8 so we can test 16-bit encoding.
-finish widths=(8) rows=8
+# Check width=8 encoding.
+finish rows=8
 ----
-b8: *colblk.UintBuilder[uint8]:
-0-1: x 00 # delta encoding: none
+0-1: x 01 # encoding: 1b
 1-2: x 00 # data[0] = 0
 2-3: x 00 # data[1] = 0
 3-4: x 00 # data[2] = 0
@@ -136,11 +80,8 @@ b8: *colblk.UintBuilder[uint8]:
 6-7: x 0a # data[5] = 10
 7-8: x 00 # data[6] = 0
 8-9: x 0a # data[7] = 10
-Keeping b16 open
-Keeping b32 open
-Keeping b64 open
 
-# Add 1000 which should force a 16-bit delta encoding.
+# Add 1000 which should force a 16-bit encoding.
 
 write
 8:1000
@@ -148,52 +89,24 @@ write
 
 size rows=(9, 8)
 ----
-b16:
-  16: *colblk.UintBuilder[uint16].Size(9, 0) = 20
-  16: *colblk.UintBuilder[uint16].Size(8, 0) = 11
-b32:
-  32: *colblk.UintBuilder[uint32].Size(9, 0) = 24
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-b64:
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(9, 0) = 20
+Size(8, 0) = 9
 
 size rows=(9, 8) offset=1
 ----
-b16:
-  16: *colblk.UintBuilder[uint16].Size(9, 1) = 20 [19 w/o offset]
-  16: *colblk.UintBuilder[uint16].Size(8, 1) = 12 [11 w/o offset]
-b32:
-  32: *colblk.UintBuilder[uint32].Size(9, 1) = 24 [23 w/o offset]
-  32: *colblk.UintBuilder[uint32].Size(8, 1) = 14 [13 w/o offset]
-b64:
-  64: *colblk.UintBuilder[uint64].Size(9, 1) = 28 [27 w/o offset]
-  64: *colblk.UintBuilder[uint64].Size(8, 1) = 18 [17 w/o offset]
+Size(9, 1) = 20 [19 w/o offset]
+Size(8, 1) = 10 [9 w/o offset]
 
 size rows=(9, 8) offset=2
 ----
-b16:
-  16: *colblk.UintBuilder[uint16].Size(9, 2) = 22 [20 w/o offset]
-  16: *colblk.UintBuilder[uint16].Size(8, 2) = 13 [11 w/o offset]
-b32:
-  32: *colblk.UintBuilder[uint32].Size(9, 2) = 26 [24 w/o offset]
-  32: *colblk.UintBuilder[uint32].Size(8, 2) = 15 [13 w/o offset]
-b64:
-  64: *colblk.UintBuilder[uint64].Size(9, 2) = 30 [28 w/o offset]
-  64: *colblk.UintBuilder[uint64].Size(8, 2) = 19 [17 w/o offset]
+Size(9, 2) = 22 [20 w/o offset]
+Size(8, 2) = 11 [9 w/o offset]
 
 
 size rows=(9, 8) offset=5
 ----
-b16:
-  16: *colblk.UintBuilder[uint16].Size(9, 5) = 24 [19 w/o offset]
-  16: *colblk.UintBuilder[uint16].Size(8, 5) = 16 [11 w/o offset]
-b32:
-  32: *colblk.UintBuilder[uint32].Size(9, 5) = 28 [23 w/o offset]
-  32: *colblk.UintBuilder[uint32].Size(8, 5) = 18 [13 w/o offset]
-b64:
-  64: *colblk.UintBuilder[uint64].Size(9, 5) = 32 [27 w/o offset]
-  64: *colblk.UintBuilder[uint64].Size(8, 5) = 22 [17 w/o offset]
+Size(9, 5) = 24 [19 w/o offset]
+Size(8, 5) = 14 [9 w/o offset]
 
 # We should be able to write up to 2^16-1 without triggering a 32-bit encoding.
 
@@ -203,28 +116,14 @@ write
 
 size rows=(10, 9, 8)
 ----
-b16:
-  16: *colblk.UintBuilder[uint16].Size(10, 0) = 22
-  16: *colblk.UintBuilder[uint16].Size(9, 0) = 20
-  16: *colblk.UintBuilder[uint16].Size(8, 0) = 11
-b32:
-  32: *colblk.UintBuilder[uint32].Size(10, 0) = 26
-  32: *colblk.UintBuilder[uint32].Size(9, 0) = 24
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-b64:
-  64: *colblk.UintBuilder[uint64].Size(10, 0) = 30
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(10, 0) = 22
+Size(9, 0) = 20
+Size(8, 0) = 9
 
-# But 2^16 should trigger a 32-bit encoding. (Finish b16 so we can test 32-bit
-# encoding.)
-
-finish widths=(16) rows=10
+finish rows=10
 ----
-b16: *colblk.UintBuilder[uint16]:
-00-01: x 00   # delta encoding: none
-# padding
-01-02: x 00   # aligning to 16-bit boundary
+00-01: x 02   # encoding: 2b
+01-02: x 00   # padding (aligning to 16-bit boundary)
 02-04: x 0000 # data[0] = 0
 04-06: x 0000 # data[1] = 0
 06-08: x 0000 # data[2] = 0
@@ -235,25 +134,19 @@ b16: *colblk.UintBuilder[uint16]:
 16-18: x 0a00 # data[7] = 10
 18-20: x e803 # data[8] = 1000
 20-22: x ffff # data[9] = 65535
-Keeping b32 open
-Keeping b64 open
 
+# 2^16 should trigger a 32-bit encoding.
+#
 write
 10:65536
 ----
 
 size rows=(11, 10, 9, 8)
 ----
-b32:
-  32: *colblk.UintBuilder[uint32].Size(11, 0) = 48
-  32: *colblk.UintBuilder[uint32].Size(10, 0) = 26
-  32: *colblk.UintBuilder[uint32].Size(9, 0) = 24
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-b64:
-  64: *colblk.UintBuilder[uint64].Size(11, 0) = 56
-  64: *colblk.UintBuilder[uint64].Size(10, 0) = 30
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(11, 0) = 48
+Size(10, 0) = 22
+Size(9, 0) = 20
+Size(8, 0) = 9
 
 # We should be able to write up to 2^32-1 without triggering a 64-bit encoding.
 
@@ -263,27 +156,16 @@ write
 
 size rows=(12, 11, 10, 9, 8)
 ----
-b32:
-  32: *colblk.UintBuilder[uint32].Size(12, 0) = 52
-  32: *colblk.UintBuilder[uint32].Size(11, 0) = 48
-  32: *colblk.UintBuilder[uint32].Size(10, 0) = 26
-  32: *colblk.UintBuilder[uint32].Size(9, 0) = 24
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-b64:
-  64: *colblk.UintBuilder[uint64].Size(12, 0) = 60
-  64: *colblk.UintBuilder[uint64].Size(11, 0) = 56
-  64: *colblk.UintBuilder[uint64].Size(10, 0) = 30
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(12, 0) = 52
+Size(11, 0) = 48
+Size(10, 0) = 22
+Size(9, 0) = 20
+Size(8, 0) = 9
 
-# But 2^32 should trigger a 64-bit encoding.
-
-finish widths=(32) rows=12
+finish rows=12
 ----
-b32: *colblk.UintBuilder[uint32]:
-00-01: x 00       # delta encoding: none
-# padding
-01-04: x 000000   # aligning to 32-bit boundary
+00-01: x 04       # encoding: 4b
+01-04: x 000000   # padding (aligning to 32-bit boundary)
 04-08: x 00000000 # data[0] = 0
 08-12: x 00000000 # data[1] = 0
 12-16: x 00000000 # data[2] = 0
@@ -296,28 +178,26 @@ b32: *colblk.UintBuilder[uint32]:
 40-44: x ffff0000 # data[9] = 65535
 44-48: x 00000100 # data[10] = 65536
 48-52: x ffffffff # data[11] = 4294967295
-Keeping b64 open
 
+# 2^32 should trigger a 64-bit encoding.
+#
 write
 12:4294967296
 ----
 
 size rows=(13, 12, 11, 10, 9, 8)
 ----
-b64:
-  64: *colblk.UintBuilder[uint64].Size(13, 0) = 112
-  64: *colblk.UintBuilder[uint64].Size(12, 0) = 60
-  64: *colblk.UintBuilder[uint64].Size(11, 0) = 56
-  64: *colblk.UintBuilder[uint64].Size(10, 0) = 30
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(13, 0) = 112
+Size(12, 0) = 52
+Size(11, 0) = 48
+Size(10, 0) = 22
+Size(9, 0) = 20
+Size(8, 0) = 9
 
-finish widths=(64) rows=13
+finish rows=13
 ----
-b64: *colblk.UintBuilder[uint64]:
-000-001: x 00               # delta encoding: none
-# padding
-001-008: x 00000000000000   # aligning to 64-bit boundary
+000-001: x 08               # encoding: 8b
+001-008: x 00000000000000   # padding (aligning to 64-bit boundary)
 008-016: x 0000000000000000 # data[0] = 0
 016-024: x 0000000000000000 # data[1] = 0
 024-032: x 0000000000000000 # data[2] = 0
@@ -335,46 +215,20 @@ b64: *colblk.UintBuilder[uint64]:
 # Repeat the above tests but with a zero default value, and without explicitly
 # setting any of the zero values.
 
-init widths=(8, 16, 32, 64) default-zero
+init default-zero
 ----
-b8
-b16
-b32
-b64
 
 # At all row counts, the column should be encoded as a constant using the column
 # type width.
 
 size rows=(5, 4, 3, 2, 1, 0)
 ----
-b8:
-  8: *colblk.UintBuilder[uint8].Size(5, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(4, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(3, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(2, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(1, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(0, 0) = 0
-b16:
-  16: *colblk.UintBuilder[uint16].Size(5, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(4, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(3, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(2, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(1, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(0, 0) = 0
-b32:
-  32: *colblk.UintBuilder[uint32].Size(5, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(4, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(3, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(2, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(1, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(0, 0) = 0
-b64:
-  64: *colblk.UintBuilder[uint64].Size(5, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(4, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(3, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(2, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(1, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(0, 0) = 0
+Size(5, 0) = 1
+Size(4, 0) = 1
+Size(3, 0) = 1
+Size(2, 0) = 1
+Size(1, 0) = 1
+Size(0, 0) = 0
 
 # Add a couple nonzero values. Size calls that include the new row count should
 # increase, but the size calls that don't include the new row count should not.
@@ -386,52 +240,20 @@ write
 
 size rows=(8, 7, 6, 5, 4, 3, 2, 1, 0)
 ----
-b8:
-  8: *colblk.UintBuilder[uint8].Size(8, 0) = 9
-  8: *colblk.UintBuilder[uint8].Size(7, 0) = 8
-  8: *colblk.UintBuilder[uint8].Size(6, 0) = 7
-  8: *colblk.UintBuilder[uint8].Size(5, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(4, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(3, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(2, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(1, 0) = 2
-  8: *colblk.UintBuilder[uint8].Size(0, 0) = 0
-b16:
-  16: *colblk.UintBuilder[uint16].Size(8, 0) = 11
-  16: *colblk.UintBuilder[uint16].Size(7, 0) = 10
-  16: *colblk.UintBuilder[uint16].Size(6, 0) = 9
-  16: *colblk.UintBuilder[uint16].Size(5, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(4, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(3, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(2, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(1, 0) = 3
-  16: *colblk.UintBuilder[uint16].Size(0, 0) = 0
-b32:
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-  32: *colblk.UintBuilder[uint32].Size(7, 0) = 12
-  32: *colblk.UintBuilder[uint32].Size(6, 0) = 11
-  32: *colblk.UintBuilder[uint32].Size(5, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(4, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(3, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(2, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(1, 0) = 5
-  32: *colblk.UintBuilder[uint32].Size(0, 0) = 0
-b64:
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
-  64: *colblk.UintBuilder[uint64].Size(7, 0) = 16
-  64: *colblk.UintBuilder[uint64].Size(6, 0) = 15
-  64: *colblk.UintBuilder[uint64].Size(5, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(4, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(3, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(2, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(1, 0) = 9
-  64: *colblk.UintBuilder[uint64].Size(0, 0) = 0
+Size(8, 0) = 9
+Size(7, 0) = 8
+Size(6, 0) = 7
+Size(5, 0) = 1
+Size(4, 0) = 1
+Size(3, 0) = 1
+Size(2, 0) = 1
+Size(1, 0) = 1
+Size(0, 0) = 0
 
 # Finish the b8 so we can test 16-bit encoding.
-finish widths=(8) rows=8
+finish rows=8
 ----
-b8: *colblk.UintBuilder[uint8]:
-0-1: x 00 # delta encoding: none
+0-1: x 01 # encoding: 1b
 1-2: x 00 # data[0] = 0
 2-3: x 00 # data[1] = 0
 3-4: x 00 # data[2] = 0
@@ -440,9 +262,6 @@ b8: *colblk.UintBuilder[uint8]:
 6-7: x 0a # data[5] = 10
 7-8: x 00 # data[6] = 0
 8-9: x 0a # data[7] = 10
-Keeping b16 open
-Keeping b32 open
-Keeping b64 open
 
 # Add 1000 which should force a 16-bit delta encoding.
 
@@ -452,15 +271,8 @@ write
 
 size rows=(9, 8)
 ----
-b16:
-  16: *colblk.UintBuilder[uint16].Size(9, 0) = 20
-  16: *colblk.UintBuilder[uint16].Size(8, 0) = 11
-b32:
-  32: *colblk.UintBuilder[uint32].Size(9, 0) = 24
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-b64:
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(9, 0) = 20
+Size(8, 0) = 9
 
 # We should be able to write up to 2^16-1 without triggering a 32-bit encoding.
 
@@ -470,28 +282,14 @@ write
 
 size rows=(10, 9, 8)
 ----
-b16:
-  16: *colblk.UintBuilder[uint16].Size(10, 0) = 22
-  16: *colblk.UintBuilder[uint16].Size(9, 0) = 20
-  16: *colblk.UintBuilder[uint16].Size(8, 0) = 11
-b32:
-  32: *colblk.UintBuilder[uint32].Size(10, 0) = 26
-  32: *colblk.UintBuilder[uint32].Size(9, 0) = 24
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-b64:
-  64: *colblk.UintBuilder[uint64].Size(10, 0) = 30
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(10, 0) = 22
+Size(9, 0) = 20
+Size(8, 0) = 9
 
-# But 2^16 should trigger a 32-bit encoding. (Finish b16 so we can test 32-bit
-# encoding.)
-
-finish widths=(16) rows=10
+finish rows=10
 ----
-b16: *colblk.UintBuilder[uint16]:
-00-01: x 00   # delta encoding: none
-# padding
-01-02: x 00   # aligning to 16-bit boundary
+00-01: x 02   # encoding: 2b
+01-02: x 00   # padding (aligning to 16-bit boundary)
 02-04: x 0000 # data[0] = 0
 04-06: x 0000 # data[1] = 0
 06-08: x 0000 # data[2] = 0
@@ -502,8 +300,8 @@ b16: *colblk.UintBuilder[uint16]:
 16-18: x 0a00 # data[7] = 10
 18-20: x e803 # data[8] = 1000
 20-22: x ffff # data[9] = 65535
-Keeping b32 open
-Keeping b64 open
+
+# 2^16 should trigger a 32-bit encoding.
 
 write
 10:65536
@@ -511,16 +309,10 @@ write
 
 size rows=(11, 10, 9, 8)
 ----
-b32:
-  32: *colblk.UintBuilder[uint32].Size(11, 0) = 48
-  32: *colblk.UintBuilder[uint32].Size(10, 0) = 26
-  32: *colblk.UintBuilder[uint32].Size(9, 0) = 24
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-b64:
-  64: *colblk.UintBuilder[uint64].Size(11, 0) = 56
-  64: *colblk.UintBuilder[uint64].Size(10, 0) = 30
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(11, 0) = 48
+Size(10, 0) = 22
+Size(9, 0) = 20
+Size(8, 0) = 9
 
 # We should be able to write up to 2^32-1 without triggering a 64-bit encoding.
 
@@ -530,27 +322,16 @@ write
 
 size rows=(12, 11, 10, 9, 8)
 ----
-b32:
-  32: *colblk.UintBuilder[uint32].Size(12, 0) = 52
-  32: *colblk.UintBuilder[uint32].Size(11, 0) = 48
-  32: *colblk.UintBuilder[uint32].Size(10, 0) = 26
-  32: *colblk.UintBuilder[uint32].Size(9, 0) = 24
-  32: *colblk.UintBuilder[uint32].Size(8, 0) = 13
-b64:
-  64: *colblk.UintBuilder[uint64].Size(12, 0) = 60
-  64: *colblk.UintBuilder[uint64].Size(11, 0) = 56
-  64: *colblk.UintBuilder[uint64].Size(10, 0) = 30
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(12, 0) = 52
+Size(11, 0) = 48
+Size(10, 0) = 22
+Size(9, 0) = 20
+Size(8, 0) = 9
 
-# But 2^32 should trigger a 64-bit encoding.
-
-finish widths=(32) rows=12
+finish rows=12
 ----
-b32: *colblk.UintBuilder[uint32]:
-00-01: x 00       # delta encoding: none
-# padding
-01-04: x 000000   # aligning to 32-bit boundary
+00-01: x 04       # encoding: 4b
+01-04: x 000000   # padding (aligning to 32-bit boundary)
 04-08: x 00000000 # data[0] = 0
 08-12: x 00000000 # data[1] = 0
 12-16: x 00000000 # data[2] = 0
@@ -563,7 +344,8 @@ b32: *colblk.UintBuilder[uint32]:
 40-44: x ffff0000 # data[9] = 65535
 44-48: x 00000100 # data[10] = 65536
 48-52: x ffffffff # data[11] = 4294967295
-Keeping b64 open
+
+# 2^32 should trigger a 64-bit encoding.
 
 write
 12:4294967296
@@ -571,20 +353,17 @@ write
 
 size rows=(13, 12, 11, 10, 9, 8)
 ----
-b64:
-  64: *colblk.UintBuilder[uint64].Size(13, 0) = 112
-  64: *colblk.UintBuilder[uint64].Size(12, 0) = 60
-  64: *colblk.UintBuilder[uint64].Size(11, 0) = 56
-  64: *colblk.UintBuilder[uint64].Size(10, 0) = 30
-  64: *colblk.UintBuilder[uint64].Size(9, 0) = 28
-  64: *colblk.UintBuilder[uint64].Size(8, 0) = 17
+Size(13, 0) = 112
+Size(12, 0) = 52
+Size(11, 0) = 48
+Size(10, 0) = 22
+Size(9, 0) = 20
+Size(8, 0) = 9
 
-finish widths=(64) rows=13
+finish rows=13
 ----
-b64: *colblk.UintBuilder[uint64]:
-000-001: x 00               # delta encoding: none
-# padding
-001-008: x 00000000000000   # aligning to 64-bit boundary
+000-001: x 08               # encoding: 8b
+001-008: x 00000000000000   # padding (aligning to 64-bit boundary)
 008-016: x 0000000000000000 # data[0] = 0
 016-024: x 0000000000000000 # data[1] = 0
 024-032: x 0000000000000000 # data[2] = 0
@@ -601,12 +380,8 @@ b64: *colblk.UintBuilder[uint64]:
 
 # Test serializing a few columns using delta encoding.
 
-init widths=(8, 16, 32, 64) default-zero
+init default-zero
 ----
-b8
-b16
-b32
-b64
 
 write
 0:1 2:92 3:1 7:86 20:221
@@ -614,56 +389,23 @@ write
 
 size rows=5
 ----
-b8:
-  8: *colblk.UintBuilder[uint8].Size(5, 0) = 6
-b16:
-  16: *colblk.UintBuilder[uint16].Size(5, 0) = 8
-b32:
-  32: *colblk.UintBuilder[uint32].Size(5, 0) = 10
-b64:
-  64: *colblk.UintBuilder[uint64].Size(5, 0) = 14
+Size(5, 0) = 6
 
-finish widths=(8,16,32,64) rows=5
+finish rows=5
 ----
-b8: *colblk.UintBuilder[uint8]:
-0-1: x 00 # delta encoding: none
+0-1: x 01 # encoding: 1b
 1-2: x 01 # data[0] = 1
 2-3: x 00 # data[1] = 0
 3-4: x 5c # data[2] = 92
 4-5: x 01 # data[3] = 1
 5-6: x 00 # data[4] = 0
-b16: *colblk.UintBuilder[uint16]:
-0-1: x 02   # delta encoding: delta8
-1-3: x 0000 # 16-bit constant: 0
-3-4: x 01   # data[0] = 1
-4-5: x 00   # data[1] = 0
-5-6: x 5c   # data[2] = 92
-6-7: x 01   # data[3] = 1
-7-8: x 00   # data[4] = 0
-b32: *colblk.UintBuilder[uint32]:
-0-1: x 02       # delta encoding: delta8
-1-5: x 00000000 # 32-bit constant: 0
-5-6: x 01       # data[0] = 1
-6-7: x 00       # data[1] = 0
-7-8: x 5c       # data[2] = 92
-8-9: x 01       # data[3] = 1
-9-10: x 00      # data[4] = 0
-b64: *colblk.UintBuilder[uint64]:
-00-01: x 02               # delta encoding: delta8
-01-09: x 0000000000000000 # 64-bit constant: 0
-09-10: x 01               # data[0] = 1
-10-11: x 00               # data[1] = 0
-11-12: x 5c               # data[2] = 92
-12-13: x 01               # data[3] = 1
-13-14: x 00               # data[4] = 0
 
 # Test a situation where the most recently written value requirs a wider delta
 # encoding, but we Finish with few enough rows that we should serialize using
 # the smaller encoding.
 
-init widths=(64)
+init
 ----
-b64
 
 write
 0:0 1:29 2:595 3:2 4:2 5:9
@@ -671,8 +413,7 @@ write
 
 size rows=(6)
 ----
-b64:
-  64: *colblk.UintBuilder[uint64].Size(6, 0) = 22
+Size(6, 0) = 14
 
 write
 6:70395
@@ -680,28 +421,35 @@ write
 
 size rows=(7)
 ----
-b64:
-  64: *colblk.UintBuilder[uint64].Size(7, 0) = 40
+Size(7, 0) = 32
 
-finish widths=(64) rows=6
+finish rows=6
 ----
-b64: *colblk.UintBuilder[uint64]:
-00-01: x 03               # delta encoding: delta16
-01-09: x 0000000000000000 # 64-bit constant: 0
-# padding
-09-10: x 00               # aligning to 16-bit boundary
-10-12: x 0000             # data[0] = 0
-12-14: x 1d00             # data[1] = 29
-14-16: x 5302             # data[2] = 595
-16-18: x 0200             # data[3] = 2
-18-20: x 0200             # data[4] = 2
-20-22: x 0900             # data[5] = 9
+00-01: x 02   # encoding: 2b
+01-02: x 00   # padding (aligning to 16-bit boundary)
+02-04: x 0000 # data[0] = 0
+04-06: x 1d00 # data[1] = 29
+06-08: x 5302 # data[2] = 595
+08-10: x 0200 # data[3] = 2
+10-12: x 0200 # data[4] = 2
+12-14: x 0900 # data[5] = 9
 
-# Test the constant encoded.
-
-init widths=(64)
+finish rows=7
 ----
-b64
+00-01: x 04       # encoding: 4b
+01-04: x 000000   # padding (aligning to 32-bit boundary)
+04-08: x 00000000 # data[0] = 0
+08-12: x 1d000000 # data[1] = 29
+12-16: x 53020000 # data[2] = 595
+16-20: x 02000000 # data[3] = 2
+20-24: x 02000000 # data[4] = 2
+24-28: x 09000000 # data[5] = 9
+28-32: x fb120100 # data[6] = 70395
+
+# Test the constant encoding.
+
+init
+----
 
 write
 0:1 1:1 2:1 3:1 4:1 5:1
@@ -709,38 +457,32 @@ write
 
 size rows=(6)
 ----
-b64:
-  64: *colblk.UintBuilder[uint64].Size(6, 0) = 9
+Size(6, 0) = 9
 
-finish widths=(64) rows=6
+finish rows=6
 ----
-b64: *colblk.UintBuilder[uint64]:
-0-1: x 01               # delta encoding: const
+0-1: x 80               # encoding: const
 1-9: x 0100000000000000 # 64-bit constant: 1
 
 # Test 32-bit delta encoding.
 
-init widths=(64)
+init
 ----
-b64
 
 write
-0:1 1:63936 2:2957252
+0:1 1:63936 2:4294967296
 ----
 
 size rows=(3) offset=1
 ----
-b64:
-  64: *colblk.UintBuilder[uint64].Size(3, 1) = 24 [23 w/o offset]
+Size(3, 1) = 24 [23 w/o offset]
 
-finish widths=(64) rows=3 offset=1
+finish rows=3 offset=1
 ----
-b64: *colblk.UintBuilder[uint64]:
 00-01: x 00               # artificial start offset
-01-02: x 04               # delta encoding: delta32
+01-02: x 84               # encoding: 4b,delta
 02-10: x 0100000000000000 # 64-bit constant: 1
-# padding
-10-12: x 0000             # aligning to 32-bit boundary
+10-12: x 0000             # padding (aligning to 32-bit boundary)
 12-16: x 00000000         # data[0] = 0 + 1 = 1
 16-20: x bff90000         # data[1] = 63935 + 1 = 63936
-20-24: x c31f2d00         # data[2] = 2957251 + 1 = 2957252
+20-24: x ffffffff         # data[2] = 4294967295 + 1 = 4294967296

--- a/sstable/colblk/uints_test.go
+++ b/sstable/colblk/uints_test.go
@@ -16,43 +16,24 @@ import (
 	"github.com/cockroachdb/pebble/internal/binfmt"
 )
 
-func TestUints(t *testing.T) {
-	var b8 UintBuilder[uint8]
-	var b16 UintBuilder[uint16]
-	var b32 UintBuilder[uint32]
-	var b64 UintBuilder[uint64]
+func TestUintEncoding(t *testing.T) {
+	for _, r := range interestingIntRanges {
+		actual := DetermineUintEncoding(r.Min, r.Max)
+		if actual != r.ExpectedEncoding {
+			t.Errorf("%d/%d expected %s, but got %s", r.Min, r.Max, r.ExpectedEncoding, actual)
+		}
+	}
+}
 
-	var out bytes.Buffer
-	var widths []int
-	var writers []ColumnWriter
+func TestUints(t *testing.T) {
+	var b UintBuilder
+
 	datadriven.RunTest(t, "testdata/uints", func(t *testing.T, td *datadriven.TestData) string {
-		out.Reset()
 		switch td.Cmd {
 		case "init":
-			widths = widths[:0]
-			writers = writers[:0]
-			td.ScanArgs(t, "widths", &widths)
 			defaultZero := td.HasArg("default-zero")
-			for _, w := range widths {
-				switch w {
-				case 8:
-					b8.init(defaultZero)
-					writers = append(writers, &b8)
-				case 16:
-					b16.init(defaultZero)
-					writers = append(writers, &b16)
-				case 32:
-					b32.init(defaultZero)
-					writers = append(writers, &b32)
-				case 64:
-					b64.init(defaultZero)
-					writers = append(writers, &b64)
-				default:
-					panic(fmt.Sprintf("unknown width: %d", w))
-				}
-				fmt.Fprintf(&out, "b%d\n", w)
-			}
-			return out.String()
+			b.init(defaultZero)
+			return ""
 		case "write":
 			for _, f := range strings.Fields(td.Input) {
 				delim := strings.IndexByte(f, ':')
@@ -60,77 +41,43 @@ func TestUints(t *testing.T) {
 				if err != nil {
 					return err.Error()
 				}
-				for _, width := range widths {
-					v, err := strconv.ParseUint(f[delim+1:], 10, width)
-					if err != nil {
-						return err.Error()
-					}
-					switch width {
-					case 8:
-						b8.Set(i, uint8(v))
-					case 16:
-						b16.Set(i, uint16(v))
-					case 32:
-						b32.Set(i, uint32(v))
-					case 64:
-						b64.Set(i, v)
-					default:
-						panic(fmt.Sprintf("unknown width: %d", width))
-					}
+				v, err := strconv.ParseUint(f[delim+1:], 10, 64)
+				if err != nil {
+					return err.Error()
 				}
+				b.Set(i, v)
 			}
-			return out.String()
+			return ""
 		case "size":
 			var offset uint32
 			var rowCounts []int
 			td.ScanArgs(t, "rows", &rowCounts)
 			td.MaybeScanArgs(t, "offset", &offset)
-			for wIdx, w := range writers {
-				fmt.Fprintf(&out, "b%d:\n", widths[wIdx])
-				for _, rows := range rowCounts {
-					sz := w.Size(rows, offset)
-					if offset > 0 {
-						fmt.Fprintf(&out, "  %d: %T.Size(%d, %d) = %d [%d w/o offset]\n", widths[wIdx], w, rows, offset, sz, sz-offset)
-					} else {
-						fmt.Fprintf(&out, "  %d: %T.Size(%d, %d) = %d\n", widths[wIdx], w, rows, offset, sz)
-					}
+			var out bytes.Buffer
+			for _, rows := range rowCounts {
+				sz := b.Size(rows, offset)
+				if offset > 0 {
+					fmt.Fprintf(&out, "Size(%d, %d) = %d [%d w/o offset]\n", rows, offset, sz, sz-offset)
+				} else {
+					fmt.Fprintf(&out, "Size(%d, %d) = %d\n", rows, offset, sz)
 				}
 			}
 			return out.String()
 		case "finish":
 			var rows int
 			var offset uint32
-			var finishWidths []int
 			td.ScanArgs(t, "rows", &rows)
-			td.ScanArgs(t, "widths", &finishWidths)
 			td.MaybeScanArgs(t, "offset", &offset)
-			var newWriters []ColumnWriter
-			var newWidths []int
-			for wIdx, width := range widths {
-				var shouldFinish bool
-				for _, fw := range finishWidths {
-					shouldFinish = shouldFinish || width == fw
-				}
-				if shouldFinish {
-					sz := writers[wIdx].Size(rows, offset)
-					buf := aligned.ByteSlice(int(sz))
-					_ = writers[wIdx].Finish(0, rows, offset, buf)
-					fmt.Fprintf(&out, "b%d: %T:\n", width, writers[wIdx])
-					f := binfmt.New(buf).LineWidth(20)
-					if offset > 0 {
-						f.HexBytesln(int(offset), "artificial start offset")
-					}
-					uintsToBinFormatter(f, rows, writers[wIdx].DataType(0), nil)
-					fmt.Fprintf(&out, "%s", f.String())
-				} else {
-					fmt.Fprintf(&out, "Keeping b%d open\n", width)
-					newWidths = append(newWidths, width)
-					newWriters = append(newWriters, writers[wIdx])
-				}
+
+			sz := b.Size(rows, offset)
+			buf := aligned.ByteSlice(int(sz))
+			_ = b.Finish(0, rows, offset, buf)
+			f := binfmt.New(buf).LineWidth(20)
+			if offset > 0 {
+				f.HexBytesln(int(offset), "artificial start offset")
 			}
-			writers = newWriters
-			widths = newWidths
-			return out.String()
+			uintsToBinFormatter(f, rows, b.DataType(0), nil)
+			return f.String()
 		default:
 			panic(fmt.Sprintf("unknown command: %s", td.Cmd))
 		}

--- a/sstable/colblk/unsafe_slice.go
+++ b/sstable/colblk/unsafe_slice.go
@@ -5,6 +5,7 @@
 package colblk
 
 import (
+	"encoding/binary"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
@@ -40,99 +41,111 @@ func (s UnsafeRawSlice[T]) set(i int, v T) {
 	*(*T)(unsafe.Pointer(uintptr(s.ptr) + unsafe.Sizeof(T(0))*uintptr(i))) = v
 }
 
-// UnsafeUint8s is an UnsafeIntegerSlice of uint8s, possibly using delta
-// encoding internally.
-type UnsafeUint8s = UnsafeIntegerSlice[uint8]
-
-// UnsafeUint16s is an UnsafeIntegerSlice of uint16s, possibly using delta
-// encoding internally.
-type UnsafeUint16s = UnsafeIntegerSlice[uint16]
-
-// UnsafeUint32s is an UnsafeIntegerSlice of uint32s, possibly using delta
-// encoding internally.
-type UnsafeUint32s = UnsafeIntegerSlice[uint32]
-
-// UnsafeUint64s is an UnsafeIntegerSlice of uint64s, possibly using delta
-// encoding internally.
-type UnsafeUint64s = UnsafeIntegerSlice[uint64]
-
-// UnsafeIntegerSlice exposes a read-only slice of integers from a column. If
-// the column's values are delta-encoded, UnsafeIntegerSlice transparently
-// applies deltas.
+// UnsafeUints exposes a read-only view of integers from a column, transparently
+// decoding data based on the UintEncoding.
 //
 // See DeltaEncoding and UintBuilder.
-type UnsafeIntegerSlice[T constraints.Integer] struct {
-	base       T
-	deltaPtr   unsafe.Pointer
-	deltaWidth uintptr
+type UnsafeUints struct {
+	base  uint64
+	ptr   unsafe.Pointer
+	width uint8
 }
 
 // Assert that UnsafeIntegerSlice implements Array.
-var _ Array[uint8] = UnsafeIntegerSlice[uint8]{}
+var _ Array[uint64] = UnsafeUints{}
 
-// DecodeUnsafeIntegerSlice decodes the structure of a slice of uints from a
+// DecodeUnsafeUints decodes the structure of a slice of uints from a
 // byte slice.
-func DecodeUnsafeIntegerSlice[T constraints.Integer](
-	b []byte, off uint32, rows int,
-) (slice UnsafeIntegerSlice[T], endOffset uint32) {
-	delta := UintDeltaEncoding(b[off])
-	off++
-	switch delta {
-	case UintDeltaEncodingNone:
-		off = align(off, uint32(unsafe.Sizeof(T(0))))
-		slice = makeUnsafeIntegerSlice[T](0, unsafe.Pointer(&b[off]), int(unsafe.Sizeof(T(0))))
-		off += uint32(unsafe.Sizeof(T(0))) * uint32(rows)
-	case UintDeltaEncodingConstant:
-		base := readLittleEndianNonaligned[T](b, off)
-		off += uint32(unsafe.Sizeof(T(0)))
-		slice = makeUnsafeIntegerSlice[T](base, unsafe.Pointer(&b[off]), 0)
-	case UintDeltaEncoding8, UintDeltaEncoding16, UintDeltaEncoding32:
-		w := delta.width()
-		base := readLittleEndianNonaligned[T](b, off)
-		off += uint32(unsafe.Sizeof(T(0)))
-		off = align(off, uint32(w))
-		slice = makeUnsafeIntegerSlice[T](base, unsafe.Pointer(&b[off]), w)
-		off += uint32(rows) * uint32(w)
-	default:
-		panic("unreachable")
+func DecodeUnsafeUints(b []byte, off uint32, rows int) (_ UnsafeUints, endOffset uint32) {
+	encoding := UintEncoding(b[off])
+	if !encoding.IsValid() {
+		panic(errors.AssertionFailedf("invalid encoding 0x%x", b))
 	}
-	return slice, off
+	off++
+	var base uint64
+	if encoding.IsDelta() {
+		base = binary.LittleEndian.Uint64(b[off:])
+		off += 8
+	}
+	w := encoding.Width()
+	if w > 0 {
+		off = align(off, uint32(w))
+	}
+	return makeUnsafeUints(base, unsafe.Pointer(&b[off]), w), off + uint32(rows*w)
 }
 
 // Assert that DecodeUnsafeIntegerSlice implements DecodeFunc.
-var _ DecodeFunc[UnsafeUint8s] = DecodeUnsafeIntegerSlice[uint8]
+var _ DecodeFunc[UnsafeUints] = DecodeUnsafeUints
 
-func makeUnsafeIntegerSlice[T constraints.Integer](
-	base T, deltaPtr unsafe.Pointer, deltaWidth int,
-) UnsafeIntegerSlice[T] {
-	return UnsafeIntegerSlice[T]{
-		base:       base,
-		deltaPtr:   deltaPtr,
-		deltaWidth: uintptr(deltaWidth),
+func makeUnsafeUints(base uint64, ptr unsafe.Pointer, width int) UnsafeUints {
+	switch width {
+	case 0, 1, 2, 4, 8:
+	default:
+		panic("invalid width")
+	}
+	return UnsafeUints{
+		base:  base,
+		ptr:   ptr,
+		width: uint8(width),
 	}
 }
 
-// At returns the `i`-th element of the slice.
-func (s UnsafeIntegerSlice[T]) At(i int) T {
+// At returns the `i`-th element.
+func (s UnsafeUints) At(i int) uint64 {
 	// TODO(jackson): Experiment with other alternatives that might be faster
 	// and avoid switching on the width.
-	switch s.deltaWidth {
+	switch s.width {
 	case 0:
 		return s.base
 	case 1:
-		return s.base + T(*(*uint8)(unsafe.Pointer(uintptr(s.deltaPtr) + uintptr(i))))
+		return s.base + uint64(*(*uint8)(unsafe.Pointer(uintptr(s.ptr) + uintptr(i))))
 	case 2:
-		return s.base + T(*(*uint16)(unsafe.Pointer(uintptr(s.deltaPtr) + uintptr(i)<<align16Shift)))
+		return s.base + uint64(*(*uint16)(unsafe.Pointer(uintptr(s.ptr) + uintptr(i)<<align16Shift)))
 	case 4:
-		return s.base + T(*(*uint32)(unsafe.Pointer(uintptr(s.deltaPtr) + uintptr(i)<<align32Shift)))
-	case 8:
-		// NB: The slice encodes 64-bit integers, there is no base (it doesn't
-		// save any bits to compute a delta) and T must be a 64-bit integer. We
-		// cast directly into a *T pointer and don't add the base.
-		return (*(*T)(unsafe.Pointer(uintptr(s.deltaPtr) + uintptr(i)<<align64Shift)))
+		return s.base + uint64(*(*uint32)(unsafe.Pointer(uintptr(s.ptr) + uintptr(i)<<align32Shift)))
 	default:
-		panic("unreachable")
+		// NB: The slice encodes 64-bit integers, there is no base (it doesn't save
+		// any bits to compute a delta). We cast directly into a *uint64 pointer and
+		// don't add the base.
+		return *(*uint64)(unsafe.Pointer(uintptr(s.ptr) + uintptr(i)<<align64Shift))
 	}
+}
+
+// UnsafeOffsets is a specialization of UnsafeInts (providing the same
+// functionality) which is optimized when the integers are offsets inside a
+// column block. It can only be used with 0, 1, 2, or 4 byte encoding without
+// delta.
+type UnsafeOffsets struct {
+	ptr   unsafe.Pointer
+	width uint8
+}
+
+// DecodeUnsafeOffsets decodes the structure of a slice of offsets from a byte
+// slice.
+func DecodeUnsafeOffsets(b []byte, off uint32, rows int) (_ UnsafeOffsets, endOffset uint32) {
+	ints, endOffset := DecodeUnsafeUints(b, off, rows)
+	if ints.base != 0 || ints.width == 8 {
+		panic(errors.AssertionFailedf("unexpected offsets encoding (base=%d, width=%d)", ints.base, ints.width))
+	}
+	return UnsafeOffsets{
+		ptr:   ints.ptr,
+		width: ints.width,
+	}, endOffset
+}
+
+// At returns the `i`-th offset.
+func (s UnsafeOffsets) At(i int) uint32 {
+	// We expect offsets to be encoded as 16-bit integers in most cases.
+	if s.width == 2 {
+		return uint32(*(*uint16)(unsafe.Pointer(uintptr(s.ptr) + uintptr(i)<<align16Shift)))
+	}
+	if s.width <= 1 {
+		return uint32(*(*uint8)(unsafe.Pointer(uintptr(s.ptr) + uintptr(i))))
+	}
+	if s.width == 0 {
+		return 0
+	}
+	return *(*uint32)(unsafe.Pointer(uintptr(s.ptr) + uintptr(i)<<align32Shift))
 }
 
 // UnsafeBuf provides a buffer without bounds checking. Every buf has a len and

--- a/sstable/colblk/unsafe_slice_test.go
+++ b/sstable/colblk/unsafe_slice_test.go
@@ -15,38 +15,79 @@ import (
 	"golang.org/x/exp/rand"
 )
 
-func BenchmarkUnsafeIntegerSlice(b *testing.B) {
+func BenchmarkUnsafeUints(b *testing.B) {
 	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
-	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 8, math.MaxUint64)
-	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 4, math.MaxUint32)
-	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 2, math.MaxUint16)
-	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 1, math.MaxUint8)
-	benchmarkUnsafeIntegerSlice[uint64](b, rng, 1000, 0, 1)
-	benchmarkUnsafeIntegerSlice[uint32](b, rng, 1000, 4, math.MaxUint32)
-	benchmarkUnsafeIntegerSlice[uint32](b, rng, 1000, 2, math.MaxUint16)
-	benchmarkUnsafeIntegerSlice[uint32](b, rng, 1000, 1, math.MaxUint8)
-	benchmarkUnsafeIntegerSlice[uint32](b, rng, 1000, 0, 1)
-	benchmarkUnsafeIntegerSlice[uint16](b, rng, 1000, 2, math.MaxUint16)
-	benchmarkUnsafeIntegerSlice[uint16](b, rng, 1000, 1, math.MaxUint8)
-	benchmarkUnsafeIntegerSlice[uint16](b, rng, 1000, 0, 1)
-	benchmarkUnsafeIntegerSlice[uint8](b, rng, 1000, 1, math.MaxUint8)
-	benchmarkUnsafeIntegerSlice[uint8](b, rng, 1000, 0, 1)
+	intRanges := []intRange{
+		// const
+		{Min: 1, Max: 1, ExpectedEncoding: makeUintEncoding(0, true)},
+		// 1b
+		{Min: 10, Max: 200, ExpectedEncoding: makeUintEncoding(1, false)},
+		// 1b,delta
+		{Min: 100, Max: 300, ExpectedEncoding: makeUintEncoding(1, true)},
+		// 2b
+		{Min: 10, Max: 20_000, ExpectedEncoding: makeUintEncoding(2, false)},
+		// 2b,delta
+		{Min: 20_000, Max: 80_000, ExpectedEncoding: makeUintEncoding(2, true)},
+		// 4b
+		{Min: 0, Max: math.MaxUint32, ExpectedEncoding: makeUintEncoding(4, false)},
+		// 4b,delta
+		{Min: 100_000, Max: math.MaxUint32 + 10, ExpectedEncoding: makeUintEncoding(4, true)},
+		// 8b
+		{Min: 0, Max: math.MaxUint64, ExpectedEncoding: makeUintEncoding(8, false)},
+	}
+	for _, r := range intRanges {
+		benchmarkUnsafeUints(b, rng, 1000, r)
+	}
 }
 
-func benchmarkUnsafeIntegerSlice[U Uint](
-	b *testing.B, rng *rand.Rand, rows, expectedWidth int, max uint64,
-) {
-	b.Run(fmt.Sprintf("%T,delta%d", U(0), expectedWidth), func(b *testing.B) {
-		var ub UintBuilder[U]
-		ub.Init()
-		for i := 0; i < rows; i++ {
-			ub.Set(i, U(rng.Uint64n(max)))
-		}
+func encodeRandUints(rng *rand.Rand, rows int, intRange intRange) []byte {
+	var ub UintBuilder
+	ub.Init()
+	for i := 0; i < rows; i++ {
+		ub.Set(i, intRange.Rand(rng))
+	}
 
-		sz := ub.Size(rows, 0)
-		buf := aligned.ByteSlice(int(sz) + 1 /* trailing padding byte */)
-		_ = ub.Finish(0, rows, 0, buf)
-		s, _ := DecodeUnsafeIntegerSlice[U](buf, 0, rows)
+	sz := ub.Size(rows, 0)
+	buf := aligned.ByteSlice(int(sz) + 1 /* trailing padding byte */)
+	_ = ub.Finish(0, rows, 0, buf)
+	return buf
+}
+
+func benchmarkUnsafeUints(b *testing.B, rng *rand.Rand, rows int, intRange intRange) {
+	b.Run(intRange.ExpectedEncoding.String(), func(b *testing.B) {
+		buf := encodeRandUints(rng, rows, intRange)
+		s, _ := DecodeUnsafeUints(buf, 0, rows)
+		var reads [256]int
+		for i := range reads {
+			reads[i] = rng.Intn(rows)
+		}
+		b.ResetTimer()
+		var result uint8
+		for i := 0; i < b.N; i++ {
+			result ^= uint8(s.At(reads[i&255]))
+		}
+		b.StopTimer()
+		fmt.Fprint(io.Discard, result)
+	})
+}
+
+func BenchmarkUnsafeUintOffsets(b *testing.B) {
+	rng := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
+	intRanges := []intRange{
+		// 2b
+		{Min: 0, Max: math.MaxUint16, ExpectedEncoding: makeUintEncoding(2, false)},
+		// 4b
+		{Min: 0, Max: math.MaxUint32, ExpectedEncoding: makeUintEncoding(4, false)},
+	}
+	for _, r := range intRanges {
+		benchmarkUnsafeOffsets(b, rng, 1000, r)
+	}
+}
+
+func benchmarkUnsafeOffsets(b *testing.B, rng *rand.Rand, rows int, intRange intRange) {
+	b.Run(intRange.ExpectedEncoding.String(), func(b *testing.B) {
+		buf := encodeRandUints(rng, rows, intRange)
+		s, _ := DecodeUnsafeOffsets(buf, 0, rows)
 		var reads [256]int
 		for i := range reads {
 			reads[i] = rng.Intn(rows)


### PR DESCRIPTION
Currently we have four uint column types; each one can be encoded with
either 0,1,2,4,or 8 bytes per value. The encoding contains a delta
that has the same width as the column type. This leads to a lot of
possible combinations of data formats (each one requiring at least a
bit of specific code, even if generated through generics).

Given that the encoding supports smaller widths transparently, there
is no real advantage to declaring column types for smaller integers.
And there is a disadvantage - it will prevent us from using larger
integers in the future without changing the type.

This change replaces the four uint column types with a single type.
We also add a specialization of the decoding type which is optimized
for offsets.

Benchmarks:
```
name                     time/op
UnsafeUints/const-10     0.59ns ± 0%
UnsafeUints/1b-10        0.70ns ± 0%
UnsafeUints/1b,delta-10  0.70ns ± 1%
UnsafeUints/2b-10        0.74ns ± 0%
UnsafeUints/2b,delta-10  0.74ns ± 0%
UnsafeUints/4b-10        0.94ns ± 0%
UnsafeUints/4b,delta-10  0.94ns ± 0%
UnsafeUints/8b-10        1.25ns ± 0%
UnsafeOffsets/2b-10      0.51ns ± 0%
UnsafeOffsets/4b-10      0.94ns ± 0%
```