### PR TITLE
sstable: clean up datadriven build commands

### DIFF
--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -108,9 +108,9 @@ build collectors=(suffix)
 a@5.SET.1:foo
 b@10.SET.2:bar
 c@15.SET.3:baz
-rangekey: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
-rangekey: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
-rangekey: f@20-z@25:{(#6,RANGEKEYDEL)}
+EncodeSpan: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
+EncodeSpan: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
+EncodeSpan: f@20-z@25:{(#6,RANGEKEYDEL)}
 ----
 point:    [a@5#1,SET-c@15#3,SET]
 rangekey: [d@10#4,RANGEKEYSET-z@25#inf,RANGEKEYDEL]
@@ -135,9 +135,9 @@ build collectors=(suffix-point-keys-only)
 a@5.SET.1:foo
 b@10.SET.2:bar
 c@15.SET.3:baz
-rangekey: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
-rangekey: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
-rangekey: f@20-z@25:{(#6,RANGEKEYDEL)}
+EncodeSpan: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
+EncodeSpan: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
+EncodeSpan: f@20-z@25:{(#6,RANGEKEYDEL)}
 ----
 point:    [a@5#1,SET-c@15#3,SET]
 rangekey: [d@10#4,RANGEKEYSET-z@25#inf,RANGEKEYDEL]
@@ -162,9 +162,9 @@ build collectors=(suffix-range-keys-only)
 a@5.SET.1:foo
 b@10.SET.2:bar
 c@15.SET.3:baz
-rangekey: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
-rangekey: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
-rangekey: f@20-z@25:{(#6,RANGEKEYDEL)}
+EncodeSpan: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
+EncodeSpan: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
+EncodeSpan: f@20-z@25:{(#6,RANGEKEYDEL)}
 ----
 point:    [a@5#1,SET-c@15#3,SET]
 rangekey: [d@10#4,RANGEKEYSET-z@25#inf,RANGEKEYDEL]
@@ -190,9 +190,9 @@ build block-size=1 collectors=(suffix-point-keys-only,suffix-range-keys-only)
 a@5.SET.1:foo
 b@10.SET.2:bar
 c@15.SET.3:baz
-rangekey: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
-rangekey: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
-rangekey: f@20-z@25:{(#6,RANGEKEYDEL)}
+EncodeSpan: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
+EncodeSpan: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
+EncodeSpan: f@20-z@25:{(#6,RANGEKEYDEL)}
 ----
 point:    [a@5#1,SET-c@15#3,SET]
 rangekey: [d@10#4,RANGEKEYSET-z@25#inf,RANGEKEYDEL]

--- a/sstable/testdata/rewriter
+++ b/sstable/testdata/rewriter
@@ -212,9 +212,9 @@ c
 # Rewrite a table that contain only range keys.
 
 build block-size=1 index-block-size=1 filter comparer-split-4b-suffix
-rangekey: a-b:{(#1,RANGEKEYSET,_xyz)}
-rangekey: b-c:{(#1,RANGEKEYSET,_xyz)}
-rangekey: c-d:{(#1,RANGEKEYSET,_xyz)}
+EncodeSpan: a-b:{(#1,RANGEKEYSET,_xyz)}
+EncodeSpan: b-c:{(#1,RANGEKEYSET,_xyz)}
+EncodeSpan: c-d:{(#1,RANGEKEYSET,_xyz)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-1]

--- a/sstable/testdata/rewriter_v3
+++ b/sstable/testdata/rewriter_v3
@@ -212,9 +212,9 @@ c
 # Rewrite a table that contain only range keys.
 
 build block-size=1 index-block-size=1 filter comparer-split-4b-suffix
-rangekey: a-b:{(#1,RANGEKEYSET,_xyz)}
-rangekey: b-c:{(#1,RANGEKEYSET,_xyz)}
-rangekey: c-d:{(#1,RANGEKEYSET,_xyz)}
+EncodeSpan: a-b:{(#1,RANGEKEYSET,_xyz)}
+EncodeSpan: b-c:{(#1,RANGEKEYSET,_xyz)}
+EncodeSpan: c-d:{(#1,RANGEKEYSET,_xyz)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-1]

--- a/sstable/testdata/virtual_reader_iter
+++ b/sstable/testdata/virtual_reader_iter
@@ -32,9 +32,9 @@ a.SET.1:a
 d.SET.2:d
 f.SET.3:f
 d.RANGEDEL.4:e
-rangekey: a-d:{(#11,RANGEKEYSET,@10,foo)}
+EncodeSpan: a-d:{(#11,RANGEKEYSET,@10,foo)}
 g.RANGEDEL.5:l
-rangekey: y-z:{(#12,RANGEKEYSET,@11,foo)}
+EncodeSpan: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]
@@ -569,9 +569,9 @@ b.SET.5:b
 d.SET.2:d
 f.SET.3:f
 d.RANGEDEL.4:e
-rangekey: a-d:{(#11,RANGEKEYSET,@10,foo)}
+EncodeSpan: a-d:{(#11,RANGEKEYSET,@10,foo)}
 g.RANGEDEL.5:l
-rangekey: y-z:{(#12,RANGEKEYSET,@11,foo)}
+EncodeSpan: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -101,9 +101,9 @@ a.SET.1:a
 d.SET.2:d
 f.SET.3:f
 d.RANGEDEL.4:e
-rangekey: a-d:{(#11,RANGEKEYSET,@10,foo)}
+EncodeSpan: a-d:{(#11,RANGEKEYSET,@10,foo)}
 g.RANGEDEL.5:l
-rangekey: y-z:{(#12,RANGEKEYSET,@11,foo)}
+EncodeSpan: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -23,9 +23,9 @@ f.SET.5:f
 g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
-rangekey: j-k:{(#9,RANGEKEYDEL)}
-rangekey: k-l:{(#10,RANGEKEYUNSET,@5)}
-rangekey: l-m:{(#11,RANGEKEYSET,@10,foo)}
+EncodeSpan: j-k:{(#9,RANGEKEYDEL)}
+EncodeSpan: k-l:{(#10,RANGEKEYUNSET,@5)}
+EncodeSpan: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -46,9 +46,9 @@ e.SINGLEDEL.5:
 f.SET.6:f
 g.DEL.7:
 h.SINGLEDEL.8:
-rangekey: j-k:{(#9,RANGEKEYDEL)}
-rangekey: k-l:{(#10,RANGEKEYUNSET,@5)}
-rangekey: l-m:{(#11,RANGEKEYSET,@10,foo)}
+EncodeSpan: j-k:{(#9,RANGEKEYDEL)}
+EncodeSpan: k-l:{(#10,RANGEKEYUNSET,@5)}
+EncodeSpan: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#8,SINGLEDEL]
 rangekey: [j#9,RANGEKEYDEL-m#inf,RANGEKEYSET]
@@ -91,9 +91,11 @@ i-j:{(#8,RANGEDEL)}
 # 1:          j---------------z
 
 build
-a.RANGEDEL.3:m
-f.RANGEDEL.2:s
-j.RANGEDEL.1:z
+EncodeSpan: a-f:{(#3,RANGEDEL)}
+EncodeSpan: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
+EncodeSpan: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+EncodeSpan: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
+EncodeSpan: s-z:{(#1,RANGEDEL)}
 ----
 rangedel: [a#3,RANGEDEL-z#inf,RANGEDEL]
 seqnums:  [1-3]
@@ -157,7 +159,7 @@ build
 b.RANGEDEL.1:c
 a.RANGEDEL.2:b
 ----
-pebble: keys must be added in order: b > a
+pebble: keys must be added in order: b#1,RANGEDEL, a#2,RANGEDEL
 
 build-raw
 .RANGEDEL.1:b
@@ -190,22 +192,21 @@ c.RANGEDEL.2:d
 rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
 seqnums:  [1-2]
 
-build-raw
-rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
-rangekey: a-b:{(#2,RANGEKEYSET,@10,foo)}
+build
+EncodeSpan: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
 seqnums:  [1-2]
 
 build-raw
-rangekey: b-c:{(#2,RANGEKEYSET,@10,foo)}
-rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
+EncodeSpan: b-c:{(#2,RANGEKEYSET,@10,foo)}
+EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo)}
 ----
-pebble: spans must be added in order: b > a
+pebble: range keys starts must be added in increasing order: b#2,RANGEKEYSET, a#1,RANGEKEYSET
 
 build-raw
-rangekey: a-c:{(#1,RANGEKEYSET,@10,foo)}
-rangekey: c-d:{(#2,RANGEKEYSET,@10,foo)}
+EncodeSpan: a-c:{(#1,RANGEKEYSET,@10,foo)}
+EncodeSpan: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-2]
@@ -214,7 +215,7 @@ seqnums:  [1-2]
 # though the key kinds must be ordered (descending).
 
 build-raw
-rangekey: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@t10) (#1,RANGEKEYDEL)}
+EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@t10) (#1,RANGEKEYDEL)}
 ----
 rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
 seqnums:  [1-1]
@@ -274,9 +275,9 @@ layout
 # Range keys, if present, are shown in the layout.
 
 build
-rangekey: a-b:{(#3,RANGEKEYSET,@3,foo)}
-rangekey: b-c:{(#2,RANGEKEYSET,@2,bar)}
-rangekey: c-d:{(#1,RANGEKEYSET,@1,baz)}
+EncodeSpan: a-b:{(#3,RANGEKEYSET,@3,foo)}
+EncodeSpan: b-c:{(#2,RANGEKEYSET,@2,bar)}
+EncodeSpan: c-d:{(#1,RANGEKEYSET,@1,baz)}
 ----
 rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-3]

--- a/sstable/testdata/writer_v3
+++ b/sstable/testdata/writer_v3
@@ -23,9 +23,9 @@ f.SET.5:f
 g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
-rangekey: j-k:{(#9,RANGEKEYDEL)}
-rangekey: k-l:{(#10,RANGEKEYUNSET,@5)}
-rangekey: l-m:{(#11,RANGEKEYSET,@10,foo)}
+EncodeSpan: j-k:{(#9,RANGEKEYDEL)}
+EncodeSpan: k-l:{(#10,RANGEKEYUNSET,@5)}
+EncodeSpan: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -65,9 +65,11 @@ i-j:{(#8,RANGEDEL)}
 # 1:          j---------------z
 
 build
-a.RANGEDEL.3:m
-f.RANGEDEL.2:s
-j.RANGEDEL.1:z
+EncodeSpan: a-f:{(#3,RANGEDEL)}
+EncodeSpan: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
+EncodeSpan: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+EncodeSpan: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
+EncodeSpan: s-z:{(#1,RANGEDEL)}
 ----
 rangedel: [a#3,RANGEDEL-z#inf,RANGEDEL]
 seqnums:  [1-3]
@@ -131,7 +133,7 @@ build
 b.RANGEDEL.1:c
 a.RANGEDEL.2:b
 ----
-pebble: keys must be added in order: b > a
+pebble: keys must be added in order: b#1,RANGEDEL, a#2,RANGEDEL
 
 build-raw
 .RANGEDEL.1:b
@@ -165,21 +167,20 @@ rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
 seqnums:  [1-2]
 
 build-raw
-rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
-rangekey: a-b:{(#2,RANGEKEYSET,@10,foo)}
+EncodeSpan: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
 seqnums:  [1-2]
 
 build-raw
-rangekey: b-c:{(#2,RANGEKEYSET,@10,foo)}
-rangekey: a-b:{(#1,RANGEKEYSET,@10,foo)}
+EncodeSpan: b-c:{(#2,RANGEKEYSET,@10,foo)}
+EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo)}
 ----
-pebble: spans must be added in order: b > a
+pebble: range keys starts must be added in increasing order: b#2,RANGEKEYSET, a#1,RANGEKEYSET
 
 build-raw
-rangekey: a-c:{(#1,RANGEKEYSET,@10,foo)}
-rangekey: c-d:{(#2,RANGEKEYSET,@10,foo)}
+EncodeSpan: a-c:{(#1,RANGEKEYSET,@10,foo)}
+EncodeSpan: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-2]
@@ -188,7 +189,7 @@ seqnums:  [1-2]
 # though the key kinds must be ordered (descending).
 
 build-raw
-rangekey: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
+EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
 ----
 rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
 seqnums:  [1-1]
@@ -248,9 +249,9 @@ layout
 # Range keys, if present, are shown in the layout.
 
 build
-rangekey: a-b:{(#3,RANGEKEYSET,@3,foo)}
-rangekey: b-c:{(#2,RANGEKEYSET,@2,bar)}
-rangekey: c-d:{(#1,RANGEKEYSET,@1,baz)}
+EncodeSpan: a-b:{(#3,RANGEKEYSET,@3,foo)}
+EncodeSpan: b-c:{(#2,RANGEKEYSET,@2,bar)}
+EncodeSpan: c-d:{(#1,RANGEKEYSET,@1,baz)}
 ----
 rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-3]


### PR DESCRIPTION
Clean up the datadriven build and build-raw commands uses by various sstable unit tests. The build command confusingly had its own fragmenters for range deletions and range keys sitting between the test instructions and the Writer being tested.

These commands are updated so that the build instructions mirror what is supplied to the writer.