### PR TITLE
colblk: add isObsolete bitmap to data block

### DIFF
--- a/sstable/colblk/cockroach_test.go
+++ b/sstable/colblk/cockroach_test.go
@@ -339,7 +339,7 @@ func TestCockroachDataBlock(t *testing.T) {
 	for w.Size() < targetBlockSize {
 		ik := base.MakeInternalKey(keys[count], base.SeqNum(rng.Uint64n(uint64(base.SeqNumMax))), base.InternalKeyKindSet)
 		kcmp := w.KeyWriter.ComparePrev(ik.UserKey)
-		w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp)
+		w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp, false /* isObsolete */)
 		count++
 	}
 	serializedBlock, _ := w.Finish(w.Rows(), w.Size())
@@ -415,7 +415,7 @@ func benchmarkCockroachDataBlockWriter(b *testing.B, keyConfig crdbtest.KeyConfi
 		for w.Size() < targetBlockSize {
 			ik := base.MakeInternalKey(keys[count], base.SeqNum(rng.Uint64n(uint64(base.SeqNumMax))), base.InternalKeyKindSet)
 			kcmp := w.KeyWriter.ComparePrev(ik.UserKey)
-			w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp)
+			w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp, false /* isObsolete */)
 			count++
 		}
 		_, _ = w.Finish(w.Rows(), w.Size())
@@ -459,7 +459,7 @@ func benchmarkCockroachDataBlockIter(b *testing.B, keyConfig crdbtest.KeyConfig,
 	for w.Size() < targetBlockSize {
 		ik := base.MakeInternalKey(keys[count], base.SeqNum(rng.Uint64n(uint64(base.SeqNumMax))), base.InternalKeyKindSet)
 		kcmp := w.KeyWriter.ComparePrev(ik.UserKey)
-		w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp)
+		w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp, false /* isObsolete */)
 		count++
 	}
 	serializedBlock, _ := w.Finish(w.Rows(), w.Size())

--- a/sstable/colblk/testdata/data_block/bundle_search
+++ b/sstable/colblk/testdata/data_block/bundle_search
@@ -10,13 +10,14 @@
 
 init bundle-size=4
 ----
-size=50:
+size=51:
 0: prefixes:       prefixbytes(4): 0 keys
 1: suffixes:       bytes: 0 rows set; 0 bytes in data
 2: trailers:       uint: 0 rows
 3: prefix changed: bitmap
 4: values:         bytes: 0 rows set; 0 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 write
 baba#1,SET:v
@@ -86,13 +87,14 @@ backwash#1,SET:v
 backwoods#1,SET:v
 bacteria#1,SET:v
 ----
-size=720:
+size=729:
 0: prefixes:       prefixbytes(4): 66 keys
 1: suffixes:       bytes: 66 rows set; 0 bytes in data
 2: trailers:       uint: 66 rows
 3: prefix changed: bitmap
 4: values:         bytes: 66 rows set; 66 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 finish
 ----
@@ -101,416 +103,420 @@ LastKey: bacteria#1,SET
 000-004: x 10000000                                                         # maximum key length: 16
 # columnar block header
 004-005: x 01                                                               # version 1
-005-007: x 0600                                                             # 6 columns
+005-007: x 0700                                                             # 7 columns
 007-011: x 42000000                                                         # 66 rows
 011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 29000000                                                         # col 0: page start 41
+012-016: x 2e000000                                                         # col 0: page start 46
 016-017: b 00000011                                                         # col 1: bytes
-017-021: x 25020000                                                         # col 1: page start 549
+017-021: x 29020000                                                         # col 1: page start 553
 021-022: b 00000010                                                         # col 2: uint
-022-026: x 26020000                                                         # col 2: page start 550
+022-026: x 2a020000                                                         # col 2: page start 554
 026-027: b 00000001                                                         # col 3: bool
-027-031: x 2f020000                                                         # col 3: page start 559
+027-031: x 33020000                                                         # col 3: page start 563
 031-032: b 00000011                                                         # col 4: bytes
-032-036: x 48020000                                                         # col 4: page start 584
+032-036: x 50020000                                                         # col 4: page start 592
 036-037: b 00000001                                                         # col 5: bool
-037-041: x ce020000                                                         # col 5: page start 718
+037-041: x d6020000                                                         # col 5: page start 726
+041-042: b 00000001                                                         # col 6: bool
+042-046: x d7020000                                                         # col 6: page start 727
 # data for column 0
 # PrefixBytes
-041-042: x 02                                                               # bundleSize: 4
+046-047: x 02                                                               # bundleSize: 4
 # Offsets table
-042-043: x 02                                                               # encoding: 2b
-043-044: x 00                                                               # padding (aligning to 16-bit boundary)
-044-046: x 0200                                                             # data[0] = 2 [214 overall]
-046-048: x 0300                                                             # data[1] = 3 [215 overall]
-048-050: x 0400                                                             # data[2] = 4 [216 overall]
-050-052: x 0700                                                             # data[3] = 7 [219 overall]
-052-054: x 0e00                                                             # data[4] = 14 [226 overall]
-054-056: x 1200                                                             # data[5] = 18 [230 overall]
-056-058: x 1500                                                             # data[6] = 21 [233 overall]
-058-060: x 1a00                                                             # data[7] = 26 [238 overall]
-060-062: x 1d00                                                             # data[8] = 29 [241 overall]
-062-064: x 2200                                                             # data[9] = 34 [246 overall]
-064-066: x 2500                                                             # data[10] = 37 [249 overall]
-066-068: x 2600                                                             # data[11] = 38 [250 overall]
-068-070: x 2d00                                                             # data[12] = 45 [257 overall]
-070-072: x 3000                                                             # data[13] = 48 [260 overall]
-072-074: x 3100                                                             # data[14] = 49 [261 overall]
-074-076: x 3400                                                             # data[15] = 52 [264 overall]
-076-078: x 3500                                                             # data[16] = 53 [265 overall]
-078-080: x 3b00                                                             # data[17] = 59 [271 overall]
-080-082: x 4100                                                             # data[18] = 65 [277 overall]
-082-084: x 4600                                                             # data[19] = 70 [282 overall]
-084-086: x 4700                                                             # data[20] = 71 [283 overall]
-086-088: x 4900                                                             # data[21] = 73 [285 overall]
-088-090: x 4c00                                                             # data[22] = 76 [288 overall]
-090-092: x 5000                                                             # data[23] = 80 [292 overall]
-092-094: x 5500                                                             # data[24] = 85 [297 overall]
-094-096: x 5800                                                             # data[25] = 88 [300 overall]
-096-098: x 5a00                                                             # data[26] = 90 [302 overall]
-098-100: x 5f00                                                             # data[27] = 95 [307 overall]
-100-102: x 6600                                                             # data[28] = 102 [314 overall]
-102-104: x 6900                                                             # data[29] = 105 [317 overall]
-104-106: x 6d00                                                             # data[30] = 109 [321 overall]
-106-108: x 7400                                                             # data[31] = 116 [328 overall]
-108-110: x 7400                                                             # data[32] = 116 [328 overall]
-110-112: x 7700                                                             # data[33] = 119 [331 overall]
-112-114: x 7d00                                                             # data[34] = 125 [337 overall]
-114-116: x 8200                                                             # data[35] = 130 [342 overall]
-116-118: x 8300                                                             # data[36] = 131 [343 overall]
-118-120: x 8c00                                                             # data[37] = 140 [352 overall]
-120-122: x 9900                                                             # data[38] = 153 [365 overall]
-122-124: x a200                                                             # data[39] = 162 [374 overall]
-124-126: x a300                                                             # data[40] = 163 [375 overall]
-126-128: x a500                                                             # data[41] = 165 [377 overall]
-128-130: x a900                                                             # data[42] = 169 [381 overall]
-130-132: x ad00                                                             # data[43] = 173 [385 overall]
-132-134: x b200                                                             # data[44] = 178 [390 overall]
-134-136: x ba00                                                             # data[45] = 186 [398 overall]
-136-138: x bc00                                                             # data[46] = 188 [400 overall]
-138-140: x c100                                                             # data[47] = 193 [405 overall]
-140-142: x c600                                                             # data[48] = 198 [410 overall]
-142-144: x ca00                                                             # data[49] = 202 [414 overall]
-144-146: x ce00                                                             # data[50] = 206 [418 overall]
-146-148: x d000                                                             # data[51] = 208 [420 overall]
-148-150: x d400                                                             # data[52] = 212 [424 overall]
-150-152: x d600                                                             # data[53] = 214 [426 overall]
-152-154: x db00                                                             # data[54] = 219 [431 overall]
-154-156: x df00                                                             # data[55] = 223 [435 overall]
-156-158: x e100                                                             # data[56] = 225 [437 overall]
-158-160: x e500                                                             # data[57] = 229 [441 overall]
-160-162: x eb00                                                             # data[58] = 235 [447 overall]
-162-164: x f100                                                             # data[59] = 241 [453 overall]
-164-166: x f700                                                             # data[60] = 247 [459 overall]
-166-168: x fd00                                                             # data[61] = 253 [465 overall]
-168-170: x fd00                                                             # data[62] = 253 [465 overall]
-170-172: x ff00                                                             # data[63] = 255 [467 overall]
-172-174: x 0301                                                             # data[64] = 259 [471 overall]
-174-176: x 0901                                                             # data[65] = 265 [477 overall]
-176-178: x 0b01                                                             # data[66] = 267 [479 overall]
-178-180: x 1001                                                             # data[67] = 272 [484 overall]
-180-182: x 1401                                                             # data[68] = 276 [488 overall]
-182-184: x 1901                                                             # data[69] = 281 [493 overall]
-184-186: x 1e01                                                             # data[70] = 286 [498 overall]
-186-188: x 2001                                                             # data[71] = 288 [500 overall]
-188-190: x 2501                                                             # data[72] = 293 [505 overall]
-190-192: x 2901                                                             # data[73] = 297 [509 overall]
-192-194: x 2f01                                                             # data[74] = 303 [515 overall]
-194-196: x 3401                                                             # data[75] = 308 [520 overall]
-196-198: x 3601                                                             # data[76] = 310 [522 overall]
-198-200: x 3801                                                             # data[77] = 312 [524 overall]
-200-202: x 3c01                                                             # data[78] = 316 [528 overall]
-202-204: x 4101                                                             # data[79] = 321 [533 overall]
-204-206: x 4501                                                             # data[80] = 325 [537 overall]
-206-208: x 4601                                                             # data[81] = 326 [538 overall]
-208-210: x 4c01                                                             # data[82] = 332 [544 overall]
-210-212: x 5101                                                             # data[83] = 337 [549 overall]
+047-048: x 02                                                               # encoding: 2b
+048-050: x 0200                                                             # data[0] = 2 [218 overall]
+050-052: x 0300                                                             # data[1] = 3 [219 overall]
+052-054: x 0400                                                             # data[2] = 4 [220 overall]
+054-056: x 0700                                                             # data[3] = 7 [223 overall]
+056-058: x 0e00                                                             # data[4] = 14 [230 overall]
+058-060: x 1200                                                             # data[5] = 18 [234 overall]
+060-062: x 1500                                                             # data[6] = 21 [237 overall]
+062-064: x 1a00                                                             # data[7] = 26 [242 overall]
+064-066: x 1d00                                                             # data[8] = 29 [245 overall]
+066-068: x 2200                                                             # data[9] = 34 [250 overall]
+068-070: x 2500                                                             # data[10] = 37 [253 overall]
+070-072: x 2600                                                             # data[11] = 38 [254 overall]
+072-074: x 2d00                                                             # data[12] = 45 [261 overall]
+074-076: x 3000                                                             # data[13] = 48 [264 overall]
+076-078: x 3100                                                             # data[14] = 49 [265 overall]
+078-080: x 3400                                                             # data[15] = 52 [268 overall]
+080-082: x 3500                                                             # data[16] = 53 [269 overall]
+082-084: x 3b00                                                             # data[17] = 59 [275 overall]
+084-086: x 4100                                                             # data[18] = 65 [281 overall]
+086-088: x 4600                                                             # data[19] = 70 [286 overall]
+088-090: x 4700                                                             # data[20] = 71 [287 overall]
+090-092: x 4900                                                             # data[21] = 73 [289 overall]
+092-094: x 4c00                                                             # data[22] = 76 [292 overall]
+094-096: x 5000                                                             # data[23] = 80 [296 overall]
+096-098: x 5500                                                             # data[24] = 85 [301 overall]
+098-100: x 5800                                                             # data[25] = 88 [304 overall]
+100-102: x 5a00                                                             # data[26] = 90 [306 overall]
+102-104: x 5f00                                                             # data[27] = 95 [311 overall]
+104-106: x 6600                                                             # data[28] = 102 [318 overall]
+106-108: x 6900                                                             # data[29] = 105 [321 overall]
+108-110: x 6d00                                                             # data[30] = 109 [325 overall]
+110-112: x 7400                                                             # data[31] = 116 [332 overall]
+112-114: x 7400                                                             # data[32] = 116 [332 overall]
+114-116: x 7700                                                             # data[33] = 119 [335 overall]
+116-118: x 7d00                                                             # data[34] = 125 [341 overall]
+118-120: x 8200                                                             # data[35] = 130 [346 overall]
+120-122: x 8300                                                             # data[36] = 131 [347 overall]
+122-124: x 8c00                                                             # data[37] = 140 [356 overall]
+124-126: x 9900                                                             # data[38] = 153 [369 overall]
+126-128: x a200                                                             # data[39] = 162 [378 overall]
+128-130: x a300                                                             # data[40] = 163 [379 overall]
+130-132: x a500                                                             # data[41] = 165 [381 overall]
+132-134: x a900                                                             # data[42] = 169 [385 overall]
+134-136: x ad00                                                             # data[43] = 173 [389 overall]
+136-138: x b200                                                             # data[44] = 178 [394 overall]
+138-140: x ba00                                                             # data[45] = 186 [402 overall]
+140-142: x bc00                                                             # data[46] = 188 [404 overall]
+142-144: x c100                                                             # data[47] = 193 [409 overall]
+144-146: x c600                                                             # data[48] = 198 [414 overall]
+146-148: x ca00                                                             # data[49] = 202 [418 overall]
+148-150: x ce00                                                             # data[50] = 206 [422 overall]
+150-152: x d000                                                             # data[51] = 208 [424 overall]
+152-154: x d400                                                             # data[52] = 212 [428 overall]
+154-156: x d600                                                             # data[53] = 214 [430 overall]
+156-158: x db00                                                             # data[54] = 219 [435 overall]
+158-160: x df00                                                             # data[55] = 223 [439 overall]
+160-162: x e100                                                             # data[56] = 225 [441 overall]
+162-164: x e500                                                             # data[57] = 229 [445 overall]
+164-166: x eb00                                                             # data[58] = 235 [451 overall]
+166-168: x f100                                                             # data[59] = 241 [457 overall]
+168-170: x f700                                                             # data[60] = 247 [463 overall]
+170-172: x fd00                                                             # data[61] = 253 [469 overall]
+172-174: x fd00                                                             # data[62] = 253 [469 overall]
+174-176: x ff00                                                             # data[63] = 255 [471 overall]
+176-178: x 0301                                                             # data[64] = 259 [475 overall]
+178-180: x 0901                                                             # data[65] = 265 [481 overall]
+180-182: x 0b01                                                             # data[66] = 267 [483 overall]
+182-184: x 1001                                                             # data[67] = 272 [488 overall]
+184-186: x 1401                                                             # data[68] = 276 [492 overall]
+186-188: x 1901                                                             # data[69] = 281 [497 overall]
+188-190: x 1e01                                                             # data[70] = 286 [502 overall]
+190-192: x 2001                                                             # data[71] = 288 [504 overall]
+192-194: x 2501                                                             # data[72] = 293 [509 overall]
+194-196: x 2901                                                             # data[73] = 297 [513 overall]
+196-198: x 2f01                                                             # data[74] = 303 [519 overall]
+198-200: x 3401                                                             # data[75] = 308 [524 overall]
+200-202: x 3601                                                             # data[76] = 310 [526 overall]
+202-204: x 3801                                                             # data[77] = 312 [528 overall]
+204-206: x 3c01                                                             # data[78] = 316 [532 overall]
+206-208: x 4101                                                             # data[79] = 321 [537 overall]
+208-210: x 4501                                                             # data[80] = 325 [541 overall]
+210-212: x 4601                                                             # data[81] = 326 [542 overall]
+212-214: x 4c01                                                             # data[82] = 332 [548 overall]
+214-216: x 5101                                                             # data[83] = 337 [553 overall]
 # Data
-212-214: x 6261                                                             # data[00]: ba (block prefix)
-214-215: x 62                                                               # data[01]: ..b (bundle prefix)
-215-216: x 61                                                               # data[02]: ...a
-216-219: x 626c65                                                           # data[03]: ...ble
-219-226: x 626c656d656e74                                                   # data[04]: ...blement
-226-230: x 626c6572                                                         # data[05]: ...bler
-230-233: x 62626c                                                           # data[06]: ..bbl (bundle prefix)
-233-238: x 65736f6d65                                                       # data[07]: .....esome
-238-241: x 696e67                                                           # data[08]: .....ing
-241-246: x 696e676c79                                                       # data[09]: .....ingly
-246-249: x 697368                                                           # data[10]: .....ish
-249-250: x 62                                                               # data[11]: ..b (bundle prefix)
-250-257: x 626c6973686c79                                                   # data[12]: ...blishly
-257-260: x 626c79                                                           # data[13]: ...bly
-260-261: x 65                                                               # data[14]: ...e
-261-264: x 6f6f6e                                                           # data[15]: ...oon
-264-265: x 62                                                               # data[16]: ..b (bundle prefix)
-265-271: x 6f6f6e657279                                                     # data[17]: ...oonery
-271-277: x 6f6f6e697368                                                     # data[18]: ...oonish
-277-282: x 7573686b61                                                       # data[19]: ...ushka
-282-283: x 79                                                               # data[20]: ...y
-283-285: x 6279                                                             # data[21]: ..by (bundle prefix)
-285-288: x 646f6d                                                           # data[22]: ....dom
-288-292: x 686f6f64                                                         # data[23]: ....hood
-292-297: x 686f757365                                                       # data[24]: ....house
-297-300: x 697368                                                           # data[25]: ....ish
-300-302: x 6279                                                             # data[26]: ..by (bundle prefix)
-302-307: x 6973686c79                                                       # data[27]: ....ishly
-307-314: x 6973686e657373                                                   # data[28]: ....ishness
-314-317: x 69736d                                                           # data[29]: ....ism
-317-321: x 6c696b65                                                         # data[30]: ....like
-321-328: x 636368616e616c                                                   # data[31]: ..cchanal (bundle prefix)
-328-328: x                                                                  # data[32]: .........
-328-331: x 69616e                                                           # data[33]: .........ian
-331-337: x 69616e69736d                                                     # data[34]: .........ianism
-337-342: x 69616e6c79                                                       # data[35]: .........ianly
-342-343: x 63                                                               # data[36]: ..c (bundle prefix)
-343-352: x 6368616e616c69736d                                               # data[37]: ...chanalism
-352-362: x 6368616e616c697a6174                                             # data[38]: ...chanalization
-362-365: x 696f6e                                                           # (continued...)
-365-374: x 6368616e616c697a65                                               # data[39]: ...chanalize
-374-375: x 6b                                                               # data[40]: ...k
-375-377: x 636b                                                             # data[41]: ..ck (bundle prefix)
-377-381: x 61636865                                                         # data[42]: ....ache
-381-385: x 626f6e65                                                         # data[43]: ....bone
-385-390: x 626f6e6564                                                       # data[44]: ....boned
-390-398: x 627265616b696e67                                                 # data[45]: ....breaking
-398-400: x 636b                                                             # data[46]: ..ck (bundle prefix)
-400-405: x 636f757274                                                       # data[47]: ....court
-405-410: x 63726f7373                                                       # data[48]: ....cross
-410-414: x 646f6f72                                                         # data[49]: ....door
-414-418: x 646f776e                                                         # data[50]: ....down
-418-420: x 636b                                                             # data[51]: ..ck (bundle prefix)
-420-424: x 64726f70                                                         # data[52]: ....drop
-424-426: x 6564                                                             # data[53]: ....ed
-426-431: x 6669656c64                                                       # data[54]: ....field
-431-435: x 66696c6c                                                         # data[55]: ....fill
-435-437: x 636b                                                             # data[56]: ..ck (bundle prefix)
-437-441: x 66697265                                                         # data[57]: ....fire
-441-447: x 666972696e67                                                     # data[58]: ....firing
-447-453: x 67616d6d6f6e                                                     # data[59]: ....gammon
-453-459: x 67726f756e64                                                     # data[60]: ....ground
-459-465: x 636b68616e64                                                     # data[61]: ..ckhand (bundle prefix)
-465-465: x                                                                  # data[62]: ........
-465-467: x 6564                                                             # data[63]: ........ed
-467-471: x 65646c79                                                         # data[64]: ........edly
-471-477: x 65646e657373                                                     # data[65]: ........edness
-477-479: x 636b                                                             # data[66]: ..ck (bundle prefix)
-479-484: x 706564616c                                                       # data[67]: ....pedal
-484-488: x 736c6170                                                         # data[68]: ....slap
-488-493: x 736c696465                                                       # data[69]: ....slide
-493-498: x 7370616365                                                       # data[70]: ....space
-498-500: x 636b                                                             # data[71]: ..ck (bundle prefix)
-500-505: x 7374616765                                                       # data[72]: ....stage
-505-509: x 73746f70                                                         # data[73]: ....stop
-509-515: x 7374726f6b65                                                     # data[74]: ....stroke
-515-520: x 747261636b                                                       # data[75]: ....track
-520-522: x 636b                                                             # data[76]: ..ck (bundle prefix)
-522-524: x 7570                                                             # data[77]: ....up
-524-528: x 77617264                                                         # data[78]: ....ward
-528-533: x 7761726473                                                       # data[79]: ....wards
-533-537: x 77617368                                                         # data[80]: ....wash
-537-538: x 63                                                               # data[81]: ..c (bundle prefix)
-538-544: x 6b776f6f6473                                                     # data[82]: ...kwoods
-544-549: x 7465726961                                                       # data[83]: ...teria
+216-218: x 6261                                                             # data[00]: ba (block prefix)
+218-219: x 62                                                               # data[01]: ..b (bundle prefix)
+219-220: x 61                                                               # data[02]: ...a
+220-223: x 626c65                                                           # data[03]: ...ble
+223-230: x 626c656d656e74                                                   # data[04]: ...blement
+230-234: x 626c6572                                                         # data[05]: ...bler
+234-237: x 62626c                                                           # data[06]: ..bbl (bundle prefix)
+237-242: x 65736f6d65                                                       # data[07]: .....esome
+242-245: x 696e67                                                           # data[08]: .....ing
+245-250: x 696e676c79                                                       # data[09]: .....ingly
+250-253: x 697368                                                           # data[10]: .....ish
+253-254: x 62                                                               # data[11]: ..b (bundle prefix)
+254-261: x 626c6973686c79                                                   # data[12]: ...blishly
+261-264: x 626c79                                                           # data[13]: ...bly
+264-265: x 65                                                               # data[14]: ...e
+265-268: x 6f6f6e                                                           # data[15]: ...oon
+268-269: x 62                                                               # data[16]: ..b (bundle prefix)
+269-275: x 6f6f6e657279                                                     # data[17]: ...oonery
+275-281: x 6f6f6e697368                                                     # data[18]: ...oonish
+281-286: x 7573686b61                                                       # data[19]: ...ushka
+286-287: x 79                                                               # data[20]: ...y
+287-289: x 6279                                                             # data[21]: ..by (bundle prefix)
+289-292: x 646f6d                                                           # data[22]: ....dom
+292-296: x 686f6f64                                                         # data[23]: ....hood
+296-301: x 686f757365                                                       # data[24]: ....house
+301-304: x 697368                                                           # data[25]: ....ish
+304-306: x 6279                                                             # data[26]: ..by (bundle prefix)
+306-311: x 6973686c79                                                       # data[27]: ....ishly
+311-318: x 6973686e657373                                                   # data[28]: ....ishness
+318-321: x 69736d                                                           # data[29]: ....ism
+321-325: x 6c696b65                                                         # data[30]: ....like
+325-332: x 636368616e616c                                                   # data[31]: ..cchanal (bundle prefix)
+332-332: x                                                                  # data[32]: .........
+332-335: x 69616e                                                           # data[33]: .........ian
+335-341: x 69616e69736d                                                     # data[34]: .........ianism
+341-346: x 69616e6c79                                                       # data[35]: .........ianly
+346-347: x 63                                                               # data[36]: ..c (bundle prefix)
+347-356: x 6368616e616c69736d                                               # data[37]: ...chanalism
+356-366: x 6368616e616c697a6174                                             # data[38]: ...chanalization
+366-369: x 696f6e                                                           # (continued...)
+369-378: x 6368616e616c697a65                                               # data[39]: ...chanalize
+378-379: x 6b                                                               # data[40]: ...k
+379-381: x 636b                                                             # data[41]: ..ck (bundle prefix)
+381-385: x 61636865                                                         # data[42]: ....ache
+385-389: x 626f6e65                                                         # data[43]: ....bone
+389-394: x 626f6e6564                                                       # data[44]: ....boned
+394-402: x 627265616b696e67                                                 # data[45]: ....breaking
+402-404: x 636b                                                             # data[46]: ..ck (bundle prefix)
+404-409: x 636f757274                                                       # data[47]: ....court
+409-414: x 63726f7373                                                       # data[48]: ....cross
+414-418: x 646f6f72                                                         # data[49]: ....door
+418-422: x 646f776e                                                         # data[50]: ....down
+422-424: x 636b                                                             # data[51]: ..ck (bundle prefix)
+424-428: x 64726f70                                                         # data[52]: ....drop
+428-430: x 6564                                                             # data[53]: ....ed
+430-435: x 6669656c64                                                       # data[54]: ....field
+435-439: x 66696c6c                                                         # data[55]: ....fill
+439-441: x 636b                                                             # data[56]: ..ck (bundle prefix)
+441-445: x 66697265                                                         # data[57]: ....fire
+445-451: x 666972696e67                                                     # data[58]: ....firing
+451-457: x 67616d6d6f6e                                                     # data[59]: ....gammon
+457-463: x 67726f756e64                                                     # data[60]: ....ground
+463-469: x 636b68616e64                                                     # data[61]: ..ckhand (bundle prefix)
+469-469: x                                                                  # data[62]: ........
+469-471: x 6564                                                             # data[63]: ........ed
+471-475: x 65646c79                                                         # data[64]: ........edly
+475-481: x 65646e657373                                                     # data[65]: ........edness
+481-483: x 636b                                                             # data[66]: ..ck (bundle prefix)
+483-488: x 706564616c                                                       # data[67]: ....pedal
+488-492: x 736c6170                                                         # data[68]: ....slap
+492-497: x 736c696465                                                       # data[69]: ....slide
+497-502: x 7370616365                                                       # data[70]: ....space
+502-504: x 636b                                                             # data[71]: ..ck (bundle prefix)
+504-509: x 7374616765                                                       # data[72]: ....stage
+509-513: x 73746f70                                                         # data[73]: ....stop
+513-519: x 7374726f6b65                                                     # data[74]: ....stroke
+519-524: x 747261636b                                                       # data[75]: ....track
+524-526: x 636b                                                             # data[76]: ..ck (bundle prefix)
+526-528: x 7570                                                             # data[77]: ....up
+528-532: x 77617264                                                         # data[78]: ....ward
+532-537: x 7761726473                                                       # data[79]: ....wards
+537-541: x 77617368                                                         # data[80]: ....wash
+541-542: x 63                                                               # data[81]: ..c (bundle prefix)
+542-548: x 6b776f6f6473                                                     # data[82]: ...kwoods
+548-553: x 7465726961                                                       # data[83]: ...teria
 # data for column 1
 # rawbytes
 # offsets table
-549-550: x 00                                                               # encoding: zero
+553-554: x 00                                                               # encoding: zero
 # data
-550-550: x                                                                  # data[0]:
-550-550: x                                                                  # data[1]:
-550-550: x                                                                  # data[2]:
-550-550: x                                                                  # data[3]:
-550-550: x                                                                  # data[4]:
-550-550: x                                                                  # data[5]:
-550-550: x                                                                  # data[6]:
-550-550: x                                                                  # data[7]:
-550-550: x                                                                  # data[8]:
-550-550: x                                                                  # data[9]:
-550-550: x                                                                  # data[10]:
-550-550: x                                                                  # data[11]:
-550-550: x                                                                  # data[12]:
-550-550: x                                                                  # data[13]:
-550-550: x                                                                  # data[14]:
-550-550: x                                                                  # data[15]:
-550-550: x                                                                  # data[16]:
-550-550: x                                                                  # data[17]:
-550-550: x                                                                  # data[18]:
-550-550: x                                                                  # data[19]:
-550-550: x                                                                  # data[20]:
-550-550: x                                                                  # data[21]:
-550-550: x                                                                  # data[22]:
-550-550: x                                                                  # data[23]:
-550-550: x                                                                  # data[24]:
-550-550: x                                                                  # data[25]:
-550-550: x                                                                  # data[26]:
-550-550: x                                                                  # data[27]:
-550-550: x                                                                  # data[28]:
-550-550: x                                                                  # data[29]:
-550-550: x                                                                  # data[30]:
-550-550: x                                                                  # data[31]:
-550-550: x                                                                  # data[32]:
-550-550: x                                                                  # data[33]:
-550-550: x                                                                  # data[34]:
-550-550: x                                                                  # data[35]:
-550-550: x                                                                  # data[36]:
-550-550: x                                                                  # data[37]:
-550-550: x                                                                  # data[38]:
-550-550: x                                                                  # data[39]:
-550-550: x                                                                  # data[40]:
-550-550: x                                                                  # data[41]:
-550-550: x                                                                  # data[42]:
-550-550: x                                                                  # data[43]:
-550-550: x                                                                  # data[44]:
-550-550: x                                                                  # data[45]:
-550-550: x                                                                  # data[46]:
-550-550: x                                                                  # data[47]:
-550-550: x                                                                  # data[48]:
-550-550: x                                                                  # data[49]:
-550-550: x                                                                  # data[50]:
-550-550: x                                                                  # data[51]:
-550-550: x                                                                  # data[52]:
-550-550: x                                                                  # data[53]:
-550-550: x                                                                  # data[54]:
-550-550: x                                                                  # data[55]:
-550-550: x                                                                  # data[56]:
-550-550: x                                                                  # data[57]:
-550-550: x                                                                  # data[58]:
-550-550: x                                                                  # data[59]:
-550-550: x                                                                  # data[60]:
-550-550: x                                                                  # data[61]:
-550-550: x                                                                  # data[62]:
-550-550: x                                                                  # data[63]:
-550-550: x                                                                  # data[64]:
-550-550: x                                                                  # data[65]:
+554-554: x                                                                  # data[0]:
+554-554: x                                                                  # data[1]:
+554-554: x                                                                  # data[2]:
+554-554: x                                                                  # data[3]:
+554-554: x                                                                  # data[4]:
+554-554: x                                                                  # data[5]:
+554-554: x                                                                  # data[6]:
+554-554: x                                                                  # data[7]:
+554-554: x                                                                  # data[8]:
+554-554: x                                                                  # data[9]:
+554-554: x                                                                  # data[10]:
+554-554: x                                                                  # data[11]:
+554-554: x                                                                  # data[12]:
+554-554: x                                                                  # data[13]:
+554-554: x                                                                  # data[14]:
+554-554: x                                                                  # data[15]:
+554-554: x                                                                  # data[16]:
+554-554: x                                                                  # data[17]:
+554-554: x                                                                  # data[18]:
+554-554: x                                                                  # data[19]:
+554-554: x                                                                  # data[20]:
+554-554: x                                                                  # data[21]:
+554-554: x                                                                  # data[22]:
+554-554: x                                                                  # data[23]:
+554-554: x                                                                  # data[24]:
+554-554: x                                                                  # data[25]:
+554-554: x                                                                  # data[26]:
+554-554: x                                                                  # data[27]:
+554-554: x                                                                  # data[28]:
+554-554: x                                                                  # data[29]:
+554-554: x                                                                  # data[30]:
+554-554: x                                                                  # data[31]:
+554-554: x                                                                  # data[32]:
+554-554: x                                                                  # data[33]:
+554-554: x                                                                  # data[34]:
+554-554: x                                                                  # data[35]:
+554-554: x                                                                  # data[36]:
+554-554: x                                                                  # data[37]:
+554-554: x                                                                  # data[38]:
+554-554: x                                                                  # data[39]:
+554-554: x                                                                  # data[40]:
+554-554: x                                                                  # data[41]:
+554-554: x                                                                  # data[42]:
+554-554: x                                                                  # data[43]:
+554-554: x                                                                  # data[44]:
+554-554: x                                                                  # data[45]:
+554-554: x                                                                  # data[46]:
+554-554: x                                                                  # data[47]:
+554-554: x                                                                  # data[48]:
+554-554: x                                                                  # data[49]:
+554-554: x                                                                  # data[50]:
+554-554: x                                                                  # data[51]:
+554-554: x                                                                  # data[52]:
+554-554: x                                                                  # data[53]:
+554-554: x                                                                  # data[54]:
+554-554: x                                                                  # data[55]:
+554-554: x                                                                  # data[56]:
+554-554: x                                                                  # data[57]:
+554-554: x                                                                  # data[58]:
+554-554: x                                                                  # data[59]:
+554-554: x                                                                  # data[60]:
+554-554: x                                                                  # data[61]:
+554-554: x                                                                  # data[62]:
+554-554: x                                                                  # data[63]:
+554-554: x                                                                  # data[64]:
+554-554: x                                                                  # data[65]:
 # data for column 2
