### PR TITLE
sstable: cleanup readBlock usage

### DIFF
--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -902,7 +902,7 @@ func TestBlockProperties(t *testing.T) {
 
 				// Enumerate point key data blocks encoded into the index.
 				if f != nil {
-					indexH, err := r.readIndex(context.Background(), nil, nil, nil)
+					indexH, err := r.readTopLevelIndexBlock(context.Background(), noEnv, noReadHandle)
 					if err != nil {
 						return err.Error()
 					}
@@ -1271,7 +1271,7 @@ func runBlockPropertiesBuildCmd(td *datadriven.TestData) (r *Reader, out string)
 }
 
 func runBlockPropsCmd(r *Reader) string {
-	bh, err := r.readIndex(context.Background(), nil, nil, nil)
+	bh, err := r.readTopLevelIndexBlock(context.Background(), noEnv, noReadHandle)
 	if err != nil {
 		return err.Error()
 	}
@@ -1320,8 +1320,7 @@ func runBlockPropsCmd(r *Reader) string {
 		// If the table has a two-level index, also decode the index
 		// block that bhp points to, along with its block properties.
 		if twoLevelIndex {
-			subIndex, err := r.readBlock(
-				context.Background(), bhp.Handle, nil, nil, nil, nil)
+			subIndex, err := r.readIndexBlock(context.Background(), noEnv, noReadHandle, bhp.Handle)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -93,7 +93,7 @@ func CopySpan(
 		r.readable, objstorage.ReadBeforeForIndexAndFilter, &preallocRH)
 	defer rh.Close()
 	rh.SetupForCompaction()
-	indexH, err := r.readIndex(ctx, rh, nil, nil)
+	indexH, err := r.readTopLevelIndexBlock(ctx, noEnv, rh)
 	if err != nil {
 		return 0, err
 	}
@@ -106,7 +106,7 @@ func CopySpan(
 		if w.filter != nil && r.Properties.FilterPolicyName != w.filter.policyName() {
 			return 0, errors.New("mismatched filters")
 		}
-		filterBlock, err := r.readFilter(ctx, rh, nil, nil)
+		filterBlock, err := r.readFilterBlock(ctx, noEnv, rh)
 		if err != nil {
 			return 0, errors.Wrap(err, "reading filter")
 		}
@@ -270,7 +270,7 @@ func intersectingIndexEntries(
 			alloc, entry.sep.UserKey = alloc.Copy(entry.sep.UserKey)
 			res = append(res, entry)
 		} else {
-			subBlk, err := r.readBlock(ctx, bh.Handle, rh, nil, nil, nil)
+			subBlk, err := r.readIndexBlock(ctx, noEnv, rh, bh.Handle)
 			if err != nil {
 				return nil, err
 			}

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -178,8 +178,7 @@ func (l *Layout) Describe(
 			continue
 		}
 
-		h, err := r.readBlock(
-			context.Background(), b.Handle, nil /* readHandle */, nil /* stats */, nil /* iterStats */, nil /* buffer pool */)
+		h, err := r.readBlockInternal(context.Background(), noEnv, noReadHandle, b.Handle)
 		if err != nil {
 			fmt.Fprintf(w, "  [err: %s]\n", err)
 			continue

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -51,6 +51,7 @@ func TestIteratorErrorOnInit(t *testing.T) {
 
 	var pool block.BufferPool
 	pool.Init(5)
+	defer pool.Release()
 
 	var stats base.InternalIteratorStats
 	for k := 0; k < 20; k++ {

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -532,8 +532,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	r, err := newReader(f, ReaderOptions{})
 	require.NoError(t, err)
 
-	b, err := r.readBlock(
-		context.Background(), r.metaIndexBH, nil, nil, nil, nil)
+	b, err := r.readMetaindexBlock(context.Background(), noEnv, noReadHandle)
 	require.NoError(t, err)
 	defer b.Release()
 

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -692,8 +692,7 @@ func (bpwc blockProviderWhenClosed) readBlockForVBR(
 	// TODO(jackson,sumeer): Consider whether to use a buffer pool in this case.
 	// The bpwc is not allowed to outlive the iterator tree, so it cannot
 	// outlive the buffer pool.
-	return bpwc.r.readBlock(
-		ctx, h, nil, stats, nil /* iterStats */, nil /* buffer pool */)
+	return bpwc.r.readValueBlock(ctx, noEnv, noReadHandle, h)
 }
 
 // ReaderProvider supports the implementation of blockProviderWhenClosed.

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -482,6 +482,7 @@ k k
 open: db/000014.sst (options: *vfs.randomReadsOption)
 read-at(509, 53): db/000014.sst
 read-at(472, 37): db/000014.sst
+read-at(53, 419): db/000014.sst
 z z
 .
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -227,7 +227,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 1.7KB
 Compression types: snappy: 3
-Block cache: 3 entries (485B)  hit rate: 0.0%
+Block cache: 2 entries (43B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -329,7 +329,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 3.5KB
 Compression types: snappy: 6
-Block cache: 9 entries (1.4KB)  hit rate: 0.0%
+Block cache: 6 entries (129B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -53,7 +53,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 569B
 Compression types: snappy: 1
-Block cache: 6 entries (945B)  hit rate: 30.8%
+Block cache: 4 entries (88B)  hit rate: 23.1%
 Table cache: 1 entries (784B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -75,7 +75,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 1
-Block cache: 3 entries (484B)  hit rate: 0.0%
+Block cache: 2 entries (44B)  hit rate: 0.0%
 Table cache: 1 entries (784B)  hit rate: 0.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -132,7 +132,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
-Block cache: 5 entries (946B)  hit rate: 33.3%
+Block cache: 2 entries (44B)  hit rate: 33.3%
 Table cache: 2 entries (1.5KB)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -176,7 +176,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
-Block cache: 5 entries (946B)  hit rate: 33.3%
+Block cache: 2 entries (44B)  hit rate: 33.3%
 Table cache: 2 entries (1.5KB)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -217,7 +217,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
-Block cache: 3 entries (484B)  hit rate: 33.3%
+Block cache: 2 entries (44B)  hit rate: 33.3%
 Table cache: 1 entries (784B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -495,7 +495,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 7
-Block cache: 12 entries (1.9KB)  hit rate: 9.1%
+Block cache: 8 entries (204B)  hit rate: 9.1%
 Table cache: 1 entries (784B)  hit rate: 53.8%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -559,7 +559,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Compression types: snappy: 10
-Block cache: 12 entries (1.9KB)  hit rate: 9.1%
+Block cache: 8 entries (204B)  hit rate: 9.1%
 Table cache: 1 entries (784B)  hit rate: 53.8%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -834,7 +834,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 1
-Block cache: 1 entries (440B)  hit rate: 0.0%
+Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 1 entries (784B)  hit rate: 0.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -882,7 +882,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 2
-Block cache: 6 entries (996B)  hit rate: 0.0%
+Block cache: 4 entries (116B)  hit rate: 0.0%
 Table cache: 1 entries (784B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -931,7 +931,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 3
-Block cache: 6 entries (996B)  hit rate: 0.0%
+Block cache: 4 entries (116B)  hit rate: 0.0%
 Table cache: 1 entries (784B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0


### PR DESCRIPTION
We move the stats and bufferPool arguments into their own
`readBlockEnv` struct. We add specific functions for different block
types.

A functional change is that now we use the buffer pool for the
top-level index block and filter block (this looks like an omission in
the existing code). This changed caused failures in some tests that
were not releasing a pool, which are now fixed.