### PR TITLE
block,colblk: tighten iterator semantics

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -191,7 +191,9 @@ type IndexBlockIterator interface {
 	// currently positioned over a valid block entry.
 	IsDataInvalidated() bool
 	// Invalidate invalidates the block iterator, removing references to the
-	// block it was initialized with.
+	// block it was initialized with. The iterator may continue to be used after
+	// a call to Invalidate, but all positioning methods should return false.
+	// Valid() must also return false.
 	Invalidate()
 	// Handle returns the underlying block buffer handle, if the iterator was
 	// initialized with one.
@@ -217,10 +219,12 @@ type IndexBlockIterator interface {
 	// the index block is empty.
 	Last() bool
 	// Next steps the index iterator to the next block entry. It returns false
-	// if the index block is exhausted.
+	// if the index block is exhausted in the forward direction. A call to Next
+	// while already exhausted in the forward direction is a no-op.
 	Next() bool
 	// Prev steps the index iterator to the previous block entry. It returns
-	// false if the index block is exhausted.
+	// false if the index block is exhausted in the reverse direction. A call to
+	// Prev while already exhausted in the reverse direction is a no-op.
 	Prev() bool
 	// Close closes the iterator, releasing any resources it holds.
 	Close() error

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -162,8 +162,10 @@ type DataBlockIterator interface {
 	// contained within the data block. It's equivalent to performing
 	//   Compare(firstUserKey, k)
 	CompareFirstUserKey(k []byte) int
-	// Invalidate invalidates the block iterator, removing references to the block
-	// it was initialized with.
+	// Invalidate invalidates the block iterator, removing references to the
+	// block it was initialized with. The iterator may continue to be used after
+	// a call to Invalidate, but all positioning methods should return false.
+	// Valid() must also return false.
 	Invalidate()
 	// IsDataInvalidated returns true when the iterator has been invalidated
 	// using an Invalidate call.

--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -118,6 +118,9 @@ func TestDataBlock(t *testing.T) {
 				if td.HasArg("verbose") {
 					o = append(o, itertest.Verbose)
 				}
+				if td.HasArg("invalidated") {
+					it = DataBlockIter{}
+				}
 				return itertest.RunInternalIterCmd(t, td, &it, o...)
 			default:
 				return fmt.Sprintf("unknown command: %s", td.Cmd)

--- a/sstable/colblk/index_block.go
+++ b/sstable/colblk/index_block.go
@@ -242,13 +242,14 @@ func (i *IndexIter) ResetForReuse() IndexIter {
 // Valid returns true if the iterator is currently positioned at a valid block
 // handle.
 func (i *IndexIter) Valid() bool {
-	return 0 <= i.row && i.row < int(i.r.br.header.Rows)
+	return 0 <= i.row && i.row < i.n
 }
 
 // Invalidate invalidates the block iterator, removing references to the block
 // it was initialized with.
 func (i *IndexIter) Invalidate() {
 	i.r = nil
+	i.n = 0
 }
 
 // IsDataInvalidated returns true when the iterator has been invalidated
@@ -321,17 +322,19 @@ func (i *IndexIter) Last() bool {
 }
 
 // Next steps the index iterator to the next block entry. It returns false if
-// the index block is exhausted.
+// the index block is exhausted in the forward direction. A call to Next while
+// already exhausted in the forward direction is a no-op.
 func (i *IndexIter) Next() bool {
-	i.row++
+	i.row = min(i.n, i.row+1)
 	return i.row < i.n
 }
 
 // Prev steps the index iterator to the previous block entry. It returns false
-// if the index block is exhausted.
+// if the index block is exhausted in the reverse direction. A call to Prev
+// while already exhausted in the reverse direction is a no-op.
 func (i *IndexIter) Prev() bool {
-	i.row--
-	return i.row >= 0
+	i.row = max(-1, i.row-1)
+	return i.row >= 0 && i.row < i.n
 }
 
 // Close closes the iterator, releasing any resources it holds.

--- a/sstable/colblk/index_block_test.go
+++ b/sstable/colblk/index_block_test.go
@@ -68,6 +68,11 @@ func TestIndexBlock(t *testing.T) {
 					valid = it.Next()
 				case "prev":
 					valid = it.Prev()
+				case "is-valid":
+					fmt.Fprintf(&buf, "Valid()=%t\n", it.Valid())
+					continue
+				case "invalidate":
+					it.Invalidate()
 				default:
 					panic(fmt.Sprintf("unknown command: %s", fields[0]))
 				}

--- a/sstable/colblk/testdata/data_block/simple
+++ b/sstable/colblk/testdata/data_block/simple
@@ -302,6 +302,21 @@ seek-lt c@10: b@2:blueberry
 seek-lt d@11: c@1:clementine
 seek-lt d@10: d@11: 
 
+iter invalidated
+first
+seek-ge foo
+next
+prev
+seek-lt foo
+last
+----
+      first: .
+seek-ge foo: .
+       next: .
+       prev: .
+seek-lt foo: .
+       last: .
+
 init
 ----
 size=51:

--- a/sstable/colblk/testdata/index_block
+++ b/sstable/colblk/testdata/index_block
@@ -125,6 +125,60 @@ block 1: 141-253 props="bp2"
 block 0: 24-48 props="bp1"
 .
 
+# Test Next-ing an index iterator that's already exhausted in the forward
+# direction. The sstable iterators do this in some circumstances. The Next
+# should be a no-op and a subsequent Prev should still return to the last block
+# handle in the block.
+
+iter
+last
+next
+next
+prev
+----
+block 5: 963-1289 props="bp6"
+.
+.
+block 5: 963-1289 props="bp6"
+
+# Test Prev-ing an index iterator that's already exhausted in the reverse
+# direction. The sstable iterators do this in some circumstances. The Prev
+# should be a no-op and a subsequent Next should still return to the first block
+# handle in the block.
+
+iter
+first
+prev
+prev
+next
+----
+block 0: 24-48 props="bp1"
+.
+.
+block 0: 24-48 props="bp1"
+
+# Test Invalidate() and ensure that Valid() and all positioning methods return
+# false after it.
+
+iter
+first
+invalidate
+is-valid
+next
+prev
+first
+last
+seek-ge a
+----
+block 0: 24-48 props="bp1"
+.
+Valid()=false
+.
+.
+.
+.
+.
+
 # Rebuild the same index block, but excluding the last row during the final Finish().
 
 build rows=5


### PR DESCRIPTION
**block,colblk: tighten index iterator semantics**

This commit more tightly defines the IndexBlockIterator semantics around behavior after a call to Invalidate and around positioning operations called after exhaustion. These semantics match the rowblk implementation and are currently required by the sstable iterator.

In the future, we may consider alternative semantics through updating the sstable iterator.

**block,colblk: tighten data block iterator semantics**

Define the semantics of calling a positioning method on an invalidated
DataBlockIterator. The sstable iterator currently depends on these semantics.