### PR TITLE
sstable: show iterator commands

### DIFF
--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -744,7 +744,7 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, printVa
 				if err != nil {
 					return err.Error()
 				}
-				return runIterCmd(d, iter, printValue, runIterCmdStats(&stats))
+				return runIterCmd(d, iter, printValue, runIterCmdStats(&stats), runIterCmdShowCommands)
 
 			case "get":
 				var b bytes.Buffer

--- a/sstable/testdata/hamletreader/hamlet_iter
+++ b/sstable/testdata/hamletreader/hamlet_iter
@@ -5,11 +5,11 @@ next
 next
 next
 ----
-<a:0>
-<aboard:0>
-<about:0>
-<above:0>
-<abroad:0>
+first: <a:0>
+ next: <aboard:0>
+ next: <about:0>
+ next: <above:0>
+ next: <abroad:0>
 
 iter
 seek-ge a
@@ -18,11 +18,11 @@ next
 next
 next
 ----
-<a:0>
-<aboard:0>
-<about:0>
-<above:0>
-<abroad:0>
+seek-ge a: <a:0>
+     next: <aboard:0>
+     next: <about:0>
+     next: <above:0>
+     next: <abroad:0>
 
 iter
 seek-ge b
@@ -30,31 +30,31 @@ next
 next
 next
 ----
-<baby:0>
-<back:0>
-<baked:0>
-<bark:0>
+seek-ge b: <baby:0>
+     next: <back:0>
+     next: <baked:0>
+     next: <bark:0>
 
 iter
 seek-ge c
 next
 next
 ----
-<call:0>
-<calumnious:0>
-<came:0>
+seek-ge c: <call:0>
+     next: <calumnious:0>
+     next: <came:0>
 
 iter
 seek-ge d
 next
 ----
-<d:0>
-<daily:0>
+seek-ge d: <d:0>
+     next: <daily:0>
 
 iter
 seek-ge e
 ----
-<e:0>
+seek-ge e: <e:0>
 
 iter
 seek-ge b
@@ -62,10 +62,10 @@ seek-ge c
 seek-ge d
 seek-ge e
 ----
-<baby:0>
-<call:0>
-<d:0>
-<e:0>
+seek-ge b: <baby:0>
+seek-ge c: <call:0>
+seek-ge d: <d:0>
+seek-ge e: <e:0>
 
 iter
 last
@@ -74,11 +74,11 @@ prev
 prev
 prev
 ----
-<youth:0>
-<yourself:0>
-<your:0>
-<young:0>
-<you:0>
+last: <youth:0>
+prev: <yourself:0>
+prev: <your:0>
+prev: <young:0>
+prev: <you:0>
 
 iter
 seek-lt e
@@ -87,11 +87,11 @@ prev
 prev
 prev
 ----
-<dye:0>
-<dwelling:0>
-<duty:0>
-<duties:0>
-<dust:0>
+seek-lt e: <dye:0>
+     prev: <dwelling:0>
+     prev: <duty:0>
+     prev: <duties:0>
+     prev: <dust:0>
 
 iter
 seek-lt d
@@ -99,31 +99,31 @@ prev
 prev
 prev
 ----
-<cut:0>
-<customary:0>
-<custom:0>
-<cursed:0>
+seek-lt d: <cut:0>
+     prev: <customary:0>
+     prev: <custom:0>
+     prev: <cursed:0>
 
 iter
 seek-lt c
 prev
 prev
 ----
-<by:0>
-<buy:0>
-<buttons:0>
+seek-lt c: <by:0>
+     prev: <buy:0>
+     prev: <buttons:0>
 
 iter
 seek-lt b
 prev
 ----
-<ay:0>
-<awhile:0>
+seek-lt b: <ay:0>
+     prev: <awhile:0>
 
 iter
 seek-lt a
 ----
-.
+seek-lt a: .
 
 iter
 seek-lt d
@@ -131,10 +131,10 @@ seek-lt c
 seek-lt b
 seek-lt a
 ----
-<cut:0>
-<by:0>
-<ay:0>
-.
+seek-lt d: <cut:0>
+seek-lt c: <by:0>
+seek-lt b: <ay:0>
+seek-lt a: .
 
 iter globalSeqNum=1
 first
@@ -143,11 +143,11 @@ next
 next
 next
 ----
-<a:1>
-<aboard:1>
-<about:1>
-<above:1>
-<abroad:1>
+first: <a:1>
+ next: <aboard:1>
+ next: <about:1>
+ next: <above:1>
+ next: <abroad:1>
 
 iter globalSeqNum=10
 first
@@ -156,16 +156,16 @@ next
 next
 next
 ----
-<a:10>
-<aboard:10>
-<about:10>
-<above:10>
-<abroad:10>
+first: <a:10>
+ next: <aboard:10>
+ next: <about:10>
+ next: <above:10>
+ next: <abroad:10>
 
 iter globalSeqNum=0
 seek-lt x
 ----
-<wrung:0>
+seek-lt x: <wrung:0>
 
 get
 b
@@ -185,9 +185,9 @@ seek-ge aboard
 prev
 prev
 ----
-<aboard:0>
-<a:0>
-.
+seek-ge aboard: <aboard:0>
+          prev: <a:0>
+          prev: .
 
 iter
 seek-ge calumnious
@@ -200,15 +200,15 @@ prev
 prev
 prev
 ----
-<calumnious:0>
-<came:0>
-<can:0>
-<canker:0>
-<can:0>
-<came:0>
-<calumnious:0>
-<call:0>
-<by:0>
+seek-ge calumnious: <calumnious:0>
+              next: <came:0>
+              next: <can:0>
+              next: <canker:0>
+              prev: <can:0>
+              prev: <came:0>
+              prev: <calumnious:0>
+              prev: <call:0>
+              prev: <by:0>
 
 iter
 seek-lt yourself
@@ -216,10 +216,10 @@ next
 next
 next
 ----
-<your:0>
-<yourself:0>
-<youth:0>
-.
+seek-lt yourself: <your:0>
+            next: <yourself:0>
+            next: <youth:0>
+            next: .
 
 iter
 seek-lt yourself
