### PR TITLE
db: delete compactions output in case of late cancellation

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -470,6 +470,12 @@ func (b *FileBacking) Ref() {
 	b.refs.Add(1)
 }
 
+// IsUnused returns if the backing is not being used by any tables in a version
+// or btree.
+func (b *FileBacking) IsUnused() bool {
+	return b.refs.Load() == 0
+}
+
 // Unref decrements the backing's ref count (and returns the new count).
 func (b *FileBacking) Unref() int32 {
 	v := b.refs.Add(-1)

--- a/internal/manifest/virtual_backings.go
+++ b/internal/manifest/virtual_backings.go
@@ -99,7 +99,7 @@ type backingWithMetadata struct {
 }
 
 // AddAndRef adds a new backing to the set and takes a reference on it. Another
-// backing for the same DiskFilNum must not exist.
+// backing for the same DiskFileNum must not exist.
 //
 // The added backing is unused until it is associated with a table via AddTable
 // or protected via Protect.


### PR DESCRIPTION
Previously, if we had a late cancellation of a compaction (ie. right before we were gonna logAndApply), we would end up not marking compaction outputs as obsolete/zombie, and neither would we delete them rightaway. This change updates the compaction running code to also clean up compaction outputs in this case of compaction cancellation.

Fixes cockroachdb/cockroach#132668.