### PR TITLE
colblk: unify MultiDataBlockIter and DataBlockIter

### DIFF
--- a/sstable/colblk/cockroach_test.go
+++ b/sstable/colblk/cockroach_test.go
@@ -370,10 +370,13 @@ func TestCockroachDataBlock(t *testing.T) {
 	serializedBlock, _ := w.Finish(w.Rows(), w.Size())
 	var reader DataBlockReader
 	var it DataBlockIter
-	reader.Init(cockroachKeySchema, serializedBlock)
-	it.Init(&reader, cockroachKeySchema.NewKeySeeker(), getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(cockroachKeySchema, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
-	}), block.IterTransforms{})
+	}))
+	reader.Init(cockroachKeySchema, serializedBlock)
+	if err := it.Init(&reader, block.IterTransforms{}); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Run("Next", func(t *testing.T) {
 		// Scan the block using Next and ensure that all the keys values match.
@@ -560,10 +563,13 @@ func benchmarkCockroachDataBlockIter(
 	serializedBlock, _ := w.Finish(w.Rows(), w.Size())
 	var reader DataBlockReader
 	var it DataBlockIter
-	reader.Init(cockroachKeySchema, serializedBlock)
-	it.Init(&reader, cockroachKeySchema.NewKeySeeker(), getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(cockroachKeySchema, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
-	}), transforms)
+	}))
+	reader.Init(cockroachKeySchema, serializedBlock)
+	if err := it.Init(&reader, transforms); err != nil {
+		b.Fatal(err)
+	}
 	avgRowSize := float64(len(serializedBlock)) / float64(count)
 
 	b.Run("Next", func(b *testing.B) {

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -331,9 +331,8 @@ func formatColblkDataBlock(
 
 	if fmtRecord != nil {
 		var iter colblk.DataBlockIter
-		if err := iter.Init(
-			&reader, r.keySchema.NewKeySeeker(), describingLazyValueHandler{}, block.IterTransforms{},
-		); err != nil {
+		iter.InitOnce(r.keySchema, describingLazyValueHandler{})
+		if err := iter.Init(&reader, block.IterTransforms{}); err != nil {
 			return err
 		}
 		defer iter.Close()

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -148,8 +148,8 @@ type Iterator interface {
 type (
 	singleLevelIteratorRowBlocks    = singleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]
 	twoLevelIteratorRowBlocks       = twoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter]
-	singleLevelIteratorColumnBlocks = singleLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.MultiDataBlockIter, *colblk.MultiDataBlockIter]
-	twoLevelIteratorColumnBlocks    = twoLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.MultiDataBlockIter, *colblk.MultiDataBlockIter]
+	singleLevelIteratorColumnBlocks = singleLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.DataBlockIter, *colblk.DataBlockIter]
+	twoLevelIteratorColumnBlocks    = twoLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.DataBlockIter, *colblk.DataBlockIter]
 )
 
 var (
@@ -182,7 +182,7 @@ func init() {
 				pool: &singleLevelIterColumnBlockPool,
 			}
 			// Note: this is a no-op if invariants are disabled or race is enabled.
-			invariants.SetFinalizer(i, checkSingleLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.MultiDataBlockIter, *colblk.MultiDataBlockIter])
+			invariants.SetFinalizer(i, checkSingleLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.DataBlockIter, *colblk.DataBlockIter])
 			return i
 		},
 	}
@@ -192,7 +192,7 @@ func init() {
 				pool: &twoLevelIterColumnBlockPool,
 			}
 			// Note: this is a no-op if invariants are disabled or race is enabled.
-			invariants.SetFinalizer(i, checkTwoLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.MultiDataBlockIter, *colblk.MultiDataBlockIter])
+			invariants.SetFinalizer(i, checkTwoLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.DataBlockIter, *colblk.DataBlockIter])
 			return i
 		},
 	}


### PR DESCRIPTION
Collapse MultiDataBlockIter and DataBlockIter into one type. This was motivated by chasing down an unintentional allocation in MultiDataBlockIter.InitHandle.