@@ -239,22 +239,22 @@ prev
 prev
 prev
 ----
-<your:0>
-<young:0>
-<you:0>
-<yond:0>
-<you:0>
-<young:0>
-<calumnious:0>
-<call:0>
-<by:0>
-<buy:0>
-<a:0>
-<aboard:0>
-<about:0>
-<aboard:0>
-<a:0>
-.
+  seek-lt yourself: <your:0>
+              prev: <young:0>
+              prev: <you:0>
+              prev: <yond:0>
+              next: <you:0>
+              next: <young:0>
+seek-ge calumnious: <calumnious:0>
+              prev: <call:0>
+              prev: <by:0>
+              prev: <buy:0>
+             first: <a:0>
+              next: <aboard:0>
+              next: <about:0>
+              prev: <aboard:0>
+              prev: <a:0>
+              prev: .
 
 iter
 seek-ge m
@@ -262,10 +262,10 @@ next
 next
 next
 ----
-<m:0>
-<madam:0>
-<made:0>
-<madness:0>
+seek-ge m: <m:0>
+     next: <madam:0>
+     next: <made:0>
+     next: <madness:0>
 
 iter
 seek-lt m
@@ -273,10 +273,10 @@ next
 next
 next
 ----
-<luxury:0>
-<m:0>
-<madam:0>
-<made:0>
+seek-lt m: <luxury:0>
+     next: <m:0>
+     next: <madam:0>
+     next: <made:0>
 
 iter
 seek-ge a
@@ -306,32 +306,32 @@ seek-ge x
 seek-ge y
 seek-ge z
 ----
-<a:0>
-<baby:0>
-<call:0>
-<d:0>
-<e:0>
-<face:0>
-<gaged:0>
-<ha:0>
-<i:0>
-<jaws:0>
-<keep:0>
-<labourer:0>
-<m:0>
-<name:0>
-<o:0>
-<pale:0>
-<quarrel:0>
-<radiant:0>
-<s:0>
-<t:0>
-<ubique:0>
-<v:0>
-<wake:0>
-<yea:0>
-<yea:0>
-.
+seek-ge a: <a:0>
+seek-ge b: <baby:0>
+seek-ge c: <call:0>
+seek-ge d: <d:0>
+seek-ge e: <e:0>
+seek-ge f: <face:0>
+seek-ge g: <gaged:0>
+seek-ge h: <ha:0>
+seek-ge i: <i:0>
+seek-ge j: <jaws:0>
+seek-ge k: <keep:0>
+seek-ge l: <labourer:0>
+seek-ge m: <m:0>
+seek-ge n: <name:0>
+seek-ge o: <o:0>
+seek-ge p: <pale:0>
+seek-ge q: <quarrel:0>
+seek-ge r: <radiant:0>
+seek-ge s: <s:0>
+seek-ge t: <t:0>
+seek-ge u: <ubique:0>
+seek-ge v: <v:0>
+seek-ge w: <wake:0>
+seek-ge x: <yea:0>
+seek-ge y: <yea:0>
+seek-ge z: .
 
 iter
 seek-lt a
@@ -361,29 +361,29 @@ seek-lt x
 seek-lt y
 seek-lt z
 ----
-.
-<ay:0>
-<by:0>
-<cut:0>
-<dye:0>
-<eyes:0>
-<further:0>
-<guilty:0>
-<hyperion:0>
-<iv:0>
-<jump:0>
-<knows:0>
-<luxury:0>
-<myself:0>
-<now:0>
-<ownself:0>
-<puts:0>
-<quills:0>
-<russet:0>
-<sworn:0>
-<two:0>
-<usurp:0>
-<vulgar:0>
-<wrung:0>
-<wrung:0>
-<youth:0>
+seek-lt a: .
+seek-lt b: <ay:0>
+seek-lt c: <by:0>
+seek-lt d: <cut:0>
+seek-lt e: <dye:0>
+seek-lt f: <eyes:0>
+seek-lt g: <further:0>
+seek-lt h: <guilty:0>
+seek-lt i: <hyperion:0>
+seek-lt j: <iv:0>
+seek-lt k: <jump:0>
+seek-lt l: <knows:0>
+seek-lt m: <luxury:0>
+seek-lt n: <myself:0>
+seek-lt o: <now:0>
+seek-lt p: <ownself:0>
+seek-lt q: <puts:0>
+seek-lt r: <quills:0>
+seek-lt s: <russet:0>
+seek-lt t: <sworn:0>
+seek-lt u: <two:0>
+seek-lt v: <usurp:0>
+seek-lt w: <vulgar:0>
+seek-lt x: <wrung:0>
+seek-lt y: <wrung:0>
+seek-lt z: <youth:0>

--- a/sstable/testdata/prefixreader/iter
+++ b/sstable/testdata/prefixreader/iter
@@ -10,63 +10,63 @@ seek-prefix-ge a
 next
 next
 ----
-<a:1>:A
-<aa:2>:AA
-.
+seek-prefix-ge a: <a:1>:A
+            next: <aa:2>:AA
+            next: .
 
 iter
 seek-prefix-ge aa
 next
 ----
-<aa:2>:AA
-.
+seek-prefix-ge aa: <aa:2>:AA
+             next: .
 
 iter
 seek-prefix-ge aa
 prev
 ----
-<aa:2>:AA
-.
+seek-prefix-ge aa: <aa:2>:AA
+             prev: .
 
 iter
 seek-prefix-ge c
 prev
 ----
-<c:3>:C
-.
+seek-prefix-ge c: <c:3>:C
+            prev: .
 
 iter
 seek-prefix-ge b
 ----
-.
+seek-prefix-ge b: .
 
 iter
 seek-prefix-ge c
 next
 ----
-<c:3>:C
-.
+seek-prefix-ge c: <c:3>:C
+            next: .
 
 iter
 seek-prefix-ge d
 next
 ----
-<d:4>:D
-.
+seek-prefix-ge d: <d:4>:D
+            next: .
 
 iter
 seek-prefix-ge e
 ----