-550-551: x 80                                                               # encoding: const
-551-559: x 0101000000000000                                                 # 64-bit constant: 257
+554-555: x 80                                                               # encoding: const
+555-563: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-559-560: x 00                                                               # bitmap encoding
-560-568: b 1111111111111111111111111111111111111111111111111111111111111111 # bitmap word 0
-568-576: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 1
-576-584: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+563-564: x 00                                                               # bitmap encoding
+564-568: x 00000000                                                         # padding to align to 64-bit boundary
+568-576: b 1111111111111111111111111111111111111111111111111111111111111111 # bitmap word 0
+576-584: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 1
+584-592: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-584-585: x 01                                                               # encoding: 1b
-585-586: x 00                                                               # data[0] = 0 [652 overall]
-586-587: x 01                                                               # data[1] = 1 [653 overall]
-587-588: x 02                                                               # data[2] = 2 [654 overall]
-588-589: x 03                                                               # data[3] = 3 [655 overall]
-589-590: x 04                                                               # data[4] = 4 [656 overall]
-590-591: x 05                                                               # data[5] = 5 [657 overall]
-591-592: x 06                                                               # data[6] = 6 [658 overall]
-592-593: x 07                                                               # data[7] = 7 [659 overall]
-593-594: x 08                                                               # data[8] = 8 [660 overall]
-594-595: x 09                                                               # data[9] = 9 [661 overall]
-595-596: x 0a                                                               # data[10] = 10 [662 overall]
-596-597: x 0b                                                               # data[11] = 11 [663 overall]
-597-598: x 0c                                                               # data[12] = 12 [664 overall]
-598-599: x 0d                                                               # data[13] = 13 [665 overall]
-599-600: x 0e                                                               # data[14] = 14 [666 overall]
-600-601: x 0f                                                               # data[15] = 15 [667 overall]
-601-602: x 10                                                               # data[16] = 16 [668 overall]
-602-603: x 11                                                               # data[17] = 17 [669 overall]
-603-604: x 12                                                               # data[18] = 18 [670 overall]
-604-605: x 13                                                               # data[19] = 19 [671 overall]
-605-606: x 14                                                               # data[20] = 20 [672 overall]
-606-607: x 15                                                               # data[21] = 21 [673 overall]
-607-608: x 16                                                               # data[22] = 22 [674 overall]
-608-609: x 17                                                               # data[23] = 23 [675 overall]
-609-610: x 18                                                               # data[24] = 24 [676 overall]
-610-611: x 19                                                               # data[25] = 25 [677 overall]
-611-612: x 1a                                                               # data[26] = 26 [678 overall]
-612-613: x 1b                                                               # data[27] = 27 [679 overall]
-613-614: x 1c                                                               # data[28] = 28 [680 overall]
-614-615: x 1d                                                               # data[29] = 29 [681 overall]
-615-616: x 1e                                                               # data[30] = 30 [682 overall]
-616-617: x 1f                                                               # data[31] = 31 [683 overall]
-617-618: x 20                                                               # data[32] = 32 [684 overall]
-618-619: x 21                                                               # data[33] = 33 [685 overall]
-619-620: x 22                                                               # data[34] = 34 [686 overall]
-620-621: x 23                                                               # data[35] = 35 [687 overall]
-621-622: x 24                                                               # data[36] = 36 [688 overall]
-622-623: x 25                                                               # data[37] = 37 [689 overall]
-623-624: x 26                                                               # data[38] = 38 [690 overall]
-624-625: x 27                                                               # data[39] = 39 [691 overall]
-625-626: x 28                                                               # data[40] = 40 [692 overall]
-626-627: x 29                                                               # data[41] = 41 [693 overall]
-627-628: x 2a                                                               # data[42] = 42 [694 overall]
-628-629: x 2b                                                               # data[43] = 43 [695 overall]
-629-630: x 2c                                                               # data[44] = 44 [696 overall]
-630-631: x 2d                                                               # data[45] = 45 [697 overall]
-631-632: x 2e                                                               # data[46] = 46 [698 overall]
-632-633: x 2f                                                               # data[47] = 47 [699 overall]
-633-634: x 30                                                               # data[48] = 48 [700 overall]
-634-635: x 31                                                               # data[49] = 49 [701 overall]
-635-636: x 32                                                               # data[50] = 50 [702 overall]
-636-637: x 33                                                               # data[51] = 51 [703 overall]
-637-638: x 34                                                               # data[52] = 52 [704 overall]
-638-639: x 35                                                               # data[53] = 53 [705 overall]
-639-640: x 36                                                               # data[54] = 54 [706 overall]
-640-641: x 37                                                               # data[55] = 55 [707 overall]
-641-642: x 38                                                               # data[56] = 56 [708 overall]
-642-643: x 39                                                               # data[57] = 57 [709 overall]
-643-644: x 3a                                                               # data[58] = 58 [710 overall]
-644-645: x 3b                                                               # data[59] = 59 [711 overall]
-645-646: x 3c                                                               # data[60] = 60 [712 overall]
-646-647: x 3d                                                               # data[61] = 61 [713 overall]
-647-648: x 3e                                                               # data[62] = 62 [714 overall]
-648-649: x 3f                                                               # data[63] = 63 [715 overall]
-649-650: x 40                                                               # data[64] = 64 [716 overall]
-650-651: x 41                                                               # data[65] = 65 [717 overall]
-651-652: x 42                                                               # data[66] = 66 [718 overall]
+592-593: x 01                                                               # encoding: 1b
+593-594: x 00                                                               # data[0] = 0 [660 overall]
+594-595: x 01                                                               # data[1] = 1 [661 overall]
+595-596: x 02                                                               # data[2] = 2 [662 overall]
+596-597: x 03                                                               # data[3] = 3 [663 overall]
+597-598: x 04                                                               # data[4] = 4 [664 overall]
+598-599: x 05                                                               # data[5] = 5 [665 overall]
+599-600: x 06                                                               # data[6] = 6 [666 overall]
+600-601: x 07                                                               # data[7] = 7 [667 overall]
+601-602: x 08                                                               # data[8] = 8 [668 overall]
+602-603: x 09                                                               # data[9] = 9 [669 overall]
+603-604: x 0a                                                               # data[10] = 10 [670 overall]
+604-605: x 0b                                                               # data[11] = 11 [671 overall]
+605-606: x 0c                                                               # data[12] = 12 [672 overall]
+606-607: x 0d                                                               # data[13] = 13 [673 overall]
+607-608: x 0e                                                               # data[14] = 14 [674 overall]
+608-609: x 0f                                                               # data[15] = 15 [675 overall]
+609-610: x 10                                                               # data[16] = 16 [676 overall]
+610-611: x 11                                                               # data[17] = 17 [677 overall]
+611-612: x 12                                                               # data[18] = 18 [678 overall]
+612-613: x 13                                                               # data[19] = 19 [679 overall]
+613-614: x 14                                                               # data[20] = 20 [680 overall]
+614-615: x 15                                                               # data[21] = 21 [681 overall]
+615-616: x 16                                                               # data[22] = 22 [682 overall]
+616-617: x 17                                                               # data[23] = 23 [683 overall]
+617-618: x 18                                                               # data[24] = 24 [684 overall]
+618-619: x 19                                                               # data[25] = 25 [685 overall]
+619-620: x 1a                                                               # data[26] = 26 [686 overall]
+620-621: x 1b                                                               # data[27] = 27 [687 overall]
+621-622: x 1c                                                               # data[28] = 28 [688 overall]
+622-623: x 1d                                                               # data[29] = 29 [689 overall]
+623-624: x 1e                                                               # data[30] = 30 [690 overall]
+624-625: x 1f                                                               # data[31] = 31 [691 overall]
+625-626: x 20                                                               # data[32] = 32 [692 overall]
+626-627: x 21                                                               # data[33] = 33 [693 overall]
+627-628: x 22                                                               # data[34] = 34 [694 overall]
+628-629: x 23                                                               # data[35] = 35 [695 overall]
+629-630: x 24                                                               # data[36] = 36 [696 overall]
+630-631: x 25                                                               # data[37] = 37 [697 overall]
+631-632: x 26                                                               # data[38] = 38 [698 overall]
+632-633: x 27                                                               # data[39] = 39 [699 overall]
+633-634: x 28                                                               # data[40] = 40 [700 overall]
+634-635: x 29                                                               # data[41] = 41 [701 overall]
+635-636: x 2a                                                               # data[42] = 42 [702 overall]
+636-637: x 2b                                                               # data[43] = 43 [703 overall]
+637-638: x 2c                                                               # data[44] = 44 [704 overall]
+638-639: x 2d                                                               # data[45] = 45 [705 overall]
+639-640: x 2e                                                               # data[46] = 46 [706 overall]
+640-641: x 2f                                                               # data[47] = 47 [707 overall]
+641-642: x 30                                                               # data[48] = 48 [708 overall]
+642-643: x 31                                                               # data[49] = 49 [709 overall]
+643-644: x 32                                                               # data[50] = 50 [710 overall]
+644-645: x 33                                                               # data[51] = 51 [711 overall]
+645-646: x 34                                                               # data[52] = 52 [712 overall]
+646-647: x 35                                                               # data[53] = 53 [713 overall]
+647-648: x 36                                                               # data[54] = 54 [714 overall]
+648-649: x 37                                                               # data[55] = 55 [715 overall]
+649-650: x 38                                                               # data[56] = 56 [716 overall]
+650-651: x 39                                                               # data[57] = 57 [717 overall]
+651-652: x 3a                                                               # data[58] = 58 [718 overall]
+652-653: x 3b                                                               # data[59] = 59 [719 overall]
+653-654: x 3c                                                               # data[60] = 60 [720 overall]
+654-655: x 3d                                                               # data[61] = 61 [721 overall]
+655-656: x 3e                                                               # data[62] = 62 [722 overall]
+656-657: x 3f                                                               # data[63] = 63 [723 overall]
+657-658: x 40                                                               # data[64] = 64 [724 overall]
+658-659: x 41                                                               # data[65] = 65 [725 overall]
+659-660: x 42                                                               # data[66] = 66 [726 overall]
 # data
-652-653: x 76                                                               # data[0]: v
-653-654: x 76                                                               # data[1]: v
-654-655: x 76                                                               # data[2]: v
-655-656: x 76                                                               # data[3]: v
-656-657: x 76                                                               # data[4]: v
-657-658: x 76                                                               # data[5]: v
-658-659: x 76                                                               # data[6]: v
-659-660: x 76                                                               # data[7]: v
-660-661: x 76                                                               # data[8]: v
-661-662: x 76                                                               # data[9]: v
-662-663: x 76                                                               # data[10]: v
-663-664: x 76                                                               # data[11]: v
-664-665: x 76                                                               # data[12]: v
-665-666: x 76                                                               # data[13]: v
-666-667: x 76                                                               # data[14]: v
-667-668: x 76                                                               # data[15]: v
-668-669: x 76                                                               # data[16]: v
-669-670: x 76                                                               # data[17]: v
-670-671: x 76                                                               # data[18]: v
-671-672: x 76                                                               # data[19]: v
-672-673: x 76                                                               # data[20]: v
-673-674: x 76                                                               # data[21]: v
-674-675: x 76                                                               # data[22]: v
-675-676: x 76                                                               # data[23]: v
-676-677: x 76                                                               # data[24]: v
-677-678: x 76                                                               # data[25]: v
-678-679: x 76                                                               # data[26]: v
-679-680: x 76                                                               # data[27]: v
-680-681: x 76                                                               # data[28]: v
-681-682: x 76                                                               # data[29]: v
-682-683: x 76                                                               # data[30]: v
-683-684: x 76                                                               # data[31]: v
-684-685: x 76                                                               # data[32]: v
-685-686: x 76                                                               # data[33]: v
-686-687: x 76                                                               # data[34]: v
-687-688: x 76                                                               # data[35]: v
-688-689: x 76                                                               # data[36]: v
-689-690: x 76                                                               # data[37]: v
-690-691: x 76                                                               # data[38]: v
-691-692: x 76                                                               # data[39]: v
-692-693: x 76                                                               # data[40]: v
-693-694: x 76                                                               # data[41]: v
-694-695: x 76                                                               # data[42]: v
-695-696: x 76                                                               # data[43]: v
-696-697: x 76                                                               # data[44]: v
-697-698: x 76                                                               # data[45]: v
-698-699: x 76                                                               # data[46]: v
-699-700: x 76                                                               # data[47]: v
-700-701: x 76                                                               # data[48]: v
-701-702: x 76                                                               # data[49]: v
-702-703: x 76                                                               # data[50]: v
-703-704: x 76                                                               # data[51]: v
-704-705: x 76                                                               # data[52]: v
-705-706: x 76                                                               # data[53]: v
-706-707: x 76                                                               # data[54]: v
-707-708: x 76                                                               # data[55]: v
-708-709: x 76                                                               # data[56]: v
-709-710: x 76                                                               # data[57]: v
-710-711: x 76                                                               # data[58]: v
-711-712: x 76                                                               # data[59]: v
-712-713: x 76                                                               # data[60]: v
-713-714: x 76                                                               # data[61]: v
-714-715: x 76                                                               # data[62]: v
-715-716: x 76                                                               # data[63]: v
-716-717: x 76                                                               # data[64]: v
-717-718: x 76                                                               # data[65]: v
+660-661: x 76                                                               # data[0]: v
+661-662: x 76                                                               # data[1]: v
+662-663: x 76                                                               # data[2]: v
+663-664: x 76                                                               # data[3]: v
+664-665: x 76                                                               # data[4]: v
+665-666: x 76                                                               # data[5]: v
+666-667: x 76                                                               # data[6]: v
+667-668: x 76                                                               # data[7]: v
+668-669: x 76                                                               # data[8]: v
+669-670: x 76                                                               # data[9]: v
+670-671: x 76                                                               # data[10]: v
+671-672: x 76                                                               # data[11]: v
+672-673: x 76                                                               # data[12]: v
+673-674: x 76                                                               # data[13]: v
+674-675: x 76                                                               # data[14]: v
+675-676: x 76                                                               # data[15]: v
+676-677: x 76                                                               # data[16]: v
+677-678: x 76                                                               # data[17]: v
+678-679: x 76                                                               # data[18]: v
+679-680: x 76                                                               # data[19]: v
+680-681: x 76                                                               # data[20]: v
+681-682: x 76                                                               # data[21]: v
+682-683: x 76                                                               # data[22]: v
+683-684: x 76                                                               # data[23]: v
+684-685: x 76                                                               # data[24]: v
+685-686: x 76                                                               # data[25]: v
+686-687: x 76                                                               # data[26]: v
+687-688: x 76                                                               # data[27]: v
+688-689: x 76                                                               # data[28]: v
+689-690: x 76                                                               # data[29]: v
+690-691: x 76                                                               # data[30]: v
+691-692: x 76                                                               # data[31]: v
+692-693: x 76                                                               # data[32]: v
+693-694: x 76                                                               # data[33]: v
+694-695: x 76                                                               # data[34]: v
+695-696: x 76                                                               # data[35]: v
+696-697: x 76                                                               # data[36]: v
+697-698: x 76                                                               # data[37]: v
+698-699: x 76                                                               # data[38]: v
+699-700: x 76                                                               # data[39]: v
+700-701: x 76                                                               # data[40]: v
+701-702: x 76                                                               # data[41]: v
+702-703: x 76                                                               # data[42]: v
+703-704: x 76                                                               # data[43]: v
+704-705: x 76                                                               # data[44]: v
+705-706: x 76                                                               # data[45]: v
+706-707: x 76                                                               # data[46]: v
+707-708: x 76                                                               # data[47]: v
+708-709: x 76                                                               # data[48]: v
+709-710: x 76                                                               # data[49]: v
+710-711: x 76                                                               # data[50]: v
+711-712: x 76                                                               # data[51]: v
+712-713: x 76                                                               # data[52]: v
+713-714: x 76                                                               # data[53]: v
+714-715: x 76                                                               # data[54]: v
+715-716: x 76                                                               # data[55]: v
+716-717: x 76                                                               # data[56]: v
+717-718: x 76                                                               # data[57]: v
+718-719: x 76                                                               # data[58]: v
+719-720: x 76                                                               # data[59]: v
+720-721: x 76                                                               # data[60]: v
+721-722: x 76                                                               # data[61]: v
+722-723: x 76                                                               # data[62]: v
+723-724: x 76                                                               # data[63]: v
+724-725: x 76                                                               # data[64]: v
+725-726: x 76                                                               # data[65]: v
 # data for column 5
-718-719: x 01                                                               # bitmap encoding
-719-720: x 00                                                               # block padding byte
+726-727: x 01                                                               # bitmap encoding
+# data for column 6
+727-728: x 01                                                               # bitmap encoding
+728-729: x 00                                                               # block padding byte
 
 iter
 seek-ge backache

--- a/sstable/colblk/testdata/data_block/external_value
+++ b/sstable/colblk/testdata/data_block/external_value
@@ -1,12 +1,13 @@
 init
 ----
-size=50:
+size=51:
 0: prefixes:       prefixbytes(16): 0 keys
 1: suffixes:       bytes: 0 rows set; 0 bytes in data
 2: trailers:       uint: 0 rows
 3: prefix changed: bitmap
 4: values:         bytes: 0 rows set; 0 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 write
 blockprefix_apple@98#0,SET:apple98
@@ -30,13 +31,14 @@ blockprefix_kiwi@99#0,SET:valueHandle-kiwi99
 blockprefix_kiwi@98#0,SET:valueHandle-kiwi98
 blockprefix_lemon@92#0,DEL:
 ----
-size=641:
+size=650:
 0: prefixes:       prefixbytes(16): 20 keys
 1: suffixes:       bytes: 20 rows set; 54 bytes in data
 2: trailers:       uint: 20 rows
 3: prefix changed: bitmap
 4: values:         bytes: 20 rows set; 331 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 finish
 ----
@@ -45,221 +47,224 @@ LastKey: blockprefix_lemon@92#0,DEL
 000-004: x 16000000                                                         # maximum key length: 22
 # columnar block header
 004-005: x 01                                                               # version 1
-005-007: x 0600                                                             # 6 columns
+005-007: x 0700                                                             # 7 columns
 007-011: x 14000000                                                         # 20 rows
 011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 29000000                                                         # col 0: page start 41
+012-016: x 2e000000                                                         # col 0: page start 46
 016-017: b 00000011                                                         # col 1: bytes
-017-021: x 6e000000                                                         # col 1: page start 110
+017-021: x 73000000                                                         # col 1: page start 115
 021-022: b 00000010                                                         # col 2: uint
-022-026: x ba000000                                                         # col 2: page start 186
+022-026: x bf000000                                                         # col 2: page start 191
 026-027: b 00000001                                                         # col 3: bool
-027-031: x e4000000                                                         # col 3: page start 228
+027-031: x e8000000                                                         # col 3: page start 232
 031-032: b 00000011                                                         # col 4: bytes
-032-036: x f8000000                                                         # col 4: page start 248
+032-036: x 00010000                                                         # col 4: page start 256
 036-037: b 00000001                                                         # col 5: bool
-037-041: x 6f020000                                                         # col 5: page start 623
+037-041: x 77020000                                                         # col 5: page start 631
+041-042: b 00000001                                                         # col 6: bool
+042-046: x 88020000                                                         # col 6: page start 648
 # data for column 0
 # PrefixBytes
-041-042: x 04                                                               # bundleSize: 16
+046-047: x 04                                                               # bundleSize: 16
 # Offsets table
-042-043: x 01                                                               # encoding: 1b
-043-044: x 0c                                                               # data[0] = 12 [78 overall]
-044-045: x 0c                                                               # data[1] = 12 [78 overall]
-045-046: x 11                                                               # data[2] = 17 [83 overall]
-046-047: x 11                                                               # data[3] = 17 [83 overall]
-047-048: x 11                                                               # data[4] = 17 [83 overall]
-048-049: x 11                                                               # data[5] = 17 [83 overall]
-049-050: x 17                                                               # data[6] = 23 [89 overall]
-050-051: x 17                                                               # data[7] = 23 [89 overall]
-051-052: x 17                                                               # data[8] = 23 [89 overall]
-052-053: x 17                                                               # data[9] = 23 [89 overall]
-053-054: x 17                                                               # data[10] = 23 [89 overall]
-054-055: x 17                                                               # data[11] = 23 [89 overall]
-055-056: x 1e                                                               # data[12] = 30 [96 overall]
-056-057: x 1e                                                               # data[13] = 30 [96 overall]
-057-058: x 1e                                                               # data[14] = 30 [96 overall]
-058-059: x 1e                                                               # data[15] = 30 [96 overall]
-059-060: x 1e                                                               # data[16] = 30 [96 overall]
-060-061: x 1e                                                               # data[17] = 30 [96 overall]
-061-062: x 1e                                                               # data[18] = 30 [96 overall]
-062-063: x 23                                                               # data[19] = 35 [101 overall]
-063-064: x 27                                                               # data[20] = 39 [105 overall]
-064-065: x 27                                                               # data[21] = 39 [105 overall]
-065-066: x 2c                                                               # data[22] = 44 [110 overall]
+047-048: x 01                                                               # encoding: 1b
+048-049: x 0c                                                               # data[0] = 12 [83 overall]
+049-050: x 0c                                                               # data[1] = 12 [83 overall]
+050-051: x 11                                                               # data[2] = 17 [88 overall]
+051-052: x 11                                                               # data[3] = 17 [88 overall]
+052-053: x 11                                                               # data[4] = 17 [88 overall]
+053-054: x 11                                                               # data[5] = 17 [88 overall]
+054-055: x 17                                                               # data[6] = 23 [94 overall]
+055-056: x 17                                                               # data[7] = 23 [94 overall]
+056-057: x 17                                                               # data[8] = 23 [94 overall]
+057-058: x 17                                                               # data[9] = 23 [94 overall]
+058-059: x 17                                                               # data[10] = 23 [94 overall]
+059-060: x 17                                                               # data[11] = 23 [94 overall]
+060-061: x 1e                                                               # data[12] = 30 [101 overall]
+061-062: x 1e                                                               # data[13] = 30 [101 overall]
+062-063: x 1e                                                               # data[14] = 30 [101 overall]
+063-064: x 1e                                                               # data[15] = 30 [101 overall]
+064-065: x 1e                                                               # data[16] = 30 [101 overall]
+065-066: x 1e                                                               # data[17] = 30 [101 overall]
+066-067: x 1e                                                               # data[18] = 30 [101 overall]
+067-068: x 23                                                               # data[19] = 35 [106 overall]
+068-069: x 27                                                               # data[20] = 39 [110 overall]
+069-070: x 27                                                               # data[21] = 39 [110 overall]
+070-071: x 2c                                                               # data[22] = 44 [115 overall]
 # Data
-066-076: x 626c6f636b7072656669                                             # data[00]: blockprefix_ (block prefix)
-076-078: x 785f                                                             # (continued...)
-078-078: x                                                                  # data[01]: ............ (bundle prefix)
-078-083: x 6170706c65                                                       # data[02]: ............apple
-083-083: x                                                                  # data[03]: .................
-083-083: x                                                                  # data[04]: .................
-083-083: x                                                                  # data[05]: .................
-083-089: x 62616e616e61                                                     # data[06]: ............banana
-089-089: x                                                                  # data[07]: ..................
-089-089: x                                                                  # data[08]: ..................
-089-089: x                                                                  # data[09]: ..................
-089-089: x                                                                  # data[10]: ..................
-089-089: x                                                                  # data[11]: ..................
-089-096: x 636f636f6e7574                                                   # data[12]: ............coconut
-096-096: x                                                                  # data[13]: ...................
-096-096: x                                                                  # data[14]: ...................
-096-096: x                                                                  # data[15]: ...................
-096-096: x                                                                  # data[16]: ...................
-096-096: x                                                                  # data[17]: ...................
-096-096: x                                                                  # data[18]: ............ (bundle prefix)
-096-101: x 6775617661                                                       # data[19]: ............guava
-101-105: x 6b697769                                                         # data[20]: ............kiwi
-105-105: x                                                                  # data[21]: ................
-105-110: x 6c656d6f6e                                                       # data[22]: ............lemon
+071-081: x 626c6f636b7072656669                                             # data[00]: blockprefix_ (block prefix)
+081-083: x 785f                                                             # (continued...)
+083-083: x                                                                  # data[01]: ............ (bundle prefix)
+083-088: x 6170706c65                                                       # data[02]: ............apple
+088-088: x                                                                  # data[03]: .................
+088-088: x                                                                  # data[04]: .................
+088-088: x                                                                  # data[05]: .................
+088-094: x 62616e616e61                                                     # data[06]: ............banana
+094-094: x                                                                  # data[07]: ..................
+094-094: x                                                                  # data[08]: ..................
+094-094: x                                                                  # data[09]: ..................
+094-094: x                                                                  # data[10]: ..................
+094-094: x                                                                  # data[11]: ..................
+094-101: x 636f636f6e7574                                                   # data[12]: ............coconut
+101-101: x                                                                  # data[13]: ...................
+101-101: x                                                                  # data[14]: ...................
+101-101: x                                                                  # data[15]: ...................
+101-101: x                                                                  # data[16]: ...................
+101-101: x                                                                  # data[17]: ...................
+101-101: x                                                                  # data[18]: ............ (bundle prefix)
+101-106: x 6775617661                                                       # data[19]: ............guava
+106-110: x 6b697769                                                         # data[20]: ............kiwi
+110-110: x                                                                  # data[21]: ................
+110-115: x 6c656d6f6e                                                       # data[22]: ............lemon
 # data for column 1
 # rawbytes
 # offsets table
-110-111: x 01                                                               # encoding: 1b
-111-112: x 00                                                               # data[0] = 0 [132 overall]
-112-113: x 03                                                               # data[1] = 3 [135 overall]
-113-114: x 06                                                               # data[2] = 6 [138 overall]
-114-115: x 09                                                               # data[3] = 9 [141 overall]
-115-116: x 0c                                                               # data[4] = 12 [144 overall]
-116-117: x 0f                                                               # data[5] = 15 [147 overall]
-117-118: x 12                                                               # data[6] = 18 [150 overall]
-118-119: x 15                                                               # data[7] = 21 [153 overall]
-119-120: x 18                                                               # data[8] = 24 [156 overall]
-120-121: x 1a                                                               # data[9] = 26 [158 overall]
-121-122: x 1c                                                               # data[10] = 28 [160 overall]
-122-123: x 1c                                                               # data[11] = 28 [160 overall]
-123-124: x 1f                                                               # data[12] = 31 [163 overall]
-124-125: x 22                                                               # data[13] = 34 [166 overall]
-125-126: x 25                                                               # data[14] = 37 [169 overall]
-126-127: x 28                                                               # data[15] = 40 [172 overall]
-127-128: x 2a                                                               # data[16] = 42 [174 overall]
-128-129: x 2d                                                               # data[17] = 45 [177 overall]
-129-130: x 30                                                               # data[18] = 48 [180 overall]
-130-131: x 33                                                               # data[19] = 51 [183 overall]
-131-132: x 36                                                               # data[20] = 54 [186 overall]
+115-116: x 01                                                               # encoding: 1b
+116-117: x 00                                                               # data[0] = 0 [137 overall]
+117-118: x 03                                                               # data[1] = 3 [140 overall]
+118-119: x 06                                                               # data[2] = 6 [143 overall]
+119-120: x 09                                                               # data[3] = 9 [146 overall]
+120-121: x 0c                                                               # data[4] = 12 [149 overall]
+121-122: x 0f                                                               # data[5] = 15 [152 overall]
+122-123: x 12                                                               # data[6] = 18 [155 overall]
+123-124: x 15                                                               # data[7] = 21 [158 overall]
+124-125: x 18                                                               # data[8] = 24 [161 overall]
+125-126: x 1a                                                               # data[9] = 26 [163 overall]
+126-127: x 1c                                                               # data[10] = 28 [165 overall]
+127-128: x 1c                                                               # data[11] = 28 [165 overall]
+128-129: x 1f                                                               # data[12] = 31 [168 overall]
+129-130: x 22                                                               # data[13] = 34 [171 overall]
+130-131: x 25                                                               # data[14] = 37 [174 overall]
+131-132: x 28                                                               # data[15] = 40 [177 overall]
+132-133: x 2a                                                               # data[16] = 42 [179 overall]
+133-134: x 2d                                                               # data[17] = 45 [182 overall]
+134-135: x 30                                                               # data[18] = 48 [185 overall]
+135-136: x 33                                                               # data[19] = 51 [188 overall]
+136-137: x 36                                                               # data[20] = 54 [191 overall]
 # data
-132-135: x 403938                                                           # data[0]: @98
-135-138: x 403532                                                           # data[1]: @52
-138-141: x 403233                                                           # data[2]: @23
-141-144: x 403131                                                           # data[3]: @11
-144-147: x 403934                                                           # data[4]: @94
-147-150: x 403933                                                           # data[5]: @93
-150-153: x 403933                                                           # data[6]: @93
-153-156: x 403732                                                           # data[7]: @72
-156-158: x 4039                                                             # data[8]: @9
-158-160: x 4031                                                             # data[9]: @1
-160-160: x                                                                  # data[10]:
-160-163: x 403932                                                           # data[11]: @92
-163-166: x 403335                                                           # data[12]: @35
-166-169: x 403232                                                           # data[13]: @22
-169-172: x 403231                                                           # data[14]: @21
-172-174: x 4031                                                             # data[15]: @1
-174-177: x 403939                                                           # data[16]: @99
-177-180: x 403939                                                           # data[17]: @99
-180-183: x 403938                                                           # data[18]: @98
-183-186: x 403932                                                           # data[19]: @92
+137-140: x 403938                                                           # data[0]: @98
+140-143: x 403532                                                           # data[1]: @52
+143-146: x 403233                                                           # data[2]: @23
+146-149: x 403131                                                           # data[3]: @11
+149-152: x 403934                                                           # data[4]: @94
+152-155: x 403933                                                           # data[5]: @93
+155-158: x 403933                                                           # data[6]: @93
+158-161: x 403732                                                           # data[7]: @72
+161-163: x 4039                                                             # data[8]: @9
+163-165: x 4031                                                             # data[9]: @1
+165-165: x                                                                  # data[10]:
+165-168: x 403932                                                           # data[11]: @92
+168-171: x 403335                                                           # data[12]: @35
+171-174: x 403232                                                           # data[13]: @22
+174-177: x 403231                                                           # data[14]: @21
+177-179: x 4031                                                             # data[15]: @1
+179-182: x 403939                                                           # data[16]: @99
+182-185: x 403939                                                           # data[17]: @99
+185-188: x 403938                                                           # data[18]: @98
+188-191: x 403932                                                           # data[19]: @92
 # data for column 2
