### PR TITLE
colblk: rename DataBlockWriter/Reader to Encoder/Decoder

### DIFF
--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -25,8 +25,8 @@ var testKeysSchema = DefaultKeySchema(testkeys.Comparer, 16)
 
 func TestDataBlock(t *testing.T) {
 	var buf bytes.Buffer
-	var w DataBlockWriter
-	var r DataBlockReader
+	var w DataBlockEncoder
+	var r DataBlockDecoder
 	var it DataBlockIter
 	rw := NewDataBlockRewriter(testKeysSchema, testkeys.Comparer.Compare, testkeys.Comparer.Split)
 	var sizes []int
@@ -149,7 +149,7 @@ func benchmarkDataBlockWriter(b *testing.B, prefixSize, valueSize int) {
 	rng := rand.New(rand.NewSource(seed))
 	keys, values := makeTestKeyRandomKVs(rng, prefixSize, valueSize, targetBlockSize)
 
-	var w DataBlockWriter
+	var w DataBlockEncoder
 	w.Init(testKeysSchema)
 	b.ResetTimer()
 

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -41,7 +41,7 @@ type RawColumnWriter struct {
 	props                Properties
 	// block writers buffering unflushed data.
 	dataBlock struct {
-		colblk.DataBlockWriter
+		colblk.DataBlockEncoder
 		// numDeletions stores the count of point tombstones in this data block.
 		// It's used to determine if this data block is considered
 		// tombstone-dense for the purposes of compaction.

--- a/sstable/colblk_writer_test.go
+++ b/sstable/colblk_writer_test.go
@@ -114,7 +114,7 @@ func describeSSTableBinary(f *binfmt.Formatter, schema colblk.KeySchema) error {
 					f.HexBytesln(block.TrailerLen, "%s block trailer", bh.Name)
 					continue
 				case "data":
-					var r colblk.DataBlockReader
+					var r colblk.DataBlockDecoder
 					// NB: The byte slice used to Init must be aligned (like an
 					// allocated block would be in practice).
 					r.Init(schema, aligned.Copy(f.Data()[bh.Offset:bh.Offset+bh.Length]))

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -322,7 +322,7 @@ func formatColblkDataBlock(
 	data []byte,
 	fmtRecord func(key *base.InternalKey, value []byte),
 ) error {
-	var reader colblk.DataBlockReader
+	var reader colblk.DataBlockDecoder
 	reader.Init(r.keySchema, data)
 	f := binfmt.New(data)
 	f.SetLinePrefix("               ")


### PR DESCRIPTION
These names are more appropriate because these types don't actually
perform any reading or writing, and there are other associated reader
and writer types.