### PR TITLE
rowblk: add IndexIter type

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
-	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -433,13 +432,12 @@ func runIterCmd(
 			if twoLevelIter, ok := origIter.(*twoLevelIterator[rowblk.Iter, *rowblk.Iter]); ok {
 				si = &twoLevelIter.secondLevel
 				if twoLevelIter.topLevelIndex.Valid() {
-					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", twoLevelIter.topLevelIndex.Key())
-					v := twoLevelIter.topLevelIndex.Value()
-					bhp, err := block.DecodeHandleWithProperties(v.InPlaceValue())
+					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", twoLevelIter.topLevelIndex.Separator())
+					bhp, err := twoLevelIter.topLevelIndex.BlockHandleWithProperties()
 					if err != nil {
-						fmt.Fprintf(&b, "|  topLevelIndex.InPlaceValue() failed to decode as BHP: %s\n", err)
+						fmt.Fprintf(&b, "|  topLevelIndex entry failed to decode as BHP: %s\n", err)
 					} else {
-						fmt.Fprintf(&b, "|  topLevelIndex.InPlaceValue() = (Offset: %d, Length: %d, Props: %x)\n",
+						fmt.Fprintf(&b, "|  topLevelIndex.BlockHandleWithProperties() = (Offset: %d, Length: %d, Props: %x)\n",
 							bhp.Offset, bhp.Length, bhp.Props)
 					}
 				} else {
@@ -448,13 +446,12 @@ func runIterCmd(
 				fmt.Fprintf(&b, "|  topLevelIndex.isDataInvalidated()=%t\n", twoLevelIter.topLevelIndex.IsDataInvalidated())
 			}
 			if si.index.Valid() {
-				fmt.Fprintf(&b, "|  index.Key() = %q\n", si.index.Key())
-				v := si.index.Value()
-				bhp, err := block.DecodeHandleWithProperties(v.InPlaceValue())
+				fmt.Fprintf(&b, "|  index.Separator() = %q\n", si.index.Separator())
+				bhp, err := si.index.BlockHandleWithProperties()
 				if err != nil {
-					fmt.Fprintf(&b, "|  index.InPlaceValue() failed to decode as BHP: %s\n", err)
+					fmt.Fprintf(&b, "|  index entry failed to decode as BHP: %s\n", err)
 				} else {
-					fmt.Fprintf(&b, "|  index.InPlaceValue() = (Offset: %d, Length: %d, Props: %x)\n",
+					fmt.Fprintf(&b, "|  index.BlockHandleWithProperties() = (Offset: %d, Length: %d, Props: %x)\n",
 						bhp.Offset, bhp.Length, bhp.Props)
 				}
 			} else {

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -52,10 +52,10 @@ type Iterator interface {
 // The data-exhausted property is tracked in a more subtle manner. We define
 // two predicates:
 // - partial-local-data-exhausted (PLDE):
-//   i.data.isDataInvalidated() || !i.data.valid()
+//   i.data.IsDataInvalidated() || !i.data.Valid()
 // - partial-global-data-exhausted (PGDE):
-//   i.index.isDataInvalidated() || !i.index.valid() || i.data.isDataInvalidated() ||
-//   !i.data.valid()
+//   i.index.IsDataInvalidated() || !i.index.Valid() || i.data.IsDataInvalidated() ||
+//   !i.data.Valid()
 //
 // PLDE is defined for a singleLevelIterator. PGDE is defined for a
 // twoLevelIterator. Oddly, in our code below the singleLevelIterator does not
@@ -96,13 +96,13 @@ type Iterator interface {
 //   state.
 //
 // Implementation detail: In the code PLDE only checks that
-// i.data.isDataInvalidated(). This narrower check is safe, since this is a
+// i.data.IsDataInvalidated(). This narrower check is safe, since this is a
 // subset of the set expressed by the OR expression. Also, it is not a
 // de-optimization since whenever we exhaust the iterator we explicitly call
-// i.data.invalidate(). PGDE checks i.index.isDataInvalidated() &&
-// i.data.isDataInvalidated(). Again, this narrower check is safe, and not a
+// i.data.Invalidate(). PGDE checks i.index.IsDataInvalidated() &&
+// i.data.IsDataInvalidated(). Again, this narrower check is safe, and not a
 // de-optimization since whenever we exhaust the iterator we explicitly call
-// i.index.invalidate() and i.data.invalidate(). The && is questionable -- for
+// i.index.Invalidate() and i.data.Invalidate(). The && is questionable -- for
 // now this is a bit of defensive code. We should seriously consider removing
 // it, since defensive code suggests we are not confident about our invariants
 // (and if we are not confident, we need more invariant assertions, not

--- a/sstable/rowblk/rowblk_index_iter.go
+++ b/sstable/rowblk/rowblk_index_iter.go
@@ -1,0 +1,113 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rowblk
+
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/block"
+)
+
+// IndexIter is a lightweight adapter that implements block.IndexIterator for a
+// row-based index block.
+type IndexIter struct {
+	iter Iter
+}
+
+// Assert that IndexIter satisfies the block.IndexBlockIterator constraint.
+var _ = satisfiesIndexBlock[IndexIter, *IndexIter](IndexIter{})
+
+func satisfiesIndexBlock[T any, PT block.IndexBlockIterator[T]](indexBlock T) PT {
+	return &indexBlock
+}
+
+// InitHandle initializes an iterator from the provided block handle.
+func (i *IndexIter) InitHandle(
+	cmp base.Compare, split base.Split, block block.BufferHandle, transforms block.IterTransforms,
+) error {
+	return i.iter.InitHandle(cmp, split, block, transforms)
+}
+
+// ResetForReuse resets the index iterator for reuse, retaining buffers to avoid
+// future allocations.
+func (i *IndexIter) ResetForReuse() IndexIter {
+	return IndexIter{iter: i.iter.ResetForReuse()}
+}
+
+// Valid returns true if the iterator is currently positioned at a valid block
+// handle.
+func (i *IndexIter) Valid() bool {
+	return i.iter.offset >= 0 && i.iter.offset < i.iter.restarts
+}
+
+// IsDataInvalidated returns true when the blockIter has been invalidated
+// using an invalidate call. NB: this is different from blockIter.Valid
+// which is part of the InternalIterator implementation.
+func (i *IndexIter) IsDataInvalidated() bool {
+	return i.iter.IsDataInvalidated()
+}
+
+// Invalidate invalidates the block iterator, removing references to the block
+// it was initialized with.
+func (i *IndexIter) Invalidate() {
+	i.iter.Invalidate()
+}
+
+// Handle returns the underlying block buffer handle, if the iterator was
+// initialized with one.
+func (i *IndexIter) Handle() block.BufferHandle {
+	return i.iter.handle
+}
+
+// Separator returns the separator at the iterator's current position. The
+// iterator must be positioned at a valid row. A Separator is a user key
+// guaranteed to be greater than or equal to every key contained within the
+// referenced block(s).
+func (i *IndexIter) Separator() []byte {
+	return i.iter.ikv.K.UserKey
+}
+
+// BlockHandleWithProperties decodes the block handle with any encoded
+// properties at the iterator's current position.
+func (i *IndexIter) BlockHandleWithProperties() (block.HandleWithProperties, error) {
+	return block.DecodeHandleWithProperties(i.iter.ikv.V.ValueOrHandle)
+}
+
+// SeekGE seeks the index iterator to the first block entry with a separator key
+// greater or equal to the given key. If it returns true, the iterator is
+// positioned over the first block that might contain the key [key], and
+// following blocks have keys ≥ Separator(). It returns false if the seek key is
+// greater than all index block separators.
+func (i *IndexIter) SeekGE(key []byte) bool {
+	return i.iter.SeekGE(key, base.SeekGEFlagsNone) != nil
+}
+
+// First seeks index iterator to the first block entry. It returns false if
+// the index block is empty.
+func (i *IndexIter) First() bool {
+	return i.iter.First() != nil
+}
+
+// Last seeks index iterator to the last block entry. It returns false if
+// the index block is empty.
+func (i *IndexIter) Last() bool {
+	return i.iter.Last() != nil
+}
+
+// Next steps the index iterator to the next block entry. It returns false
+// if the index block is exhausted.
+func (i *IndexIter) Next() bool {
+	return i.iter.Next() != nil
+}
+
+// Prev steps the index iterator to the previous block entry. It returns
+// false if the index block is exhausted.
+func (i *IndexIter) Prev() bool {
+	return i.iter.Prev() != nil
+}
+
+// Close closes the iterator, releasing any resources it holds.
+func (i *IndexIter) Close() error {
+	return i.iter.Close()
+}

--- a/sstable/testdata/reader_bpf/Pebblev3/iter
+++ b/sstable/testdata/reader_bpf/Pebblev3/iter
@@ -95,11 +95,11 @@ next
 .
 .
 | *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
-|  topLevelIndex.Key() = "x#inf,SEPARATOR"
-|  topLevelIndex.InPlaceValue() = (Offset: 193, Length: 26, Props: 00020801)
+|  topLevelIndex.Key() = "x"
+|  topLevelIndex.BlockHandleWithProperties() = (Offset: 193, Length: 26, Props: 00020801)
 |  topLevelIndex.isDataInvalidated()=false
-|  index.Key() = "x#inf,SEPARATOR"
-|  index.InPlaceValue() = (Offset: 62, Length: 29, Props: 00020801)
+|  index.Separator() = "x"
+|  index.BlockHandleWithProperties() = (Offset: 62, Length: 29, Props: 00020801)
 |  index.isDataInvalidated()=false
 |  data.isDataInvalidated()=false
 |  hideObsoletePoints = false
@@ -108,8 +108,8 @@ next
 |  exhaustedBounds = 1
 .
 | *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
-|  topLevelIndex.Key() = "wc#inf,SEPARATOR"
-|  topLevelIndex.InPlaceValue() = (Offset: 161, Length: 27, Props: 00020201)
+|  topLevelIndex.Key() = "wc"
+|  topLevelIndex.BlockHandleWithProperties() = (Offset: 161, Length: 27, Props: 00020201)
 |  topLevelIndex.isDataInvalidated()=false
 |  index iter invalid
 |  index.isDataInvalidated()=true
@@ -120,8 +120,8 @@ next
 |  exhaustedBounds = 1
 .
 | *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
-|  topLevelIndex.Key() = "wc#inf,SEPARATOR"
-|  topLevelIndex.InPlaceValue() = (Offset: 161, Length: 27, Props: 00020201)
+|  topLevelIndex.Key() = "wc"
+|  topLevelIndex.BlockHandleWithProperties() = (Offset: 161, Length: 27, Props: 00020201)
 |  topLevelIndex.isDataInvalidated()=false
 |  index iter invalid
 |  index.isDataInvalidated()=true
@@ -132,11 +132,11 @@ next
 |  exhaustedBounds = 1
 <wz@8:8>
 | *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
-|  topLevelIndex.Key() = "x#inf,SEPARATOR"
-|  topLevelIndex.InPlaceValue() = (Offset: 193, Length: 26, Props: 00020801)
+|  topLevelIndex.Key() = "x"
+|  topLevelIndex.BlockHandleWithProperties() = (Offset: 193, Length: 26, Props: 00020801)
 |  topLevelIndex.isDataInvalidated()=false
-|  index.Key() = "x#inf,SEPARATOR"
-|  index.InPlaceValue() = (Offset: 62, Length: 29, Props: 00020801)
+|  index.Separator() = "x"
+|  index.BlockHandleWithProperties() = (Offset: 62, Length: 29, Props: 00020801)
 |  index.isDataInvalidated()=false
 |  data.isDataInvalidated()=false
 |  hideObsoletePoints = false


### PR DESCRIPTION
Add an IndexIter type that abstracts some of the details of a rowblk index block away from the sstable iterator. Future work will define a constraint and make single-level and two-level iterators generic with respect to the type of the index block, allowing the addition of a colblk implementation.