### PR TITLE
db: drop hints that produce too many virtual sstables

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2113,9 +2113,9 @@ func checkDeleteCompactionHints(
 		}
 		if filesDeletedByCurrentHint < 0 {
 			// This hint does not delete a sufficient number of files to warrant
-			// a delete-only compaction at this stage. Add it to unresolvedHints
-			// so it can be re-evaluated later.
-			unresolvedHints = append(unresolvedHints, h)
+			// a delete-only compaction at this stage. Drop it (ie. don't add it
+			// to either resolved or unresolved hints) so it doesn't stick around
+			// forever.
 			continue
 		}
 		// This hint will be resolved and dropped.

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -677,7 +677,7 @@ o: (o, .)
 maybe-compact
 ----
 Deletion hints:
-  L0.000005 l-m seqnums(tombstone=11-11, file-smallest=10, type=point-and-range-key)
+  (none)
 Compactions:
   (none)
 
@@ -701,4 +701,4 @@ o: (o, .)
 
 get-hints
 ----
-L0.000005 l-m seqnums(tombstone=11-11, file-smallest=10, type=point-and-range-key)
+(none)


### PR DESCRIPTION
Previously we kept around hints that were creating too many virtual sstables instead of dropping them. This change drops them to save future compaction pickers from having to iterate over them.

Fixes #4055.