### PR TITLE
cache: remove entry.shard field

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -143,7 +143,7 @@ func (c *shard) Set(id uint64, fileNum base.DiskFileNum, offset uint64, value *V
 	switch {
 	case e == nil:
 		// no cache entry? add it
-		e = newEntry(c, k, int64(len(value.buf)))
+		e = newEntry(k, int64(len(value.buf)))
 		e.setValue(value)
 		if c.metaAdd(k, e) {
 			value.ref.trace("add-cold")

--- a/internal/cache/entry.go
+++ b/internal/cache/entry.go
@@ -59,19 +59,17 @@ type entry struct {
 	// referenced is atomically set to indicate that this entry has been accessed
 	// since the last time one of the clock hands swept it.
 	referenced atomic.Bool
-	shard      *shard
 	// Reference count for the entry. The entry is freed when the reference count
 	// drops to zero.
 	ref refcnt
 }
 
-func newEntry(s *shard, key key, size int64) *entry {
+func newEntry(key key, size int64) *entry {
 	e := entryAllocNew()
 	*e = entry{
 		key:   key,
 		size:  size,
 		ptype: etCold,
-		shard: s,
 	}
 	e.blockLink.next = e
 	e.blockLink.prev = e


### PR DESCRIPTION
This field is unused and makes the `entry` unnecessarily larger.