### PR TITLE
tool: fix up wal dump, add wal dump-merged

### DIFF
--- a/tool/testdata/wal_dump
+++ b/tool/testdata/wal_dump
@@ -6,15 +6,15 @@ wal dump
 ../testdata/db-stage-2/000002.log
 ----
 000002.log
-0(21) seq=10 count=1
+0(21) seq=10 count=1, len=21
     SET(test formatter: foo,test value formatter: one)
-32(21) seq=11 count=1
+32(21) seq=11 count=1, len=21
     SET(test formatter: bar,test value formatter: two)
-64(23) seq=12 count=1
+64(23) seq=12 count=1, len=23
     SET(test formatter: baz,test value formatter: three)
-98(22) seq=13 count=1
+98(22) seq=13 count=1, len=22
     SET(test formatter: foo,test value formatter: four)
-131(17) seq=14 count=1
+131(17) seq=14 count=1, len=17
     DEL(test formatter: bar)
 EOF
 
@@ -24,15 +24,15 @@ wal dump
 --value=size
 ----
 000002.log
-0(21) seq=10 count=1
+0(21) seq=10 count=1, len=21
     SET(foo,<3>)
-32(21) seq=11 count=1
+32(21) seq=11 count=1, len=21
     SET(bar,<3>)
-64(23) seq=12 count=1
+64(23) seq=12 count=1, len=23
     SET(baz,<5>)
-98(22) seq=13 count=1
+98(22) seq=13 count=1, len=22
     SET(foo,<4>)
-131(17) seq=14 count=1
+131(17) seq=14 count=1, len=17
     DEL(bar)
 EOF
 
@@ -42,11 +42,11 @@ wal dump
 ../testdata/db-stage-4/000005.log
 ----
 000005.log
-0(22) seq=15 count=1
+0(22) seq=15 count=1, len=22
     SET(foo,<4>)
-33(22) seq=16 count=1
+33(22) seq=16 count=1, len=22
     SET(quux,<3>)
-66(17) seq=17 count=1
+66(17) seq=17 count=1, len=17
     DEL(baz)
 EOF
 
@@ -56,11 +56,11 @@ wal dump
 --value=%x
 ----
 000005.log
-0(22) seq=15 count=1
+0(22) seq=15 count=1, len=22
     SET(666f6f,66697665)
-33(22) seq=16 count=1
+33(22) seq=16 count=1, len=22
     SET(71757578,736978)
-66(17) seq=17 count=1
+66(17) seq=17 count=1, len=17
     DEL(62617a)
 EOF
 
@@ -70,11 +70,11 @@ wal dump
 --value=pretty:test-comparer
 ----
 000005.log
-0(22) seq=15 count=1
+0(22) seq=15 count=1, len=22
     SET(foo,test value formatter: five)
-33(22) seq=16 count=1
+33(22) seq=16 count=1, len=22
     SET(quux,test value formatter: six)
-66(17) seq=17 count=1
+66(17) seq=17 count=1, len=17
     DEL(baz)
 EOF
 
@@ -84,11 +84,11 @@ wal dump
 --value=%x
 ----
 000005.log
-0(22) seq=15 count=1
+0(22) seq=15 count=1, len=22
     SET(test formatter: foo,66697665)
-33(22) seq=16 count=1
+33(22) seq=16 count=1, len=22
     SET(test formatter: quux,736978)
-66(17) seq=17 count=1
+66(17) seq=17 count=1, len=17
     DEL(test formatter: baz)
 EOF
 
@@ -98,11 +98,11 @@ wal dump
 --value=quoted
 ----
 000005.log
-0(22) seq=15 count=1
+0(22) seq=15 count=1, len=22
     SET(foo,five)
-33(22) seq=16 count=1
+33(22) seq=16 count=1, len=22
     SET(quux,six)
-66(17) seq=17 count=1
+66(17) seq=17 count=1, len=17
     DEL(baz)
 EOF
 
@@ -110,7 +110,7 @@ wal dump
 ./testdata/mixed/000004.log
 ----
 000004.log
