### PR TITLE
base: consolidate internal key parsing functions

### DIFF
--- a/internal/manifest/testutils.go
+++ b/internal/manifest/testutils.go
@@ -150,7 +150,7 @@ func (p *debugParser) DiskFileNum() base.DiskFileNum {
 
 // InternalKey parses the next token as an internal key.
 func (p *debugParser) InternalKey() base.InternalKey {
-	return base.ParsePrettyInternalKey(p.Next())
+	return base.ParseInternalKey(p.Next())
 }
 
 // Errf panics with an error which includes the original string and the last

--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -44,7 +44,7 @@ func TestDataBlock(t *testing.T) {
 			case "write":
 				for _, line := range strings.Split(td.Input, "\n") {
 					j := strings.IndexRune(line, ':')
-					ik := base.ParsePrettyInternalKey(line[:j])
+					ik := base.ParseInternalKey(line[:j])
 
 					kcmp := w.KeyWriter.ComparePrev(ik.UserKey)
 					valueString := line[j+1:]


### PR DESCRIPTION
Consolidate two internal key parsing functions into one that supports
both formats. We should reduce uses of the older format over time.