### PR TITLE
crdbtest: move cockroach colblk.KeySchema

### DIFF
--- a/internal/crdbtest/crdbtest.go
+++ b/internal/crdbtest/crdbtest.go
@@ -11,14 +11,19 @@ import (
 	"cmp"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"slices"
+	"sync"
 	"time"
+	"unsafe"
 
+	"github.com/cockroachdb/crlib/crbytes"
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/sstable/colblk"
 )
 
 const withWall = 9
@@ -486,3 +491,378 @@ func (g *cockroachKeyGen) randTimestamp() (wallTime uint64, logicalTime uint32) 
 	}
 	return wallTime, logicalTime
 }
+
+const (
+	cockroachColRoachKey int = iota
+	cockroachColMVCCWallTime
+	cockroachColMVCCLogical
+	cockroachColUntypedVersion
+	cockroachColCount
+)
+
+var KeySchema = colblk.KeySchema{
+	ColumnTypes: []colblk.DataType{
+		cockroachColRoachKey:       colblk.DataTypePrefixBytes,
+		cockroachColMVCCWallTime:   colblk.DataTypeUint,
+		cockroachColMVCCLogical:    colblk.DataTypeUint,
+		cockroachColUntypedVersion: colblk.DataTypeBytes,
+	},
+	NewKeyWriter: func() colblk.KeyWriter {
+		kw := &cockroachKeyWriter{}
+		kw.roachKeys.Init(16)
+		kw.wallTimes.Init()
+		kw.logicalTimes.InitWithDefault()
+		kw.untypedVersions.Init()
+		return kw
+	},
+	NewKeySeeker: func() colblk.KeySeeker {
+		return &cockroachKeySeeker{}
+	},
+}
+
+type cockroachKeyWriter struct {
+	roachKeys       colblk.PrefixBytesBuilder
+	wallTimes       colblk.UintBuilder
+	logicalTimes    colblk.UintBuilder
+	untypedVersions colblk.RawBytesBuilder
+	prevSuffix      []byte
+}
+
+func (kw *cockroachKeyWriter) ComparePrev(key []byte) colblk.KeyComparison {
+	var cmpv colblk.KeyComparison
+	cmpv.PrefixLen = int32(Split(key)) // TODO(jackson): Inline
+	if kw.roachKeys.Rows() == 0 {
+		cmpv.UserKeyComparison = 1
+		return cmpv
+	}
+	lp := kw.roachKeys.UnsafeGet(kw.roachKeys.Rows() - 1)
+	cmpv.CommonPrefixLen = int32(crbytes.CommonPrefix(lp, key[:cmpv.PrefixLen-1]))
+	if cmpv.CommonPrefixLen == cmpv.PrefixLen-1 {
+		// Adjust CommonPrefixLen to include the sentinel byte,
+		cmpv.CommonPrefixLen = cmpv.PrefixLen
+		cmpv.UserKeyComparison = int32(CompareSuffixes(key[cmpv.PrefixLen:], kw.prevSuffix))
+		return cmpv
+	}
+	// The keys have different MVCC prefixes. We haven't determined which is
+	// greater, but we know the index at which they diverge. The base.Comparer
+	// contract dictates that prefixes must be lexicographically ordered.
+	if len(lp) == int(cmpv.CommonPrefixLen) {
+		// cmpv.PrefixLen > cmpv.PrefixLenShared; key is greater.
+		cmpv.UserKeyComparison = +1
+	} else {
+		// Both keys have at least 1 additional byte at which they diverge.
+		// Compare the diverging byte.
+		cmpv.UserKeyComparison = int32(cmp.Compare(key[cmpv.CommonPrefixLen], lp[cmpv.CommonPrefixLen]))
+	}
+	return cmpv
+}
+
+func (kw *cockroachKeyWriter) WriteKey(
+	row int, key []byte, keyPrefixLen, keyPrefixLenSharedWithPrev int32,
+) {
+	// TODO(jackson): Avoid copying the previous suffix.
+	// TODO(jackson): Use keyPrefixLen to speed up decoding.
+	roachKey, untypedVersion, wallTime, logicalTime := DecodeEngineKey(key)
+	kw.prevSuffix = append(kw.prevSuffix[:0], key[keyPrefixLen:]...)
+	// When the roach key is the same, keyPrefixLenSharedWithPrev includes the
+	// separator byte.
+	kw.roachKeys.Put(roachKey, min(int(keyPrefixLenSharedWithPrev), len(roachKey)))
+	kw.wallTimes.Set(row, wallTime)
+	// The w.logicalTimes builder was initialized with InitWithDefault, so if we
+	// don't set a value, the column value is implicitly zero. We only need to
+	// Set anything for non-zero values.
+	if logicalTime > 0 {
+		kw.logicalTimes.Set(row, uint64(logicalTime))
+	}
+	kw.untypedVersions.Put(untypedVersion)
+}
+
+func (kw *cockroachKeyWriter) MaterializeKey(dst []byte, i int) []byte {
+	dst = append(dst, kw.roachKeys.UnsafeGet(i)...)
+	// Append separator byte.
+	dst = append(dst, 0)
+	if untypedVersion := kw.untypedVersions.UnsafeGet(i); len(untypedVersion) > 0 {
+		dst = append(dst, untypedVersion...)
+		dst = append(dst, byte(len(untypedVersion)))
+		return dst
+	}
+	return AppendTimestamp(dst, kw.wallTimes.Get(i), uint32(kw.logicalTimes.Get(i)))
+}
+
+func (kw *cockroachKeyWriter) Reset() {
+	kw.roachKeys.Reset()
+	kw.wallTimes.Reset()
+	kw.logicalTimes.Reset()
+	kw.untypedVersions.Reset()
+}
+
+func (kw *cockroachKeyWriter) WriteDebug(dst io.Writer, rows int) {
+	fmt.Fprint(dst, "prefixes: ")
+	kw.roachKeys.WriteDebug(dst, rows)
+	fmt.Fprintln(dst)
+	fmt.Fprint(dst, "wall times: ")
+	kw.wallTimes.WriteDebug(dst, rows)
+	fmt.Fprintln(dst)
+	fmt.Fprint(dst, "logical times: ")
+	kw.logicalTimes.WriteDebug(dst, rows)
+	fmt.Fprintln(dst)
+	fmt.Fprint(dst, "untyped suffixes: ")
+	kw.untypedVersions.WriteDebug(dst, rows)
+	fmt.Fprintln(dst)
+}
+
+func (kw *cockroachKeyWriter) NumColumns() int {
+	return cockroachColCount
+}
+
+func (kw *cockroachKeyWriter) DataType(col int) colblk.DataType {
+	return KeySchema.ColumnTypes[col]
+}
+
+func (kw *cockroachKeyWriter) Size(rows int, offset uint32) uint32 {
+	offset = kw.roachKeys.Size(rows, offset)
+	offset = kw.wallTimes.Size(rows, offset)
+	offset = kw.logicalTimes.Size(rows, offset)
+	offset = kw.untypedVersions.Size(rows, offset)
+	return offset
+}
+
+func (kw *cockroachKeyWriter) Finish(
+	col int, rows int, offset uint32, buf []byte,
+) (endOffset uint32) {
+	switch col {
+	case cockroachColRoachKey:
+		return kw.roachKeys.Finish(0, rows, offset, buf)
+	case cockroachColMVCCWallTime:
+		return kw.wallTimes.Finish(0, rows, offset, buf)
+	case cockroachColMVCCLogical:
+		return kw.logicalTimes.Finish(0, rows, offset, buf)
+	case cockroachColUntypedVersion:
+		return kw.untypedVersions.Finish(0, rows, offset, buf)
+	default:
+		panic(fmt.Sprintf("unknown default key column: %d", col))
+	}
+}
+
+var cockroachKeySeekerPool = sync.Pool{
+	New: func() interface{} { return &cockroachKeySeeker{} },
+}
+
+type cockroachKeySeeker struct {
+	roachKeys       colblk.PrefixBytes
+	roachKeyChanged colblk.Bitmap
+	mvccWallTimes   colblk.UnsafeUints
+	mvccLogical     colblk.UnsafeUints
+	untypedVersions colblk.RawBytes
+}
+
+var _ colblk.KeySeeker = (*cockroachKeySeeker)(nil)
+
+// Init is part of the KeySeeker interface.
+func (ks *cockroachKeySeeker) Init(d *colblk.DataBlockDecoder) error {
+	bd := d.BlockDecoder()
+	ks.roachKeys = bd.PrefixBytes(cockroachColRoachKey)
+	ks.roachKeyChanged = d.PrefixChanged()
+	ks.mvccWallTimes = bd.Uints(cockroachColMVCCWallTime)
+	ks.mvccLogical = bd.Uints(cockroachColMVCCLogical)
+	ks.untypedVersions = bd.RawBytes(cockroachColUntypedVersion)
+	return nil
+}
+
+// CompareFirstUserKey compares the provided key to the first user key
+// contained within the data block. It's equivalent to performing
+//
+//	Compare(firstUserKey, k)
+func (ks *cockroachKeySeeker) IsLowerBound(k []byte, syntheticSuffix []byte) bool {
+	roachKey, untypedVersion, wallTime, logicalTime := DecodeEngineKey(k)
+	if v := Compare(ks.roachKeys.UnsafeFirstSlice(), roachKey); v != 0 {
+		return v > 0
+	}
+	if len(syntheticSuffix) > 0 {
+		return Compare(syntheticSuffix, k[len(roachKey)+1:]) >= 0
+	}
+	if len(untypedVersion) > 0 {
+		if invariants.Enabled && ks.mvccWallTimes.At(0) != 0 {
+			panic("comparing timestamp with untyped suffix")
+		}
+		return Compare(ks.untypedVersions.At(0), untypedVersion) >= 0
+	}
+	if v := cmp.Compare(ks.mvccWallTimes.At(0), wallTime); v != 0 {
+		return v > 0
+	}
+	return cmp.Compare(uint32(ks.mvccLogical.At(0)), logicalTime) >= 0
+}
+
+// SeekGE is part of the KeySeeker interface.
+func (ks *cockroachKeySeeker) SeekGE(
+	key []byte, boundRow int, searchDir int8,
+) (row int, equalPrefix bool) {
+	// TODO(jackson): Inline Split.
+	si := Split(key)
+	row, eq := ks.roachKeys.Search(key[:si-1])
+	if eq {
+		return ks.seekGEOnSuffix(row, key[si:]), true
+	}
+	return row, false
+}
+
+// seekGEOnSuffix is a helper function for SeekGE when a seek key's prefix
+// exactly matches a row. seekGEOnSuffix finds the first row at index or later
+// with the same prefix as index and a suffix greater than or equal to [suffix],
+// or if no such row exists, the next row with a different prefix.
+func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row int) {
+	// The search key's prefix exactly matches the prefix of the row at index.
+	const withWall = 9
+	const withLogical = withWall + 4
+	const withSynthetic = withLogical + 1
+	var seekWallTime uint64
+	var seekLogicalTime uint32
+	switch len(seekSuffix) {
+	case 0:
+		// The search key has no suffix, so it's the smallest possible key with
+		// its prefix. Return the row. This is a common case where the user is
+		// seeking to the most-recent row and just wants the smallest key with
+		// the prefix.
+		return index
+	case withLogical, withSynthetic:
+		seekWallTime = binary.BigEndian.Uint64(seekSuffix)
+		seekLogicalTime = binary.BigEndian.Uint32(seekSuffix[8:])
+	case withWall:
+		seekWallTime = binary.BigEndian.Uint64(seekSuffix)
+	default:
+		// The suffix is untyped. Compare the untyped suffixes.
+		// Binary search between [index, prefixChanged.SeekSetBitGE(index+1)].
+		//
+		// Define f(i) = true iff key at i is >= seek key.
+		// Invariant: f(l-1) == false, f(u) == true.
+		l := index
+		u := ks.roachKeyChanged.SeekSetBitGE(index + 1)
+		for l < u {
+			h := int(uint(l+u) >> 1) // avoid overflow when computing h
+			// l ≤ h < u
+			if bytes.Compare(ks.untypedVersions.At(h), seekSuffix) >= 0 {
+				u = h // preserves f(u) == true
+			} else {
+				l = h + 1 // preserves f(l-1) == false
+			}
+		}
+		return l
+	}
+	// Seeking among MVCC versions using a MVCC timestamp.
+
+	// TODO(jackson): What if the row has an untyped suffix?
+
+	// First check the suffix at index, because querying for the latest value is
+	// the most common case.
+	if latestWallTime := ks.mvccWallTimes.At(index); latestWallTime < seekWallTime ||
+		(latestWallTime == seekWallTime && uint32(ks.mvccLogical.At(index)) <= seekLogicalTime) {
+		return index
+	}
+
+	// Binary search between [index+1, prefixChanged.SeekSetBitGE(index+1)].
+	//
+	// Define f(i) = true iff key at i is >= seek key.
+	// Invariant: f(l-1) == false, f(u) == true.
+	l := index + 1
+	u := ks.roachKeyChanged.SeekSetBitGE(index + 1)
+	for l < u {
+		h := int(uint(l+u) >> 1) // avoid overflow when computing h
+		// l ≤ h < u
+		hWallTime := ks.mvccWallTimes.At(h)
+		if hWallTime < seekWallTime ||
+			(hWallTime == seekWallTime && uint32(ks.mvccLogical.At(h)) <= seekLogicalTime) {
+			u = h // preserves f(u) = true
+		} else {
+			l = h + 1 // preserves f(l-1) = false
+		}
+	}
+	return l
+}
+
+// MaterializeUserKey is part of the KeySeeker interface.
+func (ks *cockroachKeySeeker) MaterializeUserKey(
+	ki *colblk.PrefixBytesIter, prevRow, row int,
+) []byte {
+	if prevRow+1 == row && prevRow >= 0 {
+		ks.roachKeys.SetNext(ki)
+	} else {
+		ks.roachKeys.SetAt(ki, row)
+	}
+
+	roachKeyLen := len(ki.Buf)
+	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(unsafe.SliceData(ki.Buf))) + uintptr(roachKeyLen))
+	mvccWall := ks.mvccWallTimes.At(row)
+	mvccLogical := uint32(ks.mvccLogical.At(row))
+	if mvccWall == 0 && mvccLogical == 0 {
+		// This is not an MVCC key. Use the untyped suffix.
+		untypedVersion := ks.untypedVersions.At(row)
+		if len(untypedVersion) == 0 {
+			res := ki.Buf[:roachKeyLen+1]
+			res[roachKeyLen] = 0
+			return res
+		}
+		// Slice first, to check that the capacity is sufficient.
+		res := ki.Buf[:roachKeyLen+1+len(untypedVersion)]
+		*(*byte)(ptr) = 0
+		memmove(
+			unsafe.Pointer(uintptr(ptr)+1),
+			unsafe.Pointer(unsafe.SliceData(untypedVersion)),
+			uintptr(len(untypedVersion)),
+		)
+		return res
+	}
+
+	// Inline binary.BigEndian.PutUint64. Note that this code is converted into
+	// word-size instructions by the compiler.
+	*(*byte)(ptr) = 0
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccWall >> 56)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccWall >> 48)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccWall >> 40)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 4)) = byte(mvccWall >> 32)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 5)) = byte(mvccWall >> 24)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 6)) = byte(mvccWall >> 16)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 7)) = byte(mvccWall >> 8)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 8)) = byte(mvccWall)
+
+	ptr = unsafe.Pointer(uintptr(ptr) + 9)
+	// This is an MVCC key.
+	if mvccLogical == 0 {
+		*(*byte)(ptr) = 9
+		return ki.Buf[:len(ki.Buf)+10]
+	}
+
+	// Inline binary.BigEndian.PutUint32.
+	*(*byte)(ptr) = byte(mvccWall >> 24)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccWall >> 16)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccWall >> 8)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccWall)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 4)) = 13
+	return ki.Buf[:len(ki.Buf)+14]
+}
+
+// MaterializeUserKeyWithSyntheticSuffix is part of the KeySeeker interface.
+func (ks *cockroachKeySeeker) MaterializeUserKeyWithSyntheticSuffix(
+	ki *colblk.PrefixBytesIter, suffix []byte, prevRow, row int,
+) []byte {
+	if prevRow+1 == row && prevRow >= 0 {
+		ks.roachKeys.SetNext(ki)
+	} else {
+		ks.roachKeys.SetAt(ki, row)
+	}
+
+	// Slice first, to check that the capacity is sufficient.
+	res := ki.Buf[:len(ki.Buf)+1+len(suffix)]
+	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(unsafe.SliceData(ki.Buf))) + uintptr(len(ki.Buf)))
+	*(*byte)(ptr) = 0
+	memmove(unsafe.Pointer(uintptr(ptr)+1), unsafe.Pointer(unsafe.SliceData(suffix)), uintptr(len(suffix)))
+	return res
+}
+
+// Release is part of the KeySeeker interface.
+func (ks *cockroachKeySeeker) Release() {
+	*ks = cockroachKeySeeker{}
+	cockroachKeySeekerPool.Put(ks)
+}
+
+//go:linkname memmove runtime.memmove
+func memmove(to, from unsafe.Pointer, n uintptr)

