### PR TITLE
colblk: add UnsafeOffsets.At2 and improve UnsafeUints.At

### DIFF
--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -660,8 +660,8 @@ func (i *DataBlockIter) Next() *base.InternalKV {
 		Trailer: base.InternalKeyTrailer(i.r.trailers.At(i.row)),
 	}
 	// Inline i.r.values.At(row).
-	startOffset := i.r.values.offsets.At(i.row)
-	v := unsafe.Slice((*byte)(i.r.values.ptr(startOffset)), i.r.values.offsets.At(i.row+1)-startOffset)
+	startOffset, endOffset := i.r.values.offsets.At2(i.row)
+	v := unsafe.Slice((*byte)(i.r.values.ptr(startOffset)), endOffset-startOffset)
 	if i.r.isValueExternal.At(i.row) {
 		i.kv.V = i.getLazyValue(v)
 	} else {


### PR DESCRIPTION
This PR is only for the last commit.

#### colblk: add UnsafeOffsets.At2 and improve UnsafeUints.At

We add a function that returns two consecutive offsets (to cut down on
the branches and size of the inlined code). We also reorganize
`UnsafeUints.At` to check the most common cases first.

```
CockroachDataBlockIter/AlphaLen=4,Shared=8,PrefixLen=32,Logical=0,value=8/Next    11.1ns ± 0%    10.3ns ± 3%  -7.17%  (p=0.016 n=4+5)
```