### PR TITLE
db: use delete-only compaction hints to do excises

### DIFF
--- a/event.go
+++ b/event.go
@@ -119,14 +119,18 @@ func (i CompactionInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 		w.Printf("[JOB %d] compacting(%s) ",
 			redact.Safe(i.JobID),
 			redact.SafeString(i.Reason))
-		w.Printf("%s", i.Annotations)
+		if len(i.Annotations) > 0 {
+			w.Printf("%s ", i.Annotations)
+		}
 		w.Printf("%s; ", levelInfos(i.Input))
 		w.Printf("OverlappingRatio: Single %.2f, Multi %.2f", i.SingleLevelOverlappingRatio, i.MultiLevelOverlappingRatio)
 		return
 	}
 	outputSize := tablesTotalSize(i.Output.Tables)
 	w.Printf("[JOB %d] compacted(%s) ", redact.Safe(i.JobID), redact.SafeString(i.Reason))
-	w.Printf("%s", i.Annotations)
+	if len(i.Annotations) > 0 {
+		w.Printf("%s ", i.Annotations)
+	}
 	w.Print(levelInfos(i.Input))
 	w.Printf(" -> L%d [%s] (%s), in %.1fs (%.1fs total), output rate %s/s",
 		redact.Safe(i.Output.Level),

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -837,7 +837,7 @@ func TestExcise(t *testing.T) {
 
 			current.IterAllLevelsAndSublevels(func(iter manifest.LevelIterator, l manifest.Layer) {
 				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
-					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, l.Level())
+					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, l.Level(), d.mu.versions.getNextFileNum)
 					if err != nil {
 						td.Fatalf(t, "error when excising %s: %s", m.FileNum, err.Error())
 					}
@@ -1189,7 +1189,7 @@ func testIngestSharedImpl(
 			for level := range current.Levels {
 				iter := current.Levels[level].Iter()
 				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
-					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, level)
+					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, level, d.mu.versions.getNextFileNum)
 					if err != nil {
 						d.mu.Lock()
 						d.mu.versions.logUnlock()
@@ -1690,7 +1690,7 @@ func TestConcurrentExcise(t *testing.T) {
 			for level := range current.Levels {
 				iter := current.Levels[level].Iter()
 				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
-					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, level)
+					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, level, d.mu.versions.getNextFileNum)
 					if err != nil {
 						d.mu.Lock()
 						d.mu.versions.logUnlock()

--- a/metrics.go
+++ b/metrics.go
@@ -84,6 +84,10 @@ type LevelMetrics struct {
 	TablesIngested uint64
 	// The number of sstables moved to this level by a "move" compaction.
 	TablesMoved uint64
+	// The number of sstables deleted in a level by a delete-only compaction.
+	TablesDeleted uint64
+	// The number of sstables excised in a level by a delete-only compaction.
+	TablesExcised uint64
 
 	MultiLevel struct {
 		// BytesInTop are the total bytes in a multilevel compaction coming from the top level.

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -127,7 +127,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L2 [000006] (605B) Score=0.00 + L3 [000007] (605B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+  [JOB 100] compacted(delete-only) multilevel L1 [000005] (650B) Score=0.00 + L2 [000006] (605B) Score=0.00 + L3 [000007] (605B) Score=0.00 -> L6 [000009] (1B), in 1.0s (2.0s total), output rate 1B/s
 
 # Test a range tombstone that is already compacted into L6.
 
@@ -431,3 +431,223 @@ Deletion hints:
   (none)
 Compactions:
   [JOB 100] compacted(delete-only) L6 [000006 000007 000008 000009 000011] (3.3KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+
+# Verify that a delete-only compaction can partially excise a file.
+
+define
+L0
+a.RANGEDEL.300:k
+L1
+b.RANGEDEL.230:h h.RANGEDEL.200:r
+L2
+d.SET.110:d i.SET.140:i
+L3
+k.SET.90:k o.SET.150:o
+L4
+m.SET.30:m u.SET.60:u
+----
+L0.0:
+  000004:[a#300,RANGEDEL-k#inf,RANGEDEL]
+L1:
+  000005:[b#230,RANGEDEL-r#inf,RANGEDEL]
+L2:
+  000006:[d#110,SET-i#140,SET]
+L3:
+  000007:[k#90,SET-o#150,SET]
+L4:
+  000008:[m#30,SET-u#60,SET]
+
+get-hints
+----
+L0.000004 a-k seqnums(tombstone=300-300, file-smallest=110, type=point-key-only)
+L1.000005 b-r seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
+
+iter
+first
+next
+next
+next
+----
+u: (u, .)
+.
+.
+.
+
+maybe-compact
+----
+Deletion hints:
+  (none)
+Compactions:
+  [JOB 100] compacted(delete-only) multilevel L1 [000005] (650B) Score=0.00 + L2 [000006] (605B) Score=0.00 + L3 [000007] (605B) Score=0.00 -> L6 [000009] (1B), in 1.0s (2.0s total), output rate 1B/s
+
+describe-lsm
+----
+L0.0:
+  000004:[a#300,RANGEDEL-k#inf,RANGEDEL]
+L1:
+  000009(000005):[k#200,RANGEDEL-r#inf,RANGEDEL]
+L4:
+  000008:[m#30,SET-u#60,SET]
+
+iter
+first
+next
+next
+next
+----
+u: (u, .)
+.
+.
+.
+
+get-hints
+----
+(none)
+
+# Verify that a delete-only compaction hint for point keys does not excise a file
+# if it has range keys
+
+reset
+----
+
+ingest ext
+set k k
+set o o
+range-key-set k o @3 foo
+----
+OK
+
+ingest ext
+set d d
+set i i
+----
+OK
+
+ingest ext
+del-range b r
+----
+OK
+
+describe-lsm
+----
+L0.0:
+  000006:[b#12,RANGEDEL-r#inf,RANGEDEL]
+L6:
+  000005:[d#11,SET-i#11,SET]
+  000004:[k#10,RANGEKEYSET-o#10,SET]
+
+get-hints
+----
+L0.000006 b-r seqnums(tombstone=12-12, file-smallest=11, type=point-key-only)
+
+iter
+first
+next
+next
+next
+----
+.
+.
+.
+.
+
+maybe-compact
+----
+Deletion hints:
+  (none)
+Compactions:
+  [JOB 100] compacted(delete-only) L6 [000005] (597B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+
+describe-lsm
+----
+L0.0:
+  000006:[b#12,RANGEDEL-r#inf,RANGEDEL]
+L6:
+  000004:[k#10,RANGEKEYSET-o#10,SET]
+
+iter
+first
+next
+next
+next
+----
+.
+.
+.
+.
+
+get-hints
+----
+(none)
+
+# Verify that a delete-only compaction hint can excise a file twice
+
+reset
+----
+
+ingest ext
+set k k
+set m m
+set o o
+range-key-set k o @3 foo
+----
+OK
+
+ingest ext
+del-range b l
+del-range m n
+range-key-del b l
+range-key-del m n
+----
+OK
+
+describe-lsm
+----
+L0.0:
+  000005:[b#11,RANGEKEYDEL-n#inf,RANGEDEL]
+L6:
+  000004:[k#10,RANGEKEYSET-o#10,SET]
+
+get-hints
+----
+(none)
+
+iter
+first
+next
+next
+next
+----
+o: (o, .)
+.
+.
+.
+
+maybe-compact
+----
+Deletion hints:
+  (none)
+Compactions:
+  (none)
+
+describe-lsm
+----
+L0.0:
+  000005:[b#11,RANGEKEYDEL-n#inf,RANGEDEL]
+L6:
+  000004:[k#10,RANGEKEYSET-o#10,SET]
+
+iter
+first
+next
+next
+next
+----
+o: (o, .)
+.
+.
+.
+
+get-hints
+----
+(none)


### PR DESCRIPTION
Previously, we'd only act on delete-only compaction hints if the entirety of a file was covered by a delete-only compaction hint. This change leverages the fact that we can now partially excise files using virtual sstables, to also use delete-only compactions to do excises of partial sstables and reduce the w-amp impact of writing rangedels and rangekeydels.

Fixes #3820.