### PR TITLE
db: use atomic for versionSet.nextFileNum

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2667,9 +2667,7 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*versionEdit, error
 func (d *DB) newCompactionOutput(
 	jobID JobID, c *compaction, writerOpts sstable.WriterOptions,
 ) (objstorage.ObjectMetadata, sstable.RawWriter, CPUWorkHandle, error) {
-	d.mu.Lock()
 	diskFileNum := d.mu.versions.getNextDiskFileNum()
-	d.mu.Unlock()
 
 	var writeCategory vfs.DiskWriteCategory
 	if d.opts.EnableSQLRowSpillMetrics {

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -49,13 +49,11 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 	reset()
 
 	loadFileMeta := func(paths []string, exciseSpan KeyRange, seqNum base.SeqNum) []*fileMetadata {
-		d.mu.Lock()
 		pendingOutputs := make([]base.FileNum, len(paths))
 		for i := range paths {
 			pendingOutputs[i] = d.mu.versions.getNextFileNum()
 		}
-		jobID := d.newJobIDLocked()
-		d.mu.Unlock()
+		jobID := d.newJobID()
 
 		// We can reuse the ingestLoad function for this test even if we're
 		// not actually ingesting a file.

--- a/ingest.go
+++ b/ingest.go
@@ -1355,14 +1355,12 @@ func (d *DB) ingest(
 	// the file number ordering to be out of alignment with sequence number
 	// ordering. The sorting of L0 tables by sequence number avoids relying on
 	// that (busted) invariant.
-	d.mu.Lock()
 	pendingOutputs := make([]base.FileNum, len(paths)+len(shared)+len(external))
 	for i := 0; i < len(paths)+len(shared)+len(external); i++ {
 		pendingOutputs[i] = d.mu.versions.getNextFileNum()
 	}
 
-	jobID := d.newJobIDLocked()
-	d.mu.Unlock()
+	jobID := d.newJobID()
 
 	// Load the metadata for all the files being ingested. This step detects
 	// and elides empty sstables.

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -283,9 +283,9 @@ func TestVirtualReadsWiring(t *testing.T) {
 	l6 := currVersion.Levels[6]
 	l6FileIter := l6.Iter()
 	parentFile := l6FileIter.First()
-	f1 := FileNum(d.mu.versions.nextFileNum)
+	f1 := FileNum(d.mu.versions.nextFileNum.Load())
 	f2 := f1 + 1
-	d.mu.versions.nextFileNum += 2
+	d.mu.versions.nextFileNum.Add(2)
 
 	seqNumA := parentFile.Smallest.SeqNum()
 	// See SeqNum comments above.


### PR DESCRIPTION
Currently, we have the nextFileNum counter protected by db.mu, which is pretty unnecessary and results in us grabbing the db mutex just for being able to generate a new filenum. This change moves that to an atomic.