-186-187: x 02                                                               # encoding: 2b
-187-188: x 00                                                               # padding (aligning to 16-bit boundary)
-188-190: x 0100                                                             # data[0] = 1
-190-192: x 0100                                                             # data[1] = 1
-192-194: x 0100                                                             # data[2] = 1
-194-196: x 1200                                                             # data[3] = 18
-196-198: x 12f5                                                             # data[4] = 62738
-198-200: x 00f4                                                             # data[5] = 62464
-200-202: x 12dd                                                             # data[6] = 56594
-202-204: x 1200                                                             # data[7] = 18
-204-206: x 0100                                                             # data[8] = 1
-206-208: x 0100                                                             # data[9] = 1
-208-210: x 0100                                                             # data[10] = 1
-210-212: x 0100                                                             # data[11] = 1
-212-214: x 0100                                                             # data[12] = 1
-214-216: x 0100                                                             # data[13] = 1
-216-218: x 0100                                                             # data[14] = 1
-218-220: x 0100                                                             # data[15] = 1
-220-222: x 0100                                                             # data[16] = 1
-222-224: x 0100                                                             # data[17] = 1
-224-226: x 0100                                                             # data[18] = 1
-226-228: x 0000                                                             # data[19] = 0
+191-192: x 02                                                               # encoding: 2b
+192-194: x 0100                                                             # data[0] = 1
+194-196: x 0100                                                             # data[1] = 1
+196-198: x 0100                                                             # data[2] = 1
+198-200: x 1200                                                             # data[3] = 18
+200-202: x 12f5                                                             # data[4] = 62738
+202-204: x 00f4                                                             # data[5] = 62464
+204-206: x 12dd                                                             # data[6] = 56594
+206-208: x 1200                                                             # data[7] = 18
+208-210: x 0100                                                             # data[8] = 1
+210-212: x 0100                                                             # data[9] = 1
+212-214: x 0100                                                             # data[10] = 1
+214-216: x 0100                                                             # data[11] = 1
+216-218: x 0100                                                             # data[12] = 1
+218-220: x 0100                                                             # data[13] = 1
+220-222: x 0100                                                             # data[14] = 1
+222-224: x 0100                                                             # data[15] = 1
+224-226: x 0100                                                             # data[16] = 1
+226-228: x 0100                                                             # data[17] = 1
+228-230: x 0100                                                             # data[18] = 1
+230-232: x 0000                                                             # data[19] = 0
 # data for column 3
-228-229: x 00                                                               # bitmap encoding
-229-232: x 000000                                                           # padding to align to 64-bit boundary
-232-240: b 0001000100000100000010110000000000000000000000000000000000000000 # bitmap word 0
-240-248: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+232-233: x 00                                                               # bitmap encoding
+233-240: x 00000000000000                                                   # padding to align to 64-bit boundary
+240-248: b 0001000100000100000010110000000000000000000000000000000000000000 # bitmap word 0
+248-256: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-248-249: x 02                                                               # encoding: 2b
-249-250: x 00                                                               # padding (aligning to 16-bit boundary)
-250-252: x 0000                                                             # data[0] = 0 [292 overall]
-252-254: x 0700                                                             # data[1] = 7 [299 overall]
-254-256: x 1b00                                                             # data[2] = 27 [319 overall]
-256-258: x 2f00                                                             # data[3] = 47 [339 overall]
-258-260: x 4300                                                             # data[4] = 67 [359 overall]
-260-262: x 4b00                                                             # data[5] = 75 [367 overall]
-262-264: x 4b00                                                             # data[6] = 75 [367 overall]
-264-266: x 6000                                                             # data[7] = 96 [388 overall]
-266-268: x 7500                                                             # data[8] = 117 [409 overall]
-268-270: x 8900                                                             # data[9] = 137 [429 overall]
-270-272: x 9d00                                                             # data[10] = 157 [449 overall]
-272-274: x a400                                                             # data[11] = 164 [456 overall]
-274-276: x ba00                                                             # data[12] = 186 [478 overall]
-276-278: x d000                                                             # data[13] = 208 [500 overall]
-278-280: x e600                                                             # data[14] = 230 [522 overall]
-280-282: x fc00                                                             # data[15] = 252 [544 overall]
-282-284: x 1101                                                             # data[16] = 273 [565 overall]
-284-286: x 2501                                                             # data[17] = 293 [585 overall]
-286-288: x 3801                                                             # data[18] = 312 [604 overall]
-288-290: x 4b01                                                             # data[19] = 331 [623 overall]
-290-292: x 4b01                                                             # data[20] = 331 [623 overall]
+256-257: x 02                                                               # encoding: 2b
+257-258: x 00                                                               # padding (aligning to 16-bit boundary)
+258-260: x 0000                                                             # data[0] = 0 [300 overall]
+260-262: x 0700                                                             # data[1] = 7 [307 overall]
+262-264: x 1b00                                                             # data[2] = 27 [327 overall]
+264-266: x 2f00                                                             # data[3] = 47 [347 overall]
+266-268: x 4300                                                             # data[4] = 67 [367 overall]
+268-270: x 4b00                                                             # data[5] = 75 [375 overall]
+270-272: x 4b00                                                             # data[6] = 75 [375 overall]
+272-274: x 6000                                                             # data[7] = 96 [396 overall]
+274-276: x 7500                                                             # data[8] = 117 [417 overall]
+276-278: x 8900                                                             # data[9] = 137 [437 overall]
+278-280: x 9d00                                                             # data[10] = 157 [457 overall]
+280-282: x a400                                                             # data[11] = 164 [464 overall]
+282-284: x ba00                                                             # data[12] = 186 [486 overall]
+284-286: x d000                                                             # data[13] = 208 [508 overall]
+286-288: x e600                                                             # data[14] = 230 [530 overall]
+288-290: x fc00                                                             # data[15] = 252 [552 overall]
+290-292: x 1101                                                             # data[16] = 273 [573 overall]
+292-294: x 2501                                                             # data[17] = 293 [593 overall]
+294-296: x 3801                                                             # data[18] = 312 [612 overall]
+296-298: x 4b01                                                             # data[19] = 331 [631 overall]
+298-300: x 4b01                                                             # data[20] = 331 [631 overall]
 # data
-292-299: x 6170706c653938                                                   # data[0]: apple98
-299-309: x a076616c756548616e64                                             # data[1]: "\xa0valueHandle-apple52"
-309-319: x 6c652d6170706c653532                                             # (continued...)
-319-329: x a076616c756548616e64                                             # data[2]: "\xa0valueHandle-apple23"
-329-339: x 6c652d6170706c653233                                             # (continued...)
-339-349: x a076616c756548616e64                                             # data[3]: "\xa0valueHandle-apple11"
-349-359: x 6c652d6170706c653131                                             # (continued...)
-359-367: x 62616e616e613934                                                 # data[4]: banana94
-367-367: x                                                                  # data[5]:
-367-377: x a076616c756548616e64                                             # data[6]: "\xa0valueHandle-banana93"
-377-387: x 6c652d62616e616e6139                                             # (continued...)
-387-388: x 33                                                               # (continued...)
-388-398: x a076616c756548616e64                                             # data[7]: "\xa0valueHandle-banana72"
-398-408: x 6c652d62616e616e6137                                             # (continued...)
-408-409: x 32                                                               # (continued...)
-409-419: x a076616c756548616e64                                             # data[8]: "\xa0valueHandle-banana9"
-419-429: x 6c652d62616e616e6139                                             # (continued...)
-429-439: x a076616c756548616e64                                             # data[9]: "\xa0valueHandle-banana1"
-439-449: x 6c652d62616e616e6131                                             # (continued...)
-449-456: x 636f636f6e7574                                                   # data[10]: coconut
-456-466: x a076616c756548616e64                                             # data[11]: "\xa0valueHandle-coconut92"
-466-476: x 6c652d636f636f6e7574                                             # (continued...)
-476-478: x 3932                                                             # (continued...)
-478-488: x a076616c756548616e64                                             # data[12]: "\xa0valueHandle-coconut35"
-488-498: x 6c652d636f636f6e7574                                             # (continued...)
-498-500: x 3335                                                             # (continued...)
-500-510: x a076616c756548616e64                                             # data[13]: "\xa0valueHandle-coconut22"
-510-520: x 6c652d636f636f6e7574                                             # (continued...)
-520-522: x 3232                                                             # (continued...)
-522-532: x a076616c756548616e64                                             # data[14]: "\xa0valueHandle-coconut21"
-532-542: x 6c652d636f636f6e7574                                             # (continued...)
-542-544: x 3231                                                             # (continued...)
-544-554: x a076616c756548616e64                                             # data[15]: "\xa0valueHandle-coconut1"
-554-564: x 6c652d636f636f6e7574                                             # (continued...)
-564-565: x 31                                                               # (continued...)
-565-575: x 8076616c756548616e64                                             # data[16]: "\x80valueHandle-guava99"
-575-585: x 6c652d67756176613939                                             # (continued...)
-585-595: x 8076616c756548616e64                                             # data[17]: "\x80valueHandle-kiwi99"
-595-604: x 6c652d6b6977693939                                               # (continued...)
-604-614: x a076616c756548616e64                                             # data[18]: "\xa0valueHandle-kiwi98"
-614-623: x 6c652d6b6977693938                                               # (continued...)
-623-623: x                                                                  # data[19]:
+300-307: x 6170706c653938                                                   # data[0]: apple98
+307-317: x a076616c756548616e64                                             # data[1]: "\xa0valueHandle-apple52"
+317-327: x 6c652d6170706c653532                                             # (continued...)
+327-337: x a076616c756548616e64                                             # data[2]: "\xa0valueHandle-apple23"
+337-347: x 6c652d6170706c653233                                             # (continued...)
+347-357: x a076616c756548616e64                                             # data[3]: "\xa0valueHandle-apple11"
+357-367: x 6c652d6170706c653131                                             # (continued...)
+367-375: x 62616e616e613934                                                 # data[4]: banana94
+375-375: x                                                                  # data[5]:
+375-385: x a076616c756548616e64                                             # data[6]: "\xa0valueHandle-banana93"
+385-395: x 6c652d62616e616e6139                                             # (continued...)
+395-396: x 33                                                               # (continued...)
+396-406: x a076616c756548616e64                                             # data[7]: "\xa0valueHandle-banana72"
+406-416: x 6c652d62616e616e6137                                             # (continued...)
+416-417: x 32                                                               # (continued...)
+417-427: x a076616c756548616e64                                             # data[8]: "\xa0valueHandle-banana9"
+427-437: x 6c652d62616e616e6139                                             # (continued...)
+437-447: x a076616c756548616e64                                             # data[9]: "\xa0valueHandle-banana1"
+447-457: x 6c652d62616e616e6131                                             # (continued...)
+457-464: x 636f636f6e7574                                                   # data[10]: coconut
+464-474: x a076616c756548616e64                                             # data[11]: "\xa0valueHandle-coconut92"
+474-484: x 6c652d636f636f6e7574                                             # (continued...)
+484-486: x 3932                                                             # (continued...)
+486-496: x a076616c756548616e64                                             # data[12]: "\xa0valueHandle-coconut35"
+496-506: x 6c652d636f636f6e7574                                             # (continued...)
+506-508: x 3335                                                             # (continued...)
+508-518: x a076616c756548616e64                                             # data[13]: "\xa0valueHandle-coconut22"
+518-528: x 6c652d636f636f6e7574                                             # (continued...)
+528-530: x 3232                                                             # (continued...)
+530-540: x a076616c756548616e64                                             # data[14]: "\xa0valueHandle-coconut21"
+540-550: x 6c652d636f636f6e7574                                             # (continued...)
+550-552: x 3231                                                             # (continued...)
+552-562: x a076616c756548616e64                                             # data[15]: "\xa0valueHandle-coconut1"
+562-572: x 6c652d636f636f6e7574                                             # (continued...)
+572-573: x 31                                                               # (continued...)
+573-583: x 8076616c756548616e64                                             # data[16]: "\x80valueHandle-guava99"
+583-593: x 6c652d67756176613939                                             # (continued...)
+593-603: x 8076616c756548616e64                                             # data[17]: "\x80valueHandle-kiwi99"
+603-612: x 6c652d6b6977693939                                               # (continued...)
+612-622: x a076616c756548616e64                                             # data[18]: "\xa0valueHandle-kiwi98"
+622-631: x 6c652d6b6977693938                                               # (continued...)
+631-631: x                                                                  # data[19]:
 # data for column 5
-623-624: x 00                                                               # bitmap encoding
-624-632: b 1100111011111011000001110000000000000000000000000000000000000000 # bitmap word 0
-632-640: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-640-641: x 00                                                               # block padding byte
+631-632: x 00                                                               # bitmap encoding
+632-640: b 1100111011111011000001110000000000000000000000000000000000000000 # bitmap word 0
+640-648: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+# data for column 6
+648-649: x 01                                                               # bitmap encoding
+649-650: x 00                                                               # block padding byte
 
 # Scan across the block using next.
 iter

--- a/sstable/colblk/testdata/data_block/finish_without_final_row
+++ b/sstable/colblk/testdata/data_block/finish_without_final_row
@@ -1,12 +1,13 @@
 init
 ----
-size=50:
+size=51:
 0: prefixes:       prefixbytes(16): 0 keys
 1: suffixes:       bytes: 0 rows set; 0 bytes in data
 2: trailers:       uint: 0 rows
 3: prefix changed: bitmap
 4: values:         bytes: 0 rows set; 0 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 write
 a@10#0,SET:apple
@@ -16,13 +17,14 @@ c@9#0,SETWITHDEL:coconut
 c@6#0,SET:cantelope
 c@1#0,SET:clementine
 ----
-size=160:
+size=161:
 0: prefixes:       prefixbytes(16): 6 keys
 1: suffixes:       bytes: 6 rows set; 13 bytes in data
 2: trailers:       uint: 6 rows
 3: prefix changed: bitmap
 4: values:         bytes: 6 rows set; 46 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 finish rows=5
 ----
@@ -31,87 +33,91 @@ LastKey: c@6#0,SET
 000-004: x 04000000                                                         # maximum key length: 4
 # columnar block header
 004-005: x 01                                                               # version 1
-005-007: x 0600                                                             # 6 columns
+005-007: x 0700                                                             # 7 columns
 007-011: x 05000000                                                         # 5 rows
 011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 29000000                                                         # col 0: page start 41
+012-016: x 2e000000                                                         # col 0: page start 46
 016-017: b 00000011                                                         # col 1: bytes
-017-021: x 35000000                                                         # col 1: page start 53
+017-021: x 3a000000                                                         # col 1: page start 58
 021-022: b 00000010                                                         # col 2: uint
-022-026: x 47000000                                                         # col 2: page start 71
+022-026: x 4c000000                                                         # col 2: page start 76
 026-027: b 00000001                                                         # col 3: bool
-027-031: x 4d000000                                                         # col 3: page start 77
+027-031: x 52000000                                                         # col 3: page start 82
 031-032: b 00000011                                                         # col 4: bytes
-032-036: x 60000000                                                         # col 4: page start 96
+032-036: x 68000000                                                         # col 4: page start 104
 036-037: b 00000001                                                         # col 5: bool
-037-041: x 8b000000                                                         # col 5: page start 139
+037-041: x 93000000                                                         # col 5: page start 147
+041-042: b 00000001                                                         # col 6: bool
+042-046: x 94000000                                                         # col 6: page start 148
 # data for column 0
 # PrefixBytes
-041-042: x 04                                                               # bundleSize: 16
+046-047: x 04                                                               # bundleSize: 16
 # Offsets table
-042-043: x 01                                                               # encoding: 1b
-043-044: x 00                                                               # data[0] = 0 [50 overall]
-044-045: x 00                                                               # data[1] = 0 [50 overall]
-045-046: x 01                                                               # data[2] = 1 [51 overall]
-046-047: x 02                                                               # data[3] = 2 [52 overall]
-047-048: x 02                                                               # data[4] = 2 [52 overall]
-048-049: x 03                                                               # data[5] = 3 [53 overall]
-049-050: x 03                                                               # data[6] = 3 [53 overall]
+047-048: x 01                                                               # encoding: 1b
+048-049: x 00                                                               # data[0] = 0 [55 overall]
+049-050: x 00                                                               # data[1] = 0 [55 overall]
+050-051: x 01                                                               # data[2] = 1 [56 overall]
+051-052: x 02                                                               # data[3] = 2 [57 overall]
+052-053: x 02                                                               # data[4] = 2 [57 overall]
+053-054: x 03                                                               # data[5] = 3 [58 overall]
+054-055: x 03                                                               # data[6] = 3 [58 overall]
 # Data
-050-050: x                                                                  # data[00]:  (block prefix)
-050-050: x                                                                  # data[01]:  (bundle prefix)
-050-051: x 61                                                               # data[02]: a
-051-052: x 62                                                               # data[03]: b
-052-052: x                                                                  # data[04]: .
-052-053: x 63                                                               # data[05]: c
-053-053: x                                                                  # data[06]: .
+055-055: x                                                                  # data[00]:  (block prefix)
+055-055: x                                                                  # data[01]:  (bundle prefix)
+055-056: x 61                                                               # data[02]: a
+056-057: x 62                                                               # data[03]: b
+057-057: x                                                                  # data[04]: .
+057-058: x 63                                                               # data[05]: c
+058-058: x                                                                  # data[06]: .
 # data for column 1
 # rawbytes
 # offsets table
-053-054: x 01                                                               # encoding: 1b
-054-055: x 00                                                               # data[0] = 0 [60 overall]
-055-056: x 03                                                               # data[1] = 3 [63 overall]
-056-057: x 05                                                               # data[2] = 5 [65 overall]
-057-058: x 07                                                               # data[3] = 7 [67 overall]
-058-059: x 09                                                               # data[4] = 9 [69 overall]
-059-060: x 0b                                                               # data[5] = 11 [71 overall]
+058-059: x 01                                                               # encoding: 1b
+059-060: x 00                                                               # data[0] = 0 [65 overall]
+060-061: x 03                                                               # data[1] = 3 [68 overall]
+061-062: x 05                                                               # data[2] = 5 [70 overall]
+062-063: x 07                                                               # data[3] = 7 [72 overall]
+063-064: x 09                                                               # data[4] = 9 [74 overall]
+064-065: x 0b                                                               # data[5] = 11 [76 overall]
 # data
-060-063: x 403130                                                           # data[0]: @10
-063-065: x 4035                                                             # data[1]: @5
-065-067: x 4032                                                             # data[2]: @2
-067-069: x 4039                                                             # data[3]: @9
-069-071: x 4036                                                             # data[4]: @6
+065-068: x 403130                                                           # data[0]: @10
+068-070: x 4035                                                             # data[1]: @5
+070-072: x 4032                                                             # data[2]: @2
+072-074: x 4039                                                             # data[3]: @9
+074-076: x 4036                                                             # data[4]: @6
 # data for column 2
-071-072: x 01                                                               # encoding: 1b
-072-073: x 01                                                               # data[0] = 1
-073-074: x 01                                                               # data[1] = 1
-074-075: x 12                                                               # data[2] = 18
-075-076: x 12                                                               # data[3] = 18
-076-077: x 01                                                               # data[4] = 1
+076-077: x 01                                                               # encoding: 1b
+077-078: x 01                                                               # data[0] = 1
+078-079: x 01                                                               # data[1] = 1
+079-080: x 12                                                               # data[2] = 18
+080-081: x 12                                                               # data[3] = 18
+081-082: x 01                                                               # data[4] = 1
 # data for column 3
-077-078: x 00                                                               # bitmap encoding
-078-080: x 0000                                                             # padding to align to 64-bit boundary
-080-088: b 0000101100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-088-096: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+082-083: x 00                                                               # bitmap encoding
+083-088: x 0000000000                                                       # padding to align to 64-bit boundary
+088-096: b 0000101100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+096-104: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-096-097: x 01                                                               # encoding: 1b
-097-098: x 00                                                               # data[0] = 0 [103 overall]
-098-099: x 05                                                               # data[1] = 5 [108 overall]
-099-100: x 0b                                                               # data[2] = 11 [114 overall]
-100-101: x 14                                                               # data[3] = 20 [123 overall]
-101-102: x 1b                                                               # data[4] = 27 [130 overall]
-102-103: x 24                                                               # data[5] = 36 [139 overall]
+104-105: x 01                                                               # encoding: 1b
+105-106: x 00                                                               # data[0] = 0 [111 overall]
+106-107: x 05                                                               # data[1] = 5 [116 overall]
+107-108: x 0b                                                               # data[2] = 11 [122 overall]
+108-109: x 14                                                               # data[3] = 20 [131 overall]
+109-110: x 1b                                                               # data[4] = 27 [138 overall]
+110-111: x 24                                                               # data[5] = 36 [147 overall]
 # data
-103-108: x 6170706c65                                                       # data[0]: apple
-108-114: x 62616e616e61                                                     # data[1]: banana
-114-123: x 626c75656265727279                                               # data[2]: blueberry
-123-130: x 636f636f6e7574                                                   # data[3]: coconut
-130-139: x 63616e74656c6f7065                                               # data[4]: cantelope
+111-116: x 6170706c65                                                       # data[0]: apple
+116-122: x 62616e616e61                                                     # data[1]: banana
+122-131: x 626c75656265727279                                               # data[2]: blueberry
+131-138: x 636f636f6e7574                                                   # data[3]: coconut
+138-147: x 63616e74656c6f7065                                               # data[4]: cantelope
 # data for column 5
-139-140: x 01                                                               # bitmap encoding
-140-141: x 00                                                               # block padding byte
+147-148: x 01                                                               # bitmap encoding
+# data for column 6
+148-149: x 01                                                               # bitmap encoding
+149-150: x 00                                                               # block padding byte
 
 iter
 first
@@ -130,13 +136,14 @@ c@6:cantelope
 
 init
 ----
-size=50:
+size=51:
 0: prefixes:       prefixbytes(16): 0 keys
 1: suffixes:       bytes: 0 rows set; 0 bytes in data
 2: trailers:       uint: 0 rows
 3: prefix changed: bitmap
 4: values:         bytes: 0 rows set; 0 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 write
 capillaceous@95720#0,SET:value
@@ -183,13 +190,14 @@ capitulate@95720#0,SET:value
 capitulation@95720#0,SET:value
 capitulator@95720#0,SET:value
 ----
-size=1038:
+size=1039:
 0: prefixes:       prefixbytes(16): 43 keys
 1: suffixes:       bytes: 43 rows set; 258 bytes in data
 2: trailers:       uint: 43 rows
 3: prefix changed: bitmap
 4: values:         bytes: 43 rows set; 215 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 # Add an additional key that substantially increases the size of the block
 # because it does not share a) the prefix b) suffix or c) trailer of the
@@ -198,13 +206,14 @@ size=1038:
 write
 dactylioglyphtic@75722285210#539623603,SETWITHDEL:value
 ----
-size=1484:
+size=1493:
 0: prefixes:       prefixbytes(16): 44 keys
 1: suffixes:       bytes: 44 rows set; 270 bytes in data
 2: trailers:       uint: 44 rows
 3: prefix changed: bitmap
 4: values:         bytes: 44 rows set; 220 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 # Finish the block without this last KV.
 
@@ -215,221 +224,221 @@ LastKey: capitulator@95720#0,SET
 0000-0004: x 1c000000                                                         # maximum key length: 28
 # columnar block header
 0004-0005: x 01                                                               # version 1
-0005-0007: x 0600                                                             # 6 columns
+0005-0007: x 0700                                                             # 7 columns
 0007-0011: x 2b000000                                                         # 43 rows
 0011-0012: b 00000100                                                         # col 0: prefixbytes
-0012-0016: x 29000000                                                         # col 0: page start 41
+0012-0016: x 2e000000                                                         # col 0: page start 46
 0016-0017: b 00000011                                                         # col 1: bytes
-0017-0021: x 8e010000                                                         # col 1: page start 398
+0017-0021: x 92010000                                                         # col 1: page start 402
 0021-0022: b 00000010                                                         # col 2: uint
-0022-0026: x ea020000                                                         # col 2: page start 746
+0022-0026: x ee020000                                                         # col 2: page start 750
 0026-0027: b 00000001                                                         # col 3: bool
-0027-0031: x f3020000                                                         # col 3: page start 755
+0027-0031: x f7020000                                                         # col 3: page start 759
 0031-0032: b 00000011                                                         # col 4: bytes
 0032-0036: x 08030000                                                         # col 4: page start 776
 0036-0037: b 00000001                                                         # col 5: bool
 0037-0041: x 0c040000                                                         # col 5: page start 1036
+0041-0042: b 00000001                                                         # col 6: bool
+0042-0046: x 0d040000                                                         # col 6: page start 1037
 # data for column 0
 # PrefixBytes
-0041-0042: x 04                                                               # bundleSize: 16
+0046-0047: x 04                                                               # bundleSize: 16
 # Offsets table
-0042-0043: x 02                                                               # encoding: 2b
-0043-0044: x 00                                                               # padding (aligning to 16-bit boundary)
-0044-0046: x 0400                                                             # data[0] = 4 [142 overall]
-0046-0048: x 0600                                                             # data[1] = 6 [144 overall]
-0048-0050: x 0c00                                                             # data[2] = 12 [150 overall]
-0050-0052: x 1000                                                             # data[3] = 16 [154 overall]
-0052-0054: x 1500                                                             # data[4] = 21 [159 overall]
-0054-0056: x 1e00                                                             # data[5] = 30 [168 overall]
-0056-0058: x 2300                                                             # data[6] = 35 [173 overall]
-0058-0060: x 2b00                                                             # data[7] = 43 [181 overall]
-0060-0062: x 3200                                                             # data[8] = 50 [188 overall]
-0062-0064: x 3b00                                                             # data[9] = 59 [197 overall]
-0064-0066: x 4000                                                             # data[10] = 64 [202 overall]
-0066-0068: x 4300                                                             # data[11] = 67 [205 overall]
-0068-0070: x 4800                                                             # data[12] = 72 [210 overall]
-0070-0072: x 5000                                                             # data[13] = 80 [218 overall]
-0072-0074: x 5500                                                             # data[14] = 85 [223 overall]
-0074-0076: x 5a00                                                             # data[15] = 90 [228 overall]
-0076-0078: x 5f00                                                             # data[16] = 95 [233 overall]
-0078-0080: x 6200                                                             # data[17] = 98 [236 overall]
-0080-0082: x 6200                                                             # data[18] = 98 [236 overall]
-0082-0084: x 6800                                                             # data[19] = 104 [242 overall]
-0084-0086: x 6b00                                                             # data[20] = 107 [245 overall]
-0086-0088: x 7100                                                             # data[21] = 113 [251 overall]
-0088-0090: x 7600                                                             # data[22] = 118 [256 overall]
-0090-0092: x 7c00                                                             # data[23] = 124 [262 overall]
-0092-0094: x 8200                                                             # data[24] = 130 [268 overall]
-0094-0096: x 8a00                                                             # data[25] = 138 [276 overall]
-0096-0098: x 9600                                                             # data[26] = 150 [288 overall]
-0098-0100: x 9f00                                                             # data[27] = 159 [297 overall]
-0100-0102: x a900                                                             # data[28] = 169 [307 overall]
-0102-0104: x af00                                                             # data[29] = 175 [313 overall]
-0104-0106: x b400                                                             # data[30] = 180 [318 overall]
-0106-0108: x bb00                                                             # data[31] = 187 [325 overall]
-0108-0110: x be00                                                             # data[32] = 190 [328 overall]
-0110-0112: x c200                                                             # data[33] = 194 [332 overall]
-0112-0114: x c700                                                             # data[34] = 199 [337 overall]
-0114-0116: x c800                                                             # data[35] = 200 [338 overall]
-0116-0118: x cc00                                                             # data[36] = 204 [342 overall]
-0118-0120: x d100                                                             # data[37] = 209 [347 overall]
-0120-0122: x d600                                                             # data[38] = 214 [352 overall]
-0122-0124: x da00                                                             # data[39] = 218 [356 overall]
-0124-0126: x df00                                                             # data[40] = 223 [361 overall]
-0126-0128: x e500                                                             # data[41] = 229 [367 overall]
-0128-0130: x ed00                                                             # data[42] = 237 [375 overall]
-0130-0132: x f200                                                             # data[43] = 242 [380 overall]
-0132-0134: x f700                                                             # data[44] = 247 [385 overall]
-0134-0136: x fe00                                                             # data[45] = 254 [392 overall]
-0136-0138: x 0401                                                             # data[46] = 260 [398 overall]
+0047-0048: x 02                                                               # encoding: 2b
+0048-0050: x 0400                                                             # data[0] = 4 [146 overall]
+0050-0052: x 0600                                                             # data[1] = 6 [148 overall]
+0052-0054: x 0c00                                                             # data[2] = 12 [154 overall]
+0054-0056: x 1000                                                             # data[3] = 16 [158 overall]
+0056-0058: x 1500                                                             # data[4] = 21 [163 overall]
+0058-0060: x 1e00                                                             # data[5] = 30 [172 overall]
+0060-0062: x 2300                                                             # data[6] = 35 [177 overall]
+0062-0064: x 2b00                                                             # data[7] = 43 [185 overall]
+0064-0066: x 3200                                                             # data[8] = 50 [192 overall]
+0066-0068: x 3b00                                                             # data[9] = 59 [201 overall]
+0068-0070: x 4000                                                             # data[10] = 64 [206 overall]
+0070-0072: x 4300                                                             # data[11] = 67 [209 overall]
+0072-0074: x 4800                                                             # data[12] = 72 [214 overall]
+0074-0076: x 5000                                                             # data[13] = 80 [222 overall]
+0076-0078: x 5500                                                             # data[14] = 85 [227 overall]
+0078-0080: x 5a00                                                             # data[15] = 90 [232 overall]
+0080-0082: x 5f00                                                             # data[16] = 95 [237 overall]
+0082-0084: x 6200                                                             # data[17] = 98 [240 overall]
+0084-0086: x 6200                                                             # data[18] = 98 [240 overall]
+0086-0088: x 6800                                                             # data[19] = 104 [246 overall]
+0088-0090: x 6b00                                                             # data[20] = 107 [249 overall]
+0090-0092: x 7100                                                             # data[21] = 113 [255 overall]
+0092-0094: x 7600                                                             # data[22] = 118 [260 overall]
+0094-0096: x 7c00                                                             # data[23] = 124 [266 overall]
+0096-0098: x 8200                                                             # data[24] = 130 [272 overall]
+0098-0100: x 8a00                                                             # data[25] = 138 [280 overall]
+0100-0102: x 9600                                                             # data[26] = 150 [292 overall]
+0102-0104: x 9f00                                                             # data[27] = 159 [301 overall]
+0104-0106: x a900                                                             # data[28] = 169 [311 overall]
+0106-0108: x af00                                                             # data[29] = 175 [317 overall]
+0108-0110: x b400                                                             # data[30] = 180 [322 overall]
+0110-0112: x bb00                                                             # data[31] = 187 [329 overall]
+0112-0114: x be00                                                             # data[32] = 190 [332 overall]
+0114-0116: x c200                                                             # data[33] = 194 [336 overall]
+0116-0118: x c700                                                             # data[34] = 199 [341 overall]
+0118-0120: x c800                                                             # data[35] = 200 [342 overall]
+0120-0122: x cc00                                                             # data[36] = 204 [346 overall]
+0122-0124: x d100                                                             # data[37] = 209 [351 overall]
+0124-0126: x d600                                                             # data[38] = 214 [356 overall]
+0126-0128: x da00                                                             # data[39] = 218 [360 overall]
+0128-0130: x df00                                                             # data[40] = 223 [365 overall]
+0130-0132: x e500                                                             # data[41] = 229 [371 overall]
+0132-0134: x ed00                                                             # data[42] = 237 [379 overall]
+0134-0136: x f200                                                             # data[43] = 242 [384 overall]
+0136-0138: x f700                                                             # data[44] = 247 [389 overall]
+0138-0140: x fe00                                                             # data[45] = 254 [396 overall]
+0140-0142: x 0401                                                             # data[46] = 260 [402 overall]
 # Data
