### PR TITLE
sstable: genericize iterators over index block iterator type

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -428,8 +428,8 @@ func runIterCmd(
 			continue
 		case "internal-iter-state":
 			fmt.Fprintf(&b, "| %T:\n", origIter)
-			si, _ := origIter.(*singleLevelIterator[rowblk.Iter, *rowblk.Iter])
-			if twoLevelIter, ok := origIter.(*twoLevelIterator[rowblk.Iter, *rowblk.Iter]); ok {
+			si, _ := origIter.(*singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
+			if twoLevelIter, ok := origIter.(*twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]); ok {
 				si = &twoLevelIter.secondLevel
 				if twoLevelIter.topLevelIndex.Valid() {
 					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", twoLevelIter.topLevelIndex.Separator())

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -976,12 +976,12 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 					NoTransforms, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r), &pool)
 				require.NoError(t, err)
 				switch i := citer.(type) {
-				case *singleLevelIterator[rowblk.Iter, *rowblk.Iter]:
+				case *singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]:
 					require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 					// Each key has one version, so no value block, regardless of
 					// sstable version.
 					require.Nil(t, i.vbRH)
-				case *twoLevelIterator[rowblk.Iter, *rowblk.Iter]:
+				case *twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]:
 					require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.secondLevel.dataRH))
 					// Each key has one version, so no value block, regardless of
 					// sstable version.
@@ -1033,7 +1033,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 			NoTransforms, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r), &pool)
 		require.NoError(t, err)
 		defer citer.Close()
-		i := citer.(*singleLevelIterator[rowblk.Iter, *rowblk.Iter])
+		i := citer.(*singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
 		require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 		require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.vbRH))
 	}
@@ -1041,7 +1041,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 		iter, err := r.NewIter(NoTransforms, nil, nil)
 		require.NoError(t, err)
 		defer iter.Close()
-		i := iter.(*singleLevelIterator[rowblk.Iter, *rowblk.Iter])
+		i := iter.(*singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
 		require.False(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 		require.False(t, objstorageprovider.TestingCheckMaxReadahead(i.vbRH))
 	}

--- a/sstable/testdata/reader_bpf/Pebblev3/iter
+++ b/sstable/testdata/reader_bpf/Pebblev3/iter
@@ -94,7 +94,7 @@ next
 ----
 .
 .
-| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
+| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,*github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "x"
 |  topLevelIndex.BlockHandleWithProperties() = (Offset: 193, Length: 26, Props: 00020801)
 |  topLevelIndex.isDataInvalidated()=false
@@ -107,7 +107,7 @@ next
 |  (boundsCmp,positionedUsingLatestBounds) = (0,true)
 |  exhaustedBounds = 1
 .
-| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
+| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,*github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "wc"
 |  topLevelIndex.BlockHandleWithProperties() = (Offset: 161, Length: 27, Props: 00020201)
 |  topLevelIndex.isDataInvalidated()=false
@@ -119,7 +119,7 @@ next
 |  (boundsCmp,positionedUsingLatestBounds) = (0,true)
 |  exhaustedBounds = 1
 .
-| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
+| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,*github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "wc"
 |  topLevelIndex.BlockHandleWithProperties() = (Offset: 161, Length: 27, Props: 00020201)
 |  topLevelIndex.isDataInvalidated()=false
@@ -131,7 +131,7 @@ next
 |  (boundsCmp,positionedUsingLatestBounds) = (1,false)
 |  exhaustedBounds = 1
 <wz@8:8>
-| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
+| *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,*github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "x"
 |  topLevelIndex.BlockHandleWithProperties() = (Offset: 193, Length: 26, Props: 00020801)
 |  topLevelIndex.isDataInvalidated()=false

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -331,15 +331,15 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			forceIgnoreValueBlocks := func(i *singleLevelIterator[rowblk.Iter, *rowblk.Iter]) {
+			forceIgnoreValueBlocks := func(i *singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]) {
 				i.vbReader = nil
 				i.data.SetGetLazyValuer(nil)
 				i.data.SetHasValuePrefix(false)
 			}
 			switch i := origIter.(type) {
-			case *twoLevelIterator[rowblk.Iter, *rowblk.Iter]:
+			case *twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]:
 				forceIgnoreValueBlocks(&i.secondLevel)
-			case *singleLevelIterator[rowblk.Iter, *rowblk.Iter]:
+			case *singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]:
 				forceIgnoreValueBlocks(i)
 			}
 			iter := newIterAdapter(origIter)


### PR DESCRIPTION
This is done in preparation for sstable iterators over colblk sstables.