### PR TITLE
colblk: implement FragmentIterTransforms, fix SeekLT

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -272,6 +272,14 @@ type FragmentIterTransforms struct {
 	SyntheticSuffix SyntheticSuffix
 }
 
+// NoTransforms returns true if there are no transforms enabled.
+func (t *FragmentIterTransforms) NoTransforms() bool {
+	// NoTransforms returns true if there are no transforms enabled.
+	return t.SyntheticSeqNum == 0 &&
+		!t.SyntheticPrefix.IsSet() &&
+		!t.SyntheticSuffix.IsSet()
+}
+
 // NoFragmentTransforms is the default value for IterTransforms.
 var NoFragmentTransforms = FragmentIterTransforms{}
 

--- a/sstable/block/block_test.go
+++ b/sstable/block/block_test.go
@@ -36,3 +36,27 @@ func TestIterTransforms(t *testing.T) {
 	transforms.SyntheticSuffix = []byte{1}
 	require.False(t, transforms.NoTransforms())
 }
+
+func TestFragmentIterTransforms(t *testing.T) {
+	require.True(t, NoFragmentTransforms.NoTransforms())
+	var transforms FragmentIterTransforms
+	require.True(t, transforms.NoTransforms())
+	require.False(t, transforms.SyntheticPrefix.IsSet())
+	require.False(t, transforms.SyntheticSuffix.IsSet())
+	transforms.SyntheticPrefix = []byte{}
+	require.False(t, transforms.SyntheticPrefix.IsSet())
+	transforms.SyntheticSuffix = []byte{}
+	require.False(t, transforms.SyntheticSuffix.IsSet())
+	require.True(t, transforms.NoTransforms())
+
+	transforms.SyntheticSeqNum = 123
+	require.False(t, transforms.NoTransforms())
+
+	transforms = NoFragmentTransforms
+	transforms.SyntheticPrefix = []byte{1}
+	require.False(t, transforms.NoTransforms())
+
+	transforms = NoFragmentTransforms
+	transforms.SyntheticSuffix = []byte{1}
+	require.False(t, transforms.NoTransforms())
+}