-0138-0142: x 63617069                                                         # data[00]: capi (block prefix)
-0142-0144: x 6c6c                                                             # data[01]: ....ll (bundle prefix)
-0144-0150: x 6163656f7573                                                     # data[02]: ......aceous
-0150-0154: x 61697265                                                         # data[03]: ......aire
-0154-0159: x 616d656e74                                                       # data[04]: ......ament
-0159-0168: x 617265637461736961                                               # data[05]: ......arectasia
-0168-0173: x 6172696c79                                                       # data[06]: ......arily
-0173-0181: x 6172696d65746572                                                 # data[07]: ......arimeter
-0181-0188: x 6172696e657373                                                   # data[08]: ......ariness
-0188-0197: x 6172696f6d6f746f72                                               # data[09]: ......ariomotor
-0197-0202: x 6172697479                                                       # data[10]: ......arity
-0202-0205: x 617279                                                           # data[11]: ......ary
-0205-0210: x 6174696f6e                                                       # data[12]: ......ation
-0210-0218: x 6963756c74757265                                                 # data[13]: ......iculture
-0218-0223: x 69666f726d                                                       # data[14]: ......iform
-0223-0228: x 697469616c                                                       # data[15]: ......itial
-0228-0233: x 697469756d                                                       # data[16]: ......itium
-0233-0236: x 6f7365                                                           # data[17]: ......ose
-0236-0236: x                                                                  # data[18]: .... (bundle prefix)
-0236-0242: x 737472617465                                                     # data[19]: ....strate
-0242-0245: x 74616c                                                           # data[20]: ....tal
-0245-0251: x 74616c646f6d                                                     # data[21]: ....taldom
-0251-0256: x 74616c6564                                                       # data[22]: ....taled
-0256-0262: x 74616c69736d                                                     # data[23]: ....talism
-0262-0268: x 74616c697374                                                     # data[24]: ....talist
-0268-0276: x 74616c6973746963                                                 # data[25]: ....talistic
-0276-0286: x 74616c6973746963616c                                             # data[26]: ....talistically
-0286-0288: x 6c79                                                             # (continued...)
-0288-0297: x 74616c697a61626c65                                               # data[27]: ....talizable
-0297-0307: x 74616c697a6174696f6e                                             # data[28]: ....talization
-0307-0313: x 74616c697a65                                                     # data[29]: ....talize
-0313-0318: x 74616c6c79                                                       # data[30]: ....tally
-0318-0325: x 74616c6e657373                                                   # data[31]: ....talness
-0325-0328: x 74616e                                                           # data[32]: ....tan
-0328-0332: x 74617465                                                         # data[33]: ....tate
-0332-0337: x 7461746564                                                       # data[34]: ....tated
-0337-0338: x 74                                                               # data[35]: ....t (bundle prefix)
-0338-0342: x 6174696d                                                         # data[36]: .....atim
-0342-0347: x 6174696f6e                                                       # data[37]: .....ation
-0347-0352: x 6174697665                                                       # data[38]: .....ative
-0352-0356: x 6174756d                                                         # data[39]: .....atum
-0356-0361: x 656c6c6172                                                       # data[40]: .....ellar
-0361-0367: x 656c6c617465                                                     # data[41]: .....ellate
-0367-0375: x 656c6c69666f726d                                                 # data[42]: .....elliform
-0375-0380: x 656c6c756d                                                       # data[43]: .....ellum
-0380-0385: x 756c617465                                                       # data[44]: .....ulate
-0385-0392: x 756c6174696f6e                                                   # data[45]: .....ulation
-0392-0398: x 756c61746f72                                                     # data[46]: .....ulator
+0142-0146: x 63617069                                                         # data[00]: capi (block prefix)
+0146-0148: x 6c6c                                                             # data[01]: ....ll (bundle prefix)
+0148-0154: x 6163656f7573                                                     # data[02]: ......aceous
+0154-0158: x 61697265                                                         # data[03]: ......aire
+0158-0163: x 616d656e74                                                       # data[04]: ......ament
+0163-0172: x 617265637461736961                                               # data[05]: ......arectasia
+0172-0177: x 6172696c79                                                       # data[06]: ......arily
+0177-0185: x 6172696d65746572                                                 # data[07]: ......arimeter
+0185-0192: x 6172696e657373                                                   # data[08]: ......ariness
+0192-0201: x 6172696f6d6f746f72                                               # data[09]: ......ariomotor
+0201-0206: x 6172697479                                                       # data[10]: ......arity
+0206-0209: x 617279                                                           # data[11]: ......ary
+0209-0214: x 6174696f6e                                                       # data[12]: ......ation
+0214-0222: x 6963756c74757265                                                 # data[13]: ......iculture
+0222-0227: x 69666f726d                                                       # data[14]: ......iform
+0227-0232: x 697469616c                                                       # data[15]: ......itial
+0232-0237: x 697469756d                                                       # data[16]: ......itium
+0237-0240: x 6f7365                                                           # data[17]: ......ose
+0240-0240: x                                                                  # data[18]: .... (bundle prefix)
+0240-0246: x 737472617465                                                     # data[19]: ....strate
+0246-0249: x 74616c                                                           # data[20]: ....tal
+0249-0255: x 74616c646f6d                                                     # data[21]: ....taldom
+0255-0260: x 74616c6564                                                       # data[22]: ....taled
+0260-0266: x 74616c69736d                                                     # data[23]: ....talism
+0266-0272: x 74616c697374                                                     # data[24]: ....talist
+0272-0280: x 74616c6973746963                                                 # data[25]: ....talistic
+0280-0290: x 74616c6973746963616c                                             # data[26]: ....talistically
+0290-0292: x 6c79                                                             # (continued...)
+0292-0301: x 74616c697a61626c65                                               # data[27]: ....talizable
+0301-0311: x 74616c697a6174696f6e                                             # data[28]: ....talization
+0311-0317: x 74616c697a65                                                     # data[29]: ....talize
+0317-0322: x 74616c6c79                                                       # data[30]: ....tally
+0322-0329: x 74616c6e657373                                                   # data[31]: ....talness
+0329-0332: x 74616e                                                           # data[32]: ....tan
+0332-0336: x 74617465                                                         # data[33]: ....tate
+0336-0341: x 7461746564                                                       # data[34]: ....tated
+0341-0342: x 74                                                               # data[35]: ....t (bundle prefix)
+0342-0346: x 6174696d                                                         # data[36]: .....atim
+0346-0351: x 6174696f6e                                                       # data[37]: .....ation
+0351-0356: x 6174697665                                                       # data[38]: .....ative
+0356-0360: x 6174756d                                                         # data[39]: .....atum
+0360-0365: x 656c6c6172                                                       # data[40]: .....ellar
+0365-0371: x 656c6c617465                                                     # data[41]: .....ellate
+0371-0379: x 656c6c69666f726d                                                 # data[42]: .....elliform
+0379-0384: x 656c6c756d                                                       # data[43]: .....ellum
+0384-0389: x 756c617465                                                       # data[44]: .....ulate
+0389-0396: x 756c6174696f6e                                                   # data[45]: .....ulation
+0396-0402: x 756c61746f72                                                     # data[46]: .....ulator
 # data for column 1
 # rawbytes
 # offsets table
-0398-0399: x 02                                                               # encoding: 2b
-0399-0400: x 00                                                               # padding (aligning to 16-bit boundary)
-0400-0402: x 0000                                                             # data[0] = 0 [488 overall]
-0402-0404: x 0600                                                             # data[1] = 6 [494 overall]
-0404-0406: x 0c00                                                             # data[2] = 12 [500 overall]
-0406-0408: x 1200                                                             # data[3] = 18 [506 overall]
-0408-0410: x 1800                                                             # data[4] = 24 [512 overall]
-0410-0412: x 1e00                                                             # data[5] = 30 [518 overall]
-0412-0414: x 2400                                                             # data[6] = 36 [524 overall]
-0414-0416: x 2a00                                                             # data[7] = 42 [530 overall]
-0416-0418: x 3000                                                             # data[8] = 48 [536 overall]
-0418-0420: x 3600                                                             # data[9] = 54 [542 overall]
-0420-0422: x 3c00                                                             # data[10] = 60 [548 overall]
-0422-0424: x 4200                                                             # data[11] = 66 [554 overall]
-0424-0426: x 4800                                                             # data[12] = 72 [560 overall]
-0426-0428: x 4e00                                                             # data[13] = 78 [566 overall]
-0428-0430: x 5400                                                             # data[14] = 84 [572 overall]
-0430-0432: x 5a00                                                             # data[15] = 90 [578 overall]
-0432-0434: x 6000                                                             # data[16] = 96 [584 overall]
-0434-0436: x 6600                                                             # data[17] = 102 [590 overall]
-0436-0438: x 6c00                                                             # data[18] = 108 [596 overall]
-0438-0440: x 7200                                                             # data[19] = 114 [602 overall]
-0440-0442: x 7800                                                             # data[20] = 120 [608 overall]
-0442-0444: x 7e00                                                             # data[21] = 126 [614 overall]
-0444-0446: x 8400                                                             # data[22] = 132 [620 overall]
-0446-0448: x 8a00                                                             # data[23] = 138 [626 overall]
-0448-0450: x 9000                                                             # data[24] = 144 [632 overall]
-0450-0452: x 9600                                                             # data[25] = 150 [638 overall]
-0452-0454: x 9c00                                                             # data[26] = 156 [644 overall]
-0454-0456: x a200                                                             # data[27] = 162 [650 overall]
-0456-0458: x a800                                                             # data[28] = 168 [656 overall]
-0458-0460: x ae00                                                             # data[29] = 174 [662 overall]
-0460-0462: x b400                                                             # data[30] = 180 [668 overall]
-0462-0464: x ba00                                                             # data[31] = 186 [674 overall]
-0464-0466: x c000                                                             # data[32] = 192 [680 overall]
-0466-0468: x c600                                                             # data[33] = 198 [686 overall]
-0468-0470: x cc00                                                             # data[34] = 204 [692 overall]
-0470-0472: x d200                                                             # data[35] = 210 [698 overall]
-0472-0474: x d800                                                             # data[36] = 216 [704 overall]
-0474-0476: x de00                                                             # data[37] = 222 [710 overall]
-0476-0478: x e400                                                             # data[38] = 228 [716 overall]
-0478-0480: x ea00                                                             # data[39] = 234 [722 overall]
-0480-0482: x f000                                                             # data[40] = 240 [728 overall]
-0482-0484: x f600                                                             # data[41] = 246 [734 overall]
-0484-0486: x fc00                                                             # data[42] = 252 [740 overall]
-0486-0488: x 0201                                                             # data[43] = 258 [746 overall]
+0402-0403: x 02                                                               # encoding: 2b
+0403-0404: x 00                                                               # padding (aligning to 16-bit boundary)
+0404-0406: x 0000                                                             # data[0] = 0 [492 overall]
+0406-0408: x 0600                                                             # data[1] = 6 [498 overall]
+0408-0410: x 0c00                                                             # data[2] = 12 [504 overall]
+0410-0412: x 1200                                                             # data[3] = 18 [510 overall]
+0412-0414: x 1800                                                             # data[4] = 24 [516 overall]
+0414-0416: x 1e00                                                             # data[5] = 30 [522 overall]
+0416-0418: x 2400                                                             # data[6] = 36 [528 overall]
+0418-0420: x 2a00                                                             # data[7] = 42 [534 overall]
+0420-0422: x 3000                                                             # data[8] = 48 [540 overall]
+0422-0424: x 3600                                                             # data[9] = 54 [546 overall]
+0424-0426: x 3c00                                                             # data[10] = 60 [552 overall]
+0426-0428: x 4200                                                             # data[11] = 66 [558 overall]
+0428-0430: x 4800                                                             # data[12] = 72 [564 overall]
+0430-0432: x 4e00                                                             # data[13] = 78 [570 overall]
+0432-0434: x 5400                                                             # data[14] = 84 [576 overall]
+0434-0436: x 5a00                                                             # data[15] = 90 [582 overall]
+0436-0438: x 6000                                                             # data[16] = 96 [588 overall]
+0438-0440: x 6600                                                             # data[17] = 102 [594 overall]
+0440-0442: x 6c00                                                             # data[18] = 108 [600 overall]
+0442-0444: x 7200                                                             # data[19] = 114 [606 overall]
+0444-0446: x 7800                                                             # data[20] = 120 [612 overall]
+0446-0448: x 7e00                                                             # data[21] = 126 [618 overall]
+0448-0450: x 8400                                                             # data[22] = 132 [624 overall]
+0450-0452: x 8a00                                                             # data[23] = 138 [630 overall]
+0452-0454: x 9000                                                             # data[24] = 144 [636 overall]
+0454-0456: x 9600                                                             # data[25] = 150 [642 overall]
+0456-0458: x 9c00                                                             # data[26] = 156 [648 overall]
+0458-0460: x a200                                                             # data[27] = 162 [654 overall]
+0460-0462: x a800                                                             # data[28] = 168 [660 overall]
+0462-0464: x ae00                                                             # data[29] = 174 [666 overall]
+0464-0466: x b400                                                             # data[30] = 180 [672 overall]
+0466-0468: x ba00                                                             # data[31] = 186 [678 overall]
+0468-0470: x c000                                                             # data[32] = 192 [684 overall]
+0470-0472: x c600                                                             # data[33] = 198 [690 overall]
+0472-0474: x cc00                                                             # data[34] = 204 [696 overall]
+0474-0476: x d200                                                             # data[35] = 210 [702 overall]
+0476-0478: x d800                                                             # data[36] = 216 [708 overall]
+0478-0480: x de00                                                             # data[37] = 222 [714 overall]
+0480-0482: x e400                                                             # data[38] = 228 [720 overall]
+0482-0484: x ea00                                                             # data[39] = 234 [726 overall]
+0484-0486: x f000                                                             # data[40] = 240 [732 overall]
+0486-0488: x f600                                                             # data[41] = 246 [738 overall]
+0488-0490: x fc00                                                             # data[42] = 252 [744 overall]
+0490-0492: x 0201                                                             # data[43] = 258 [750 overall]
 # data
-0488-0494: x 403935373230                                                     # data[0]: @95720
-0494-0500: x 403935373230                                                     # data[1]: @95720
-0500-0506: x 403935373230                                                     # data[2]: @95720
-0506-0512: x 403935373230                                                     # data[3]: @95720
-0512-0518: x 403935373230                                                     # data[4]: @95720
-0518-0524: x 403935373230                                                     # data[5]: @95720
-0524-0530: x 403935373230                                                     # data[6]: @95720
-0530-0536: x 403935373230                                                     # data[7]: @95720
-0536-0542: x 403935373230                                                     # data[8]: @95720
-0542-0548: x 403935373230                                                     # data[9]: @95720
-0548-0554: x 403935373230                                                     # data[10]: @95720
-0554-0560: x 403935373230                                                     # data[11]: @95720
-0560-0566: x 403935373230                                                     # data[12]: @95720
-0566-0572: x 403935373230                                                     # data[13]: @95720
-0572-0578: x 403935373230                                                     # data[14]: @95720
-0578-0584: x 403935373230                                                     # data[15]: @95720
-0584-0590: x 403935373230                                                     # data[16]: @95720
-0590-0596: x 403935373230                                                     # data[17]: @95720
-0596-0602: x 403935373230                                                     # data[18]: @95720
-0602-0608: x 403935373230                                                     # data[19]: @95720
-0608-0614: x 403935373230                                                     # data[20]: @95720
-0614-0620: x 403935373230                                                     # data[21]: @95720
-0620-0626: x 403935373230                                                     # data[22]: @95720
-0626-0632: x 403935373230                                                     # data[23]: @95720
-0632-0638: x 403935373230                                                     # data[24]: @95720
-0638-0644: x 403935373230                                                     # data[25]: @95720
-0644-0650: x 403935373230                                                     # data[26]: @95720
-0650-0656: x 403935373230                                                     # data[27]: @95720
-0656-0662: x 403935373230                                                     # data[28]: @95720
-0662-0668: x 403935373230                                                     # data[29]: @95720
-0668-0674: x 403935373230                                                     # data[30]: @95720
-0674-0680: x 403935373230                                                     # data[31]: @95720
-0680-0686: x 403935373230                                                     # data[32]: @95720
-0686-0692: x 403935373230                                                     # data[33]: @95720
-0692-0698: x 403935373230                                                     # data[34]: @95720
-0698-0704: x 403935373230                                                     # data[35]: @95720
-0704-0710: x 403935373230                                                     # data[36]: @95720
-0710-0716: x 403935373230                                                     # data[37]: @95720
-0716-0722: x 403935373230                                                     # data[38]: @95720
-0722-0728: x 403935373230                                                     # data[39]: @95720
-0728-0734: x 403935373230                                                     # data[40]: @95720
-0734-0740: x 403935373230                                                     # data[41]: @95720
-0740-0746: x 403935373230                                                     # data[42]: @95720
+0492-0498: x 403935373230                                                     # data[0]: @95720
+0498-0504: x 403935373230                                                     # data[1]: @95720
+0504-0510: x 403935373230                                                     # data[2]: @95720
+0510-0516: x 403935373230                                                     # data[3]: @95720
+0516-0522: x 403935373230                                                     # data[4]: @95720
+0522-0528: x 403935373230                                                     # data[5]: @95720
+0528-0534: x 403935373230                                                     # data[6]: @95720
+0534-0540: x 403935373230                                                     # data[7]: @95720
+0540-0546: x 403935373230                                                     # data[8]: @95720
+0546-0552: x 403935373230                                                     # data[9]: @95720
+0552-0558: x 403935373230                                                     # data[10]: @95720
+0558-0564: x 403935373230                                                     # data[11]: @95720
+0564-0570: x 403935373230                                                     # data[12]: @95720
+0570-0576: x 403935373230                                                     # data[13]: @95720
+0576-0582: x 403935373230                                                     # data[14]: @95720
+0582-0588: x 403935373230                                                     # data[15]: @95720
+0588-0594: x 403935373230                                                     # data[16]: @95720
+0594-0600: x 403935373230                                                     # data[17]: @95720
+0600-0606: x 403935373230                                                     # data[18]: @95720
+0606-0612: x 403935373230                                                     # data[19]: @95720
+0612-0618: x 403935373230                                                     # data[20]: @95720
+0618-0624: x 403935373230                                                     # data[21]: @95720
+0624-0630: x 403935373230                                                     # data[22]: @95720
+0630-0636: x 403935373230                                                     # data[23]: @95720
+0636-0642: x 403935373230                                                     # data[24]: @95720
+0642-0648: x 403935373230                                                     # data[25]: @95720
+0648-0654: x 403935373230                                                     # data[26]: @95720
+0654-0660: x 403935373230                                                     # data[27]: @95720
+0660-0666: x 403935373230                                                     # data[28]: @95720
+0666-0672: x 403935373230                                                     # data[29]: @95720
+0672-0678: x 403935373230                                                     # data[30]: @95720
+0678-0684: x 403935373230                                                     # data[31]: @95720
+0684-0690: x 403935373230                                                     # data[32]: @95720
+0690-0696: x 403935373230                                                     # data[33]: @95720
+0696-0702: x 403935373230                                                     # data[34]: @95720
+0702-0708: x 403935373230                                                     # data[35]: @95720
+0708-0714: x 403935373230                                                     # data[36]: @95720
+0714-0720: x 403935373230                                                     # data[37]: @95720
+0720-0726: x 403935373230                                                     # data[38]: @95720
+0726-0732: x 403935373230                                                     # data[39]: @95720
+0732-0738: x 403935373230                                                     # data[40]: @95720
+0738-0744: x 403935373230                                                     # data[41]: @95720
+0744-0750: x 403935373230                                                     # data[42]: @95720
 # data for column 2
-0746-0747: x 80                                                               # encoding: const
-0747-0755: x 0100000000000000                                                 # 64-bit constant: 1
+0750-0751: x 80                                                               # encoding: const
+0751-0759: x 0100000000000000                                                 # 64-bit constant: 1
 # data for column 3
-0755-0756: x 00                                                               # bitmap encoding
-0756-0760: x 00000000                                                         # padding to align to 64-bit boundary
+0759-0760: x 00                                                               # bitmap encoding
 0760-0768: b 1111111111111111111111111111111111111111000001110000000000000000 # bitmap word 0
 0768-0776: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
@@ -526,4 +535,6 @@ LastKey: capitulator@95720#0,SET
 1031-1036: x 76616c7565                                                       # data[42]: value
 # data for column 5
 1036-1037: x 01                                                               # bitmap encoding
-1037-1038: x 00                                                               # block padding byte
+# data for column 6
+1037-1038: x 01                                                               # bitmap encoding
+1038-1039: x 00                                                               # block padding byte

--- a/sstable/colblk/testdata/data_block/next_prefix
+++ b/sstable/colblk/testdata/data_block/next_prefix
@@ -1,12 +1,13 @@
 init
 ----
-size=50:
+size=51:
 0: prefixes:       prefixbytes(16): 0 keys
 1: suffixes:       bytes: 0 rows set; 0 bytes in data
 2: trailers:       uint: 0 rows
 3: prefix changed: bitmap
 4: values:         bytes: 0 rows set; 0 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 write
 blockprefix_apple@98#0,SET:apple98
@@ -30,13 +31,14 @@ blockprefix_kiwi@99#0,SET:kiwi99
 blockprefix_kiwi@98#0,SET:kiwi98
 blockprefix_lemon@92#0,DEL:
 ----
-size=408:
+size=417:
 0: prefixes:       prefixbytes(16): 20 keys
 1: suffixes:       bytes: 20 rows set; 54 bytes in data
 2: trailers:       uint: 20 rows
 3: prefix changed: bitmap
 4: values:         bytes: 20 rows set; 136 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 finish
 ----
@@ -45,196 +47,199 @@ LastKey: blockprefix_lemon@92#0,DEL
 000-004: x 16000000                                                         # maximum key length: 22
 # columnar block header
 004-005: x 01                                                               # version 1
-005-007: x 0600                                                             # 6 columns
+005-007: x 0700                                                             # 7 columns
 007-011: x 14000000                                                         # 20 rows
 011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 29000000                                                         # col 0: page start 41
+012-016: x 2e000000                                                         # col 0: page start 46
 016-017: b 00000011                                                         # col 1: bytes
-017-021: x 6e000000                                                         # col 1: page start 110
+017-021: x 73000000                                                         # col 1: page start 115
 021-022: b 00000010                                                         # col 2: uint
-022-026: x ba000000                                                         # col 2: page start 186
+022-026: x bf000000                                                         # col 2: page start 191
 026-027: b 00000001                                                         # col 3: bool
-027-031: x e4000000                                                         # col 3: page start 228
+027-031: x e8000000                                                         # col 3: page start 232
 031-032: b 00000011                                                         # col 4: bytes
-032-036: x f8000000                                                         # col 4: page start 248
+032-036: x 00010000                                                         # col 4: page start 256
 036-037: b 00000001                                                         # col 5: bool
-037-041: x 96010000                                                         # col 5: page start 406
+037-041: x 9e010000                                                         # col 5: page start 414
+041-042: b 00000001                                                         # col 6: bool
+042-046: x 9f010000                                                         # col 6: page start 415
 # data for column 0
 # PrefixBytes
-041-042: x 04                                                               # bundleSize: 16
+046-047: x 04                                                               # bundleSize: 16
 # Offsets table
-042-043: x 01                                                               # encoding: 1b
-043-044: x 0c                                                               # data[0] = 12 [78 overall]
-044-045: x 0c                                                               # data[1] = 12 [78 overall]
-045-046: x 11                                                               # data[2] = 17 [83 overall]
-046-047: x 11                                                               # data[3] = 17 [83 overall]
-047-048: x 11                                                               # data[4] = 17 [83 overall]
-048-049: x 11                                                               # data[5] = 17 [83 overall]
-049-050: x 17                                                               # data[6] = 23 [89 overall]
-050-051: x 17                                                               # data[7] = 23 [89 overall]
-051-052: x 17                                                               # data[8] = 23 [89 overall]
-052-053: x 17                                                               # data[9] = 23 [89 overall]
-053-054: x 17                                                               # data[10] = 23 [89 overall]
-054-055: x 17                                                               # data[11] = 23 [89 overall]
-055-056: x 1e                                                               # data[12] = 30 [96 overall]
-056-057: x 1e                                                               # data[13] = 30 [96 overall]
-057-058: x 1e                                                               # data[14] = 30 [96 overall]
-058-059: x 1e                                                               # data[15] = 30 [96 overall]
-059-060: x 1e                                                               # data[16] = 30 [96 overall]
-060-061: x 1e                                                               # data[17] = 30 [96 overall]
-061-062: x 1e                                                               # data[18] = 30 [96 overall]
-062-063: x 23                                                               # data[19] = 35 [101 overall]
-063-064: x 27                                                               # data[20] = 39 [105 overall]
-064-065: x 27                                                               # data[21] = 39 [105 overall]
-065-066: x 2c                                                               # data[22] = 44 [110 overall]
+047-048: x 01                                                               # encoding: 1b
+048-049: x 0c                                                               # data[0] = 12 [83 overall]
+049-050: x 0c                                                               # data[1] = 12 [83 overall]
+050-051: x 11                                                               # data[2] = 17 [88 overall]
+051-052: x 11                                                               # data[3] = 17 [88 overall]
+052-053: x 11                                                               # data[4] = 17 [88 overall]
+053-054: x 11                                                               # data[5] = 17 [88 overall]
+054-055: x 17                                                               # data[6] = 23 [94 overall]
+055-056: x 17                                                               # data[7] = 23 [94 overall]
+056-057: x 17                                                               # data[8] = 23 [94 overall]
+057-058: x 17                                                               # data[9] = 23 [94 overall]
+058-059: x 17                                                               # data[10] = 23 [94 overall]
+059-060: x 17                                                               # data[11] = 23 [94 overall]
+060-061: x 1e                                                               # data[12] = 30 [101 overall]
+061-062: x 1e                                                               # data[13] = 30 [101 overall]
+062-063: x 1e                                                               # data[14] = 30 [101 overall]
+063-064: x 1e                                                               # data[15] = 30 [101 overall]
+064-065: x 1e                                                               # data[16] = 30 [101 overall]
+065-066: x 1e                                                               # data[17] = 30 [101 overall]
+066-067: x 1e                                                               # data[18] = 30 [101 overall]
+067-068: x 23                                                               # data[19] = 35 [106 overall]
+068-069: x 27                                                               # data[20] = 39 [110 overall]
+069-070: x 27                                                               # data[21] = 39 [110 overall]
+070-071: x 2c                                                               # data[22] = 44 [115 overall]
 # Data
-066-076: x 626c6f636b7072656669                                             # data[00]: blockprefix_ (block prefix)
-076-078: x 785f                                                             # (continued...)
-078-078: x                                                                  # data[01]: ............ (bundle prefix)
-078-083: x 6170706c65                                                       # data[02]: ............apple
-083-083: x                                                                  # data[03]: .................
-083-083: x                                                                  # data[04]: .................
-083-083: x                                                                  # data[05]: .................
-083-089: x 62616e616e61                                                     # data[06]: ............banana
-089-089: x                                                                  # data[07]: ..................
-089-089: x                                                                  # data[08]: ..................
-089-089: x                                                                  # data[09]: ..................
-089-089: x                                                                  # data[10]: ..................
-089-089: x                                                                  # data[11]: ..................
-089-096: x 636f636f6e7574                                                   # data[12]: ............coconut
-096-096: x                                                                  # data[13]: ...................
-096-096: x                                                                  # data[14]: ...................
-096-096: x                                                                  # data[15]: ...................
-096-096: x                                                                  # data[16]: ...................
-096-096: x                                                                  # data[17]: ...................
-096-096: x                                                                  # data[18]: ............ (bundle prefix)
-096-101: x 6775617661                                                       # data[19]: ............guava
-101-105: x 6b697769                                                         # data[20]: ............kiwi
-105-105: x                                                                  # data[21]: ................
-105-110: x 6c656d6f6e                                                       # data[22]: ............lemon
+071-081: x 626c6f636b7072656669                                             # data[00]: blockprefix_ (block prefix)
+081-083: x 785f                                                             # (continued...)
+083-083: x                                                                  # data[01]: ............ (bundle prefix)
+083-088: x 6170706c65                                                       # data[02]: ............apple
+088-088: x                                                                  # data[03]: .................
+088-088: x                                                                  # data[04]: .................
+088-088: x                                                                  # data[05]: .................
+088-094: x 62616e616e61                                                     # data[06]: ............banana
+094-094: x                                                                  # data[07]: ..................
+094-094: x                                                                  # data[08]: ..................
+094-094: x                                                                  # data[09]: ..................
+094-094: x                                                                  # data[10]: ..................
+094-094: x                                                                  # data[11]: ..................
+094-101: x 636f636f6e7574                                                   # data[12]: ............coconut
+101-101: x                                                                  # data[13]: ...................
+101-101: x                                                                  # data[14]: ...................
+101-101: x                                                                  # data[15]: ...................
+101-101: x                                                                  # data[16]: ...................
+101-101: x                                                                  # data[17]: ...................
+101-101: x                                                                  # data[18]: ............ (bundle prefix)
+101-106: x 6775617661                                                       # data[19]: ............guava
+106-110: x 6b697769                                                         # data[20]: ............kiwi
+110-110: x                                                                  # data[21]: ................
+110-115: x 6c656d6f6e                                                       # data[22]: ............lemon
 # data for column 1
 # rawbytes
 # offsets table
-110-111: x 01                                                               # encoding: 1b
-111-112: x 00                                                               # data[0] = 0 [132 overall]
-112-113: x 03                                                               # data[1] = 3 [135 overall]
-113-114: x 06                                                               # data[2] = 6 [138 overall]
-114-115: x 09                                                               # data[3] = 9 [141 overall]
-115-116: x 0c                                                               # data[4] = 12 [144 overall]
-116-117: x 0f                                                               # data[5] = 15 [147 overall]
-117-118: x 12                                                               # data[6] = 18 [150 overall]
-118-119: x 15                                                               # data[7] = 21 [153 overall]
-119-120: x 18                                                               # data[8] = 24 [156 overall]
-120-121: x 1a                                                               # data[9] = 26 [158 overall]
-121-122: x 1c                                                               # data[10] = 28 [160 overall]
-122-123: x 1c                                                               # data[11] = 28 [160 overall]
-123-124: x 1f                                                               # data[12] = 31 [163 overall]
-124-125: x 22                                                               # data[13] = 34 [166 overall]
-125-126: x 25                                                               # data[14] = 37 [169 overall]
-126-127: x 28                                                               # data[15] = 40 [172 overall]
-127-128: x 2a                                                               # data[16] = 42 [174 overall]
-128-129: x 2d                                                               # data[17] = 45 [177 overall]
-129-130: x 30                                                               # data[18] = 48 [180 overall]
-130-131: x 33                                                               # data[19] = 51 [183 overall]
-131-132: x 36                                                               # data[20] = 54 [186 overall]
+115-116: x 01                                                               # encoding: 1b
+116-117: x 00                                                               # data[0] = 0 [137 overall]
+117-118: x 03                                                               # data[1] = 3 [140 overall]
+118-119: x 06                                                               # data[2] = 6 [143 overall]
+119-120: x 09                                                               # data[3] = 9 [146 overall]
+120-121: x 0c                                                               # data[4] = 12 [149 overall]
+121-122: x 0f                                                               # data[5] = 15 [152 overall]
+122-123: x 12                                                               # data[6] = 18 [155 overall]
+123-124: x 15                                                               # data[7] = 21 [158 overall]
+124-125: x 18                                                               # data[8] = 24 [161 overall]
+125-126: x 1a                                                               # data[9] = 26 [163 overall]
+126-127: x 1c                                                               # data[10] = 28 [165 overall]
+127-128: x 1c                                                               # data[11] = 28 [165 overall]
+128-129: x 1f                                                               # data[12] = 31 [168 overall]
+129-130: x 22                                                               # data[13] = 34 [171 overall]
+130-131: x 25                                                               # data[14] = 37 [174 overall]
+131-132: x 28                                                               # data[15] = 40 [177 overall]
+132-133: x 2a                                                               # data[16] = 42 [179 overall]
+133-134: x 2d                                                               # data[17] = 45 [182 overall]
+134-135: x 30                                                               # data[18] = 48 [185 overall]
+135-136: x 33                                                               # data[19] = 51 [188 overall]
+136-137: x 36                                                               # data[20] = 54 [191 overall]
 # data
