### PR TITLE
db: remove unnecessary NewIter allocations

### DIFF
--- a/db.go
+++ b/db.go
@@ -1487,7 +1487,7 @@ func (i *Iterator) constructPointIter(
 			li := &levels[levelsIndex]
 
 			li.init(ctx, i.opts, &i.comparer, i.newIters, files, level, internalOpts)
-			li.initRangeDel(mlevels[mlevelsIndex].setRangeDelIter)
+			li.initRangeDel(&mlevels[mlevelsIndex])
 			li.initCombinedIterState(&i.lazyCombinedIter.combinedIterState)
 			mlevels[mlevelsIndex].levelIter = li
 			mlevels[mlevelsIndex].iter = invalidating.MaybeWrapIfInvariants(li)

--- a/level_checker.go
+++ b/level_checker.go
@@ -642,7 +642,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		li := &levelIter{}
 		li.init(context.Background(), iterOpts, c.comparer, c.newIters, manifestIter,
 			manifest.L0Sublevel(sublevel), internalIterOpts{})
-		li.initRangeDel(mlevelAlloc[0].setRangeDelIter)
+		li.initRangeDel(&mlevelAlloc[0])
 		mlevelAlloc[0].iter = li
 		mlevelAlloc = mlevelAlloc[1:]
 	}
@@ -655,7 +655,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		li := &levelIter{}
 		li.init(context.Background(), iterOpts, c.comparer, c.newIters,
 			current.Levels[level].Iter(), manifest.Level(level), internalIterOpts{})
-		li.initRangeDel(mlevelAlloc[0].setRangeDelIter)
+		li.initRangeDel(&mlevelAlloc[0])
 		mlevelAlloc[0].iter = li
 		mlevelAlloc = mlevelAlloc[1:]
 	}

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -44,6 +44,9 @@ type mergingIterLevel struct {
 	tombstone *keyspan.Span
 }
 
+// Assert that *mergingIterLevel implements rangeDelIterSetter.
+var _ rangeDelIterSetter = (*mergingIterLevel)(nil)
+
 func (ml *mergingIterLevel) setRangeDelIter(iter keyspan.FragmentIterator) {
 	ml.tombstone = nil
 	if ml.rangeDelIter != nil {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -302,7 +302,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 
 				i := len(levelIters)
 				levelIters = append(levelIters, mergingIterLevel{iter: li})
-				li.initRangeDel(levelIters[i].setRangeDelIter)
+				li.initRangeDel(&levelIters[i])
 			}
 			miter := &mergingIter{}
 			miter.init(nil /* opts */, &stats, cmp, func(a []byte) int { return len(a) }, levelIters...)
@@ -688,7 +688,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 		l := newLevelIter(
 			context.Background(), IterOptions{}, testkeys.Comparer, newIters, levelSlices[i].Iter(),
 			manifest.Level(level), internalIterOpts{})
-		l.initRangeDel(mils[level].setRangeDelIter)
+		l.initRangeDel(&mils[level])
 		mils[level].iter = l
 	}
 	var stats base.InternalIteratorStats


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble
                     │    old.txt    │              newest.txt               │
                     │    sec/op     │    sec/op     vs base                 │
NewIterReadAmp/10-10   1309.0n ± ∞ ¹   810.7n ± ∞ ¹  -38.07% (p=0.016 n=4+5)
¹ need >= 6 samples for confidence interval at level 0.95

                     │   old.txt   │          newest.txt          │
                     │    B/op     │   B/op     vs base           │
NewIterReadAmp/10-10   241.0 ± ∞ ¹   0.0 ± ∞ ¹  ~ (p=0.079 n=4+5)
¹ need >= 6 samples for confidence interval at level 0.95

                     │   old.txt   │          newest.txt           │
                     │  allocs/op  │ allocs/op   vs base           │
NewIterReadAmp/10-10   11.00 ± ∞ ¹   0.00 ± ∞ ¹  ~ (p=0.079 n=4+5)
```

Close #4000.