### PR TITLE
sstable: remove unnecessary loop while identifying filter block

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -559,29 +559,9 @@ func (r *Reader) readMetaindex(
 	}
 
 	for name, fp := range filters {
-		types := []struct {
-			ftype  FilterType
-			prefix string
-		}{
-			{TableFilter, "fullfilter."},
-		}
-		var done bool
-		for _, t := range types {
-			if bh, ok := meta[t.prefix+name]; ok {
-				r.filterBH = bh
-
-				switch t.ftype {
-				case TableFilter:
-					r.tableFilter = newTableFilterReader(fp, r.filterMetricsTracker)
-				default:
-					return base.CorruptionErrorf("unknown filter type: %v", errors.Safe(t.ftype))
-				}
-
-				done = true
-				break
-			}
-		}
-		if done {
+		if bh, ok := meta["fullfilter."+name]; ok {
+			r.filterBH = bh
+			r.tableFilter = newTableFilterReader(fp, r.filterMetricsTracker)
 			break
 		}
 	}


### PR DESCRIPTION
When opening an sstable and reading the metaindex, we loop over the known filters looking for a block with a matching name. Previously there was an inner loop that statically only ever had one iteration. This inner loop was a vestige from early Pebble's support for 'block-based' bloom filters. There's only ever been a single filter type since #32.