### PR TITLE
sstable: remove describe-binary

### DIFF
--- a/sstable/colblk_writer_test.go
+++ b/sstable/colblk_writer_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
-	"github.com/cockroachdb/pebble/internal/aligned"
-	"github.com/cockroachdb/pebble/internal/binfmt"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -73,76 +71,9 @@ func TestColumnarWriter(t *testing.T) {
 				return buf.String()
 			case "props":
 				return r.Properties.String()
-			case "describe-binary":
-				f := binfmt.New(obj.Data())
-				if err := describeSSTableBinary(f, keySchema); err != nil {
-					return err.Error()
-				}
-				return f.String()
 			default:
 				panic(fmt.Sprintf("unrecognized command %q", td.Cmd))
 			}
 		})
 	})
-}
-
-func describeSSTableBinary(f *binfmt.Formatter, schema colblk.KeySchema) error {
-	layout, err := decodeLayout(testkeys.Comparer, f.Data())
-	if err != nil {
-		return err
-	}
-	blockHandles := layout.orderedBlocks()
-	for i, bh := range blockHandles {
-		if f.Offset() < int(bh.Offset) {
-			f.HexBytesln(int(bh.Offset)-f.Offset(), "???")
-		}
-		if bh.Name == "footer" {
-			// Skip the footer; we'll format it down below.
-			continue
-		}
-		f.CommentLine("block %d %s (%04d-%04d)", i, bh.Name, bh.Offset, bh.Offset+bh.Length)
-
-		if layout.Format >= TableFormatPebblev5 {
-			// We can only describe uncompressed data.
-			if block.CompressionIndicator(f.Data()[bh.Offset+bh.Length]) == block.NoCompressionIndicator {
-				switch bh.Name {
-				case "top-index", "index":
-					var d colblk.IndexBlockDecoder
-					// NB: The byte slice used to Init must be aligned (like an
-					// allocated block would be in practice).
-					d.Init(aligned.Copy(f.Data()[bh.Offset : bh.Offset+bh.Length]))
-					d.Describe(f)
-					f.HexBytesln(block.TrailerLen, "%s block trailer", bh.Name)
-					continue
-				case "data":
-					var d colblk.DataBlockDecoder
-					// NB: The byte slice used to Init must be aligned (like an
-					// allocated block would be in practice).
-					d.Init(schema, aligned.Copy(f.Data()[bh.Offset:bh.Offset+bh.Length]))
-					d.Describe(f)
-					f.HexBytesln(block.TrailerLen, "%s block trailer", bh.Name)
-					continue
-				case "range-del", "range-key":
-					var d colblk.KeyspanDecoder
-					d.Init(aligned.Copy(f.Data()[bh.Offset : bh.Offset+bh.Length]))
-					d.Describe(f)
-					f.HexBytesln(block.TrailerLen, "%s block trailer", bh.Name)
-					continue
-				case "properties":
-					f.HexTextln(int(bh.Length))
-					f.HexBytesln(block.TrailerLen, "%s block trailer", bh.Name)
-					continue
-				}
-				// Otherwise fall through.
-			}
-		}
-		// Fall back to just formatting the entire block as an opaque hex bytes.
-		f.HexBytesln(int(bh.Length), bh.Name)
-		f.HexBytesln(block.TrailerLen, "%s block trailer", bh.Name)
-	}
-	if f.Remaining() > rocksDBFooterLen {
-		f.HexBytesln(f.Remaining()-rocksDBFooterLen, "???")
-	}
-	describeFooter(f)
-	return nil
 }

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -74,7 +74,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/binfmt"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable/block"
 )
@@ -254,31 +253,6 @@ type footer struct {
 	metaindexBH block.Handle
 	indexBH     block.Handle
 	footerBH    block.Handle
-}
-
-func describeFooter(f *binfmt.Formatter) {
-	f.CommentLine("sstable footer")
-	data := f.Data()
-	switch string(data[len(data)-len(rocksDBMagic):]) {
-	case levelDBMagic:
-		f.Uvarint("metaindex.Offset")
-		f.Uvarint("metaindex.Length")
-		f.Uvarint("index.Offset")
-		f.Uvarint("index.Length")
-		f.HexBytesln(f.Remaining()-len(levelDBMagic), "padding")
-		f.HexBytesln(len(levelDBMagic), "magic")
-	case rocksDBMagic, pebbleDBMagic:
-		f.HexBytesln(1, "checksum type")
-		f.Uvarint("metaindex.Offset")
-		f.Uvarint("metaindex.Length")
-		f.Uvarint("index.Offset")
-		f.Uvarint("index.Length")
-		f.HexBytesln(f.Remaining()-len(levelDBMagic)-4, "padding")
-		f.HexBytesln(4, "table version")
-		f.HexBytesln(len(rocksDBMagic), "magic")
-	default:
-		f.HexBytesln(f.Remaining(), "unknown magic ???")
-	}
 }
 
 // TODO(sumeer): should the threshold be configurable.

