### PR TITLE
block: move block handle encoding and decoding

### DIFF
--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/stretchr/testify/require"
 )
@@ -913,7 +914,7 @@ func TestBlockProperties(t *testing.T) {
 					var i int
 					iter, _ := rowblk.NewIter(r.Compare, r.Split, indexH.Get(), NoTransforms)
 					for kv := iter.First(); kv != nil; kv = iter.Next() {
-						bh, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
+						bh, err := block.DecodeHandleWithProperties(kv.InPlaceValue())
 						if err != nil {
 							return err.Error()
 						}
@@ -1304,7 +1305,7 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 
 	for kv := i.First(); kv != nil; kv = i.Next() {
 		sb.WriteString(fmt.Sprintf("%s:\n", kv.K))
-		bhp, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
+		bhp, err := block.DecodeHandleWithProperties(kv.InPlaceValue())
 		if err != nil {
 			return err.Error()
 		}
@@ -1326,7 +1327,7 @@ func runBlockPropsCmd(r *Reader, td *datadriven.TestData) string {
 			}
 			for kv := subiter.First(); kv != nil; kv = subiter.Next() {
 				sb.WriteString(fmt.Sprintf("  %s:\n", kv.K))
-				dataBH, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
+				dataBH, err := block.DecodeHandleWithProperties(kv.InPlaceValue())
 				if err != nil {
 					return err.Error()
 				}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -240,7 +240,7 @@ var ErrEmptySpan = errors.New("cannot copy empty span")
 // decoded block handle value.
 type indexEntry struct {
 	sep InternalKey
-	bh  BlockHandleWithProperties
+	bh  block.HandleWithProperties
 }
 
 // intersectingIndexEntries returns the entries from the index with separator
@@ -262,7 +262,7 @@ func intersectingIndexEntries(
 	var alloc bytealloc.A
 	res := make([]indexEntry, 0, r.Properties.NumDataBlocks)
 	for kv := top.SeekGE(start.UserKey, base.SeekGEFlagsNone); kv != nil; kv = top.Next() {
-		bh, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
+		bh, err := block.DecodeHandleWithProperties(kv.InPlaceValue())
 		if err != nil {
 			return nil, err
 		}
@@ -285,7 +285,7 @@ func intersectingIndexEntries(
 			defer sub.Close() // in-loop, but it is a short loop.
 
 			for kv := sub.SeekGE(start.UserKey, base.SeekGEFlagsNone); kv != nil; kv = sub.Next() {
-				bh, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
+				bh, err := block.DecodeHandleWithProperties(kv.InPlaceValue())
 				if err != nil {
 					return nil, err
 				}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -434,7 +435,7 @@ func runIterCmd(
 				if twoLevelIter.topLevelIndex.Valid() {
 					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", twoLevelIter.topLevelIndex.Key())
 					v := twoLevelIter.topLevelIndex.Value()
-					bhp, err := decodeBlockHandleWithProperties(v.InPlaceValue())
+					bhp, err := block.DecodeHandleWithProperties(v.InPlaceValue())
 					if err != nil {
 						fmt.Fprintf(&b, "|  topLevelIndex.InPlaceValue() failed to decode as BHP: %s\n", err)
 					} else {
@@ -449,7 +450,7 @@ func runIterCmd(
 			if si.index.Valid() {
 				fmt.Fprintf(&b, "|  index.Key() = %q\n", si.index.Key())
 				v := si.index.Value()
-				bhp, err := decodeBlockHandleWithProperties(v.InPlaceValue())
+				bhp, err := block.DecodeHandleWithProperties(v.InPlaceValue())
 				if err != nil {
 					fmt.Fprintf(&b, "|  index.InPlaceValue() failed to decode as BHP: %s\n", err)
 				} else {

--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -4,11 +4,7 @@
 
 package sstable
 
-import (
-	"sync/atomic"
-
-	"github.com/cockroachdb/pebble/sstable/block"
-)
+import "sync/atomic"
 
 // FilterMetrics holds metrics for the filter policy.
 type FilterMetrics struct {
@@ -38,13 +34,6 @@ func (m *FilterMetricsTracker) Load() FilterMetrics {
 		Hits:   m.hits.Load(),
 		Misses: m.misses.Load(),
 	}
-}
-
-// BlockHandleWithProperties is used for data blocks and first/lower level
-// index blocks, since they can be annotated using BlockPropertyCollectors.
-type BlockHandleWithProperties struct {
-	block.Handle
-	Props []byte
 }
 
 type filterWriter interface {

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -28,7 +28,7 @@ type Layout struct {
 	// ValidateBlockChecksums, which validates a static list of BlockHandles
 	// referenced in this struct.
 
-	Data       []BlockHandleWithProperties
+	Data       []block.HandleWithProperties
 	Index      []block.Handle
 	TopIndex   block.Handle
 	Filter     block.Handle
@@ -222,7 +222,7 @@ func (l *Layout) Describe(
 		case "index", "top-index":
 			iter, _ := rowblk.NewIter(r.Compare, r.Split, h.Get(), NoTransforms)
 			iter.Describe(w, b.Offset, func(w io.Writer, key *base.InternalKey, value []byte, enc rowblk.KVEncoding) {
-				bh, err := decodeBlockHandleWithProperties(value)
+				bh, err := block.DecodeHandleWithProperties(value)
 				if err != nil {
 					fmt.Fprintf(w, "%10d    [err: %s]\n", b.Offset+uint64(enc.Offset), err)
 					return
@@ -256,7 +256,7 @@ func (l *Layout) Describe(
 						bh = vbih.h
 						isValueBlocksIndexHandle = true
 					} else {
-						bh, n = decodeBlockHandle(value)
+						bh, n = block.DecodeHandle(value)
 					}
 					if n == 0 || n != len(value) {
 						fmt.Fprintf(w, "%10d    [err: %s]\n", enc.Offset, err)
@@ -480,7 +480,7 @@ func (w *layoutWriter) clearFromCache(offset uint64) {
 }
 
 func (w *layoutWriter) recordToMetaindex(key string, h block.Handle) {
-	n := encodeBlockHandle(w.tmp[:], h)
+	n := h.EncodeVarints(w.tmp[:])
 	w.recordToMetaindexRaw(key, w.tmp[:n])
 }
 

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -473,7 +473,7 @@ func (i *singleLevelIterator[P, PD]) loadBlock(dir int8) loadBlockResult {
 	}
 	// Load the next block.
 	v := i.index.Value()
-	bhp, err := decodeBlockHandleWithProperties(v.InPlaceValue())
+	bhp, err := block.DecodeHandleWithProperties(v.InPlaceValue())
 	if i.dataBH == bhp.Handle && PD(&i.data).Valid() {
 		// We're already at the data block we want to load. Reset bounds in case
 		// they changed since the last seek, but don't reload the block from cache

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -51,7 +51,7 @@ func (i *twoLevelIterator[D, PD]) loadIndex(dir int8) loadBlockResult {
 		return loadBlockFailed
 	}
 	v := i.topLevelIndex.Value()
-	bhp, err := decodeBlockHandleWithProperties(v.InPlaceValue())
+	bhp, err := block.DecodeHandleWithProperties(v.InPlaceValue())
 	if err != nil {
 		i.secondLevel.err = base.CorruptionErrorf("pebble/table: corrupt top level index entry (%v)", err)
 		return loadBlockFailed

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -724,7 +724,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 	}()
 	require.NoError(t, err)
 	for kv := iter.First(); kv != nil; kv = iter.Next() {
-		bh, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
+		bh, err := block.DecodeHandleWithProperties(kv.InPlaceValue())
 		require.NoError(t, err)
 		fmt.Fprintf(&buf, " %s: size %d\n", string(kv.K.UserKey), bh.Length)
 		if twoLevelIndex {
@@ -737,7 +737,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 			}()
 			require.NoError(t, err)
 			for kv := iter2.First(); kv != nil; kv = iter2.Next() {
-				bh, err := decodeBlockHandleWithProperties(kv.InPlaceValue())
+				bh, err := block.DecodeHandleWithProperties(kv.InPlaceValue())
 				require.NoError(t, err)
 				fmt.Fprintf(&buf, "   %s: size %d\n", string(kv.K.UserKey), bh.Length)
 			}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -164,7 +164,7 @@ func rewriteBlocks[R blockRewriter](
 	rw R,
 	checksumType block.ChecksumType,
 	compression block.Compression,
-	input []BlockHandleWithProperties,
+	input []block.HandleWithProperties,
 	output []blockWithSpan,
 	totalWorkers, worker int,
 	from, to []byte,
@@ -206,7 +206,7 @@ func checkWriterFilterMatchesReader(r *Reader, w *RawWriter) error {
 }
 
 func rewriteDataBlocksToWriter(
-	r *Reader, w *RawWriter, data []BlockHandleWithProperties, from, to []byte, concurrency int,
+	r *Reader, w *RawWriter, data []block.HandleWithProperties, from, to []byte, concurrency int,
 ) error {
 	if r.Properties.NumEntries == 0 {
 		// No point keys.

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -296,7 +296,7 @@ const valueBlocksIndexHandleMaxLen = blockHandleMaxLenWithoutProperties + 3
 const _ = uint(blockHandleLikelyMaxLen - valueBlocksIndexHandleMaxLen)
 
 func encodeValueBlocksIndexHandle(dst []byte, v valueBlocksIndexHandle) int {
-	n := encodeBlockHandle(dst, v.h)
+	n := v.h.EncodeVarints(dst)
 	dst[n] = v.blockNumByteLength
 	n++
 	dst[n] = v.blockOffsetByteLength
@@ -309,7 +309,7 @@ func encodeValueBlocksIndexHandle(dst []byte, v valueBlocksIndexHandle) int {
 func decodeValueBlocksIndexHandle(src []byte) (valueBlocksIndexHandle, int, error) {
 	var vbih valueBlocksIndexHandle
 	var n int
-	vbih.h, n = decodeBlockHandle(src)
+	vbih.h, n = block.DecodeHandle(src)
 	if n <= 0 {
 		return vbih, 0, errors.Errorf("bad BlockHandle %x", src)
 	}

--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/block"
 )
 
 type writeTask struct {
@@ -59,12 +60,12 @@ func newWriteQueue(size int, writer *RawWriter) *writeQueue {
 }
 
 func (w *writeQueue) performWrite(task *writeTask) error {
-	var bhp BlockHandleWithProperties
+	var bhp block.HandleWithProperties
 	var err error
 	if bhp.Handle, err = w.writer.layout.WritePrecompressedDataBlock(task.buf.physical); err != nil {
 		return err
 	}
-	bhp = BlockHandleWithProperties{Handle: bhp.Handle, Props: task.buf.dataBlockProps}
+	bhp = block.HandleWithProperties{Handle: bhp.Handle, Props: task.buf.dataBlockProps}
 	if err = w.writer.addIndexEntry(
 		task.indexEntrySep, bhp, task.buf.tmp[:], task.flushableIndexBlock, task.currIndexBlock,
 		task.indexInflightSize, task.finishedIndexProps); err != nil {


### PR DESCRIPTION
Move block.HandleWithProperties and the routines for encoding and decoding block handles in their variable-width format into the block package.