--- a/sstable/colblk/keyspan.go
+++ b/sstable/colblk/keyspan.go
@@ -285,7 +285,22 @@ func (r *KeyspanReader) Describe(f *binfmt.Formatter) {
 
 // searchBoundaryKeys returns the index of the first boundary key greater than
 // or equal to key and whether or not the key was found exactly.
-func (r *KeyspanReader) searchBoundaryKeys(cmp base.Compare, key []byte) (index int, equal bool) {
+func (r *KeyspanReader) searchBoundaryKeysWithSyntheticPrefix(
+	cmp base.Compare, key []byte, syntheticPrefix block.SyntheticPrefix,
+) (index int, equal bool) {
+	if syntheticPrefix.IsSet() {
+		// The seek key must have the synthetic prefix, otherwise it falls entirely
+		// before or after the block's boundary keys.
+		var keyPrefix []byte
+		keyPrefix, key = splitKey(key, len(syntheticPrefix))
+		if cmp := bytes.Compare(keyPrefix, syntheticPrefix); cmp != 0 {
+			if cmp < 0 {
+				return 0, false
+			}
+			return int(r.boundaryKeysCount), false
+		}
+	}
+
 	i, j := 0, int(r.boundaryKeysCount)
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h
@@ -358,16 +373,21 @@ func (i *KeyspanIter) Close() {
 // A keyspanIter is an iterator over a keyspan block. It implements the
 // keyspan.FragmentIterator interface.
 type keyspanIter struct {
-	r          *KeyspanReader
-	cmp        base.Compare
-	transforms block.FragmentIterTransforms
-	span       keyspan.Span
+	r            *KeyspanReader
+	cmp          base.Compare
+	transforms   block.FragmentIterTransforms
+	noTransforms bool
+	span         keyspan.Span
 	// When positioned, the current span's start key is the user key at
 	//   i.r.userKeys.At(i.startBoundIndex)
 	// and the current span's end key is the user key at
 	//   i.r.userKeys.At(i.startBoundIndex+1)
 	startBoundIndex int
 	keyBuf          [2]keyspan.Key
+	// startKeyBuf and endKeyBuf are used when transforms.SyntheticPrefix is
+	// set.
+	startKeyBuf []byte
+	endKeyBuf   []byte
 }
 
 // Assert that KeyspanIter implements the FragmentIterator interface.
@@ -381,10 +401,17 @@ func (i *keyspanIter) init(
 	i.r = r
 	i.cmp = cmp
 	i.transforms = transforms
+	i.noTransforms = transforms.NoTransforms()
 	i.span.Start, i.span.End = nil, nil
 	i.startBoundIndex = -1
 	if i.span.Keys == nil {
 		i.span.Keys = i.keyBuf[:0]
+	}
+	i.startKeyBuf = i.startKeyBuf[:0]
+	i.endKeyBuf = i.endKeyBuf[:0]
+	if transforms.SyntheticPrefix.IsSet() {
+		i.startKeyBuf = append(i.startKeyBuf, transforms.SyntheticPrefix...)
+		i.endKeyBuf = append(i.endKeyBuf, transforms.SyntheticPrefix...)
 	}
 }
 
@@ -393,7 +420,7 @@ func (i *keyspanIter) init(
 // span with an end key greater than the given key.
 func (i *keyspanIter) SeekGE(key []byte) (*keyspan.Span, error) {
 	// Seek among the boundary keys.
-	j, eq := i.r.searchBoundaryKeys(i.cmp, key)
+	j, eq := i.r.searchBoundaryKeysWithSyntheticPrefix(i.cmp, key, i.transforms.SyntheticPrefix)
 	// If the found boundary key does not exactly equal the given key, it's
 	// strictly greater than key. We need to back up one to consider the span
 	// that ends at the this boundary key.
@@ -407,14 +434,14 @@ func (i *keyspanIter) SeekGE(key []byte) (*keyspan.Span, error) {
 // given key. This is equivalent to seeking to the last span with a start
 // key less than the given key.
 func (i *keyspanIter) SeekLT(key []byte) (*keyspan.Span, error) {
-	// Seek among the boundary keys.
-	j, eq := i.r.searchBoundaryKeys(i.cmp, key)
-	// If eq is true, the found boundary key exactly equals the given key. A
-	// span that starts at exactly [key] does not contain any keys strictly less
-	// than [key], so back up one index.
-	if eq {
-		j--
-	}
+	j, _ := i.r.searchBoundaryKeysWithSyntheticPrefix(i.cmp, key, i.transforms.SyntheticPrefix)
+	// searchBoundaryKeys seeks to the first boundary key greater than or equal
+	// to key. The span beginning at the boundary key j necessarily does NOT
+	// cover any key less < key (it only contains keys ≥ key). Back up one to
+	// the first span that begins before [key], or to -1 if there is no such
+	// span.
+	j--
+
 	// If all boundaries are less than [key], or only the last boundary is
 	// greater than the key, then we want the last span so we clamp the index to
 	// the second to last boundary.
@@ -499,8 +526,6 @@ func (i *keyspanIter) isNonemptySpan(startBoundIndex int) bool {
 // materializeSpan constructs the current span from i.startBoundIndex and
 // i.{start,end}KeyIndex.
 func (i *keyspanIter) materializeSpan() *keyspan.Span {
-	// TODO(jackson): Apply i.transforms.
-
 	i.span = keyspan.Span{
 		Start: i.r.boundaryKeys.At(i.startBoundIndex),
 		End:   i.r.boundaryKeys.At(i.startBoundIndex + 1),
@@ -518,6 +543,50 @@ func (i *keyspanIter) materializeSpan() *keyspan.Span {
 			Value:   i.r.values.At(int(j)),
 		})
 	}
+	if i.noTransforms {
+		return &i.span
+	}
+	if i.transforms.SyntheticSeqNum != block.NoSyntheticSeqNum {
+		for j := range i.span.Keys {
+			i.span.Keys[j].Trailer = base.MakeTrailer(
+				base.SeqNum(i.transforms.SyntheticSeqNum), i.span.Keys[j].Trailer.Kind())
+		}
+	}
+	if i.transforms.SyntheticSuffix.IsSet() {
+		for j := range i.span.Keys {
+			k := &i.span.Keys[j]
+			switch k.Kind() {
+			case base.InternalKeyKindRangeKeySet:
+				if len(k.Suffix) > 0 {
+					// TODO(jackson): Assert synthetic suffix is >= k.Suffix.
+					k.Suffix = i.transforms.SyntheticSuffix
+				}
+			case base.InternalKeyKindRangeKeyDelete:
+				// Nothing to do.
+			default:
+				panic(base.AssertionFailedf("synthetic suffix not supported with key kind %s", k.Kind()))
+			}
+		}
+	}
+	if i.transforms.SyntheticPrefix.IsSet() || invariants.Sometimes(10) {
+		i.startKeyBuf = i.startKeyBuf[:len(i.transforms.SyntheticPrefix)]
+		i.endKeyBuf = i.endKeyBuf[:len(i.transforms.SyntheticPrefix)]
+		if invariants.Enabled {
+			if !bytes.Equal(i.startKeyBuf, i.transforms.SyntheticPrefix) {
+				panic(errors.AssertionFailedf("keyspanIter: synthetic prefix mismatch %q, %q",
+					i.startKeyBuf, i.transforms.SyntheticPrefix))
+			}
+			if !bytes.Equal(i.endKeyBuf, i.transforms.SyntheticPrefix) {
+				panic(errors.AssertionFailedf("keyspanIter: synthetic prefix mismatch %q, %q",
+					i.endKeyBuf, i.transforms.SyntheticPrefix))
+			}
+		}
+		i.startKeyBuf = append(i.startKeyBuf, i.span.Start...)
+		i.endKeyBuf = append(i.endKeyBuf, i.span.End...)
+		i.span.Start = i.startKeyBuf
+		i.span.End = i.endKeyBuf
+	}
+
 	return &i.span
 }
 

--- a/sstable/colblk/keyspan_test.go
+++ b/sstable/colblk/keyspan_test.go
@@ -53,7 +53,17 @@ func TestKeyspanBlock(t *testing.T) {
 			return buf.String()
 		case "iter":
 			var iter keyspanIter
-			iter.init(base.DefaultComparer.Compare, &kr, block.NoFragmentTransforms)
+			var syntheticSeqNum uint64
+			var syntheticPrefix, syntheticSuffix string
+			td.MaybeScanArgs(t, "synthetic-seq-num", &syntheticSeqNum)
+			td.MaybeScanArgs(t, "synthetic-prefix", &syntheticPrefix)
+			td.MaybeScanArgs(t, "synthetic-suffix", &syntheticSuffix)
+			transforms := block.FragmentIterTransforms{
+				SyntheticSeqNum: block.SyntheticSeqNum(syntheticSeqNum),
+				SyntheticPrefix: []byte(syntheticPrefix),
+				SyntheticSuffix: []byte(syntheticSuffix),
+			}
+			iter.init(base.DefaultComparer.Compare, &kr, transforms)
 			return keyspan.RunFragmentIteratorCmd(&iter, td.Input, nil)
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)

--- a/sstable/colblk/testdata/keyspan_block
+++ b/sstable/colblk/testdata/keyspan_block
@@ -162,6 +162,21 @@ d-e:{(#0,RANGEDEL)}
 c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
 
 iter
+seek-lt coconut
+seek-lt c
+seek-lt banana
+seek-lt b
+seek-lt apple
+seek-lt a
+----
+c-d:{(#100,RANGEDEL) (#0,RANGEDEL)}
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+b-c:{(#100,RANGEDEL) (#20,RANGEDEL) (#0,RANGEDEL)}
+a-b:{(#0,RANGEDEL)}
+a-b:{(#0,RANGEDEL)}
+.
+
+iter
 first
 next
 next
@@ -393,7 +408,82 @@ seek-lt g
 seek-lt z
 seek-lt e
 ----
-e-g:{(#5,RANGEKEYSET,@1,tree)}
+b-d:{(#4,RANGEKEYSET,@3,coconut)}
 e-g:{(#5,RANGEKEYSET,@1,tree)}
 e-g:{(#5,RANGEKEYSET,@1,tree)}
 b-d:{(#4,RANGEKEYSET,@3,coconut)}
+
+iter synthetic-seq-num=99
+first
+next
+next
+----
+b-d:{(#99,RANGEKEYSET,@3,coconut)}
+e-g:{(#99,RANGEKEYSET,@1,tree)}
+.
+
+iter synthetic-suffix=@9
+first
+next
+next
+----
+b-d:{(#4,RANGEKEYSET,@9,coconut)}
+e-g:{(#5,RANGEKEYSET,@9,tree)}
+.
+
+iter synthetic-prefix=foo
+first
+next
+next
+----
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+fooe-foog:{(#5,RANGEKEYSET,@1,tree)}
+.
+
+iter synthetic-prefix=foo
+seek-ge fax
+seek-ge fun
+prev
+----
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+.
+fooe-foog:{(#5,RANGEKEYSET,@1,tree)}
+
+iter synthetic-prefix=foo
+seek-ge fooa
+seek-ge foob
+seek-ge foobanana
+seek-ge foococonut
+seek-ge fooc
+seek-ge foofoo
+----
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+fooe-foog:{(#5,RANGEKEYSET,@1,tree)}
+
+iter synthetic-prefix=foo
+seek-lt fax
+next
+seek-lt fun
+----
+.
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+fooe-foog:{(#5,RANGEKEYSET,@1,tree)}
+
+iter synthetic-prefix=foo
+seek-lt fooa
+seek-lt foob
+seek-lt foobanana
+seek-lt foococonut
+seek-lt fooc
+seek-lt foofoo
+----
+.
+.
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+foob-food:{(#4,RANGEKEYSET,@3,coconut)}
+fooe-foog:{(#5,RANGEKEYSET,@1,tree)}


### PR DESCRIPTION
Fix a bug in (*colblk.KeyspanIter).SeekLT that caused the iterator to surface the wrong span, and implement the FragmentIterTransforms on the colblk.KeyspanIter.