### PR TITLE
sstable: define type aliases {single,two}LevelIteratorRowBlocks

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
-	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -381,8 +380,8 @@ func runIterCmd(
 			continue
 		case "internal-iter-state":
 			fmt.Fprintf(&b, "| %T:\n", origIter)
-			si, _ := origIter.(*singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
-			if twoLevelIter, ok := origIter.(*twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]); ok {
+			si, _ := origIter.(*singleLevelIteratorRowBlocks)
+			if twoLevelIter, ok := origIter.(*twoLevelIteratorRowBlocks); ok {
 				si = &twoLevelIter.secondLevel
 				if twoLevelIter.topLevelIndex.Valid() {
 					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", twoLevelIter.topLevelIndex.Separator())

--- a/sstable/format.go
+++ b/sstable/format.go
@@ -245,6 +245,12 @@ func ParseTableFormat(magic []byte, version uint32) (TableFormat, error) {
 	}
 }
 
+// BlockColumnar returns true iff the table format uses the columnar format for
+// data, index and keyspan blocks.
+func (f TableFormat) BlockColumnar() bool {
+	return f >= TableFormatPebblev5
+}
+
 // AsTuple returns the TableFormat's (Magic String, Version) tuple.
 func (f TableFormat) AsTuple() (string, uint32) {
 	switch f {

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -144,15 +144,18 @@ type Iterator interface {
 //
 // TODO(sumeer): remove the aforementioned defensive code.
 
+type singleLevelIteratorRowBlocks = singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]
+type twoLevelIteratorRowBlocks = twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]
+
 var (
-	singleLevelIterRowBlockPool sync.Pool // *singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]
-	twoLevelIterRowBlockPool    sync.Pool // *twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]
+	singleLevelIterRowBlockPool sync.Pool // *singleLevelIteratorRowBlocks
+	twoLevelIterRowBlockPool    sync.Pool // *twoLevelIteratorRowBlocks
 )
 
 func init() {
 	singleLevelIterRowBlockPool = sync.Pool{
 		New: func() interface{} {
-			i := &singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]{pool: &singleLevelIterRowBlockPool}
+			i := &singleLevelIteratorRowBlocks{pool: &singleLevelIterRowBlockPool}
 			// Note: this is a no-op if invariants are disabled or race is enabled.
 			invariants.SetFinalizer(i, checkSingleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
 			return i
@@ -160,7 +163,7 @@ func init() {
 	}
 	twoLevelIterRowBlockPool = sync.Pool{
 		New: func() interface{} {
-			i := &twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]{pool: &twoLevelIterRowBlockPool}
+			i := &twoLevelIteratorRowBlocks{pool: &twoLevelIterRowBlockPool}
 			// Note: this is a no-op if invariants are disabled or race is enabled.
 			invariants.SetFinalizer(i, checkTwoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
 			return i

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -976,12 +976,12 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 					NoTransforms, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r), &pool)
 				require.NoError(t, err)
 				switch i := citer.(type) {
-				case *singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]:
+				case *singleLevelIteratorRowBlocks:
 					require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 					// Each key has one version, so no value block, regardless of
 					// sstable version.
 					require.Nil(t, i.vbRH)
-				case *twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]:
+				case *twoLevelIteratorRowBlocks:
 					require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.secondLevel.dataRH))
 					// Each key has one version, so no value block, regardless of
 					// sstable version.
@@ -1033,7 +1033,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 			NoTransforms, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r), &pool)
 		require.NoError(t, err)
 		defer citer.Close()
-		i := citer.(*singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
+		i := citer.(*singleLevelIteratorRowBlocks)
 		require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 		require.True(t, objstorageprovider.TestingCheckMaxReadahead(i.vbRH))
 	}
@@ -1041,7 +1041,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 		iter, err := r.NewIter(NoTransforms, nil, nil)
 		require.NoError(t, err)
 		defer iter.Close()
-		i := iter.(*singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
+		i := iter.(*singleLevelIteratorRowBlocks)
 		require.False(t, objstorageprovider.TestingCheckMaxReadahead(i.dataRH))
 		require.False(t, objstorageprovider.TestingCheckMaxReadahead(i.vbRH))
 	}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -354,15 +354,15 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			forceIgnoreValueBlocks := func(i *singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]) {
+			forceIgnoreValueBlocks := func(i *singleLevelIteratorRowBlocks) {
 				i.vbReader = nil
 				i.data.SetGetLazyValuer(nil)
 				i.data.SetHasValuePrefix(false)
 			}
 			switch i := origIter.(type) {
-			case *twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]:
+			case *twoLevelIteratorRowBlocks:
 				forceIgnoreValueBlocks(&i.secondLevel)
-			case *singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]:
+			case *singleLevelIteratorRowBlocks:
 				forceIgnoreValueBlocks(i)
 			}
 			iter := newIterAdapter(origIter)


### PR DESCRIPTION
Define type aliases singleLevelIteratorRowBlocks and twoLevelIteratorRowBlocks. The full types with all type parameters is a bit unwieldly.