### PR TITLE
sstable/block: remove FragmentIterTransforms.ElideSameSeqNum

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -268,9 +268,6 @@ func (t *IterTransforms) NoTransforms() bool {
 // range key data at iteration time.
 type FragmentIterTransforms struct {
 	SyntheticSeqNum SyntheticSeqNum
-	// ElideSameSeqNum, if true, returns only the first-occurring (in forward
-	// order) keyspan.Key for each sequence number.
-	ElideSameSeqNum bool
 	SyntheticPrefix SyntheticPrefix
 	SyntheticSuffix SyntheticSuffix
 }

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -286,7 +286,6 @@ func (r *Reader) NewRawRangeDelIter(
 	if err != nil {
 		return nil, err
 	}
-	transforms.ElideSameSeqNum = true
 	if r.tableFormat.BlockColumnar() {
 		iter = colblk.NewKeyspanIter(r.Compare, h, transforms)
 	} else {

--- a/sstable/rowblk/rowblk_fragment_iter_test.go
+++ b/sstable/rowblk/rowblk_fragment_iter_test.go
@@ -81,7 +81,6 @@ func TestBlockFragmentIterator(t *testing.T) {
 
 		case "iter":
 			var transforms block.FragmentIterTransforms
-			transforms.ElideSameSeqNum = d.HasArg("elide-same-seq-num")
 			var seqNum uint64
 			d.MaybeScanArgs(t, "synthetic-seq-num", &seqNum)
 			transforms.SyntheticSeqNum = block.SyntheticSeqNum(seqNum)

--- a/sstable/rowblk/testdata/rowblk_fragment_iter
+++ b/sstable/rowblk/testdata/rowblk_fragment_iter
@@ -55,15 +55,6 @@ next
     next:  a-b:{(#11,RANGEDEL)}
 
 
-iter elide-same-seq-num
-first
-next
-next
-----
-   first:  a-b:{(#11,RANGEDEL)}
-    next:  b-d:{(#12,RANGEDEL) (#11,RANGEDEL)}
-    next:  d-e:{(#12,RANGEDEL) (#11,RANGEDEL)}
-
 iter synthetic-seq-num=10
 first
 next
@@ -72,15 +63,6 @@ next
    first:  a-b:{(#10,RANGEDEL)}
     next:  b-d:{(#10,RANGEDEL) (#10,RANGEDEL) (#10,RANGEDEL)}
     next:  d-e:{(#10,RANGEDEL) (#10,RANGEDEL)}
-
-iter synthetic-seq-num=10 elide-same-seq-num
-first
-next
-next
-----
-   first:  a-b:{(#10,RANGEDEL)}
-    next:  b-d:{(#10,RANGEDEL)}
-    next:  d-e:{(#10,RANGEDEL)}
 
 # Tests with synthetic prefix.
 iter synthetic-prefix=foo_


### PR DESCRIPTION
ElideSameSeqNum was only ever set by (*sstable.Reader).NewRawRangeDelIter where it should be no-op (because two range deletions with the same sequence number would be duplicate keys). Remove the option.