-0(42) seq=39 count=4
+0(42) seq=39 count=4, len=42
     SET(test formatter: a@2,test value formatter: )
     RANGEKEYSET(test formatter: a-test formatter: z:{(#40,RANGEKEYSET,@3)})
     RANGEKEYUNSET(test formatter: a-test formatter: z:{(#41,RANGEKEYUNSET,@4)})

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -9,8 +9,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/batchrepr"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/pebble/record"
@@ -22,8 +25,9 @@ import (
 // walT implements WAL-level tools, including both configuration state and the
 // commands themselves.
 type walT struct {
-	Root *cobra.Command
-	Dump *cobra.Command
+	Root       *cobra.Command
+	Dump       *cobra.Command
+	DumpMerged *cobra.Command
 
 	opts     *pebble.Options
 	fmtKey   keyFormatter
@@ -56,8 +60,19 @@ Print the contents of the WAL files.
 		Args: cobra.MinimumNArgs(1),
 		Run:  w.runDump,
 	}
+	w.DumpMerged = &cobra.Command{
+		Use:   "dump-merged <wal-files>",
+		Short: "print WAL contents",
+		Long: `
+Print the merged contents of multiple WAL segment files that
+together form a single logical WAL.
+`,
+		Args: cobra.MinimumNArgs(1),
+		Run:  w.runDumpMerged,
+	}
 
 	w.Root.AddCommand(w.Dump)
+	w.Root.AddCommand(w.DumpMerged)
 	w.Root.PersistentFlags().BoolVarP(&w.verbose, "verbose", "v", false, "verbose output")
 
 	w.Dump.Flags().Var(
@@ -67,10 +82,24 @@ Print the contents of the WAL files.
 	return w
 }
 
+type errAndArg struct {
+	err error
+	arg string
+}
+
 func (w *walT) runDump(cmd *cobra.Command, args []string) {
 	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
 	w.fmtKey.setForComparer(w.defaultComparer, w.comparers)
 	w.fmtValue.setForComparer(w.defaultComparer, w.comparers)
+	var errs []errAndArg
+	logErr := func(arg string, offset int64, err error) {
+		err = errors.Wrapf(err, "%s: offset %d: ", arg, offset)
+		fmt.Fprintf(stderr, "%s\n", err)
+		errs = append(errs, errAndArg{
+			arg: arg,
+			err: err,
+		})
+	}
 
 	for _, arg := range args {
 		func() {
@@ -107,10 +136,10 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 					// preallocation and WAL recycling. We need to distinguish these
 					// errors from EOF in order to recognize that the record was
 					// truncated, but want to otherwise treat them like EOF.
-					switch err {
-					case record.ErrZeroedChunk:
+					switch {
+					case errors.Is(err, record.ErrZeroedChunk):
 						fmt.Fprintf(stdout, "EOF [%s] (may be due to WAL preallocation)\n", err)
-					case record.ErrInvalidChunk:
+					case errors.Is(err, record.ErrInvalidChunk):
 						fmt.Fprintf(stdout, "EOF [%s] (may be due to WAL recycling)\n", err)
 					default:
 						fmt.Fprintf(stdout, "%s\n", err)
@@ -123,50 +152,148 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 					fmt.Fprintf(stdout, "corrupt batch within log file %q: %v", arg, err)
 					return
 				}
-				fmt.Fprintf(stdout, "%d(%d) seq=%d count=%d\n",
-					offset, len(b.Repr()), b.SeqNum(), b.Count())
-				for r, idx := b.Reader(), 0; ; idx++ {
-					kind, ukey, value, ok, err := r.Next()
-					if !ok {
-						if err != nil {
-							fmt.Fprintf(stdout, "corrupt batch within log file %q: %v", arg, err)
-						}
-						break
-					}
-					fmt.Fprintf(stdout, "    %s(", kind)
-					switch kind {
-					case base.InternalKeyKindDelete:
-						fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
-					case base.InternalKeyKindSet:
-						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(ukey, value))
-					case base.InternalKeyKindMerge:
-						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(ukey, value))
-					case base.InternalKeyKindLogData:
-						fmt.Fprintf(stdout, "<%d>", len(value))
-					case base.InternalKeyKindIngestSST:
-						fileNum, _ := binary.Uvarint(ukey)
-						fmt.Fprintf(stdout, "%s", base.FileNum(fileNum))
-					case base.InternalKeyKindSingleDelete:
-						fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
-					case base.InternalKeyKindSetWithDelete:
-						fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
-					case base.InternalKeyKindRangeDelete:
-						fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtKey.fn(value))
-					case base.InternalKeyKindRangeKeySet, base.InternalKeyKindRangeKeyUnset, base.InternalKeyKindRangeKeyDelete:
-						ik := base.MakeInternalKey(ukey, b.SeqNum()+base.SeqNum(idx), kind)
-						s, err := rangekey.Decode(ik, value, nil)
-						if err != nil {
-							fmt.Fprintf(stdout, "%s: error decoding %s", w.fmtKey.fn(ukey), err)
-						} else {
-							fmt.Fprintf(stdout, "%s", s.Pretty(w.fmtKey.fn))
-						}
-					case base.InternalKeyKindDeleteSized:
-						v, _ := binary.Uvarint(value)
-						fmt.Fprintf(stdout, "%s,%d", w.fmtKey.fn(ukey), v)
-					}
-					fmt.Fprintf(stdout, ")\n")
-				}
+				fmt.Fprintf(stdout, "%d(%d) seq=%d count=%d, len=%d\n",
+					offset, len(b.Repr()), b.SeqNum(), b.Count(), buf.Len())
+				w.dumpBatch(stdout, &b, b.Reader(), func(err error) {
+					logErr(arg, offset, err)
+				})
 			}
 		}()
+	}
+	if len(errs) > 0 {
+		fmt.Fprintln(stderr, "Errors: ")
+		for _, ea := range errs {
+			fmt.Fprintf(stderr, "%s: %s\n", ea.arg, ea.err)
+		}
+	}
+}
+
+func (w *walT) runDumpMerged(cmd *cobra.Command, args []string) {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	w.fmtKey.setForComparer(w.defaultComparer, w.comparers)
+	w.fmtValue.setForComparer(w.defaultComparer, w.comparers)
+	var a wal.FileAccumulator
+	for _, arg := range args {
+		isLog, err := a.MaybeAccumulate(w.opts.FS, arg)
+		if !isLog {
+			fmt.Fprintf(stderr, "%q does not parse as a log file\n", arg)
+			os.Exit(1)
+		} else if err != nil {
+			fmt.Fprintf(stderr, "%s: %s\n", arg, err)
+			os.Exit(1)
+		}
+	}
+	logs := a.Finish()
+	var errs []error
+	for _, log := range logs {
+		fmt.Fprintf(stdout, "log file %s contains %d segment files:\n", log.Num, log.NumSegments())
+		errs = append(errs, w.runDumpMergedOne(cmd, log)...)
+	}
+	if len(errs) > 0 {
+		fmt.Fprintln(stderr, "Errors: ")
+		for _, err := range errs {
+			fmt.Fprintf(stderr, "%s\n", err)
+		}
+	}
+}
+
+func (w *walT) runDumpMergedOne(cmd *cobra.Command, ll wal.LogicalLog) []error {
+	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	var buf bytes.Buffer
+	var errs []error
+	var b pebble.Batch
+
+	logErr := func(offset wal.Offset, err error) {
+		err = errors.Wrapf(err, "offset %s: ", offset)
+		fmt.Fprintln(stderr, err)
+		errs = append(errs, err)
+	}
+
+	rr := ll.OpenForRead()
+	for {
+		buf.Reset()
+		r, offset, err := rr.NextRecord()
+		if err == nil {
+			_, err = io.Copy(&buf, r)
+		}
+		if err != nil {
+			// It is common to encounter a zeroed or invalid chunk due to WAL
+			// preallocation and WAL recycling. We need to distinguish these
+			// errors from EOF in order to recognize that the record was
+			// truncated and to avoid replaying subsequent WALs, but want
+			// to otherwise treat them like EOF.
+			if err == io.EOF {
+				break
+			} else if record.IsInvalidRecord(err) {
+				break
+			}
+			return append(errs, err)
+		}
+		if buf.Len() < batchrepr.HeaderLen {
+			logErr(offset, errors.Newf("%d-byte batch too short", buf.Len()))
+			continue
+		}
+		b = pebble.Batch{}
+		if err := b.SetRepr(buf.Bytes()); err != nil {
+			logErr(offset, errors.Newf("unable to parse batch: %x", buf.Bytes()))
+			continue
+		}
+		fmt.Fprintf(stdout, "%s(%d) seq=%d count=%d, len=%d\n",
+			offset, len(b.Repr()), b.SeqNum(), b.Count(), buf.Len())
+		w.dumpBatch(stdout, &b, b.Reader(), func(err error) {
+			logErr(offset, err)
+		})
+	}
+	return nil
+}
+
+func (w *walT) dumpBatch(
+	stdout io.Writer, b *pebble.Batch, r batchrepr.Reader, logErr func(error),
+) {
+	for idx := 0; ; idx++ {
+		kind, ukey, value, ok, err := r.Next()
+		if !ok {
+			if err != nil {
+				logErr(errors.Newf("unable to decode %d'th key in batch; %s", idx, err))
+			}
+			break
+		}
+		fmt.Fprintf(stdout, "    %s(", kind)
+		switch kind {
+		case base.InternalKeyKindDelete:
+			fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
+		case base.InternalKeyKindSet:
+			fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(ukey, value))
+		case base.InternalKeyKindMerge:
+			fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtValue.fn(ukey, value))
+		case base.InternalKeyKindLogData:
+			fmt.Fprintf(stdout, "<%d>", len(value))
+		case base.InternalKeyKindIngestSST:
+			fileNum, _ := binary.Uvarint(ukey)
+			fmt.Fprintf(stdout, "%s", base.FileNum(fileNum))
+		case base.InternalKeyKindSingleDelete:
+			fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
+		case base.InternalKeyKindSetWithDelete:
+			fmt.Fprintf(stdout, "%s", w.fmtKey.fn(ukey))
+		case base.InternalKeyKindRangeDelete:
+			fmt.Fprintf(stdout, "%s,%s", w.fmtKey.fn(ukey), w.fmtKey.fn(value))
+		case base.InternalKeyKindRangeKeySet, base.InternalKeyKindRangeKeyUnset, base.InternalKeyKindRangeKeyDelete:
+			ik := base.MakeInternalKey(ukey, b.SeqNum()+base.SeqNum(idx), kind)
+			s, err := rangekey.Decode(ik, value, nil)
+			if err != nil {
+				logErr(errors.Newf("%s: error decoding %s", w.fmtKey.fn(ukey), err))
+			} else {
+				fmt.Fprintf(stdout, "%s", s.Pretty(w.fmtKey.fn))
+			}
+		case base.InternalKeyKindDeleteSized:
+			v, _ := binary.Uvarint(value)
+			fmt.Fprintf(stdout, "%s,%d", w.fmtKey.fn(ukey), v)
+		default:
+			err := errors.Newf("invalid key kind %d in key at index %d/%d of batch with seqnum %d at offset %d",
+				kind, idx, b.Count(), b.SeqNum())
+			fmt.Fprintf(stdout, "<error: %s>", err)
+			logErr(err)
+		}
+		fmt.Fprintf(stdout, ")\n")
 	}
 }


### PR DESCRIPTION
Adjust the wal dump tool to error on unrecognized key kinds, and surface errors
encounted more prominently in the output.

Additionally, add a new `wal dump-merged` command that dumps the merged view of
a WAL that's composed of multiple physical segment files.

Informs #3865.