### PR TITLE
colblk: add SeekUnsetBitGE/LE

### DIFF
--- a/internal/crdbtest/crdbtest.go
+++ b/internal/crdbtest/crdbtest.go
@@ -71,7 +71,7 @@ var Comparer = base.Comparer{
 		}
 		n := len(dst)
 		// Engine key comparison uses bytes.Compare on the roachpb.Key, which is the same semantics as
-		// pebble.DefaultComparer, so reuse the latter's Successor implementation.
+		// pebble.DefaultComparer, so reuse the latter's SeekSetBitGE implementation.
 		dst = base.DefaultComparer.Successor(dst, aKey)
 		// Did it pick a successor different than aKey -- if it did not we can't do better than a.
 		buf := dst[n:]

--- a/sstable/colblk/bitmap.go
+++ b/sstable/colblk/bitmap.go
@@ -73,10 +73,10 @@ func (b Bitmap) At(i int) bool {
 	return val&(1<<(uint(i)&63)) != 0
 }
 
-// Successor returns the next bit greater than or equal to i set in the bitmap.
+// SeekSetBitGE returns the next bit greater than or equal to i set in the bitmap.
 // The i parameter must be in [0, bitCount). Returns the number of bits
 // represented by the bitmap if no next bit is set.
-func (b Bitmap) Successor(i int) int {
+func (b Bitmap) SeekSetBitGE(i int) int {
 	if b.data.ptr == nil {
 		// Zero bitmap case.
 		return b.bitCount
@@ -291,7 +291,7 @@ func (b *BitmapBuilder) Finish(col, nRows int, offset uint32, buf []byte) uint32
 	}
 	// Ensure the last word of the bitmap does not contain any set bits beyond
 	// the last row. This is not just for determinism but also to ensure that
-	// the summary bitmap is correct (which is necessary for Bitmap.Successor
+	// the summary bitmap is correct (which is necessary for Bitmap.SeekSetBitGE
 	// correctness).
 	if i := nRows % 64; len(b.words) >= nBitmapWords && i != 0 {
 		b.words[nBitmapWords-1] &= (1 << i) - 1

--- a/sstable/colblk/bitmap_test.go
+++ b/sstable/colblk/bitmap_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"testing"
 	"time"
 	"unicode"
@@ -77,6 +78,35 @@ func TestBitmapFixed(t *testing.T) {
 			panic(fmt.Sprintf("unknown command: %s", td.Cmd))
 		}
 	})
+}
+
+func TestNextPrevBitInWord(t *testing.T) {
+	words := []uint64{0, math.MaxUint64}
+	for i := 0; i < 1000; i++ {
+		words = append(words, rand.Uint64())
+	}
+	for _, w := range words {
+		// Check that we can reconstruct the word if we jump from set bit to set
+		// bit.
+		var val uint64
+		for i := 0; i < 64; i++ {
+			i = nextBitInWord(w, uint(i))
+			if i == 64 {
+				break
+			}
+			val |= 1 << i
+		}
+		require.Equal(t, w, val)
+		val = 0
+		for i := 63; i >= 0; i-- {
+			i = prevBitInWord(w, uint(i))
+			if i == -1 {
+				break
+			}
+			val |= 1 << i
+		}
+		require.Equal(t, w, val)
+	}
 }
 
 func dumpBitmap(w io.Writer, b Bitmap) {

--- a/sstable/colblk/cockroach_test.go
+++ b/sstable/colblk/cockroach_test.go
@@ -243,12 +243,12 @@ func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row 
 		seekWallTime = binary.LittleEndian.Uint64(seekSuffix)
 	default:
 		// The suffix is untyped. Compare the untyped suffixes.
-		// Binary search between [index, prefixChanged.Successor(index)].
+		// Binary search between [index, prefixChanged.SeekSetBitGE(index)].
 		//
 		// Define f(l-1) == false and f(u) == true.
 		// Invariant: f(l-1) == false, f(u) == true.
 		l := index
-		u := ks.reader.prefixChanged.Successor(index)
+		u := ks.reader.prefixChanged.SeekSetBitGE(index)
 		for l < u {
 			h := int(uint(l+u) >> 1) // avoid overflow when computing h
 			// l ≤ h < u
@@ -264,12 +264,12 @@ func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row 
 
 	// TODO(jackson): What if the row has an untyped suffix?
 
-	// Binary search between [index, prefixChanged.Successor(index)].
+	// Binary search between [index, prefixChanged.SeekSetBitGE(index)].
 	//
 	// Define f(l-1) == false and f(u) == true.
 	// Invariant: f(l-1) == false, f(u) == true.
 	l := index
-	u := ks.reader.prefixChanged.Successor(index)
+	u := ks.reader.prefixChanged.SeekSetBitGE(index)
 	for l < u {
 		h := int(uint(l+u) >> 1) // avoid overflow when computing h
 		// l ≤ h < u

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -328,12 +328,12 @@ func (ks *defaultKeySeeker) seekGEOnSuffix(index int, suffix []byte) (row int) {
 		return index
 	}
 	// Otherwise, the row at [index] sorts before the search key and we need to
-	// search forward. Binary search between [index+1, prefixChanged.Successor(index+1)].
+	// search forward. Binary search between [index+1, prefixChanged.SeekSetBitGE(index+1)].
 	//
 	// Define f(l-1) == false and f(u) == true.
 	// Invariant: f(l-1) == false, f(u) == true.
 	l := index + 1
-	u := ks.reader.prefixChanged.Successor(index + 1)
+	u := ks.reader.prefixChanged.SeekSetBitGE(index + 1)
 	for l < u {
 		h := int(uint(l+u) >> 1) // avoid overflow when computing h
 		// l ≤ h < u
@@ -861,7 +861,7 @@ func (i *DataBlockIter) Next() *base.InternalKV {
 // prefix as the previous entry. Checking the value prefix byte bit requires
 // locating that byte which requires decoding 3 varints per key/value pair.
 func (i *DataBlockIter) NextPrefix(_ []byte) *base.InternalKV {
-	return i.decodeRow(i.r.prefixChanged.Successor(i.row + 1))
+	return i.decodeRow(i.r.prefixChanged.SeekSetBitGE(i.row + 1))
 }
 
 // Prev moves the iterator to the previous KV pair in the block.

--- a/sstable/colblk/testdata/bitmap
+++ b/sstable/colblk/testdata/bitmap
@@ -84,6 +84,46 @@ bitmap.SeekSetBitLE(14) = 14
 bitmap.SeekSetBitLE(15) = 14
 bitmap.SeekSetBitLE(16) = 14
 
+seek-unset-ge indexes=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
+----
+bitmap.SeekUnsetBitGE(0) = 1
+bitmap.SeekUnsetBitGE(1) = 1
+bitmap.SeekUnsetBitGE(2) = 3
+bitmap.SeekUnsetBitGE(3) = 3
+bitmap.SeekUnsetBitGE(4) = 5
+bitmap.SeekUnsetBitGE(5) = 5
+bitmap.SeekUnsetBitGE(6) = 9
+bitmap.SeekUnsetBitGE(7) = 9
+bitmap.SeekUnsetBitGE(8) = 9
+bitmap.SeekUnsetBitGE(9) = 9
+bitmap.SeekUnsetBitGE(10) = 10
+bitmap.SeekUnsetBitGE(11) = 11
+bitmap.SeekUnsetBitGE(12) = 15
+bitmap.SeekUnsetBitGE(13) = 15
+bitmap.SeekUnsetBitGE(14) = 15
+bitmap.SeekUnsetBitGE(15) = 15
+bitmap.SeekUnsetBitGE(16) = 16
+
+seek-unset-le indexes=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
+----
+bitmap.SeekUnsetBitLE(0) = -1
+bitmap.SeekUnsetBitLE(1) = 1
+bitmap.SeekUnsetBitLE(2) = 1
+bitmap.SeekUnsetBitLE(3) = 3
+bitmap.SeekUnsetBitLE(4) = 3
+bitmap.SeekUnsetBitLE(5) = 5
+bitmap.SeekUnsetBitLE(6) = 5
+bitmap.SeekUnsetBitLE(7) = 5
+bitmap.SeekUnsetBitLE(8) = 5
+bitmap.SeekUnsetBitLE(9) = 9
+bitmap.SeekUnsetBitLE(10) = 10
+bitmap.SeekUnsetBitLE(11) = 11
+bitmap.SeekUnsetBitLE(12) = 11
+bitmap.SeekUnsetBitLE(13) = 11
+bitmap.SeekUnsetBitLE(14) = 11
+bitmap.SeekUnsetBitLE(15) = 15
+bitmap.SeekUnsetBitLE(16) = 16
+
 # Test calling Invert() before finishing.
 
 build invert

--- a/sstable/colblk/testdata/bitmap
+++ b/sstable/colblk/testdata/bitmap
@@ -44,45 +44,45 @@ Binary representation:
 08-16: b 1101010101110001000000000000000000000000000000000000000000000000 # bitmap word 0
 16-24: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
 
-successor indexes=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
+seek-set-ge indexes=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
 ----
-bitmap.Successor(0) = 0
-bitmap.Successor(1) = 2
-bitmap.Successor(2) = 2
-bitmap.Successor(3) = 4
-bitmap.Successor(4) = 4
-bitmap.Successor(5) = 6
-bitmap.Successor(6) = 6
-bitmap.Successor(7) = 7
-bitmap.Successor(8) = 8
-bitmap.Successor(9) = 12
-bitmap.Successor(10) = 12
-bitmap.Successor(11) = 12
-bitmap.Successor(12) = 12
-bitmap.Successor(13) = 13
-bitmap.Successor(14) = 14
-bitmap.Successor(15) = 17
-bitmap.Successor(16) = 17
+bitmap.SeekSetBitGE(0) = 0
+bitmap.SeekSetBitGE(1) = 2
+bitmap.SeekSetBitGE(2) = 2
+bitmap.SeekSetBitGE(3) = 4
+bitmap.SeekSetBitGE(4) = 4
+bitmap.SeekSetBitGE(5) = 6
+bitmap.SeekSetBitGE(6) = 6
+bitmap.SeekSetBitGE(7) = 7
+bitmap.SeekSetBitGE(8) = 8
+bitmap.SeekSetBitGE(9) = 12
+bitmap.SeekSetBitGE(10) = 12
+bitmap.SeekSetBitGE(11) = 12
+bitmap.SeekSetBitGE(12) = 12
+bitmap.SeekSetBitGE(13) = 13
+bitmap.SeekSetBitGE(14) = 14
+bitmap.SeekSetBitGE(15) = 17
+bitmap.SeekSetBitGE(16) = 17
 
-predecessor indexes=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
+seek-set-le indexes=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
 ----
-bitmap.Predecessor(0) = 0
-bitmap.Predecessor(1) = 0
-bitmap.Predecessor(2) = 2
-bitmap.Predecessor(3) = 2
-bitmap.Predecessor(4) = 4
-bitmap.Predecessor(5) = 4
-bitmap.Predecessor(6) = 6
-bitmap.Predecessor(7) = 7
-bitmap.Predecessor(8) = 8
-bitmap.Predecessor(9) = 8
-bitmap.Predecessor(10) = 8
-bitmap.Predecessor(11) = 8
-bitmap.Predecessor(12) = 12
-bitmap.Predecessor(13) = 13
-bitmap.Predecessor(14) = 14
-bitmap.Predecessor(15) = 14
-bitmap.Predecessor(16) = 14
+bitmap.SeekSetBitLE(0) = 0
+bitmap.SeekSetBitLE(1) = 0
+bitmap.SeekSetBitLE(2) = 2
+bitmap.SeekSetBitLE(3) = 2
+bitmap.SeekSetBitLE(4) = 4
+bitmap.SeekSetBitLE(5) = 4
+bitmap.SeekSetBitLE(6) = 6
+bitmap.SeekSetBitLE(7) = 7
+bitmap.SeekSetBitLE(8) = 8
+bitmap.SeekSetBitLE(9) = 8
+bitmap.SeekSetBitLE(10) = 8
+bitmap.SeekSetBitLE(11) = 8
+bitmap.SeekSetBitLE(12) = 12
+bitmap.SeekSetBitLE(13) = 13
+bitmap.SeekSetBitLE(14) = 14
+bitmap.SeekSetBitLE(15) = 14
+bitmap.SeekSetBitLE(16) = 14
 
 # Test calling Invert() before finishing.
 


### PR DESCRIPTION
#### colblk: move out nextInBit/prevInBit functions

This change uninlines these functions and adds a test for them.

#### colblk: rename Successor/Predecessor to SeekSetBitGE/SeekSetBitLE

The previous names were misleading since we can return the same
index.

#### colblk: add SeekUnsetBitGE/LE

These variants will be useful for skipping blocks of set bits, for
example to skip obsolete keys.