### PR TITLE
sstable: fix colblk copyDataBlocks off-by-one

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1139,7 +1139,7 @@ func (w *RawColumnWriter) copyDataBlocks(
 	// blocks in one IO request as possible, while still utilizing the write queue in this
 	// writer.
 	lastBlockOffset := uint64(0)
-	for i := 0; i < len(blocks); i++ {
+	for i := 0; i < len(blocks); {
 		if blocks[i].bh.Offset < lastBlockOffset {
 			panic("pebble: copyDataBlocks called with blocks out of order")
 		}


### PR DESCRIPTION
We would skip one data block if we exceeded the size of the buffer.