### PR TITLE
base: make comparer tolerate empty keys

### DIFF
--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -110,12 +110,6 @@ var Comparer = &base.Comparer{
 //     value is smaller.
 func compare(a, b []byte) int {
 	ai, bi := split(a), split(b)
-	if ai == 0 && len(a) > 0 {
-		panic(fmt.Sprintf("Compare called with bare suffix %s", a))
-	}
-	if bi == 0 && len(b) > 0 {
-		panic(fmt.Sprintf("Compare called with bare suffix %s", b))
-	}
 	if v := bytes.Compare(a[:ai], b[:bi]); v != 0 {
 		return v
 	}
@@ -124,10 +118,7 @@ func compare(a, b []byte) int {
 
 func split(a []byte) int {
 	i := bytes.LastIndexByte(a, suffixDelim)
-	if i == 0 {
-		panic(fmt.Sprintf("Split called on bare suffix %q", a))
-	}
-	if i > 0 {
+	if i >= 0 {
 		return i
 	}
 	return len(a)


### PR DESCRIPTION
When synthetic prefix is used, we can trim the synthetic prefix from a
given seek key and compare it with the "bare" key in a table. After
trimming the key prefix can become "empty" (with just the terminator
left). This change extends the comparer test suite to check that we
can remove leading bytes from prefixes and adjusts the testkeys and
crdb comparers.

Fixes #3906