### PR TITLE
colblk: implement block.DataBlockIterator

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -158,8 +158,10 @@ type DataBlockIterator interface {
 	// KV returns the key-value pair at the current iterator position. The
 	// iterator must be Valid().
 	KV() *base.InternalKV
-	// FirstUserKey returns the first user key contained within the data block.
-	FirstUserKey() []byte
+	// CompareFirstUserKey compares the provided key to the first user key
+	// contained within the data block. It's equivalent to performing
+	//   Compare(firstUserKey, k)
+	CompareFirstUserKey(k []byte) int
 	// Invalidate invalidates the block iterator, removing references to the block
 	// it was initialized with.
 	Invalidate()

--- a/sstable/block/buffer_pool.go
+++ b/sstable/block/buffer_pool.go
@@ -89,7 +89,8 @@ func (bh BufferHandle) Get() []byte {
 	return nil
 }
 
-// Release releases the buffer, either back to the block cache or BufferPool.
+// Release releases the buffer, either back to the block cache or BufferPool. It
+// is okay to call Release on a zero-value BufferHandle (to no effect).
 func (bh BufferHandle) Release() {
 	bh.h.Release()
 	bh.b.Release()

--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -75,9 +75,9 @@ func TestDataBlock(t *testing.T) {
 				fmt.Fprintf(&buf, "LastKey: %s\n%s", lastKey.Pretty(testkeys.Comparer.FormatKey), f.String())
 				return buf.String()
 			case "iter":
-				it.Init(&r, testKeysSchema.NewKeySeeker(), func([]byte) base.LazyValue {
+				it.Init(&r, testKeysSchema.NewKeySeeker(), getLazyValuer(func([]byte) base.LazyValue {
 					return base.LazyValue{ValueOrHandle: []byte("mock external value")}
-				})
+				}))
 				return itertest.RunInternalIterCmd(t, td, &it)
 			default:
 				return fmt.Sprintf("unknown command: %s", td.Cmd)
@@ -143,4 +143,10 @@ func randTestKey(rng *rand.Rand, buf []byte, prefixLen int) []byte {
 	}
 	testkeys.WriteSuffix(buf[prefixLen:], suffix)
 	return buf
+}
+
+type getLazyValuer func([]byte) base.LazyValue
+
+func (g getLazyValuer) GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue {
+	return g(handle)
 }

--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -234,6 +234,12 @@ func (b PrefixBytes) At(i int) []byte {
 	return slices.Concat(b.SharedPrefix(), b.RowBundlePrefix(i), b.RowSuffix(i))
 }
 
+// UnsafeFirstSlice returns first slice in the PrefixBytes. The returned slice
+// points directly into the PrefixBytes buffer and must not be mutated.
+func (b *PrefixBytes) UnsafeFirstSlice() []byte {
+	return b.rawBytes.slice(0, b.rawBytes.offsets.At(2))
+}
+
 // PrefixBytesIter is an iterator and associated buffers for PrefixBytes. It
 // provides a means for efficiently iterating over the []byte slices contained
 // within a PrefixBytes, avoiding unnecessary copying when portions of slices

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -364,14 +364,10 @@ func (i *singleLevelIterator[I, PI, D, PD]) initBounds() {
 func (i *singleLevelIterator[I, PI, D, PD]) initBoundsForAlreadyLoadedBlock() {
 	// TODO(radu): determine automatically if we need to call First or not and
 	// unify this function with initBounds().
-	if PD(&i.data).FirstUserKey() == nil {
-		panic("initBoundsForAlreadyLoadedBlock must not be called on empty or corrupted block")
-	}
 	i.blockLower = i.lower
 	if i.blockLower != nil {
-		firstUserKey := PD(&i.data).FirstUserKey()
 		// TODO(radu): this should be <= 0
-		if firstUserKey != nil && i.cmp(i.blockLower, firstUserKey) < 0 {
+		if PD(&i.data).CompareFirstUserKey(i.blockLower) > 0 {
 			// The lower-bound is less than the first key in the block. No need
 			// to check the lower-bound again for this block.
 			i.blockLower = nil
@@ -1043,7 +1039,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekLT(
 
 	var dontSeekWithinBlock bool
 	if !PD(&i.data).IsDataInvalidated() && PD(&i.data).Valid() && PI(&i.index).Valid() &&
-		boundsCmp < 0 && i.cmp(PD(&i.data).FirstUserKey(), key) < 0 {
+		boundsCmp < 0 && PD(&i.data).CompareFirstUserKey(key) < 0 {
 		// Fast-path: The bounds have moved backward, and this SeekLT is
 		// respecting the upper bound (guaranteed by Iterator). We know that
 		// the iterator must already be positioned within or just outside the

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -521,9 +521,12 @@ func (i *Iter) cacheEntry() {
 	i.cachedBuf = append(i.cachedBuf, i.key...)
 }
 
-// FirstUserKey returns the user key of the first key in the block.
-func (i *Iter) FirstUserKey() []byte {
-	return i.firstUserKey
+// CompareFirstUserKey compares the provided key to the first user key
+// contained within the data block. It's equivalent to performing
+//
+//	Compare(firstUserKey, k)
+func (i *Iter) CompareFirstUserKey(k []byte) int {
+	return i.cmp(i.firstUserKey, k)
 }
 
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble


### PR DESCRIPTION
Add a DataBlockIterConfig type that wraps a colblk.DataBlockIter and completes
the remainder of the block.DataBlockIterator interface. We choose to implement
the interface on this wrapper type to maintain configuration state (the
KeySchema and lazy value retriever) across usages of for individual blocks,
leaving DataBlockIter to be completely reset for each new block use.