-132-135: x 403938                                                           # data[0]: @98
-135-138: x 403532                                                           # data[1]: @52
-138-141: x 403233                                                           # data[2]: @23
-141-144: x 403131                                                           # data[3]: @11
-144-147: x 403934                                                           # data[4]: @94
-147-150: x 403933                                                           # data[5]: @93
-150-153: x 403933                                                           # data[6]: @93
-153-156: x 403732                                                           # data[7]: @72
-156-158: x 4039                                                             # data[8]: @9
-158-160: x 4031                                                             # data[9]: @1
-160-160: x                                                                  # data[10]:
-160-163: x 403932                                                           # data[11]: @92
-163-166: x 403335                                                           # data[12]: @35
-166-169: x 403232                                                           # data[13]: @22
-169-172: x 403231                                                           # data[14]: @21
-172-174: x 4031                                                             # data[15]: @1
-174-177: x 403939                                                           # data[16]: @99
-177-180: x 403939                                                           # data[17]: @99
-180-183: x 403938                                                           # data[18]: @98
-183-186: x 403932                                                           # data[19]: @92
+137-140: x 403938                                                           # data[0]: @98
+140-143: x 403532                                                           # data[1]: @52
+143-146: x 403233                                                           # data[2]: @23
+146-149: x 403131                                                           # data[3]: @11
+149-152: x 403934                                                           # data[4]: @94
+152-155: x 403933                                                           # data[5]: @93
+155-158: x 403933                                                           # data[6]: @93
+158-161: x 403732                                                           # data[7]: @72
+161-163: x 4039                                                             # data[8]: @9
+163-165: x 4031                                                             # data[9]: @1
+165-165: x                                                                  # data[10]:
+165-168: x 403932                                                           # data[11]: @92
+168-171: x 403335                                                           # data[12]: @35
+171-174: x 403232                                                           # data[13]: @22
+174-177: x 403231                                                           # data[14]: @21
+177-179: x 4031                                                             # data[15]: @1
+179-182: x 403939                                                           # data[16]: @99
+182-185: x 403939                                                           # data[17]: @99
+185-188: x 403938                                                           # data[18]: @98
+188-191: x 403932                                                           # data[19]: @92
 # data for column 2
-186-187: x 02                                                               # encoding: 2b
-187-188: x 00                                                               # padding (aligning to 16-bit boundary)
-188-190: x 0100                                                             # data[0] = 1
-190-192: x 0100                                                             # data[1] = 1
-192-194: x 0100                                                             # data[2] = 1
-194-196: x 1200                                                             # data[3] = 18
-196-198: x 12f5                                                             # data[4] = 62738
-198-200: x 00f4                                                             # data[5] = 62464
-200-202: x 12dd                                                             # data[6] = 56594
-202-204: x 1200                                                             # data[7] = 18
-204-206: x 0100                                                             # data[8] = 1
-206-208: x 0100                                                             # data[9] = 1
-208-210: x 0100                                                             # data[10] = 1
-210-212: x 0100                                                             # data[11] = 1
-212-214: x 0100                                                             # data[12] = 1
-214-216: x 0100                                                             # data[13] = 1
-216-218: x 0100                                                             # data[14] = 1
-218-220: x 0100                                                             # data[15] = 1
-220-222: x 0100                                                             # data[16] = 1
-222-224: x 0100                                                             # data[17] = 1
-224-226: x 0100                                                             # data[18] = 1
-226-228: x 0000                                                             # data[19] = 0
+191-192: x 02                                                               # encoding: 2b
+192-194: x 0100                                                             # data[0] = 1
+194-196: x 0100                                                             # data[1] = 1
+196-198: x 0100                                                             # data[2] = 1
+198-200: x 1200                                                             # data[3] = 18
+200-202: x 12f5                                                             # data[4] = 62738
+202-204: x 00f4                                                             # data[5] = 62464
+204-206: x 12dd                                                             # data[6] = 56594
+206-208: x 1200                                                             # data[7] = 18
+208-210: x 0100                                                             # data[8] = 1
+210-212: x 0100                                                             # data[9] = 1
+212-214: x 0100                                                             # data[10] = 1
+214-216: x 0100                                                             # data[11] = 1
+216-218: x 0100                                                             # data[12] = 1
+218-220: x 0100                                                             # data[13] = 1
+220-222: x 0100                                                             # data[14] = 1
+222-224: x 0100                                                             # data[15] = 1
+224-226: x 0100                                                             # data[16] = 1
+226-228: x 0100                                                             # data[17] = 1
+228-230: x 0100                                                             # data[18] = 1
+230-232: x 0000                                                             # data[19] = 0
 # data for column 3
-228-229: x 00                                                               # bitmap encoding
-229-232: x 000000                                                           # padding to align to 64-bit boundary
-232-240: b 0001000100000100000010110000000000000000000000000000000000000000 # bitmap word 0
-240-248: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+232-233: x 00                                                               # bitmap encoding
+233-240: x 00000000000000                                                   # padding to align to 64-bit boundary
+240-248: b 0001000100000100000010110000000000000000000000000000000000000000 # bitmap word 0
+248-256: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-248-249: x 01                                                               # encoding: 1b
-249-250: x 00                                                               # data[0] = 0 [270 overall]
-250-251: x 07                                                               # data[1] = 7 [277 overall]
-251-252: x 0e                                                               # data[2] = 14 [284 overall]
-252-253: x 15                                                               # data[3] = 21 [291 overall]
-253-254: x 1c                                                               # data[4] = 28 [298 overall]
-254-255: x 24                                                               # data[5] = 36 [306 overall]
-255-256: x 24                                                               # data[6] = 36 [306 overall]
-256-257: x 2c                                                               # data[7] = 44 [314 overall]
-257-258: x 34                                                               # data[8] = 52 [322 overall]
-258-259: x 3b                                                               # data[9] = 59 [329 overall]
-259-260: x 42                                                               # data[10] = 66 [336 overall]
-260-261: x 49                                                               # data[11] = 73 [343 overall]
-261-262: x 52                                                               # data[12] = 82 [352 overall]
-262-263: x 5b                                                               # data[13] = 91 [361 overall]
-263-264: x 64                                                               # data[14] = 100 [370 overall]
-264-265: x 6d                                                               # data[15] = 109 [379 overall]
-265-266: x 75                                                               # data[16] = 117 [387 overall]
-266-267: x 7c                                                               # data[17] = 124 [394 overall]
-267-268: x 82                                                               # data[18] = 130 [400 overall]
-268-269: x 88                                                               # data[19] = 136 [406 overall]
-269-270: x 88                                                               # data[20] = 136 [406 overall]
+256-257: x 01                                                               # encoding: 1b
+257-258: x 00                                                               # data[0] = 0 [278 overall]
+258-259: x 07                                                               # data[1] = 7 [285 overall]
+259-260: x 0e                                                               # data[2] = 14 [292 overall]
+260-261: x 15                                                               # data[3] = 21 [299 overall]
+261-262: x 1c                                                               # data[4] = 28 [306 overall]
+262-263: x 24                                                               # data[5] = 36 [314 overall]
+263-264: x 24                                                               # data[6] = 36 [314 overall]
+264-265: x 2c                                                               # data[7] = 44 [322 overall]
+265-266: x 34                                                               # data[8] = 52 [330 overall]
+266-267: x 3b                                                               # data[9] = 59 [337 overall]
+267-268: x 42                                                               # data[10] = 66 [344 overall]
+268-269: x 49                                                               # data[11] = 73 [351 overall]
+269-270: x 52                                                               # data[12] = 82 [360 overall]
+270-271: x 5b                                                               # data[13] = 91 [369 overall]
+271-272: x 64                                                               # data[14] = 100 [378 overall]
+272-273: x 6d                                                               # data[15] = 109 [387 overall]
+273-274: x 75                                                               # data[16] = 117 [395 overall]
+274-275: x 7c                                                               # data[17] = 124 [402 overall]
+275-276: x 82                                                               # data[18] = 130 [408 overall]
+276-277: x 88                                                               # data[19] = 136 [414 overall]
+277-278: x 88                                                               # data[20] = 136 [414 overall]
 # data
-270-277: x 6170706c653938                                                   # data[0]: apple98
-277-284: x 6170706c653532                                                   # data[1]: apple52
-284-291: x 6170706c653233                                                   # data[2]: apple23
-291-298: x 6170706c653131                                                   # data[3]: apple11
-298-306: x 62616e616e613934                                                 # data[4]: banana94
-306-306: x                                                                  # data[5]:
-306-314: x 62616e616e613933                                                 # data[6]: banana93
-314-322: x 62616e616e613732                                                 # data[7]: banana72
-322-329: x 62616e616e6139                                                   # data[8]: banana9
-329-336: x 62616e616e6131                                                   # data[9]: banana1
-336-343: x 636f636f6e7574                                                   # data[10]: coconut
-343-352: x 636f636f6e75743932                                               # data[11]: coconut92
-352-361: x 636f636f6e75743335                                               # data[12]: coconut35
-361-370: x 636f636f6e75743232                                               # data[13]: coconut22
-370-379: x 636f636f6e75743231                                               # data[14]: coconut21
-379-387: x 636f636f6e757431                                                 # data[15]: coconut1
-387-394: x 67756176613939                                                   # data[16]: guava99
-394-400: x 6b6977693939                                                     # data[17]: kiwi99
-400-406: x 6b6977693938                                                     # data[18]: kiwi98
-406-406: x                                                                  # data[19]:
+278-285: x 6170706c653938                                                   # data[0]: apple98
+285-292: x 6170706c653532                                                   # data[1]: apple52
+292-299: x 6170706c653233                                                   # data[2]: apple23
+299-306: x 6170706c653131                                                   # data[3]: apple11
+306-314: x 62616e616e613934                                                 # data[4]: banana94
+314-314: x                                                                  # data[5]:
+314-322: x 62616e616e613933                                                 # data[6]: banana93
+322-330: x 62616e616e613732                                                 # data[7]: banana72
+330-337: x 62616e616e6139                                                   # data[8]: banana9
+337-344: x 62616e616e6131                                                   # data[9]: banana1
+344-351: x 636f636f6e7574                                                   # data[10]: coconut
+351-360: x 636f636f6e75743932                                               # data[11]: coconut92
+360-369: x 636f636f6e75743335                                               # data[12]: coconut35
+369-378: x 636f636f6e75743232                                               # data[13]: coconut22
+378-387: x 636f636f6e75743231                                               # data[14]: coconut21
+387-395: x 636f636f6e757431                                                 # data[15]: coconut1
+395-402: x 67756176613939                                                   # data[16]: guava99
+402-408: x 6b6977693939                                                     # data[17]: kiwi99
+408-414: x 6b6977693938                                                     # data[18]: kiwi98
+414-414: x                                                                  # data[19]:
 # data for column 5
-406-407: x 01                                                               # bitmap encoding
-407-408: x 00                                                               # block padding byte
+414-415: x 01                                                               # bitmap encoding
+# data for column 6
+415-416: x 01                                                               # bitmap encoding
+416-417: x 00                                                               # block padding byte
 
 # Scan across the block using next prefix.
 

--- a/sstable/colblk/testdata/data_block/simple
+++ b/sstable/colblk/testdata/data_block/simple
@@ -1,12 +1,13 @@
 init
 ----
-size=50:
+size=51:
 0: prefixes:       prefixbytes(16): 0 keys
 1: suffixes:       bytes: 0 rows set; 0 bytes in data
 2: trailers:       uint: 0 rows
 3: prefix changed: bitmap
 4: values:         bytes: 0 rows set; 0 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 write
 a@10#0,SET:apple
@@ -16,24 +17,26 @@ c@9#0,SETWITHDEL:coconut
 c@6#0,SET:cantelope
 c@1#0,SET:clementine
 ----
-size=160:
+size=161:
 0: prefixes:       prefixbytes(16): 6 keys
 1: suffixes:       bytes: 6 rows set; 13 bytes in data
 2: trailers:       uint: 6 rows
 3: prefix changed: bitmap
 4: values:         bytes: 6 rows set; 46 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 write
-d@11#0,DEL:
+d@11#0,DEL: obsolete
 ----
-size=169:
+size=193:
 0: prefixes:       prefixbytes(16): 7 keys
 1: suffixes:       bytes: 7 rows set; 16 bytes in data
 2: trailers:       uint: 7 rows
 3: prefix changed: bitmap
-4: values:         bytes: 7 rows set; 46 bytes in data
+4: values:         bytes: 7 rows set; 47 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 finish
 ----
@@ -42,76 +45,78 @@ LastKey: d@11#0,DEL
 000-004: x 04000000                                                         # maximum key length: 4
 # columnar block header
 004-005: x 01                                                               # version 1
-005-007: x 0600                                                             # 6 columns
+005-007: x 0700                                                             # 7 columns
 007-011: x 07000000                                                         # 7 rows
 011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 29000000                                                         # col 0: page start 41
+012-016: x 2e000000                                                         # col 0: page start 46
 016-017: b 00000011                                                         # col 1: bytes
-017-021: x 38000000                                                         # col 1: page start 56
+017-021: x 3d000000                                                         # col 1: page start 61
 021-022: b 00000010                                                         # col 2: uint
-022-026: x 51000000                                                         # col 2: page start 81
+022-026: x 56000000                                                         # col 2: page start 86
 026-027: b 00000001                                                         # col 3: bool
-027-031: x 59000000                                                         # col 3: page start 89
+027-031: x 5e000000                                                         # col 3: page start 94
 031-032: b 00000011                                                         # col 4: bytes
 032-036: x 70000000                                                         # col 4: page start 112
 036-037: b 00000001                                                         # col 5: bool
-037-041: x a7000000                                                         # col 5: page start 167
+037-041: x a8000000                                                         # col 5: page start 168
+041-042: b 00000001                                                         # col 6: bool
+042-046: x a9000000                                                         # col 6: page start 169
 # data for column 0
 # PrefixBytes
-041-042: x 04                                                               # bundleSize: 16
+046-047: x 04                                                               # bundleSize: 16
 # Offsets table
-042-043: x 01                                                               # encoding: 1b
-043-044: x 00                                                               # data[0] = 0 [52 overall]
-044-045: x 00                                                               # data[1] = 0 [52 overall]
-045-046: x 01                                                               # data[2] = 1 [53 overall]
-046-047: x 02                                                               # data[3] = 2 [54 overall]
-047-048: x 02                                                               # data[4] = 2 [54 overall]
-048-049: x 03                                                               # data[5] = 3 [55 overall]
-049-050: x 03                                                               # data[6] = 3 [55 overall]
-050-051: x 03                                                               # data[7] = 3 [55 overall]
-051-052: x 04                                                               # data[8] = 4 [56 overall]
+047-048: x 01                                                               # encoding: 1b
+048-049: x 00                                                               # data[0] = 0 [57 overall]
+049-050: x 00                                                               # data[1] = 0 [57 overall]
+050-051: x 01                                                               # data[2] = 1 [58 overall]
+051-052: x 02                                                               # data[3] = 2 [59 overall]
+052-053: x 02                                                               # data[4] = 2 [59 overall]
+053-054: x 03                                                               # data[5] = 3 [60 overall]
+054-055: x 03                                                               # data[6] = 3 [60 overall]
+055-056: x 03                                                               # data[7] = 3 [60 overall]
+056-057: x 04                                                               # data[8] = 4 [61 overall]
 # Data
-052-052: x                                                                  # data[00]:  (block prefix)
-052-052: x                                                                  # data[01]:  (bundle prefix)
-052-053: x 61                                                               # data[02]: a
-053-054: x 62                                                               # data[03]: b
-054-054: x                                                                  # data[04]: .
-054-055: x 63                                                               # data[05]: c
-055-055: x                                                                  # data[06]: .
-055-055: x                                                                  # data[07]: .
-055-056: x 64                                                               # data[08]: d
+057-057: x                                                                  # data[00]:  (block prefix)
+057-057: x                                                                  # data[01]:  (bundle prefix)
+057-058: x 61                                                               # data[02]: a
+058-059: x 62                                                               # data[03]: b
+059-059: x                                                                  # data[04]: .
+059-060: x 63                                                               # data[05]: c
+060-060: x                                                                  # data[06]: .
+060-060: x                                                                  # data[07]: .
+060-061: x 64                                                               # data[08]: d
 # data for column 1
 # rawbytes
 # offsets table
-056-057: x 01                                                               # encoding: 1b
-057-058: x 00                                                               # data[0] = 0 [65 overall]
-058-059: x 03                                                               # data[1] = 3 [68 overall]
-059-060: x 05                                                               # data[2] = 5 [70 overall]
-060-061: x 07                                                               # data[3] = 7 [72 overall]
-061-062: x 09                                                               # data[4] = 9 [74 overall]
-062-063: x 0b                                                               # data[5] = 11 [76 overall]
-063-064: x 0d                                                               # data[6] = 13 [78 overall]
-064-065: x 10                                                               # data[7] = 16 [81 overall]
+061-062: x 01                                                               # encoding: 1b
+062-063: x 00                                                               # data[0] = 0 [70 overall]
+063-064: x 03                                                               # data[1] = 3 [73 overall]
+064-065: x 05                                                               # data[2] = 5 [75 overall]
+065-066: x 07                                                               # data[3] = 7 [77 overall]
+066-067: x 09                                                               # data[4] = 9 [79 overall]
+067-068: x 0b                                                               # data[5] = 11 [81 overall]
+068-069: x 0d                                                               # data[6] = 13 [83 overall]
+069-070: x 10                                                               # data[7] = 16 [86 overall]
 # data
-065-068: x 403130                                                           # data[0]: @10
-068-070: x 4035                                                             # data[1]: @5
-070-072: x 4032                                                             # data[2]: @2
-072-074: x 4039                                                             # data[3]: @9
-074-076: x 4036                                                             # data[4]: @6
-076-078: x 4031                                                             # data[5]: @1
-078-081: x 403131                                                           # data[6]: @11
+070-073: x 403130                                                           # data[0]: @10
+073-075: x 4035                                                             # data[1]: @5
+075-077: x 4032                                                             # data[2]: @2
+077-079: x 4039                                                             # data[3]: @9
+079-081: x 4036                                                             # data[4]: @6
+081-083: x 4031                                                             # data[5]: @1
+083-086: x 403131                                                           # data[6]: @11
 # data for column 2
-081-082: x 01                                                               # encoding: 1b
-082-083: x 01                                                               # data[0] = 1
-083-084: x 01                                                               # data[1] = 1
-084-085: x 12                                                               # data[2] = 18
-085-086: x 12                                                               # data[3] = 18
-086-087: x 01                                                               # data[4] = 1
-087-088: x 01                                                               # data[5] = 1
-088-089: x 00                                                               # data[6] = 0
+086-087: x 01                                                               # encoding: 1b
+087-088: x 01                                                               # data[0] = 1
+088-089: x 01                                                               # data[1] = 1
+089-090: x 12                                                               # data[2] = 18
+090-091: x 12                                                               # data[3] = 18
+091-092: x 01                                                               # data[4] = 1
+092-093: x 01                                                               # data[5] = 1
+093-094: x 00                                                               # data[6] = 0
 # data for column 3
-089-090: x 00                                                               # bitmap encoding
-090-096: x 000000000000                                                     # padding to align to 64-bit boundary
+094-095: x 00                                                               # bitmap encoding
+095-096: x 00                                                               # padding to align to 64-bit boundary
 096-104: b 0100101100000000000000000000000000000000000000000000000000000000 # bitmap word 0
 104-112: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
@@ -125,7 +130,7 @@ LastKey: d@11#0,DEL
 117-118: x 1b                                                               # data[4] = 27 [148 overall]
 118-119: x 24                                                               # data[5] = 36 [157 overall]
 119-120: x 2e                                                               # data[6] = 46 [167 overall]
-120-121: x 2e                                                               # data[7] = 46 [167 overall]
+120-121: x 2f                                                               # data[7] = 47 [168 overall]
 # data
 121-126: x 6170706c65                                                       # data[0]: apple
 126-132: x 62616e616e61                                                     # data[1]: banana
@@ -133,10 +138,15 @@ LastKey: d@11#0,DEL
 141-148: x 636f636f6e7574                                                   # data[3]: coconut
 148-157: x 63616e74656c6f7065                                               # data[4]: cantelope
 157-167: x 636c656d656e74696e65                                             # data[5]: clementine
-167-167: x                                                                  # data[6]:
+167-168: x 20                                                               # data[6]:
 # data for column 5
-167-168: x 01                                                               # bitmap encoding
-168-169: x 00                                                               # block padding byte
+168-169: x 01                                                               # bitmap encoding
+# data for column 6
+169-170: x 00                                                               # bitmap encoding
+170-176: x 000000000000                                                     # padding to align to 64-bit boundary
+176-184: b 0100000000000000000000000000000000000000000000000000000000000000 # bitmap word 0
+184-192: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+192-193: x 00                                                               # block padding byte
 
 iter
 first
@@ -154,7 +164,7 @@ b@2:blueberry
 c@9:coconut
 c@6:cantelope
 c@1:clementine
-d@11:
+d@11: 
 .
 
 iter
@@ -167,7 +177,7 @@ prev
 prev
 prev
 ----
-d@11:
+d@11: 
 c@1:clementine
 c@6:cantelope
 c@9:coconut
@@ -229,9 +239,9 @@ c@1:clementine
 c@1:clementine
 c@1:clementine
 c@1:clementine
-d@11:
-d@11:
-d@11:
+d@11: 
+d@11: 
+d@11: 
 .
 
 iter
@@ -290,17 +300,18 @@ c@6:cantelope
 c@1:clementine
 c@1:clementine
 c@1:clementine
-d@11:
+d@11: 
 
 init
 ----
-size=50:
+size=51:
 0: prefixes:       prefixbytes(16): 0 keys
 1: suffixes:       bytes: 0 rows set; 0 bytes in data
 2: trailers:       uint: 0 rows
 3: prefix changed: bitmap
 4: values:         bytes: 0 rows set; 0 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 write
 aaaaaaaaaaaaaaappalling@10#0,SET:a
@@ -321,13 +332,14 @@ aaaaaaaaaaaaaaapproves@10#0,SET:a
 aaaaaaaaaaaaaaarresting@10#0,SET:a
 aaaaaaaaaaaaaaarrived@10#0,SET:a
 ----
-size=334:
+size=335:
 0: prefixes:       prefixbytes(16): 17 keys
 1: suffixes:       bytes: 17 rows set; 51 bytes in data
 2: trailers:       uint: 17 rows
 3: prefix changed: bitmap
 4: values:         bytes: 17 rows set; 17 bytes in data
 5: is-value-ext:   bitmap
+6: is-obsolete:    bitmap
 
 finish
 ----
@@ -336,113 +348,114 @@ LastKey: aaaaaaaaaaaaaaarrived@10#0,SET
 000-004: x 1c000000                                                         # maximum key length: 28
 # columnar block header
 004-005: x 01                                                               # version 1
-005-007: x 0600                                                             # 6 columns
+005-007: x 0700                                                             # 7 columns
 007-011: x 11000000                                                         # 17 rows
 011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 29000000                                                         # col 0: page start 41
+012-016: x 2e000000                                                         # col 0: page start 46
 016-017: b 00000011                                                         # col 1: bytes
-017-021: x c3000000                                                         # col 1: page start 195
+017-021: x c8000000                                                         # col 1: page start 200
 021-022: b 00000010                                                         # col 2: uint
-022-026: x 09010000                                                         # col 2: page start 265
+022-026: x 0e010000                                                         # col 2: page start 270
 026-027: b 00000001                                                         # col 3: bool
-027-031: x 12010000                                                         # col 3: page start 274
+027-031: x 17010000                                                         # col 3: page start 279
 031-032: b 00000011                                                         # col 4: bytes
 032-036: x 28010000                                                         # col 4: page start 296
 036-037: b 00000001                                                         # col 5: bool
 037-041: x 4c010000                                                         # col 5: page start 332
+041-042: b 00000001                                                         # col 6: bool
+042-046: x 4d010000                                                         # col 6: page start 333
 # data for column 0
 # PrefixBytes
-041-042: x 04                                                               # bundleSize: 16
+046-047: x 04                                                               # bundleSize: 16
 # Offsets table
-042-043: x 01                                                               # encoding: 1b
-043-044: x 0f                                                               # data[0] = 15 [78 overall]
-044-045: x 0f                                                               # data[1] = 15 [78 overall]
-045-046: x 17                                                               # data[2] = 23 [86 overall]
-046-047: x 1d                                                               # data[3] = 29 [92 overall]
-047-048: x 26                                                               # data[4] = 38 [101 overall]
-048-049: x 2e                                                               # data[5] = 46 [109 overall]
-049-050: x 33                                                               # data[6] = 51 [114 overall]
-050-051: x 3b                                                               # data[7] = 59 [122 overall]
-051-052: x 42                                                               # data[8] = 66 [129 overall]
-052-053: x 48                                                               # data[9] = 72 [135 overall]
-053-054: x 4c                                                               # data[10] = 76 [139 overall]
-054-055: x 56                                                               # data[11] = 86 [149 overall]
-055-056: x 5c                                                               # data[12] = 92 [155 overall]
-056-057: x 63                                                               # data[13] = 99 [162 overall]
-057-058: x 69                                                               # data[14] = 105 [168 overall]
-058-059: x 6f                                                               # data[15] = 111 [174 overall]
-059-060: x 76                                                               # data[16] = 118 [181 overall]
-060-061: x 7e                                                               # data[17] = 126 [189 overall]
-061-062: x 84                                                               # data[18] = 132 [195 overall]
-062-063: x 84                                                               # data[19] = 132 [195 overall]
+047-048: x 01                                                               # encoding: 1b
+048-049: x 0f                                                               # data[0] = 15 [83 overall]
+049-050: x 0f                                                               # data[1] = 15 [83 overall]
+050-051: x 17                                                               # data[2] = 23 [91 overall]
+051-052: x 1d                                                               # data[3] = 29 [97 overall]
+052-053: x 26                                                               # data[4] = 38 [106 overall]
+053-054: x 2e                                                               # data[5] = 46 [114 overall]
+054-055: x 33                                                               # data[6] = 51 [119 overall]
+055-056: x 3b                                                               # data[7] = 59 [127 overall]
+056-057: x 42                                                               # data[8] = 66 [134 overall]
+057-058: x 48                                                               # data[9] = 72 [140 overall]
+058-059: x 4c                                                               # data[10] = 76 [144 overall]
+059-060: x 56                                                               # data[11] = 86 [154 overall]
+060-061: x 5c                                                               # data[12] = 92 [160 overall]
+061-062: x 63                                                               # data[13] = 99 [167 overall]
+062-063: x 69                                                               # data[14] = 105 [173 overall]
+063-064: x 6f                                                               # data[15] = 111 [179 overall]
+064-065: x 76                                                               # data[16] = 118 [186 overall]
+065-066: x 7e                                                               # data[17] = 126 [194 overall]
+066-067: x 84                                                               # data[18] = 132 [200 overall]
+067-068: x 84                                                               # data[19] = 132 [200 overall]
 # Data
-063-073: x 61616161616161616161                                             # data[00]: aaaaaaaaaaaaaaa (block prefix)
-073-078: x 6161616161                                                       # (continued...)
-078-078: x                                                                  # data[01]: ............... (bundle prefix)
-078-086: x 7070616c6c696e67                                                 # data[02]: ...............ppalling
-086-092: x 70706172656c                                                     # data[03]: ...............pparel
-092-101: x 707061726974696f6e                                               # data[04]: ...............pparition
-101-109: x 7070656172696e67                                                 # data[05]: ...............ppearing
-109-114: x 7070656e64                                                       # data[06]: ...............ppend
-114-122: x 7070656e64616765                                                 # data[07]: ...............ppendage
-122-129: x 7070656e646978                                                   # data[08]: ...............ppendix
-129-135: x 70706c617564                                                     # data[09]: ...............pplaud
-135-139: x 70706c65                                                         # data[10]: ...............pple
-139-149: x 70706c69636174696f6e                                             # data[11]: ...............pplication
-149-155: x 70706c696564                                                     # data[12]: ...............pplied
-155-162: x 70706c79696e67                                                   # data[13]: ...............pplying
-162-168: x 70706f696e74                                                     # data[14]: ...............ppoint
-168-174: x 70706f736573                                                     # data[15]: ...............pposes
-174-181: x 7070726f766573                                                   # data[16]: ...............pproves
-181-189: x 7272657374696e67                                                 # data[17]: ...............rresting
-189-195: x 727269766564                                                     # data[18]: ...............rrived (bundle prefix)
-195-195: x                                                                  # data[19]: .....................
+068-078: x 61616161616161616161                                             # data[00]: aaaaaaaaaaaaaaa (block prefix)
+078-083: x 6161616161                                                       # (continued...)
+083-083: x                                                                  # data[01]: ............... (bundle prefix)
+083-091: x 7070616c6c696e67                                                 # data[02]: ...............ppalling
+091-097: x 70706172656c                                                     # data[03]: ...............pparel
+097-106: x 707061726974696f6e                                               # data[04]: ...............pparition
+106-114: x 7070656172696e67                                                 # data[05]: ...............ppearing
+114-119: x 7070656e64                                                       # data[06]: ...............ppend
+119-127: x 7070656e64616765                                                 # data[07]: ...............ppendage
+127-134: x 7070656e646978                                                   # data[08]: ...............ppendix
+134-140: x 70706c617564                                                     # data[09]: ...............pplaud
+140-144: x 70706c65                                                         # data[10]: ...............pple
+144-154: x 70706c69636174696f6e                                             # data[11]: ...............pplication
+154-160: x 70706c696564                                                     # data[12]: ...............pplied
+160-167: x 70706c79696e67                                                   # data[13]: ...............pplying
+167-173: x 70706f696e74                                                     # data[14]: ...............ppoint
+173-179: x 70706f736573                                                     # data[15]: ...............pposes
+179-186: x 7070726f766573                                                   # data[16]: ...............pproves
+186-194: x 7272657374696e67                                                 # data[17]: ...............rresting
+194-200: x 727269766564                                                     # data[18]: ...............rrived (bundle prefix)
+200-200: x                                                                  # data[19]: .....................
 # data for column 1
 # rawbytes
 # offsets table
-195-196: x 01                                                               # encoding: 1b
-196-197: x 00                                                               # data[0] = 0 [214 overall]
-197-198: x 03                                                               # data[1] = 3 [217 overall]
-198-199: x 06                                                               # data[2] = 6 [220 overall]
-199-200: x 09                                                               # data[3] = 9 [223 overall]
-200-201: x 0c                                                               # data[4] = 12 [226 overall]
-201-202: x 0f                                                               # data[5] = 15 [229 overall]
-202-203: x 12                                                               # data[6] = 18 [232 overall]
-203-204: x 15                                                               # data[7] = 21 [235 overall]
-204-205: x 18                                                               # data[8] = 24 [238 overall]
-205-206: x 1b                                                               # data[9] = 27 [241 overall]
-206-207: x 1e                                                               # data[10] = 30 [244 overall]
-207-208: x 21                                                               # data[11] = 33 [247 overall]
-208-209: x 24                                                               # data[12] = 36 [250 overall]
-209-210: x 27                                                               # data[13] = 39 [253 overall]
-210-211: x 2a                                                               # data[14] = 42 [256 overall]
-211-212: x 2d                                                               # data[15] = 45 [259 overall]
-212-213: x 30                                                               # data[16] = 48 [262 overall]
-213-214: x 33                                                               # data[17] = 51 [265 overall]
+200-201: x 01                                                               # encoding: 1b
+201-202: x 00                                                               # data[0] = 0 [219 overall]
+202-203: x 03                                                               # data[1] = 3 [222 overall]
+203-204: x 06                                                               # data[2] = 6 [225 overall]
+204-205: x 09                                                               # data[3] = 9 [228 overall]
+205-206: x 0c                                                               # data[4] = 12 [231 overall]
+206-207: x 0f                                                               # data[5] = 15 [234 overall]
+207-208: x 12                                                               # data[6] = 18 [237 overall]
+208-209: x 15                                                               # data[7] = 21 [240 overall]
+209-210: x 18                                                               # data[8] = 24 [243 overall]
+210-211: x 1b                                                               # data[9] = 27 [246 overall]
+211-212: x 1e                                                               # data[10] = 30 [249 overall]
+212-213: x 21                                                               # data[11] = 33 [252 overall]
+213-214: x 24                                                               # data[12] = 36 [255 overall]
+214-215: x 27                                                               # data[13] = 39 [258 overall]
+215-216: x 2a                                                               # data[14] = 42 [261 overall]
+216-217: x 2d                                                               # data[15] = 45 [264 overall]
+217-218: x 30                                                               # data[16] = 48 [267 overall]
+218-219: x 33                                                               # data[17] = 51 [270 overall]
 # data
