### PR TITLE
internal/manifest: make annotations concurrent-safe

### DIFF
--- a/db.go
+++ b/db.go
@@ -2302,9 +2302,6 @@ func (d *DB) EstimateDiskUsageByBackingType(
 	readState := d.loadReadState()
 	defer readState.unref()
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	totalSize = *d.mu.annotators.totalSize.VersionRangeAnnotation(readState.current, bounds)
 	remoteSize = *d.mu.annotators.remoteSize.VersionRangeAnnotation(readState.current, bounds)
 	externalSize = *d.mu.annotators.externalSize.VersionRangeAnnotation(readState.current, bounds)


### PR DESCRIPTION
Previously, we required any annotation mutations to be mutually-excluded through, say, db.mu being held. This was problematic as some uses of annotations, like level sizes, were complex to compute and required IO (or network requests). Holding up db.mu while we send a bunch of requests to S3 was causing a huge performance penalty across Pebble, so this change makes annotator safe for concurrent use with a slight possibility of double-calculating annotation values in case of races, something that shouldn't change any results.

Fixes #4001.