### PR TITLE
db: consolidate datadriven DB opts parsing; fix block-size bug

### DIFF
--- a/testdata/iter_histories/next_prefix
+++ b/testdata/iter_histories/next_prefix
@@ -84,7 +84,7 @@ p@10: (p@10, .)
 p@1: (p@1, .)
 q@100: (q@100, .)
 
-reset target-file-size=1
+reset target-file-sizes=(1)
 ----
 
 populate keylen=1 timestamps=(1, 10, 100)

--- a/testdata/iter_histories/prefix_iteration
+++ b/testdata/iter_histories/prefix_iteration
@@ -68,7 +68,7 @@ d@7: (., [d-"d\x00") @5=foo UPDATED)
 # Test a LSM with range keys fragmented within a prefix.
 # This is a regression test for cockroachdb/cockroach#86102.
 
-reset target-file-size=1
+reset target-file-sizes=(1)
 ----
 
 batch commit

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -209,7 +209,7 @@ num-entries: 4
 num-deletions: 2
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 68
+range-deletions-bytes-estimate: 78
 
 # Hints that partially overlap tables in lower levels only count blocks that are
 # contained within the hint.
@@ -247,7 +247,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 33
+range-deletions-bytes-estimate: 52
 
 # Table 000005 deletes the second block in table 000006 (containing 'd') and the
 # first block in table 000007 (containing 'e').
@@ -258,7 +258,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 66
+range-deletions-bytes-estimate: 78
 
 # Test the interaction between point and range key deletions.
 
@@ -491,7 +491,7 @@ range-deletions-bytes-estimate: 26
 
 # Test point tombstone compensation that uses DELSIZED keys.
 
-define format-major-version=15
+define format-major-version=15 block-size=32768
 L6
   bar.SET.0:<rand-bytes=10>
   bax.SET.0:<rand-bytes=10>


### PR DESCRIPTION
This commit cleans up and consolidates a couple places where we parsed datadriven command args for configuring pebble.Options. It fixes a bug where the block-size command arg would be ignored in one parse site.