### PR TITLE
sstable: fix RawColumnWriter's value-block determination

### DIFF
--- a/sstable/format.go
+++ b/sstable/format.go
@@ -214,9 +214,9 @@ const (
 //     RANGEDELs when a Pebble-external writer is trying to construct a strict
 //     obsolete sstable.
 
-// ParseTableFormat parses the given magic bytes and version into its
+// parseTableFormat parses the given magic bytes and version into its
 // corresponding internal TableFormat.
-func ParseTableFormat(magic []byte, version uint32) (TableFormat, error) {
+func parseTableFormat(magic []byte, version uint32) (TableFormat, error) {
 	switch string(magic) {
 	case levelDBMagic:
 		return TableFormatLevelDB, nil
@@ -286,6 +286,8 @@ func (f TableFormat) AsTuple() (string, uint32) {
 // String returns the TableFormat (Magic String,Version) tuple.
 func (f TableFormat) String() string {
 	switch f {
+	case TableFormatUnspecified:
+		return "unspecified"
 	case TableFormatLevelDB:
 		return "(LevelDB)"
 	case TableFormatRocksDBv2:
@@ -303,4 +305,22 @@ func (f TableFormat) String() string {
 	default:
 		panic("sstable: unknown table format version tuple")
 	}
+}
+
+var tableFormatStrings = func() map[string]TableFormat {
+	strs := make(map[string]TableFormat, NumTableFormats)
+	for f := TableFormatUnspecified; f < NumTableFormats; f++ {
+		strs[f.String()] = f
+	}
+	return strs
+}()
+
+// ParseTableFormatString parses a TableFormat from its human-readable string
+// representation.
+func ParseTableFormatString(s string) (TableFormat, error) {
+	f, ok := tableFormatStrings[s]
+	if !ok {
+		return TableFormatUnspecified, errors.Errorf("unknown table format %q", s)
+	}
+	return f, nil
 }

--- a/sstable/format_test.go
+++ b/sstable/format_test.go
@@ -88,7 +88,7 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			// Tuple -> TableFormat.
-			f, err := ParseTableFormat([]byte(tc.magic), tc.version)
+			f, err := parseTableFormat([]byte(tc.magic), tc.version)
 			if err != nil {
 				// Keep the formatting consistent with what the Reader observes
 				// through readFooter.

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -351,7 +351,7 @@ func parseFooter(buf []byte, off, size int64) (footer, error) {
 		footer.footerBH.Length = uint64(len(buf))
 		version := binary.LittleEndian.Uint32(buf[rocksDBVersionOffset:rocksDBMagicOffset])
 
-		format, err := ParseTableFormat(magic, version)
+		format, err := parseTableFormat(magic, version)
 		if err != nil {
 			return footer, err
 		}
@@ -430,7 +430,7 @@ func supportsTwoLevelIndex(format TableFormat) bool {
 	switch format {
 	case TableFormatLevelDB:
 		return false
-	case TableFormatRocksDBv2, TableFormatPebblev1, TableFormatPebblev2, TableFormatPebblev3, TableFormatPebblev4:
+	case TableFormatRocksDBv2, TableFormatPebblev1, TableFormatPebblev2, TableFormatPebblev3, TableFormatPebblev4, TableFormatPebblev5:
 		return true
 	default:
 		panic("sstable: unspecified table format version")

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -1,7 +1,7 @@
 # Size of value index is 3 bytes plus 5 + 5 = 10 bytes of trailer of the value
 # block and value index block. So size 18 - 13 = 5 size of the value in the
 # value block.
-build
+build table-format=(Pebble,v4)
 a@2.SET.1:a2
 b@5.SET.7:b5
 b@4.DEL.3:
@@ -30,12 +30,39 @@ scan-cloned-lazy-values
 ----
 0(in-place: len 2): a2
 1(in-place: len 2): b5
-2(in-place: len 0): 
+2(in-place: len 0):
+3(in-place: len 4): bat3
+4(lazy: len 5, attr: 5): vbat2
+
+# Repeat the above test with (Pebble,v5) [columnar blocks].
+
+build table-format=(Pebble,v5)
+a@2.SET.1:a2
+b@5.SET.7:b5
+b@4.DEL.3:
+b@3.SET.2:bat3
+b@2.SET.1:vbat2
+----
+value-blocks: num-values 1, num-blocks: 1, size: 18
+
+scan
+----
+a@2#1,SET:a2
+b@5#7,SET:b5
+b@4#3,DEL:
+b@3#2,SET:bat3
+b@2#1,SET:vbat2
+
+scan-cloned-lazy-values
+----
+0(in-place: len 2): a2
+1(in-place: len 2): b5
+2(in-place: len 0):
 3(in-place: len 4): bat3
 4(lazy: len 5, attr: 5): vbat2
 
 # Same data as previous, with disable-value-blocks set to true
-build disable-value-blocks=true
+build disable-value-blocks=true table-format=(Pebble,v4)
 a@2.SET.1:a2
 b@5.SET.7:b5
 b@4.DEL.3:
@@ -60,10 +87,29 @@ b@4#3,DEL:
 b@3#2,SET:bat3
 b@2#1,SET:vbat2
 
+# Same as above but with (Pebble,v5) [columnar blocks].
+
+build disable-value-blocks=true table-format=(Pebble,v5)
+a@2.SET.1:a2
+b@5.SET.7:b5
+b@4.DEL.3:
+b@3.SET.2:bat3
+b@2.SET.1:vbat2
+----
+value-blocks: num-values 0, num-blocks: 0, size: 0
+
+scan
+----
+a@2#1,SET:a2
+b@5#7,SET:b5
+b@4#3,DEL:
+b@3#2,SET:bat3
+b@2#1,SET:vbat2
+
 # Size of value index is 3 bytes plus 5 + 5 = 10 bytes of trailer of the value
 # block and value index block. So size 33 - 13 = 20 is the total size of the
 # values in the value block.
-build
+build table-format=(Pebble,v4)
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 blue@8.SET.16:blue8s
@@ -102,7 +148,43 @@ scan-cloned-lazy-values
 0(in-place: len 6): blue10
 1(lazy: len 5, attr: 5): blue8
 2(lazy: len 6, attr: 6): blue8s
-3(in-place: len 0): 
+3(in-place: len 0):
+4(in-place: len 5): blue4
+5(lazy: len 5, attr: 5): blue3
+6(in-place: len 4): red9
+7(lazy: len 4, attr: 4): red7
+
+# Same as above but with (Pebble,v5) [columnar blocks].
+
+build table-format=(Pebble,v5)
+blue@10.SET.20:blue10
+blue@8.SET.18:blue8
+blue@8.SET.16:blue8s
+blue@6.DEL.14:
+blue@4.SET.12:blue4
+blue@3.SET.10:blue3
+red@9.SET.18:red9
+red@7.SET.8:red7
+----
+value-blocks: num-values 4, num-blocks: 1, size: 33
+
+scan
+----
+blue@10#20,SET:blue10
+blue@8#18,SET:blue8
+blue@8#16,SET:blue8s
+blue@6#14,DEL:
+blue@4#12,SET:blue4
+blue@3#10,SET:blue3
+red@9#18,SET:red9
+red@7#8,SET:red7
+
+scan-cloned-lazy-values
+----
+0(in-place: len 6): blue10
+1(lazy: len 5, attr: 5): blue8
+2(lazy: len 6, attr: 6): blue8s
+3(in-place: len 0):
 4(in-place: len 5): blue4
 5(lazy: len 5, attr: 5): blue3
 6(in-place: len 4): red9
@@ -113,7 +195,7 @@ scan-cloned-lazy-values
 # block has to encode two tuples, each of 4 bytes (blockNumByteLength=1,
 # blockOffsetByteLength=2, blockLengthByteLength=1), so 2*4=8. The total is
 # 15+26+8=49 bytes, which corresponds to "size: 49" below.
-build block-size=8
+build block-size=8 table-format=(Pebble,v4)
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 blue@8.SET.16:blue8s
@@ -233,8 +315,360 @@ layout
       1074    magic number: 0xf09faab3f09faab3
       1082  EOF
 
+# Same as above but with (Pebble,v5) [columnar blocks].
+
+build block-size=8 table-format=(Pebble,v5)
+blue@10.SET.20:blue10
+blue@8.SET.18:blue8
+blue@8.SET.16:blue8s
+blue@6.SET.16:blue6isverylong
+----
+value-blocks: num-values 3, num-blocks: 2, size: 49
+
+scan
+----
+blue@10#20,SET:blue10
+blue@8#18,SET:blue8
+blue@8#16,SET:blue8s
+blue@6#16,SET:blue6isverylong
+
+scan-cloned-lazy-values
+----
+0(in-place: len 6): blue10
+1(lazy: len 5, attr: 5): blue8
+2(lazy: len 6, attr: 6): blue8s
+3(lazy: len 15, attr: 7): blue6isverylong
+
+layout
+----
+         0  data (81)
+               # data block header
+               00-04: x 07000000                                                         # maximum key length: 7
+               # columnar block header
+               04-05: x 01                                                               # version 1
+               05-07: x 0700                                                             # 7 columns
+               07-11: x 01000000                                                         # 1 rows
+               11-12: b 00000100                                                         # col 0: prefixbytes
+               12-16: x 2e000000                                                         # col 0: page start 46
+               16-17: b 00000011                                                         # col 1: bytes
+               17-21: x 37000000                                                         # col 1: page start 55
+               21-22: b 00000010                                                         # col 2: uint
+               22-26: x 3d000000                                                         # col 2: page start 61
+               26-27: b 00000001                                                         # col 3: bool
+               27-31: x 46000000                                                         # col 3: page start 70
+               31-32: b 00000011                                                         # col 4: bytes
+               32-36: x 58000000                                                         # col 4: page start 88
+               36-37: b 00000001                                                         # col 5: bool
+               37-41: x 61000000                                                         # col 5: page start 97
+               41-42: b 00000001                                                         # col 6: bool
+               42-46: x 62000000                                                         # col 6: page start 98
+               # data for column 0
+               # PrefixBytes
+               46-47: x 04                                                               # bundleSize: 16
+               # Offsets table
+               47-48: x 01                                                               # encoding: 1b
+               48-49: x 04                                                               # data[0] = 4 [55 overall]
+               49-50: x 04                                                               # data[1] = 4 [55 overall]
+               50-51: x 04                                                               # data[2] = 4 [55 overall]
+               # Data
+               51-55: x 626c7565                                                         # data[00]: blue (block prefix)
+               55-55: x                                                                  # data[01]: .... (bundle prefix)
+               55-55: x                                                                  # data[02]: ....
+               # data for column 1
+               # rawbytes
+               # offsets table
+               55-56: x 01                                                               # encoding: 1b
+               56-57: x 00                                                               # data[0] = 0 [58 overall]
+               57-58: x 03                                                               # data[1] = 3 [61 overall]
+               # data
+               58-61: x 403130                                                           # data[0]: @10
+               # data for column 2
+               61-62: x 80                                                               # encoding: const
+               62-70: x 0114000000000000                                                 # 64-bit constant: 5121
+               # data for column 3
+               70-71: x 00                                                               # bitmap encoding
+               71-72: x 00                                                               # padding to align to 64-bit boundary
+               72-80: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               80-88: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               88-89: x 01                                                               # encoding: 1b
+               89-90: x 00                                                               # data[0] = 0 [91 overall]
+               90-91: x 06                                                               # data[1] = 6 [97 overall]
+               # data
+               91-97: x 626c75653130                                                     # data[0]: blue10
+               # data for column 5
+               97-98: x 01                                                               # bitmap encoding
+               # data for column 6
+               98-99: x 01                                                               # bitmap encoding
+               99-100: x 00                                                              # block padding byte
+  blue@10#20,SET:blue10
+        81    [trailer compression=snappy checksum=0x3a342f9]
+        86  data (85)
+               # data block header
+               000-004: x 06000000                                                         # maximum key length: 6
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 01000000                                                         # 1 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 37000000                                                         # col 1: page start 55
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 3c000000                                                         # col 2: page start 60
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 45000000                                                         # col 3: page start 69
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 5f000000                                                         # col 5: page start 95
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 70000000                                                         # col 6: page start 112
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 04                                                               # data[0] = 4 [55 overall]
+               049-050: x 04                                                               # data[1] = 4 [55 overall]
+               050-051: x 04                                                               # data[2] = 4 [55 overall]
+               # Data
+               051-055: x 626c7565                                                         # data[00]: blue (block prefix)
+               055-055: x                                                                  # data[01]: .... (bundle prefix)
+               055-055: x                                                                  # data[02]: ....
+               # data for column 1
+               # rawbytes
+               # offsets table
+               055-056: x 01                                                               # encoding: 1b
+               056-057: x 00                                                               # data[0] = 0 [58 overall]
+               057-058: x 02                                                               # data[1] = 2 [60 overall]
+               # data
+               058-060: x 4038                                                             # data[0]: @8
+               # data for column 2
+               060-061: x 80                                                               # encoding: const
+               061-069: x 0112000000000000                                                 # 64-bit constant: 4609
+               # data for column 3
+               069-070: x 00                                                               # bitmap encoding
+               070-072: x 0000                                                             # padding to align to 64-bit boundary
+               072-080: b 0000000000000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000000000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [91 overall]
+               090-091: x 04                                                               # data[1] = 4 [95 overall]
+               # data
+               091-095: x a5050000                                                         # data[0]: "\xa5\x05\x00\x00"
+               # data for column 5
+               095-096: x 00                                                               # bitmap encoding
+               096-104: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               104-112: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 6
+               112-113: x 01                                                               # bitmap encoding
+               113-114: x 00                                                               # block padding byte
+  blue@8#18,SET:value handle {valueLen:5 blockNum:0 offsetInBlock:0}
+       171    [trailer compression=snappy checksum=0x17efbf53]
+       176  data (94)
+               # data block header
+               000-004: x 06000000                                                         # maximum key length: 6
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 01000000                                                         # 1 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 37000000                                                         # col 1: page start 55
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 3c000000                                                         # col 2: page start 60
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 45000000                                                         # col 3: page start 69
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 5f000000                                                         # col 5: page start 95
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 70000000                                                         # col 6: page start 112
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 04                                                               # data[0] = 4 [55 overall]
+               049-050: x 04                                                               # data[1] = 4 [55 overall]
+               050-051: x 04                                                               # data[2] = 4 [55 overall]
+               # Data
+               051-055: x 626c7565                                                         # data[00]: blue (block prefix)
+               055-055: x                                                                  # data[01]: .... (bundle prefix)
+               055-055: x                                                                  # data[02]: ....
+               # data for column 1
+               # rawbytes
+               # offsets table
+               055-056: x 01                                                               # encoding: 1b
+               056-057: x 00                                                               # data[0] = 0 [58 overall]
+               057-058: x 02                                                               # data[1] = 2 [60 overall]
+               # data
+               058-060: x 4038                                                             # data[0]: @8
+               # data for column 2
+               060-061: x 80                                                               # encoding: const
+               061-069: x 0110000000000000                                                 # 64-bit constant: 4097
+               # data for column 3
+               069-070: x 00                                                               # bitmap encoding
+               070-072: x 0000                                                             # padding to align to 64-bit boundary
+               072-080: b 0000000000000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000000000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [91 overall]
+               090-091: x 04                                                               # data[1] = 4 [95 overall]
+               # data
+               091-095: x a6060005                                                         # data[0]: "\xa6\x06\x00\x05"
+               # data for column 5
+               095-096: x 00                                                               # bitmap encoding
+               096-104: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               104-112: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 6
+               112-113: x 00                                                               # bitmap encoding
+               113-120: x 00000000000000                                                   # padding to align to 64-bit boundary
+               120-128: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               128-136: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               136-137: x 00                                                               # block padding byte
+  blue@8#16,SET:value handle {valueLen:6 blockNum:0 offsetInBlock:5}
+       270    [trailer compression=snappy checksum=0x9371e6fd]
+       275  data (90)
+               # data block header
+               000-004: x 06000000                                                         # maximum key length: 6
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 01000000                                                         # 1 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 37000000                                                         # col 1: page start 55
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 3c000000                                                         # col 2: page start 60
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 45000000                                                         # col 3: page start 69
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 5f000000                                                         # col 5: page start 95
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 70000000                                                         # col 6: page start 112
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 04                                                               # data[0] = 4 [55 overall]
+               049-050: x 04                                                               # data[1] = 4 [55 overall]
+               050-051: x 04                                                               # data[2] = 4 [55 overall]
+               # Data
+               051-055: x 626c7565                                                         # data[00]: blue (block prefix)
+               055-055: x                                                                  # data[01]: .... (bundle prefix)
+               055-055: x                                                                  # data[02]: ....
+               # data for column 1
+               # rawbytes
+               # offsets table
+               055-056: x 01                                                               # encoding: 1b
+               056-057: x 00                                                               # data[0] = 0 [58 overall]
+               057-058: x 02                                                               # data[1] = 2 [60 overall]
+               # data
+               058-060: x 4036                                                             # data[0]: @6
+               # data for column 2
+               060-061: x 80                                                               # encoding: const
+               061-069: x 0110000000000000                                                 # 64-bit constant: 4097
+               # data for column 3
+               069-070: x 00                                                               # bitmap encoding
+               070-072: x 0000                                                             # padding to align to 64-bit boundary
+               072-080: b 0000000000000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000000000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [91 overall]
+               090-091: x 04                                                               # data[1] = 4 [95 overall]
+               # data
+               091-095: x a70f0100                                                         # data[0]: "\xa7\x0f\x01\x00"
+               # data for column 5
+               095-096: x 00                                                               # bitmap encoding
+               096-104: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               104-112: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 6
+               112-113: x 01                                                               # bitmap encoding
+               113-114: x 00                                                               # block padding byte
+  blue@6#16,SET:value handle {valueLen:15 blockNum:1 offsetInBlock:0}
+       365    [trailer compression=snappy checksum=0xcfdbcc3c]
+       370  index (42)
+         0    block:0/81
+       412    [trailer compression=none checksum=0x80ae3e61]
+       417  index (49)
+         0    block:86/85
+       466    [trailer compression=none checksum=0xf2bc08f4]
+       471  index (54)
+         0    block:176/94
+       525    [trailer compression=none checksum=0x4eed6c67]
+       530  index (44)
+         0    block:275/90
+       574    [trailer compression=none checksum=0xbacbe8f5]
+       579  top-index (81)
+         0    block:370/42
+         1    block:417/49
+         2    block:471/54
+         3    block:530/44
+       660    [trailer compression=none checksum=0xdacecc3b]
+       665  value-block (11)
+       681  value-block (15)
+       701  value-index (8)
+       714  properties (549)
+       714    obsolete-key (16) [restart]
+       730    pebble.num.value-blocks (27)
+       757    pebble.num.values.in.value-blocks (21)
+       778    pebble.value-blocks.size (21)
+       799    rocksdb.block.based.table.index.type (43)
+       842    rocksdb.comparator (37)
+       879    rocksdb.compression (16)
+       895    rocksdb.compression_options (106)
+      1001    rocksdb.data.size (14)
+      1015    rocksdb.deleted.keys (15)
+      1030    rocksdb.filter.size (15)
+      1045    rocksdb.index.partitions (20)
+      1065    rocksdb.index.size (9)
+      1074    rocksdb.merge.operands (18)
+      1092    rocksdb.merge.operator (24)
+      1116    rocksdb.num.data.blocks (19)
+      1135    rocksdb.num.entries (11)
+      1146    rocksdb.num.range-deletions (19)
+      1165    rocksdb.property.collectors (36)
+      1201    rocksdb.raw.key.size (16)
+      1217    rocksdb.raw.value.size (14)
+      1231    rocksdb.top-level.index.size (24)
+      1255    [restart 714]
+      1263    [trailer compression=none checksum=0x2e004e9b]
+      1268  meta-index (64)
+      1268    pebble.value_index block:701/8 value-blocks-index-lengths: 1(num), 2(offset), 1(length) [restart]
+      1295    rocksdb.properties block:714/549 [restart]
+      1320    [restart 1268]
+      1324    [restart 1295]
+      1332    [trailer compression=none checksum=0x926e2244]
+      1337  footer (53)
+      1337    checksum type: crc32c
+      1338    meta: offset=1268, length=64
+      1341    index: offset=579, length=81
+      1344    [padding]
+      1378    version: 5
+      1382    magic number: 0xf09faab3f09faab3
+      1390  EOF
+
 # Require that [c,e) must be in-place.
-build in-place-bound=(c,e)
+build in-place-bound=(c,e) table-format=(Pebble,v4)
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 c@10.SET.16:c10
@@ -271,8 +705,38 @@ scan-cloned-lazy-values
 4(in-place: len 5): eat20
 5(lazy: len 5, attr: 5): eat18
 
+# Same as above with (Pebble,v5) [columnar blocks].
+
+build in-place-bound=(c,e) table-format=(Pebble,v5)
+blue@10.SET.20:blue10
+blue@8.SET.18:blue8
+c@10.SET.16:c10
+c@8.SET.14:c8
+e@20.SET.25:eat20
+e@18.SET.23:eat18
+----
+value-blocks: num-values 2, num-blocks: 1, size: 23
+
+scan
+----
+blue@10#20,SET:blue10
+blue@8#18,SET:blue8
+c@10#16,SET:c10
+c@8#14,SET:c8
+e@20#25,SET:eat20
+e@18#23,SET:eat18
+
+scan-cloned-lazy-values
+----
+0(in-place: len 6): blue10
+1(lazy: len 5, attr: 5): blue8
+2(in-place: len 3): c10
+3(in-place: len 2): c8
+4(in-place: len 5): eat20
+5(lazy: len 5, attr: 5): eat18
+
 # Try write empty values to value blocks.
-build
+build table-format=(Pebble,v4)
 b@5.SET.7:b5
 b@3.SET.2:
 c@6.DEL.7:
@@ -344,3 +808,148 @@ layout
        660    version: 4
        664    magic number: 0xf09faab3f09faab3
        672  EOF
+
+# Same as above but with (Pebble,v5) [columnar blocks].
+
+build table-format=(Pebble,v5)
+b@5.SET.7:b5
+b@3.SET.2:
+c@6.DEL.7:
+c@5.DEL.6:
+----
+value-blocks: num-values 0, num-blocks: 0, size: 0
+
+scan
+----
+b@5#7,SET:b5
+b@3#2,SET:
+c@6#7,DEL:
+c@5#6,DEL:
+
+layout
+----
+         0  data (100)
+               # data block header
+               000-004: x 03000000                                                         # maximum key length: 3
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 04000000                                                         # 4 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 38000000                                                         # col 1: page start 56
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 46000000                                                         # col 2: page start 70
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 50000000                                                         # col 3: page start 80
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 68000000                                                         # col 4: page start 104
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 70000000                                                         # col 5: page start 112
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 71000000                                                         # col 6: page start 113
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [54 overall]
+               049-050: x 00                                                               # data[1] = 0 [54 overall]
+               050-051: x 01                                                               # data[2] = 1 [55 overall]
+               051-052: x 01                                                               # data[3] = 1 [55 overall]
+               052-053: x 02                                                               # data[4] = 2 [56 overall]
+               053-054: x 02                                                               # data[5] = 2 [56 overall]
+               # Data
+               054-054: x                                                                  # data[00]:  (block prefix)
+               054-054: x                                                                  # data[01]:  (bundle prefix)
+               054-055: x 62                                                               # data[02]: b
+               055-055: x                                                                  # data[03]: .
+               055-056: x 63                                                               # data[04]: c
+               056-056: x                                                                  # data[05]: .
+               # data for column 1
+               # rawbytes
+               # offsets table
+               056-057: x 01                                                               # encoding: 1b
+               057-058: x 00                                                               # data[0] = 0 [62 overall]
+               058-059: x 02                                                               # data[1] = 2 [64 overall]
+               059-060: x 04                                                               # data[2] = 4 [66 overall]
+               060-061: x 06                                                               # data[3] = 6 [68 overall]
+               061-062: x 08                                                               # data[4] = 8 [70 overall]
+               # data
+               062-064: x 4035                                                             # data[0]: @5
+               064-066: x 4033                                                             # data[1]: @3
+               066-068: x 4036                                                             # data[2]: @6
+               068-070: x 4035                                                             # data[3]: @5
+               # data for column 2
+               070-071: x 02                                                               # encoding: 2b
+               071-072: x 00                                                               # padding (aligning to 16-bit boundary)
+               072-074: x 0107                                                             # data[0] = 1793
+               074-076: x 0102                                                             # data[1] = 513
+               076-078: x 0007                                                             # data[2] = 1792
+               078-080: x 0006                                                             # data[3] = 1536
+               # data for column 3
+               080-081: x 00                                                               # bitmap encoding
+               081-088: x 00000000000000                                                   # padding to align to 64-bit boundary
+               088-096: b 0000010100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               096-104: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               104-105: x 01                                                               # encoding: 1b
+               105-106: x 00                                                               # data[0] = 0 [110 overall]
+               106-107: x 02                                                               # data[1] = 2 [112 overall]
+               107-108: x 02                                                               # data[2] = 2 [112 overall]
+               108-109: x 02                                                               # data[3] = 2 [112 overall]
+               109-110: x 02                                                               # data[4] = 2 [112 overall]
+               # data
+               110-112: x 6235                                                             # data[0]: b5
+               112-112: x                                                                  # data[1]:
+               112-112: x                                                                  # data[2]:
+               112-112: x                                                                  # data[3]:
+               # data for column 5
+               112-113: x 01                                                               # bitmap encoding
+               # data for column 6
+               113-114: x 01                                                               # bitmap encoding
+               114-115: x 00                                                               # block padding byte
+  b@5#7,SET:b5
+  b@3#2,SET:
+  c@6#7,DEL:
+  c@5#6,DEL:
+       100    [trailer compression=snappy checksum=0x73ac4dc7]
+       105  index (36)
+         0    block:0/100
+       141    [trailer compression=none checksum=0x760132f1]
+       146  properties (479)
+       146    obsolete-key (16) [restart]
+       162    pebble.raw.point-tombstone.key.size (39)
+       201    rocksdb.block.based.table.index.type (43)
+       244    rocksdb.comparator (37)
+       281    rocksdb.compression (16)
+       297    rocksdb.compression_options (106)
+       403    rocksdb.data.size (13)
+       416    rocksdb.deleted.keys (15)
+       431    rocksdb.filter.size (15)
+       446    rocksdb.index.size (14)
+       460    rocksdb.merge.operands (18)
+       478    rocksdb.merge.operator (24)
+       502    rocksdb.num.data.blocks (19)
+       521    rocksdb.num.entries (11)
+       532    rocksdb.num.range-deletions (19)
+       551    rocksdb.property.collectors (36)
+       587    rocksdb.raw.key.size (16)
+       603    rocksdb.raw.value.size (14)
+       617    [restart 146]
+       625    [trailer compression=none checksum=0x6d52d476]
+       630  meta-index (33)
+       630    rocksdb.properties block:146/479 [restart]
+       655    [restart 630]
+       663    [trailer compression=none checksum=0x95dbb0f4]
+       668  footer (53)
+       668    checksum type: crc32c
+       669    meta: offset=630, length=33
+       672    index: offset=105, length=36
+       674    [padding]
+       709    version: 5
+       713    magic number: 0xf09faab3f09faab3
+       721  EOF


### PR DESCRIPTION
Fix a bug in RawColumnWriter's determination of whether to possibly store a value in a value block. It erroneously required the current key kind to NOT be a SET. Also, adapt TestWriterWithValueBlocks to test (Pebble,v5) [columnar blocks].