-214-217: x 403130                                                           # data[0]: @10
-217-220: x 403130                                                           # data[1]: @10
-220-223: x 403130                                                           # data[2]: @10
-223-226: x 403130                                                           # data[3]: @10
-226-229: x 403130                                                           # data[4]: @10
-229-232: x 403130                                                           # data[5]: @10
-232-235: x 403130                                                           # data[6]: @10
-235-238: x 403130                                                           # data[7]: @10
-238-241: x 403130                                                           # data[8]: @10
-241-244: x 403130                                                           # data[9]: @10
-244-247: x 403130                                                           # data[10]: @10
-247-250: x 403130                                                           # data[11]: @10
-250-253: x 403130                                                           # data[12]: @10
-253-256: x 403130                                                           # data[13]: @10
-256-259: x 403130                                                           # data[14]: @10
-259-262: x 403130                                                           # data[15]: @10
-262-265: x 403130                                                           # data[16]: @10
+219-222: x 403130                                                           # data[0]: @10
+222-225: x 403130                                                           # data[1]: @10
+225-228: x 403130                                                           # data[2]: @10
+228-231: x 403130                                                           # data[3]: @10
+231-234: x 403130                                                           # data[4]: @10
+234-237: x 403130                                                           # data[5]: @10
+237-240: x 403130                                                           # data[6]: @10
+240-243: x 403130                                                           # data[7]: @10
+243-246: x 403130                                                           # data[8]: @10
+246-249: x 403130                                                           # data[9]: @10
+249-252: x 403130                                                           # data[10]: @10
+252-255: x 403130                                                           # data[11]: @10
+255-258: x 403130                                                           # data[12]: @10
+258-261: x 403130                                                           # data[13]: @10
+261-264: x 403130                                                           # data[14]: @10
+264-267: x 403130                                                           # data[15]: @10
+267-270: x 403130                                                           # data[16]: @10
 # data for column 2
-265-266: x 80                                                               # encoding: const
-266-274: x 0100000000000000                                                 # 64-bit constant: 1
+270-271: x 80                                                               # encoding: const
+271-279: x 0100000000000000                                                 # 64-bit constant: 1
 # data for column 3
-274-275: x 00                                                               # bitmap encoding
-275-280: x 0000000000                                                       # padding to align to 64-bit boundary
+279-280: x 00                                                               # bitmap encoding
 280-288: b 1111111111111111000000010000000000000000000000000000000000000000 # bitmap word 0
 288-296: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
@@ -487,7 +500,9 @@ LastKey: aaaaaaaaaaaaaaarrived@10#0,SET
 331-332: x 61                                                               # data[16]: a
 # data for column 5
 332-333: x 01                                                               # bitmap encoding