--- a/sstable/testdata/columnar_writer/simple_binary
+++ b/sstable/testdata/columnar_writer/simple_binary
@@ -5,162 +5,117 @@ b.DEL.2:
 point:    [a#1,SET-b#2,DEL]
 seqnums:  [1-2]
 
-describe-binary
-----
-# block 0 data (0000-0096)
-# data block header
-000-004: x 01000000                                                         # maximum key length: 1
-# columnar block header
-004-005: x 01                                                               # version 1
-005-007: x 0700                                                             # 7 columns
-007-011: x 02000000                                                         # 2 rows
-011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 2e000000                                                         # col 0: page start 46
-016-017: b 00000011                                                         # col 1: bytes
-017-021: x 36000000                                                         # col 1: page start 54
-021-022: b 00000010                                                         # col 2: uint
-022-026: x 37000000                                                         # col 2: page start 55
-026-027: b 00000001                                                         # col 3: bool
-027-031: x 42000000                                                         # col 3: page start 66
-031-032: b 00000011                                                         # col 4: bytes
-032-036: x 58000000                                                         # col 4: page start 88
-036-037: b 00000001                                                         # col 5: bool
-037-041: x 5d000000                                                         # col 5: page start 93
-041-042: b 00000001                                                         # col 6: bool
-042-046: x 5e000000                                                         # col 6: page start 94
-# data for column 0
-# PrefixBytes
-046-047: x 04                                                               # bundleSize: 16
-# Offsets table
-047-048: x 01                                                               # encoding: 1b
-048-049: x 00                                                               # data[0] = 0 [52 overall]
-049-050: x 00                                                               # data[1] = 0 [52 overall]
-050-051: x 01                                                               # data[2] = 1 [53 overall]
-051-052: x 02                                                               # data[3] = 2 [54 overall]
-# Data
-052-052: x                                                                  # data[00]:  (block prefix)
-052-052: x                                                                  # data[01]:  (bundle prefix)
-052-053: x 61                                                               # data[02]: a
-053-054: x 62                                                               # data[03]: b
-# data for column 1
-# rawbytes
-# offsets table
-054-055: x 00                                                               # encoding: zero
-# data
-055-055: x                                                                  # data[0]:
-055-055: x                                                                  # data[1]:
-# data for column 2
-055-056: x 81                                                               # encoding: 1b,delta
-056-064: x 0101000000000000                                                 # 64-bit constant: 257
-064-065: x 00                                                               # data[0] = 0 + 257 = 257
-065-066: x ff                                                               # data[1] = 255 + 257 = 512
-# data for column 3
-066-067: x 00                                                               # bitmap encoding
-067-072: x 0000000000                                                       # padding to align to 64-bit boundary
-072-080: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-088-089: x 01                                                               # encoding: 1b
-089-090: x 00                                                               # data[0] = 0 [92 overall]
-090-091: x 01                                                               # data[1] = 1 [93 overall]
-091-092: x 01                                                               # data[2] = 1 [93 overall]
-# data
-092-093: x 61                                                               # data[0]: a
-093-093: x                                                                  # data[1]:
-# data for column 5
-093-094: x 01                                                               # bitmap encoding
-# data for column 6
-094-095: x 01                                                               # bitmap encoding
-095-096: x 00                                                               # block padding byte
-096-101: x 000a6472a7                                                       # data block trailer
-# block 1 index (0101-0152)
-# index block header
-# columnar block header
-101-102: x 01                                                               # version 1
-102-104: x 0400                                                             # 4 columns
-104-108: x 01000000                                                         # 1 rows
-108-109: b 00000011                                                         # col 0: bytes
-109-113: x 1b000000                                                         # col 0: page start 27
-113-114: b 00000010                                                         # col 1: uint
-114-118: x 1f000000                                                         # col 1: page start 31
-118-119: b 00000010                                                         # col 2: uint
-119-123: x 20000000                                                         # col 2: page start 32
-123-124: b 00000011                                                         # col 3: bytes
-124-128: x 22000000                                                         # col 3: page start 34
-# data for column 0
-# rawbytes
-# offsets table
-128-129: x 01                                                               # encoding: 1b
-129-130: x 00                                                               # data[0] = 0 [30 overall]
-130-131: x 01                                                               # data[1] = 1 [31 overall]
-# data
-131-132: x 62                                                               # data[0]: b
-# data for column 1
-132-133: x 00                                                               # encoding: zero
-# data for column 2
-133-134: x 01                                                               # encoding: 1b
-134-135: x 60                                                               # data[0] = 96
-# data for column 3
-# rawbytes
-# offsets table
-135-136: x 01                                                               # encoding: 1b
-136-137: x 00                                                               # data[0] = 0 [37 overall]
-137-138: x 0d                                                               # data[1] = 13 [50 overall]
-# data
-138-151: x 000b00ffffffffffffffffff01                                       # data[0]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-151-152: x 00                                                               # block padding byte
-152-157: x 00e1f1c82b                                                       # index block trailer
-# block 2 properties (0157-0718)
-157-177: x 000c016f62736f6c6574652d6b65790100210c70                         # ...obsolete-key..!.p
-177-197: x 6562626c652e696e7465726e616c2e746573746b                         # ebble.internal.testk
-197-217: x 6579732e73756666697865730000ffffffffffff                         # eys.suffixes........
-217-237: x ffffff01071c017261772e706f696e742d746f6d                         # .......raw.point-tom
-237-257: x 6273746f6e652e6b65792e73697a650100240472                         # bstone.key.size..$.r
-257-277: x 6f636b7364622e626c6f636b2e62617365642e74                         # ocksdb.block.based.t
-277-297: x 61626c652e696e6465782e747970650000000008                         # able.index.type.....
-297-317: x 0a18636f6d70617261746f72706562626c652e69                         # ..comparatorpebble.i
-317-337: x 6e7465726e616c2e746573746b6579730c070d72                         # nternal.testkeys...r
-337-357: x 657373696f6e4e6f436f6d7072657373696f6e13                         # essionNoCompression.
-357-377: x 085f5f6f7074696f6e7377696e646f775f626974                         # .__optionswindow_bit
-377-397: x 733d2d31343b206c6576656c3d33323736373b20                         # s=-14; level=32767; 
-397-417: x 73747261746567793d303b206d61785f64696374                         # strategy=0; max_dict
-417-437: x 5f62797465733d303b207a7374645f6d61785f74                         # _bytes=0; zstd_max_t
-437-457: x 7261696e5f62797465733d303b20656e61626c65                         # rain_bytes=0; enable
-457-477: x 643d303b20080901646174612e73697a6565090b                         # d=0; ...data.sizee..
-477-497: x 01656c657465642e6b65797301080b0166696c74                         # .eleted.keys....filt
-497-517: x 65722e73697a6500080a01696e6465782e73697a                         # er.size....index.siz
-517-537: x 6538080e016d657267652e6f706572616e647300                         # e8...merge.operands.
-537-557: x 130312746f72706562626c652e636f6e63617465                         # ...torpebble.concate
-557-577: x 6e617465080f016e756d2e646174612e626c6f63                         # nate...num.data.bloc
-577-597: x 6b73010c0701656e7472696573020c0f0172616e                         # ks....entries....ran
-597-617: x 67652d64656c6574696f6e730008133070726f70                         # ge-deletions...0prop
-617-637: x 657274792e636f6c6c6563746f72735b70656262                         # erty.collectors[pebb
-637-657: x 6c652e696e7465726e616c2e746573746b657973                         # le.internal.testkeys
-657-677: x 2e73756666697865732c6f62736f6c6574652d6b                         # .suffixes,obsolete-k
-677-697: x 65795d080c017261772e6b65792e73697a65120c                         # ey]...raw.key.size..
-697-717: x 0a0176616c75652e73697a650100000000010000                         # ..value.size........
-717-718: x 00                                                               # .
-718-723: x 00b671b48a                                                       # properties block trailer
-# block 3 meta-index (0723-0756)
-723-743: x 001204726f636b7364622e70726f706572746965                         # meta-index
-743-756: x 739d01b1040000000001000000                                       # (continued...)
-756-761: x 00070c955c                                                       # meta-index block trailer
-# sstable footer
-761-762: x 01                                                               # checksum type
-762-764: x d305                                                             # uvarint(723): metaindex.Offset
-764-765: x 21                                                               # uvarint(33): metaindex.Length
-765-766: x 65                                                               # uvarint(101): index.Offset
-766-767: x 33                                                               # uvarint(51): index.Length
-767-787: x 0000000000000000000000000000000000000000                         # padding
-787-802: x 000000000000000000000000000000                                   # (continued...)
-802-806: x 05000000                                                         # table version
-806-814: x f09faab3f09faab3                                                 # magic
-
 open
 ----
 ok
+
+layout
+----
+         0  data (96)
+               # data block header
+               00-04: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               04-05: x 01                                                               # version 1
+               05-07: x 0700                                                             # 7 columns
+               07-11: x 02000000                                                         # 2 rows
+               11-12: b 00000100                                                         # col 0: prefixbytes
+               12-16: x 2e000000                                                         # col 0: page start 46
+               16-17: b 00000011                                                         # col 1: bytes
+               17-21: x 36000000                                                         # col 1: page start 54
+               21-22: b 00000010                                                         # col 2: uint
+               22-26: x 37000000                                                         # col 2: page start 55
+               26-27: b 00000001                                                         # col 3: bool
+               27-31: x 42000000                                                         # col 3: page start 66
+               31-32: b 00000011                                                         # col 4: bytes
+               32-36: x 58000000                                                         # col 4: page start 88
+               36-37: b 00000001                                                         # col 5: bool
+               37-41: x 5d000000                                                         # col 5: page start 93
+               41-42: b 00000001                                                         # col 6: bool
+               42-46: x 5e000000                                                         # col 6: page start 94
+               # data for column 0
+               # PrefixBytes
+               46-47: x 04                                                               # bundleSize: 16
+               # Offsets table
+               47-48: x 01                                                               # encoding: 1b
+               48-49: x 00                                                               # data[0] = 0 [52 overall]
+               49-50: x 00                                                               # data[1] = 0 [52 overall]
+               50-51: x 01                                                               # data[2] = 1 [53 overall]
+               51-52: x 02                                                               # data[3] = 2 [54 overall]
+               # Data
+               52-52: x                                                                  # data[00]:  (block prefix)
+               52-52: x                                                                  # data[01]:  (bundle prefix)
+               52-53: x 61                                                               # data[02]: a
+               53-54: x 62                                                               # data[03]: b
+               # data for column 1
+               # rawbytes
+               # offsets table
+               54-55: x 00                                                               # encoding: zero
+               # data
+               55-55: x                                                                  # data[0]:
+               55-55: x                                                                  # data[1]:
+               # data for column 2
+               55-56: x 81                                                               # encoding: 1b,delta
+               56-64: x 0101000000000000                                                 # 64-bit constant: 257
+               64-65: x 00                                                               # data[0] = 0 + 257 = 257
+               65-66: x ff                                                               # data[1] = 255 + 257 = 512
+               # data for column 3
+               66-67: x 00                                                               # bitmap encoding
+               67-72: x 0000000000                                                       # padding to align to 64-bit boundary
+               72-80: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               80-88: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               88-89: x 01                                                               # encoding: 1b
+               89-90: x 00                                                               # data[0] = 0 [92 overall]
+               90-91: x 01                                                               # data[1] = 1 [93 overall]
+               91-92: x 01                                                               # data[2] = 1 [93 overall]
+               # data
+               92-93: x 61                                                               # data[0]: a
+               93-93: x                                                                  # data[1]:
+               # data for column 5
+               93-94: x 01                                                               # bitmap encoding
+               # data for column 6
+               94-95: x 01                                                               # bitmap encoding
+               95-96: x 00                                                               # block padding byte
+        96    [trailer compression=none checksum=0xa772640a]
+       101  index (51)
+         0    block:0/96
+       152    [trailer compression=none checksum=0x2bc8f1e1]
+       157  properties (561)
+       157    obsolete-key (16) [restart]
+       173    pebble.internal.testkeys.suffixes (48)
+       221    pebble.raw.point-tombstone.key.size (32)
+       253    rocksdb.block.based.table.index.type (43)
+       296    rocksdb.comparator (37)
+       333    rocksdb.compression (23)
+       356    rocksdb.compression_options (106)
+       462    rocksdb.data.size (13)
+       475    rocksdb.deleted.keys (15)
+       490    rocksdb.filter.size (15)
+       505    rocksdb.index.size (14)
+       519    rocksdb.merge.operands (18)
+       537    rocksdb.merge.operator (24)
+       561    rocksdb.num.data.blocks (19)
+       580    rocksdb.num.entries (11)
+       591    rocksdb.num.range-deletions (19)
+       610    rocksdb.property.collectors (70)
+       680    rocksdb.raw.key.size (16)
+       696    rocksdb.raw.value.size (14)
+       710    [restart 157]
+       718    [trailer compression=none checksum=0x8ab471b6]
+       723  meta-index (33)
+       723    rocksdb.properties block:157/561 [restart]
+       748    [restart 723]
+       756    [trailer compression=none checksum=0x5c950c07]
+       761  footer (53)
+       761    checksum type: crc32c
+       762    meta: offset=723, length=33
+       765    index: offset=101, length=51
+       767    [padding]
+       802    version: 5
+       806    magic number: 0xf09faab3f09faab3
+       814  EOF
 
 props
 ----
@@ -192,159 +147,119 @@ c.SET.1:cantelope
 point:    [a#1,SET-c#1,SET]
 seqnums:  [1-1]
 
-describe-binary
+open
 ----
-# block 0 data (0000-0116)
-# data block header
-000-004: x 01000000                                                         # maximum key length: 1
-# columnar block header
-004-005: x 01                                                               # version 1
-005-007: x 0700                                                             # 7 columns
-007-011: x 03000000                                                         # 3 rows
-011-012: b 00000100                                                         # col 0: prefixbytes
-012-016: x 2e000000                                                         # col 0: page start 46
-016-017: b 00000011                                                         # col 1: bytes
-017-021: x 38000000                                                         # col 1: page start 56
-021-022: b 00000010                                                         # col 2: uint
-022-026: x 39000000                                                         # col 2: page start 57
-026-027: b 00000001                                                         # col 3: bool
-027-031: x 42000000                                                         # col 3: page start 66
-031-032: b 00000011                                                         # col 4: bytes
-032-036: x 58000000                                                         # col 4: page start 88
-036-037: b 00000001                                                         # col 5: bool
-037-041: x 71000000                                                         # col 5: page start 113
-041-042: b 00000001                                                         # col 6: bool
-042-046: x 72000000                                                         # col 6: page start 114
-# data for column 0
-# PrefixBytes
-046-047: x 04                                                               # bundleSize: 16
-# Offsets table
-047-048: x 01                                                               # encoding: 1b
-048-049: x 00                                                               # data[0] = 0 [53 overall]
-049-050: x 00                                                               # data[1] = 0 [53 overall]
-050-051: x 01                                                               # data[2] = 1 [54 overall]
-051-052: x 02                                                               # data[3] = 2 [55 overall]
-052-053: x 03                                                               # data[4] = 3 [56 overall]
-# Data
-053-053: x                                                                  # data[00]:  (block prefix)
-053-053: x                                                                  # data[01]:  (bundle prefix)
-053-054: x 61                                                               # data[02]: a
-054-055: x 62                                                               # data[03]: b
-055-056: x 63                                                               # data[04]: c
-# data for column 1
-# rawbytes
-# offsets table
-056-057: x 00                                                               # encoding: zero
-# data
-057-057: x                                                                  # data[0]:
-057-057: x                                                                  # data[1]:
-057-057: x                                                                  # data[2]:
-# data for column 2
-057-058: x 80                                                               # encoding: const
-058-066: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-066-067: x 00                                                               # bitmap encoding
-067-072: x 0000000000                                                       # padding to align to 64-bit boundary
-072-080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-088-089: x 01                                                               # encoding: 1b
-089-090: x 00                                                               # data[0] = 0 [93 overall]
-090-091: x 05                                                               # data[1] = 5 [98 overall]
-091-092: x 0b                                                               # data[2] = 11 [104 overall]
-092-093: x 14                                                               # data[3] = 20 [113 overall]
-# data
-093-098: x 6170706c65                                                       # data[0]: apple
-098-104: x 62616e616e61                                                     # data[1]: banana
-104-113: x 63616e74656c6f7065                                               # data[2]: cantelope
-# data for column 5
-113-114: x 01                                                               # bitmap encoding
-# data for column 6
-114-115: x 01                                                               # bitmap encoding
-115-116: x 00                                                               # block padding byte
-116-121: x 002953b1e7                                                       # data block trailer
-# block 1 index (0121-0172)
-# index block header
-# columnar block header
-121-122: x 01                                                               # version 1
-122-124: x 0400                                                             # 4 columns
-124-128: x 01000000                                                         # 1 rows
-128-129: b 00000011                                                         # col 0: bytes
-129-133: x 1b000000                                                         # col 0: page start 27
-133-134: b 00000010                                                         # col 1: uint
-134-138: x 1f000000                                                         # col 1: page start 31
-138-139: b 00000010                                                         # col 2: uint
-139-143: x 20000000                                                         # col 2: page start 32
-143-144: b 00000011                                                         # col 3: bytes
-144-148: x 22000000                                                         # col 3: page start 34
-# data for column 0
-# rawbytes
-# offsets table
-148-149: x 01                                                               # encoding: 1b
-149-150: x 00                                                               # data[0] = 0 [30 overall]
-150-151: x 01                                                               # data[1] = 1 [31 overall]
-# data
-151-152: x 63                                                               # data[0]: c
-# data for column 1
-152-153: x 00                                                               # encoding: zero
-# data for column 2
-153-154: x 01                                                               # encoding: 1b
-154-155: x 74                                                               # data[0] = 116
-# data for column 3
-# rawbytes
-# offsets table
-155-156: x 01                                                               # encoding: 1b
-156-157: x 00                                                               # data[0] = 0 [37 overall]
-157-158: x 0d                                                               # data[1] = 13 [50 overall]
-# data
-158-171: x 000b00ffffffffffffffffff01                                       # data[0]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-171-172: x 00                                                               # block padding byte
-172-177: x 0066ef86cf                                                       # index block trailer
-# block 2 properties (0177-0706)
-177-197: x 000c016f62736f6c6574652d6b65790100210c70                         # ...obsolete-key..!.p
-197-217: x 6562626c652e696e7465726e616c2e746573746b                         # ebble.internal.testk
-217-237: x 6579732e73756666697865730000ffffffffffff                         # eys.suffixes........
-237-257: x ffffff01002404726f636b7364622e626c6f636b                         # .....$.rocksdb.block
-257-277: x 2e62617365642e7461626c652e696e6465782e74                         # .based.table.index.t
-277-297: x 79706500000000080a18636f6d70617261746f72                         # ype.......comparator
-297-317: x 706562626c652e696e7465726e616c2e74657374                         # pebble.internal.test
-317-337: x 6b6579730c070d72657373696f6e4e6f436f6d70                         # keys...ressionNoComp
-337-357: x 72657373696f6e13085f5f6f7074696f6e737769                         # ression..__optionswi
-357-377: x 6e646f775f626974733d2d31343b206c6576656c                         # ndow_bits=-14; level
-377-397: x 3d33323736373b2073747261746567793d303b20                         # =32767; strategy=0; 
-397-417: x 6d61785f646963745f62797465733d303b207a73                         # max_dict_bytes=0; zs
-417-437: x 74645f6d61785f747261696e5f62797465733d30                         # td_max_train_bytes=0
-437-457: x 3b20656e61626c65643d303b2008090164617461                         # ; enabled=0; ...data
-457-477: x 2e73697a6579090b01656c657465642e6b657973                         # .sizey...eleted.keys
-477-497: x 00080b0166696c7465722e73697a6500080a0169                         # ....filter.size....i
-497-517: x 6e6465782e73697a6538080e016d657267652e6f                         # ndex.size8...merge.o
-517-537: x 706572616e647300130312746f72706562626c65                         # perands....torpebble
-537-557: x 2e636f6e636174656e617465080f016e756d2e64                         # .concatenate...num.d
-557-577: x 6174612e626c6f636b73010c0701656e74726965                         # ata.blocks....entrie
-577-597: x 73030c0f0172616e67652d64656c6574696f6e73                         # s....range-deletions
-597-617: x 0008133070726f70657274792e636f6c6c656374                         # ...0property.collect
-617-637: x 6f72735b706562626c652e696e7465726e616c2e                         # ors[pebble.internal.
-637-657: x 746573746b6579732e73756666697865732c6f62                         # testkeys.suffixes,ob
-657-677: x 736f6c6574652d6b65795d080c017261772e6b65                         # solete-key]...raw.ke
-677-697: x 792e73697a651b0c0a0176616c75652e73697a65                         # y.size....value.size
-697-706: x 140000000001000000                                               # .........
-706-711: x 00fb1e07d5                                                       # properties block trailer
-# block 3 meta-index (0711-0744)
-711-731: x 001204726f636b7364622e70726f706572746965                         # meta-index
-731-744: x 73b10191040000000001000000                                       # (continued...)
-744-749: x 0033c6a434                                                       # meta-index block trailer
-# sstable footer
-749-750: x 01                                                               # checksum type
-750-752: x c705                                                             # uvarint(711): metaindex.Offset
-752-753: x 21                                                               # uvarint(33): metaindex.Length
-753-754: x 79                                                               # uvarint(121): index.Offset
-754-755: x 33                                                               # uvarint(51): index.Length
-755-775: x 0000000000000000000000000000000000000000                         # padding
-775-790: x 000000000000000000000000000000                                   # (continued...)
-790-794: x 05000000                                                         # table version
-794-802: x f09faab3f09faab3                                                 # magic
+ok
+
+layout
+----
+         0  data (116)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 03000000                                                         # 3 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 38000000                                                         # col 1: page start 56
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 39000000                                                         # col 2: page start 57
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 42000000                                                         # col 3: page start 66
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 71000000                                                         # col 5: page start 113
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 72000000                                                         # col 6: page start 114
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [53 overall]
+               049-050: x 00                                                               # data[1] = 0 [53 overall]
+               050-051: x 01                                                               # data[2] = 1 [54 overall]
+               051-052: x 02                                                               # data[3] = 2 [55 overall]
+               052-053: x 03                                                               # data[4] = 3 [56 overall]
+               # Data
+               053-053: x                                                                  # data[00]:  (block prefix)
+               053-053: x                                                                  # data[01]:  (bundle prefix)
+               053-054: x 61                                                               # data[02]: a
+               054-055: x 62                                                               # data[03]: b
+               055-056: x 63                                                               # data[04]: c
+               # data for column 1
+               # rawbytes
+               # offsets table
+               056-057: x 00                                                               # encoding: zero
+               # data
+               057-057: x                                                                  # data[0]:
+               057-057: x                                                                  # data[1]:
+               057-057: x                                                                  # data[2]:
+               # data for column 2
+               057-058: x 80                                                               # encoding: const
+               058-066: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               066-067: x 00                                                               # bitmap encoding
+               067-072: x 0000000000                                                       # padding to align to 64-bit boundary
+               072-080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [93 overall]
+               090-091: x 05                                                               # data[1] = 5 [98 overall]
+               091-092: x 0b                                                               # data[2] = 11 [104 overall]
+               092-093: x 14                                                               # data[3] = 20 [113 overall]
+               # data
+               093-098: x 6170706c65                                                       # data[0]: apple
+               098-104: x 62616e616e61                                                     # data[1]: banana
+               104-113: x 63616e74656c6f7065                                               # data[2]: cantelope
+               # data for column 5
+               113-114: x 01                                                               # bitmap encoding
+               # data for column 6
+               114-115: x 01                                                               # bitmap encoding
+               115-116: x 00                                                               # block padding byte
+       116    [trailer compression=none checksum=0xe7b15329]
+       121  index (51)
+         0    block:0/116
+       172    [trailer compression=none checksum=0xcf86ef66]
+       177  properties (529)
+       177    obsolete-key (16) [restart]
+       193    pebble.internal.testkeys.suffixes (48)
+       241    rocksdb.block.based.table.index.type (43)
+       284    rocksdb.comparator (37)
+       321    rocksdb.compression (23)
+       344    rocksdb.compression_options (106)
+       450    rocksdb.data.size (13)
+       463    rocksdb.deleted.keys (15)
+       478    rocksdb.filter.size (15)
+       493    rocksdb.index.size (14)
+       507    rocksdb.merge.operands (18)
+       525    rocksdb.merge.operator (24)
+       549    rocksdb.num.data.blocks (19)
+       568    rocksdb.num.entries (11)
+       579    rocksdb.num.range-deletions (19)
+       598    rocksdb.property.collectors (70)
+       668    rocksdb.raw.key.size (16)
+       684    rocksdb.raw.value.size (14)
+       698    [restart 177]
+       706    [trailer compression=none checksum=0xd5071efb]
+       711  meta-index (33)
+       711    rocksdb.properties block:177/529 [restart]
+       736    [restart 711]
+       744    [trailer compression=none checksum=0x34a4c633]
+       749  footer (53)
+       749    checksum type: crc32c
+       750    meta: offset=711, length=33
+       753    index: offset=121, length=51
+       755    [padding]
+       790    version: 5
+       794    magic number: 0xf09faab3f09faab3
+       802  EOF
 
 build block-size=150
 a.SET.1:apple
@@ -372,863 +287,676 @@ u.SET.1:ume
 point:    [a#1,SET-u#1,SET]
 seqnums:  [1-1]
 
-describe-binary
+open
 ----
-# block 0 data (0000-0116)
-# data block header
-0000-0004: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0004-0005: x 01                                                               # version 1
-0005-0007: x 0700                                                             # 7 columns
-0007-0011: x 03000000                                                         # 3 rows
-0011-0012: b 00000100                                                         # col 0: prefixbytes
-0012-0016: x 2e000000                                                         # col 0: page start 46
-0016-0017: b 00000011                                                         # col 1: bytes
-0017-0021: x 38000000                                                         # col 1: page start 56
-0021-0022: b 00000010                                                         # col 2: uint
-0022-0026: x 39000000                                                         # col 2: page start 57
-0026-0027: b 00000001                                                         # col 3: bool
-0027-0031: x 42000000                                                         # col 3: page start 66
-0031-0032: b 00000011                                                         # col 4: bytes
-0032-0036: x 58000000                                                         # col 4: page start 88
-0036-0037: b 00000001                                                         # col 5: bool
-0037-0041: x 71000000                                                         # col 5: page start 113
-0041-0042: b 00000001                                                         # col 6: bool
-0042-0046: x 72000000                                                         # col 6: page start 114
-# data for column 0
-# PrefixBytes
-0046-0047: x 04                                                               # bundleSize: 16
-# Offsets table
-0047-0048: x 01                                                               # encoding: 1b
-0048-0049: x 00                                                               # data[0] = 0 [53 overall]
-0049-0050: x 00                                                               # data[1] = 0 [53 overall]
-0050-0051: x 01                                                               # data[2] = 1 [54 overall]
-0051-0052: x 02                                                               # data[3] = 2 [55 overall]
-0052-0053: x 03                                                               # data[4] = 3 [56 overall]
-# Data
-0053-0053: x                                                                  # data[00]:  (block prefix)
-0053-0053: x                                                                  # data[01]:  (bundle prefix)
-0053-0054: x 61                                                               # data[02]: a
-0054-0055: x 62                                                               # data[03]: b
-0055-0056: x 63                                                               # data[04]: c
-# data for column 1
-# rawbytes
-# offsets table
-0056-0057: x 00                                                               # encoding: zero
-# data
-0057-0057: x                                                                  # data[0]:
-0057-0057: x                                                                  # data[1]:
-0057-0057: x                                                                  # data[2]:
-# data for column 2
-0057-0058: x 80                                                               # encoding: const
-0058-0066: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-0066-0067: x 00                                                               # bitmap encoding
-0067-0072: x 0000000000                                                       # padding to align to 64-bit boundary
-0072-0080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0080-0088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-0088-0089: x 01                                                               # encoding: 1b
-0089-0090: x 00                                                               # data[0] = 0 [93 overall]
-0090-0091: x 05                                                               # data[1] = 5 [98 overall]
-0091-0092: x 0b                                                               # data[2] = 11 [104 overall]
-0092-0093: x 14                                                               # data[3] = 20 [113 overall]
-# data
-0093-0098: x 6170706c65                                                       # data[0]: apple
-0098-0104: x 62616e616e61                                                     # data[1]: banana
-0104-0113: x 63616e74656c6f7065                                               # data[2]: cantelope
-# data for column 5
-0113-0114: x 01                                                               # bitmap encoding
-# data for column 6
-0114-0115: x 01                                                               # bitmap encoding
-0115-0116: x 00                                                               # block padding byte
-0116-0121: x 002953b1e7                                                       # data block trailer
-# block 1 data (0121-0237)
-# data block header
-0121-0125: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0125-0126: x 01                                                               # version 1
-0126-0128: x 0700                                                             # 7 columns
-0128-0132: x 02000000                                                         # 2 rows
-0132-0133: b 00000100                                                         # col 0: prefixbytes
-0133-0137: x 2e000000                                                         # col 0: page start 46
-0137-0138: b 00000011                                                         # col 1: bytes
-0138-0142: x 36000000                                                         # col 1: page start 54
-0142-0143: b 00000010                                                         # col 2: uint
-0143-0147: x 37000000                                                         # col 2: page start 55
-0147-0148: b 00000001                                                         # col 3: bool
-0148-0152: x 40000000                                                         # col 3: page start 64
-0152-0153: b 00000011                                                         # col 4: bytes
-0153-0157: x 58000000                                                         # col 4: page start 88
-0157-0158: b 00000001                                                         # col 5: bool
-0158-0162: x 71000000                                                         # col 5: page start 113
-0162-0163: b 00000001                                                         # col 6: bool
-0163-0167: x 72000000                                                         # col 6: page start 114
-# data for column 0
-# PrefixBytes
-0167-0168: x 04                                                               # bundleSize: 16
-# Offsets table
-0168-0169: x 01                                                               # encoding: 1b
-0169-0170: x 00                                                               # data[0] = 0 [52 overall]
-0170-0171: x 00                                                               # data[1] = 0 [52 overall]
-0171-0172: x 01                                                               # data[2] = 1 [53 overall]
-0172-0173: x 02                                                               # data[3] = 2 [54 overall]
-# Data
-0173-0173: x                                                                  # data[00]:  (block prefix)
-0173-0173: x                                                                  # data[01]:  (bundle prefix)
-0173-0174: x 64                                                               # data[02]: d
-0174-0175: x 65                                                               # data[03]: e
-# data for column 1
-# rawbytes
-# offsets table
-0175-0176: x 00                                                               # encoding: zero
-# data
-0176-0176: x                                                                  # data[0]:
-0176-0176: x                                                                  # data[1]:
-# data for column 2
-0176-0177: x 80                                                               # encoding: const
-0177-0185: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-0185-0186: x 00                                                               # bitmap encoding
-0186-0193: x 00000000000000                                                   # padding to align to 64-bit boundary
-0193-0201: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0201-0209: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-0209-0210: x 01                                                               # encoding: 1b
-0210-0211: x 00                                                               # data[0] = 0 [92 overall]
-0211-0212: x 0b                                                               # data[1] = 11 [103 overall]
-0212-0213: x 15                                                               # data[2] = 21 [113 overall]
-# data
-0213-0224: x 647261676f6e6672756974                                           # data[0]: dragonfruit
-0224-0234: x 656c6465726265727279                                             # data[1]: elderberry
-# data for column 5
-0234-0235: x 01                                                               # bitmap encoding
-# data for column 6
-0235-0236: x 01                                                               # bitmap encoding
-0236-0237: x 00                                                               # block padding byte
-0237-0242: x 007d1e6fd5                                                       # data block trailer
-# block 2 data (0242-0359)
-# data block header
-0242-0246: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0246-0247: x 01                                                               # version 1
-0247-0249: x 0700                                                             # 7 columns
-0249-0253: x 03000000                                                         # 3 rows
-0253-0254: b 00000100                                                         # col 0: prefixbytes
-0254-0258: x 2e000000                                                         # col 0: page start 46
-0258-0259: b 00000011                                                         # col 1: bytes
-0259-0263: x 38000000                                                         # col 1: page start 56
-0263-0264: b 00000010                                                         # col 2: uint
-0264-0268: x 39000000                                                         # col 2: page start 57
-0268-0269: b 00000001                                                         # col 3: bool
-0269-0273: x 42000000                                                         # col 3: page start 66
-0273-0274: b 00000011                                                         # col 4: bytes
-0274-0278: x 58000000                                                         # col 4: page start 88
-0278-0279: b 00000001                                                         # col 5: bool
-0279-0283: x 72000000                                                         # col 5: page start 114
-0283-0284: b 00000001                                                         # col 6: bool
-0284-0288: x 73000000                                                         # col 6: page start 115
-# data for column 0
-# PrefixBytes
-0288-0289: x 04                                                               # bundleSize: 16
-# Offsets table
-0289-0290: x 01                                                               # encoding: 1b
-0290-0291: x 00                                                               # data[0] = 0 [53 overall]
-0291-0292: x 00                                                               # data[1] = 0 [53 overall]
-0292-0293: x 01                                                               # data[2] = 1 [54 overall]
-0293-0294: x 02                                                               # data[3] = 2 [55 overall]
-0294-0295: x 03                                                               # data[4] = 3 [56 overall]
-# Data
-0295-0295: x                                                                  # data[00]:  (block prefix)
-0295-0295: x                                                                  # data[01]:  (bundle prefix)
-0295-0296: x 66                                                               # data[02]: f
-0296-0297: x 67                                                               # data[03]: g
-0297-0298: x 68                                                               # data[04]: h
-# data for column 1
-# rawbytes
-# offsets table
-0298-0299: x 00                                                               # encoding: zero
-# data
-0299-0299: x                                                                  # data[0]:
-0299-0299: x                                                                  # data[1]:
-0299-0299: x                                                                  # data[2]:
-# data for column 2
-0299-0300: x 80                                                               # encoding: const
-0300-0308: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-0308-0309: x 00                                                               # bitmap encoding
-0309-0314: x 0000000000                                                       # padding to align to 64-bit boundary
-0314-0322: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0322-0330: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-0330-0331: x 01                                                               # encoding: 1b
-0331-0332: x 00                                                               # data[0] = 0 [93 overall]
-0332-0333: x 03                                                               # data[1] = 3 [96 overall]
-0333-0334: x 0d                                                               # data[2] = 13 [106 overall]
-0334-0335: x 15                                                               # data[3] = 21 [114 overall]
-# data
-0335-0338: x 666967                                                           # data[0]: fig
-0338-0348: x 67726170656672756974                                             # data[1]: grapefruit
-0348-0356: x 686f6e6579646577                                                 # data[2]: honeydew
-# data for column 5
-0356-0357: x 01                                                               # bitmap encoding
-# data for column 6
-0357-0358: x 01                                                               # bitmap encoding
-0358-0359: x 00                                                               # block padding byte
-0359-0364: x 00c6ef4ef7                                                       # data block trailer
-# block 3 data (0364-0477)
-# data block header
-0364-0368: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0368-0369: x 01                                                               # version 1
-0369-0371: x 0700                                                             # 7 columns
-0371-0375: x 03000000                                                         # 3 rows
-0375-0376: b 00000100                                                         # col 0: prefixbytes
-0376-0380: x 2e000000                                                         # col 0: page start 46
-0380-0381: b 00000011                                                         # col 1: bytes
-0381-0385: x 38000000                                                         # col 1: page start 56
-0385-0386: b 00000010                                                         # col 2: uint
-0386-0390: x 39000000                                                         # col 2: page start 57
-0390-0391: b 00000001                                                         # col 3: bool
-0391-0395: x 42000000                                                         # col 3: page start 66
-0395-0396: b 00000011                                                         # col 4: bytes
-0396-0400: x 58000000                                                         # col 4: page start 88
-0400-0401: b 00000001                                                         # col 5: bool
-0401-0405: x 6e000000                                                         # col 5: page start 110
-0405-0406: b 00000001                                                         # col 6: bool
-0406-0410: x 6f000000                                                         # col 6: page start 111
-# data for column 0
-# PrefixBytes
-0410-0411: x 04                                                               # bundleSize: 16
-# Offsets table
-0411-0412: x 01                                                               # encoding: 1b
-0412-0413: x 00                                                               # data[0] = 0 [53 overall]
-0413-0414: x 00                                                               # data[1] = 0 [53 overall]
-0414-0415: x 01                                                               # data[2] = 1 [54 overall]
-0415-0416: x 02                                                               # data[3] = 2 [55 overall]
-0416-0417: x 03                                                               # data[4] = 3 [56 overall]
-# Data
-0417-0417: x                                                                  # data[00]:  (block prefix)
-0417-0417: x                                                                  # data[01]:  (bundle prefix)
-0417-0418: x 69                                                               # data[02]: i
-0418-0419: x 6a                                                               # data[03]: j
-0419-0420: x 6b                                                               # data[04]: k
-# data for column 1
-# rawbytes
-# offsets table
-0420-0421: x 00                                                               # encoding: zero
-# data
-0421-0421: x                                                                  # data[0]:
-0421-0421: x                                                                  # data[1]:
-0421-0421: x                                                                  # data[2]:
-# data for column 2
-0421-0422: x 80                                                               # encoding: const
-0422-0430: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-0430-0431: x 00                                                               # bitmap encoding
-0431-0436: x 0000000000                                                       # padding to align to 64-bit boundary
-0436-0444: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0444-0452: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-0452-0453: x 01                                                               # encoding: 1b
-0453-0454: x 00                                                               # data[0] = 0 [93 overall]
-0454-0455: x 04                                                               # data[1] = 4 [97 overall]
-0455-0456: x 0d                                                               # data[2] = 13 [106 overall]
-0456-0457: x 11                                                               # data[3] = 17 [110 overall]
-# data
-0457-0461: x 696d6265                                                         # data[0]: imbe
-0461-0470: x 6a61636b6672756974                                               # data[1]: jackfruit
-0470-0474: x 6b697769                                                         # data[2]: kiwi
-# data for column 5
-0474-0475: x 01                                                               # bitmap encoding
-# data for column 6
-0475-0476: x 01                                                               # bitmap encoding
-0476-0477: x 00                                                               # block padding byte
-0477-0482: x 0006f8d16c                                                       # data block trailer
-# block 4 data (0482-0597)
-# data block header
-0482-0486: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0486-0487: x 01                                                               # version 1
-0487-0489: x 0700                                                             # 7 columns
-0489-0493: x 03000000                                                         # 3 rows
-0493-0494: b 00000100                                                         # col 0: prefixbytes
-0494-0498: x 2e000000                                                         # col 0: page start 46
-0498-0499: b 00000011                                                         # col 1: bytes
-0499-0503: x 38000000                                                         # col 1: page start 56
-0503-0504: b 00000010                                                         # col 2: uint
-0504-0508: x 39000000                                                         # col 2: page start 57
-0508-0509: b 00000001                                                         # col 3: bool
-0509-0513: x 42000000                                                         # col 3: page start 66
-0513-0514: b 00000011                                                         # col 4: bytes
-0514-0518: x 58000000                                                         # col 4: page start 88
-0518-0519: b 00000001                                                         # col 5: bool
-0519-0523: x 70000000                                                         # col 5: page start 112
-0523-0524: b 00000001                                                         # col 6: bool
-0524-0528: x 71000000                                                         # col 6: page start 113
-# data for column 0
-# PrefixBytes
-0528-0529: x 04                                                               # bundleSize: 16
-# Offsets table
-0529-0530: x 01                                                               # encoding: 1b
-0530-0531: x 00                                                               # data[0] = 0 [53 overall]
-0531-0532: x 00                                                               # data[1] = 0 [53 overall]
-0532-0533: x 01                                                               # data[2] = 1 [54 overall]
-0533-0534: x 02                                                               # data[3] = 2 [55 overall]
-0534-0535: x 03                                                               # data[4] = 3 [56 overall]
-# Data
-0535-0535: x                                                                  # data[00]:  (block prefix)
-0535-0535: x                                                                  # data[01]:  (bundle prefix)
-0535-0536: x 6c                                                               # data[02]: l
-0536-0537: x 6d                                                               # data[03]: m
-0537-0538: x 6e                                                               # data[04]: n
-# data for column 1
-# rawbytes
-# offsets table
-0538-0539: x 00                                                               # encoding: zero
-# data
-0539-0539: x                                                                  # data[0]:
-0539-0539: x                                                                  # data[1]:
-0539-0539: x                                                                  # data[2]:
-# data for column 2
-0539-0540: x 80                                                               # encoding: const
-0540-0548: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-0548-0549: x 00                                                               # bitmap encoding
-0549-0554: x 0000000000                                                       # padding to align to 64-bit boundary
-0554-0562: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0562-0570: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-0570-0571: x 01                                                               # encoding: 1b
-0571-0572: x 00                                                               # data[0] = 0 [93 overall]
-0572-0573: x 05                                                               # data[1] = 5 [98 overall]
-0573-0574: x 0a                                                               # data[2] = 10 [103 overall]
-0574-0575: x 13                                                               # data[3] = 19 [112 overall]
-# data
-0575-0580: x 6c656d6f6e                                                       # data[0]: lemon
-0580-0585: x 6d616e676f                                                       # data[1]: mango
-0585-0594: x 6e6563746172696e65                                               # data[2]: nectarine
-# data for column 5
-0594-0595: x 01                                                               # bitmap encoding
-# data for column 6
-0595-0596: x 01                                                               # bitmap encoding
-0596-0597: x 00                                                               # block padding byte
-0597-0602: x 00b8471d43                                                       # data block trailer
-# block 5 data (0602-0715)
-# data block header
-0602-0606: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0606-0607: x 01                                                               # version 1
-0607-0609: x 0700                                                             # 7 columns
-0609-0613: x 02000000                                                         # 2 rows
-0613-0614: b 00000100                                                         # col 0: prefixbytes
-0614-0618: x 2e000000                                                         # col 0: page start 46
-0618-0619: b 00000011                                                         # col 1: bytes
-0619-0623: x 36000000                                                         # col 1: page start 54
-0623-0624: b 00000010                                                         # col 2: uint
-0624-0628: x 37000000                                                         # col 2: page start 55
-0628-0629: b 00000001                                                         # col 3: bool
-0629-0633: x 40000000                                                         # col 3: page start 64
-0633-0634: b 00000011                                                         # col 4: bytes
-0634-0638: x 58000000                                                         # col 4: page start 88
-0638-0639: b 00000001                                                         # col 5: bool
-0639-0643: x 6e000000                                                         # col 5: page start 110
-0643-0644: b 00000001                                                         # col 6: bool
-0644-0648: x 6f000000                                                         # col 6: page start 111
-# data for column 0
-# PrefixBytes
-0648-0649: x 04                                                               # bundleSize: 16
-# Offsets table
-0649-0650: x 01                                                               # encoding: 1b
-0650-0651: x 00                                                               # data[0] = 0 [52 overall]
-0651-0652: x 00                                                               # data[1] = 0 [52 overall]
-0652-0653: x 01                                                               # data[2] = 1 [53 overall]
-0653-0654: x 02                                                               # data[3] = 2 [54 overall]
-# Data
-0654-0654: x                                                                  # data[00]:  (block prefix)
-0654-0654: x                                                                  # data[01]:  (bundle prefix)
-0654-0655: x 6f                                                               # data[02]: o
-0655-0656: x 70                                                               # data[03]: p
-# data for column 1
-# rawbytes
-# offsets table
-0656-0657: x 00                                                               # encoding: zero
-# data
-0657-0657: x                                                                  # data[0]:
-0657-0657: x                                                                  # data[1]:
-# data for column 2
-0657-0658: x 80                                                               # encoding: const
-0658-0666: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-0666-0667: x 00                                                               # bitmap encoding
-0667-0674: x 00000000000000                                                   # padding to align to 64-bit boundary
-0674-0682: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0682-0690: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-0690-0691: x 01                                                               # encoding: 1b
-0691-0692: x 00                                                               # data[0] = 0 [92 overall]
-0692-0693: x 06                                                               # data[1] = 6 [98 overall]
-0693-0694: x 12                                                               # data[2] = 18 [110 overall]
-# data
-0694-0700: x 6f72616e6765                                                     # data[0]: orange
-0700-0712: x 70616d706c656d6f75737365                                         # data[1]: pamplemousse
-# data for column 5
-0712-0713: x 01                                                               # bitmap encoding
-# data for column 6
-0713-0714: x 01                                                               # bitmap encoding
-0714-0715: x 00                                                               # block padding byte
-0715-0720: x 0098bca1c9                                                       # data block trailer
-# block 6 data (0720-0830)
-# data block header
-0720-0724: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0724-0725: x 01                                                               # version 1
-0725-0727: x 0700                                                             # 7 columns
-0727-0731: x 02000000                                                         # 2 rows
-0731-0732: b 00000100                                                         # col 0: prefixbytes
-0732-0736: x 2e000000                                                         # col 0: page start 46
-0736-0737: b 00000011                                                         # col 1: bytes
-0737-0741: x 36000000                                                         # col 1: page start 54
-0741-0742: b 00000010                                                         # col 2: uint
-0742-0746: x 37000000                                                         # col 2: page start 55
-0746-0747: b 00000001                                                         # col 3: bool
-0747-0751: x 40000000                                                         # col 3: page start 64
-0751-0752: b 00000011                                                         # col 4: bytes
-0752-0756: x 58000000                                                         # col 4: page start 88
-0756-0757: b 00000001                                                         # col 5: bool
-0757-0761: x 6b000000                                                         # col 5: page start 107
-0761-0762: b 00000001                                                         # col 6: bool
-0762-0766: x 6c000000                                                         # col 6: page start 108
-# data for column 0
-# PrefixBytes
-0766-0767: x 04                                                               # bundleSize: 16
-# Offsets table
-0767-0768: x 01                                                               # encoding: 1b
-0768-0769: x 00                                                               # data[0] = 0 [52 overall]
-0769-0770: x 00                                                               # data[1] = 0 [52 overall]
-0770-0771: x 01                                                               # data[2] = 1 [53 overall]
-0771-0772: x 02                                                               # data[3] = 2 [54 overall]
-# Data
-0772-0772: x                                                                  # data[00]:  (block prefix)
-0772-0772: x                                                                  # data[01]:  (bundle prefix)
-0772-0773: x 71                                                               # data[02]: q
-0773-0774: x 72                                                               # data[03]: r
-# data for column 1
-# rawbytes
-# offsets table
-0774-0775: x 00                                                               # encoding: zero
-# data
-0775-0775: x                                                                  # data[0]:
-0775-0775: x                                                                  # data[1]:
-# data for column 2
-0775-0776: x 80                                                               # encoding: const
-0776-0784: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-0784-0785: x 00                                                               # bitmap encoding
-0785-0792: x 00000000000000                                                   # padding to align to 64-bit boundary
-0792-0800: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0800-0808: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-0808-0809: x 01                                                               # encoding: 1b
-0809-0810: x 00                                                               # data[0] = 0 [92 overall]
-0810-0811: x 06                                                               # data[1] = 6 [98 overall]
-0811-0812: x 0f                                                               # data[2] = 15 [107 overall]
-# data
-0812-0818: x 7175696e6365                                                     # data[0]: quince
-0818-0827: x 726173706265727279                                               # data[1]: raspberry
-# data for column 5
-0827-0828: x 01                                                               # bitmap encoding
-# data for column 6
-0828-0829: x 01                                                               # bitmap encoding
-0829-0830: x 00                                                               # block padding byte
-0830-0835: x 008a91d79e                                                       # data block trailer
-# block 7 data (0835-0949)
-# data block header
-0835-0839: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0839-0840: x 01                                                               # version 1
-0840-0842: x 0700                                                             # 7 columns
-0842-0846: x 02000000                                                         # 2 rows
-0846-0847: b 00000100                                                         # col 0: prefixbytes
-0847-0851: x 2e000000                                                         # col 0: page start 46
-0851-0852: b 00000011                                                         # col 1: bytes
-0852-0856: x 36000000                                                         # col 1: page start 54
-0856-0857: b 00000010                                                         # col 2: uint
-0857-0861: x 37000000                                                         # col 2: page start 55
-0861-0862: b 00000001                                                         # col 3: bool
-0862-0866: x 40000000                                                         # col 3: page start 64
-0866-0867: b 00000011                                                         # col 4: bytes
-0867-0871: x 58000000                                                         # col 4: page start 88
-0871-0872: b 00000001                                                         # col 5: bool
-0872-0876: x 6f000000                                                         # col 5: page start 111
-0876-0877: b 00000001                                                         # col 6: bool
-0877-0881: x 70000000                                                         # col 6: page start 112
-# data for column 0
-# PrefixBytes
-0881-0882: x 04                                                               # bundleSize: 16
-# Offsets table
-0882-0883: x 01                                                               # encoding: 1b
-0883-0884: x 00                                                               # data[0] = 0 [52 overall]
-0884-0885: x 00                                                               # data[1] = 0 [52 overall]
-0885-0886: x 01                                                               # data[2] = 1 [53 overall]
-0886-0887: x 02                                                               # data[3] = 2 [54 overall]
-# Data
-0887-0887: x                                                                  # data[00]:  (block prefix)
-0887-0887: x                                                                  # data[01]:  (bundle prefix)
-0887-0888: x 73                                                               # data[02]: s
-0888-0889: x 74                                                               # data[03]: t
-# data for column 1
-# rawbytes
-# offsets table
-0889-0890: x 00                                                               # encoding: zero
-# data
-0890-0890: x                                                                  # data[0]:
-0890-0890: x                                                                  # data[1]:
-# data for column 2
-0890-0891: x 80                                                               # encoding: const
-0891-0899: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-0899-0900: x 00                                                               # bitmap encoding
-0900-0907: x 00000000000000                                                   # padding to align to 64-bit boundary
-0907-0915: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-0915-0923: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-0923-0924: x 01                                                               # encoding: 1b
-0924-0925: x 00                                                               # data[0] = 0 [92 overall]
-0925-0926: x 0a                                                               # data[1] = 10 [102 overall]
-0926-0927: x 13                                                               # data[2] = 19 [111 overall]
-# data
-0927-0937: x 73747261776265727279                                             # data[0]: strawberry
-0937-0946: x 74616e676572696e65                                               # data[1]: tangerine
-# data for column 5
-0946-0947: x 01                                                               # bitmap encoding
-# data for column 6
-0947-0948: x 01                                                               # bitmap encoding
-0948-0949: x 00                                                               # block padding byte
-0949-0954: x 002bb22760                                                       # data block trailer
-# block 8 data (0954-1043)
-# data block header
-0954-0958: x 01000000                                                         # maximum key length: 1
-# columnar block header
-0958-0959: x 01                                                               # version 1
-0959-0961: x 0700                                                             # 7 columns
-0961-0965: x 01000000                                                         # 1 rows
-0965-0966: b 00000100                                                         # col 0: prefixbytes
-0966-0970: x 2e000000                                                         # col 0: page start 46
-0970-0971: b 00000011                                                         # col 1: bytes
-0971-0975: x 34000000                                                         # col 1: page start 52
-0975-0976: b 00000010                                                         # col 2: uint
-0976-0980: x 35000000                                                         # col 2: page start 53
-0980-0981: b 00000001                                                         # col 3: bool
-0981-0985: x 3e000000                                                         # col 3: page start 62
-0985-0986: b 00000011                                                         # col 4: bytes
-0986-0990: x 50000000                                                         # col 4: page start 80
-0990-0991: b 00000001                                                         # col 5: bool
-0991-0995: x 56000000                                                         # col 5: page start 86
-0995-0996: b 00000001                                                         # col 6: bool
-0996-1000: x 57000000                                                         # col 6: page start 87
-# data for column 0
-# PrefixBytes
-1000-1001: x 04                                                               # bundleSize: 16
-# Offsets table
-1001-1002: x 01                                                               # encoding: 1b
-1002-1003: x 01                                                               # data[0] = 1 [52 overall]
-1003-1004: x 01                                                               # data[1] = 1 [52 overall]
-1004-1005: x 01                                                               # data[2] = 1 [52 overall]
-# Data
-1005-1006: x 75                                                               # data[00]: u (block prefix)
-1006-1006: x                                                                  # data[01]: . (bundle prefix)
-1006-1006: x                                                                  # data[02]: .
-# data for column 1
-# rawbytes
-# offsets table
-1006-1007: x 00                                                               # encoding: zero
-# data
-1007-1007: x                                                                  # data[0]:
-# data for column 2
-1007-1008: x 80                                                               # encoding: const
-1008-1016: x 0101000000000000                                                 # 64-bit constant: 257
-# data for column 3
-1016-1017: x 00                                                               # bitmap encoding
-1017-1018: x 00                                                               # padding to align to 64-bit boundary
-1018-1026: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
-1026-1034: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
-# data for column 4
-# rawbytes
-# offsets table
-1034-1035: x 01                                                               # encoding: 1b
-1035-1036: x 00                                                               # data[0] = 0 [83 overall]
-1036-1037: x 03                                                               # data[1] = 3 [86 overall]
-# data
-1037-1040: x 756d65                                                           # data[0]: ume
-# data for column 5
-1040-1041: x 01                                                               # bitmap encoding
-# data for column 6
-1041-1042: x 01                                                               # bitmap encoding
-1042-1043: x 00                                                               # block padding byte
-1043-1048: x 00e86e8c22                                                       # data block trailer
-# block 9 index (1048-1158)
-# index block header
-# columnar block header
-1048-1049: x 01                                                               # version 1
-1049-1051: x 0400                                                             # 4 columns
-1051-1055: x 04000000                                                         # 4 rows
-1055-1056: b 00000011                                                         # col 0: bytes
-1056-1060: x 1b000000                                                         # col 0: page start 27
-1060-1061: b 00000010                                                         # col 1: uint
-1061-1065: x 25000000                                                         # col 1: page start 37
-1065-1066: b 00000010                                                         # col 2: uint
-1066-1070: x 2e000000                                                         # col 2: page start 46
-1070-1071: b 00000011                                                         # col 3: bytes
-1071-1075: x 33000000                                                         # col 3: page start 51
-# data for column 0
-# rawbytes
-# offsets table
-1075-1076: x 01                                                               # encoding: 1b
-1076-1077: x 00                                                               # data[0] = 0 [33 overall]
-1077-1078: x 01                                                               # data[1] = 1 [34 overall]
-1078-1079: x 02                                                               # data[2] = 2 [35 overall]
-1079-1080: x 03                                                               # data[3] = 3 [36 overall]
-1080-1081: x 04                                                               # data[4] = 4 [37 overall]
-# data
-1081-1082: x 63                                                               # data[0]: c
-1082-1083: x 65                                                               # data[1]: e
-1083-1084: x 68                                                               # data[2]: h
-1084-1085: x 6b                                                               # data[3]: k
-# data for column 1
-1085-1086: x 02                                                               # encoding: 2b
-1086-1088: x 0000                                                             # data[0] = 0
-1088-1090: x 7900                                                             # data[1] = 121
-1090-1092: x f200                                                             # data[2] = 242
-1092-1094: x 6c01                                                             # data[3] = 364
-# data for column 2
-1094-1095: x 01                                                               # encoding: 1b
-1095-1096: x 74                                                               # data[0] = 116
-1096-1097: x 74                                                               # data[1] = 116
-1097-1098: x 75                                                               # data[2] = 117
-1098-1099: x 71                                                               # data[3] = 113
-# data for column 3
-# rawbytes
-# offsets table
-1099-1100: x 01                                                               # encoding: 1b
-1100-1101: x 00                                                               # data[0] = 0 [57 overall]
-1101-1102: x 0d                                                               # data[1] = 13 [70 overall]
-1102-1103: x 1a                                                               # data[2] = 26 [83 overall]
-1103-1104: x 27                                                               # data[3] = 39 [96 overall]
-1104-1105: x 34                                                               # data[4] = 52 [109 overall]
-# data
-1105-1118: x 000b00ffffffffffffffffff01                                       # data[0]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1118-1131: x 000b00ffffffffffffffffff01                                       # data[1]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1131-1144: x 000b00ffffffffffffffffff01                                       # data[2]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1144-1157: x 000b00ffffffffffffffffff01                                       # data[3]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1157-1158: x 00                                                               # block padding byte
-1158-1163: x 005f9cf83d                                                       # index block trailer
-# block 10 index (1163-1273)
-# index block header
-# columnar block header
-1163-1164: x 01                                                               # version 1
-1164-1166: x 0400                                                             # 4 columns
-1166-1170: x 04000000                                                         # 4 rows
-1170-1171: b 00000011                                                         # col 0: bytes
-1171-1175: x 1b000000                                                         # col 0: page start 27
-1175-1176: b 00000010                                                         # col 1: uint
-1176-1180: x 25000000                                                         # col 1: page start 37
-1180-1181: b 00000010                                                         # col 2: uint
-1181-1185: x 2e000000                                                         # col 2: page start 46
-1185-1186: b 00000011                                                         # col 3: bytes
-1186-1190: x 33000000                                                         # col 3: page start 51
-# data for column 0
-# rawbytes
-# offsets table
-1190-1191: x 01                                                               # encoding: 1b
-1191-1192: x 00                                                               # data[0] = 0 [33 overall]
-1192-1193: x 01                                                               # data[1] = 1 [34 overall]
-1193-1194: x 02                                                               # data[2] = 2 [35 overall]
-1194-1195: x 03                                                               # data[3] = 3 [36 overall]
-1195-1196: x 04                                                               # data[4] = 4 [37 overall]
-# data
-1196-1197: x 6e                                                               # data[0]: n
-1197-1198: x 70                                                               # data[1]: p
-1198-1199: x 72                                                               # data[2]: r
-1199-1200: x 74                                                               # data[3]: t
-# data for column 1
-1200-1201: x 02                                                               # encoding: 2b
-1201-1203: x e201                                                             # data[0] = 482
-1203-1205: x 5a02                                                             # data[1] = 602
-1205-1207: x d002                                                             # data[2] = 720
-1207-1209: x 4303                                                             # data[3] = 835
-# data for column 2
-1209-1210: x 01                                                               # encoding: 1b
-1210-1211: x 73                                                               # data[0] = 115
-1211-1212: x 71                                                               # data[1] = 113
-1212-1213: x 6e                                                               # data[2] = 110
-1213-1214: x 72                                                               # data[3] = 114
-# data for column 3
-# rawbytes
-# offsets table
-1214-1215: x 01                                                               # encoding: 1b
-1215-1216: x 00                                                               # data[0] = 0 [57 overall]
-1216-1217: x 0d                                                               # data[1] = 13 [70 overall]
-1217-1218: x 1a                                                               # data[2] = 26 [83 overall]
-1218-1219: x 27                                                               # data[3] = 39 [96 overall]
-1219-1220: x 34                                                               # data[4] = 52 [109 overall]
-# data
-1220-1233: x 000b00ffffffffffffffffff01                                       # data[0]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1233-1246: x 000b00ffffffffffffffffff01                                       # data[1]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1246-1259: x 000b00ffffffffffffffffff01                                       # data[2]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1259-1272: x 000b00ffffffffffffffffff01                                       # data[3]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1272-1273: x 00                                                               # block padding byte
-1273-1278: x 0064282e2b                                                       # index block trailer
-# block 11 index (1278-1337)
-# index block header
-# columnar block header
-1278-1279: x 01                                                               # version 1
-1279-1281: x 0400                                                             # 4 columns
-1281-1285: x 01000000                                                         # 1 rows
-1285-1286: b 00000011                                                         # col 0: bytes
-1286-1290: x 1b000000                                                         # col 0: page start 27
-1290-1291: b 00000010                                                         # col 1: uint
-1291-1295: x 1f000000                                                         # col 1: page start 31
-1295-1296: b 00000010                                                         # col 2: uint
-1296-1300: x 28000000                                                         # col 2: page start 40
-1300-1301: b 00000011                                                         # col 3: bytes
-1301-1305: x 2a000000                                                         # col 3: page start 42
-# data for column 0
-# rawbytes
-# offsets table
-1305-1306: x 01                                                               # encoding: 1b
-1306-1307: x 00                                                               # data[0] = 0 [30 overall]
-1307-1308: x 01                                                               # data[1] = 1 [31 overall]
-# data
-1308-1309: x 75                                                               # data[0]: u
-# data for column 1
-1309-1310: x 80                                                               # encoding: const
-1310-1318: x ba03000000000000                                                 # 64-bit constant: 954
-# data for column 2
-1318-1319: x 01                                                               # encoding: 1b
-1319-1320: x 59                                                               # data[0] = 89
-# data for column 3
-# rawbytes
-# offsets table
-1320-1321: x 01                                                               # encoding: 1b
-1321-1322: x 00                                                               # data[0] = 0 [45 overall]
-1322-1323: x 0d                                                               # data[1] = 13 [58 overall]
-# data
-1323-1336: x 000b00ffffffffffffffffff01                                       # data[0]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1336-1337: x 00                                                               # block padding byte
-1337-1342: x 00a3fd502d                                                       # index block trailer
-# block 12 top-index (1342-1438)
-# index block header
-# columnar block header
-1342-1343: x 01                                                               # version 1
-1343-1345: x 0400                                                             # 4 columns
-1345-1349: x 03000000                                                         # 3 rows
-1349-1350: b 00000011                                                         # col 0: bytes
-1350-1354: x 1b000000                                                         # col 0: page start 27
-1354-1355: b 00000010                                                         # col 1: uint
-1355-1359: x 23000000                                                         # col 1: page start 35
-1359-1360: b 00000010                                                         # col 2: uint
-1360-1364: x 2f000000                                                         # col 2: page start 47
-1364-1365: b 00000011                                                         # col 3: bytes
-1365-1369: x 33000000                                                         # col 3: page start 51
-# data for column 0
-# rawbytes
-# offsets table
-1369-1370: x 01                                                               # encoding: 1b
-1370-1371: x 00                                                               # data[0] = 0 [32 overall]
-1371-1372: x 01                                                               # data[1] = 1 [33 overall]
-1372-1373: x 02                                                               # data[2] = 2 [34 overall]
-1373-1374: x 03                                                               # data[3] = 3 [35 overall]
-# data
-1374-1375: x 6b                                                               # data[0]: k
-1375-1376: x 74                                                               # data[1]: t
-1376-1377: x 75                                                               # data[2]: u
-# data for column 1
-1377-1378: x 81                                                               # encoding: 1b,delta
-1378-1386: x 1804000000000000                                                 # 64-bit constant: 1048
-1386-1387: x 00                                                               # data[0] = 0 + 1048 = 1048
-1387-1388: x 73                                                               # data[1] = 115 + 1048 = 1163
-1388-1389: x e6                                                               # data[2] = 230 + 1048 = 1278
-# data for column 2
-1389-1390: x 01                                                               # encoding: 1b
-1390-1391: x 6e                                                               # data[0] = 110
-1391-1392: x 6e                                                               # data[1] = 110
-1392-1393: x 3b                                                               # data[2] = 59
-# data for column 3
-# rawbytes
-# offsets table
-1393-1394: x 01                                                               # encoding: 1b
-1394-1395: x 00                                                               # data[0] = 0 [56 overall]
-1395-1396: x 0d                                                               # data[1] = 13 [69 overall]
-1396-1397: x 1a                                                               # data[2] = 26 [82 overall]
-1397-1398: x 27                                                               # data[3] = 39 [95 overall]
-# data
-1398-1411: x 000b00ffffffffffffffffff01                                       # data[0]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1411-1424: x 000b00ffffffffffffffffff01                                       # data[1]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1424-1437: x 000b00ffffffffffffffffff01                                       # data[2]: "\x00\v\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"
-1437-1438: x 00                                                               # block padding byte
-1438-1443: x 0044312d46                                                       # top-index block trailer
-# block 13 properties (1443-2014)
-1443-1463: x 000c016f62736f6c6574652d6b65790100210c70                         # ...obsolete-key..!.p
-1463-1483: x 6562626c652e696e7465726e616c2e746573746b                         # ebble.internal.testk
-1483-1503: x 6579732e73756666697865730000ffffffffffff                         # eys.suffixes........
-1503-1523: x ffffff01002404726f636b7364622e626c6f636b                         # .....$.rocksdb.block
-1523-1543: x 2e62617365642e7461626c652e696e6465782e74                         # .based.table.index.t
-1543-1563: x 79706502000000080a18636f6d70617261746f72                         # ype.......comparator
-1563-1583: x 706562626c652e696e7465726e616c2e74657374                         # pebble.internal.test
-1583-1603: x 6b6579730c070d72657373696f6e4e6f436f6d70                         # keys...ressionNoComp
-1603-1623: x 72657373696f6e13085f5f6f7074696f6e737769                         # ression..__optionswi
-1623-1643: x 6e646f775f626974733d2d31343b206c6576656c                         # ndow_bits=-14; level
-1643-1663: x 3d33323736373b2073747261746567793d303b20                         # =32767; strategy=0; 
-1663-1683: x 6d61785f646963745f62797465733d303b207a73                         # max_dict_bytes=0; zs
-1683-1703: x 74645f6d61785f747261696e5f62797465733d30                         # td_max_train_bytes=0
-1703-1723: x 3b20656e61626c65643d303b2008090264617461                         # ; enabled=0; ...data
-1723-1743: x 2e73697a659808090b01656c657465642e6b6579                         # .size.....eleted.key
-1743-1763: x 7300080b0166696c7465722e73697a6500081001                         # s....filter.size....
-1763-1783: x 696e6465782e706172746974696f6e73030e0402                         # index.partitions....
-1783-1803: x 73697a658b03080e016d657267652e6f70657261                         # size.....merge.opera
-1803-1823: x 6e647300130312746f72706562626c652e636f6e                         # nds....torpebble.con
-1823-1843: x 636174656e617465080f016e756d2e646174612e                         # catenate...num.data.
-1843-1863: x 626c6f636b730c0c0701656e7472696573150c0f                         # blocks....entries...
-1863-1883: x 0172616e67652d64656c6574696f6e7300081330                         # .range-deletions...0
-1883-1903: x 70726f70657274792e636f6c6c6563746f72735b                         # property.collectors[
-1903-1923: x 706562626c652e696e7465726e616c2e74657374                         # pebble.internal.test
-1923-1943: x 6b6579732e73756666697865732c6f62736f6c65                         # keys.suffixes,obsole
-1943-1963: x 74652d6b65795d080c027261772e6b65792e7369                         # te-key]...raw.key.si
-1963-1983: x 7a65bd010c0a0276616c75652e73697a65990108                         # ze.....value.size...
-1983-2003: x 1401746f702d6c6576656c2e696e6465782e7369                         # ..top-level.index.si
-2003-2014: x 7a65000000000001000000                                           # ze.........
-2014-2019: x 0003de4235                                                       # properties block trailer
-# block 14 meta-index (2019-2052)
-2019-2039: x 001204726f636b7364622e70726f706572746965                         # meta-index
-2039-2052: x 73a30bbb040000000001000000                                       # (continued...)
-2052-2057: x 00f6a94d5e                                                       # meta-index block trailer
-# sstable footer
-2057-2058: x 01                                                               # checksum type
-2058-2060: x e30f                                                             # uvarint(2019): metaindex.Offset
-2060-2061: x 21                                                               # uvarint(33): metaindex.Length
-2061-2063: x be0a                                                             # uvarint(1342): index.Offset
-2063-2064: x 60                                                               # uvarint(96): index.Length
-2064-2084: x 0000000000000000000000000000000000000000                         # padding
-2084-2098: x 0000000000000000000000000000                                     # (continued...)
-2098-2102: x 05000000                                                         # table version
-2102-2110: x f09faab3f09faab3                                                 # magic
+ok
+
+layout
+----
+         0  data (116)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 03000000                                                         # 3 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 38000000                                                         # col 1: page start 56
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 39000000                                                         # col 2: page start 57
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 42000000                                                         # col 3: page start 66
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 71000000                                                         # col 5: page start 113
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 72000000                                                         # col 6: page start 114
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [53 overall]
+               049-050: x 00                                                               # data[1] = 0 [53 overall]
+               050-051: x 01                                                               # data[2] = 1 [54 overall]
+               051-052: x 02                                                               # data[3] = 2 [55 overall]
+               052-053: x 03                                                               # data[4] = 3 [56 overall]
+               # Data
+               053-053: x                                                                  # data[00]:  (block prefix)
+               053-053: x                                                                  # data[01]:  (bundle prefix)
+               053-054: x 61                                                               # data[02]: a
+               054-055: x 62                                                               # data[03]: b
+               055-056: x 63                                                               # data[04]: c
+               # data for column 1
+               # rawbytes
+               # offsets table
+               056-057: x 00                                                               # encoding: zero
+               # data
+               057-057: x                                                                  # data[0]:
+               057-057: x                                                                  # data[1]:
+               057-057: x                                                                  # data[2]:
+               # data for column 2
+               057-058: x 80                                                               # encoding: const
+               058-066: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               066-067: x 00                                                               # bitmap encoding
+               067-072: x 0000000000                                                       # padding to align to 64-bit boundary
+               072-080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [93 overall]
+               090-091: x 05                                                               # data[1] = 5 [98 overall]
+               091-092: x 0b                                                               # data[2] = 11 [104 overall]
+               092-093: x 14                                                               # data[3] = 20 [113 overall]
+               # data
+               093-098: x 6170706c65                                                       # data[0]: apple
+               098-104: x 62616e616e61                                                     # data[1]: banana
+               104-113: x 63616e74656c6f7065                                               # data[2]: cantelope
+               # data for column 5
+               113-114: x 01                                                               # bitmap encoding
+               # data for column 6
+               114-115: x 01                                                               # bitmap encoding
+               115-116: x 00                                                               # block padding byte
+       116    [trailer compression=none checksum=0xe7b15329]
+       121  data (116)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 02000000                                                         # 2 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 36000000                                                         # col 1: page start 54
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 37000000                                                         # col 2: page start 55
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 40000000                                                         # col 3: page start 64
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 71000000                                                         # col 5: page start 113
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 72000000                                                         # col 6: page start 114
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [52 overall]
+               049-050: x 00                                                               # data[1] = 0 [52 overall]
+               050-051: x 01                                                               # data[2] = 1 [53 overall]
+               051-052: x 02                                                               # data[3] = 2 [54 overall]
+               # Data
+               052-052: x                                                                  # data[00]:  (block prefix)
+               052-052: x                                                                  # data[01]:  (bundle prefix)
+               052-053: x 64                                                               # data[02]: d
+               053-054: x 65                                                               # data[03]: e
+               # data for column 1
+               # rawbytes
+               # offsets table
+               054-055: x 00                                                               # encoding: zero
+               # data
+               055-055: x                                                                  # data[0]:
+               055-055: x                                                                  # data[1]:
+               # data for column 2
+               055-056: x 80                                                               # encoding: const
+               056-064: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               064-065: x 00                                                               # bitmap encoding
+               065-072: x 00000000000000                                                   # padding to align to 64-bit boundary
+               072-080: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [92 overall]
+               090-091: x 0b                                                               # data[1] = 11 [103 overall]
+               091-092: x 15                                                               # data[2] = 21 [113 overall]
+               # data
+               092-103: x 647261676f6e6672756974                                           # data[0]: dragonfruit
+               103-113: x 656c6465726265727279                                             # data[1]: elderberry
+               # data for column 5
+               113-114: x 01                                                               # bitmap encoding
+               # data for column 6
+               114-115: x 01                                                               # bitmap encoding
+               115-116: x 00                                                               # block padding byte
+       237    [trailer compression=none checksum=0xd56f1e7d]
+       242  data (117)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 03000000                                                         # 3 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 38000000                                                         # col 1: page start 56
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 39000000                                                         # col 2: page start 57
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 42000000                                                         # col 3: page start 66
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 72000000                                                         # col 5: page start 114
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 73000000                                                         # col 6: page start 115
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [53 overall]
+               049-050: x 00                                                               # data[1] = 0 [53 overall]
+               050-051: x 01                                                               # data[2] = 1 [54 overall]
+               051-052: x 02                                                               # data[3] = 2 [55 overall]
+               052-053: x 03                                                               # data[4] = 3 [56 overall]
+               # Data
+               053-053: x                                                                  # data[00]:  (block prefix)
+               053-053: x                                                                  # data[01]:  (bundle prefix)
+               053-054: x 66                                                               # data[02]: f
+               054-055: x 67                                                               # data[03]: g
+               055-056: x 68                                                               # data[04]: h
+               # data for column 1
+               # rawbytes
+               # offsets table
+               056-057: x 00                                                               # encoding: zero
+               # data
+               057-057: x                                                                  # data[0]:
+               057-057: x                                                                  # data[1]:
+               057-057: x                                                                  # data[2]:
+               # data for column 2
+               057-058: x 80                                                               # encoding: const
+               058-066: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               066-067: x 00                                                               # bitmap encoding
+               067-072: x 0000000000                                                       # padding to align to 64-bit boundary
+               072-080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [93 overall]
+               090-091: x 03                                                               # data[1] = 3 [96 overall]
+               091-092: x 0d                                                               # data[2] = 13 [106 overall]
+               092-093: x 15                                                               # data[3] = 21 [114 overall]
+               # data
+               093-096: x 666967                                                           # data[0]: fig
+               096-106: x 67726170656672756974                                             # data[1]: grapefruit
+               106-114: x 686f6e6579646577                                                 # data[2]: honeydew
+               # data for column 5
+               114-115: x 01                                                               # bitmap encoding
+               # data for column 6
+               115-116: x 01                                                               # bitmap encoding
+               116-117: x 00                                                               # block padding byte
+       359    [trailer compression=none checksum=0xf74eefc6]
+       364  data (113)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 03000000                                                         # 3 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 38000000                                                         # col 1: page start 56
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 39000000                                                         # col 2: page start 57
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 42000000                                                         # col 3: page start 66
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 6e000000                                                         # col 5: page start 110
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 6f000000                                                         # col 6: page start 111
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [53 overall]
+               049-050: x 00                                                               # data[1] = 0 [53 overall]
+               050-051: x 01                                                               # data[2] = 1 [54 overall]
+               051-052: x 02                                                               # data[3] = 2 [55 overall]
+               052-053: x 03                                                               # data[4] = 3 [56 overall]
+               # Data
+               053-053: x                                                                  # data[00]:  (block prefix)
+               053-053: x                                                                  # data[01]:  (bundle prefix)
+               053-054: x 69                                                               # data[02]: i
+               054-055: x 6a                                                               # data[03]: j
+               055-056: x 6b                                                               # data[04]: k
+               # data for column 1
+               # rawbytes
+               # offsets table
+               056-057: x 00                                                               # encoding: zero
+               # data
+               057-057: x                                                                  # data[0]:
+               057-057: x                                                                  # data[1]:
+               057-057: x                                                                  # data[2]:
+               # data for column 2
+               057-058: x 80                                                               # encoding: const
+               058-066: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               066-067: x 00                                                               # bitmap encoding
+               067-072: x 0000000000                                                       # padding to align to 64-bit boundary
+               072-080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [93 overall]
+               090-091: x 04                                                               # data[1] = 4 [97 overall]
+               091-092: x 0d                                                               # data[2] = 13 [106 overall]
+               092-093: x 11                                                               # data[3] = 17 [110 overall]
+               # data
+               093-097: x 696d6265                                                         # data[0]: imbe
+               097-106: x 6a61636b6672756974                                               # data[1]: jackfruit
+               106-110: x 6b697769                                                         # data[2]: kiwi
+               # data for column 5
+               110-111: x 01                                                               # bitmap encoding
+               # data for column 6
+               111-112: x 01                                                               # bitmap encoding
+               112-113: x 00                                                               # block padding byte
+       477    [trailer compression=none checksum=0x6cd1f806]
+       482  data (115)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 03000000                                                         # 3 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 38000000                                                         # col 1: page start 56
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 39000000                                                         # col 2: page start 57
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 42000000                                                         # col 3: page start 66
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 70000000                                                         # col 5: page start 112
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 71000000                                                         # col 6: page start 113
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [53 overall]
+               049-050: x 00                                                               # data[1] = 0 [53 overall]
+               050-051: x 01                                                               # data[2] = 1 [54 overall]
+               051-052: x 02                                                               # data[3] = 2 [55 overall]
+               052-053: x 03                                                               # data[4] = 3 [56 overall]
+               # Data
+               053-053: x                                                                  # data[00]:  (block prefix)
+               053-053: x                                                                  # data[01]:  (bundle prefix)
+               053-054: x 6c                                                               # data[02]: l
+               054-055: x 6d                                                               # data[03]: m
+               055-056: x 6e                                                               # data[04]: n
+               # data for column 1
+               # rawbytes
+               # offsets table
+               056-057: x 00                                                               # encoding: zero
+               # data
+               057-057: x                                                                  # data[0]:
+               057-057: x                                                                  # data[1]:
+               057-057: x                                                                  # data[2]:
+               # data for column 2
+               057-058: x 80                                                               # encoding: const
+               058-066: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               066-067: x 00                                                               # bitmap encoding
+               067-072: x 0000000000                                                       # padding to align to 64-bit boundary
+               072-080: b 0000011100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [93 overall]
+               090-091: x 05                                                               # data[1] = 5 [98 overall]
+               091-092: x 0a                                                               # data[2] = 10 [103 overall]
+               092-093: x 13                                                               # data[3] = 19 [112 overall]
+               # data
+               093-098: x 6c656d6f6e                                                       # data[0]: lemon
+               098-103: x 6d616e676f                                                       # data[1]: mango
+               103-112: x 6e6563746172696e65                                               # data[2]: nectarine
+               # data for column 5
+               112-113: x 01                                                               # bitmap encoding
+               # data for column 6
+               113-114: x 01                                                               # bitmap encoding
+               114-115: x 00                                                               # block padding byte
+       597    [trailer compression=none checksum=0x431d47b8]
+       602  data (113)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 02000000                                                         # 2 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 36000000                                                         # col 1: page start 54
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 37000000                                                         # col 2: page start 55
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 40000000                                                         # col 3: page start 64
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 6e000000                                                         # col 5: page start 110
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 6f000000                                                         # col 6: page start 111
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [52 overall]
+               049-050: x 00                                                               # data[1] = 0 [52 overall]
+               050-051: x 01                                                               # data[2] = 1 [53 overall]
+               051-052: x 02                                                               # data[3] = 2 [54 overall]
+               # Data
+               052-052: x                                                                  # data[00]:  (block prefix)
+               052-052: x                                                                  # data[01]:  (bundle prefix)
+               052-053: x 6f                                                               # data[02]: o
+               053-054: x 70                                                               # data[03]: p
+               # data for column 1
+               # rawbytes
+               # offsets table
+               054-055: x 00                                                               # encoding: zero
+               # data
+               055-055: x                                                                  # data[0]:
+               055-055: x                                                                  # data[1]:
+               # data for column 2
+               055-056: x 80                                                               # encoding: const
+               056-064: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               064-065: x 00                                                               # bitmap encoding
+               065-072: x 00000000000000                                                   # padding to align to 64-bit boundary
+               072-080: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [92 overall]
+               090-091: x 06                                                               # data[1] = 6 [98 overall]
+               091-092: x 12                                                               # data[2] = 18 [110 overall]
+               # data
+               092-098: x 6f72616e6765                                                     # data[0]: orange
+               098-110: x 70616d706c656d6f75737365                                         # data[1]: pamplemousse
+               # data for column 5
+               110-111: x 01                                                               # bitmap encoding
+               # data for column 6
+               111-112: x 01                                                               # bitmap encoding
+               112-113: x 00                                                               # block padding byte
+       715    [trailer compression=none checksum=0xc9a1bc98]
+       720  data (110)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 02000000                                                         # 2 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 36000000                                                         # col 1: page start 54
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 37000000                                                         # col 2: page start 55
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 40000000                                                         # col 3: page start 64
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 6b000000                                                         # col 5: page start 107
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 6c000000                                                         # col 6: page start 108
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [52 overall]
+               049-050: x 00                                                               # data[1] = 0 [52 overall]
+               050-051: x 01                                                               # data[2] = 1 [53 overall]
+               051-052: x 02                                                               # data[3] = 2 [54 overall]
+               # Data
+               052-052: x                                                                  # data[00]:  (block prefix)
+               052-052: x                                                                  # data[01]:  (bundle prefix)
+               052-053: x 71                                                               # data[02]: q
+               053-054: x 72                                                               # data[03]: r
+               # data for column 1
+               # rawbytes
+               # offsets table
+               054-055: x 00                                                               # encoding: zero
+               # data
+               055-055: x                                                                  # data[0]:
+               055-055: x                                                                  # data[1]:
+               # data for column 2
+               055-056: x 80                                                               # encoding: const
+               056-064: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               064-065: x 00                                                               # bitmap encoding
+               065-072: x 00000000000000                                                   # padding to align to 64-bit boundary
+               072-080: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [92 overall]
+               090-091: x 06                                                               # data[1] = 6 [98 overall]
+               091-092: x 0f                                                               # data[2] = 15 [107 overall]
+               # data
+               092-098: x 7175696e6365                                                     # data[0]: quince
+               098-107: x 726173706265727279                                               # data[1]: raspberry
+               # data for column 5
+               107-108: x 01                                                               # bitmap encoding
+               # data for column 6
+               108-109: x 01                                                               # bitmap encoding
+               109-110: x 00                                                               # block padding byte
+       830    [trailer compression=none checksum=0x9ed7918a]
+       835  data (114)
+               # data block header
+               000-004: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               004-005: x 01                                                               # version 1
+               005-007: x 0700                                                             # 7 columns
+               007-011: x 02000000                                                         # 2 rows
+               011-012: b 00000100                                                         # col 0: prefixbytes
+               012-016: x 2e000000                                                         # col 0: page start 46
+               016-017: b 00000011                                                         # col 1: bytes
+               017-021: x 36000000                                                         # col 1: page start 54
+               021-022: b 00000010                                                         # col 2: uint
+               022-026: x 37000000                                                         # col 2: page start 55
+               026-027: b 00000001                                                         # col 3: bool
+               027-031: x 40000000                                                         # col 3: page start 64
+               031-032: b 00000011                                                         # col 4: bytes
+               032-036: x 58000000                                                         # col 4: page start 88
+               036-037: b 00000001                                                         # col 5: bool
+               037-041: x 6f000000                                                         # col 5: page start 111
+               041-042: b 00000001                                                         # col 6: bool
+               042-046: x 70000000                                                         # col 6: page start 112
+               # data for column 0
+               # PrefixBytes
+               046-047: x 04                                                               # bundleSize: 16
+               # Offsets table
+               047-048: x 01                                                               # encoding: 1b
+               048-049: x 00                                                               # data[0] = 0 [52 overall]
+               049-050: x 00                                                               # data[1] = 0 [52 overall]
+               050-051: x 01                                                               # data[2] = 1 [53 overall]
+               051-052: x 02                                                               # data[3] = 2 [54 overall]
+               # Data
+               052-052: x                                                                  # data[00]:  (block prefix)
+               052-052: x                                                                  # data[01]:  (bundle prefix)
+               052-053: x 73                                                               # data[02]: s
+               053-054: x 74                                                               # data[03]: t
+               # data for column 1
+               # rawbytes
+               # offsets table
+               054-055: x 00                                                               # encoding: zero
+               # data
+               055-055: x                                                                  # data[0]:
+               055-055: x                                                                  # data[1]:
+               # data for column 2
+               055-056: x 80                                                               # encoding: const
+               056-064: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               064-065: x 00                                                               # bitmap encoding
+               065-072: x 00000000000000                                                   # padding to align to 64-bit boundary
+               072-080: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               080-088: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               088-089: x 01                                                               # encoding: 1b
+               089-090: x 00                                                               # data[0] = 0 [92 overall]
+               090-091: x 0a                                                               # data[1] = 10 [102 overall]
+               091-092: x 13                                                               # data[2] = 19 [111 overall]
+               # data
+               092-102: x 73747261776265727279                                             # data[0]: strawberry
+               102-111: x 74616e676572696e65                                               # data[1]: tangerine
+               # data for column 5
+               111-112: x 01                                                               # bitmap encoding
+               # data for column 6
+               112-113: x 01                                                               # bitmap encoding
+               113-114: x 00                                                               # block padding byte
+       949    [trailer compression=none checksum=0x6027b22b]
+       954  data (89)
+               # data block header
+               00-04: x 01000000                                                         # maximum key length: 1
+               # columnar block header
+               04-05: x 01                                                               # version 1
+               05-07: x 0700                                                             # 7 columns
+               07-11: x 01000000                                                         # 1 rows
+               11-12: b 00000100                                                         # col 0: prefixbytes
+               12-16: x 2e000000                                                         # col 0: page start 46
+               16-17: b 00000011                                                         # col 1: bytes
+               17-21: x 34000000                                                         # col 1: page start 52
+               21-22: b 00000010                                                         # col 2: uint
+               22-26: x 35000000                                                         # col 2: page start 53
+               26-27: b 00000001                                                         # col 3: bool
+               27-31: x 3e000000                                                         # col 3: page start 62
+               31-32: b 00000011                                                         # col 4: bytes
+               32-36: x 50000000                                                         # col 4: page start 80
+               36-37: b 00000001                                                         # col 5: bool
+               37-41: x 56000000                                                         # col 5: page start 86
+               41-42: b 00000001                                                         # col 6: bool
+               42-46: x 57000000                                                         # col 6: page start 87
+               # data for column 0
+               # PrefixBytes
+               46-47: x 04                                                               # bundleSize: 16
+               # Offsets table
+               47-48: x 01                                                               # encoding: 1b
+               48-49: x 01                                                               # data[0] = 1 [52 overall]
+               49-50: x 01                                                               # data[1] = 1 [52 overall]
+               50-51: x 01                                                               # data[2] = 1 [52 overall]
+               # Data
+               51-52: x 75                                                               # data[00]: u (block prefix)
+               52-52: x                                                                  # data[01]: . (bundle prefix)
+               52-52: x                                                                  # data[02]: .
+               # data for column 1
+               # rawbytes
+               # offsets table
+               52-53: x 00                                                               # encoding: zero
+               # data
+               53-53: x                                                                  # data[0]:
+               # data for column 2
+               53-54: x 80                                                               # encoding: const
+               54-62: x 0101000000000000                                                 # 64-bit constant: 257
+               # data for column 3
+               62-63: x 00                                                               # bitmap encoding
+               63-64: x 00                                                               # padding to align to 64-bit boundary
+               64-72: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+               72-80: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+               # data for column 4
+               # rawbytes
+               # offsets table
+               80-81: x 01                                                               # encoding: 1b
+               81-82: x 00                                                               # data[0] = 0 [83 overall]
+               82-83: x 03                                                               # data[1] = 3 [86 overall]
+               # data
+               83-86: x 756d65                                                           # data[0]: ume
+               # data for column 5
+               86-87: x 01                                                               # bitmap encoding
+               # data for column 6
+               87-88: x 01                                                               # bitmap encoding
+               88-89: x 00                                                               # block padding byte
+      1043    [trailer compression=none checksum=0x228c6ee8]
+      1048  index (110)
+         0    block:0/116
+         1    block:121/116
+         2    block:242/117
+         3    block:364/113
+      1158    [trailer compression=none checksum=0x3df89c5f]
+      1163  index (110)
+         0    block:482/115
+         1    block:602/113
+         2    block:720/110
+         3    block:835/114
+      1273    [trailer compression=none checksum=0x2b2e2864]
+      1278  index (59)
+         0    block:954/89
+      1337    [trailer compression=none checksum=0x2d50fda3]
+      1342  top-index (96)
+         0    block:1048/110
+         1    block:1163/110
+         2    block:1278/59
+      1438    [trailer compression=none checksum=0x462d3144]
+      1443  properties (571)
+      1443    obsolete-key (16) [restart]
+      1459    pebble.internal.testkeys.suffixes (48)
+      1507    rocksdb.block.based.table.index.type (43)
+      1550    rocksdb.comparator (37)
+      1587    rocksdb.compression (23)
+      1610    rocksdb.compression_options (106)
+      1716    rocksdb.data.size (14)
+      1730    rocksdb.deleted.keys (15)
+      1745    rocksdb.filter.size (15)
+      1760    rocksdb.index.partitions (20)
+      1780    rocksdb.index.size (9)
+      1789    rocksdb.merge.operands (18)
+      1807    rocksdb.merge.operator (24)
+      1831    rocksdb.num.data.blocks (19)
+      1850    rocksdb.num.entries (11)
+      1861    rocksdb.num.range-deletions (19)
+      1880    rocksdb.property.collectors (70)
+      1950    rocksdb.raw.key.size (17)
+      1967    rocksdb.raw.value.size (15)
+      1982    rocksdb.top-level.index.size (24)
+      2006    [restart 1443]
+      2014    [trailer compression=none checksum=0x3542de03]
+      2019  meta-index (33)
+      2019    rocksdb.properties block:1443/571 [restart]
+      2044    [restart 2019]
+      2052    [trailer compression=none checksum=0x5e4da9f6]
+      2057  footer (53)
+      2057    checksum type: crc32c
+      2058    meta: offset=2019, length=33
+      2061    index: offset=1342, length=96
+      2064    [padding]
+      2098    version: 5
+      2102    magic number: 0xf09faab3f09faab3
+      2110  EOF
 
 open
 ----
@@ -1932,119 +1660,97 @@ EncodeSpan: a-b:{(#10,RANGEDEL)}
 rangedel: [a#10,RANGEDEL-b#inf,RANGEDEL]
 seqnums:  [10-10]
 
-describe-binary
+open
 ----
-# block 0 index (0000-0028)
-# index block header
-# columnar block header
-000-001: x 01                                       # version 1
-001-003: x 0400                                     # 4 columns
-003-007: x 00000000                                 # 0 rows
-007-008: b 00000011                                 # col 0: bytes
-008-012: x 1b000000                                 # col 0: page start 27
-012-013: b 00000010                                 # col 1: uint
-013-017: x 1b000000                                 # col 1: page start 27
-017-018: b 00000010                                 # col 2: uint
-018-022: x 1b000000                                 # col 2: page start 27
-022-023: b 00000011                                 # col 3: bytes
-023-027: x 1b000000                                 # col 3: page start 27
-# data for column 0
-# data for column 1
-# data for column 2
-# data for column 3
-027-028: x 00                                       # block padding byte
-028-033: x 00f2727db9                               # index block trailer
-# block 1 range-del (0033-0090)
-# keyspan block header
-033-037: x 02000000                                 # user key count: 2
-# columnar block header
-037-038: x 01                                       # version 1
-038-040: x 0500                                     # 5 columns
-040-044: x 01000000                                 # 1 rows
-044-045: b 00000011                                 # col 0: bytes
-045-049: x 24000000                                 # col 0: page start 36
-049-050: b 00000010                                 # col 1: uint
-050-054: x 2a000000                                 # col 1: page start 42
-054-055: b 00000010                                 # col 2: uint
-055-059: x 2d000000                                 # col 2: page start 45
-059-060: b 00000011                                 # col 3: bytes
-060-064: x 36000000                                 # col 3: page start 54
-064-065: b 00000011                                 # col 4: bytes
-065-069: x 37000000                                 # col 4: page start 55
-# data for column 0
-# rawbytes
-# offsets table
-069-070: x 01                                       # encoding: 1b
-070-071: x 00                                       # data[0] = 0 [40 overall]
-071-072: x 01                                       # data[1] = 1 [41 overall]
-072-073: x 02                                       # data[2] = 2 [42 overall]
-# data
-073-074: x 61                                       # data[0]: a
-074-075: x 62                                       # data[1]: b
-# data for column 1
-075-076: x 01                                       # encoding: 1b
-076-077: x 00                                       # data[0] = 0
-077-078: x 01                                       # data[1] = 1
-# data for column 2
-078-079: x 80                                       # encoding: const
-079-087: x 0f0a000000000000                         # 64-bit constant: 2575
-# data for column 3
-# rawbytes
-# offsets table
-087-088: x 00                                       # encoding: zero
-# data
-088-088: x                                          # data[0]:
-# data for column 4
-# rawbytes
-# offsets table
-088-089: x 00                                       # encoding: zero
-# data
-089-089: x                                          # data[0]:
-089-090: x 00                                       # block padding byte
-090-095: x 0049ef6fdf                               # range-del block trailer
-# block 2 properties (0095-0614)
-095-115: x 000c026f62736f6c6574652d6b65790174002101 # ...obsolete-key.t.!.
-115-135: x 706562626c652e696e7465726e616c2e74657374 # pebble.internal.test
-135-155: x 6b6579732e737566666978657300002404726f63 # keys.suffixes..$.roc
-155-175: x 6b7364622e626c6f636b2e62617365642e746162 # ksdb.block.based.tab
-175-195: x 6c652e696e6465782e7479706500000000080a18 # le.index.type.......
-195-215: x 636f6d70617261746f72706562626c652e696e74 # comparatorpebble.int
-215-235: x 65726e616c2e746573746b6579730c070d726573 # ernal.testkeys...res
-235-255: x 73696f6e4e6f436f6d7072657373696f6e13085f # sionNoCompression.._
-255-275: x 5f6f7074696f6e7377696e646f775f626974733d # _optionswindow_bits=
-275-295: x 2d31343b206c6576656c3d33323736373b207374 # -14; level=32767; st
-295-315: x 7261746567793d303b206d61785f646963745f62 # rategy=0; max_dict_b
-315-335: x 797465733d303b207a7374645f6d61785f747261 # ytes=0; zstd_max_tra
-335-355: x 696e5f62797465733d303b20656e61626c65643d # in_bytes=0; enabled=
-355-375: x 303b20080901646174612e73697a6500090b0165 # 0; ...data.size....e
-375-395: x 6c657465642e6b65797301080b0166696c746572 # leted.keys....filter
-395-415: x 2e73697a6500080a01696e6465782e73697a6521 # .size....index.size!
-415-435: x 080e016d657267652e6f706572616e6473001303 # ...merge.operands...
-435-455: x 12746f72706562626c652e636f6e636174656e61 # .torpebble.concatena
-455-475: x 7465080f016e756d2e646174612e626c6f636b73 # te...num.data.blocks
-475-495: x 000c0701656e7472696573010c0f0172616e6765 # ....entries....range
-495-515: x 2d64656c6574696f6e730108133070726f706572 # -deletions...0proper
-515-535: x 74792e636f6c6c6563746f72735b706562626c65 # ty.collectors[pebble
-535-555: x 2e696e7465726e616c2e746573746b6579732e73 # .internal.testkeys.s
-555-575: x 756666697865732c6f62736f6c6574652d6b6579 # uffixes,obsolete-key
-575-595: x 5d080c017261772e6b65792e73697a65020c0a01 # ]...raw.key.size....
-595-614: x 76616c75652e73697a65000000000001000000   # value.size.........
-614-619: x 0079b98f3c                               # properties block trailer
-# block 3 meta-index (0619-0678)
-619-639: x 001203726f636b7364622e70726f706572746965 # meta-index
-639-659: x 735f8704001202726f636b7364622e72616e6765 # (continued...)
-659-678: x 5f64656c322139000000001800000002000000   # (continued...)
-678-683: x 0054fc106f                               # meta-index block trailer
-# sstable footer
-683-684: x 01                                       # checksum type
-684-686: x eb04                                     # uvarint(619): metaindex.Offset
-686-687: x 3b                                       # uvarint(59): metaindex.Length
-687-688: x 00                                       # uvarint(0): index.Offset
-688-689: x 1c                                       # uvarint(28): index.Length
-689-709: x 0000000000000000000000000000000000000000 # padding
-709-724: x 000000000000000000000000000000           # (continued...)
-724-728: x 05000000                                 # table version
-728-736: x f09faab3f09faab3                         # magic
+ok
+
+layout
+----
+         0  index (28)
+        28    [trailer compression=none checksum=0xb97d72f2]
+        33  range-del (57)
+               # keyspan block header
+               00-04: x 02000000         # user key count: 2
+               # columnar block header
+               04-05: x 01               # version 1
+               05-07: x 0500             # 5 columns
+               07-11: x 01000000         # 1 rows
+               11-12: b 00000011         # col 0: bytes
+               12-16: x 24000000         # col 0: page start 36
+               16-17: b 00000010         # col 1: uint
+               17-21: x 2a000000         # col 1: page start 42
+               21-22: b 00000010         # col 2: uint
+               22-26: x 2d000000         # col 2: page start 45
+               26-27: b 00000011         # col 3: bytes
+               27-31: x 36000000         # col 3: page start 54
+               31-32: b 00000011         # col 4: bytes
+               32-36: x 37000000         # col 4: page start 55
+               # data for column 0
+               # rawbytes
+               # offsets table
+               36-37: x 01               # encoding: 1b
+               37-38: x 00               # data[0] = 0 [40 overall]
+               38-39: x 01               # data[1] = 1 [41 overall]
+               39-40: x 02               # data[2] = 2 [42 overall]
+               # data
+               40-41: x 61               # data[0]: a
+               41-42: x 62               # data[1]: b
+               # data for column 1
+               42-43: x 01               # encoding: 1b
+               43-44: x 00               # data[0] = 0
+               44-45: x 01               # data[1] = 1
+               # data for column 2
+               45-46: x 80               # encoding: const
+               46-54: x 0f0a000000000000 # 64-bit constant: 2575
+               # data for column 3
+               # rawbytes
+               # offsets table
+               54-55: x 00               # encoding: zero
+               # data
+               55-55: x                  # data[0]:
+               # data for column 4
+               # rawbytes
+               # offsets table
+               55-56: x 00               # encoding: zero
+               # data
+               56-56: x                  # data[0]:
+               56-57: x 00               # block padding byte
+        90    [trailer compression=none checksum=0xdf6fef49]
+        95  properties (519)
+        95    obsolete-key (17) [restart]
+       112    pebble.internal.testkeys.suffixes (37)
+       149    rocksdb.block.based.table.index.type (43)
+       192    rocksdb.comparator (37)
+       229    rocksdb.compression (23)
+       252    rocksdb.compression_options (106)
+       358    rocksdb.data.size (13)
+       371    rocksdb.deleted.keys (15)
+       386    rocksdb.filter.size (15)
+       401    rocksdb.index.size (14)
+       415    rocksdb.merge.operands (18)
+       433    rocksdb.merge.operator (24)
+       457    rocksdb.num.data.blocks (19)
+       476    rocksdb.num.entries (11)
+       487    rocksdb.num.range-deletions (19)
+       506    rocksdb.property.collectors (70)
+       576    rocksdb.raw.key.size (16)
+       592    rocksdb.raw.value.size (14)
+       606    [restart 95]
+       614    [trailer compression=none checksum=0x3c8fb979]
+       619  meta-index (59)
+       619    rocksdb.properties block:95/519 [restart]
+       643    rocksdb.range_del2 block:33/57 [restart]
+       666    [restart 619]
+       670    [restart 643]
+       678    [trailer compression=none checksum=0x6f10fc54]
+       683  footer (53)
+       683    checksum type: crc32c
+       684    meta: offset=619, length=59
+       687    index: offset=0, length=28
+       689    [padding]
+       724    version: 5
+       728    magic number: 0xf09faab3f09faab3
+       736  EOF
 
 # Test a sstable containing only range keys.
 
@@ -2055,134 +1761,112 @@ EncodeSpan: b-c:{(#9,RANGEKEYDEL)}
 rangekey: [a#10,RANGEKEYSET-c#inf,RANGEKEYDEL]
 seqnums:  [9-10]
 
-describe-binary
+open
 ----
-# block 0 index (0000-0028)
-# index block header
-# columnar block header
-000-001: x 01                                       # version 1
-001-003: x 0400                                     # 4 columns
-003-007: x 00000000                                 # 0 rows
-007-008: b 00000011                                 # col 0: bytes
-008-012: x 1b000000                                 # col 0: page start 27
-012-013: b 00000010                                 # col 1: uint
-013-017: x 1b000000                                 # col 1: page start 27
-017-018: b 00000010                                 # col 2: uint
-018-022: x 1b000000                                 # col 2: page start 27
-022-023: b 00000011                                 # col 3: bytes
-023-027: x 1b000000                                 # col 3: page start 27
-# data for column 0
-# data for column 1
-# data for column 2
-# data for column 3
-027-028: x 00                                       # block padding byte
-028-033: x 00f2727db9                               # index block trailer
-# block 1 range-key (0033-0101)
-# keyspan block header
-033-037: x 03000000                                 # user key count: 3
-# columnar block header
-037-038: x 01                                       # version 1
-038-040: x 0500                                     # 5 columns
-040-044: x 02000000                                 # 2 rows
-044-045: b 00000011                                 # col 0: bytes
-045-049: x 24000000                                 # col 0: page start 36
-049-050: b 00000010                                 # col 1: uint
-050-054: x 2c000000                                 # col 1: page start 44
-054-055: b 00000010                                 # col 2: uint
-055-059: x 30000000                                 # col 2: page start 48
-059-060: b 00000011                                 # col 3: bytes
-060-064: x 36000000                                 # col 3: page start 54
-064-065: b 00000011                                 # col 4: bytes
-065-069: x 3c000000                                 # col 4: page start 60
-# data for column 0
-# rawbytes
-# offsets table
-069-070: x 01                                       # encoding: 1b
-070-071: x 00                                       # data[0] = 0 [41 overall]
-071-072: x 01                                       # data[1] = 1 [42 overall]
-072-073: x 02                                       # data[2] = 2 [43 overall]
-073-074: x 03                                       # data[3] = 3 [44 overall]
-# data
-074-075: x 61                                       # data[0]: a
-075-076: x 62                                       # data[1]: b
-076-077: x 63                                       # data[2]: c
-# data for column 1
-077-078: x 01                                       # encoding: 1b
-078-079: x 00                                       # data[0] = 0
-079-080: x 01                                       # data[1] = 1
-080-081: x 02                                       # data[2] = 2
-# data for column 2
-081-082: x 02                                       # encoding: 2b
-082-083: x 00                                       # padding (aligning to 16-bit boundary)
-083-085: x 150a                                     # data[0] = 2581
-085-087: x 1309                                     # data[1] = 2323
-# data for column 3
-# rawbytes
-# offsets table
-087-088: x 01                                       # encoding: 1b
-088-089: x 00                                       # data[0] = 0 [58 overall]
-089-090: x 02                                       # data[1] = 2 [60 overall]
-090-091: x 02                                       # data[2] = 2 [60 overall]
-# data
-091-093: x 4035                                     # data[0]: @5
-093-093: x                                          # data[1]:
-# data for column 4
-# rawbytes
-# offsets table
-093-094: x 01                                       # encoding: 1b
-094-095: x 00                                       # data[0] = 0 [64 overall]
-095-096: x 03                                       # data[1] = 3 [67 overall]
-096-097: x 03                                       # data[2] = 3 [67 overall]
-# data
-097-100: x 666f6f                                   # data[0]: foo
-100-100: x                                          # data[1]:
-100-101: x 00                                       # block padding byte
-101-106: x 00e75b3245                               # range-key block trailer
-# block 2 properties (0106-0707)
-106-126: x 000c026f62736f6c6574652d6b65790174002103 # ...obsolete-key.t.!.
-126-146: x 706562626c652e696e7465726e616c2e74657374 # pebble.internal.test
-146-166: x 6b6579732e73756666697865730005010712016e # keys.suffixes......n
-166-186: x 756d2e72616e67652d6b65792d64656c73011504 # um.range-key-dels...
-186-206: x 017365747301150601756e736574730007160172 # .sets....unsets....r
-206-226: x 61772e72616e67652d6b65792e6b65792e73697a # aw.range-key.key.siz
-226-246: x 6504150a0176616c75652e73697a650300240472 # e....value.size..$.r
-246-266: x 6f636b7364622e626c6f636b2e62617365642e74 # ocksdb.block.based.t
-266-286: x 61626c652e696e6465782e747970650000000008 # able.index.type.....
-286-306: x 0a18636f6d70617261746f72706562626c652e69 # ..comparatorpebble.i
-306-326: x 6e7465726e616c2e746573746b6579730c070d72 # nternal.testkeys...r
-326-346: x 657373696f6e4e6f436f6d7072657373696f6e13 # essionNoCompression.
-346-366: x 085f5f6f7074696f6e7377696e646f775f626974 # .__optionswindow_bit
-366-386: x 733d2d31343b206c6576656c3d33323736373b20 # s=-14; level=32767; 
-386-406: x 73747261746567793d303b206d61785f64696374 # strategy=0; max_dict
-406-426: x 5f62797465733d303b207a7374645f6d61785f74 # _bytes=0; zstd_max_t
-426-446: x 7261696e5f62797465733d303b20656e61626c65 # rain_bytes=0; enable
-446-466: x 643d303b20080901646174612e73697a6500090b # d=0; ...data.size...
-466-486: x 01656c657465642e6b65797300080b0166696c74 # .eleted.keys....filt
-486-506: x 65722e73697a6500080a01696e6465782e73697a # er.size....index.siz
-506-526: x 6521080e016d657267652e6f706572616e647300 # e!...merge.operands.
-526-546: x 130312746f72706562626c652e636f6e63617465 # ...torpebble.concate
-546-566: x 6e617465080f016e756d2e646174612e626c6f63 # nate...num.data.bloc
-566-586: x 6b73000c0701656e7472696573000c0f0172616e # ks....entries....ran
-586-606: x 67652d64656c6574696f6e730008133070726f70 # ge-deletions...0prop
-606-626: x 657274792e636f6c6c6563746f72735b70656262 # erty.collectors[pebb
-626-646: x 6c652e696e7465726e616c2e746573746b657973 # le.internal.testkeys
-646-666: x 2e73756666697865732c6f62736f6c6574652d6b # .suffixes,obsolete-k
-666-686: x 65795d080c017261772e6b65792e73697a65000c # ey]...raw.key.size..
-686-706: x 0a0176616c75652e73697a650000000000010000 # ..value.size........
-706-707: x 00                                       # .
-707-712: x 00753aab4b                               # properties block trailer
-# block 3 meta-index (0712-0769)
-712-732: x 001002706562626c652e72616e67655f6b657921 # meta-index
-732-752: x 44001203726f636b7364622e70726f7065727469 # (continued...)
-752-769: x 65736ad904000000001500000002000000       # (continued...)
-769-774: x 00ca19728f                               # meta-index block trailer
-# sstable footer
-774-775: x 01                                       # checksum type
-775-777: x c805                                     # uvarint(712): metaindex.Offset
-777-778: x 39                                       # uvarint(57): metaindex.Length
-778-779: x 00                                       # uvarint(0): index.Offset
-779-780: x 1c                                       # uvarint(28): index.Length
-780-800: x 0000000000000000000000000000000000000000 # padding
-800-815: x 000000000000000000000000000000           # (continued...)
-815-819: x 05000000                                 # table version
-819-827: x f09faab3f09faab3                         # magic
+ok
+
+layout
+----
+         0  index (28)
+        28    [trailer compression=none checksum=0xb97d72f2]
+        33  range-key (68)
+               # keyspan block header
+               00-04: x 03000000 # user key count: 3
+               # columnar block header
+               04-05: x 01       # version 1
+               05-07: x 0500     # 5 columns
+               07-11: x 02000000 # 2 rows
+               11-12: b 00000011 # col 0: bytes
+               12-16: x 24000000 # col 0: page start 36
+               16-17: b 00000010 # col 1: uint
+               17-21: x 2c000000 # col 1: page start 44
+               21-22: b 00000010 # col 2: uint
+               22-26: x 30000000 # col 2: page start 48
+               26-27: b 00000011 # col 3: bytes
+               27-31: x 36000000 # col 3: page start 54
+               31-32: b 00000011 # col 4: bytes
+               32-36: x 3c000000 # col 4: page start 60
+               # data for column 0
+               # rawbytes
+               # offsets table
+               36-37: x 01       # encoding: 1b
+               37-38: x 00       # data[0] = 0 [41 overall]
+               38-39: x 01       # data[1] = 1 [42 overall]
+               39-40: x 02       # data[2] = 2 [43 overall]
+               40-41: x 03       # data[3] = 3 [44 overall]
+               # data
+               41-42: x 61       # data[0]: a
+               42-43: x 62       # data[1]: b
+               43-44: x 63       # data[2]: c
+               # data for column 1
+               44-45: x 01       # encoding: 1b
+               45-46: x 00       # data[0] = 0
+               46-47: x 01       # data[1] = 1
+               47-48: x 02       # data[2] = 2
+               # data for column 2
+               48-49: x 02       # encoding: 2b
+               49-50: x 00       # padding (aligning to 16-bit boundary)
+               50-52: x 150a     # data[0] = 2581
+               52-54: x 1309     # data[1] = 2323
+               # data for column 3
+               # rawbytes
+               # offsets table
+               54-55: x 01       # encoding: 1b
+               55-56: x 00       # data[0] = 0 [58 overall]
+               56-57: x 02       # data[1] = 2 [60 overall]
+               57-58: x 02       # data[2] = 2 [60 overall]
+               # data
+               58-60: x 4035     # data[0]: @5
+               60-60: x          # data[1]:
+               # data for column 4
+               # rawbytes
+               # offsets table
+               60-61: x 01       # encoding: 1b
+               61-62: x 00       # data[0] = 0 [64 overall]
+               62-63: x 03       # data[1] = 3 [67 overall]
+               63-64: x 03       # data[2] = 3 [67 overall]
+               # data
+               64-67: x 666f6f   # data[0]: foo
+               67-67: x          # data[1]:
+               67-68: x 00       # block padding byte
+       101    [trailer compression=none checksum=0x45325be7]
+       106  properties (601)
+       106    obsolete-key (17) [restart]
+       123    pebble.internal.testkeys.suffixes (39)
+       162    pebble.num.range-key-dels (22)
+       184    pebble.num.range-key-sets (8)
+       192    pebble.num.range-key-unsets (10)
+       202    pebble.raw.range-key.key.size (26)
+       228    pebble.raw.range-key.value.size (14)
+       242    rocksdb.block.based.table.index.type (43)
+       285    rocksdb.comparator (37)
+       322    rocksdb.compression (23)
+       345    rocksdb.compression_options (106)
+       451    rocksdb.data.size (13)
+       464    rocksdb.deleted.keys (15)
+       479    rocksdb.filter.size (15)
+       494    rocksdb.index.size (14)
+       508    rocksdb.merge.operands (18)
+       526    rocksdb.merge.operator (24)
+       550    rocksdb.num.data.blocks (19)
+       569    rocksdb.num.entries (11)
+       580    rocksdb.num.range-deletions (19)
+       599    rocksdb.property.collectors (70)
+       669    rocksdb.raw.key.size (16)
+       685    rocksdb.raw.value.size (14)
+       699    [restart 106]
+       707    [trailer compression=none checksum=0x4bab3a75]
+       712  meta-index (57)
+       712    pebble.range_key block:33/68 [restart]
+       733    rocksdb.properties block:106/601 [restart]
+       757    [restart 712]
+       761    [restart 733]
+       769    [trailer compression=none checksum=0x8f7219ca]
+       774  footer (53)
+       774    checksum type: crc32c
+       775    meta: offset=712, length=57
+       778    index: offset=0, length=28
+       780    [padding]
+       815    version: 5
+       819    magic number: 0xf09faab3f09faab3
+       827  EOF


### PR DESCRIPTION
This directive is very similar to `layout` and we don't need both.