--- a/sstable/colblk/cockroach_test.go
+++ b/sstable/colblk/cockroach_test.go
@@ -2,398 +2,23 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package colblk
+package colblk_test
 
 import (
 	"bytes"
-	"cmp"
-	"encoding/binary"
 	"fmt"
-	"io"
 	"math/rand/v2"
 	"slices"
-	"sync"
 	"testing"
 	"time"
-	"unsafe"
 
-	"github.com/cockroachdb/crlib/crbytes"
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/crdbtest"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/stretchr/testify/require"
 )
-
-const (
-	cockroachColRoachKey int = iota
-	cockroachColMVCCWallTime
-	cockroachColMVCCLogical
-	cockroachColUntypedVersion
-	cockroachColCount
-)
-
-var cockroachKeySchema = KeySchema{
-	ColumnTypes: []DataType{
-		cockroachColRoachKey:       DataTypePrefixBytes,
-		cockroachColMVCCWallTime:   DataTypeUint,
-		cockroachColMVCCLogical:    DataTypeUint,
-		cockroachColUntypedVersion: DataTypeBytes,
-	},
-	NewKeyWriter: func() KeyWriter {
-		kw := &cockroachKeyWriter{}
-		kw.roachKeys.Init(16)
-		kw.wallTimes.Init()
-		kw.logicalTimes.InitWithDefault()
-		kw.untypedVersions.Init()
-		return kw
-	},
-	NewKeySeeker: func() KeySeeker {
-		return &cockroachKeySeeker{}
-	},
-}
-
-type cockroachKeyWriter struct {
-	roachKeys       PrefixBytesBuilder
-	wallTimes       UintBuilder
-	logicalTimes    UintBuilder
-	untypedVersions RawBytesBuilder
-	prevSuffix      []byte
-}
-
-func (kw *cockroachKeyWriter) ComparePrev(key []byte) KeyComparison {
-	var cmpv KeyComparison
-	cmpv.PrefixLen = int32(crdbtest.Split(key)) // TODO(jackson): Inline
-	if kw.roachKeys.Rows() == 0 {
-		cmpv.UserKeyComparison = 1
-		return cmpv
-	}
-	lp := kw.roachKeys.UnsafeGet(kw.roachKeys.Rows() - 1)
-	cmpv.CommonPrefixLen = int32(crbytes.CommonPrefix(lp, key[:cmpv.PrefixLen-1]))
-	if cmpv.CommonPrefixLen == cmpv.PrefixLen-1 {
-		// Adjust CommonPrefixLen to include the sentinel byte,
-		cmpv.CommonPrefixLen = cmpv.PrefixLen
-		cmpv.UserKeyComparison = int32(crdbtest.CompareSuffixes(key[cmpv.PrefixLen:], kw.prevSuffix))
-		return cmpv
-	}
-	// The keys have different MVCC prefixes. We haven't determined which is
-	// greater, but we know the index at which they diverge. The base.Comparer
-	// contract dictates that prefixes must be lexicographically ordered.
-	if len(lp) == int(cmpv.CommonPrefixLen) {
-		// cmpv.PrefixLen > cmpv.PrefixLenShared; key is greater.
-		cmpv.UserKeyComparison = +1
-	} else {
-		// Both keys have at least 1 additional byte at which they diverge.
-		// Compare the diverging byte.
-		cmpv.UserKeyComparison = int32(cmp.Compare(key[cmpv.CommonPrefixLen], lp[cmpv.CommonPrefixLen]))
-	}
-	return cmpv
-}
-
-func (kw *cockroachKeyWriter) WriteKey(
-	row int, key []byte, keyPrefixLen, keyPrefixLenSharedWithPrev int32,
-) {
-	// TODO(jackson): Avoid copying the previous suffix.
-	// TODO(jackson): Use keyPrefixLen to speed up decoding.
-	roachKey, untypedVersion, wallTime, logicalTime := crdbtest.DecodeEngineKey(key)
-	kw.prevSuffix = append(kw.prevSuffix[:0], key[keyPrefixLen:]...)
-	// When the roach key is the same, keyPrefixLenSharedWithPrev includes the
-	// separator byte.
-	kw.roachKeys.Put(roachKey, min(int(keyPrefixLenSharedWithPrev), len(roachKey)))
-	kw.wallTimes.Set(row, wallTime)
-	// The w.logicalTimes builder was initialized with InitWithDefault, so if we
-	// don't set a value, the column value is implicitly zero. We only need to
-	// Set anything for non-zero values.
-	if logicalTime > 0 {
-		kw.logicalTimes.Set(row, uint64(logicalTime))
-	}
-	kw.untypedVersions.Put(untypedVersion)
-}
-
-func (kw *cockroachKeyWriter) MaterializeKey(dst []byte, i int) []byte {
-	dst = append(dst, kw.roachKeys.UnsafeGet(i)...)
-	// Append separator byte.
-	dst = append(dst, 0)
-	if untypedVersion := kw.untypedVersions.UnsafeGet(i); len(untypedVersion) > 0 {
-		dst = append(dst, untypedVersion...)
-		dst = append(dst, byte(len(untypedVersion)))
-		return dst
-	}
-	return crdbtest.AppendTimestamp(dst, kw.wallTimes.Get(i), uint32(kw.logicalTimes.Get(i)))
-}
-
-func (kw *cockroachKeyWriter) Reset() {
-	kw.roachKeys.Reset()
-	kw.wallTimes.Reset()
-	kw.logicalTimes.Reset()
-	kw.untypedVersions.Reset()
-}
-
-func (kw *cockroachKeyWriter) WriteDebug(dst io.Writer, rows int) {
-	fmt.Fprint(dst, "prefixes: ")
-	kw.roachKeys.WriteDebug(dst, rows)
-	fmt.Fprintln(dst)
-	fmt.Fprint(dst, "wall times: ")
-	kw.wallTimes.WriteDebug(dst, rows)
-	fmt.Fprintln(dst)
-	fmt.Fprint(dst, "logical times: ")
-	kw.logicalTimes.WriteDebug(dst, rows)
-	fmt.Fprintln(dst)
-	fmt.Fprint(dst, "untyped suffixes: ")
-	kw.untypedVersions.WriteDebug(dst, rows)
-	fmt.Fprintln(dst)
-}
-
-func (kw *cockroachKeyWriter) NumColumns() int {
-	return cockroachColCount
-}
-
-func (kw *cockroachKeyWriter) DataType(col int) DataType {
-	return cockroachKeySchema.ColumnTypes[col]
-}
-
-func (kw *cockroachKeyWriter) Size(rows int, offset uint32) uint32 {
-	offset = kw.roachKeys.Size(rows, offset)
-	offset = kw.wallTimes.Size(rows, offset)
-	offset = kw.logicalTimes.Size(rows, offset)
-	offset = kw.untypedVersions.Size(rows, offset)
-	return offset
-}
-
-func (kw *cockroachKeyWriter) Finish(
-	col int, rows int, offset uint32, buf []byte,
-) (endOffset uint32) {
-	switch col {
-	case cockroachColRoachKey:
-		return kw.roachKeys.Finish(0, rows, offset, buf)
-	case cockroachColMVCCWallTime:
-		return kw.wallTimes.Finish(0, rows, offset, buf)
-	case cockroachColMVCCLogical:
-		return kw.logicalTimes.Finish(0, rows, offset, buf)
-	case cockroachColUntypedVersion:
-		return kw.untypedVersions.Finish(0, rows, offset, buf)
-	default:
-		panic(fmt.Sprintf("unknown default key column: %d", col))
-	}
-}
-
-var cockroachKeySeekerPool = sync.Pool{
-	New: func() interface{} { return &cockroachKeySeeker{} },
-}
-
-type cockroachKeySeeker struct {
-	roachKeys       PrefixBytes
-	roachKeyChanged Bitmap
-	mvccWallTimes   UnsafeUints
-	mvccLogical     UnsafeUints
-	untypedVersions RawBytes
-}
-
-var _ KeySeeker = (*cockroachKeySeeker)(nil)
-
-// Init is part of the KeySeeker interface.
-func (ks *cockroachKeySeeker) Init(d *DataBlockDecoder) error {
-	ks.roachKeys = d.d.PrefixBytes(cockroachColRoachKey)
-	ks.roachKeyChanged = d.prefixChanged
-	ks.mvccWallTimes = d.d.Uints(cockroachColMVCCWallTime)
-	ks.mvccLogical = d.d.Uints(cockroachColMVCCLogical)
-	ks.untypedVersions = d.d.RawBytes(cockroachColUntypedVersion)
-	return nil
-}
-
-// CompareFirstUserKey compares the provided key to the first user key
-// contained within the data block. It's equivalent to performing
-//
-//	Compare(firstUserKey, k)
-func (ks *cockroachKeySeeker) IsLowerBound(k []byte, syntheticSuffix []byte) bool {
-	roachKey, untypedVersion, wallTime, logicalTime := crdbtest.DecodeEngineKey(k)
-	if v := crdbtest.Compare(ks.roachKeys.UnsafeFirstSlice(), roachKey); v != 0 {
-		return v > 0
-	}
-	if len(syntheticSuffix) > 0 {
-		return crdbtest.Compare(syntheticSuffix, k[len(roachKey)+1:]) >= 0
-	}
-	if len(untypedVersion) > 0 {
-		if invariants.Enabled && ks.mvccWallTimes.At(0) != 0 {
-			panic("comparing timestamp with untyped suffix")
-		}
-		return crdbtest.Compare(ks.untypedVersions.At(0), untypedVersion) >= 0
-	}
-	if v := cmp.Compare(ks.mvccWallTimes.At(0), wallTime); v != 0 {
-		return v > 0
-	}
-	return cmp.Compare(uint32(ks.mvccLogical.At(0)), logicalTime) >= 0
-}
-
-// SeekGE is part of the KeySeeker interface.
-func (ks *cockroachKeySeeker) SeekGE(
-	key []byte, boundRow int, searchDir int8,
-) (row int, equalPrefix bool) {
-	// TODO(jackson): Inline crdbtest.Split.
-	si := crdbtest.Split(key)
-	row, eq := ks.roachKeys.Search(key[:si-1])
-	if eq {
-		return ks.seekGEOnSuffix(row, key[si:]), true
-	}
-	return row, false
-}
-
-// seekGEOnSuffix is a helper function for SeekGE when a seek key's prefix
-// exactly matches a row. seekGEOnSuffix finds the first row at index or later
-// with the same prefix as index and a suffix greater than or equal to [suffix],
-// or if no such row exists, the next row with a different prefix.
-func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row int) {
-	// The search key's prefix exactly matches the prefix of the row at index.
-	const withWall = 9
-	const withLogical = withWall + 4
-	const withSynthetic = withLogical + 1
-	var seekWallTime uint64
-	var seekLogicalTime uint32
-	switch len(seekSuffix) {
-	case 0:
-		// The search key has no suffix, so it's the smallest possible key with
-		// its prefix. Return the row. This is a common case where the user is
-		// seeking to the most-recent row and just wants the smallest key with
-		// the prefix.
-		return index
-	case withLogical, withSynthetic:
-		seekWallTime = binary.BigEndian.Uint64(seekSuffix)
-		seekLogicalTime = binary.BigEndian.Uint32(seekSuffix[8:])
-	case withWall:
-		seekWallTime = binary.BigEndian.Uint64(seekSuffix)
-	default:
-		// The suffix is untyped. Compare the untyped suffixes.
-		// Binary search between [index, prefixChanged.SeekSetBitGE(index+1)].
-		//
-		// Define f(i) = true iff key at i is >= seek key.
-		// Invariant: f(l-1) == false, f(u) == true.
-		l := index
-		u := ks.roachKeyChanged.SeekSetBitGE(index + 1)
-		for l < u {
-			h := int(uint(l+u) >> 1) // avoid overflow when computing h
-			// l ≤ h < u
-			if bytes.Compare(ks.untypedVersions.At(h), seekSuffix) >= 0 {
-				u = h // preserves f(u) == true
-			} else {
-				l = h + 1 // preserves f(l-1) == false
-			}
-		}
-		return l
-	}
-	// Seeking among MVCC versions using a MVCC timestamp.
-
-	// TODO(jackson): What if the row has an untyped suffix?
-
-	// First check the suffix at index, because querying for the latest value is
-	// the most common case.
-	if latestWallTime := ks.mvccWallTimes.At(index); latestWallTime < seekWallTime ||
-		(latestWallTime == seekWallTime && uint32(ks.mvccLogical.At(index)) <= seekLogicalTime) {
-		return index
-	}
-
-	// Binary search between [index+1, prefixChanged.SeekSetBitGE(index+1)].
-	//
-	// Define f(i) = true iff key at i is >= seek key.
-	// Invariant: f(l-1) == false, f(u) == true.
-	l := index + 1
-	u := ks.roachKeyChanged.SeekSetBitGE(index + 1)
-	for l < u {
-		h := int(uint(l+u) >> 1) // avoid overflow when computing h
-		// l ≤ h < u
-		hWallTime := ks.mvccWallTimes.At(h)
-		if hWallTime < seekWallTime ||
-			(hWallTime == seekWallTime && uint32(ks.mvccLogical.At(h)) <= seekLogicalTime) {
-			u = h // preserves f(u) = true
-		} else {
-			l = h + 1 // preserves f(l-1) = false
-		}
-	}
-	return l
-}
-
-// MaterializeUserKey is part of the KeySeeker interface.
-func (ks *cockroachKeySeeker) MaterializeUserKey(ki *PrefixBytesIter, prevRow, row int) []byte {
-	if prevRow+1 == row && prevRow >= 0 {
-		ks.roachKeys.SetNext(ki)
-	} else {
-		ks.roachKeys.SetAt(ki, row)
-	}
-
-	roachKeyLen := len(ki.buf)
-	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(unsafe.SliceData(ki.buf))) + uintptr(roachKeyLen))
-	mvccWall := ks.mvccWallTimes.At(row)
-	mvccLogical := uint32(ks.mvccLogical.At(row))
-	if mvccWall == 0 && mvccLogical == 0 {
-		// This is not an MVCC key. Use the untyped suffix.
-		untypedVersion := ks.untypedVersions.At(row)
-		if len(untypedVersion) == 0 {
-			res := ki.buf[:roachKeyLen+1]
-			res[roachKeyLen] = 0
-			return res
-		}
-		// Slice first, to check that the capacity is sufficient.
-		res := ki.buf[:roachKeyLen+1+len(untypedVersion)]
-		*(*byte)(ptr) = 0
-		memmove(
-			unsafe.Pointer(uintptr(ptr)+1),
-			unsafe.Pointer(unsafe.SliceData(untypedVersion)),
-			uintptr(len(untypedVersion)),
-		)
-		return res
-	}
-
-	// Inline binary.BigEndian.PutUint64. Note that this code is converted into
-	// word-size instructions by the compiler.
-	*(*byte)(ptr) = 0
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccWall >> 56)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccWall >> 48)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccWall >> 40)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 4)) = byte(mvccWall >> 32)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 5)) = byte(mvccWall >> 24)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 6)) = byte(mvccWall >> 16)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 7)) = byte(mvccWall >> 8)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 8)) = byte(mvccWall)
-
-	ptr = unsafe.Pointer(uintptr(ptr) + 9)
-	// This is an MVCC key.
-	if mvccLogical == 0 {
-		*(*byte)(ptr) = 9
-		return ki.buf[:len(ki.buf)+10]
-	}
-
-	// Inline binary.BigEndian.PutUint32.
-	*(*byte)(ptr) = byte(mvccWall >> 24)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccWall >> 16)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccWall >> 8)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccWall)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 4)) = 13
-	return ki.buf[:len(ki.buf)+14]
-}
-
-// MaterializeUserKeyWithSyntheticSuffix is part of the KeySeeker interface.
-func (ks *cockroachKeySeeker) MaterializeUserKeyWithSyntheticSuffix(
-	ki *PrefixBytesIter, suffix []byte, prevRow, row int,
-) []byte {
-	if prevRow+1 == row && prevRow >= 0 {
-		ks.roachKeys.SetNext(ki)
-	} else {
-		ks.roachKeys.SetAt(ki, row)
-	}
-
-	// Slice first, to check that the capacity is sufficient.
-	res := ki.buf[:len(ki.buf)+1+len(suffix)]
-	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(unsafe.SliceData(ki.buf))) + uintptr(len(ki.buf)))
-	*(*byte)(ptr) = 0
-	memmove(unsafe.Pointer(uintptr(ptr)+1), unsafe.Pointer(unsafe.SliceData(suffix)), uintptr(len(suffix)))
-	return res
-}
-
-// Release is part of the KeySeeker interface.
-func (ks *cockroachKeySeeker) Release() {
-	*ks = cockroachKeySeeker{}
-	cockroachKeySeekerPool.Put(ks)
-}
 
 func TestCockroachDataBlock(t *testing.T) {
 	const targetBlockSize = 32 << 10
@@ -408,12 +33,12 @@ func TestCockroachDataBlock(t *testing.T) {
 		BaseWallTime:      seed,
 	}, valueLen)
 
