### PR TITLE
sstable: make CopySpan() support columnar blocks

### DIFF
--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -167,6 +167,15 @@ type PhysicalBlock struct {
 	trailer Trailer
 }
 
+// NewPhysicalBlock returns a new PhysicalBlock with the provided block
+// data. The trailer is set from the last TrailerLen bytes of the
+// block. The data could be compressed.
+func NewPhysicalBlock(data []byte) PhysicalBlock {
+	trailer := Trailer(data[len(data)-TrailerLen:])
+	data = data[:len(data)-TrailerLen]
+	return PhysicalBlock{data: data, trailer: trailer}
+}
+
 // LengthWithTrailer returns the length of the data block, including the trailer.
 func (b *PhysicalBlock) LengthWithTrailer() int {
 	return len(b.data) + TrailerLen

--- a/sstable/copier_test.go
+++ b/sstable/copier_test.go
@@ -1,0 +1,180 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/cache"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/colblk"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+func TestCopySpan(t *testing.T) {
+	fs := vfs.NewMem()
+	blockCache := cache.New(1 << 20 /* 1 MB */)
+	defer blockCache.Unref()
+	datadriven.RunTest(t, "testdata/copy_span", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "build":
+			// Build an sstable from the specified keys
+			f, err := fs.Create(d.CmdArgs[0].Key, vfs.WriteCategoryUnspecified)
+			if err != nil {
+				return err.Error()
+			}
+			tableFormat := TableFormatMax
+			for i := range d.CmdArgs[1:] {
+				switch d.CmdArgs[i+1].Key {
+				case "format":
+					switch d.CmdArgs[i+1].Vals[0] {
+					case "pebblev4":
+						tableFormat = TableFormatPebblev4
+					case "pebblev5":
+						tableFormat = TableFormatPebblev5
+					}
+				}
+			}
+			w := NewWriter(objstorageprovider.NewFileWritable(f), WriterOptions{
+				BlockSize:   1,
+				TableFormat: tableFormat,
+				Comparer:    testkeys.Comparer,
+				KeySchema:   colblk.DefaultKeySchema(testkeys.Comparer, 16),
+			})
+			for _, key := range strings.Split(d.Input, "\n") {
+				j := strings.Index(key, ":")
+				ikey := base.ParseInternalKey(key[:j])
+				value := []byte(key[j+1:])
+				if err := w.Set(ikey.UserKey, value); err != nil {
+					return err.Error()
+				}
+			}
+			if err := w.Close(); err != nil {
+				return err.Error()
+			}
+
+			return ""
+
+		case "iter":
+			// Iterate over the specified sstable
+			f, err := fs.Open(d.CmdArgs[0].Key)
+			if err != nil {
+				return err.Error()
+			}
+			readable, err := NewSimpleReadable(f)
+			if err != nil {
+				return err.Error()
+			}
+			r, err := NewReader(context.TODO(), readable, ReaderOptions{
+				Comparer:  testkeys.Comparer,
+				KeySchema: colblk.DefaultKeySchema(testkeys.Comparer, 16),
+			})
+			defer r.Close()
+			if err != nil {
+				return err.Error()
+			}
+			iter, err := r.NewIter(block.NoTransforms, nil, nil)
+			if err != nil {
+				return err.Error()
+			}
+			defer iter.Close()
+			var result strings.Builder
+			for key := iter.First(); key != nil; key = iter.Next() {
+				fmt.Fprintf(&result, "%s: %s\n", key.K, key.V.InPlaceValue())
+			}
+			return result.String()
+
+		case "copy-span":
+			// Copy a span from one sstable to another
+			if len(d.CmdArgs) != 4 {
+				t.Fatalf("expected input sstable, output sstable, start and end keys")
+			}
+
+			inputFile := d.CmdArgs[0].Key
+			outputFile := d.CmdArgs[1].Key
+			start := base.ParseInternalKey(d.CmdArgs[2].String())
+			end := base.ParseInternalKey(d.CmdArgs[3].String())
+			output, err := fs.Create(outputFile, vfs.WriteCategoryUnspecified)
+			if err != nil {
+				return err.Error()
+			}
+			writable := objstorageprovider.NewFileWritable(output)
+
+			f, err := fs.Open(inputFile)
+			if err != nil {
+				t.Fatalf("failed to open sstable: %v", err)
+			}
+			readable, err := NewSimpleReadable(f)
+			if err != nil {
+				return err.Error()
+			}
+			rOpts := ReaderOptions{
+				Comparer:  testkeys.Comparer,
+				KeySchema: colblk.DefaultKeySchema(testkeys.Comparer, 16),
+			}
+			rOpts.internal.CacheOpts.Cache = blockCache
+			r, err := NewReader(context.TODO(), readable, rOpts)
+			if err != nil {
+				return err.Error()
+			}
+			defer r.Close()
+			wOpts := WriterOptions{
+				Comparer:  testkeys.Comparer,
+				KeySchema: colblk.DefaultKeySchema(testkeys.Comparer, 16),
+			}
+			// CopySpan closes readable but not reader. We need to open a new readable for it.
+			f2, err := fs.Open(inputFile)
+			if err != nil {
+				t.Fatalf("failed to open sstable: %v", err)
+			}
+			readable2, err := NewSimpleReadable(f2)
+			if err != nil {
+				return err.Error()
+			}
+			size, err := CopySpan(context.TODO(), readable2, r, rOpts, writable, wOpts, start, end)
+			if err != nil {
+				return err.Error()
+			}
+			return fmt.Sprintf("copied %d bytes", size)
+
+		case "describe":
+			f, err := fs.Open(d.CmdArgs[0].Key)
+			if err != nil {
+				return err.Error()
+			}
+			readable, err := NewSimpleReadable(f)
+			if err != nil {
+				return err.Error()
+			}
+			r, err := NewReader(context.TODO(), readable, ReaderOptions{
+				Comparer:  testkeys.Comparer,
+				KeySchema: colblk.DefaultKeySchema(testkeys.Comparer, 16),
+			})
+			if err != nil {
+				return err.Error()
+			}
+			defer r.Close()
+			l, err := r.Layout()
+			if err != nil {
+				return err.Error()
+			}
+			var buf bytes.Buffer
+			l.Describe(&buf, true, r, nil)
+			return buf.String()
+
+		default:
+			t.Fatalf("unknown command: %s", d.Cmd)
+			return ""
+		}
+	})
+}

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -272,6 +272,10 @@ type WriterOptions struct {
 	// DeletionSizeRatioThreshold mirrors
 	// Options.Experimental.DeletionSizeRatioThreshold.
 	DeletionSizeRatioThreshold float32
+
+	// disableObsoleteCollector is used to disable the obsolete key block property
+	// collector automatically added by sstable block writers.
+	disableObsoleteCollector bool
 }
 
 // SetInternal sets the internal writer options. Note that even though this

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -6,6 +6,7 @@ package sstable
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -1881,7 +1882,8 @@ func newRowWriter(writable objstorage.Writable, o WriterOptions) *RawRowWriter {
 	w.props.PropertyCollectorNames = "[]"
 
 	numBlockPropertyCollectors := len(o.BlockPropertyCollectors)
-	if w.tableFormat >= TableFormatPebblev4 {
+	shouldAddObsoleteCollector := w.tableFormat >= TableFormatPebblev4 && !o.disableObsoleteCollector
+	if shouldAddObsoleteCollector {
 		numBlockPropertyCollectors++
 	}
 
@@ -1894,7 +1896,7 @@ func newRowWriter(writable objstorage.Writable, o WriterOptions) *RawRowWriter {
 		for _, constructFn := range o.BlockPropertyCollectors {
 			w.blockPropCollectors = append(w.blockPropCollectors, constructFn())
 		}
-		if w.tableFormat >= TableFormatPebblev4 {
+		if shouldAddObsoleteCollector {
 			w.blockPropCollectors = append(w.blockPropCollectors, &w.obsoleteCollector)
 		}
 
@@ -2010,6 +2012,76 @@ func (w *RawRowWriter) rewriteSuffixes(
 				origPolicyName: w.filter.policyName(), origMetaName: w.filter.metaName(), data: filterBlock,
 			}
 		}
+	}
+	return nil
+}
+
+// copyDataBlocks implements RawWriter.
+func (w *RawRowWriter) copyDataBlocks(
+	ctx context.Context, blocks []indexEntry, rh objstorage.ReadHandle,
+) error {
+	blockOffset := blocks[0].bh.Offset
+	// The block lengths don't include their trailers, which just sit after the
+	// block length, before the next offset; We get the ones between the blocks
+	// we copy implicitly but need to explicitly add the last trailer to length.
+	length := blocks[len(blocks)-1].bh.Offset + blocks[len(blocks)-1].bh.Length + block.TrailerLen - blockOffset
+	if spanEnd := length + blockOffset; spanEnd < blockOffset {
+		return base.AssertionFailedf("invalid intersecting span for CopySpan [%d, %d)", blockOffset, spanEnd)
+	}
+	if err := objstorage.Copy(ctx, rh, w.layout.writable, blockOffset, length); err != nil {
+		return err
+	}
+	// Update w.meta.Size so subsequently flushed metadata has correct offsets.
+	w.meta.Size += length
+	for i := range blocks {
+		blocks[i].bh.Offset = w.layout.offset
+		// blocks[i].bh.Length remains unmodified.
+		sepKey := base.MakeInternalKey(blocks[i].sep, base.SeqNumMax, base.InternalKeyKindSeparator)
+		if err := w.addIndexEntrySep(sepKey, blocks[i].bh, w.dataBlockBuf.tmp[:]); err != nil {
+			return err
+		}
+		w.layout.offset += uint64(blocks[i].bh.Length) + block.TrailerLen
+	}
+	return nil
+}
+
+// addDataBlock implements RawWriter.
+func (w *RawRowWriter) addDataBlock(b, sep []byte, bhp block.HandleWithProperties) error {
+	// layout.WriteDataBlock keeps layout.offset up-to-date for us.
+	bh, err := w.layout.WriteDataBlock(b, &w.dataBlockBuf.blockBuf)
+	if err != nil {
+		return err
+	}
+	bhp.Handle = bh
+
+	sepKey := base.MakeInternalKey(sep, base.SeqNumMax, base.InternalKeyKindSeparator)
+	if err := w.addIndexEntrySep(sepKey, bhp, w.dataBlockBuf.tmp[:]); err != nil {
+		return err
+	}
+	w.meta.Size += uint64(bh.Length) + block.TrailerLen
+	return nil
+}
+
+// copyProperties implements RawWriter.
+func (w *RawRowWriter) copyProperties(props Properties) {
+	w.props = props
+	// Remove all user properties to disable block properties, which we do not
+	// calculate.
+	w.props.UserProperties = nil
+	// Reset props that we'll re-derive as we build our own index.
+	w.props.IndexPartitions = 0
+	w.props.TopLevelIndexSize = 0
+	w.props.IndexSize = 0
+	w.props.IndexType = 0
+}
+
+// copyFilter implements RawWriter.
+func (w *RawRowWriter) copyFilter(filter []byte, filterName string) error {
+	if w.filter != nil && filterName != w.filter.policyName() {
+		return errors.New("mismatched filters")
+	}
+	w.filter = copyFilterWriter{
+		origPolicyName: w.filter.policyName(), origMetaName: w.filter.metaName(), data: filter,
 	}
 	return nil
 }

--- a/sstable/testdata/copy_span
+++ b/sstable/testdata/copy_span
@@ -1,0 +1,72 @@
+
+# Simple test case with row blocks.
+
+build test1 format=pebblev4
+a.SET.5:foo
+b.SET.3:bar
+c.SET.4:baz
+d.SET.5:foobar
+----
+
+iter test1
+----
+a#0,SET: foo
+b#0,SET: bar
+c#0,SET: baz
+d#0,SET: foobar
+
+copy-span test1 test2 b.SET.10 cc.SET.0
+----
+copied 661 bytes
+
+iter test2
+----
+b#0,SET: bar
+c#0,SET: baz
+d#0,SET: foobar
+
+copy-span test1 test21 a.SET.10 bb.SET.0
+----
+copied 658 bytes
+
+iter test21
+----
+a#0,SET: foo
+b#0,SET: bar
+c#0,SET: baz
+
+# Try the above with columnar blocks.
+
+build test3 format=pebblev5
+a.SET.5:foo
+b.SET.3:bar
+c.SET.4:baz
+d.SET.5:foobar
+----
+
+iter test3
+----
+a#0,SET: foo
+b#0,SET: bar
+c#0,SET: baz
+d#0,SET: foobar
+
+copy-span test3 test4 b.SET.10 cc.SET.0
+----
+copied 790 bytes
+
+iter test4
+----
+b#0,SET: bar
+c#0,SET: baz
+d#0,SET: foobar
+
+copy-span test3 test5 a.SET.10 bb.SET.0
+----
+copied 787 bytes
+
+iter test5
+----
+a#0,SET: foo
+b#0,SET: bar
+c#0,SET: baz

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -341,7 +341,7 @@ ok
 lsm verbose
 ----
 L6:
-  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:710
+  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:712
   000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:612
 
 reopen


### PR DESCRIPTION
Previously, sstable.CopySpan() was heavily coupled to the internals of a RawRowWriter. This change updates CopySpan and the RawWriter interface to work in a more implementation-agnostic way, so that the columnar writer can also be used with the downloader.

Fixes #4010.