-.
+seek-prefix-ge e: .
 
 iter
 seek-prefix-ge c
 seek-prefix-ge d
 seek-prefix-ge e
 ----
-<c:3>:C
-<d:4>:D
-.
+seek-prefix-ge c: <c:3>:C
+seek-prefix-ge d: <d:4>:D
+seek-prefix-ge e: .
 
 iter
 seek-prefix-ge c
@@ -75,11 +75,11 @@ seek-prefix-ge a
 next
 next
 ----
-<c:3>:C
-.
-<a:1>:A
-<aa:2>:AA
-.
+seek-prefix-ge c: <c:3>:C
+            next: .
+seek-prefix-ge a: <a:1>:A
+            next: <aa:2>:AA
+            next: .
 
 iter
 seek-prefix-ge aa
@@ -90,13 +90,13 @@ next
 seek-prefix-ge c
 next
 ----
-<aa:2>:AA
-.
-<a:1>:A
-<aa:2>:AA
-.
-<c:3>:C
-.
+seek-prefix-ge aa: <aa:2>:AA
+             next: .
+ seek-prefix-ge a: <a:1>:A
+             next: <aa:2>:AA
+             next: .
+ seek-prefix-ge c: <c:3>:C
+             next: .
 
 iter
 seek-prefix-ge c
@@ -107,22 +107,22 @@ seek-prefix-ge a
 next
 next
 ----
-<c:3>:C
-.
-<aa:2>:AA
-.
-<a:1>:A
-<aa:2>:AA
-.
+ seek-prefix-ge c: <c:3>:C
+             next: .
+seek-prefix-ge aa: <aa:2>:AA
+             next: .
+ seek-prefix-ge a: <a:1>:A
+             next: <aa:2>:AA
+             next: .
 
 iter
 seek-prefix-ge a
 next
 next
 ----
-<a:1>:A
-<aa:2>:AA
-.
+seek-prefix-ge a: <a:1>:A
+            next: <aa:2>:AA
+            next: .
 
 iter
 seek-prefix-ge a
@@ -130,17 +130,17 @@ next
 prev
 prev
 ----
-<a:1>:A
-<aa:2>:AA
-<a:1>:A
-.
+seek-prefix-ge a: <a:1>:A
+            next: <aa:2>:AA
+            prev: <a:1>:A
+            prev: .
 
 iter
 seek-prefix-ge a
 prev
 ----
-<a:1>:A
-.
+seek-prefix-ge a: <a:1>:A
+            prev: .
 
 iter
 seek-prefix-ge a
@@ -150,12 +150,12 @@ next
 next
 next
 ----
-<a:1>:A
-<a:1>:A
-<aa:2>:AA
-<c:3>:C
-<d:4>:D
-.
+seek-prefix-ge a: <a:1>:A
+       seek-ge a: <a:1>:A
+            next: <aa:2>:AA
+            next: <c:3>:C
+            next: <d:4>:D
+            next: .
 
 iter
 seek-prefix-ge a
@@ -164,11 +164,11 @@ next
 next
 next
 ----
-<a:1>:A
-<aa:2>:AA
-<c:3>:C
-<d:4>:D
-.
+seek-prefix-ge a: <a:1>:A
+      seek-ge aa: <aa:2>:AA
+            next: <c:3>:C
+            next: <d:4>:D
+            next: .
 
 iter
 seek-prefix-ge aa
@@ -176,10 +176,10 @@ seek-ge c
 next
 next
 ----
-<aa:2>:AA
-<c:3>:C
-<d:4>:D
-.
+seek-prefix-ge aa: <aa:2>:AA
+        seek-ge c: <c:3>:C
+             next: <d:4>:D
+             next: .
 
 iter
 seek-prefix-ge aa
@@ -188,11 +188,11 @@ next
 next
 next
 ----
-<aa:2>:AA
-<aa:2>:AA
-<c:3>:C
-<d:4>:D
-.
+seek-prefix-ge aa: <aa:2>:AA
+        seek-lt c: <aa:2>:AA
+             next: <c:3>:C
+             next: <d:4>:D
+             next: .
 
 iter
 seek-prefix-ge aa
@@ -200,19 +200,19 @@ seek-lt c
 prev
 prev
 ----
-<aa:2>:AA
-<aa:2>:AA
-<a:1>:A
-.
+seek-prefix-ge aa: <aa:2>:AA
+        seek-lt c: <aa:2>:AA
+             prev: <a:1>:A
+             prev: .
 
 iter
 seek-lt c
 seek-prefix-ge aa
 prev
 ----
-<aa:2>:AA
-<aa:2>:AA
-.
+        seek-lt c: <aa:2>:AA
+seek-prefix-ge aa: <aa:2>:AA
+             prev: .
 
 iter
 seek-lt c
@@ -221,10 +221,10 @@ next
 next
 
 ----
-<aa:2>:AA
-<a:1>:A
-<aa:2>:AA
-.
+       seek-lt c: <aa:2>:AA
+seek-prefix-ge a: <a:1>:A
+            next: <aa:2>:AA
+            next: .
 
 iter
 seek-ge aa
@@ -233,15 +233,15 @@ next
 next
 
 ----
-<aa:2>:AA
-<a:1>:A
-<aa:2>:AA
-.
+      seek-ge aa: <aa:2>:AA
+seek-prefix-ge a: <a:1>:A
+            next: <aa:2>:AA
+            next: .
 
 iter
 seek-prefix-ge 1
 ----
-.
+seek-prefix-ge 1: .
 
 get
 a
@@ -263,8 +263,8 @@ seek-prefix-ge aa true
 seek-prefix-ge d true
 seek-prefix-ge c false
 ----
-<a:1>:A
-<a:1>:A
-<aa:2>:AA
-<d:4>:D
-<c:3>:C
+seek-prefix-ge a false: <a:1>:A
+ seek-prefix-ge a true: <a:1>:A
+seek-prefix-ge aa true: <aa:2>:AA
+ seek-prefix-ge d true: <d:4>:D
+seek-prefix-ge c false: <c:3>:C

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -12,11 +12,11 @@ next
 next
 next
 ----
