### PR TITLE
sstable: remove block transforms

### DIFF
--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -1321,7 +1321,7 @@ func runBlockPropsCmd(r *Reader) string {
 		// block that bhp points to, along with its block properties.
 		if twoLevelIndex {
 			subIndex, err := r.readBlock(
-				context.Background(), bhp.Handle, nil, nil, nil, nil, nil)
+				context.Background(), bhp.Handle, nil, nil, nil, nil)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -270,7 +270,7 @@ func intersectingIndexEntries(
 			alloc, entry.sep.UserKey = alloc.Copy(entry.sep.UserKey)
 			res = append(res, entry)
 		} else {
-			subBlk, err := r.readBlock(ctx, bh.Handle, nil, rh, nil, nil, nil)
+			subBlk, err := r.readBlock(ctx, bh.Handle, rh, nil, nil, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -179,7 +179,7 @@ func (l *Layout) Describe(
 		}
 
 		h, err := r.readBlock(
-			context.Background(), b.Handle, nil /* transform */, nil /* readHandle */, nil /* stats */, nil /* iterStats */, nil /* buffer pool */)
+			context.Background(), b.Handle, nil /* readHandle */, nil /* stats */, nil /* iterStats */, nil /* buffer pool */)
 		if err != nil {
 			fmt.Fprintf(w, "  [err: %s]\n", err)
 			continue

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -568,7 +568,7 @@ func (i *singleLevelIterator[I, PI, P, PD]) loadBlock(dir int8) loadBlockResult 
 	}
 	ctx := objiotracing.WithBlockType(i.ctx, objiotracing.DataBlock)
 	block, err := i.reader.readBlock(
-		ctx, i.dataBH, nil /* transform */, i.dataRH, i.stats, &i.iterStats, i.bufferPool)
+		ctx, i.dataBH, i.dataRH, i.stats, &i.iterStats, i.bufferPool)
 	if err != nil {
 		i.err = err
 		return loadBlockFailed
@@ -589,7 +589,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) readBlockForVBR(
 	h block.Handle, stats *base.InternalIteratorStats,
 ) (block.BufferHandle, error) {
 	ctx := objiotracing.WithBlockType(i.ctx, objiotracing.ValueBlock)
-	return i.reader.readBlock(ctx, h, nil, i.vbRH, stats, &i.iterStats, i.bufferPool)
+	return i.reader.readBlock(ctx, h, i.vbRH, stats, &i.iterStats, i.bufferPool)
 }
 
 // resolveMaybeExcluded is invoked when the block-property filterer has found

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -71,7 +71,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) loadIndex(dir int8) loadBlockResult {
 	}
 	ctx := objiotracing.WithBlockType(i.secondLevel.ctx, objiotracing.MetadataBlock)
 	indexBlock, err := i.secondLevel.reader.readBlock(
-		ctx, bhp.Handle, nil /* transform */, i.secondLevel.indexFilterRH, i.secondLevel.stats, &i.secondLevel.iterStats, i.secondLevel.bufferPool)
+		ctx, bhp.Handle, i.secondLevel.indexFilterRH, i.secondLevel.stats, &i.secondLevel.iterStats, i.secondLevel.bufferPool)
 	if err == nil {
 		err = PI(&i.secondLevel.index).InitHandle(i.secondLevel.cmp, i.secondLevel.reader.Split, indexBlock, i.secondLevel.transforms)
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -646,7 +646,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 		require.NoError(t, err)
 		fmt.Fprintf(&buf, " %s: size %d\n", string(iter.Separator()), bh.Length)
 		if twoLevelIndex {
-			b, err := r.readBlock(context.Background(), bh.Handle, nil, nil, nil, nil, nil)
+			b, err := r.readBlock(context.Background(), bh.Handle, nil, nil, nil, nil)
 			require.NoError(t, err)
 			defer b.Release()
 			iter2 := r.tableFormat.newIndexIter()

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -533,7 +533,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	require.NoError(t, err)
 
 	b, err := r.readBlock(
-		context.Background(), r.metaIndexBH, nil, nil, nil, nil, nil)
+		context.Background(), r.metaIndexBH, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer b.Release()
 

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -693,7 +693,7 @@ func (bpwc blockProviderWhenClosed) readBlockForVBR(
 	// The bpwc is not allowed to outlive the iterator tree, so it cannot
 	// outlive the buffer pool.
 	return bpwc.r.readBlock(
-		ctx, h, nil, nil, stats, nil /* iterStats */, nil /* buffer pool */)
+		ctx, h, nil, stats, nil /* iterStats */, nil /* buffer pool */)
 }
 
 // ReaderProvider supports the implementation of blockProviderWhenClosed.


### PR DESCRIPTION
The code to transform a raw block at load time is not currently used
or tested. Removing it to keep the code a bit cleaner (it's easy
enough to add back if we ever need it again).