### PR TITLE
sstable: convert RawWriter into an interface

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2666,7 +2666,7 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*versionEdit, error
 // compaction or flush.
 func (d *DB) newCompactionOutput(
 	jobID JobID, c *compaction, writerOpts sstable.WriterOptions,
-) (objstorage.ObjectMetadata, *sstable.RawWriter, CPUWorkHandle, error) {
+) (objstorage.ObjectMetadata, *sstable.RawRowWriter, CPUWorkHandle, error) {
 	d.mu.Lock()
 	diskFileNum := d.mu.versions.getNextDiskFileNum()
 	d.mu.Unlock()

--- a/data_test.go
+++ b/data_test.go
@@ -586,7 +586,7 @@ func runBuildRemoteCmd(td *datadriven.TestData, d *DB, storage remote.Storage) e
 	for kv := iter.First(); kv != nil; kv = iter.Next() {
 		tmp := kv.K
 		tmp.SetSeqNum(0)
-		if err := w.Raw().Add(tmp, kv.InPlaceValue()); err != nil {
+		if err := w.Raw().AddWithForceObsolete(tmp, kv.InPlaceValue(), false); err != nil {
 			return err
 		}
 	}
@@ -599,7 +599,7 @@ func runBuildRemoteCmd(td *datadriven.TestData, d *DB, storage remote.Storage) e
 		for ; s != nil && err == nil; s, err = rdi.Next() {
 			err = rangedel.Encode(*s, func(k base.InternalKey, v []byte) error {
 				k.SetSeqNum(0)
-				return w.Raw().Add(k, v)
+				return w.Raw().AddWithForceObsolete(k, v, false)
 			})
 			if err != nil {
 				return err
@@ -680,7 +680,7 @@ func runBuildCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
 	for kv := iter.First(); kv != nil; kv = iter.Next() {
 		tmp := kv.K
 		tmp.SetSeqNum(0)
-		if err := w.Raw().Add(tmp, kv.InPlaceValue()); err != nil {
+		if err := w.Raw().AddWithForceObsolete(tmp, kv.InPlaceValue(), false); err != nil {
 			return err
 		}
 	}
@@ -693,7 +693,7 @@ func runBuildCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
 		for ; s != nil && err == nil; s, err = rdi.Next() {
 			err = rangedel.Encode(*s, func(k base.InternalKey, v []byte) error {
 				k.SetSeqNum(0)
-				return w.Raw().Add(k, v)
+				return w.Raw().AddWithForceObsolete(k, v, false)
 			})
 			if err != nil {
 				return err

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -3224,7 +3224,7 @@ func TestIngestFileNumReuseCrash(t *testing.T) {
 func TestIngest_UpdateSequenceNumber(t *testing.T) {
 	mem := vfs.NewMem()
 	cmp := base.DefaultComparer.Compare
-	parse := func(input string) (*sstable.RawWriter, error) {
+	parse := func(input string) (*sstable.RawRowWriter, error) {
 		f, err := mem.Create("ext", vfs.WriteCategoryUnspecified)
 		if err != nil {
 			return nil, err

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -132,7 +132,7 @@ func (r *Runner) MoreDataToWrite() bool {
 // Result.Tables. Should only be called if MoreDataToWrite() returned true.
 //
 // WriteTable always closes the Writer.
-func (r *Runner) WriteTable(objMeta objstorage.ObjectMetadata, tw *sstable.RawWriter) {
+func (r *Runner) WriteTable(objMeta objstorage.ObjectMetadata, tw *sstable.RawRowWriter) {
 	if r.err != nil {
 		panic("error already encountered")
 	}
@@ -159,7 +159,7 @@ func (r *Runner) WriteTable(objMeta objstorage.ObjectMetadata, tw *sstable.RawWr
 	r.tables[len(r.tables)-1].WriterMeta = *writerMeta
 }
 
-func (r *Runner) writeKeysToTable(tw *sstable.RawWriter) (splitKey []byte, _ error) {
+func (r *Runner) writeKeysToTable(tw *sstable.RawRowWriter) (splitKey []byte, _ error) {
 	firstKey := base.MinUserKey(r.cmp, spanStartOrNil(&r.lastRangeDelSpan), spanStartOrNil(&r.lastRangeKeySpan))
 	if r.key != nil && firstKey == nil {
 		firstKey = r.key.UserKey

--- a/internal/compact/spans.go
+++ b/internal/compact/spans.go
@@ -182,7 +182,7 @@ func (c *RangeKeySpanCompactor) elideInLastStripe(
 //
 // The span can contain either only RANGEDEL keys or only range keys.
 func SplitAndEncodeSpan(
-	cmp base.Compare, span *keyspan.Span, upToKey []byte, tw *sstable.RawWriter,
+	cmp base.Compare, span *keyspan.Span, upToKey []byte, tw *sstable.RawRowWriter,
 ) error {
 	if span.Empty() {
 		return nil

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -508,7 +508,7 @@ func buildLevelIterTables(
 		files[i] = f
 	}
 
-	writers := make([]*sstable.RawWriter, len(files))
+	writers := make([]*sstable.RawRowWriter, len(files))
 	for i := range files {
 		writers[i] = sstable.NewRawWriter(objstorageprovider.NewFileWritable(files[i]), sstable.WriterOptions{
 			BlockRestartInterval: restartInterval,

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -340,7 +340,7 @@ func buildMergingIterTables(
 		files[i] = f
 	}
 
-	writers := make([]*sstable.RawWriter, len(files))
+	writers := make([]*sstable.RawRowWriter, len(files))
 	for i := range files {
 		writers[i] = sstable.NewRawWriter(objstorageprovider.NewFileWritable(files[i]), sstable.WriterOptions{
 			BlockRestartInterval: restartInterval,
@@ -543,7 +543,7 @@ func buildLevelsForMergingIterSeqSeek(
 	}
 
 	const targetL6FirstFileSize = 2 << 20
-	writers := make([][]*sstable.RawWriter, levelCount)
+	writers := make([][]*sstable.RawRowWriter, levelCount)
 	// A policy unlikely to have false positives.
 	filterPolicy := bloom.FilterPolicy(100)
 	for i := range files {

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -96,7 +96,7 @@ func writeSSTForIngestion(
 		if err != nil {
 			return nil, err
 		}
-		if err := w.Raw().Add(k.K, valBytes); err != nil {
+		if err := w.Raw().AddWithForceObsolete(k.K, valBytes, false); err != nil {
 			return nil, err
 		}
 	}

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1928,7 +1928,7 @@ func (r *replicateOp) runSharedReplicate(
 			if err != nil {
 				panic(err)
 			}
-			return w.Raw().Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val)
+			return w.Raw().AddWithForceObsolete(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false)
 		},
 		func(start, end []byte, seqNum base.SeqNum) error {
 			return w.DeleteRange(start, end)
@@ -1991,7 +1991,7 @@ func (r *replicateOp) runExternalReplicate(
 			if err != nil {
 				panic(err)
 			}
-			return w.Raw().Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val)
+			return w.Raw().AddWithForceObsolete(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false)
 		},
 		func(start, end []byte, seqNum base.SeqNum) error {
 			return w.DeleteRange(start, end)

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -441,7 +441,7 @@ func TestScanInternal(t *testing.T) {
 					var err error
 					value, _, err = kv.Value(value)
 					require.NoError(t, err)
-					require.NoError(t, w.Raw().Add(kv.K, value))
+					require.NoError(t, w.Raw().AddWithForceObsolete(kv.K, value, false))
 				}
 				points.Close()
 				require.NoError(t, w.Close())

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -195,7 +195,7 @@ func rewriteBlocks[R blockRewriter](
 	return nil
 }
 
-func checkWriterFilterMatchesReader(r *Reader, w *RawWriter) error {
+func checkWriterFilterMatchesReader(r *Reader, w *RawRowWriter) error {
 	if r.Properties.FilterPolicyName != w.filter.policyName() {
 		return errors.New("mismatched filters")
 	}
@@ -206,7 +206,7 @@ func checkWriterFilterMatchesReader(r *Reader, w *RawWriter) error {
 }
 
 func rewriteDataBlocksToWriter(
-	r *Reader, w *RawWriter, data []block.HandleWithProperties, from, to []byte, concurrency int,
+	r *Reader, w *RawRowWriter, data []block.HandleWithProperties, from, to []byte, concurrency int,
 ) error {
 	if r.Properties.NumEntries == 0 {
 		// No point keys.
@@ -326,7 +326,7 @@ func rewriteDataBlocksToWriter(
 	return nil
 }
 
-func rewriteRangeKeyBlockToWriter(r *Reader, w *RawWriter, from, to []byte) error {
+func rewriteRangeKeyBlockToWriter(r *Reader, w *RawRowWriter, from, to []byte) error {
 	iter, err := r.NewRawRangeKeyIter(context.TODO(), NoFragmentTransforms)
 	if err != nil {
 		return err

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -204,18 +204,6 @@ rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
 pebble: spans must be added in order: b > a
 
 build-raw
-a.RANGEKEYDEL.1:c
-b.RANGEKEYDEL.2:d
-----
-pebble: overlapping range keys must be fragmented: a#1,RANGEKEYDEL, b#2,RANGEKEYDEL
-
-build-raw
-a.RANGEKEYDEL.2:c
-a.RANGEKEYDEL.1:d
-----
-pebble: overlapping range keys must be fragmented: a#2,RANGEKEYDEL, a#1,RANGEKEYDEL
-
-build-raw
 rangekey: a-c:{(#1,RANGEKEYSET,@10,foo)}
 rangekey: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
@@ -224,12 +212,6 @@ seqnums:  [1-2]
 
 # Range keys may have perfectly aligned spans (including sequence numbers),
 # though the key kinds must be ordered (descending).
-
-build-raw
-a.RANGEKEYDEL.1:b
-a.RANGEKEYDEL.1:b
-----
-pebble: range keys starts must be added in increasing order: a#1,RANGEKEYDEL, a#1,RANGEKEYDEL
 
 build-raw
 rangekey: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@t10) (#1,RANGEKEYDEL)}

--- a/sstable/testdata/writer_v3
+++ b/sstable/testdata/writer_v3
@@ -178,18 +178,6 @@ rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
 pebble: spans must be added in order: b > a
 
 build-raw
-a.RANGEKEYDEL.1:c
-b.RANGEKEYDEL.2:d
-----
-pebble: overlapping range keys must be fragmented: a#1,RANGEKEYDEL, b#2,RANGEKEYDEL
-
-build-raw
-a.RANGEKEYDEL.2:c
-a.RANGEKEYDEL.1:d
-----
-pebble: overlapping range keys must be fragmented: a#2,RANGEKEYDEL, a#1,RANGEKEYDEL
-
-build-raw
 rangekey: a-c:{(#1,RANGEKEYSET,@10,foo)}
 rangekey: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
@@ -198,12 +186,6 @@ seqnums:  [1-2]
 
 # Range keys may have perfectly aligned spans (including sequence numbers),
 # though the key kinds must be ordered (descending).
-
-build-raw
-a.RANGEKEYDEL.1:b
-a.RANGEKEYDEL.1:b
-----
-pebble: range keys starts must be added in increasing order: a#1,RANGEKEYDEL, a#1,RANGEKEYDEL
 
 build-raw
 rangekey: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}

--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -40,7 +40,7 @@ func (task *writeTask) clear() {
 type writeQueue struct {
 	tasks  chan *writeTask
 	wg     sync.WaitGroup
-	writer *RawWriter
+	writer *RawRowWriter
 
 	// err represents an error which is encountered when the write queue attempts
 	// to write a block to disk. The error is stored here to skip unnecessary block
@@ -49,7 +49,7 @@ type writeQueue struct {
 	closed bool
 }
 
-func newWriteQueue(size int, writer *RawWriter) *writeQueue {
+func newWriteQueue(size int, writer *RawRowWriter) *writeQueue {
 	w := &writeQueue{}
 	w.tasks = make(chan *writeTask, size)
 	w.writer = writer

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -13,12 +13,13 @@ import (
 
 // Writer is a table writer.
 type Writer struct {
-	rw *RawWriter
+	rw RawWriter
 	// To allow potentially overlapping (i.e. un-fragmented) range keys spans to
 	// be added to the Writer, a keyspan.Fragmenter is used to retain the keys
 	// and values, emitting fragmented, coalesced spans as appropriate. Range
 	// keys must be added in order of their start user-key.
 	fragmenter  keyspan.Fragmenter
+	comparer    *base.Comparer
 	rkBuf       []byte
 	keyspanKeys []keyspan.Key
 }
@@ -38,11 +39,12 @@ func NewWriter(writable objstorage.Writable, o WriterOptions) *Writer {
 			Format: o.Comparer.FormatKey,
 			Emit:   rw.encodeFragmentedRangeKeySpan,
 		},
+		comparer: o.Comparer,
 	}
 }
 
 // Raw returns the underlying RawWriter.
-func (w *Writer) Raw() *RawWriter { return w.rw }
+func (w *Writer) Raw() RawWriter { return w.rw }
 
 // Set sets the value for the given key. The sequence number is set to 0.
 // Intended for use to externally construct an sstable before ingestion into a
@@ -51,15 +53,15 @@ func (w *Writer) Raw() *RawWriter { return w.rw }
 //
 // TODO(peter): untested
 func (w *Writer) Set(key, value []byte) error {
-	if w.rw.err != nil {
-		return w.rw.err
+	if err := w.rw.Error(); err != nil {
+		return err
 	}
-	if w.rw.isStrictObsolete {
+	if w.rw.IsStrictObsolete() {
 		return errors.Errorf("use AddWithForceObsolete")
 	}
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable delete the added points.
-	return w.rw.addPoint(base.MakeInternalKey(key, 0, InternalKeyKindSet), value, false)
+	return w.rw.AddWithForceObsolete(base.MakeInternalKey(key, 0, InternalKeyKindSet), value, false)
 }
 
 // Delete deletes the value for the given key. The sequence number is set to
@@ -68,15 +70,15 @@ func (w *Writer) Set(key, value []byte) error {
 //
 // TODO(peter): untested
 func (w *Writer) Delete(key []byte) error {
-	if w.rw.err != nil {
-		return w.rw.err
+	if err := w.rw.Error(); err != nil {
+		return err
 	}
-	if w.rw.isStrictObsolete {
+	if w.rw.IsStrictObsolete() {
 		return errors.Errorf("use AddWithForceObsolete")
 	}
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable delete the added points.
-	return w.rw.addPoint(base.MakeInternalKey(key, 0, InternalKeyKindDelete), nil, false)
+	return w.rw.AddWithForceObsolete(base.MakeInternalKey(key, 0, InternalKeyKindDelete), nil, false)
 }
 
 // DeleteRange deletes all of the keys (and values) in the range [start,end)
@@ -89,8 +91,8 @@ func (w *Writer) Delete(key []byte) error {
 //
 // TODO(peter): untested
 func (w *Writer) DeleteRange(start, end []byte) error {
-	if w.rw.err != nil {
-		return w.rw.err
+	if err := w.rw.Error(); err != nil {
+		return err
 	}
 	return w.rw.EncodeSpan(keyspan.Span{
 		Start: start,
@@ -108,16 +110,16 @@ func (w *Writer) DeleteRange(start, end []byte) error {
 //
 // TODO(peter): untested
 func (w *Writer) Merge(key, value []byte) error {
-	if w.rw.err != nil {
-		return w.rw.err
+	if err := w.rw.Error(); err != nil {
+		return err
 	}
-	if w.rw.isStrictObsolete {
+	if w.rw.IsStrictObsolete() {
 		return errors.Errorf("use AddWithForceObsolete")
 	}
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable that delete the added points. If the user configured this writer
 	// to be strict-obsolete, addPoint will reject the addition of this MERGE.
-	return w.rw.addPoint(base.MakeInternalKey(key, 0, InternalKeyKindMerge), value, false)
+	return w.rw.AddWithForceObsolete(base.MakeInternalKey(key, 0, InternalKeyKindMerge), value, false)
 }
 
 // RangeKeySet sets a range between start (inclusive) and end (exclusive) with
@@ -182,18 +184,18 @@ func (w *Writer) RangeKeyDelete(start, end []byte) error {
 }
 
 func (w *Writer) addRangeKeySpanToFragmenter(span keyspan.Span) error {
-	if w.rw.compare(span.Start, span.End) >= 0 {
+	if w.comparer.Compare(span.Start, span.End) >= 0 {
 		return errors.Errorf(
 			"pebble: start key must be strictly less than end key",
 		)
 	}
-	if w.fragmenter.Start() != nil && w.rw.compare(w.fragmenter.Start(), span.Start) > 0 {
+	if w.fragmenter.Start() != nil && w.comparer.Compare(w.fragmenter.Start(), span.Start) > 0 {
 		return errors.Errorf("pebble: spans must be added in order: %s > %s",
-			w.rw.formatKey(w.fragmenter.Start()), w.rw.formatKey(span.Start))
+			w.comparer.FormatKey(w.fragmenter.Start()), w.comparer.FormatKey(span.Start))
 	}
 	// Add this span to the fragmenter.
 	w.fragmenter.Add(span)
-	return w.rw.err
+	return w.rw.Error()
 }
 
 // tempRangeKeyBuf returns a slice of length n from the Writer's rkBuf byte
@@ -228,10 +230,125 @@ func (w *Writer) tempRangeKeyCopy(k []byte) []byte {
 // Close finishes writing the table and closes the underlying file that the
 // table was written to.
 func (w *Writer) Close() (err error) {
-	if w.rw.err == nil {
+	if w.rw.Error() == nil {
 		// Write the range-key block, flushing any remaining spans from the
 		// fragmenter first.
 		w.fragmenter.Finish()
 	}
 	return w.rw.Close()
+}
+
+// RawWriter defines an interface for sstable writers. Implementations may vary
+// depending on the TableFormat being written.
+type RawWriter interface {
+	// Error returns the current accumulated error if any.
+	Error() error
+	// IsStrictObsolete returns true if the writer is configured to write and
+	// enforce a 'strict obsolete' sstable. This includes prohibiting the
+	// addition of MERGE keys. See the documentation in format.go for more
+	// details.
+	IsStrictObsolete() bool
+	// AddWithForceObsolete must be used when writing a strict-obsolete sstable.
+	//
+	// forceObsolete indicates whether the caller has determined that this key is
+	// obsolete even though it may be the latest point key for this userkey. This
+	// should be set to true for keys obsoleted by RANGEDELs, and is required for
+	// strict-obsolete sstables. It's optional for non-strict-obsolete sstables.
+	//
+	// Note that there are two properties, S1 and S2 (see comment in format.go)
+	// that strict-obsolete ssts must satisfy. S2, due to RANGEDELs, is solely the
+	// responsibility of the caller. S1 is solely the responsibility of the
+	// callee.
+	AddWithForceObsolete(
+		key InternalKey, value []byte, forceObsolete bool,
+	) error
+	// EncodeSpan encodes the keys in the given span. The span can contain
+	// either only RANGEDEL keys or only range keys.
+	//
+	// This is a low-level API that bypasses the fragmenter. The spans passed to
+	// this function must be fragmented and ordered.
+	EncodeSpan(span keyspan.Span) error
+	// Close finishes writing the table and closes the underlying file that the
+	// table was written to.
+	Close() error
+	// Metadata returns the metadata for the finished sstable. Only valid to
+	// call after the sstable has been finished.
+	Metadata() (*WriterMetadata, error)
+}
+
+// WriterMetadata holds info about a finished sstable.
+type WriterMetadata struct {
+	Size          uint64
+	SmallestPoint InternalKey
+	// LargestPoint, LargestRangeKey, LargestRangeDel should not be accessed
+	// before Writer.Close is called, because they may only be set on
+	// Writer.Close.
+	LargestPoint     InternalKey
+	SmallestRangeDel InternalKey
+	LargestRangeDel  InternalKey
+	SmallestRangeKey InternalKey
+	LargestRangeKey  InternalKey
+	HasPointKeys     bool
+	HasRangeDelKeys  bool
+	HasRangeKeys     bool
+	SmallestSeqNum   base.SeqNum
+	LargestSeqNum    base.SeqNum
+	Properties       Properties
+}
+
+// SetSmallestPointKey sets the smallest point key to the given key.
+// NB: this method set the "absolute" smallest point key. Any existing key is
+// overridden.
+func (m *WriterMetadata) SetSmallestPointKey(k InternalKey) {
+	m.SmallestPoint = k
+	m.HasPointKeys = true
+}
+
+// SetSmallestRangeDelKey sets the smallest rangedel key to the given key.
+// NB: this method set the "absolute" smallest rangedel key. Any existing key is
+// overridden.
+func (m *WriterMetadata) SetSmallestRangeDelKey(k InternalKey) {
+	m.SmallestRangeDel = k
+	m.HasRangeDelKeys = true
+}
+
+// SetSmallestRangeKey sets the smallest range key to the given key.
+// NB: this method set the "absolute" smallest range key. Any existing key is
+// overridden.
+func (m *WriterMetadata) SetSmallestRangeKey(k InternalKey) {
+	m.SmallestRangeKey = k
+	m.HasRangeKeys = true
+}
+
+// SetLargestPointKey sets the largest point key to the given key.
+// NB: this method set the "absolute" largest point key. Any existing key is
+// overridden.
+func (m *WriterMetadata) SetLargestPointKey(k InternalKey) {
+	m.LargestPoint = k
+	m.HasPointKeys = true
+}
+
+// SetLargestRangeDelKey sets the largest rangedel key to the given key.
+// NB: this method set the "absolute" largest rangedel key. Any existing key is
+// overridden.
+func (m *WriterMetadata) SetLargestRangeDelKey(k InternalKey) {
+	m.LargestRangeDel = k
+	m.HasRangeDelKeys = true
+}
+
+// SetLargestRangeKey sets the largest range key to the given key.
+// NB: this method set the "absolute" largest range key. Any existing key is
+// overridden.
+func (m *WriterMetadata) SetLargestRangeKey(k InternalKey) {
+	m.LargestRangeKey = k
+	m.HasRangeKeys = true
+}
+
+func (m *WriterMetadata) updateSeqNum(seqNum base.SeqNum) {
+	if m.SmallestSeqNum > seqNum {
+		m.SmallestSeqNum = seqNum
+	}
+	if m.LargestSeqNum < seqNum {
+		m.LargestSeqNum = seqNum
+	}
 }

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -528,7 +528,7 @@ func TestParallelWriterErrorProp(t *testing.T) {
 	w := NewWriter(objstorageprovider.NewFileWritable(f), opts)
 	// Directly testing this, because it's difficult to get the Writer to
 	// encounter an error, precisely when the writeQueue is doing block writes.
-	w.rw.coordination.writeQueue.err = errors.New("write queue write error")
+	w.rw.(*RawRowWriter).coordination.writeQueue.err = errors.New("write queue write error")
 	w.Set(ikey("a").UserKey, nil)
 	w.Set(ikey("b").UserKey, nil)
 	err = w.Close()

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -176,7 +176,7 @@ func newTableCacheContainerTest(
 		}
 		tw := sstable.NewWriter(w, sstable.WriterOptions{TableFormat: sstable.TableFormatPebblev2})
 		ik := base.ParseInternalKey(fmt.Sprintf("k.SET.%d", i))
-		if err := tw.Raw().Add(ik, xxx[:i]); err != nil {
+		if err := tw.Raw().AddWithForceObsolete(ik, xxx[:i], false); err != nil {
 			return nil, nil, errors.Wrap(err, "tw.Set")
 		}
 		if err := tw.RangeKeySet([]byte("k"), []byte("l"), nil, xxx[:i]); err != nil {


### PR DESCRIPTION
Convert RawWriter into an interface that's satisfied by the existing RawRowWriter type. Future work will introduce a RawColWriter that writes sstables with columnar blocks.