-333-334: x 00                                                               # block padding byte
+# data for column 6
+333-334: x 01                                                               # bitmap encoding
+334-335: x 00                                                               # block padding byte
 
 iter
 seek-ge aaa

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -305,7 +305,7 @@ func (w *RawColumnWriter) AddWithForceObsolete(
 	// including the key in the block. The data block writer permits us to
 	// finish the block excluding the last-appended KV.
 	entriesWithoutKV := w.dataBlock.Rows()
-	w.dataBlock.Add(key, valueStoredWithKey, valuePrefix, eval.kcmp)
+	w.dataBlock.Add(key, valueStoredWithKey, valuePrefix, eval.kcmp, eval.isObsolete)
 
 	// Now that we've appended the KV pair, we can compute the exact size of the
 	// block with this key-value pair included. Check to see if we should flush
@@ -317,7 +317,7 @@ func (w *RawColumnWriter) AddWithForceObsolete(
 		w.flushDataBlockWithoutNextKey(key.UserKey)
 		// flushDataBlockWithoutNextKey reset the data block builder, and we can
 		// add the key to this next block now.
-		w.dataBlock.Add(key, valueStoredWithKey, valuePrefix, eval.kcmp)
+		w.dataBlock.Add(key, valueStoredWithKey, valuePrefix, eval.kcmp, eval.isObsolete)
 		w.pendingDataBlockSize = w.dataBlock.Size()
 	} else {
 		// We're not flushing the data block, and we're committing to including

--- a/sstable/testdata/columnar_writer/simple_binary
+++ b/sstable/testdata/columnar_writer/simple_binary
@@ -7,146 +7,150 @@ seqnums:  [1-2]
 
 describe-binary
 ----
-# block 0 data (0000-0087)
+# block 0 data (0000-0096)
 # data block header
 000-004: x 01000000                                                         # maximum key length: 1
 # columnar block header
 004-005: x 01                                                               # version 1
-005-007: x 0600                                                             # 6 columns
+005-007: x 0700                                                             # 7 columns
 007-011: x 02000000                                                         # 2 rows
 011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 29000000                                                         # col 0: page start 41
+012-016: x 2e000000                                                         # col 0: page start 46
 016-017: b 00000011                                                         # col 1: bytes
-017-021: x 31000000                                                         # col 1: page start 49
+017-021: x 36000000                                                         # col 1: page start 54
 021-022: b 00000010                                                         # col 2: uint
-022-026: x 32000000                                                         # col 2: page start 50
+022-026: x 37000000                                                         # col 2: page start 55
 026-027: b 00000001                                                         # col 3: bool
-027-031: x 3d000000                                                         # col 3: page start 61
+027-031: x 42000000                                                         # col 3: page start 66
 031-032: b 00000011                                                         # col 4: bytes
-032-036: x 50000000                                                         # col 4: page start 80
+032-036: x 58000000                                                         # col 4: page start 88
 036-037: b 00000001                                                         # col 5: bool
-037-041: x 55000000                                                         # col 5: page start 85
+037-041: x 5d000000                                                         # col 5: page start 93
+041-042: b 00000001                                                         # col 6: bool
+042-046: x 5e000000                                                         # col 6: page start 94
 # data for column 0
 # PrefixBytes
-041-042: x 04                                                               # bundleSize: 16
+046-047: x 04                                                               # bundleSize: 16
 # Offsets table
-042-043: x 01                                                               # encoding: 1b
-043-044: x 00                                                               # data[0] = 0 [47 overall]
-044-045: x 00                                                               # data[1] = 0 [47 overall]
-045-046: x 01                                                               # data[2] = 1 [48 overall]
-046-047: x 02                                                               # data[3] = 2 [49 overall]
+047-048: x 01                                                               # encoding: 1b
+048-049: x 00                                                               # data[0] = 0 [52 overall]
+049-050: x 00                                                               # data[1] = 0 [52 overall]
+050-051: x 01                                                               # data[2] = 1 [53 overall]
+051-052: x 02                                                               # data[3] = 2 [54 overall]
 # Data
-047-047: x                                                                  # data[00]:  (block prefix)
-047-047: x                                                                  # data[01]:  (bundle prefix)
-047-048: x 61                                                               # data[02]: a
-048-049: x 62                                                               # data[03]: b
+052-052: x                                                                  # data[00]:  (block prefix)
+052-052: x                                                                  # data[01]:  (bundle prefix)
+052-053: x 61                                                               # data[02]: a
+053-054: x 62                                                               # data[03]: b
 # data for column 1
 # rawbytes
 # offsets table
-049-050: x 00                                                               # encoding: zero
+054-055: x 00                                                               # encoding: zero
 # data
-050-050: x                                                                  # data[0]:
-050-050: x                                                                  # data[1]:
+055-055: x                                                                  # data[0]:
+055-055: x                                                                  # data[1]:
 # data for column 2
-050-051: x 81                                                               # encoding: 1b,delta
-051-059: x 0101000000000000                                                 # 64-bit constant: 257
-059-060: x 00                                                               # data[0] = 0 + 257 = 257
-060-061: x ff                                                               # data[1] = 255 + 257 = 512
+055-056: x 81                                                               # encoding: 1b,delta
+056-064: x 0101000000000000                                                 # 64-bit constant: 257
+064-065: x 00                                                               # data[0] = 0 + 257 = 257
+065-066: x ff                                                               # data[1] = 255 + 257 = 512
 # data for column 3
-061-062: x 00                                                               # bitmap encoding
-062-064: x 0000                                                             # padding to align to 64-bit boundary
-064-072: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-072-080: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+066-067: x 00                                                               # bitmap encoding
+067-072: x 0000000000                                                       # padding to align to 64-bit boundary
+072-080: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-080-081: x 01                                                               # encoding: 1b
-081-082: x 00                                                               # data[0] = 0 [84 overall]
-082-083: x 01                                                               # data[1] = 1 [85 overall]
-083-084: x 01                                                               # data[2] = 1 [85 overall]
+088-089: x 01                                                               # encoding: 1b
+089-090: x 00                                                               # data[0] = 0 [92 overall]
+090-091: x 01                                                               # data[1] = 1 [93 overall]
+091-092: x 01                                                               # data[2] = 1 [93 overall]
 # data
-084-085: x 61                                                               # data[0]: a
-085-085: x                                                                  # data[1]:
+092-093: x 61                                                               # data[0]: a
+093-093: x                                                                  # data[1]:
 # data for column 5
-085-086: x 01                                                               # bitmap encoding
-086-087: x 00                                                               # block padding byte
-087-092: x 002e904bd9                                                       # data block trailer
-# block 1 index (0092-0128)
+093-094: x 01                                                               # bitmap encoding
+# data for column 6
+094-095: x 01                                                               # bitmap encoding
+095-096: x 00                                                               # block padding byte
+096-101: x 000a6472a7                                                       # data block trailer
+# block 1 index (0101-0137)
 # index block header
 # columnar block header
-092-093: x 01                                                               # version 1
-093-095: x 0400                                                             # 4 columns
-095-099: x 01000000                                                         # 1 rows
-099-100: b 00000011                                                         # col 0: bytes
-100-104: x 1b000000                                                         # col 0: page start 27
-104-105: b 00000010                                                         # col 1: uint
-105-109: x 1f000000                                                         # col 1: page start 31
-109-110: b 00000010                                                         # col 2: uint
-110-114: x 20000000                                                         # col 2: page start 32
-114-115: b 00000011                                                         # col 3: bytes
-115-119: x 22000000                                                         # col 3: page start 34
+101-102: x 01                                                               # version 1
+102-104: x 0400                                                             # 4 columns
+104-108: x 01000000                                                         # 1 rows
+108-109: b 00000011                                                         # col 0: bytes
+109-113: x 1b000000                                                         # col 0: page start 27
+113-114: b 00000010                                                         # col 1: uint
+114-118: x 1f000000                                                         # col 1: page start 31
+118-119: b 00000010                                                         # col 2: uint
+119-123: x 20000000                                                         # col 2: page start 32
+123-124: b 00000011                                                         # col 3: bytes
+124-128: x 22000000                                                         # col 3: page start 34
 # data for column 0
 # rawbytes
 # offsets table
-119-120: x 01                                                               # encoding: 1b
-120-121: x 00                                                               # data[0] = 0 [30 overall]
-121-122: x 01                                                               # data[1] = 1 [31 overall]
+128-129: x 01                                                               # encoding: 1b
+129-130: x 00                                                               # data[0] = 0 [30 overall]
+130-131: x 01                                                               # data[1] = 1 [31 overall]
 # data
-122-123: x 63                                                               # data[0]: c
+131-132: x 63                                                               # data[0]: c
 # data for column 1
-123-124: x 00                                                               # encoding: zero
+132-133: x 00                                                               # encoding: zero
 # data for column 2
-124-125: x 01                                                               # encoding: 1b
-125-126: x 57                                                               # data[0] = 87
+133-134: x 01                                                               # encoding: 1b
+134-135: x 60                                                               # data[0] = 96
 # data for column 3
 # rawbytes
 # offsets table
-126-127: x 00                                                               # encoding: zero
+135-136: x 00                                                               # encoding: zero
 # data
-127-127: x                                                                  # data[0]:
-127-128: x 00                                                               # block padding byte
-128-133: x 00ecb5f58d                                                       # index block trailer
-# block 2 properties (0133-0621)
-133-153: x 000c016f62736f6c6574652d6b65790000230170                         # ...obsolete-key..#.p
-153-173: x 6562626c652e7261772e706f696e742d746f6d62                         # ebble.raw.point-tomb
-173-193: x 73746f6e652e6b65792e73697a6501002404726f                         # stone.key.size..$.ro
-193-213: x 636b7364622e626c6f636b2e62617365642e7461                         # cksdb.block.based.ta
-213-233: x 626c652e696e6465782e7479706500000000080a                         # ble.index.type......
-233-253: x 1a636f6d70617261746f726c6576656c64622e42                         # .comparatorleveldb.B
-253-273: x 79746577697365436f6d70617261746f720c070d                         # ytewiseComparator...
-273-293: x 72657373696f6e4e6f436f6d7072657373696f6e                         # ressionNoCompression
-293-313: x 13085f5f6f7074696f6e7377696e646f775f6269                         # ..__optionswindow_bi
-313-333: x 74733d2d31343b206c6576656c3d33323736373b                         # ts=-14; level=32767;
-333-353: x 2073747261746567793d303b206d61785f646963                         #  strategy=0; max_dic
-353-373: x 745f62797465733d303b207a7374645f6d61785f                         # t_bytes=0; zstd_max_
-373-393: x 747261696e5f62797465733d303b20656e61626c                         # train_bytes=0; enabl
-393-413: x 65643d303b20080901646174612e73697a650009                         # ed=0; ...data.size..
-413-433: x 0b01656c657465642e6b65797301080b0166696c                         # ..eleted.keys....fil
-433-453: x 7465722e73697a6500080a01696e6465782e7369                         # ter.size....index.si
-453-473: x 7a6529080e016d657267652e6f706572616e6473                         # ze)...merge.operands
-473-493: x 00130312746f72706562626c652e636f6e636174                         # ....torpebble.concat
-493-513: x 656e617465080f016e756d2e646174612e626c6f                         # enate...num.data.blo
-513-533: x 636b73010c0701656e7472696573020c0f017261                         # cks....entries....ra
-533-553: x 6e67652d64656c6574696f6e730008130e70726f                         # nge-deletions....pro
-553-573: x 70657274792e636f6c6c6563746f72735b6f6273                         # perty.collectors[obs
-573-593: x 6f6c6574652d6b65795d080c017261772e6b6579                         # olete-key]...raw.key
-593-613: x 2e73697a65120c0a0176616c75652e73697a6501                         # .size....value.size.
-613-621: x 0000000001000000                                                 # ........
-621-626: x 00e72c41d2                                                       # properties block trailer
-# block 3 meta-index (0626-0659)
-626-646: x 001204726f636b7364622e70726f706572746965                         # meta-index
-646-659: x 738501e8030000000001000000                                       # (continued...)
-659-664: x 00c6e8fa4e                                                       # meta-index block trailer
+136-136: x                                                                  # data[0]:
+136-137: x 00                                                               # block padding byte
+137-142: x 006e700d74                                                       # index block trailer
+# block 2 properties (0142-0630)
+142-162: x 000c016f62736f6c6574652d6b65790000230170                         # ...obsolete-key..#.p
+162-182: x 6562626c652e7261772e706f696e742d746f6d62                         # ebble.raw.point-tomb
+182-202: x 73746f6e652e6b65792e73697a6501002404726f                         # stone.key.size..$.ro
+202-222: x 636b7364622e626c6f636b2e62617365642e7461                         # cksdb.block.based.ta
+222-242: x 626c652e696e6465782e7479706500000000080a                         # ble.index.type......
+242-262: x 1a636f6d70617261746f726c6576656c64622e42                         # .comparatorleveldb.B
+262-282: x 79746577697365436f6d70617261746f720c070d                         # ytewiseComparator...
+282-302: x 72657373696f6e4e6f436f6d7072657373696f6e                         # ressionNoCompression
+302-322: x 13085f5f6f7074696f6e7377696e646f775f6269                         # ..__optionswindow_bi
+322-342: x 74733d2d31343b206c6576656c3d33323736373b                         # ts=-14; level=32767;
+342-362: x 2073747261746567793d303b206d61785f646963                         #  strategy=0; max_dic
+362-382: x 745f62797465733d303b207a7374645f6d61785f                         # t_bytes=0; zstd_max_
+382-402: x 747261696e5f62797465733d303b20656e61626c                         # train_bytes=0; enabl
+402-422: x 65643d303b20080901646174612e73697a650009                         # ed=0; ...data.size..
+422-442: x 0b01656c657465642e6b65797301080b0166696c                         # ..eleted.keys....fil
+442-462: x 7465722e73697a6500080a01696e6465782e7369                         # ter.size....index.si
+462-482: x 7a6529080e016d657267652e6f706572616e6473                         # ze)...merge.operands
+482-502: x 00130312746f72706562626c652e636f6e636174                         # ....torpebble.concat
+502-522: x 656e617465080f016e756d2e646174612e626c6f                         # enate...num.data.blo
+522-542: x 636b73010c0701656e7472696573020c0f017261                         # cks....entries....ra
+542-562: x 6e67652d64656c6574696f6e730008130e70726f                         # nge-deletions....pro
+562-582: x 70657274792e636f6c6c6563746f72735b6f6273                         # perty.collectors[obs
+582-602: x 6f6c6574652d6b65795d080c017261772e6b6579                         # olete-key]...raw.key
+602-622: x 2e73697a65120c0a0176616c75652e73697a6501                         # .size....value.size.
+622-630: x 0000000001000000                                                 # ........
+630-635: x 00e72c41d2                                                       # properties block trailer
+# block 3 meta-index (0635-0668)
+635-655: x 001204726f636b7364622e70726f706572746965                         # meta-index
+655-668: x 738e01e8030000000001000000                                       # (continued...)
+668-673: x 00d1441df9                                                       # meta-index block trailer
 # sstable footer
-664-665: x 01                                                               # checksum type
-665-667: x f204                                                             # uvarint(626): metaindex.Offset
-667-668: x 21                                                               # uvarint(33): metaindex.Length
-668-669: x 5c                                                               # uvarint(92): index.Offset
-669-670: x 24                                                               # uvarint(36): index.Length
-670-690: x 0000000000000000000000000000000000000000                         # padding
-690-705: x 000000000000000000000000000000                                   # (continued...)
-705-709: x 05000000                                                         # table version
-709-717: x f09faab3f09faab3                                                 # magic
+673-674: x 01                                                               # checksum type
+674-676: x fb04                                                             # uvarint(635): metaindex.Offset
+676-677: x 21                                                               # uvarint(33): metaindex.Length
+677-678: x 65                                                               # uvarint(101): index.Offset
+678-679: x 24                                                               # uvarint(36): index.Length
+679-699: x 0000000000000000000000000000000000000000                         # padding
+699-714: x 000000000000000000000000000000                                   # (continued...)
+714-718: x 05000000                                                         # table version
+718-726: x f09faab3f09faab3                                                 # magic
 
 build block-size=150
 a.SET.1:apple
@@ -158,147 +162,151 @@ seqnums:  [1-1]
 
 describe-binary
 ----
-# block 0 data (0000-0107)
+# block 0 data (0000-0116)
 # data block header
 000-004: x 01000000                                                         # maximum key length: 1
 # columnar block header
 004-005: x 01                                                               # version 1
-005-007: x 0600                                                             # 6 columns
+005-007: x 0700                                                             # 7 columns
 007-011: x 03000000                                                         # 3 rows
 011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 29000000                                                         # col 0: page start 41
+012-016: x 2e000000                                                         # col 0: page start 46
 016-017: b 00000011                                                         # col 1: bytes
-017-021: x 33000000                                                         # col 1: page start 51
+017-021: x 38000000                                                         # col 1: page start 56
 021-022: b 00000010                                                         # col 2: uint
-022-026: x 34000000                                                         # col 2: page start 52
+022-026: x 39000000                                                         # col 2: page start 57
 026-027: b 00000001                                                         # col 3: bool
-027-031: x 3d000000                                                         # col 3: page start 61
+027-031: x 42000000                                                         # col 3: page start 66
 031-032: b 00000011                                                         # col 4: bytes
-032-036: x 50000000                                                         # col 4: page start 80
+032-036: x 58000000                                                         # col 4: page start 88
 036-037: b 00000001                                                         # col 5: bool
-037-041: x 69000000                                                         # col 5: page start 105
+037-041: x 71000000                                                         # col 5: page start 113
+041-042: b 00000001                                                         # col 6: bool
+042-046: x 72000000                                                         # col 6: page start 114
 # data for column 0
 # PrefixBytes
-041-042: x 04                                                               # bundleSize: 16
+046-047: x 04                                                               # bundleSize: 16
 # Offsets table
-042-043: x 01                                                               # encoding: 1b
-043-044: x 00                                                               # data[0] = 0 [48 overall]
-044-045: x 00                                                               # data[1] = 0 [48 overall]
-045-046: x 01                                                               # data[2] = 1 [49 overall]
-046-047: x 02                                                               # data[3] = 2 [50 overall]
-047-048: x 03                                                               # data[4] = 3 [51 overall]
+047-048: x 01                                                               # encoding: 1b
+048-049: x 00                                                               # data[0] = 0 [53 overall]
+049-050: x 00                                                               # data[1] = 0 [53 overall]
+050-051: x 01                                                               # data[2] = 1 [54 overall]
+051-052: x 02                                                               # data[3] = 2 [55 overall]
+052-053: x 03                                                               # data[4] = 3 [56 overall]
 # Data
-048-048: x                                                                  # data[00]:  (block prefix)
-048-048: x                                                                  # data[01]:  (bundle prefix)
-048-049: x 61                                                               # data[02]: a
-049-050: x 62                                                               # data[03]: b
-050-051: x 63                                                               # data[04]: c
+053-053: x                                                                  # data[00]:  (block prefix)
+053-053: x                                                                  # data[01]:  (bundle prefix)
+053-054: x 61                                                               # data[02]: a
+054-055: x 62                                                               # data[03]: b
+055-056: x 63                                                               # data[04]: c
 # data for column 1
 # rawbytes
 # offsets table
-051-052: x 00                                                               # encoding: zero
+056-057: x 00                                                               # encoding: zero
 # data
-052-052: x                                                                  # data[0]:
-052-052: x                                                                  # data[1]:
-052-052: x                                                                  # data[2]:
+057-057: x                                                                  # data[0]:
+057-057: x                                                                  # data[1]:
+057-057: x                                                                  # data[2]:
 # data for column 2
-052-053: x 80                                                               # encoding: const
-053-061: x 0101000000000000                                                 # 64-bit constant: 257
+057-058: x 80                                                               # encoding: const
+058-066: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-061-062: x 00                                                               # bitmap encoding
-062-064: x 0000                                                             # padding to align to 64-bit boundary
-064-072: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-072-080: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+066-067: x 00                                                               # bitmap encoding
+067-072: x 0000000000                                                       # padding to align to 64-bit boundary
+072-080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-080-081: x 01                                                               # encoding: 1b
-081-082: x 00                                                               # data[0] = 0 [85 overall]
-082-083: x 05                                                               # data[1] = 5 [90 overall]
-083-084: x 0b                                                               # data[2] = 11 [96 overall]
-084-085: x 14                                                               # data[3] = 20 [105 overall]
+088-089: x 01                                                               # encoding: 1b
+089-090: x 00                                                               # data[0] = 0 [93 overall]
+090-091: x 05                                                               # data[1] = 5 [98 overall]
+091-092: x 0b                                                               # data[2] = 11 [104 overall]
+092-093: x 14                                                               # data[3] = 20 [113 overall]
 # data
-085-090: x 6170706c65                                                       # data[0]: apple
-090-096: x 62616e616e61                                                     # data[1]: banana
-096-105: x 63616e74656c6f7065                                               # data[2]: cantelope
+093-098: x 6170706c65                                                       # data[0]: apple
+098-104: x 62616e616e61                                                     # data[1]: banana
+104-113: x 63616e74656c6f7065                                               # data[2]: cantelope
 # data for column 5
-105-106: x 01                                                               # bitmap encoding
-106-107: x 00                                                               # block padding byte
-107-112: x 00df14c47e                                                       # data block trailer
-# block 1 index (0112-0148)
+113-114: x 01                                                               # bitmap encoding
+# data for column 6
+114-115: x 01                                                               # bitmap encoding
+115-116: x 00                                                               # block padding byte
+116-121: x 002953b1e7                                                       # data block trailer
+# block 1 index (0121-0157)
 # index block header
 # columnar block header
-112-113: x 01                                                               # version 1
-113-115: x 0400                                                             # 4 columns
-115-119: x 01000000                                                         # 1 rows
-119-120: b 00000011                                                         # col 0: bytes
-120-124: x 1b000000                                                         # col 0: page start 27
-124-125: b 00000010                                                         # col 1: uint
-125-129: x 1f000000                                                         # col 1: page start 31
-129-130: b 00000010                                                         # col 2: uint
-130-134: x 20000000                                                         # col 2: page start 32
-134-135: b 00000011                                                         # col 3: bytes
-135-139: x 22000000                                                         # col 3: page start 34
+121-122: x 01                                                               # version 1
+122-124: x 0400                                                             # 4 columns
+124-128: x 01000000                                                         # 1 rows
+128-129: b 00000011                                                         # col 0: bytes
+129-133: x 1b000000                                                         # col 0: page start 27
+133-134: b 00000010                                                         # col 1: uint
+134-138: x 1f000000                                                         # col 1: page start 31
+138-139: b 00000010                                                         # col 2: uint
+139-143: x 20000000                                                         # col 2: page start 32
+143-144: b 00000011                                                         # col 3: bytes
+144-148: x 22000000                                                         # col 3: page start 34
 # data for column 0
 # rawbytes
 # offsets table
-139-140: x 01                                                               # encoding: 1b
-140-141: x 00                                                               # data[0] = 0 [30 overall]
-141-142: x 01                                                               # data[1] = 1 [31 overall]
+148-149: x 01                                                               # encoding: 1b
+149-150: x 00                                                               # data[0] = 0 [30 overall]
+150-151: x 01                                                               # data[1] = 1 [31 overall]
 # data
-142-143: x 64                                                               # data[0]: d
+151-152: x 64                                                               # data[0]: d
 # data for column 1
-143-144: x 00                                                               # encoding: zero
+152-153: x 00                                                               # encoding: zero
 # data for column 2
-144-145: x 01                                                               # encoding: 1b
-145-146: x 6b                                                               # data[0] = 107
+153-154: x 01                                                               # encoding: 1b
+154-155: x 74                                                               # data[0] = 116
 # data for column 3
 # rawbytes
 # offsets table
-146-147: x 00                                                               # encoding: zero
+155-156: x 00                                                               # encoding: zero
 # data
-147-147: x                                                                  # data[0]:
-147-148: x 00                                                               # block padding byte
-148-153: x 006881aa07                                                       # index block trailer
-# block 2 properties (0153-0602)
-153-173: x 000c016f62736f6c6574652d6b65790000240472                         # ...obsolete-key..$.r
-173-193: x 6f636b7364622e626c6f636b2e62617365642e74                         # ocksdb.block.based.t
-193-213: x 61626c652e696e6465782e747970650000000008                         # able.index.type.....
-213-233: x 0a1a636f6d70617261746f726c6576656c64622e                         # ..comparatorleveldb.
-233-253: x 4279746577697365436f6d70617261746f720c07                         # BytewiseComparator..
-253-273: x 0d72657373696f6e4e6f436f6d7072657373696f                         # .ressionNoCompressio
-273-293: x 6e13085f5f6f7074696f6e7377696e646f775f62                         # n..__optionswindow_b
-293-313: x 6974733d2d31343b206c6576656c3d3332373637                         # its=-14; level=32767
-313-333: x 3b2073747261746567793d303b206d61785f6469                         # ; strategy=0; max_di
-333-353: x 63745f62797465733d303b207a7374645f6d6178                         # ct_bytes=0; zstd_max
-353-373: x 5f747261696e5f62797465733d303b20656e6162                         # _train_bytes=0; enab
-373-393: x 6c65643d303b20080901646174612e73697a6500                         # led=0; ...data.size.
-393-413: x 090b01656c657465642e6b65797300080b016669                         # ...eleted.keys....fi
-413-433: x 6c7465722e73697a6500080a01696e6465782e73                         # lter.size....index.s
-433-453: x 697a6529080e016d657267652e6f706572616e64                         # ize)...merge.operand
-453-473: x 7300130312746f72706562626c652e636f6e6361                         # s....torpebble.conca
-473-493: x 74656e617465080f016e756d2e646174612e626c                         # tenate...num.data.bl
-493-513: x 6f636b73010c0701656e7472696573030c0f0172                         # ocks....entries....r
-513-533: x 616e67652d64656c6574696f6e730008130e7072                         # ange-deletions....pr
-533-553: x 6f70657274792e636f6c6c6563746f72735b6f62                         # operty.collectors[ob
-553-573: x 736f6c6574652d6b65795d080c017261772e6b65                         # solete-key]...raw.ke
-573-593: x 792e73697a651b0c0a0176616c75652e73697a65                         # y.size....value.size
-593-602: x 140000000001000000                                               # .........
-602-607: x 0049367307                                                       # properties block trailer
-# block 3 meta-index (0607-0640)
-607-627: x 001204726f636b7364622e70726f706572746965                         # meta-index
-627-640: x 739901c1030000000001000000                                       # (continued...)
-640-645: x 004f665792                                                       # meta-index block trailer
+156-156: x                                                                  # data[0]:
+156-157: x 00                                                               # block padding byte
+157-162: x 00a8858853                                                       # index block trailer
+# block 2 properties (0162-0611)
+162-182: x 000c016f62736f6c6574652d6b65790000240472                         # ...obsolete-key..$.r
+182-202: x 6f636b7364622e626c6f636b2e62617365642e74                         # ocksdb.block.based.t
+202-222: x 61626c652e696e6465782e747970650000000008                         # able.index.type.....
+222-242: x 0a1a636f6d70617261746f726c6576656c64622e                         # ..comparatorleveldb.
+242-262: x 4279746577697365436f6d70617261746f720c07                         # BytewiseComparator..
+262-282: x 0d72657373696f6e4e6f436f6d7072657373696f                         # .ressionNoCompressio
+282-302: x 6e13085f5f6f7074696f6e7377696e646f775f62                         # n..__optionswindow_b
+302-322: x 6974733d2d31343b206c6576656c3d3332373637                         # its=-14; level=32767
+322-342: x 3b2073747261746567793d303b206d61785f6469                         # ; strategy=0; max_di
+342-362: x 63745f62797465733d303b207a7374645f6d6178                         # ct_bytes=0; zstd_max
+362-382: x 5f747261696e5f62797465733d303b20656e6162                         # _train_bytes=0; enab
+382-402: x 6c65643d303b20080901646174612e73697a6500                         # led=0; ...data.size.
+402-422: x 090b01656c657465642e6b65797300080b016669                         # ...eleted.keys....fi
+422-442: x 6c7465722e73697a6500080a01696e6465782e73                         # lter.size....index.s
+442-462: x 697a6529080e016d657267652e6f706572616e64                         # ize)...merge.operand
+462-482: x 7300130312746f72706562626c652e636f6e6361                         # s....torpebble.conca
+482-502: x 74656e617465080f016e756d2e646174612e626c                         # tenate...num.data.bl
+502-522: x 6f636b73010c0701656e7472696573030c0f0172                         # ocks....entries....r
+522-542: x 616e67652d64656c6574696f6e730008130e7072                         # ange-deletions....pr
+542-562: x 6f70657274792e636f6c6c6563746f72735b6f62                         # operty.collectors[ob
+562-582: x 736f6c6574652d6b65795d080c017261772e6b65                         # solete-key]...raw.ke
+582-602: x 792e73697a651b0c0a0176616c75652e73697a65                         # y.size....value.size
+602-611: x 140000000001000000                                               # .........
+611-616: x 0049367307                                                       # properties block trailer
+# block 3 meta-index (0616-0649)
+616-636: x 001204726f636b7364622e70726f706572746965                         # meta-index
+636-649: x 73a201c1030000000001000000                                       # (continued...)
+649-654: x 00eabf36fd                                                       # meta-index block trailer
 # sstable footer
-645-646: x 01                                                               # checksum type
-646-648: x df04                                                             # uvarint(607): metaindex.Offset
-648-649: x 21                                                               # uvarint(33): metaindex.Length
-649-650: x 70                                                               # uvarint(112): index.Offset
-650-651: x 24                                                               # uvarint(36): index.Length
-651-671: x 0000000000000000000000000000000000000000                         # padding
-671-686: x 000000000000000000000000000000                                   # (continued...)
-686-690: x 05000000                                                         # table version
-690-698: x f09faab3f09faab3                                                 # magic
+654-655: x 01                                                               # checksum type
+655-657: x e804                                                             # uvarint(616): metaindex.Offset
+657-658: x 21                                                               # uvarint(33): metaindex.Length
+658-659: x 79                                                               # uvarint(121): index.Offset
+659-660: x 24                                                               # uvarint(36): index.Length
+660-680: x 0000000000000000000000000000000000000000                         # padding
+680-695: x 000000000000000000000000000000                                   # (continued...)
+695-699: x 05000000                                                         # table version
+699-707: x f09faab3f09faab3                                                 # magic
 
 build block-size=150
 a.SET.1:apple
@@ -328,579 +336,730 @@ seqnums:  [1-1]
 
 describe-binary
 ----
-# block 0 data (0000-0107)
+# block 0 data (0000-0116)
 # data block header
 0000-0004: x 01000000                                                         # maximum key length: 1
 # columnar block header
 0004-0005: x 01                                                               # version 1
-0005-0007: x 0600                                                             # 6 columns
+0005-0007: x 0700                                                             # 7 columns
 0007-0011: x 03000000                                                         # 3 rows
 0011-0012: b 00000100                                                         # col 0: prefixbytes
-0012-0016: x 29000000                                                         # col 0: page start 41
+0012-0016: x 2e000000                                                         # col 0: page start 46
 0016-0017: b 00000011                                                         # col 1: bytes
-0017-0021: x 33000000                                                         # col 1: page start 51
+0017-0021: x 38000000                                                         # col 1: page start 56
 0021-0022: b 00000010                                                         # col 2: uint
-0022-0026: x 34000000                                                         # col 2: page start 52
+0022-0026: x 39000000                                                         # col 2: page start 57
 0026-0027: b 00000001                                                         # col 3: bool
-0027-0031: x 3d000000                                                         # col 3: page start 61
+0027-0031: x 42000000                                                         # col 3: page start 66
 0031-0032: b 00000011                                                         # col 4: bytes
-0032-0036: x 50000000                                                         # col 4: page start 80
+0032-0036: x 58000000                                                         # col 4: page start 88
 0036-0037: b 00000001                                                         # col 5: bool
-0037-0041: x 69000000                                                         # col 5: page start 105
+0037-0041: x 71000000                                                         # col 5: page start 113
+0041-0042: b 00000001                                                         # col 6: bool
+0042-0046: x 72000000                                                         # col 6: page start 114
 # data for column 0
 # PrefixBytes
-0041-0042: x 04                                                               # bundleSize: 16
+0046-0047: x 04                                                               # bundleSize: 16
 # Offsets table
-0042-0043: x 01                                                               # encoding: 1b
-0043-0044: x 00                                                               # data[0] = 0 [48 overall]
-0044-0045: x 00                                                               # data[1] = 0 [48 overall]
-0045-0046: x 01                                                               # data[2] = 1 [49 overall]
-0046-0047: x 02                                                               # data[3] = 2 [50 overall]
-0047-0048: x 03                                                               # data[4] = 3 [51 overall]
+0047-0048: x 01                                                               # encoding: 1b
+0048-0049: x 00                                                               # data[0] = 0 [53 overall]
+0049-0050: x 00                                                               # data[1] = 0 [53 overall]
+0050-0051: x 01                                                               # data[2] = 1 [54 overall]
+0051-0052: x 02                                                               # data[3] = 2 [55 overall]
+0052-0053: x 03                                                               # data[4] = 3 [56 overall]
 # Data
-0048-0048: x                                                                  # data[00]:  (block prefix)
-0048-0048: x                                                                  # data[01]:  (bundle prefix)
-0048-0049: x 61                                                               # data[02]: a
-0049-0050: x 62                                                               # data[03]: b
-0050-0051: x 63                                                               # data[04]: c
+0053-0053: x                                                                  # data[00]:  (block prefix)
+0053-0053: x                                                                  # data[01]:  (bundle prefix)
+0053-0054: x 61                                                               # data[02]: a
+0054-0055: x 62                                                               # data[03]: b
+0055-0056: x 63                                                               # data[04]: c
 # data for column 1
 # rawbytes
 # offsets table
-0051-0052: x 00                                                               # encoding: zero
+0056-0057: x 00                                                               # encoding: zero
 # data
-0052-0052: x                                                                  # data[0]:
-0052-0052: x                                                                  # data[1]:
-0052-0052: x                                                                  # data[2]:
+0057-0057: x                                                                  # data[0]:
+0057-0057: x                                                                  # data[1]:
+0057-0057: x                                                                  # data[2]:
 # data for column 2
-0052-0053: x 80                                                               # encoding: const
-0053-0061: x 0101000000000000                                                 # 64-bit constant: 257
+0057-0058: x 80                                                               # encoding: const
+0058-0066: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-0061-0062: x 00                                                               # bitmap encoding
-0062-0064: x 0000                                                             # padding to align to 64-bit boundary
-0064-0072: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0072-0080: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+0066-0067: x 00                                                               # bitmap encoding
+0067-0072: x 0000000000                                                       # padding to align to 64-bit boundary
+0072-0080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+0080-0088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-0080-0081: x 01                                                               # encoding: 1b
-0081-0082: x 00                                                               # data[0] = 0 [85 overall]
-0082-0083: x 05                                                               # data[1] = 5 [90 overall]
-0083-0084: x 0b                                                               # data[2] = 11 [96 overall]
-0084-0085: x 14                                                               # data[3] = 20 [105 overall]
+0088-0089: x 01                                                               # encoding: 1b
+0089-0090: x 00                                                               # data[0] = 0 [93 overall]
+0090-0091: x 05                                                               # data[1] = 5 [98 overall]
+0091-0092: x 0b                                                               # data[2] = 11 [104 overall]
+0092-0093: x 14                                                               # data[3] = 20 [113 overall]
 # data
-0085-0090: x 6170706c65                                                       # data[0]: apple
-0090-0096: x 62616e616e61                                                     # data[1]: banana
-0096-0105: x 63616e74656c6f7065                                               # data[2]: cantelope
+0093-0098: x 6170706c65                                                       # data[0]: apple
+0098-0104: x 62616e616e61                                                     # data[1]: banana
+0104-0113: x 63616e74656c6f7065                                               # data[2]: cantelope
 # data for column 5
-0105-0106: x 01                                                               # bitmap encoding
-0106-0107: x 00                                                               # block padding byte
-0107-0112: x 00df14c47e                                                       # data block trailer
-# block 1 data (0112-0223)
+0113-0114: x 01                                                               # bitmap encoding
+# data for column 6
+0114-0115: x 01                                                               # bitmap encoding
+0115-0116: x 00                                                               # block padding byte
+0116-0121: x 002953b1e7                                                       # data block trailer
+# block 1 data (0121-0237)
 # data block header
-0112-0116: x 01000000                                                         # maximum key length: 1
+0121-0125: x 01000000                                                         # maximum key length: 1
 # columnar block header
-0116-0117: x 01                                                               # version 1
-0117-0119: x 0600                                                             # 6 columns
-0119-0123: x 03000000                                                         # 3 rows
-0123-0124: b 00000100                                                         # col 0: prefixbytes
-0124-0128: x 29000000                                                         # col 0: page start 41
-0128-0129: b 00000011                                                         # col 1: bytes
-0129-0133: x 33000000                                                         # col 1: page start 51
-0133-0134: b 00000010                                                         # col 2: uint
-0134-0138: x 34000000                                                         # col 2: page start 52
-0138-0139: b 00000001                                                         # col 3: bool
-0139-0143: x 3d000000                                                         # col 3: page start 61
-0143-0144: b 00000011                                                         # col 4: bytes
-0144-0148: x 50000000                                                         # col 4: page start 80
-0148-0149: b 00000001                                                         # col 5: bool
-0149-0153: x 6d000000                                                         # col 5: page start 109
+0125-0126: x 01                                                               # version 1
+0126-0128: x 0700                                                             # 7 columns
+0128-0132: x 02000000                                                         # 2 rows
+0132-0133: b 00000100                                                         # col 0: prefixbytes
+0133-0137: x 2e000000                                                         # col 0: page start 46
+0137-0138: b 00000011                                                         # col 1: bytes
+0138-0142: x 36000000                                                         # col 1: page start 54
+0142-0143: b 00000010                                                         # col 2: uint
+0143-0147: x 37000000                                                         # col 2: page start 55
+0147-0148: b 00000001                                                         # col 3: bool
+0148-0152: x 40000000                                                         # col 3: page start 64
+0152-0153: b 00000011                                                         # col 4: bytes
+0153-0157: x 58000000                                                         # col 4: page start 88
+0157-0158: b 00000001                                                         # col 5: bool
+0158-0162: x 71000000                                                         # col 5: page start 113
+0162-0163: b 00000001                                                         # col 6: bool
+0163-0167: x 72000000                                                         # col 6: page start 114
 # data for column 0
 # PrefixBytes
-0153-0154: x 04                                                               # bundleSize: 16
+0167-0168: x 04                                                               # bundleSize: 16
 # Offsets table
-0154-0155: x 01                                                               # encoding: 1b
-0155-0156: x 00                                                               # data[0] = 0 [48 overall]
-0156-0157: x 00                                                               # data[1] = 0 [48 overall]
-0157-0158: x 01                                                               # data[2] = 1 [49 overall]
-0158-0159: x 02                                                               # data[3] = 2 [50 overall]
-0159-0160: x 03                                                               # data[4] = 3 [51 overall]
+0168-0169: x 01                                                               # encoding: 1b
+0169-0170: x 00                                                               # data[0] = 0 [52 overall]
+0170-0171: x 00                                                               # data[1] = 0 [52 overall]
+0171-0172: x 01                                                               # data[2] = 1 [53 overall]
+0172-0173: x 02                                                               # data[3] = 2 [54 overall]
 # Data
-0160-0160: x                                                                  # data[00]:  (block prefix)
-0160-0160: x                                                                  # data[01]:  (bundle prefix)
-0160-0161: x 64                                                               # data[02]: d
-0161-0162: x 65                                                               # data[03]: e
-0162-0163: x 66                                                               # data[04]: f
+0173-0173: x                                                                  # data[00]:  (block prefix)
+0173-0173: x                                                                  # data[01]:  (bundle prefix)
+0173-0174: x 64                                                               # data[02]: d
+0174-0175: x 65                                                               # data[03]: e
 # data for column 1
 # rawbytes
 # offsets table
-0163-0164: x 00                                                               # encoding: zero
+0175-0176: x 00                                                               # encoding: zero
 # data
-0164-0164: x                                                                  # data[0]:
-0164-0164: x                                                                  # data[1]:
-0164-0164: x                                                                  # data[2]:
+0176-0176: x                                                                  # data[0]:
+0176-0176: x                                                                  # data[1]:
 # data for column 2
-0164-0165: x 80                                                               # encoding: const
-0165-0173: x 0101000000000000                                                 # 64-bit constant: 257
+0176-0177: x 80                                                               # encoding: const
+0177-0185: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-0173-0174: x 00                                                               # bitmap encoding
-0174-0176: x 0000                                                             # padding to align to 64-bit boundary
-0176-0184: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0184-0192: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+0185-0186: x 00                                                               # bitmap encoding
+0186-0193: x 00000000000000                                                   # padding to align to 64-bit boundary
+0193-0201: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+0201-0209: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-0192-0193: x 01                                                               # encoding: 1b
-0193-0194: x 00                                                               # data[0] = 0 [85 overall]
-0194-0195: x 0b                                                               # data[1] = 11 [96 overall]
-0195-0196: x 15                                                               # data[2] = 21 [106 overall]
-0196-0197: x 18                                                               # data[3] = 24 [109 overall]
+0209-0210: x 01                                                               # encoding: 1b
+0210-0211: x 00                                                               # data[0] = 0 [92 overall]
+0211-0212: x 0b                                                               # data[1] = 11 [103 overall]
+0212-0213: x 15                                                               # data[2] = 21 [113 overall]
 # data
-0197-0208: x 647261676f6e6672756974                                           # data[0]: dragonfruit
-0208-0218: x 656c6465726265727279                                             # data[1]: elderberry
-0218-0221: x 666967                                                           # data[2]: fig
+0213-0224: x 647261676f6e6672756974                                           # data[0]: dragonfruit
+0224-0234: x 656c6465726265727279                                             # data[1]: elderberry
 # data for column 5
-0221-0222: x 01                                                               # bitmap encoding
-0222-0223: x 00                                                               # block padding byte
-0223-0228: x 004c9ba3f9                                                       # data block trailer
-# block 2 data (0228-0337)
+0234-0235: x 01                                                               # bitmap encoding
+# data for column 6
+0235-0236: x 01                                                               # bitmap encoding
+0236-0237: x 00                                                               # block padding byte
+0237-0242: x 007d1e6fd5                                                       # data block trailer
+# block 2 data (0242-0359)
 # data block header
-0228-0232: x 01000000                                                         # maximum key length: 1
+0242-0246: x 01000000                                                         # maximum key length: 1
 # columnar block header
-0232-0233: x 01                                                               # version 1
-0233-0235: x 0600                                                             # 6 columns
-0235-0239: x 03000000                                                         # 3 rows
-0239-0240: b 00000100                                                         # col 0: prefixbytes
-0240-0244: x 29000000                                                         # col 0: page start 41
-0244-0245: b 00000011                                                         # col 1: bytes
-0245-0249: x 33000000                                                         # col 1: page start 51
-0249-0250: b 00000010                                                         # col 2: uint
-0250-0254: x 34000000                                                         # col 2: page start 52
-0254-0255: b 00000001                                                         # col 3: bool
-0255-0259: x 3d000000                                                         # col 3: page start 61
-0259-0260: b 00000011                                                         # col 4: bytes
-0260-0264: x 50000000                                                         # col 4: page start 80
-0264-0265: b 00000001                                                         # col 5: bool
-0265-0269: x 6b000000                                                         # col 5: page start 107
+0246-0247: x 01                                                               # version 1
+0247-0249: x 0700                                                             # 7 columns
+0249-0253: x 03000000                                                         # 3 rows
+0253-0254: b 00000100                                                         # col 0: prefixbytes
+0254-0258: x 2e000000                                                         # col 0: page start 46
+0258-0259: b 00000011                                                         # col 1: bytes
+0259-0263: x 38000000                                                         # col 1: page start 56
+0263-0264: b 00000010                                                         # col 2: uint
+0264-0268: x 39000000                                                         # col 2: page start 57
+0268-0269: b 00000001                                                         # col 3: bool
+0269-0273: x 42000000                                                         # col 3: page start 66
+0273-0274: b 00000011                                                         # col 4: bytes
+0274-0278: x 58000000                                                         # col 4: page start 88
+0278-0279: b 00000001                                                         # col 5: bool
+0279-0283: x 72000000                                                         # col 5: page start 114
+0283-0284: b 00000001                                                         # col 6: bool
+0284-0288: x 73000000                                                         # col 6: page start 115
 # data for column 0
 # PrefixBytes
-0269-0270: x 04                                                               # bundleSize: 16
+0288-0289: x 04                                                               # bundleSize: 16
 # Offsets table
-0270-0271: x 01                                                               # encoding: 1b
-0271-0272: x 00                                                               # data[0] = 0 [48 overall]
-0272-0273: x 00                                                               # data[1] = 0 [48 overall]
-0273-0274: x 01                                                               # data[2] = 1 [49 overall]
-0274-0275: x 02                                                               # data[3] = 2 [50 overall]
-0275-0276: x 03                                                               # data[4] = 3 [51 overall]
+0289-0290: x 01                                                               # encoding: 1b
+0290-0291: x 00                                                               # data[0] = 0 [53 overall]
+0291-0292: x 00                                                               # data[1] = 0 [53 overall]
+0292-0293: x 01                                                               # data[2] = 1 [54 overall]
+0293-0294: x 02                                                               # data[3] = 2 [55 overall]
+0294-0295: x 03                                                               # data[4] = 3 [56 overall]
 # Data
-0276-0276: x                                                                  # data[00]:  (block prefix)
-0276-0276: x                                                                  # data[01]:  (bundle prefix)
-0276-0277: x 67                                                               # data[02]: g
-0277-0278: x 68                                                               # data[03]: h
-0278-0279: x 69                                                               # data[04]: i
+0295-0295: x                                                                  # data[00]:  (block prefix)
+0295-0295: x                                                                  # data[01]:  (bundle prefix)
+0295-0296: x 66                                                               # data[02]: f
+0296-0297: x 67                                                               # data[03]: g
+0297-0298: x 68                                                               # data[04]: h
 # data for column 1
 # rawbytes
 # offsets table
-0279-0280: x 00                                                               # encoding: zero
+0298-0299: x 00                                                               # encoding: zero
 # data
-0280-0280: x                                                                  # data[0]:
-0280-0280: x                                                                  # data[1]:
-0280-0280: x                                                                  # data[2]:
+0299-0299: x                                                                  # data[0]:
+0299-0299: x                                                                  # data[1]:
+0299-0299: x                                                                  # data[2]:
 # data for column 2
-0280-0281: x 80                                                               # encoding: const
-0281-0289: x 0101000000000000                                                 # 64-bit constant: 257
+0299-0300: x 80                                                               # encoding: const
+0300-0308: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-0289-0290: x 00                                                               # bitmap encoding
-0290-0292: x 0000                                                             # padding to align to 64-bit boundary
-0292-0300: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0300-0308: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+0308-0309: x 00                                                               # bitmap encoding
+0309-0314: x 0000000000                                                       # padding to align to 64-bit boundary
+0314-0322: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+0322-0330: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-0308-0309: x 01                                                               # encoding: 1b
-0309-0310: x 00                                                               # data[0] = 0 [85 overall]
-0310-0311: x 0a                                                               # data[1] = 10 [95 overall]
-0311-0312: x 12                                                               # data[2] = 18 [103 overall]
-0312-0313: x 16                                                               # data[3] = 22 [107 overall]
+0330-0331: x 01                                                               # encoding: 1b
+0331-0332: x 00                                                               # data[0] = 0 [93 overall]
+0332-0333: x 03                                                               # data[1] = 3 [96 overall]
+0333-0334: x 0d                                                               # data[2] = 13 [106 overall]
+0334-0335: x 15                                                               # data[3] = 21 [114 overall]
 # data
-0313-0323: x 67726170656672756974                                             # data[0]: grapefruit
-0323-0331: x 686f6e6579646577                                                 # data[1]: honeydew
-0331-0335: x 696d6265                                                         # data[2]: imbe
+0335-0338: x 666967                                                           # data[0]: fig
+0338-0348: x 67726170656672756974                                             # data[1]: grapefruit
+0348-0356: x 686f6e6579646577                                                 # data[2]: honeydew
 # data for column 5
-0335-0336: x 01                                                               # bitmap encoding
-0336-0337: x 00                                                               # block padding byte
-0337-0342: x 00595c9cc2                                                       # data block trailer
-# block 3 data (0342-0453)
+0356-0357: x 01                                                               # bitmap encoding
+# data for column 6
+0357-0358: x 01                                                               # bitmap encoding
+0358-0359: x 00                                                               # block padding byte
+0359-0364: x 00c6ef4ef7                                                       # data block trailer
+# block 3 data (0364-0477)
 # data block header
-0342-0346: x 01000000                                                         # maximum key length: 1
+0364-0368: x 01000000                                                         # maximum key length: 1
 # columnar block header
-0346-0347: x 01                                                               # version 1
-0347-0349: x 0600                                                             # 6 columns
-0349-0353: x 04000000                                                         # 4 rows
-0353-0354: b 00000100                                                         # col 0: prefixbytes
-0354-0358: x 29000000                                                         # col 0: page start 41
-0358-0359: b 00000011                                                         # col 1: bytes
-0359-0363: x 35000000                                                         # col 1: page start 53
-0363-0364: b 00000010                                                         # col 2: uint
-0364-0368: x 36000000                                                         # col 2: page start 54
-0368-0369: b 00000001                                                         # col 3: bool
-0369-0373: x 3f000000                                                         # col 3: page start 63
-0373-0374: b 00000011                                                         # col 4: bytes
-0374-0378: x 50000000                                                         # col 4: page start 80
-0378-0379: b 00000001                                                         # col 5: bool
-0379-0383: x 6d000000                                                         # col 5: page start 109
+0368-0369: x 01                                                               # version 1
+0369-0371: x 0700                                                             # 7 columns
+0371-0375: x 03000000                                                         # 3 rows
+0375-0376: b 00000100                                                         # col 0: prefixbytes
+0376-0380: x 2e000000                                                         # col 0: page start 46
+0380-0381: b 00000011                                                         # col 1: bytes
+0381-0385: x 38000000                                                         # col 1: page start 56
+0385-0386: b 00000010                                                         # col 2: uint
+0386-0390: x 39000000                                                         # col 2: page start 57
+0390-0391: b 00000001                                                         # col 3: bool
+0391-0395: x 42000000                                                         # col 3: page start 66
+0395-0396: b 00000011                                                         # col 4: bytes
+0396-0400: x 58000000                                                         # col 4: page start 88
+0400-0401: b 00000001                                                         # col 5: bool
+0401-0405: x 6e000000                                                         # col 5: page start 110
+0405-0406: b 00000001                                                         # col 6: bool
+0406-0410: x 6f000000                                                         # col 6: page start 111
 # data for column 0
 # PrefixBytes
-0383-0384: x 04                                                               # bundleSize: 16
+0410-0411: x 04                                                               # bundleSize: 16
 # Offsets table
-0384-0385: x 01                                                               # encoding: 1b
-0385-0386: x 00                                                               # data[0] = 0 [49 overall]
-0386-0387: x 00                                                               # data[1] = 0 [49 overall]
-0387-0388: x 01                                                               # data[2] = 1 [50 overall]
-0388-0389: x 02                                                               # data[3] = 2 [51 overall]
-0389-0390: x 03                                                               # data[4] = 3 [52 overall]
-0390-0391: x 04                                                               # data[5] = 4 [53 overall]
+0411-0412: x 01                                                               # encoding: 1b
+0412-0413: x 00                                                               # data[0] = 0 [53 overall]
+0413-0414: x 00                                                               # data[1] = 0 [53 overall]
+0414-0415: x 01                                                               # data[2] = 1 [54 overall]
+0415-0416: x 02                                                               # data[3] = 2 [55 overall]
+0416-0417: x 03                                                               # data[4] = 3 [56 overall]
 # Data
-0391-0391: x                                                                  # data[00]:  (block prefix)
-0391-0391: x                                                                  # data[01]:  (bundle prefix)
-0391-0392: x 6a                                                               # data[02]: j
-0392-0393: x 6b                                                               # data[03]: k
-0393-0394: x 6c                                                               # data[04]: l
-0394-0395: x 6d                                                               # data[05]: m
+0417-0417: x                                                                  # data[00]:  (block prefix)
+0417-0417: x                                                                  # data[01]:  (bundle prefix)
+0417-0418: x 69                                                               # data[02]: i
+0418-0419: x 6a                                                               # data[03]: j
+0419-0420: x 6b                                                               # data[04]: k
 # data for column 1
 # rawbytes
 # offsets table
-0395-0396: x 00                                                               # encoding: zero
+0420-0421: x 00                                                               # encoding: zero
 # data
-0396-0396: x                                                                  # data[0]:
-0396-0396: x                                                                  # data[1]:
-0396-0396: x                                                                  # data[2]:
-0396-0396: x                                                                  # data[3]:
+0421-0421: x                                                                  # data[0]:
+0421-0421: x                                                                  # data[1]:
+0421-0421: x                                                                  # data[2]:
 # data for column 2
-0396-0397: x 80                                                               # encoding: const
-0397-0405: x 0101000000000000                                                 # 64-bit constant: 257
+0421-0422: x 80                                                               # encoding: const
+0422-0430: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-0405-0406: x 00                                                               # bitmap encoding
-0406-0414: b 0000111100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0414-0422: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+0430-0431: x 00                                                               # bitmap encoding
+0431-0436: x 0000000000                                                       # padding to align to 64-bit boundary
+0436-0444: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+0444-0452: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-0422-0423: x 01                                                               # encoding: 1b
-0423-0424: x 00                                                               # data[0] = 0 [86 overall]
-0424-0425: x 09                                                               # data[1] = 9 [95 overall]
-0425-0426: x 0d                                                               # data[2] = 13 [99 overall]
-0426-0427: x 12                                                               # data[3] = 18 [104 overall]
-0427-0428: x 17                                                               # data[4] = 23 [109 overall]
+0452-0453: x 01                                                               # encoding: 1b
+0453-0454: x 00                                                               # data[0] = 0 [93 overall]
+0454-0455: x 04                                                               # data[1] = 4 [97 overall]
+0455-0456: x 0d                                                               # data[2] = 13 [106 overall]
+0456-0457: x 11                                                               # data[3] = 17 [110 overall]
 # data
-0428-0437: x 6a61636b6672756974                                               # data[0]: jackfruit
-0437-0441: x 6b697769                                                         # data[1]: kiwi
-0441-0446: x 6c656d6f6e                                                       # data[2]: lemon
-0446-0451: x 6d616e676f                                                       # data[3]: mango
+0457-0461: x 696d6265                                                         # data[0]: imbe
+0461-0470: x 6a61636b6672756974                                               # data[1]: jackfruit
+0470-0474: x 6b697769                                                         # data[2]: kiwi
 # data for column 5
-0451-0452: x 01                                                               # bitmap encoding
-0452-0453: x 00                                                               # block padding byte
-0453-0458: x 005ebf5b33                                                       # data block trailer
-# block 4 data (0458-0572)
+0474-0475: x 01                                                               # bitmap encoding
+# data for column 6
+0475-0476: x 01                                                               # bitmap encoding
+0476-0477: x 00                                                               # block padding byte
+0477-0482: x 0006f8d16c                                                       # data block trailer
+# block 4 data (0482-0597)
 # data block header
-0458-0462: x 01000000                                                         # maximum key length: 1
+0482-0486: x 01000000                                                         # maximum key length: 1
 # columnar block header
-0462-0463: x 01                                                               # version 1
-0463-0465: x 0600                                                             # 6 columns
-0465-0469: x 03000000                                                         # 3 rows
-0469-0470: b 00000100                                                         # col 0: prefixbytes
-0470-0474: x 29000000                                                         # col 0: page start 41
-0474-0475: b 00000011                                                         # col 1: bytes
-0475-0479: x 33000000                                                         # col 1: page start 51
-0479-0480: b 00000010                                                         # col 2: uint
-0480-0484: x 34000000                                                         # col 2: page start 52
-0484-0485: b 00000001                                                         # col 3: bool
-0485-0489: x 3d000000                                                         # col 3: page start 61
-0489-0490: b 00000011                                                         # col 4: bytes
-0490-0494: x 50000000                                                         # col 4: page start 80
-0494-0495: b 00000001                                                         # col 5: bool
-0495-0499: x 70000000                                                         # col 5: page start 112
+0486-0487: x 01                                                               # version 1
+0487-0489: x 0700                                                             # 7 columns
+0489-0493: x 03000000                                                         # 3 rows
+0493-0494: b 00000100                                                         # col 0: prefixbytes
+0494-0498: x 2e000000                                                         # col 0: page start 46
+0498-0499: b 00000011                                                         # col 1: bytes
+0499-0503: x 38000000                                                         # col 1: page start 56
+0503-0504: b 00000010                                                         # col 2: uint
+0504-0508: x 39000000                                                         # col 2: page start 57
+0508-0509: b 00000001                                                         # col 3: bool
+0509-0513: x 42000000                                                         # col 3: page start 66
+0513-0514: b 00000011                                                         # col 4: bytes
+0514-0518: x 58000000                                                         # col 4: page start 88
+0518-0519: b 00000001                                                         # col 5: bool
+0519-0523: x 70000000                                                         # col 5: page start 112
+0523-0524: b 00000001                                                         # col 6: bool
+0524-0528: x 71000000                                                         # col 6: page start 113
 # data for column 0
 # PrefixBytes
-0499-0500: x 04                                                               # bundleSize: 16
+0528-0529: x 04                                                               # bundleSize: 16
 # Offsets table
-0500-0501: x 01                                                               # encoding: 1b
-0501-0502: x 00                                                               # data[0] = 0 [48 overall]
-0502-0503: x 00                                                               # data[1] = 0 [48 overall]
-0503-0504: x 01                                                               # data[2] = 1 [49 overall]
-0504-0505: x 02                                                               # data[3] = 2 [50 overall]
-0505-0506: x 03                                                               # data[4] = 3 [51 overall]
+0529-0530: x 01                                                               # encoding: 1b
+0530-0531: x 00                                                               # data[0] = 0 [53 overall]
+0531-0532: x 00                                                               # data[1] = 0 [53 overall]
+0532-0533: x 01                                                               # data[2] = 1 [54 overall]
+0533-0534: x 02                                                               # data[3] = 2 [55 overall]
+0534-0535: x 03                                                               # data[4] = 3 [56 overall]
 # Data
-0506-0506: x                                                                  # data[00]:  (block prefix)
-0506-0506: x                                                                  # data[01]:  (bundle prefix)
-0506-0507: x 6e                                                               # data[02]: n
-0507-0508: x 6f                                                               # data[03]: o
-0508-0509: x 70                                                               # data[04]: p
+0535-0535: x                                                                  # data[00]:  (block prefix)
+0535-0535: x                                                                  # data[01]:  (bundle prefix)
+0535-0536: x 6c                                                               # data[02]: l
+0536-0537: x 6d                                                               # data[03]: m
+0537-0538: x 6e                                                               # data[04]: n
 # data for column 1
 # rawbytes
 # offsets table
-0509-0510: x 00                                                               # encoding: zero
+0538-0539: x 00                                                               # encoding: zero
 # data
-0510-0510: x                                                                  # data[0]:
-0510-0510: x                                                                  # data[1]:
-0510-0510: x                                                                  # data[2]:
+0539-0539: x                                                                  # data[0]:
+0539-0539: x                                                                  # data[1]:
+0539-0539: x                                                                  # data[2]:
 # data for column 2
-0510-0511: x 80                                                               # encoding: const
-0511-0519: x 0101000000000000                                                 # 64-bit constant: 257
+0539-0540: x 80                                                               # encoding: const
+0540-0548: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-0519-0520: x 00                                                               # bitmap encoding
-0520-0522: x 0000                                                             # padding to align to 64-bit boundary
-0522-0530: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0530-0538: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+0548-0549: x 00                                                               # bitmap encoding
+0549-0554: x 0000000000                                                       # padding to align to 64-bit boundary
+0554-0562: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+0562-0570: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-0538-0539: x 01                                                               # encoding: 1b
-0539-0540: x 00                                                               # data[0] = 0 [85 overall]
-0540-0541: x 09                                                               # data[1] = 9 [94 overall]
-0541-0542: x 0f                                                               # data[2] = 15 [100 overall]
-0542-0543: x 1b                                                               # data[3] = 27 [112 overall]
+0570-0571: x 01                                                               # encoding: 1b
+0571-0572: x 00                                                               # data[0] = 0 [93 overall]
+0572-0573: x 05                                                               # data[1] = 5 [98 overall]
+0573-0574: x 0a                                                               # data[2] = 10 [103 overall]
+0574-0575: x 13                                                               # data[3] = 19 [112 overall]
 # data
-0543-0552: x 6e6563746172696e65                                               # data[0]: nectarine
-0552-0558: x 6f72616e6765                                                     # data[1]: orange
-0558-0570: x 70616d706c656d6f75737365                                         # data[2]: pamplemousse
+0575-0580: x 6c656d6f6e                                                       # data[0]: lemon
+0580-0585: x 6d616e676f                                                       # data[1]: mango
+0585-0594: x 6e6563746172696e65                                               # data[2]: nectarine
 # data for column 5
-0570-0571: x 01                                                               # bitmap encoding
-0571-0572: x 00                                                               # block padding byte
-0572-0577: x 008e3c8f2c                                                       # data block trailer
-# block 5 data (0577-0689)
+0594-0595: x 01                                                               # bitmap encoding
+# data for column 6
+0595-0596: x 01                                                               # bitmap encoding
+0596-0597: x 00                                                               # block padding byte
+0597-0602: x 00b8471d43                                                       # data block trailer
+# block 5 data (0602-0715)
 # data block header
-0577-0581: x 01000000                                                         # maximum key length: 1
+0602-0606: x 01000000                                                         # maximum key length: 1
 # columnar block header
-0581-0582: x 01                                                               # version 1
-0582-0584: x 0600                                                             # 6 columns
-0584-0588: x 03000000                                                         # 3 rows
-0588-0589: b 00000100                                                         # col 0: prefixbytes
-0589-0593: x 29000000                                                         # col 0: page start 41
-0593-0594: b 00000011                                                         # col 1: bytes
-0594-0598: x 33000000                                                         # col 1: page start 51
-0598-0599: b 00000010                                                         # col 2: uint
-0599-0603: x 34000000                                                         # col 2: page start 52
-0603-0604: b 00000001                                                         # col 3: bool
-0604-0608: x 3d000000                                                         # col 3: page start 61
-0608-0609: b 00000011                                                         # col 4: bytes
-0609-0613: x 50000000                                                         # col 4: page start 80
-0613-0614: b 00000001                                                         # col 5: bool
-0614-0618: x 6e000000                                                         # col 5: page start 110
+0606-0607: x 01                                                               # version 1
+0607-0609: x 0700                                                             # 7 columns
+0609-0613: x 02000000                                                         # 2 rows
+0613-0614: b 00000100                                                         # col 0: prefixbytes
+0614-0618: x 2e000000                                                         # col 0: page start 46
+0618-0619: b 00000011                                                         # col 1: bytes
+0619-0623: x 36000000                                                         # col 1: page start 54
+0623-0624: b 00000010                                                         # col 2: uint
+0624-0628: x 37000000                                                         # col 2: page start 55
+0628-0629: b 00000001                                                         # col 3: bool
+0629-0633: x 40000000                                                         # col 3: page start 64
+0633-0634: b 00000011                                                         # col 4: bytes
+0634-0638: x 58000000                                                         # col 4: page start 88
+0638-0639: b 00000001                                                         # col 5: bool
+0639-0643: x 6e000000                                                         # col 5: page start 110
+0643-0644: b 00000001                                                         # col 6: bool
+0644-0648: x 6f000000                                                         # col 6: page start 111
 # data for column 0
 # PrefixBytes
-0618-0619: x 04                                                               # bundleSize: 16
+0648-0649: x 04                                                               # bundleSize: 16
 # Offsets table
-0619-0620: x 01                                                               # encoding: 1b
-0620-0621: x 00                                                               # data[0] = 0 [48 overall]
-0621-0622: x 00                                                               # data[1] = 0 [48 overall]
-0622-0623: x 01                                                               # data[2] = 1 [49 overall]
-0623-0624: x 02                                                               # data[3] = 2 [50 overall]
-0624-0625: x 03                                                               # data[4] = 3 [51 overall]
+0649-0650: x 01                                                               # encoding: 1b
+0650-0651: x 00                                                               # data[0] = 0 [52 overall]
+0651-0652: x 00                                                               # data[1] = 0 [52 overall]
+0652-0653: x 01                                                               # data[2] = 1 [53 overall]
+0653-0654: x 02                                                               # data[3] = 2 [54 overall]
 # Data
-0625-0625: x                                                                  # data[00]:  (block prefix)
-0625-0625: x                                                                  # data[01]:  (bundle prefix)
-0625-0626: x 71                                                               # data[02]: q
-0626-0627: x 72                                                               # data[03]: r
-0627-0628: x 73                                                               # data[04]: s
+0654-0654: x                                                                  # data[00]:  (block prefix)
+0654-0654: x                                                                  # data[01]:  (bundle prefix)
+0654-0655: x 6f                                                               # data[02]: o
+0655-0656: x 70                                                               # data[03]: p
 # data for column 1
 # rawbytes
 # offsets table
-0628-0629: x 00                                                               # encoding: zero
+0656-0657: x 00                                                               # encoding: zero
 # data
-0629-0629: x                                                                  # data[0]:
-0629-0629: x                                                                  # data[1]:
-0629-0629: x                                                                  # data[2]:
+0657-0657: x                                                                  # data[0]:
+0657-0657: x                                                                  # data[1]:
 # data for column 2
-0629-0630: x 80                                                               # encoding: const
-0630-0638: x 0101000000000000                                                 # 64-bit constant: 257
+0657-0658: x 80                                                               # encoding: const
+0658-0666: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-0638-0639: x 00                                                               # bitmap encoding
-0639-0641: x 0000                                                             # padding to align to 64-bit boundary
-0641-0649: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0649-0657: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+0666-0667: x 00                                                               # bitmap encoding
+0667-0674: x 00000000000000                                                   # padding to align to 64-bit boundary
+0674-0682: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+0682-0690: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-0657-0658: x 01                                                               # encoding: 1b
-0658-0659: x 00                                                               # data[0] = 0 [85 overall]
-0659-0660: x 06                                                               # data[1] = 6 [91 overall]
-0660-0661: x 0f                                                               # data[2] = 15 [100 overall]
-0661-0662: x 19                                                               # data[3] = 25 [110 overall]
+0690-0691: x 01                                                               # encoding: 1b
+0691-0692: x 00                                                               # data[0] = 0 [92 overall]
+0692-0693: x 06                                                               # data[1] = 6 [98 overall]
+0693-0694: x 12                                                               # data[2] = 18 [110 overall]
 # data
-0662-0668: x 7175696e6365                                                     # data[0]: quince
-0668-0677: x 726173706265727279                                               # data[1]: raspberry
-0677-0687: x 73747261776265727279                                             # data[2]: strawberry
+0694-0700: x 6f72616e6765                                                     # data[0]: orange
+0700-0712: x 70616d706c656d6f75737365                                         # data[1]: pamplemousse
 # data for column 5
-0687-0688: x 01                                                               # bitmap encoding
-0688-0689: x 00                                                               # block padding byte
-0689-0694: x 0030469e54                                                       # data block trailer
-# block 6 data (0694-0792)
+0712-0713: x 01                                                               # bitmap encoding
+# data for column 6
+0713-0714: x 01                                                               # bitmap encoding
+0714-0715: x 00                                                               # block padding byte
+0715-0720: x 0098bca1c9                                                       # data block trailer
+# block 6 data (0720-0830)
 # data block header
-0694-0698: x 01000000                                                         # maximum key length: 1
+0720-0724: x 01000000                                                         # maximum key length: 1
 # columnar block header
-0698-0699: x 01                                                               # version 1
-0699-0701: x 0600                                                             # 6 columns
-0701-0705: x 02000000                                                         # 2 rows
-0705-0706: b 00000100                                                         # col 0: prefixbytes
-0706-0710: x 29000000                                                         # col 0: page start 41
-0710-0711: b 00000011                                                         # col 1: bytes
-0711-0715: x 31000000                                                         # col 1: page start 49
-0715-0716: b 00000010                                                         # col 2: uint
-0716-0720: x 32000000                                                         # col 2: page start 50
-0720-0721: b 00000001                                                         # col 3: bool
-0721-0725: x 3b000000                                                         # col 3: page start 59
-0725-0726: b 00000011                                                         # col 4: bytes
-0726-0730: x 50000000                                                         # col 4: page start 80
-0730-0731: b 00000001                                                         # col 5: bool
-0731-0735: x 60000000                                                         # col 5: page start 96
+0724-0725: x 01                                                               # version 1
+0725-0727: x 0700                                                             # 7 columns
+0727-0731: x 02000000                                                         # 2 rows
+0731-0732: b 00000100                                                         # col 0: prefixbytes
+0732-0736: x 2e000000                                                         # col 0: page start 46
+0736-0737: b 00000011                                                         # col 1: bytes
+0737-0741: x 36000000                                                         # col 1: page start 54
+0741-0742: b 00000010                                                         # col 2: uint
+0742-0746: x 37000000                                                         # col 2: page start 55
+0746-0747: b 00000001                                                         # col 3: bool
+0747-0751: x 40000000                                                         # col 3: page start 64
+0751-0752: b 00000011                                                         # col 4: bytes
+0752-0756: x 58000000                                                         # col 4: page start 88
+0756-0757: b 00000001                                                         # col 5: bool
+0757-0761: x 6b000000                                                         # col 5: page start 107
+0761-0762: b 00000001                                                         # col 6: bool
+0762-0766: x 6c000000                                                         # col 6: page start 108
 # data for column 0
 # PrefixBytes
-0735-0736: x 04                                                               # bundleSize: 16
+0766-0767: x 04                                                               # bundleSize: 16
 # Offsets table
-0736-0737: x 01                                                               # encoding: 1b
-0737-0738: x 00                                                               # data[0] = 0 [47 overall]
-0738-0739: x 00                                                               # data[1] = 0 [47 overall]
-0739-0740: x 01                                                               # data[2] = 1 [48 overall]
-0740-0741: x 02                                                               # data[3] = 2 [49 overall]
+0767-0768: x 01                                                               # encoding: 1b
+0768-0769: x 00                                                               # data[0] = 0 [52 overall]
+0769-0770: x 00                                                               # data[1] = 0 [52 overall]
+0770-0771: x 01                                                               # data[2] = 1 [53 overall]
+0771-0772: x 02                                                               # data[3] = 2 [54 overall]
 # Data
-0741-0741: x                                                                  # data[00]:  (block prefix)
-0741-0741: x                                                                  # data[01]:  (bundle prefix)
-0741-0742: x 74                                                               # data[02]: t
-0742-0743: x 75                                                               # data[03]: u
+0772-0772: x                                                                  # data[00]:  (block prefix)
+0772-0772: x                                                                  # data[01]:  (bundle prefix)
+0772-0773: x 71                                                               # data[02]: q
+0773-0774: x 72                                                               # data[03]: r
 # data for column 1
 # rawbytes
 # offsets table
-0743-0744: x 00                                                               # encoding: zero
+0774-0775: x 00                                                               # encoding: zero
 # data
-0744-0744: x                                                                  # data[0]:
-0744-0744: x                                                                  # data[1]:
+0775-0775: x                                                                  # data[0]:
+0775-0775: x                                                                  # data[1]:
 # data for column 2
-0744-0745: x 80                                                               # encoding: const
-0745-0753: x 0101000000000000                                                 # 64-bit constant: 257
+0775-0776: x 80                                                               # encoding: const
+0776-0784: x 0101000000000000                                                 # 64-bit constant: 257
 # data for column 3
-0753-0754: x 00                                                               # bitmap encoding
-0754-0758: x 00000000                                                         # padding to align to 64-bit boundary
-0758-0766: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0766-0774: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+0784-0785: x 00                                                               # bitmap encoding
+0785-0792: x 00000000000000                                                   # padding to align to 64-bit boundary
+0792-0800: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+0800-0808: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 # data for column 4
 # rawbytes
 # offsets table
-0774-0775: x 01                                                               # encoding: 1b
-0775-0776: x 00                                                               # data[0] = 0 [84 overall]
-0776-0777: x 09                                                               # data[1] = 9 [93 overall]
-0777-0778: x 0c                                                               # data[2] = 12 [96 overall]
+0808-0809: x 01                                                               # encoding: 1b
+0809-0810: x 00                                                               # data[0] = 0 [92 overall]
+0810-0811: x 06                                                               # data[1] = 6 [98 overall]
+0811-0812: x 0f                                                               # data[2] = 15 [107 overall]
 # data
-0778-0787: x 74616e676572696e65                                               # data[0]: tangerine
-0787-0790: x 756d65                                                           # data[1]: ume
+0812-0818: x 7175696e6365                                                     # data[0]: quince
+0818-0827: x 726173706265727279                                               # data[1]: raspberry
 # data for column 5
-0790-0791: x 01                                                               # bitmap encoding
-0791-0792: x 00                                                               # block padding byte
-0792-0797: x 00ebbaeb58                                                       # data block trailer
-# block 7 index (0797-0865)
+0827-0828: x 01                                                               # bitmap encoding
+# data for column 6
+0828-0829: x 01                                                               # bitmap encoding
+0829-0830: x 00                                                               # block padding byte
+0830-0835: x 008a91d79e                                                       # data block trailer
+# block 7 data (0835-0949)
+# data block header
+0835-0839: x 01000000                                                         # maximum key length: 1
+# columnar block header
+0839-0840: x 01                                                               # version 1
+0840-0842: x 0700                                                             # 7 columns
+0842-0846: x 02000000                                                         # 2 rows
+0846-0847: b 00000100                                                         # col 0: prefixbytes
+0847-0851: x 2e000000                                                         # col 0: page start 46
+0851-0852: b 00000011                                                         # col 1: bytes
+0852-0856: x 36000000                                                         # col 1: page start 54
+0856-0857: b 00000010                                                         # col 2: uint
+0857-0861: x 37000000                                                         # col 2: page start 55
+0861-0862: b 00000001                                                         # col 3: bool
+0862-0866: x 40000000                                                         # col 3: page start 64
+0866-0867: b 00000011                                                         # col 4: bytes
+0867-0871: x 58000000                                                         # col 4: page start 88
+0871-0872: b 00000001                                                         # col 5: bool
+0872-0876: x 6f000000                                                         # col 5: page start 111
+0876-0877: b 00000001                                                         # col 6: bool
+0877-0881: x 70000000                                                         # col 6: page start 112
+# data for column 0
+# PrefixBytes
+0881-0882: x 04                                                               # bundleSize: 16
+# Offsets table
+0882-0883: x 01                                                               # encoding: 1b
+0883-0884: x 00                                                               # data[0] = 0 [52 overall]
+0884-0885: x 00                                                               # data[1] = 0 [52 overall]
+0885-0886: x 01                                                               # data[2] = 1 [53 overall]
+0886-0887: x 02                                                               # data[3] = 2 [54 overall]
+# Data
+0887-0887: x                                                                  # data[00]:  (block prefix)
+0887-0887: x                                                                  # data[01]:  (bundle prefix)
+0887-0888: x 73                                                               # data[02]: s
+0888-0889: x 74                                                               # data[03]: t
+# data for column 1
+# rawbytes
+# offsets table
+0889-0890: x 00                                                               # encoding: zero
+# data
+0890-0890: x                                                                  # data[0]:
+0890-0890: x                                                                  # data[1]:
+# data for column 2
+0890-0891: x 80                                                               # encoding: const
+0891-0899: x 0101000000000000                                                 # 64-bit constant: 257
+# data for column 3
+0899-0900: x 00                                                               # bitmap encoding
+0900-0907: x 00000000000000                                                   # padding to align to 64-bit boundary
+0907-0915: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+0915-0923: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+# data for column 4
+# rawbytes
+# offsets table
+0923-0924: x 01                                                               # encoding: 1b
+0924-0925: x 00                                                               # data[0] = 0 [92 overall]
+0925-0926: x 0a                                                               # data[1] = 10 [102 overall]
+0926-0927: x 13                                                               # data[2] = 19 [111 overall]
+# data
+0927-0937: x 73747261776265727279                                             # data[0]: strawberry
+0937-0946: x 74616e676572696e65                                               # data[1]: tangerine
+# data for column 5
+0946-0947: x 01                                                               # bitmap encoding
+# data for column 6
+0947-0948: x 01                                                               # bitmap encoding
+0948-0949: x 00                                                               # block padding byte
+0949-0954: x 002bb22760                                                       # data block trailer
+# block 8 data (0954-1043)
+# data block header
+0954-0958: x 01000000                                                         # maximum key length: 1
+# columnar block header
+0958-0959: x 01                                                               # version 1
+0959-0961: x 0700                                                             # 7 columns
+0961-0965: x 01000000                                                         # 1 rows
+0965-0966: b 00000100                                                         # col 0: prefixbytes
+0966-0970: x 2e000000                                                         # col 0: page start 46
+0970-0971: b 00000011                                                         # col 1: bytes
+0971-0975: x 34000000                                                         # col 1: page start 52
+0975-0976: b 00000010                                                         # col 2: uint
+0976-0980: x 35000000                                                         # col 2: page start 53
+0980-0981: b 00000001                                                         # col 3: bool
+0981-0985: x 3e000000                                                         # col 3: page start 62
+0985-0986: b 00000011                                                         # col 4: bytes
+0986-0990: x 50000000                                                         # col 4: page start 80
+0990-0991: b 00000001                                                         # col 5: bool
+0991-0995: x 56000000                                                         # col 5: page start 86
+0995-0996: b 00000001                                                         # col 6: bool
+0996-1000: x 57000000                                                         # col 6: page start 87
+# data for column 0
+# PrefixBytes
+1000-1001: x 04                                                               # bundleSize: 16
+# Offsets table
+1001-1002: x 01                                                               # encoding: 1b
+1002-1003: x 01                                                               # data[0] = 1 [52 overall]
+1003-1004: x 01                                                               # data[1] = 1 [52 overall]
+1004-1005: x 01                                                               # data[2] = 1 [52 overall]
+# Data
+1005-1006: x 75                                                               # data[00]: u (block prefix)
+1006-1006: x                                                                  # data[01]: . (bundle prefix)
+1006-1006: x                                                                  # data[02]: .
+# data for column 1
+# rawbytes
+# offsets table
+1006-1007: x 00                                                               # encoding: zero
+# data
+1007-1007: x                                                                  # data[0]:
+# data for column 2
+1007-1008: x 80                                                               # encoding: const
+1008-1016: x 0101000000000000                                                 # 64-bit constant: 257
+# data for column 3
+1016-1017: x 00                                                               # bitmap encoding
+1017-1018: x 00                                                               # padding to align to 64-bit boundary
+1018-1026: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+1026-1034: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+# data for column 4
+# rawbytes
+# offsets table
+1034-1035: x 01                                                               # encoding: 1b
+1035-1036: x 00                                                               # data[0] = 0 [83 overall]
+1036-1037: x 03                                                               # data[1] = 3 [86 overall]
+# data
+1037-1040: x 756d65                                                           # data[0]: ume
+# data for column 5
+1040-1041: x 01                                                               # bitmap encoding
+# data for column 6
+1041-1042: x 01                                                               # bitmap encoding
+1042-1043: x 00                                                               # block padding byte
+1043-1048: x 00e86e8c22                                                       # data block trailer
+# block 9 index (1048-1126)
 # index block header
 # columnar block header
-0797-0798: x 01                                                               # version 1
-0798-0800: x 0400                                                             # 4 columns
-0800-0804: x 07000000                                                         # 7 rows
-0804-0805: b 00000011                                                         # col 0: bytes
-0805-0809: x 1b000000                                                         # col 0: page start 27
-0809-0810: b 00000010                                                         # col 1: uint
-0810-0814: x 2b000000                                                         # col 1: page start 43
-0814-0815: b 00000010                                                         # col 2: uint
-0815-0819: x 3a000000                                                         # col 2: page start 58
-0819-0820: b 00000011                                                         # col 3: bytes
-0820-0824: x 42000000                                                         # col 3: page start 66
+1048-1049: x 01                                                               # version 1
+1049-1051: x 0400                                                             # 4 columns
+1051-1055: x 09000000                                                         # 9 rows
+1055-1056: b 00000011                                                         # col 0: bytes
+1056-1060: x 1b000000                                                         # col 0: page start 27
+1060-1061: b 00000010                                                         # col 1: uint
+1061-1065: x 2f000000                                                         # col 1: page start 47
+1065-1066: b 00000010                                                         # col 2: uint
+1066-1070: x 42000000                                                         # col 2: page start 66
+1070-1071: b 00000011                                                         # col 3: bytes
+1071-1075: x 4c000000                                                         # col 3: page start 76
 # data for column 0
 # rawbytes
 # offsets table
-0824-0825: x 01                                                               # encoding: 1b
-0825-0826: x 00                                                               # data[0] = 0 [36 overall]
-0826-0827: x 01                                                               # data[1] = 1 [37 overall]
-0827-0828: x 02                                                               # data[2] = 2 [38 overall]
-0828-0829: x 03                                                               # data[3] = 3 [39 overall]
-0829-0830: x 04                                                               # data[4] = 4 [40 overall]
-0830-0831: x 05                                                               # data[5] = 5 [41 overall]
-0831-0832: x 06                                                               # data[6] = 6 [42 overall]
-0832-0833: x 07                                                               # data[7] = 7 [43 overall]
+1075-1076: x 01                                                               # encoding: 1b
+1076-1077: x 00                                                               # data[0] = 0 [38 overall]
+1077-1078: x 01                                                               # data[1] = 1 [39 overall]
+1078-1079: x 02                                                               # data[2] = 2 [40 overall]
+1079-1080: x 03                                                               # data[3] = 3 [41 overall]
+1080-1081: x 04                                                               # data[4] = 4 [42 overall]
+1081-1082: x 05                                                               # data[5] = 5 [43 overall]
+1082-1083: x 06                                                               # data[6] = 6 [44 overall]
+1083-1084: x 07                                                               # data[7] = 7 [45 overall]
+1084-1085: x 08                                                               # data[8] = 8 [46 overall]
+1085-1086: x 09                                                               # data[9] = 9 [47 overall]
 # data
-0833-0834: x 63                                                               # data[0]: c
-0834-0835: x 66                                                               # data[1]: f
-0835-0836: x 69                                                               # data[2]: i
-0836-0837: x 6d                                                               # data[3]: m
-0837-0838: x 70                                                               # data[4]: p
-0838-0839: x 73                                                               # data[5]: s
-0839-0840: x 76                                                               # data[6]: v
+1086-1087: x 63                                                               # data[0]: c
+1087-1088: x 65                                                               # data[1]: e
+1088-1089: x 68                                                               # data[2]: h
+1089-1090: x 6b                                                               # data[3]: k
+1090-1091: x 6e                                                               # data[4]: n
+1091-1092: x 70                                                               # data[5]: p
+1092-1093: x 72                                                               # data[6]: r
+1093-1094: x 74                                                               # data[7]: t
+1094-1095: x 76                                                               # data[8]: v
 # data for column 1
-0840-0841: x 02                                                               # encoding: 2b
-0841-0843: x 0000                                                             # data[0] = 0
-0843-0845: x 7000                                                             # data[1] = 112
-0845-0847: x e400                                                             # data[2] = 228
-0847-0849: x 5601                                                             # data[3] = 342
-0849-0851: x ca01                                                             # data[4] = 458
-0851-0853: x 4102                                                             # data[5] = 577
-0853-0855: x b602                                                             # data[6] = 694
+1095-1096: x 02                                                               # encoding: 2b
+1096-1098: x 0000                                                             # data[0] = 0
+1098-1100: x 7900                                                             # data[1] = 121
+1100-1102: x f200                                                             # data[2] = 242
+1102-1104: x 6c01                                                             # data[3] = 364
+1104-1106: x e201                                                             # data[4] = 482
+1106-1108: x 5a02                                                             # data[5] = 602
+1108-1110: x d002                                                             # data[6] = 720
+1110-1112: x 4303                                                             # data[7] = 835
+1112-1114: x ba03                                                             # data[8] = 954
 # data for column 2
-0855-0856: x 01                                                               # encoding: 1b
-0856-0857: x 6b                                                               # data[0] = 107
-0857-0858: x 6f                                                               # data[1] = 111
-0858-0859: x 6d                                                               # data[2] = 109
-0859-0860: x 6f                                                               # data[3] = 111
-0860-0861: x 72                                                               # data[4] = 114
-0861-0862: x 70                                                               # data[5] = 112
-0862-0863: x 62                                                               # data[6] = 98
+1114-1115: x 01                                                               # encoding: 1b
+1115-1116: x 74                                                               # data[0] = 116
+1116-1117: x 74                                                               # data[1] = 116
+1117-1118: x 75                                                               # data[2] = 117
+1118-1119: x 71                                                               # data[3] = 113
+1119-1120: x 73                                                               # data[4] = 115
+1120-1121: x 71                                                               # data[5] = 113
+1121-1122: x 6e                                                               # data[6] = 110
+1122-1123: x 72                                                               # data[7] = 114
+1123-1124: x 59                                                               # data[8] = 89
 # data for column 3
 # rawbytes
 # offsets table
-0863-0864: x 00                                                               # encoding: zero
+1124-1125: x 00                                                               # encoding: zero
 # data
-0864-0864: x                                                                  # data[0]:
-0864-0864: x                                                                  # data[1]:
-0864-0864: x                                                                  # data[2]:
-0864-0864: x                                                                  # data[3]:
-0864-0864: x                                                                  # data[4]:
-0864-0864: x                                                                  # data[5]:
-0864-0864: x                                                                  # data[6]:
-0864-0865: x 00                                                               # block padding byte
-0865-0870: x 00eca560ff                                                       # index block trailer
-# block 8 properties (0870-1321)
-0870-0890: x 000c016f62736f6c6574652d6b65790000240472                         # ...obsolete-key..$.r
-0890-0910: x 6f636b7364622e626c6f636b2e62617365642e74                         # ocksdb.block.based.t
-0910-0930: x 61626c652e696e6465782e747970650000000008                         # able.index.type.....
-0930-0950: x 0a1a636f6d70617261746f726c6576656c64622e                         # ..comparatorleveldb.
-0950-0970: x 4279746577697365436f6d70617261746f720c07                         # BytewiseComparator..
-0970-0990: x 0d72657373696f6e4e6f436f6d7072657373696f                         # .ressionNoCompressio
-0990-1010: x 6e13085f5f6f7074696f6e7377696e646f775f62                         # n..__optionswindow_b
-1010-1030: x 6974733d2d31343b206c6576656c3d3332373637                         # its=-14; level=32767
-1030-1050: x 3b2073747261746567793d303b206d61785f6469                         # ; strategy=0; max_di
-1050-1070: x 63745f62797465733d303b207a7374645f6d6178                         # ct_bytes=0; zstd_max
-1070-1090: x 5f747261696e5f62797465733d303b20656e6162                         # _train_bytes=0; enab
-1090-1110: x 6c65643d303b20080901646174612e73697a6500                         # led=0; ...data.size.
-1110-1130: x 090b01656c657465642e6b65797300080b016669                         # ...eleted.keys....fi
-1130-1150: x 6c7465722e73697a6500080a01696e6465782e73                         # lter.size....index.s
-1150-1170: x 697a6549080e016d657267652e6f706572616e64                         # izeI...merge.operand
-1170-1190: x 7300130312746f72706562626c652e636f6e6361                         # s....torpebble.conca
-1190-1210: x 74656e617465080f016e756d2e646174612e626c                         # tenate...num.data.bl
-1210-1230: x 6f636b73070c0701656e7472696573150c0f0172                         # ocks....entries....r
-1230-1250: x 616e67652d64656c6574696f6e730008130e7072                         # ange-deletions....pr
-1250-1270: x 6f70657274792e636f6c6c6563746f72735b6f62                         # operty.collectors[ob
-1270-1290: x 736f6c6574652d6b65795d080c027261772e6b65                         # solete-key]...raw.ke
-1290-1310: x 792e73697a65bd010c0a0276616c75652e73697a                         # y.size.....value.siz
-1310-1321: x 6599010000000001000000                                           # e..........
-1321-1326: x 001bda0557                                                       # properties block trailer
-# block 9 meta-index (1326-1359)
-1326-1346: x 001204726f636b7364622e70726f706572746965                         # meta-index
-1346-1359: x 73e606c3030000000001000000                                       # (continued...)
-1359-1364: x 00661cc8ba                                                       # meta-index block trailer
+1125-1125: x                                                                  # data[0]:
+1125-1125: x                                                                  # data[1]:
+1125-1125: x                                                                  # data[2]:
+1125-1125: x                                                                  # data[3]:
+1125-1125: x                                                                  # data[4]:
+1125-1125: x                                                                  # data[5]:
+1125-1125: x                                                                  # data[6]:
+1125-1125: x                                                                  # data[7]:
+1125-1125: x                                                                  # data[8]:
+1125-1126: x 00                                                               # block padding byte
+1126-1131: x 0054096967                                                       # index block trailer
+# block 10 properties (1131-1582)
+1131-1151: x 000c016f62736f6c6574652d6b65790000240472                         # ...obsolete-key..$.r
+1151-1171: x 6f636b7364622e626c6f636b2e62617365642e74                         # ocksdb.block.based.t
+1171-1191: x 61626c652e696e6465782e747970650000000008                         # able.index.type.....
+1191-1211: x 0a1a636f6d70617261746f726c6576656c64622e                         # ..comparatorleveldb.
+1211-1231: x 4279746577697365436f6d70617261746f720c07                         # BytewiseComparator..
+1231-1251: x 0d72657373696f6e4e6f436f6d7072657373696f                         # .ressionNoCompressio
+1251-1271: x 6e13085f5f6f7074696f6e7377696e646f775f62                         # n..__optionswindow_b
+1271-1291: x 6974733d2d31343b206c6576656c3d3332373637                         # its=-14; level=32767
+1291-1311: x 3b2073747261746567793d303b206d61785f6469                         # ; strategy=0; max_di
+1311-1331: x 63745f62797465733d303b207a7374645f6d6178                         # ct_bytes=0; zstd_max
+1331-1351: x 5f747261696e5f62797465733d303b20656e6162                         # _train_bytes=0; enab
+1351-1371: x 6c65643d303b20080901646174612e73697a6500                         # led=0; ...data.size.
+1371-1391: x 090b01656c657465642e6b65797300080b016669                         # ...eleted.keys....fi
+1391-1411: x 6c7465722e73697a6500080a01696e6465782e73                         # lter.size....index.s
+1411-1431: x 697a6553080e016d657267652e6f706572616e64                         # izeS...merge.operand
+1431-1451: x 7300130312746f72706562626c652e636f6e6361                         # s....torpebble.conca
+1451-1471: x 74656e617465080f016e756d2e646174612e626c                         # tenate...num.data.bl
+1471-1491: x 6f636b73090c0701656e7472696573150c0f0172                         # ocks....entries....r
+1491-1511: x 616e67652d64656c6574696f6e730008130e7072                         # ange-deletions....pr
+1511-1531: x 6f70657274792e636f6c6c6563746f72735b6f62                         # operty.collectors[ob
+1531-1551: x 736f6c6574652d6b65795d080c027261772e6b65                         # solete-key]...raw.ke
+1551-1571: x 792e73697a65bd010c0a0276616c75652e73697a                         # y.size.....value.siz
+1571-1582: x 6599010000000001000000                                           # e..........
+1582-1587: x 000f05509b                                                       # properties block trailer
+# block 11 meta-index (1587-1620)
+1587-1607: x 001204726f636b7364622e70726f706572746965                         # meta-index
+1607-1620: x 73eb08c3030000000001000000                                       # (continued...)
+1620-1625: x 00a46d3a42                                                       # meta-index block trailer
 # sstable footer
-1364-1365: x 01                                                               # checksum type
-1365-1367: x ae0a                                                             # uvarint(1326): metaindex.Offset
-1367-1368: x 21                                                               # uvarint(33): metaindex.Length
-1368-1370: x 9d06                                                             # uvarint(797): index.Offset
-1370-1371: x 44                                                               # uvarint(68): index.Length
-1371-1391: x 0000000000000000000000000000000000000000                         # padding
-1391-1405: x 0000000000000000000000000000                                     # (continued...)
-1405-1409: x 05000000                                                         # table version
-1409-1417: x f09faab3f09faab3                                                 # magic
+1625-1626: x 01                                                               # checksum type
+1626-1628: x b30c                                                             # uvarint(1587): metaindex.Offset
+1628-1629: x 21                                                               # uvarint(33): metaindex.Length
+1629-1631: x 9808                                                             # uvarint(1048): index.Offset
+1631-1632: x 4e                                                               # uvarint(78): index.Length
+1632-1652: x 0000000000000000000000000000000000000000                         # padding
+1652-1666: x 0000000000000000000000000000                                     # (continued...)
+1666-1670: x 05000000                                                         # table version
+1670-1678: x f09faab3f09faab3                                                 # magic
 
 # Test a sstable containing only a range deletion.
 


### PR DESCRIPTION
Add an isObsolete bitmap to the colblk data block schema, encoding whether a key is obsolete (i.e. shadowed by an identical point key or range deletion with a higher sequence number).

Iteration-time filtering of obsolete keys is not yet implemented.