-<a:1>:A
-<b:2>:B
-<c:3>:C
-<d:4>:D
-.
+first: <a:1>:A
+ next: <b:2>:B
+ next: <c:3>:C
+ next: <d:4>:D
+ next: .
 
 iter
 seek-ge a
@@ -25,11 +25,11 @@ next
 next
 next
 ----
-<a:1>:A
-<b:2>:B
-<c:3>:C
-<d:4>:D
-.
+seek-ge a: <a:1>:A
+     next: <b:2>:B
+     next: <c:3>:C
+     next: <d:4>:D
+     next: .
 
 iter
 seek-ge b
@@ -37,38 +37,38 @@ next
 next
 next
 ----
-<b:2>:B
-<c:3>:C
-<d:4>:D
-.
+seek-ge b: <b:2>:B
+     next: <c:3>:C
+     next: <d:4>:D
+     next: .
 
 iter
 seek-ge c
 next
 next
 ----
-<c:3>:C
-<d:4>:D
-.
+seek-ge c: <c:3>:C
+     next: <d:4>:D
+     next: .
 
 iter
 seek-ge d
 next
 ----
-<d:4>:D
-.
+seek-ge d: <d:4>:D
+     next: .
 
 iter
 seek-ge e
 ----
-.
+seek-ge e: .
 
 iter
 seek-ge d
 seek-ge z
 ----
-<d:4>:D
-.
+seek-ge d: <d:4>:D
+seek-ge z: .
 
 iter
 seek-ge b
@@ -76,10 +76,10 @@ seek-ge c
 seek-ge d
 seek-ge e
 ----
-<b:2>:B
-<c:3>:C
-<d:4>:D
-.
+seek-ge b: <b:2>:B
+seek-ge c: <c:3>:C
+seek-ge d: <d:4>:D
+seek-ge e: .
 
 iter
 last
@@ -88,11 +88,11 @@ prev
 prev
 prev
 ----
-<d:4>:D
-<c:3>:C
-<b:2>:B
-<a:1>:A
-.
+last: <d:4>:D
+prev: <c:3>:C
+prev: <b:2>:B
+prev: <a:1>:A
+prev: .
 
 iter
 seek-lt e
@@ -101,11 +101,11 @@ prev
 prev
 prev
 ----
-<d:4>:D
-<c:3>:C
-<b:2>:B
-<a:1>:A
-.
+seek-lt e: <d:4>:D
+     prev: <c:3>:C
+     prev: <b:2>:B
+     prev: <a:1>:A
+     prev: .
 
 iter
 seek-lt d
@@ -113,31 +113,31 @@ prev
 prev
 prev
 ----
-<c:3>:C
-<b:2>:B
-<a:1>:A
-.
+seek-lt d: <c:3>:C
+     prev: <b:2>:B
+     prev: <a:1>:A
+     prev: .
 
 iter
 seek-lt c
 prev
 prev
 ----
-<b:2>:B
-<a:1>:A
-.
+seek-lt c: <b:2>:B
+     prev: <a:1>:A
+     prev: .
 
 iter
 seek-lt b
 prev
 ----
-<a:1>:A
-.
+seek-lt b: <a:1>:A
+     prev: .
 
 iter
 seek-lt a
 ----
-.
+seek-lt a: .
 
 iter
 seek-lt d
@@ -145,10 +145,10 @@ seek-lt c
 seek-lt b
 seek-lt a
 ----
-<c:3>:C
-<b:2>:B
-<a:1>:A
-.
+seek-lt d: <c:3>:C
+seek-lt c: <b:2>:B
+seek-lt b: <a:1>:A
+seek-lt a: .
 
 iter globalSeqNum=1
 first
@@ -157,11 +157,11 @@ next
 next
 next
 ----
-<a:1>:A
-<b:1>:B
-<c:1>:C
-<d:1>:D
-.
+first: <a:1>:A
+ next: <b:1>:B
+ next: <c:1>:C
+ next: <d:1>:D
+ next: .
 
 iter globalSeqNum=10
 first
@@ -170,16 +170,16 @@ next
 next
 next
 ----
-<a:10>:A
-<b:10>:B
-<c:10>:C
-<d:10>:D
-.
+first: <a:10>:A
+ next: <b:10>:B
+ next: <c:10>:C
+ next: <d:10>:D
+ next: .
 
 iter globalSeqNum=0
 seek-lt x
 ----
-<d:4>:D
+seek-lt x: <d:4>:D
 
 get
 b
@@ -207,14 +207,14 @@ set-bounds lower= upper=
 seek-ge c
 seek-lt b
 ----
-<c:3>:C
-<a:1>:A
-.
-.
-.
-.
-<c:3>:C
-<a:1>:A
+                 seek-ge c: <c:3>:C
+                 seek-lt b: <a:1>:A
+set-bounds lower=b upper=c: .
+                 seek-ge c: .
+                 seek-lt b: .
+  set-bounds lower= upper=: .
+                 seek-ge c: <c:3>:C
+                 seek-lt b: <a:1>:A
 
 # Verify that seeking past the end of the sstable leaves the iterator
 # in a state where prev returns the last key in the table.
@@ -224,9 +224,9 @@ seek-lt d
 seek-ge f
 prev
 ----
-<c:3>:C
-.
-<d:4>:D
+seek-lt d: <c:3>:C
+seek-ge f: .
+     prev: <d:4>:D
 
 # Verify that seeking before the beginning of the sstable leaves the
 # iterator in a state where next returns the first key in the table.
@@ -236,9 +236,9 @@ seek-ge b
 seek-lt a
 next
 ----
-<b:2>:B
-.
-<a:1>:A
+seek-ge b: <b:2>:B
+seek-lt a: .
+     next: <a:1>:A
 
 
 # Verify the optimization to use next when doing SeekGE.
@@ -251,12 +251,12 @@ seek-ge c true
 seek-ge d true
 seek-ge e true
 ----
-<a:1>:A
-<a:1>:A
-<b:2>:B
-<c:3>:C
-<d:4>:D
-.
+seek-ge a false: <a:1>:A
+ seek-ge a true: <a:1>:A
+ seek-ge b true: <b:2>:B
+ seek-ge c true: <c:3>:C
+ seek-ge d true: <d:4>:D
+ seek-ge e true: .
 
 # Verify the optimization to use next when doing SeekPrefixGE.
 
