### PR TITLE
lint: stop test when go vet fails

### DIFF
--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -98,6 +98,12 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	// In most cases, go vet fails because of a build error; running the rest of
+	// the checks would just result in a lot of noise.
+	if t.Failed() {
+		t.Log("go vet failed; skipping other lint checks")
+	}
+
 	t.Run("TestGCAssert", func(t *testing.T) {
 		installTool(t, gcassert)
 		t.Parallel()


### PR DESCRIPTION
In most cases `go vet` fails because of a build error, in which case
the rest of the tests result in a lot of noise. This commit stops the
lint test suite if `go vet` fails.