### PR TITLE
vfs: redesign MemFS strict mode

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -327,7 +327,7 @@ func TestCheckpointCompaction(t *testing.T) {
 
 func TestCheckpointFlushWAL(t *testing.T) {
 	const checkpointPath = "checkpoints/checkpoint"
-	fs := vfs.NewStrictMem()
+	fs := vfs.NewCrashableMem()
 	opts := &Options{FS: fs, Logger: testLogger{t: t}}
 	key, value := []byte("key"), []byte("value")
 
@@ -345,7 +345,7 @@ func TestCheckpointFlushWAL(t *testing.T) {
 		err = d.Checkpoint(checkpointPath, WithFlushedWAL())
 		require.NoError(t, err)
 		require.NoError(t, d.Close())
-		fs.ResetToSyncedState()
+		fs = fs.CrashClone(vfs.CrashCloneCfg{UnsyncedDataPercent: 0})
 	}
 
 	// Check that the WAL has been flushed in the checkpoint.

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -57,7 +57,7 @@ func parseOptions(
 				return true
 			case "TestOptions.strictfs":
 				opts.strictFS = true
-				opts.Opts.FS = vfs.NewStrictMem()
+				opts.Opts.FS = vfs.NewCrashableMem()
 				return true
 			case "TestOptions.ingest_using_apply":
 				opts.ingestUsingApply = true
@@ -755,7 +755,7 @@ func RandomOptions(
 	testOpts.Threads = rng.Intn(runtime.GOMAXPROCS(0)) + 1
 	if testOpts.strictFS {
 		opts.DisableWAL = false
-		opts.FS = vfs.NewStrictMem()
+		opts.FS = vfs.NewCrashableMem()
 	} else if !testOpts.useDisk {
 		opts.FS = vfs.NewMem()
 	}

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -551,7 +551,7 @@ b
 a:2
 b:2
 
-ignoreSyncs true
+crash-clone
 ----
 
 lsm
@@ -592,7 +592,7 @@ close
 
 # At this point, the changes to the manifest should be lost. Note that 7.sst
 # is gone because that file was never synced.
-resetToSynced
+reset-to-crash-clone
 ----
 000002.log
 000004.sst
@@ -605,9 +605,6 @@ ext
 ext1
 marker.format-version.000004.017
 marker.manifest.000001.MANIFEST-000001
-
-ignoreSyncs false
-----
 
 open
 ----

--- a/vfs/testdata/memfs_crashable
+++ b/vfs/testdata/memfs_crashable
@@ -5,12 +5,18 @@ create /foo
 open /foo
 ----
 
-reset-to-synced
+crash-clone 0 fs0
+----
+
+switch-fs fs0
 ----
 
 open /foo
 ----
 error: open /foo: file does not exist
+
+switch-fs initial
+----
 
 # Create directory and a file in it and write and read from it.
 mkdirall /bar
@@ -45,7 +51,10 @@ open /bar
 ----
 
 # Resetting causes both the directory and file to disappear.
-reset-to-synced
+crash-clone 0 fs1
+----
+
+switch-fs fs1
 ----
 
 open-dir /bar
@@ -55,6 +64,9 @@ error: open /bar: file does not exist
 open /bar/y
 ----
 error: open bar/y: file does not exist
+
+switch-fs initial
+----
 
 # Create the directory and file again. Link the file to another file in the same
 # dir, and to a file in the root dir. Sync the root dir. After reset, the
@@ -89,7 +101,10 @@ f.sync
 f.close
 ----
 
-reset-to-synced
+crash-clone 0 fs2
+----
+
+switch-fs fs2
 ----
 
 open-dir /bar
@@ -106,6 +121,9 @@ error: open /bar/z: file does not exist
 open /z
 ----
 
+switch-fs initial
+----
+
 # Create the file in the directory again and this time sync /bar directory. The
 # file is preserved after reset.
 create /bar/y
@@ -120,13 +138,19 @@ f.sync
 f.close
 ----
 
-reset-to-synced
+crash-clone 0 fs3
+----
+
+switch-fs fs3
 ----
 
 open-dir /bar
 ----
 
 open /bar/y
+----
+
+switch-fs initial
 ----
 
 # Unsynced data in the file is lost on reset.
@@ -156,7 +180,10 @@ f.sync
 f.close
 ----
 
-reset-to-synced
+crash-clone 0 fs4
+----
+
+switch-fs fs4
 ----
 
 open /bar/y
@@ -173,8 +200,11 @@ error: EOF
 f.close
 ----
 
-# reuse-for-write works correctly in strict mode in that unsynced data does not overwrite
-# previous contents when a reset happens.
+switch-fs initial
+----
+
+# reuse-for-write works correctly in that unsynced data does not overwrite
+# previous contents when a crash happens.
 create /z
 ----
 
@@ -215,7 +245,10 @@ f.sync
 f.close
 ----
 
-reset-to-synced
+crash-clone 0 fs5
+----
+
+switch-fs fs5
 ----
 
 open /y
@@ -224,59 +257,6 @@ open /y
 f.read 8
 ----
 xbcdefgh
-
-f.close
-----
-
-# Ignore syncs.
-create /z
-----
-
-f.write
-a
-----
-
-f.sync
-----
-
-ignore-syncs
-----
-
-f.write
-b
-----
-
-f.sync
-----
-
-f.close
-----
-
-stop-ignoring-syncs
-----
-
-open-dir /
-----
-
-f.sync
-----
-
-f.close
-----
-
-reset-to-synced
-----
-
-open /z
-----
-
-f.read 1
-----
-a
-
-f.read 1
-----
-error: EOF
 
 f.close
 ----

--- a/wal/reader_test.go
+++ b/wal/reader_test.go
@@ -97,7 +97,7 @@ func TestList(t *testing.T) {
 // TestReader tests the virtual WAL reader that merges across multiple physical
 // log files.
 func TestReader(t *testing.T) {
-	fs := vfs.NewStrictMem()
+	fs := vfs.NewCrashableMem()
 	rng := rand.New(rand.NewSource(1))
 	var buf bytes.Buffer
 	datadriven.RunTest(t, "testdata/reader", func(t *testing.T, td *datadriven.TestData) string {
@@ -190,10 +190,9 @@ func TestReader(t *testing.T) {
 				}
 			}
 			if td.HasArg("close-unclean") {
-				fs.SetIgnoreSyncs(true)
+				crashFS := fs.CrashClone(vfs.CrashCloneCfg{UnsyncedDataPercent: 0})
 				require.NoError(t, w.Close())
-				fs.ResetToSyncedState()
-				fs.SetIgnoreSyncs(false)
+				fs = crashFS
 			} else {
 				require.NoError(t, w.Close())
 			}


### PR DESCRIPTION
Currently we use `MemFS` in "strict" mode to test crash recovery in
the following way:
 - at the desired crash point we call `SetIgnoreSyncs(true)`
 - after we close the database, we call `ResetToSyncedState()` and
   `SetIgnoreSyncs(false)` and proceed using the same filesystem.

This model is a bit fragile in the sense that both the previous
operation that we're simulating a crash of and the new operation use
the same filesystem. For example, a background operation that is
finishing up some cleanup could in principle interfere with the new
process.

We switch to a "crash clone" model, where we instead extract a
crash-consistent copy of the filesystem; further testing can proceed
on this independent copy. This allows for more usage patterns - e.g.
we can take multiple crash clones at various points and check them all
afterwards.

We also add functionality to randomly retain part of the unsynced
data (which is closer to what would happen in a real crash).