@@ -268,12 +268,12 @@ seek-prefix-ge c true
 seek-prefix-ge d true
 seek-prefix-ge e true
 ----
-<a:1>:A
-<a:1>:A
-<b:2>:B
-<c:3>:C
-<d:4>:D
-.
+seek-prefix-ge a false: <a:1>:A
+ seek-prefix-ge a true: <a:1>:A
+ seek-prefix-ge b true: <b:2>:B
+ seek-prefix-ge c true: <c:3>:C
+ seek-prefix-ge d true: <d:4>:D
+ seek-prefix-ge e true: .
 
 # Verify that iteration from before the beginning or after the end of
 # the sstable does not "wrap around". A bug previously allowed this to
@@ -291,11 +291,11 @@ next
 next
 next
 ----
-<a:1>:a
-.
-<a:1>:a
-.
-.
+first: <a:1>:a
+ prev: .
+ next: <a:1>:a
+ next: .
+ next: .
 
 iter
 last
@@ -304,11 +304,11 @@ prev
 prev
 prev
 ----
-<a:1>:a
-.
-<a:1>:a
-.
-.
+last: <a:1>:a
+next: .
+prev: <a:1>:a
+prev: .
+prev: .
 
 # Build a sufficiently large SST to enable two-level indexes.
 
@@ -418,13 +418,13 @@ next
 next
 next
 ----
-<a:1>:A
-.
-<a:1>:A
-<aae:1>:E
-<aaf:1>:F
-<aag:1>:G
-<aah:1>:H
+first: <a:1>:A
+ prev: .
+ next: <a:1>:A
+ next: <aae:1>:E
+ next: <aaf:1>:F
+ next: <aag:1>:G
+ next: <aah:1>:H
 
 iter
 last
@@ -433,11 +433,11 @@ prev
 prev
 prev
 ----
-<ddz:4>:Z
-.
-<ddz:4>:Z
-<ddy:4>:Y
-<ddx:4>:X
+last: <ddz:4>:Z
+next: .
+prev: <ddz:4>:Z
+prev: <ddy:4>:Y
+prev: <ddx:4>:X
 
 iter
 first
@@ -448,13 +448,13 @@ seek-ge x
 prev
 prev
 ----
-<a:1>:A
-.
-<a:1>:A
-<aae:1>:E
-.
-<ddz:4>:Z
-<ddy:4>:Y
+    first: <a:1>:A
+     prev: .
+     next: <a:1>:A
+     next: <aae:1>:E
+seek-ge x: .
+     prev: <ddz:4>:Z
+     prev: <ddy:4>:Y
 
 iter
 first
@@ -465,13 +465,13 @@ seek-prefix-ge x
 prev
 prev
 ----
-<a:1>:A
-.
-<a:1>:A
-<aae:1>:E
-.
-.
-.
+           first: <a:1>:A
+            prev: .
+            next: <a:1>:A
+            next: <aae:1>:E
+seek-prefix-ge x: .
+            prev: .
+            prev: .
 
 iter
 last
@@ -482,13 +482,13 @@ seek-lt a
 next
 next
 ----
-<ddz:4>:Z
-.
-<ddz:4>:Z
-<ddy:4>:Y
-.
-<a:1>:A
-<aae:1>:E
+     last: <ddz:4>:Z
+     next: .
+     prev: <ddz:4>:Z
+     prev: <ddy:4>:Y
+seek-lt a: .
+     next: <a:1>:A
+     next: <aae:1>:E
 
 # Test that SeekPrefixGE does not position the iterator far outside the iterator bounds.
 # Doing so would break the subsequent SeekGE that is utilizing the next instead of seek
@@ -501,12 +501,12 @@ set-bounds lower=aae upper=b
 seek-ge aae
 next
 ----
-.
-<a:1>:A
-.
-.
-<aae:1>:E
-<aaf:1>:F
+set-bounds lower=a upper=aae: .
+                   seek-ge a: <a:1>:A
+          seek-prefix-ge aad: .
+set-bounds lower=aae upper=b: .
+                 seek-ge aae: <aae:1>:E
+                        next: <aaf:1>:F
 
 # Test that using Next does not mislead a twoLevelIterator into believing that the
 # iterator has been positioned based on the latest iterator bounds. The Next call
@@ -521,13 +521,13 @@ set-bounds lower=bbf upper=c
 seek-ge bbf
 next
 ----
-.
-<bbq:2>:Q
-.
-.
-.
-<bbf:2>:F
-<bbg:2>:G
+set-bounds lower=bbq upper=d: .
+                 seek-ge bbq: <bbq:2>:Q
+set-bounds lower=b upper=bbf: .
+          next-ignore-result: .
+set-bounds lower=bbf upper=c: .
+                 seek-ge bbf: <bbf:2>:F
+                        next: <bbg:2>:G
 
 build
 a@10.SET.10:a10
@@ -547,13 +547,13 @@ next
 next
 next
 ----
-<a@10:10>:a10
-<a@5:5>:a5
-<b@20:20>:b20
-<b@17:17>:b17
-<c@30:30>:c30
-<d@40:40>:d40
-.
+first: <a@10:10>:a10
+ next: <a@5:5>:a5
+ next: <b@20:20>:b20
+ next: <b@17:17>:b17
+ next: <c@30:30>:c30
+ next: <d@40:40>:d40
+ next: .
 
 iter
 seek-ge a@5
@@ -567,16 +567,16 @@ seek-ge b@18
 prev
 next
 ----
-<a@5:5>:a5
-<a@10:10>:a10
-<a@5:5>:a5
-<b@20:20>:b20
-<b@17:17>:b17
-<b@17:17>:b17
-<b@20:20>:b20
-<b@17:17>:b17
-<b@20:20>:b20
-<b@17:17>:b17
+ seek-ge a@5: <a@5:5>:a5
+        prev: <a@10:10>:a10
+   seek-lt b: <a@5:5>:a5
+        next: <b@20:20>:b20
+        next: <b@17:17>:b17
+   seek-lt c: <b@17:17>:b17
+        prev: <b@20:20>:b20
+seek-ge b@18: <b@17:17>:b17
+        prev: <b@20:20>:b20
+        next: <b@17:17>:b17
 
 iter
 seek-ge a@10
