### PR TITLE
Makefile: bump crossversion-meta release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ crossversion-meta:
 
 .PHONY: stress-crossversion
 stress-crossversion:
-	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-22.1 crl-release-22.2 crl-release-23.1 crl-release-23.2 master
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-23.1 crl-release-23.2 crl-release-24.1 crl-release-24.2 master
 
 .PHONY: gen-bazel
 gen-bazel:


### PR DESCRIPTION
Update the stress-crossversion Makefile target to test release branches from crl-release-23.1 through crl-release-24.2 (and then master).