### PR TITLE
internal/crdbtest: use the key seeker pool

### DIFF
--- a/internal/crdbtest/crdbtest.go
+++ b/internal/crdbtest/crdbtest.go
@@ -516,7 +516,7 @@ var KeySchema = colblk.KeySchema{
 		return kw
 	},
 	NewKeySeeker: func() colblk.KeySeeker {
-		return &cockroachKeySeeker{}
+		return cockroachKeySeekerPool.Get().(*cockroachKeySeeker)
 	},
 }
 


### PR DESCRIPTION
Previously crdbtest.KeySchema.NewKeySeeker did not make use of the pool when allocating new key seekers.