@@ -585,11 +585,11 @@ next-prefix
 next-prefix
 next-prefix
 ----
-<a@10:10>:a10
-<b@20:20>:b20
-<c@30:30>:c30
-<d@40:40>:d40
-.
+seek-ge a@10: <a@10:10>:a10
+ next-prefix: <b@20:20>:b20
+ next-prefix: <c@30:30>:c30
+ next-prefix: <d@40:40>:d40
+ next-prefix: .
 
 build
 a@10.SET.10:a10
@@ -617,13 +617,13 @@ next-prefix
 next-prefix
 next-prefix
 ----
-<a@10:10>:a10
-<aa@30:10>:aa30
-<abcd@50:10>:abcd50
-<b@20:20>:b20
-<c:20>:c
-<d@70:16>:d70
-.
+seek-ge a@10: <a@10:10>:a10
+ next-prefix: <aa@30:10>:aa30
+ next-prefix: <abcd@50:10>:abcd50
+ next-prefix: <b@20:20>:b20
+ next-prefix: <c:20>:c
+ next-prefix: <d@70:16>:d70
+ next-prefix: .
 
 
 build
@@ -695,26 +695,26 @@ next-prefix
 seek-ge aa@10
 next-prefix
 ----
-<a@49:49>:a49
-<b@20:20>:b20
-.
-<a@47:47>:a47
-<b@20:20>:b20
-.
-<a@36:36>:a36
-<b@20:20>:b20
-.
-<a@33:33>:a33
-<b@20:20>:b20
-.
-<a@30:30>:a30
-<b@20:20>:b20
-.
-<a@26:26>:a26
-<b@20:20>:b20
-.
-<a@20:20>:a20
-<b@20:20>:b20
-.
-<b@20:20>:b20
-.
+ seek-ge a@49: <a@49:49>:a49
+  next-prefix: <b@20:20>:b20
+  next-prefix: .
+ seek-ge a@47: <a@47:47>:a47
+  next-prefix: <b@20:20>:b20
+  next-prefix: .
+ seek-ge a@36: <a@36:36>:a36
+  next-prefix: <b@20:20>:b20
+  next-prefix: .
+ seek-ge a@33: <a@33:33>:a33
+  next-prefix: <b@20:20>:b20
+  next-prefix: .
+ seek-ge a@30: <a@30:30>:a30
+  next-prefix: <b@20:20>:b20
+  next-prefix: .
+ seek-ge a@26: <a@26:26>:a26
+  next-prefix: <b@20:20>:b20
+  next-prefix: .
+ seek-ge a@20: <a@20:20>:a20
+  next-prefix: <b@20:20>:b20
+  next-prefix: .
+seek-ge aa@10: <b@20:20>:b20
+  next-prefix: .

--- a/sstable/testdata/reader_bpf/Pebblev2/iter
+++ b/sstable/testdata/reader_bpf/Pebblev2/iter
@@ -21,10 +21,10 @@ next
 next
 next
 ----
-<c@10:10>
-<d@7:9>
-<e@15:8>
-<f@7:5>
+first: <c@10:10>
+ next: <d@7:9>
+ next: <e@15:8>
+ next: <f@7:5>
 
 
 # The block property filter matches data block 2 and 4.
@@ -32,8 +32,8 @@ iter block-property-filter=(7,8)
 first
 next
 ----
-<d@7:9>
-<f@7:5>
+first: <d@7:9>
+ next: <f@7:5>
 
 # Use the same block property filter, but use seeks to find these entries.
 # With the bug the second seek-ge below would step to the second lower-level
@@ -47,10 +47,10 @@ seek-ge c
 next
 next
 ----
-.
-.
-.
-.
-<d@7:9>
-<f@7:5>
-.
+set-bounds lower=a upper=c: .
+                 seek-ge a: .
+            seek-ge b true: .
+set-bounds lower=c upper=g: .
+                 seek-ge c: <d@7:9>
+                      next: <f@7:5>
+                      next: .

--- a/sstable/testdata/reader_bpf/Pebblev3/iter
+++ b/sstable/testdata/reader_bpf/Pebblev3/iter
@@ -21,10 +21,10 @@ next
 next
 next
 ----
-<c@10:10>
-<d@7:9>
-<e@15:8>
-<f@7:5>
+first: <c@10:10>
+ next: <d@7:9>
+ next: <e@15:8>
+ next: <f@7:5>
 
 
 # The block property filter matches data block 2 and 4.
@@ -32,8 +32,8 @@ iter block-property-filter=(7,8)
 first
 next
 ----
-<d@7:9>
-<f@7:5>
+first: <d@7:9>
+ next: <f@7:5>
 
 # Use the same block property filter, but use seeks to find these entries.
 # With the bug the second seek-ge below would step to the second lower-level
@@ -47,13 +47,13 @@ seek-ge c
 next
 next
 ----
-.
-.
-.
-.
-<d@7:9>
-<f@7:5>
-.
+set-bounds lower=a upper=c: .
+                 seek-ge a: .
+            seek-ge b true: .
+set-bounds lower=c upper=g: .
+                 seek-ge c: <d@7:9>
+                      next: <f@7:5>
+                      next: .
 
 # Regression test for #2816
 #
@@ -92,8 +92,8 @@ seek-ge wc
 internal-iter-state
 next
 ----
-.
-.
+set-bounds lower=v upper=v: .
+              seek-ge wz@8: .
 | *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,*github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "x"
 |  topLevelIndex.BlockHandleWithProperties() = (Offset: 193, Length: 26, Props: 00020801)
@@ -106,7 +106,7 @@ next
 |  dataBH = (Offset: 62, Length: 29)
 |  (boundsCmp,positionedUsingLatestBounds) = (0,true)
 |  exhaustedBounds = 1
