### PR TITLE
metamorphic: abridge failure output

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -256,7 +256,7 @@ To reduce:  go test ./internal/metamorphic -tags invariants -run '%s$' --run-dir
 				err,
 				out,
 				optionsStr,
-				formattedOps,
+				opsPath,
 				readFile(filepath.Join(runDir, "history")),
 				topLevelTestName, runDir,
 			)
@@ -332,7 +332,7 @@ To reduce:  go test ./internal/metamorphic -tags invariants -run '%s$' --compare
 						metaDir, names[0], names[i], text,
 						names[0], optionsStrA,
 						names[i], optionsStrB,
-						formattedOps,
+						opsPath,
 						topLevelTestName, metaDir, names[0], names[i])
 					os.Exit(1)
 				}


### PR DESCRIPTION
When printing the details of a metamorphic test failure print the path to the file containing the formatted operations rather than the operations themselves. There are typically thousands of operations and scrolling over them is a nuisance.