### PR TITLE
sstable: separate [Index|Data]BlockIterator interfaces and constraints

### DIFF
--- a/sstable/colblk/index_block.go
+++ b/sstable/colblk/index_block.go
@@ -160,12 +160,8 @@ type IndexIter struct {
 	allocReader IndexReader
 }
 
-// Assert that IndexIter satisfies the block.IndexBlockIterator constraint.
-var _ = satisfiesIndexBlock[IndexIter, *IndexIter](IndexIter{})
-
-func satisfiesIndexBlock[T any, PT block.IndexBlockIterator[T]](indexBlock T) PT {
-	return &indexBlock
-}
+// Assert that IndexIter satisfies the block.IndexBlockIterator interface.
+var _ block.IndexBlockIterator = (*IndexIter)(nil)
 
 // Init initializes an index iterator from the provided reader.
 func (i *IndexIter) Init(r *IndexReader) {

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -39,7 +39,7 @@ import (
 // &data/&index to the PD/PI type in order to access its interface methods. This
 // pattern is taken from the Go generics proposal:
 // https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#pointer-method-example
-type singleLevelIterator[I any, PI block.IndexBlockIterator[I], D any, PD block.DataBlockIterator[D]] struct {
+type singleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIterator[D]] struct {
 	ctx context.Context
 	cmp Compare
 	// Global lower/upper bound for the iterator.

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable/rowblk"
 )
 
-type twoLevelIterator[I any, PI block.IndexBlockIterator[I], D any, PD block.DataBlockIterator[D]] struct {
+type twoLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIterator[D]] struct {
 	secondLevel   singleLevelIterator[I, PI, D, PD]
 	topLevelIndex rowblk.IndexIter
 	// pool is the pool from which the iterator was allocated and to which the

--- a/sstable/rowblk/rowblk_index_iter.go
+++ b/sstable/rowblk/rowblk_index_iter.go
@@ -15,12 +15,8 @@ type IndexIter struct {
 	iter Iter
 }
 
-// Assert that IndexIter satisfies the block.IndexBlockIterator constraint.
-var _ = satisfiesIndexBlock[IndexIter, *IndexIter](IndexIter{})
-
-func satisfiesIndexBlock[T any, PT block.IndexBlockIterator[T]](indexBlock T) PT {
-	return &indexBlock
-}
+// Assert that IndexIter satisfies the block.IndexBlockIterator interface.
+var _ block.IndexBlockIterator = (*IndexIter)(nil)
 
 // InitHandle initializes an iterator from the provided block handle.
 func (i *IndexIter) InitHandle(

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -202,8 +202,8 @@ type blockEntry struct {
 	valSize  int32
 }
 
-// blockIter implements the base.InternalIterator interface.
-var _ base.InternalIterator = (*Iter)(nil)
+// *Iter implements the block.DataBlockIterator interface.
+var _ block.DataBlockIterator = (*Iter)(nil)
 
 // NewIter constructs a new row-oriented block iterator over the provided serialized block.
 func NewIter(


### PR DESCRIPTION
Remove the pointer constraints from block.DataBlockIterator and block.IndexBlockIterator interfaces. Instead define new constraints internal to the sstable package adjacent to where they're required. The block.DataBlockIterator and block.IndexBlockIterator interfaces can be used as ordinary interfaces without compile-time knowledge of the type where it's more convenient to do so.