### PR TITLE
colblk: fix UintBuilder inconsistent size bug

### DIFF
--- a/sstable/colblk/testdata/uints
+++ b/sstable/colblk/testdata/uints
@@ -9,7 +9,7 @@
 init default-zero
 ----
 
-size rows=(100)
+size rows=100
 ----
 Size(100, 0) = 1
 
@@ -532,10 +532,44 @@ uints
 init
 ----
 
-size rows=(0) offset=0
+size rows=0 offset=0
 ----
 Size(0, 0) = 0
 
 finish rows=0 offset=0
 ----
 uints
+
+init default-zero
+----
+
+write
+0:1000000
+1:1000010
+2:1000020
+3:1000030
+4:1000040
+----
+
+size rows=4 offset=0
+----
+Size(4, 0) = 20
+
+# Write a row that changes the encoding.
+write
+5:44333222111
+----
+
+size rows=4 offset=0
+----
+Size(4, 0) = 13
+
+finish rows=4 offset=0
+----
+uints
+ ├── 00-01: x 81               # encoding: 1b,delta
+ ├── 01-09: x 40420f0000000000 # 64-bit constant: 1000000
+ ├── 09-10: x 00               # data[0] = 0 + 1000000 = 1000000
+ ├── 10-11: x 0a               # data[1] = 10 + 1000000 = 1000010
+ ├── 11-12: x 14               # data[2] = 20 + 1000000 = 1000020
+ └── 12-13: x 1e               # data[3] = 30 + 1000000 = 1000030

--- a/sstable/colblk/testdata/uints
+++ b/sstable/colblk/testdata/uints
@@ -551,6 +551,7 @@ write
 4:1000040
 ----
 
+# The encoding pessimistically assumes that we may have a 0 value.
 size rows=4 offset=0
 ----
 Size(4, 0) = 20
@@ -560,16 +561,17 @@ write
 5:44333222111
 ----
 
+# Make sure the encoding hasn't changed.
 size rows=4 offset=0
 ----
-Size(4, 0) = 13
+Size(4, 0) = 20
 
 finish rows=4 offset=0
 ----
 uints
- ├── 00-01: x 81               # encoding: 1b,delta
- ├── 01-09: x 40420f0000000000 # 64-bit constant: 1000000
- ├── 09-10: x 00               # data[0] = 0 + 1000000 = 1000000
- ├── 10-11: x 0a               # data[1] = 10 + 1000000 = 1000010
- ├── 11-12: x 14               # data[2] = 20 + 1000000 = 1000020
- └── 12-13: x 1e               # data[3] = 30 + 1000000 = 1000030
+ ├── 00-01: x 04       # encoding: 4b
+ ├── 01-04: x 000000   # padding (aligning to 32-bit boundary)
+ ├── 04-08: x 40420f00 # data[0] = 1000000
+ ├── 08-12: x 4a420f00 # data[1] = 1000010
+ ├── 12-16: x 54420f00 # data[2] = 1000020
+ └── 16-20: x 5e420f00 # data[3] = 1000030

--- a/sstable/colblk/uints.go
+++ b/sstable/colblk/uints.go
@@ -283,6 +283,12 @@ func (b *UintBuilder) determineEncoding(rows int) (_ UintEncoding, minimum uint6
 
 	// We have to recalculate the minimum and maximum.
 	minimum, maximum := computeMinMax(b.array.elems.Slice(rows))
+	if b.useDefault {
+		// Mirror the pessimism of the fast path so that the result is consistent.
+		// Otherwise, adding a row can result in a different encoding even when not
+		// including that row.
+		minimum = 0
+	}
 	return DetermineUintEncoding(minimum, maximum), minimum
 }
 

--- a/sstable/colblk/uints.go
+++ b/sstable/colblk/uints.go
@@ -271,6 +271,13 @@ func (b *UintBuilder) determineEncoding(rows int) (_ UintEncoding, minimum uint6
 	if b.stats.encodingRow < rows {
 		// b.delta.encoding became the current value within the first [rows], so we
 		// can use it.
+		//
+		// Note that if useDefault is set, this encoding assumes there is at least
+		// one element with the default (zero) value, which might be pessimistic.
+		//
+		// Note that b.stats.minimum includes all rows set so far so it might be
+		// strictly smaller than all values up to [rows]; but it is still a suitable
+		// base for b.stats.encoding.
 		return b.stats.encoding, b.stats.minimum
 	}
 


### PR DESCRIPTION
#### colblk: add test demonstrating Size bug

UintBuilder has a clever fast path for determining the current
encoding. The fast path is a bit pessimistic when we are
useing the "default" mode: it assumes that there will be at least one
value of 0.

The "slow" path is not pessimistic and thus the results might not be
consistent depending on which path is taken. This is a problem because
we could get the Size, add a row, then get the Size for the previous
number of rows again; now we no longer use the fast path and can get a
different result if all the rows have been set to non-zero values.

This commit adds a test that demonstrates this issue.

#### colblk: fix UintBuilder inconsistent size bug

This commit fixes the UintBuilder bug described in the previous
commit. We make the non-fast-path consistent with the fast path so
that the encoding can't change unexpectedly.