### PR TITLE
metamorphic: no synthetic suffix with overlapping RangeKeySets

### DIFF
--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1415,6 +1415,13 @@ func (g *generator) writerIngestExternalFiles() {
 				continue
 			}
 
+			// We can only use a synthetic suffix if we don't have overlapping range
+			// key sets (because they will become logically conflicting when we
+			// replace their suffixes with the synthetic one).
+			if g.keyManager.ExternalObjectHasOverlappingRangeKeySets(objs[i].externalObjID) {
+				continue
+			}
+
 			// Generate a suffix that sorts before any previously generated suffix.
 			objs[i].syntheticSuffix = g.keyGenerator.IncMaxSuffix()
 		}


### PR DESCRIPTION
Applying a synthetic suffix to overlapping `RangeKeySet`s leads to a logical ambiguity - they both have the same suffix but they can have different values. In practical terms it causes metamorphic test failures because their relative sorting order is indeterminate.

Add code in the metamorphic tests to keep track of `RangeKeySet`s and prevent the use of synthetic suffix when the external object has overlapping `RangeKeySet`s.

Fixes #3833
Fixes #3824