### PR TITLE
sstable/block: fix compression roundtrip test

### DIFF
--- a/sstable/block/compression_cgo.go
+++ b/sstable/block/compression_cgo.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 
 	"github.com/DataDog/zstd"
+	"github.com/cockroachdb/errors"
 )
 
 // UseStandardZstdLib indicates whether the zstd implementation is a port of the
@@ -27,6 +28,12 @@ const UseStandardZstdLib = true
 // decodeZstd decompresses src with the Zstandard algorithm. The destination
 // buffer must already be sufficiently sized, otherwise decodeZstd may error.
 func decodeZstd(dst, src []byte) ([]byte, error) {
+	if len(src) == 0 {
+		return nil, errors.Errorf("decodeZstd: empty src buffer")
+	}
+	if len(dst) == 0 {
+		return nil, errors.Errorf("decodeZstd: empty dst buffer")
+	}
 	n, err := zstd.DecompressInto(dst, src)
 	// NB: zstd.DecompressInto may return n < 0 if err != nil.
 	if err != nil {

--- a/sstable/block/compression_test.go
+++ b/sstable/block/compression_test.go
@@ -24,11 +24,11 @@ func TestCompressionRoundtrip(t *testing.T) {
 
 	for compression := DefaultCompression + 1; compression < NCompression; compression++ {
 		t.Run(compression.String(), func(t *testing.T) {
-			payload := make([]byte, rng.Intn(10<<10 /* 10 KiB */))
+			payload := make([]byte, 1+rng.Intn(10<<10 /* 10 KiB */))
 			rng.Read(payload)
 			// Create a randomly-sized buffer to house the compressed output. If it's
 			// not sufficient, Compress should allocate one that is.
-			compressedBuf := make([]byte, rng.Intn(1<<10 /* 1 KiB */))
+			compressedBuf := make([]byte, 1+rng.Intn(1<<10 /* 1 KiB */))
 
 			btyp, compressed := compress(compression, payload, compressedBuf)
 			v, err := decompress(btyp, compressed)


### PR DESCRIPTION
This test occasionally failed with an index out of range.

Fixes #3922