-	var decoder DataBlockDecoder
-	var it DataBlockIter
-	it.InitOnce(cockroachKeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
+	var decoder colblk.DataBlockDecoder
+	var it colblk.DataBlockIter
+	it.InitOnce(crdbtest.KeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
-	decoder.Init(cockroachKeySchema, serializedBlock)
+	decoder.Init(crdbtest.KeySchema, serializedBlock)
 	if err := it.Init(&decoder, block.IterTransforms{}); err != nil {
 		t.Fatal(err)
 	}
@@ -455,8 +80,8 @@ func generateDataBlock(
 ) (data []byte, keys [][]byte, values [][]byte) {
 	keys, values = crdbtest.RandomKVs(rng, targetBlockSize/valueLen, cfg, valueLen)
 
-	var w DataBlockEncoder
-	w.Init(cockroachKeySchema)
+	var w colblk.DataBlockEncoder
+	w.Init(crdbtest.KeySchema)
 	count := 0
 	for w.Size() < targetBlockSize {
 		ik := base.MakeInternalKey(keys[count], base.SeqNum(rng.Uint64N(uint64(base.SeqNumMax))), base.InternalKeyKindSet)
@@ -497,8 +122,8 @@ func benchmarkCockroachDataBlockWriter(b *testing.B, keyConfig crdbtest.KeyConfi
 	rng := rand.New(rand.NewPCG(0, seed))
 	_, keys, values := generateDataBlock(rng, targetBlockSize, keyConfig, valueLen)
 
-	var w DataBlockEncoder
-	w.Init(cockroachKeySchema)
+	var w colblk.DataBlockEncoder
+	w.Init(crdbtest.KeySchema)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -634,12 +259,12 @@ func benchmarkCockroachDataBlockIter(
 
 	serializedBlock, keys, _ := generateDataBlock(rng, targetBlockSize, cfg.KeyConfig, cfg.ValueLen)
 
-	var decoder DataBlockDecoder
-	var it DataBlockIter
-	it.InitOnce(cockroachKeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
+	var decoder colblk.DataBlockDecoder
+	var it colblk.DataBlockIter
+	it.InitOnce(crdbtest.KeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
-	decoder.Init(cockroachKeySchema, serializedBlock)
+	decoder.Init(crdbtest.KeySchema, serializedBlock)
 	if err := it.Init(&decoder, transforms); err != nil {
 		b.Fatal(err)
 	}
@@ -688,4 +313,10 @@ func benchmarkCockroachDataBlockIter(
 			b.ReportMetric(avgRowSize, "bytes/row")
 		})
 	}
+}
+
+type getLazyValuer func([]byte) base.LazyValue
+
+func (g getLazyValuer) GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue {
+	return g(handle)
 }

--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -246,9 +246,9 @@ func (b *PrefixBytes) UnsafeFirstSlice() []byte {
 // within a PrefixBytes, avoiding unnecessary copying when portions of slices
 // are shared.
 type PrefixBytesIter struct {
-	// buf is used for materializing a user key. It is preallocated to the maximum
+	// Buf is used for materializing a user key. It is preallocated to the maximum
 	// key length in the data block.
-	buf                      []byte
+	Buf                      []byte
 	syntheticPrefixLen       uint32
 	sharedAndBundlePrefixLen uint32
 	offsetIndex              int
@@ -263,14 +263,14 @@ func (i *PrefixBytesIter) Init(maxKeyLength int, syntheticPrefix block.Synthetic
 	// block with 1 byte to spare (so that pointer arithmetic is never pointing
 	// beyond the allocation, which would violate Go rules).
 	n := maxKeyLength + 1
-	if cap(i.buf) < n {
+	if cap(i.Buf) < n {
 		ptr := mallocgc(uintptr(n), nil, false)
-		i.buf = unsafe.Slice((*byte)(ptr), n)
+		i.Buf = unsafe.Slice((*byte)(ptr), n)
 	}
-	i.buf = i.buf[:0]
+	i.Buf = i.Buf[:0]
 	i.syntheticPrefixLen = uint32(len(syntheticPrefix))
 	if syntheticPrefix.IsSet() {
-		i.buf = append(i.buf, syntheticPrefix...)
+		i.Buf = append(i.Buf, syntheticPrefix...)
 	}
 }
 
@@ -294,9 +294,9 @@ func (b *PrefixBytes) SetAt(it *PrefixBytesIter, i int) {
 	rowSuffixLen := rowSuffixEnd - rowSuffixStart
 
 	it.sharedAndBundlePrefixLen = it.syntheticPrefixLen + uint32(b.sharedPrefixLen) + bundlePrefixLen
-	it.buf = it.buf[:it.sharedAndBundlePrefixLen+rowSuffixLen]
+	it.Buf = it.Buf[:it.sharedAndBundlePrefixLen+rowSuffixLen]
 
-	ptr := unsafe.Pointer(unsafe.SliceData(it.buf))
+	ptr := unsafe.Pointer(unsafe.SliceData(it.Buf))
 	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(it.syntheticPrefixLen))
 	// Copy the shared key prefix.
 	memmove(ptr, b.rawBytes.data, uintptr(b.sharedPrefixLen))
@@ -336,9 +336,9 @@ func (b *PrefixBytes) SetNext(it *PrefixBytesIter) {
 			// nothing left to do, we can leave buf as-is.
 			return
 		}
-		it.buf = it.buf[:it.sharedAndBundlePrefixLen+rowSuffixLen]
+		it.Buf = it.Buf[:it.sharedAndBundlePrefixLen+rowSuffixLen]
 		// Copy in the per-row suffix.
-		ptr := unsafe.Pointer(unsafe.SliceData(it.buf))
+		ptr := unsafe.Pointer(unsafe.SliceData(it.Buf))
 		memmove(
 			unsafe.Pointer(uintptr(ptr)+uintptr(it.sharedAndBundlePrefixLen)),
 			unsafe.Pointer(uintptr(b.rawBytes.data)+uintptr(rowSuffixStart)),
@@ -360,9 +360,9 @@ func (b *PrefixBytes) SetNext(it *PrefixBytesIter) {
 	it.nextBundleOffsetIndex = it.offsetIndex + (1 << b.bundleShift)
 
 	it.sharedAndBundlePrefixLen = it.syntheticPrefixLen + uint32(b.sharedPrefixLen) + bundlePrefixLen
-	it.buf = it.buf[:it.sharedAndBundlePrefixLen+rowSuffixLen]
+	it.Buf = it.Buf[:it.sharedAndBundlePrefixLen+rowSuffixLen]
 	// Copy in the new bundle suffix.
-	ptr := unsafe.Pointer(unsafe.SliceData(it.buf))
+	ptr := unsafe.Pointer(unsafe.SliceData(it.Buf))
 	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(it.syntheticPrefixLen) + uintptr(b.sharedPrefixLen))
 	memmove(
 		ptr,

--- a/sstable/colblk/prefix_bytes_test.go
+++ b/sstable/colblk/prefix_bytes_test.go
@@ -283,7 +283,7 @@ func BenchmarkPrefixBytes(b *testing.B) {
 			pb, _ := DecodePrefixBytes(buf, 0, n)
 			b.ResetTimer()
 			var pbi PrefixBytesIter
-			pbi.buf = make([]byte, 0, maxLen)
+			pbi.Buf = make([]byte, 0, maxLen)
 			for i := 0; i < b.N; i++ {
 				j := i % n
 				if j == 0 {
@@ -291,9 +291,9 @@ func BenchmarkPrefixBytes(b *testing.B) {
 				} else {
 					pb.SetNext(&pbi)
 				}
-				if invariants.Enabled && !bytes.Equal(pbi.buf, userKeys[j]) {
+				if invariants.Enabled && !bytes.Equal(pbi.Buf, userKeys[j]) {
 					b.Fatalf("Constructed key %q (%q, %q, %q) for index %d; expected %q",
-						pbi.buf, pb.SharedPrefix(), pb.RowBundlePrefix(j), pb.RowSuffix(j), j, userKeys[j])
+						pbi.Buf, pb.SharedPrefix(), pb.RowBundlePrefix(j), pb.RowSuffix(j), j, userKeys[j])
 				}
 			}
 		})


### PR DESCRIPTION
Move the test implementation of a cockroach colblk.KeySchema into crdbtest so that it may be used by other packages, and most notably, the ycsb benchmarks implemented in cmd/pebble.