### PR TITLE
colblk: show iter commands

### DIFF
--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -100,15 +100,21 @@ func TestDataBlock(t *testing.T) {
 				fmt.Fprintf(&buf, "LastKey: %s\n%s", lastKey.Pretty(testkeys.Comparer.FormatKey), f.String())
 				return buf.String()
 			case "iter":
-				var transforms block.IterTransforms
 				var seqNum uint64
+				var syntheticPrefix, syntheticSuffix string
 				td.MaybeScanArgs(t, "synthetic-seq-num", &seqNum)
-				transforms.SyntheticSeqNum = block.SyntheticSeqNum(seqNum)
-				transforms.HideObsoletePoints = td.HasArg("hide-obsolete-points")
+				td.MaybeScanArgs(t, "synthetic-prefix", &syntheticPrefix)
+				td.MaybeScanArgs(t, "synthetic-suffix", &syntheticSuffix)
+				transforms := block.IterTransforms{
+					SyntheticSeqNum:    block.SyntheticSeqNum(seqNum),
+					HideObsoletePoints: td.HasArg("hide-obsolete-points"),
+					SyntheticPrefix:    []byte(syntheticPrefix),
+					SyntheticSuffix:    []byte(syntheticSuffix),
+				}
 				it.Init(&r, testKeysSchema.NewKeySeeker(), getLazyValuer(func([]byte) base.LazyValue {
 					return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 				}), transforms)
-				var o []itertest.IterOpt
+				o := []itertest.IterOpt{itertest.ShowCommands}
 				if td.HasArg("verbose") {
 					o = append(o, itertest.Verbose)
 				}

--- a/sstable/colblk/testdata/data_block/bundle_search
+++ b/sstable/colblk/testdata/data_block/bundle_search
@@ -528,11 +528,11 @@ seek-ge bac
 seek-ge bacl
 seek-ge bacu
 ----
-backache:v
-backslide:v
-backslide:v
-backhanded:v
-backhanded:v
-bacchanal:v
-bacteria:v
-.
+  seek-ge backache: backache:v
+ seek-ge backslide: backslide:v
+  seek-ge backslid: backslide:v
+seek-ge backhanded: backhanded:v
+ seek-ge backhande: backhanded:v
+       seek-ge bac: bacchanal:v
+      seek-ge bacl: bacteria:v
+      seek-ge bacu: .

--- a/sstable/colblk/testdata/data_block/external_value
+++ b/sstable/colblk/testdata/data_block/external_value
@@ -290,27 +290,27 @@ next
 next
 next
 ----
-blockprefix_apple@98:apple98
-blockprefix_apple@52:mock external value
-blockprefix_apple@23:mock external value
-blockprefix_apple@11:mock external value
-blockprefix_banana@94:banana94
-blockprefix_banana@93:
-blockprefix_banana@93:mock external value
-blockprefix_banana@72:mock external value
-blockprefix_banana@9:mock external value
-blockprefix_banana@1:mock external value
-blockprefix_coconut:coconut
-blockprefix_coconut@92:mock external value
-blockprefix_coconut@35:mock external value
-blockprefix_coconut@22:mock external value
-blockprefix_coconut@21:mock external value
-blockprefix_coconut@1:mock external value
-blockprefix_guava@99:mock external value
-blockprefix_kiwi@99:mock external value
-blockprefix_kiwi@98:mock external value
-blockprefix_lemon@92:
-.
+first: blockprefix_apple@98:apple98
+ next: blockprefix_apple@52:mock external value
+ next: blockprefix_apple@23:mock external value
+ next: blockprefix_apple@11:mock external value
+ next: blockprefix_banana@94:banana94
+ next: blockprefix_banana@93:
+ next: blockprefix_banana@93:mock external value
+ next: blockprefix_banana@72:mock external value
+ next: blockprefix_banana@9:mock external value
+ next: blockprefix_banana@1:mock external value
+ next: blockprefix_coconut:coconut
+ next: blockprefix_coconut@92:mock external value
+ next: blockprefix_coconut@35:mock external value
+ next: blockprefix_coconut@22:mock external value
+ next: blockprefix_coconut@21:mock external value
+ next: blockprefix_coconut@1:mock external value
+ next: blockprefix_guava@99:mock external value
+ next: blockprefix_kiwi@99:mock external value
+ next: blockprefix_kiwi@98:mock external value
+ next: blockprefix_lemon@92:
+ next: .
 
 # Scan across the block using next prefix.
 
@@ -323,17 +323,17 @@ next-prefix
 next-prefix
 next-prefix
 ----
-blockprefix_apple@98:apple98
-blockprefix_banana@94:banana94
-blockprefix_coconut:coconut
-blockprefix_guava@99:mock external value
-blockprefix_kiwi@99:mock external value
-blockprefix_lemon@92:
-.
+      first: blockprefix_apple@98:apple98
+next-prefix: blockprefix_banana@94:banana94
+next-prefix: blockprefix_coconut:coconut
+next-prefix: blockprefix_guava@99:mock external value
+next-prefix: blockprefix_kiwi@99:mock external value
+next-prefix: blockprefix_lemon@92:
+next-prefix: .
 
 iter
 seek-ge blockprefix_banana@73
 next-prefix
 ----
-blockprefix_banana@72:mock external value
-blockprefix_coconut:coconut
+seek-ge blockprefix_banana@73: blockprefix_banana@72:mock external value
+                  next-prefix: blockprefix_coconut:coconut

--- a/sstable/colblk/testdata/data_block/finish_without_final_row
+++ b/sstable/colblk/testdata/data_block/finish_without_final_row
@@ -127,12 +127,12 @@ next
 next
 next
 ----
-a@10:apple
-b@5:banana
-b@2:blueberry
-c@9:coconut
-c@6:cantelope
-.
+first: a@10:apple
+ next: b@5:banana
+ next: b@2:blueberry
+ next: c@9:coconut
+ next: c@6:cantelope
+ next: .
 
 init
 ----

--- a/sstable/colblk/testdata/data_block/next_prefix
+++ b/sstable/colblk/testdata/data_block/next_prefix
@@ -252,17 +252,17 @@ next-prefix
 next-prefix
 next-prefix
 ----
-blockprefix_apple@98:apple98
-blockprefix_banana@94:banana94
-blockprefix_coconut:coconut
-blockprefix_guava@99:guava99
-blockprefix_kiwi@99:kiwi99
-blockprefix_lemon@92:
-.
+      first: blockprefix_apple@98:apple98
+next-prefix: blockprefix_banana@94:banana94
+next-prefix: blockprefix_coconut:coconut
+next-prefix: blockprefix_guava@99:guava99
+next-prefix: blockprefix_kiwi@99:kiwi99
+next-prefix: blockprefix_lemon@92:
+next-prefix: .
 
 iter
 seek-ge blockprefix_banana@73
 next-prefix
 ----
-blockprefix_banana@72:banana72
-blockprefix_coconut:coconut
+seek-ge blockprefix_banana@73: blockprefix_banana@72:banana72
+                  next-prefix: blockprefix_coconut:coconut

--- a/sstable/colblk/testdata/data_block/simple
+++ b/sstable/colblk/testdata/data_block/simple
@@ -158,14 +158,14 @@ next
 next
 next
 ----
-a@10:apple
-b@5:banana
-b@2:blueberry
-c@9:coconut
-c@6:cantelope
-c@1:clementine
-d@11: 
-.
+first: a@10:apple
+ next: b@5:banana
+ next: b@2:blueberry
+ next: c@9:coconut
+ next: c@6:cantelope
+ next: c@1:clementine
+ next: d@11: 
+ next: .
 
 iter
 last
@@ -177,14 +177,14 @@ prev
 prev
 prev
 ----
-d@11: 
-c@1:clementine
-c@6:cantelope
-c@9:coconut
-b@2:blueberry
-b@5:banana
-a@10:apple
-.
+last: d@11: 
+prev: c@1:clementine
+prev: c@6:cantelope
+prev: c@9:coconut
+prev: b@2:blueberry
+prev: b@5:banana
+prev: a@10:apple
+prev: .
 
 iter
 seek-ge a
@@ -200,18 +200,18 @@ seek-ge b@2
 seek-ge b@1
 seek-ge c
 ----
-a@10:apple
-a@10:apple
-b@5:banana
-b@5:banana
-b@5:banana
-b@5:banana
-b@5:banana
-b@2:blueberry
-b@2:blueberry
-b@2:blueberry
-c@9:coconut
-c@9:coconut
+       seek-ge a: a@10:apple
+    seek-ge a@10: a@10:apple
+     seek-ge a@3: b@5:banana
+     seek-ge a@1: b@5:banana
+       seek-ge b: b@5:banana
+seek-ge b@999999: b@5:banana
+     seek-ge b@5: b@5:banana
+     seek-ge b@4: b@2:blueberry
+     seek-ge b@3: b@2:blueberry
+     seek-ge b@2: b@2:blueberry
+     seek-ge b@1: c@9:coconut
+       seek-ge c: c@9:coconut
 
 iter
 seek-ge c@10
@@ -229,20 +229,20 @@ seek-ge d
 seek-ge d@11
 seek-ge d@10
 ----
-c@9:coconut
-c@9:coconut
-c@6:cantelope
-c@6:cantelope
-c@6:cantelope
-c@1:clementine
-c@1:clementine
-c@1:clementine
-c@1:clementine
-c@1:clementine
-d@11: 
-d@11: 
-d@11: 
-.
+seek-ge c@10: c@9:coconut
+ seek-ge c@9: c@9:coconut
+ seek-ge c@8: c@6:cantelope
+ seek-ge c@7: c@6:cantelope
+ seek-ge c@6: c@6:cantelope
+ seek-ge c@5: c@1:clementine
+ seek-ge c@4: c@1:clementine
+ seek-ge c@3: c@1:clementine
+ seek-ge c@2: c@1:clementine
+ seek-ge c@1: c@1:clementine
+ seek-ge c@0: d@11: 
+   seek-ge d: d@11: 
+seek-ge d@11: d@11: 
+seek-ge d@10: .
 
 iter
 seek-lt a
@@ -258,18 +258,18 @@ seek-lt b@2
 seek-lt b@1
 seek-lt c
 ----
-.
-.
-a@10:apple
-a@10:apple
-a@10:apple
-a@10:apple
-a@10:apple
-b@5:banana
-b@5:banana
-b@5:banana
-b@2:blueberry
-b@2:blueberry
+       seek-lt a: .
+    seek-lt a@10: .
+     seek-lt a@3: a@10:apple
+     seek-lt a@1: a@10:apple
+       seek-lt b: a@10:apple
+seek-lt b@999999: a@10:apple
+     seek-lt b@5: a@10:apple
+     seek-lt b@4: b@5:banana
+     seek-lt b@3: b@5:banana
+     seek-lt b@2: b@5:banana
+     seek-lt b@1: b@2:blueberry
+       seek-lt c: b@2:blueberry
 
 iter
 seek-lt c@10
@@ -287,20 +287,20 @@ seek-lt d
 seek-lt d@11
 seek-lt d@10
 ----
-b@2:blueberry
-b@2:blueberry
-c@9:coconut
-c@9:coconut
-c@9:coconut
-c@6:cantelope
-c@6:cantelope
-c@6:cantelope
-c@6:cantelope
-c@6:cantelope
-c@1:clementine
-c@1:clementine
-c@1:clementine
-d@11: 
+seek-lt c@10: b@2:blueberry
+ seek-lt c@9: b@2:blueberry
+ seek-lt c@8: c@9:coconut
+ seek-lt c@7: c@9:coconut
+ seek-lt c@6: c@9:coconut
+ seek-lt c@5: c@6:cantelope
+ seek-lt c@4: c@6:cantelope
+ seek-lt c@3: c@6:cantelope
+ seek-lt c@2: c@6:cantelope
+ seek-lt c@1: c@6:cantelope
+ seek-lt c@0: c@1:clementine
+   seek-lt d: c@1:clementine
+seek-lt d@11: c@1:clementine
+seek-lt d@10: d@11: 
 
 init
 ----
@@ -513,13 +513,13 @@ seek-ge aaaaaaaaaaaaaaapparh
 seek-ge aaaaaaaaaaaaaaarresting@10
 seek-ge aaaaaaaaaaaaaaarrived@10
 ----
-aaaaaaaaaaaaaaappalling@10:a
-aaaaaaaaaaaaaaappalling@10:a
-aaaaaaaaaaaaaaappalling@10:a
-aaaaaaaaaaaaaaapparel@10:a
-aaaaaaaaaaaaaaapparition@10:a
-aaaaaaaaaaaaaaarresting@10:a
-aaaaaaaaaaaaaaarrived@10:a
+                       seek-ge aaa: aaaaaaaaaaaaaaappalling@10:a
+                 seek-ge aaaaaaaaa: aaaaaaaaaaaaaaappalling@10:a
+         seek-ge aaaaaaaaaaaaaaapp: aaaaaaaaaaaaaaappalling@10:a
+  seek-ge aaaaaaaaaaaaaaapparel@10: aaaaaaaaaaaaaaapparel@10:a
+      seek-ge aaaaaaaaaaaaaaapparh: aaaaaaaaaaaaaaapparition@10:a
+seek-ge aaaaaaaaaaaaaaarresting@10: aaaaaaaaaaaaaaarresting@10:a
+  seek-ge aaaaaaaaaaaaaaarrived@10: aaaaaaaaaaaaaaarrived@10:a
 
 iter
 seek-lt aaa
@@ -530,10 +530,10 @@ seek-lt aaaaaaaaaaaaaaapparh
 seek-lt aaaaaaaaaaaaaaarresting@10
 seek-lt aaaaaaaaaaaaaaarrived@10
 ----
-.
-.
-.
-aaaaaaaaaaaaaaappalling@10:a
-aaaaaaaaaaaaaaapparel@10:a
-aaaaaaaaaaaaaaapproves@10:a
-aaaaaaaaaaaaaaarresting@10:a
+                       seek-lt aaa: .
+                 seek-lt aaaaaaaaa: .
+         seek-lt aaaaaaaaaaaaaaapp: .
+  seek-lt aaaaaaaaaaaaaaapparel@10: aaaaaaaaaaaaaaappalling@10:a
+      seek-lt aaaaaaaaaaaaaaapparh: aaaaaaaaaaaaaaapparel@10:a
+seek-lt aaaaaaaaaaaaaaarresting@10: aaaaaaaaaaaaaaapproves@10:a
+  seek-lt aaaaaaaaaaaaaaarrived@10: aaaaaaaaaaaaaaarresting@10:a

--- a/sstable/colblk/testdata/data_block/transforms
+++ b/sstable/colblk/testdata/data_block/transforms
@@ -21,18 +21,18 @@ prev
 prev
 next
 ----
-a@10#1234,SET:apple
-b@5#1234,SET:banana
-b@2#1234,SETWITHDEL:blueberry
-c@9#1234,SETWITHDEL:coconut
-c@6#1234,SET:cantaloupe
-c@9#1234,SETWITHDEL:coconut
-b@2#1234,SETWITHDEL:blueberry
-b@5#1234,SET:banana
-b@2#1234,SETWITHDEL:blueberry
-b@5#1234,SET:banana
-a@10#1234,SET:apple
-b@5#1234,SET:banana
+    first: a@10#1234,SET:apple
+     next: b@5#1234,SET:banana
+     next: b@2#1234,SETWITHDEL:blueberry
+seek-ge c: c@9#1234,SETWITHDEL:coconut
+     next: c@6#1234,SET:cantaloupe
+     prev: c@9#1234,SETWITHDEL:coconut
+     prev: b@2#1234,SETWITHDEL:blueberry
+     prev: b@5#1234,SET:banana
+seek-lt c: b@2#1234,SETWITHDEL:blueberry
+     prev: b@5#1234,SET:banana
+     prev: a@10#1234,SET:apple
+     next: b@5#1234,SET:banana
 
 write-block
 a@10#1,SET:apple obsolete
@@ -51,10 +51,10 @@ next
 next
 next
 ----
-b@5:banana
-c@9:coconut
-c@1:clementine
-.
+first: b@5:banana
+ next: c@9:coconut
+ next: c@1:clementine
+ next: .
 
 iter hide-obsolete-points
 first
@@ -68,16 +68,16 @@ prev
 prev
 prev
 ----
-b@5:banana
-c@9:coconut
-c@1:clementine
-.
-c@1:clementine
-c@9:coconut
-c@1:clementine
-c@9:coconut
-b@5:banana
-.
+first: b@5:banana
+ next: c@9:coconut
+ next: c@1:clementine
+ next: .
+ prev: c@1:clementine
+ prev: c@9:coconut
+ next: c@1:clementine
+ prev: c@9:coconut
+ prev: b@5:banana
+ prev: .
 
 
 iter hide-obsolete-points
@@ -89,31 +89,31 @@ prev
 prev
 next
 ----
-c@1:clementine
-c@9:coconut
-c@1:clementine
-c@9:coconut
-b@5:banana
-.
-b@5:banana
+last: c@1:clementine
+prev: c@9:coconut
+next: c@1:clementine
+prev: c@9:coconut
+prev: b@5:banana
+prev: .
+next: b@5:banana
 
 iter hide-obsolete-points
 seek-ge a
 prev
 next
 ----
-b@5:banana
-.
-b@5:banana
+seek-ge a: b@5:banana
+     prev: .
+     next: b@5:banana
 
 iter hide-obsolete-points
 seek-ge d
 prev
 prev
 ----
-.
-c@1:clementine
-c@9:coconut
+seek-ge d: .
+     prev: c@1:clementine
+     prev: c@9:coconut
 
 iter hide-obsolete-points
 seek-lt c
@@ -123,12 +123,12 @@ prev
 prev
 prev
 ----
-b@5:banana
-c@9:coconut
-c@1:clementine
-c@9:coconut
-b@5:banana
-.
+seek-lt c: b@5:banana
+     next: c@9:coconut
+     next: c@1:clementine
+     prev: c@9:coconut
+     prev: b@5:banana
+     prev: .
 
 # Test a block with only obsolete points.
 write-block
@@ -160,24 +160,24 @@ seek-lt b
 next
 prev
 ----
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
-.
+    first: .
+     next: .
+     prev: .
+     last: .
+     next: .
+     prev: .
+seek-ge a: .
+     next: .
+     prev: .
+seek-ge b: .
+     next: .
+     prev: .
+seek-ge c: .
+     next: .
+     prev: .
+seek-lt z: .
+     next: .
+     prev: .
+seek-lt b: .
+     next: .
+     prev: .


### PR DESCRIPTION
It's pretty hard to look at an `iter` testcase and see which key
matches which command. This commit adds a `ShowCommands` option and
uses it for the data block tests.