### PR TITLE
sstable: return interface type from NewRawWriter

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2740,7 +2740,11 @@ func (d *DB) newCompactionOutput(
 		d.opts.Experimental.MaxWriterConcurrency > 0 &&
 			(cpuWorkHandle.Permitted() || d.opts.Experimental.ForceWriterParallelism)
 
-	tw := sstable.NewRawWriter(writable, writerOpts)
+	// TODO(jackson): Make the compaction body generic over the RawWriter type,
+	// so that we don't need to pay the cost of dynamic dispatch. For now, we
+	// type assert into the only concrete RawWriter type we see (until colblk is
+	// integrated).
+	tw := sstable.NewRawWriter(writable, writerOpts).(*sstable.RawRowWriter)
 	return objMeta, tw, cpuWorkHandle, nil
 }
 

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -139,10 +139,10 @@ func TestEventListener(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{
+			w := sstable.NewWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{
 				TableFormat: d.FormatMajorVersion().MaxTableFormat(),
 			})
-			if err := w.Add(base.MakeInternalKey([]byte("a"), 0, InternalKeyKindSet), nil); err != nil {
+			if err := w.Set([]byte("a"), nil); err != nil {
 				return err.Error()
 			}
 			if err := w.Close(); err != nil {
@@ -173,10 +173,10 @@ func TestEventListener(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{
+				w := sstable.NewWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{
 					TableFormat: d.FormatMajorVersion().MaxTableFormat(),
 				})
-				if err := w.Add(base.MakeInternalKey([]byte{key}, 0, InternalKeyKindSet), nil); err != nil {
+				if err := w.Set([]byte{key}, nil); err != nil {
 					return err
 				}
 				if err := w.Close(); err != nil {

--- a/internal/compact/spans.go
+++ b/internal/compact/spans.go
@@ -182,7 +182,7 @@ func (c *RangeKeySpanCompactor) elideInLastStripe(
 //
 // The span can contain either only RANGEDEL keys or only range keys.
 func SplitAndEncodeSpan(
-	cmp base.Compare, span *keyspan.Span, upToKey []byte, tw *sstable.RawRowWriter,
+	cmp base.Compare, span *keyspan.Span, upToKey []byte, tw sstable.RawWriter,
 ) error {
 	if span.Empty() {
 		return nil

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -201,12 +201,12 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 					switch ikey.Kind() {
 					case InternalKeyKindRangeDelete:
 						if writeUnfragmented {
-							err = w.Add(ikey, value)
+							err = w.AddWithForceObsolete(ikey, value, false /* forceObsolete */)
 							break
 						}
 						frag.Add(rangedel.Decode(ikey, value, nil))
 					default:
-						err = w.Add(ikey, value)
+						err = w.AddWithForceObsolete(ikey, value, false /* forceObsolete */)
 					}
 					if err != nil {
 						return err.Error()
@@ -214,7 +214,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				}
 				frag.Finish()
 				for _, v := range tombstones {
-					if err := rangedel.Encode(v, w.Add); err != nil {
+					if err := w.EncodeSpan(v); err != nil {
 						return err.Error()
 					}
 				}

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -603,7 +603,7 @@ func benchmarkRangeDelIterate(b *testing.B, entries, deleted int, snapshotCompac
 	})
 	for i := 0; i < entries; i++ {
 		key := base.MakeInternalKey(makeKey(i), 0, InternalKeyKindSet)
-		if err := w.Add(key, nil); err != nil {
+		if err := w.AddWithForceObsolete(key, nil, false /* forceObsolete */); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -61,7 +61,7 @@ func CopySpan(
 		o.FilterPolicy = nil
 	}
 	o.TableFormat = r.tableFormat
-	w := NewRawWriter(output, o)
+	w := newRowWriter(output, o)
 
 	// We don't want the writer to attempt to write out block property data in
 	// index blocks. This data won't be valid since we're not passing the actual

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -391,7 +391,7 @@ func buildRandomSSTable(f vfs.File, cfg randomTableConfig) (*WriterMetadata, err
 			value = valueBuf[:cfg.rng.Intn(cfg.maxValLen+1)]
 			cfg.rng.Read(value)
 		}
-		if err := w.Add(keys[i], value); err != nil {
+		if err := w.AddWithForceObsolete(keys[i], value, false /* forceObsolete */); err != nil {
 			return nil, err
 		}
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1804,7 +1804,7 @@ func buildTestTableWithProvider(
 		value := make([]byte, i%100)
 		key = binary.BigEndian.AppendUint64(key, i)
 		ikey.UserKey = key
-		w.Add(ikey, value)
+		require.NoError(t, w.AddWithForceObsolete(ikey, value, false /* forceObsolete */))
 	}
 
 	require.NoError(t, w.Close())
@@ -1844,7 +1844,7 @@ func buildBenchmarkTable(
 		binary.BigEndian.PutUint64(key, i+uint64(offset))
 		keys = append(keys, key)
 		ikey.UserKey = key
-		w.Add(ikey, nil)
+		require.NoError(b, w.AddWithForceObsolete(ikey, nil, false /* forceObsolete */))
 	}
 
 	if err := w.Close(); err != nil {

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -97,7 +97,7 @@ func rewriteKeySuffixesInBlocks(
 
 	tableFormat := r.tableFormat
 	o.TableFormat = tableFormat
-	w := NewRawWriter(out, o)
+	w := newRowWriter(out, o)
 	defer func() {
 		if w != nil {
 			w.Close()
@@ -388,7 +388,7 @@ func RewriteKeySuffixesViaWriter(
 	}
 
 	o.IsStrictObsolete = false
-	w := NewRawWriter(out, o)
+	w := newRowWriter(out, o)
 	defer func() {
 		if w != nil {
 			w.Close()

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -465,7 +465,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 						IndexBlockSize: indexBlockSize,
 					})
 					for _, k := range keys[:nk] {
-						if err := w.Add(InternalKey{UserKey: []byte(k)}, xxx[:vLen]); err != nil {
+						if err := w.AddWithForceObsolete(InternalKey{UserKey: []byte(k)}, xxx[:vLen], false /* forceObsolete */); err != nil {
 							t.Errorf("nk=%d, vLen=%d: set: %v", nk, vLen, err)
 							continue loop
 						}

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -215,7 +215,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 						rKeySpan.Keys = append(rKeySpan.Keys, k)
 					} else {
 						k := base.InternalKey{UserKey: s.Start, Trailer: k.Trailer}
-						if err = w.Add(k, s.End); err != nil {
+						if err = w.AddWithForceObsolete(k, s.End, false /* forceObsolete */); err != nil {
 							return err.Error()
 						}
 					}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -32,7 +32,7 @@ func writeAndIngest(t *testing.T, mem vfs.FS, d *DB, k InternalKey, v []byte, fi
 	f, err := mem.Create(path, vfs.WriteCategoryUnspecified)
 	require.NoError(t, err)
 	w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{})
-	require.NoError(t, w.Add(k, v))
+	require.NoError(t, w.AddWithForceObsolete(k, v, false /* forceObsolete */))
 	require.NoError(t, w.Close())
 	require.NoError(t, d.Ingest(context.Background(), []string{path}))
 }


### PR DESCRIPTION
Previously the NewRawWriter type returned a concreate *RawRowWriter type, and some callers (including NewWriter) relied on this. This commit updates the callers appropriately to remove the dependency.