### PR TITLE
colblk: implement synthetic prefix and suffix

### DIFF
--- a/internal/crdbtest/crdbtest.go
+++ b/internal/crdbtest/crdbtest.go
@@ -155,7 +155,9 @@ func EncodeTimestamp(key []byte, walltime uint64, logical uint32) []byte {
 }
 
 // DecodeTimestamp decodes a MVCC timestamp from a serialized MVCC key.
-func DecodeTimestamp(mvccKey []byte) ([]byte, []byte, uint64, uint32) {
+func DecodeTimestamp(
+	mvccKey []byte,
+) (prefix []byte, untypedSuffix []byte, wallTime uint64, logicalTime uint32) {
 	tsLen := int(mvccKey[len(mvccKey)-1])
 	keyPartEnd := len(mvccKey) - tsLen
 	if keyPartEnd < 0 {
@@ -450,10 +452,3 @@ func (g *cockroachKeyGen) randTimestamp() (wallTime uint64, logicalTime uint32) 
 	}
 	return wallTime, logicalTime
 }
-
-//func randCockroachKey(rng *rand.Rand, cfg KeyConfig, blockPrefix []byte) []byte {
-//	key := make([]byte, 0, cfg.PrefixLen+MaxSuffixLen)
-//	key = append(key, blockPrefix...)
-//	wallTime, logicalTime := g.rand
-//	return EncodeTimestamp(key, wallTime, cfg.Logical)
-//}

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -256,6 +256,14 @@ type IterTransforms struct {
 // NoTransforms is the default value for IterTransforms.
 var NoTransforms = IterTransforms{}
 
+// NoTransforms returns true if there are no transforms enabled.
+func (t *IterTransforms) NoTransforms() bool {
+	return t.SyntheticSeqNum == 0 &&
+		!t.HideObsoletePoints &&
+		!t.SyntheticPrefix.IsSet() &&
+		!t.SyntheticSuffix.IsSet()
+}
+
 // FragmentIterTransforms allow on-the-fly transformation of range deletion or
 // range key data at iteration time.
 type FragmentIterTransforms struct {
@@ -293,7 +301,7 @@ const NoSyntheticSeqNum SyntheticSeqNum = 0
 // RangeKeyUnset keys are not supported when a synthetic suffix is used.
 type SyntheticSuffix []byte
 
-// IsSet returns true if the synthetic suffix is not enpty.
+// IsSet returns true if the synthetic suffix is not empty.
 func (ss SyntheticSuffix) IsSet() bool {
 	return len(ss) > 0
 }

--- a/sstable/block/block_test.go
+++ b/sstable/block/block_test.go
@@ -1,0 +1,38 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package block
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIterTransforms(t *testing.T) {
+	require.True(t, NoTransforms.NoTransforms())
+	var transforms IterTransforms
+	require.True(t, transforms.NoTransforms())
+	require.False(t, transforms.SyntheticPrefix.IsSet())
+	require.False(t, transforms.SyntheticSuffix.IsSet())
+	transforms.SyntheticPrefix = []byte{}
+	require.False(t, transforms.SyntheticPrefix.IsSet())
+	transforms.SyntheticSuffix = []byte{}
+	require.False(t, transforms.SyntheticSuffix.IsSet())
+	require.True(t, transforms.NoTransforms())
+	transforms.HideObsoletePoints = true
+	require.False(t, transforms.NoTransforms())
+
+	transforms = NoTransforms
+	transforms.SyntheticSeqNum = 123
+	require.False(t, transforms.NoTransforms())
+
+	transforms = NoTransforms
+	transforms.SyntheticPrefix = []byte{1}
+	require.False(t, transforms.NoTransforms())
+
+	transforms = NoTransforms
+	transforms.SyntheticSuffix = []byte{1}
+	require.False(t, transforms.NoTransforms())
+}

--- a/sstable/colblk/cockroach_test.go
+++ b/sstable/colblk/cockroach_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/crdbtest"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
@@ -198,12 +200,18 @@ func (ks *cockroachKeySeeker) Init(r *DataBlockReader) error {
 // contained within the data block. It's equivalent to performing
 //
 //	Compare(firstUserKey, k)
-func (ks *cockroachKeySeeker) IsLowerBound(k []byte) bool {
+func (ks *cockroachKeySeeker) IsLowerBound(k []byte, syntheticSuffix []byte) bool {
 	prefix, untypedSuffix, wallTime, logicalTime := crdbtest.DecodeTimestamp(k)
 	if v := crdbtest.Compare(ks.prefixes.UnsafeFirstSlice(), prefix); v != 0 {
 		return v > 0
 	}
+	if len(syntheticSuffix) > 0 {
+		return crdbtest.Compare(syntheticSuffix, k[len(prefix):]) >= 0
+	}
 	if len(untypedSuffix) > 0 {
+		if invariants.Enabled && ks.mvccWallTimes.At(0) != 0 {
+			panic("comparing timestamp with untyped suffix")
+		}
 		return crdbtest.Compare(ks.untypedSuffixes.At(0), untypedSuffix) >= 0
 	}
 	if v := cmp.Compare(ks.mvccWallTimes.At(0), wallTime); v != 0 {
@@ -250,12 +258,12 @@ func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row 
 		seekWallTime = binary.LittleEndian.Uint64(seekSuffix)
 	default:
 		// The suffix is untyped. Compare the untyped suffixes.
-		// Binary search between [index, prefixChanged.SeekSetBitGE(index)].
+		// Binary search between [index, prefixChanged.SeekSetBitGE(index+1)].
 		//
 		// Define f(l-1) == false and f(u) == true.
 		// Invariant: f(l-1) == false, f(u) == true.
 		l := index
-		u := ks.reader.prefixChanged.SeekSetBitGE(index)
+		u := ks.reader.prefixChanged.SeekSetBitGE(index + 1)
 		for l < u {
 			h := int(uint(l+u) >> 1) // avoid overflow when computing h
 			// l ≤ h < u
@@ -309,6 +317,7 @@ func (ks *cockroachKeySeeker) MaterializeUserKey(ki *PrefixBytesIter, prevRow, r
 	if mvccWall == 0 && mvccLogical == 0 {
 		// This is not an MVCC key. Use the untyped suffix.
 		untypedSuffixed := ks.untypedSuffixes.At(row)
+		// Slice first, to check that the capacity is sufficient.
 		res := ki.buf[:len(ki.buf)+len(untypedSuffixed)]
 		memmove(ptr, unsafe.Pointer(unsafe.SliceData(untypedSuffixed)), uintptr(len(untypedSuffixed)))
 		return res
@@ -341,6 +350,23 @@ func (ks *cockroachKeySeeker) MaterializeUserKey(ki *PrefixBytesIter, prevRow, r
 	return ki.buf[:len(ki.buf)+13]
 }
 
+// MaterializeUserKeyWithSyntheticSuffix is part of the KeySeeker interface.
+func (ks *cockroachKeySeeker) MaterializeUserKeyWithSyntheticSuffix(
+	ki *PrefixBytesIter, suffix []byte, prevRow, row int,
+) []byte {
+	if prevRow+1 == row && prevRow >= 0 {
+		ks.prefixes.SetNext(ki)
+	} else {
+		ks.prefixes.SetAt(ki, row)
+	}
+
+	// Slice first, to check that the capacity is sufficient.
+	res := ki.buf[:len(ki.buf)+len(suffix)]
+	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(unsafe.SliceData(ki.buf))) + uintptr(len(ki.buf)))
+	memmove(ptr, unsafe.Pointer(unsafe.SliceData(suffix)), uintptr(len(suffix)))
+	return res
+}
+
 // Release is part of the KeySeeker interface.
 func (ks *cockroachKeySeeker) Release() {
 	*ks = cockroachKeySeeker{}
@@ -370,7 +396,7 @@ func TestCockroachDataBlock(t *testing.T) {
 	serializedBlock, _ := w.Finish(w.Rows(), w.Size())
 	var reader DataBlockReader
 	var it DataBlockIter
-	it.InitOnce(cockroachKeySchema, getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(cockroachKeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
 	reader.Init(cockroachKeySchema, serializedBlock)
@@ -528,6 +554,18 @@ func BenchmarkCockroachDataBlockIterTransforms(b *testing.B) {
 				HideObsoletePoints: true,
 			},
 		},
+		{
+			description: "SyntheticPrefix",
+			transforms: block.IterTransforms{
+				SyntheticPrefix: []byte("prefix_"),
+			},
+		},
+		{
+			description: "SyntheticSuffix",
+			transforms: block.IterTransforms{
+				SyntheticSuffix: crdbtest.EncodeTimestamp(make([]byte, 0, 20), 1_000_000_000_000, 0)[1:],
+			},
+		},
 	}
 	for _, cfg := range shortBenchConfigs {
 		for _, t := range transforms {
@@ -571,7 +609,7 @@ func benchmarkCockroachDataBlockIter(
 	serializedBlock, _ := w.Finish(w.Rows(), w.Size())
 	var reader DataBlockReader
 	var it DataBlockIter
-	it.InitOnce(cockroachKeySchema, getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(cockroachKeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
 	reader.Init(cockroachKeySchema, serializedBlock)
@@ -579,6 +617,12 @@ func benchmarkCockroachDataBlockIter(
 		b.Fatal(err)
 	}
 	avgRowSize := float64(len(serializedBlock)) / float64(count)
+
+	if transforms.SyntheticPrefix.IsSet() {
+		for i := range keys {
+			keys[i] = slices.Concat(transforms.SyntheticPrefix, keys[i])
+		}
+	}
 
 	b.Run("Next", func(b *testing.B) {
 		kv := it.First()

--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -28,10 +28,9 @@ func TestDataBlock(t *testing.T) {
 	var w DataBlockWriter
 	var r DataBlockReader
 	var it DataBlockIter
-	var rw DataBlockRewriter
-	rw.KeySchema = testKeysSchema
+	rw := NewDataBlockRewriter(testKeysSchema, testkeys.Comparer.Compare, testkeys.Comparer.Split)
 	var sizes []int
-	it.InitOnce(testKeysSchema, getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(testKeysSchema, testkeys.Comparer.Compare, testkeys.Comparer.Split, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
 

--- a/sstable/colblk/testdata/data_block/transforms
+++ b/sstable/colblk/testdata/data_block/transforms
@@ -1,3 +1,4 @@
+# Test synthetic sequence numbers.
 write-block
 a@10#1,SET:apple
 b@5#2,SET:banana
@@ -207,3 +208,194 @@ seek-lt z: .
 seek-lt b: .
      next: .
      prev: .
+
+# Test synthetic prefix.
+write-block
+blockprefix_a@10#1,SET:apple
+blockprefix_b@5#3,SET:banana
+blockprefix_blueberry#3,SET:blueberry
+blockprefix_c@9#4,SET:coconut
+blockprefix_c@6#5,SET:cantaloupe
+blockprefix_c@1#7,SET:clementine
+----
+
+iter synthetic-prefix=foo_
+first
+next
+next
+next
+next
+next
+prev
+----
+first: foo_blockprefix_a@10:apple
+ next: foo_blockprefix_b@5:banana
+ next: foo_blockprefix_blueberry:blueberry
+ next: foo_blockprefix_c@9:coconut
+ next: foo_blockprefix_c@6:cantaloupe
+ next: foo_blockprefix_c@1:clementine
+ prev: foo_blockprefix_c@6:cantaloupe
+
+iter synthetic-prefix=foo_
+last
+prev
+next
+prev
+prev
+prev
+prev
+prev
+prev
+next
+----
+last: foo_blockprefix_c@1:clementine
+prev: foo_blockprefix_c@6:cantaloupe
+next: foo_blockprefix_c@1:clementine
+prev: foo_blockprefix_c@6:cantaloupe
+prev: foo_blockprefix_c@9:coconut
+prev: foo_blockprefix_blueberry:blueberry
+prev: foo_blockprefix_b@5:banana
+prev: foo_blockprefix_a@10:apple
+prev: .
+next: foo_blockprefix_a@10:apple
+
+iter synthetic-prefix=foo_
+seek-ge foo_blockprefix
+seek-ge foo_blockprefix_b
+seek-ge foo_blockprefix_bb
+seek-ge foo_blockprefix_d
+prev
+seek-ge fo
+seek-ge foa_a
+seek-ge foz_a
+prev
+----
+   seek-ge foo_blockprefix: foo_blockprefix_a@10:apple
+ seek-ge foo_blockprefix_b: foo_blockprefix_b@5:banana
+seek-ge foo_blockprefix_bb: foo_blockprefix_blueberry:blueberry
+ seek-ge foo_blockprefix_d: .
+                      prev: foo_blockprefix_c@1:clementine
+                seek-ge fo: foo_blockprefix_a@10:apple
+             seek-ge foa_a: foo_blockprefix_a@10:apple
+             seek-ge foz_a: .
+                      prev: foo_blockprefix_c@1:clementine
+
+iter synthetic-prefix=foo_
+seek-lt foo_blockprefix_d
+seek-lt foo_blockprefix_bb
+seek-lt foo_blockprefix_b
+seek-lt foo_blockprefix
+next
+seek-lt foz_a
+seek-lt foa_a
+next
+seek-lt fo
+next
+----
+ seek-lt foo_blockprefix_d: foo_blockprefix_c@1:clementine
+seek-lt foo_blockprefix_bb: foo_blockprefix_b@5:banana
+ seek-lt foo_blockprefix_b: foo_blockprefix_a@10:apple
+   seek-lt foo_blockprefix: .
+                      next: foo_blockprefix_a@10:apple
+             seek-lt foz_a: foo_blockprefix_c@1:clementine
+             seek-lt foa_a: .
+                      next: foo_blockprefix_a@10:apple
+                seek-lt fo: .
+                      next: foo_blockprefix_a@10:apple
+
+iter synthetic-prefix=foo_
+is-lower-bound fo
+is-lower-bound foo_
+is-lower-bound foo_blockprefix_a@10
+is-lower-bound foo_blockprefix_a@9
+is-lower-bound fop
+----
+                  is-lower-bound fo: true
+                is-lower-bound foo_: true
+is-lower-bound foo_blockprefix_a@10: true
+ is-lower-bound foo_blockprefix_a@9: false
+                 is-lower-bound fop: false
+
+# Test synthetic suffix.
+write-block
+a@1#1,SET:a
+b@2#1,SET:b
+c@3#1,SET:c
+d@1#1,SET:d
+----
+
+iter synthetic-suffix=@10
+first
+next
+next
+next
+next
+prev
+----
+first: a@10:a
+ next: b@10:b
+ next: c@10:c
+ next: d@10:d
+ next: .
+ prev: d@10:d
+
+iter synthetic-suffix=@10
+last
+prev
+prev
+prev
+prev
+next
+----
+last: d@10:d
+prev: c@10:c
+prev: b@10:b
+prev: a@10:a
+prev: .
+next: a@10:a
+
+iter synthetic-suffix=@10
+seek-ge b
+seek-ge b@11
+seek-ge b@10
+seek-ge b@9
+seek-ge d
+seek-ge d@11
+seek-ge d@10
+seek-ge d@9
+----
+   seek-ge b: b@10:b
+seek-ge b@11: b@10:b
+seek-ge b@10: b@10:b
+ seek-ge b@9: c@10:c
+   seek-ge d: d@10:d
+seek-ge d@11: d@10:d
+seek-ge d@10: d@10:d
+ seek-ge d@9: .
+
+iter synthetic-suffix=@10
+seek-lt e
+seek-lt d@9
+seek-lt d@10
+seek-lt d@11
+seek-lt d
+seek-lt c@9
+seek-lt c@10
+seek-lt c@11
+seek-lt c
+seek-lt a@9
+seek-lt a@10
+seek-lt a
+----
+   seek-lt e: d@10:d
+ seek-lt d@9: d@10:d
+seek-lt d@10: c@10:c
+seek-lt d@11: c@10:c
+   seek-lt d: c@10:c
+ seek-lt c@9: c@10:c
+seek-lt c@10: b@10:b
+seek-lt c@11: b@10:b
+   seek-lt c: b@10:b
+ seek-lt a@9: a@10:a
+seek-lt a@10: .
+   seek-lt a: .

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -959,7 +959,7 @@ func (w *RawColumnWriter) rewriteSuffixes(
 	}
 	// Copy data blocks in parallel, rewriting suffixes as we go.
 	blocks, err := rewriteDataBlocksInParallel(r, wo, l.Data, from, to, concurrency, func() blockRewriter {
-		return &colblk.DataBlockRewriter{KeySchema: wo.KeySchema}
+		return colblk.NewDataBlockRewriter(wo.KeySchema, w.comparer.Compare, w.comparer.Split)
 	})
 	if err != nil {
 		return errors.Wrap(err, "rewriting data blocks")

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -331,7 +331,7 @@ func formatColblkDataBlock(
 
 	if fmtRecord != nil {
 		var iter colblk.DataBlockIter
-		iter.InitOnce(r.keySchema, describingLazyValueHandler{})
+		iter.InitOnce(r.keySchema, r.Compare, r.Split, describingLazyValueHandler{})
 		if err := iter.Init(&reader, block.IterTransforms{}); err != nil {
 			return err
 		}

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -251,7 +251,7 @@ func newColumnBlockSingleLevelIterator(
 		getLazyValuer = i.vbReader
 		i.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.vbRHPrealloc)
 	}
-	i.data.InitOnce(r.keySchema, getLazyValuer)
+	i.data.InitOnce(r.keySchema, i.cmp, r.Split, getLazyValuer)
 	indexH, err := r.readIndex(ctx, i.indexFilterRH, stats, &i.iterStats)
 	if err == nil {
 		err = i.index.InitHandle(i.cmp, r.Split, indexH, transforms)

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -196,7 +196,7 @@ func newColumnBlockTwoLevelIterator(
 		getLazyValuer = i.secondLevel.vbReader
 		i.secondLevel.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
-	i.secondLevel.data.InitOnce(r.keySchema, getLazyValuer)
+	i.secondLevel.data.InitOnce(r.keySchema, r.Compare, r.Split, getLazyValuer)
 	i.useFilterBlock = shouldUseFilterBlock(r, filterBlockSizeLimit)
 	topLevelIndexH, err := r.readIndex(ctx, i.secondLevel.indexFilterRH, stats, &i.secondLevel.iterStats)
 	if err == nil {


### PR DESCRIPTION
First commit is #3996

#### colblk: implement synthetic prefix and suffix

`DataBlockIter` now takes into account the synthetic prefix and suffix
transforms.