-.
+              seek-ge wb@2: .
 | *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,*github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "wc"
 |  topLevelIndex.BlockHandleWithProperties() = (Offset: 161, Length: 27, Props: 00020201)
@@ -118,7 +118,7 @@ next
 |  dataBH = (Offset: 62, Length: 29)
 |  (boundsCmp,positionedUsingLatestBounds) = (0,true)
 |  exhaustedBounds = 1
-.
+set-bounds lower=v upper=z: .
 | *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,*github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "wc"
 |  topLevelIndex.BlockHandleWithProperties() = (Offset: 161, Length: 27, Props: 00020201)
@@ -130,7 +130,7 @@ next
 |  dataBH = (Offset: 62, Length: 29)
 |  (boundsCmp,positionedUsingLatestBounds) = (1,false)
 |  exhaustedBounds = 1
-<wz@8:8>
+                seek-ge wc: <wz@8:8>
 | *sstable.twoLevelIterator[github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,*github.com/cockroachdb/pebble/sstable/rowblk.IndexIter,github.com/cockroachdb/pebble/sstable/rowblk.Iter,*github.com/cockroachdb/pebble/sstable/rowblk.Iter]:
 |  topLevelIndex.Key() = "x"
 |  topLevelIndex.BlockHandleWithProperties() = (Offset: 193, Length: 26, Props: 00020801)
@@ -143,4 +143,4 @@ next
 |  dataBH = (Offset: 62, Length: 29)
 |  (boundsCmp,positionedUsingLatestBounds) = (0,false)
 |  exhaustedBounds = 0
-.
+                      next: .

--- a/sstable/testdata/reader_hide_obsolete/iter
+++ b/sstable/testdata/reader_hide_obsolete/iter
@@ -26,22 +26,22 @@ prev
 prev
 prev
 ----
-<a:1>:A
-<b:4>:
-<b:2>:B
-<c:5>:
-<c:3>:C
-<d:4>:D4
-<d:2>:D2
-.
-<d:2>:D2
-<d:4>:D4
-<c:3>:C
-<c:5>:
-<b:2>:B
-<b:4>:
-<a:1>:A
-.
+first: <a:1>:A
+ next: <b:4>:
+ next: <b:2>:B
+ next: <c:5>:
+ next: <c:3>:C
+ next: <d:4>:D4
+ next: <d:2>:D2
+ next: .
+ prev: <d:2>:D2
+ prev: <d:4>:D4
+ prev: <c:3>:C
+ prev: <c:5>:
+ prev: <b:2>:B
+ prev: <b:4>:
+ prev: <a:1>:A
+ prev: .
 
 iter hide-obsolete-points=true
 first
@@ -55,16 +55,16 @@ prev
 prev
 prev
 ----
-<a:1>:A
-<b:4>:
-<c:5>:
-<d:4>:D4
-.
-<d:4>:D4
-<c:5>:
-<b:4>:
-<a:1>:A
-.
+first: <a:1>:A
+ next: <b:4>:
+ next: <c:5>:
+ next: <d:4>:D4
+ next: .
+ prev: <d:4>:D4
+ prev: <c:5>:
+ prev: <b:4>:
+ prev: <a:1>:A
+ prev: .
 
 iter hide-obsolete-points=true
 seek-ge c
@@ -78,16 +78,16 @@ next
 prev
 prev
 ----
-<c:5>:
-<b:4>:
-<a:1>:A
-<b:4>:
-<c:5>:
-<d:4>:D4
-<b:4>:
-<c:5>:
-<b:4>:
-<a:1>:A
+seek-ge c: <c:5>:
+     prev: <b:4>:
+     prev: <a:1>:A
+     next: <b:4>:
+     next: <c:5>:
+     next: <d:4>:D4
+seek-lt c: <b:4>:
+     next: <c:5>:
+     prev: <b:4>:
+     prev: <a:1>:A
 
 build
 a.SET.3:A
@@ -111,14 +111,14 @@ next
 next
 next
 ----
-<a:3>:A
-<a:2>:A2
-<b:20>:B20
-<b:18>:B18
-<b:16>:B16
-<b:14>:B14
-<c:30>:C30
-<c:28>:C28
+first: <a:3>:A
+ next: <a:2>:A2
+ next: <b:20>:B20
+ next: <b:18>:B18
+ next: <b:16>:B16
+ next: <b:14>:B14
+ next: <c:30>:C30
+ next: <c:28>:C28
 
 iter hide-obsolete-points=true
 first
@@ -136,20 +136,20 @@ prev
 prev
 prev
 ----
-<a:3>:A
-<b:20>:B20
-<b:18>:B18
-<b:16>:B16
-<c:30>:C30
-<c:28>:C28
-<c:26>:
-<c:26>:
-<c:28>:C28
-<c:30>:C30
-<b:16>:B16
-<b:18>:B18
-<b:20>:B20
-<a:3>:A
+first: <a:3>:A
+ next: <b:20>:B20
+ next: <b:18>:B18
+ next: <b:16>:B16
+ next: <c:30>:C30
+ next: <c:28>:C28
+ next: <c:26>:
+ last: <c:26>:
+ prev: <c:28>:C28
+ prev: <c:30>:C30
+ prev: <b:16>:B16
+ prev: <b:18>:B18
+ prev: <b:20>:B20
+ prev: <a:3>:A
 
 build
 b.MERGE.20:B20
@@ -169,13 +169,13 @@ next
 next
 next
 ----
-<b:20>:B20
-<b:16>:B16
-<b:14>:B14
-<c:30>:C30
-<c:28>:
-<c:26>:
-.
+first: <b:20>:B20
+ next: <b:16>:B16
+ next: <b:14>:B14
+ next: <c:30>:C30
+ next: <c:28>:
+ next: <c:26>:
+ next: .
 
 iter hide-obsolete-points=true
 first
@@ -184,11 +184,11 @@ next
 next
 next
 ----
-<b:20>:B20
-<b:16>:B16
-<c:30>:C30
-<c:28>:
-.
+first: <b:20>:B20
+ next: <b:16>:B16
+ next: <c:30>:C30
+ next: <c:28>:
+ next: .
 
 build
 b.SETWITHDEL.20:B20
