### PR TITLE
manual: add cgo memory accounting

### DIFF
--- a/db.go
+++ b/db.go
@@ -2041,6 +2041,8 @@ func (d *DB) Metrics() *Metrics {
 
 	metrics.Uptime = d.timeNow().Sub(d.openedAt)
 
+	metrics.manualMemory = manual.GetMetrics()
+
 	return metrics
 }
 
@@ -2368,7 +2370,7 @@ func (d *DB) newMemTable(
 		memtblOpts.releaseAccountingReservation = mem.releaseAccountingReservation
 	} else {
 		mem = new(memTable)
-		memtblOpts.arenaBuf = manual.New(int(size))
+		memtblOpts.arenaBuf = manual.New(manual.MemTable, int(size))
 		memtblOpts.releaseAccountingReservation = d.opts.Cache.Reserve(int(size))
 		d.memTableCount.Add(1)
 		d.memTableReserved.Add(int64(size))

--- a/internal/cache/block_map.go
+++ b/internal/cache/block_map.go
@@ -27,14 +27,14 @@ type blockMapAllocator struct{}
 
 func (blockMapAllocator) Alloc(n int) []swiss.Group[key, *entry] {
 	size := uintptr(n) * unsafe.Sizeof(swiss.Group[key, *entry]{})
-	buf := manual.New(int(size))
+	buf := manual.New(manual.BlockCacheMap, int(size))
 	return unsafe.Slice((*swiss.Group[key, *entry])(unsafe.Pointer(unsafe.SliceData(buf))), n)
 }
 
 func (blockMapAllocator) Free(v []swiss.Group[key, *entry]) {
 	size := uintptr(len(v)) * unsafe.Sizeof(swiss.Group[key, *entry]{})
 	buf := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(v))), size)
