### PR TITLE
testkeys: fix assertion panic message

### DIFF
--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -125,7 +125,7 @@ func compare(a, b []byte) int {
 func split(a []byte) int {
 	i := bytes.LastIndexByte(a, suffixDelim)
 	if i == 0 {
-		panic("split called on bare prefix")
+		panic(fmt.Sprintf("Split called on bare suffix %q", a))
 	}
 	if i > 0 {
 		return i


### PR DESCRIPTION
It's okay to call Split on a bare prefix but not a bare suffix.

Informs #3906.