@@ -204,18 +204,18 @@ next
 next
 next
 ----
-<b:20>:B20
-<b:16>:B16
-<b:14>:B14
-<b:12>:B12
-.
+first: <b:20>:B20
+ next: <b:16>:B16
+ next: <b:14>:B14
+ next: <b:12>:B12
+ next: .
 
 iter hide-obsolete-points=true
 first
 next
 ----
-<b:20>:B20
-.
+first: <b:20>:B20
+ next: .
 
 build writing-to-lowest-level
 a.SET.10:A10
@@ -233,19 +233,19 @@ next
 next
 next
 ----
-<a:10>:A10
-<b:20>:
-<b:16>:B16
-<b:14>:B14
-<b:12>:B12
-.
+first: <a:10>:A10
+ next: <b:20>:
+ next: <b:16>:B16
+ next: <b:14>:B14
+ next: <b:12>:B12
+ next: .
 
 iter hide-obsolete-points=true
 first
 next
 ----
-<a:10>:A10
-.
+first: <a:10>:A10
+ next: .
 
 build writing-to-lowest-level
 a.SET.10:A10
@@ -267,21 +267,21 @@ next
 next
 next
 ----
-<a:10>:A10
-<b:16>:B16
-<b:14>:B14
-<c:30>:
-<c:28>:C28
-<d:40>:
-<d:30>:D30
-.
+first: <a:10>:A10
+ next: <b:16>:B16
+ next: <b:14>:B14
+ next: <c:30>:
+ next: <c:28>:C28
+ next: <d:40>:
+ next: <d:30>:D30
+ next: .
 
 iter hide-obsolete-points=true
 first
 next
 ----
-<a:10>:A10
-.
+first: <a:10>:A10
+ next: .
 
 build writing-to-lowest-level
 force-obsolete: a.SET.1:A
@@ -299,12 +299,12 @@ next
 next
 next
 ----
-<a:1>:A
-<b:4>:
-<b:2>:B
-<c:5>:
-<d:10>:D10
-.
+first: <a:1>:A
+ next: <b:4>:
+ next: <b:2>:B
+ next: <c:5>:
+ next: <d:10>:D10
+ next: .
 
 iter hide-obsolete-points=true
 first
@@ -331,14 +331,14 @@ force-obsolete: cc.DEL.5:
 iter hide-obsolete-points-without-filter=true
 last
 ----
-<a:10>:A10
+last: <a:10>:A10
 
 iter hide-obsolete-points-without-filter=true
 seek-lt d
 ----
-<a:10>:A10
+seek-lt d: <a:10>:A10
 
 iter hide-obsolete-points-without-filter=true
 seek-lt c
 ----
-<a:10>:A10
+seek-lt c: <a:10>:A10

--- a/sstable/testdata/readerstats_LevelDB/iter
+++ b/sstable/testdata/readerstats_LevelDB/iter
@@ -34,26 +34,26 @@ stats
 first
 stats
 ----
-<a:1>
+      first: <a:1>
 {BlockBytes:74 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<b:2>
+       next: <b:2>
 {BlockBytes:74 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<c:3>
+       next: <c:3>
 {BlockBytes:108 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<d:4>
+       next: <d:4>
 {BlockBytes:108 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-.
+       next: .
 {BlockBytes:108 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<a:1>
+      first: <a:1>
 {BlockBytes:142 BlockBytesInCache:34 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<b:2>
+       next: <b:2>
 {BlockBytes:142 BlockBytesInCache:34 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<c:3>
+       next: <c:3>
 {BlockBytes:176 BlockBytesInCache:68 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<d:4>
+       next: <d:4>
 {BlockBytes:176 BlockBytesInCache:68 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-.
+       next: .
 {BlockBytes:176 BlockBytesInCache:68 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
 {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<a:1>
+      first: <a:1>
 {BlockBytes:34 BlockBytesInCache:34 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}

--- a/sstable/testdata/readerstats_Pebblev3/iter
+++ b/sstable/testdata/readerstats_Pebblev3/iter
@@ -32,13 +32,13 @@ stats
 next
 stats
 ----
-<c@10:10>
+first: <c@10:10>
 {BlockBytes:251 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:0 ValueBytes:0 ValueBytesFetched:0}}
-<c@9:9>
+ next: <c@9:9>
 {BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:1 ValueBytes:4 ValueBytesFetched:4}}
-<c@8:8>
+ next: <c@8:8>
 {BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:8 ValueBytesFetched:8}}
-<d@7:9>
+ next: <d@7:9>
 {BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:8 ValueBytesFetched:8}}
 
 # seek-ge e@37 starts at the restart point at the beginning of the block and
@@ -54,12 +54,12 @@ next
 next
 stats
 ----
-<e@37:47>
+seek-ge e@37: <e@37:47>
 {BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:4 ValueBytes:18 ValueBytesFetched:5}}
-<e@36:46>
-<e@35:45>
-<e@34:44>
-<e@33:43>
+        next: <e@36:46>
+        next: <e@35:45>
+        next: <e@34:44>
+        next: <e@33:43>
 {BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:8 ValueBytes:38 ValueBytesFetched:25}}
 
 # seek-ge e@26 lands at the restart point e@26.
@@ -71,9 +71,9 @@ stats
 prev
 stats
 ----
-<e@26:36>
+seek-ge e@26: <e@26:36>
 {BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:1 ValueBytes:5 ValueBytesFetched:5}}
-<e@27:37>
+        prev: <e@27:37>
 {BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:2 ValueBytes:10 ValueBytesFetched:10}}
-<e@28:38>
+        prev: <e@28:38>
 {BlockBytes:328 BlockBytesInCache:0 BlockReadDuration:0s KeyBytes:0 ValueBytes:0 PointCount:0 PointsCoveredByRangeTombstones:0 SeparatedPointValue:{Count:3 ValueBytes:15 ValueBytesFetched:15}}


### PR DESCRIPTION
This change is analagous to #3988 but for the sstable package's datadriven iter command. Including the command in the output makes it more legible.