-	manual.Free(buf)
+	manual.Free(manual.BlockCacheMap, buf)
 }
 
 var blockMapOptions = []swiss.Option[key, *entry]{

--- a/internal/cache/entry_normal.go
+++ b/internal/cache/entry_normal.go
@@ -80,7 +80,7 @@ func (c *entryAllocCache) alloc() *entry {
 		if entriesGoAllocated {
 			return &entry{}
 		}
-		b := manual.New(entrySize)
+		b := manual.New(manual.BlockCacheEntry, entrySize)
 		return (*entry)(unsafe.Pointer(&b[0]))
 	}
 	e := c.entries[n-1]
@@ -91,7 +91,7 @@ func (c *entryAllocCache) alloc() *entry {
 func (c *entryAllocCache) dealloc(e *entry) {
 	if !entriesGoAllocated {
 		buf := (*[manual.MaxArrayLen]byte)(unsafe.Pointer(e))[:entrySize:entrySize]
-		manual.Free(buf)
+		manual.Free(manual.BlockCacheEntry, buf)
 	}
 }
 

--- a/internal/cache/value_cgo.go
+++ b/internal/cache/value_cgo.go
@@ -22,7 +22,7 @@ func newValue(n int) *Value {
 	// When we're not performing leak detection, the lifetime of the returned
 	// Value is exactly the lifetime of the backing buffer and we can manually
 	// allocate both.
-	b := manual.New(ValueMetadataSize + n)
+	b := manual.New(manual.BlockCacheData, ValueMetadataSize+n)
 	v := (*Value)(unsafe.Pointer(&b[0]))
 	v.buf = b[ValueMetadataSize:]
 	v.ref.init(1)
@@ -35,5 +35,5 @@ func (v *Value) free() {
 	n := ValueMetadataSize + cap(v.buf)
 	buf := (*[manual.MaxArrayLen]byte)(unsafe.Pointer(v))[:n:n]
 	v.buf = nil
-	manual.Free(buf)
+	manual.Free(manual.BlockCacheData, buf)
 }

--- a/internal/cache/value_invariants.go
+++ b/internal/cache/value_invariants.go
@@ -25,7 +25,7 @@ func newValue(n int) *Value {
 	if n == 0 {
 		return nil
 	}
-	b := manual.New(n)
+	b := manual.New(manual.BlockCacheData, n)
 	v := &Value{buf: b}
 	v.ref.init(1)
 	// Note: this is a no-op if invariants and tracing are disabled or race is
@@ -47,7 +47,7 @@ func (v *Value) free() {
 	for i := range v.buf {
 		v.buf[i] = 0xff
 	}
-	manual.Free(v.buf)
+	manual.Free(manual.BlockCacheData, v.buf)
 	// Setting Value.buf to nil is needed for correctness of the leak checking
 	// that is performed when the "invariants" or "tracing" build tags are
 	// enabled.

--- a/internal/manual/manual.go
+++ b/internal/manual/manual.go
@@ -1,60 +1,63 @@
-// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
 package manual
 
-// #include <stdlib.h>
-import "C"
-import "unsafe"
+import (
+	"fmt"
+	"sync/atomic"
 
-// The go:linkname directives provides backdoor access to private functions in
-// the runtime. Below we're accessing the throw function.
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
 
-//go:linkname throw runtime.throw
-func throw(s string)
+// Purpose identifies the use-case for an allocation.
+type Purpose uint8
 
-// TODO(peter): Rather than relying an C malloc/free, we could fork the Go
-// runtime page allocator and allocate large chunks of memory using mmap or
-// similar.
+const (
+	_ Purpose = iota
 
-// New allocates a slice of size n. The returned slice is from manually managed
-// memory and MUST be released by calling Free. Failure to do so will result in
-// a memory leak.
-func New(n int) []byte {
-	if n == 0 {
-		return make([]byte, 0)
-	}
-	// We need to be conscious of the Cgo pointer passing rules:
-	//
-	//   https://golang.org/cmd/cgo/#hdr-Passing_pointers
-	//
-	//   ...
-	//   Note: the current implementation has a bug. While Go code is permitted
-	//   to write nil or a C pointer (but not a Go pointer) to C memory, the
-	//   current implementation may sometimes cause a runtime error if the
-	//   contents of the C memory appear to be a Go pointer. Therefore, avoid
-	//   passing uninitialized C memory to Go code if the Go code is going to
-	//   store pointer values in it. Zero out the memory in C before passing it
-	//   to Go.
-	ptr := C.calloc(C.size_t(n), 1)
-	if ptr == nil {
-		// NB: throw is like panic, except it guarantees the process will be
-		// terminated. The call below is exactly what the Go runtime invokes when
-		// it cannot allocate memory.
-		throw("out of memory")
-	}
-	// Interpret the C pointer as a pointer to a Go array, then slice.
-	return (*[MaxArrayLen]byte)(unsafe.Pointer(ptr))[:n:n]
+	BlockCacheMap
+	BlockCacheEntry
+	BlockCacheData
+	MemTable
+
+	NumPurposes
+)
+
+// Metrics contains memory statistics by purpose.
+type Metrics [NumPurposes]struct {
+	// InUseBytes is the total number of bytes currently allocated. This is just
+	// the sum of the lengths of the allocations and does not include any overhead
+	// or fragmentation.
+	InUseBytes uint64
 }
 
-// Free frees the specified slice.
-func Free(b []byte) {
-	if cap(b) != 0 {
-		if len(b) == 0 {
-			b = b[:cap(b)]
-		}
-		ptr := unsafe.Pointer(&b[0])
-		C.free(ptr)
+var counters [NumPurposes]struct {
+	InUseBytes atomic.Int64
+	// Pad to separate counters into cache lines. This reduces the overhead when
+	// multiple purposes are used frequently. We assume 64 byte cache line size
+	// which is the case for ARM64 servers and AMD64.
+	_ [7]uint64
+}
+
+func recordAlloc(purpose Purpose, n int) {
+	counters[purpose].InUseBytes.Add(int64(n))
+}
+
+func recordFree(purpose Purpose, n int) {
+	newVal := counters[purpose].InUseBytes.Add(-int64(n))
+	if invariants.Enabled && newVal < 0 {
+		panic(fmt.Sprintf("negative counter value %d", newVal))
 	}
+}
+
+// GetMetrics returns manual memory usage statistics.
+func GetMetrics() Metrics {
+	var res Metrics
+	for i := range res {
+		// We load the freed count first to avoid a negative value, since we don't load both counters atomically.
+		res[i].InUseBytes = uint64(counters[i].InUseBytes.Load())
+	}
+	return res
 }

--- a/internal/manual/manual_cgo.go
+++ b/internal/manual/manual_cgo.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manual
+
+// #include <stdlib.h>
+import "C"
+import "unsafe"
+
+// The go:linkname directives provides backdoor access to private functions in
+// the runtime. Below we're accessing the throw function.
+
+//go:linkname throw runtime.throw
+func throw(s string)
+
+// TODO(peter): Rather than relying an C malloc/free, we could fork the Go
+// runtime page allocator and allocate large chunks of memory using mmap or
+// similar.
+
+// New allocates a slice of size n. The returned slice is from manually managed
+// memory and MUST be released by calling Free. Failure to do so will result in
+// a memory leak.
+func New(purpose Purpose, n int) []byte {
+	if n == 0 {
+		return make([]byte, 0)
+	}
+	recordAlloc(purpose, n)
+	// We need to be conscious of the Cgo pointer passing rules:
+	//
+	//   https://golang.org/cmd/cgo/#hdr-Passing_pointers
+	//
+	//   ...
+	//   Note: the current implementation has a bug. While Go code is permitted
+	//   to write nil or a C pointer (but not a Go pointer) to C memory, the
+	//   current implementation may sometimes cause a runtime error if the
+	//   contents of the C memory appear to be a Go pointer. Therefore, avoid
+	//   passing uninitialized C memory to Go code if the Go code is going to
+	//   store pointer values in it. Zero out the memory in C before passing it
+	//   to Go.
+	ptr := C.calloc(C.size_t(n), 1)
+	if ptr == nil {
+		// NB: throw is like panic, except it guarantees the process will be
+		// terminated. The call below is exactly what the Go runtime invokes when
+		// it cannot allocate memory.
+		throw("out of memory")
+	}
+	// Interpret the C pointer as a pointer to a Go array, then slice.
+	return (*[MaxArrayLen]byte)(unsafe.Pointer(ptr))[:n:n]
+}
+
+// Free frees the specified slice. It has to be exactly the slice that was
+// returned by New.
+func Free(purpose Purpose, b []byte) {
+	if cap(b) != 0 {
+		recordFree(purpose, cap(b))
+		if len(b) == 0 {
+			b = b[:cap(b)]
+		}
+		ptr := unsafe.Pointer(&b[0])
+		C.free(ptr)
+	}
+}

--- a/internal/manual/manual_nocgo.go
+++ b/internal/manual/manual_nocgo.go
@@ -11,10 +11,13 @@ package manual
 // compilation).
 
 // New allocates a slice of size n.
-func New(n int) []byte {
+func New(purpose Purpose, n int) []byte {
+	recordAlloc(purpose, n)
 	return make([]byte, n)
 }
 
-// Free frees the specified slice.
-func Free(b []byte) {
+// Free frees the specified slice. It has to be exactly the slice that was
+// returned by New.
+func Free(purpose Purpose, b []byte) {
+	recordFree(purpose, cap(b))
 }

--- a/mem_table.go
+++ b/mem_table.go
@@ -92,7 +92,7 @@ type memTable struct {
 func (m *memTable) free() {
 	if m != nil {
 		m.releaseAccountingReservation()
-		manual.Free(m.arenaBuf)
+		manual.Free(manual.MemTable, m.arenaBuf)
 		m.arenaBuf = nil
 	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
@@ -99,6 +100,9 @@ func exampleMetrics() Metrics {
 		l.MultiLevel.BytesInTop = base + 4
 		l.MultiLevel.BytesIn = base + 4
 		l.MultiLevel.BytesRead = base + 4
+	}
+	for i := range m.manualMemory {
+		m.manualMemory[i].InUseBytes = uint64((i + 1) * 1024)
 	}
 	return m
 }
@@ -329,6 +333,9 @@ func TestMetrics(t *testing.T) {
 			d.mu.Unlock()
 
 			m := d.Metrics()
+			// Don't show memory usage as that can depend on architecture, invariants
+			// tag, etc.
+			m.manualMemory = manual.Metrics{}
 			// Some subset of cases show non-determinism in cache hits/misses.
 			if td.HasArg("zero-cache-hits-misses") {
 				// Avoid non-determinism.

--- a/open.go
+++ b/open.go
@@ -246,7 +246,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 			for _, mem := range d.mu.mem.queue {
 				switch t := mem.flushable.(type) {
 				case *memTable:
-					manual.Free(t.arenaBuf)
+					manual.Free(manual.MemTable, t.arenaBuf)
 					t.arenaBuf = nil
 				}
 			}

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -230,6 +230,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 1  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 
 # Set up a scenario where the table to be ingested overlaps with the memtable.
 # The table is ingested as a flushable. The flush metrics refect the flushed
@@ -331,6 +332,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 2  as flushable: 1 (1.2KB in 2 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 
 sstables
 ----

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -60,6 +60,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 1  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 
 
 iter

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -29,6 +29,7 @@ Snapshots: 4  earliest seq num: 1024
 Table iters: 21
 Filter utility: 47.4%
 Ingestions: 27  as flushable: 36 (34B in 35 tables)
+Cgo memory usage: 15KB  block cache: 9.0KB (data: 4.0KB, maps: 2.0KB, entries: 3.0KB)  memtables: 5.0KB
 
 init
 ----
@@ -81,6 +82,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 
 disk-usage
 ----
@@ -137,6 +139,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 2
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
@@ -180,6 +183,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 2
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
@@ -220,6 +224,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
@@ -264,6 +269,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -335,6 +341,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -390,6 +397,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -494,6 +502,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -557,6 +566,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -634,6 +644,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 3  as flushable: 2 (1.7KB in 3 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -736,6 +747,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 4  as flushable: 2 (1.7KB in 3 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -790,6 +802,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 
 compact a-z
 ----
@@ -828,6 +841,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 
 build ext1.sst
 set b 2
@@ -875,6 +889,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 1  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
        pebble-ingest,     latency: {BlockBytes:59 BlockBytesInCache:0 BlockReadDuration:10ms}
 
@@ -923,6 +938,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 1  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
        pebble-ingest,     latency: {BlockBytes:59 BlockBytesInCache:0 BlockReadDuration:10ms}
 
@@ -962,6 +978,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 
 compact a-z
 ----
@@ -1000,5 +1017,6 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:147 BlockBytesInCache:0 BlockReadDuration:30ms}

--- a/tool/data_test.go
+++ b/tool/data_test.go
@@ -146,6 +146,20 @@ func runTests(t *testing.T, path string) {
 				if err := c.Execute(); err != nil {
 					return err.Error()
 				}
+				output := buf.String()
+				if output == "" {
+					return ""
+				}
+				output = strings.TrimSuffix(output, "\n")
+				buf.Reset()
+				for _, l := range strings.Split(output, "\n") {
+					if strings.HasPrefix(l, "Cgo memory usage:") {
+						buf.WriteString("Cgo memory usage: <redacted>")
+					} else {
+						buf.WriteString(l)
+					}
+					buf.WriteString("\n")
+				}
 				return buf.String()
 			})
 		})

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -39,6 +39,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: <redacted>
 
 db lsm --url
 ../testdata/db-stage-4
@@ -73,6 +74,7 @@ Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: <redacted>
 
 LSM viewer: https://raduberinde.github.io/lsmview/decode.html#eJyE0EFLw0AQBeC7v2J4uU5lN42W7lHsrTe9SSgTOi2hm13NRqGV_HdJCaUWMXvaxzfMwPuG1y_1Ce5t_G6CNAqHtbk3YHRSeR1ZKvVwKMBI9UnhFmbJSI14r6nbHPQIZxhe2v0lW8ZWO6nPJ2CGVziqpM1swc-rNc1oF2Nm5_yyeh0XO1qY5dMQ9CN8NsmRzWlGdjj8HuvQpf820JWN8ZTZ_KI3wyFSK2GvtB1qKPuy59sm7HUPf3g-4fMJLyb8YcIff3vJOOjx3HclLRi7GFH2dz8BAAD__2dulBM=
 ----


### PR DESCRIPTION
This commit adds a breakdown of cgo memory usage in Pebble. This will
show up as part of the periodic LSM metrics dump in the logs.

Fixes #3908
