### PR TITLE
sstable: clean up TestRewriteSuffixProps, fix subtle bug

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -967,7 +967,7 @@ func (w *RawColumnWriter) rewriteSuffixes(
 
 	// oldShortIDs maps the shortID for the block property collector in the old
 	// blocks to the shortID in the new blocks. Initialized once for the sstable.
-	oldShortIDs, err := getShortIDs(r, w.blockPropCollectors)
+	oldShortIDs, n, err := getShortIDs(r, w.blockPropCollectors)
 	if err != nil {
 		return errors.Wrap(err, "getting short IDs")
 	}
@@ -980,7 +980,7 @@ func (w *RawColumnWriter) rewriteSuffixes(
 		for i := range oldProps {
 			oldProps[i] = nil
 		}
-		decoder := makeBlockPropertiesDecoder(len(oldProps), l.Data[i].Props)
+		decoder := makeBlockPropertiesDecoder(n, l.Data[i].Props)
 		for !decoder.Done() {
 			id, val, err := decoder.Next()
 			if err != nil {

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -1945,7 +1945,7 @@ func (w *RawRowWriter) rewriteSuffixes(
 
 	// oldShortIDs maps the shortID for the block property collector in the old
 	// blocks to the shortID in the new blocks. Initialized once for the sstable.
-	oldShortIDs, err := getShortIDs(r, w.blockPropCollectors)
+	oldShortIDs, n, err := getShortIDs(r, w.blockPropCollectors)
 	if err != nil {
 		return errors.Wrap(err, "getting short IDs")
 	}
@@ -1962,7 +1962,7 @@ func (w *RawRowWriter) rewriteSuffixes(
 		for i := range oldProps {
 			oldProps[i] = nil
 		}
-		decoder := makeBlockPropertiesDecoder(len(oldProps), l.Data[i].Props)
+		decoder := makeBlockPropertiesDecoder(n, l.Data[i].Props)
 		for !decoder.Done() {
 			id, val, err := decoder.Next()
 			if err != nil {

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -238,23 +238,33 @@ func rewriteRangeKeyBlockToWriter(r *Reader, w RawWriter, from, to []byte) error
 // collector in r, with the values containing a new shortID corresponding to the
 // index of the corresponding block property collector in collectors.
 //
+// Additionally, getShortIDs returns n—n is the number of encoded properties
+// that a reader needs to process in order to get values for all the given
+// collectors.  This can be different than len(collectors) when the latter is
+// different from the number of block property collectors used when the sstable
+// was written.  Note that shortIDs[n:] are all invalid.
+//
 // getShortIDs errors if any of the collectors are not found in the sstable.
-func getShortIDs(r *Reader, collectors []BlockPropertyCollector) ([]shortID, error) {
+func getShortIDs(
+	r *Reader, collectors []BlockPropertyCollector,
+) (shortIDs []shortID, n int, err error) {
 	if len(collectors) == 0 {
-		return nil, nil
+		return nil, 0, nil
 	}
-	shortIDs := make([]shortID, math.MaxUint8)
+	shortIDs = make([]shortID, math.MaxUint8)
 	for i := range shortIDs {
 		shortIDs[i] = invalidShortID
 	}
 	for i, p := range collectors {
 		prop, ok := r.Properties.UserProperties[p.Name()]
 		if !ok {
-			return nil, errors.Errorf("sstable does not contain property %s", p.Name())
+			return nil, 0, errors.Errorf("sstable does not contain property %s", p.Name())
 		}
-		shortIDs[shortID(prop[0])] = shortID(i)
+		oldShortID := shortID(prop[0])
+		shortIDs[oldShortID] = shortID(i)
+		n = max(n, int(oldShortID)+1)
 	}
-	return shortIDs, nil
+	return shortIDs, n, nil
 }
 
 type copyFilterWriter struct {


### PR DESCRIPTION
This commit cleans up the TestRewriteSuffixProps unit test, refactoring it to use the testkey comparator and new block-property collectors that are functions of the testkey integer suffix.

It also fixes a bug where if the suffix rewriting WriterOptions contained fewer block property collectors than the original sstable had when it was written, suffix rewriting could fail to decode all the relevant properties from a block handle.