### PR TITLE
sstable: add jemalloc size classes to tests

### DIFF
--- a/options.go
+++ b/options.go
@@ -1188,6 +1188,9 @@ type WALFailoverOptions struct {
 // ReadaheadConfig controls the use of read-ahead.
 type ReadaheadConfig = objstorageprovider.ReadaheadConfig
 
+// JemallocSizeClasses exports sstable.JemallocSizeClasses.
+var JemallocSizeClasses = sstable.JemallocSizeClasses
+
 // DebugCheckLevels calls CheckLevels on the provided database.
 // It may be set in the DebugCheck field of Options to check
 // level invariants whenever a new version is installed.

--- a/sstable/block/testdata/flush_governor
+++ b/sstable/block/testdata/flush_governor
@@ -84,3 +84,26 @@ init target-block-size=1000 size-class-aware-threshold=60 size-classes=(500, 600
 low watermark: 600
 high watermark: 1018
 boundaries: [818 868 918 968]
+
+# Test with jemalloc boundaries.
+init target-block-size=32768 jemalloc-size-classes
+----
+low watermark: 19661
+high watermark: 40928
+boundaries: [20448 24544 28640 32736]
+
+# We should flush to avoid exceeding the boundary.
+should-flush size-before=32000 size-after=32766
+----
+should flush
+
+# We should not flush since we waste less space against the 40KiB boundary.
+should-flush size-before=30000 size-after=39000
+----
+should not flush
+
+# We should flush even if we would waste less space against the 48KiB boundary
+# (it's not the first boundary after the target size).
+should-flush size-before=39000 size-after=48500
+----
+should flush

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -302,6 +302,23 @@ type WriterOptions struct {
 	disableObsoleteCollector bool
 }
 
+// JemallocSizeClasses are a subset of available size classes in jemalloc[1],
+// suitable for the AllocatorSizeClasses option.
+//
+// The size classes are used when writing sstables for determining target block
+// sizes for flushes, with the goal of reducing internal memory fragmentation
+// when the blocks are later loaded into the block cache. We only use the size
+// classes between 16KiB - 256KiB as block limits fall in that range.
+//
+// [1] https://jemalloc.net/jemalloc.3.html#size_classes
+var JemallocSizeClasses = []int{
+	16 * 1024,
+	20 * 1024, 24 * 1024, 28 * 1024, 32 * 1024, // 4KiB spacing
+	40 * 1024, 48 * 1024, 56 * 1024, 64 * 1024, // 8KiB spacing
+	80 * 1024, 96 * 1024, 112 * 1024, 128 * 1024, // 16KiB spacing.
+	160 * 1024, 192 * 1024, 224 * 1024, 256 * 1024, // 32KiB spacing.
+}
+
 // SetInternal sets the internal writer options. Note that even though this
 // method is public, a caller outside the pebble package can't construct a value
 // to pass to it.


### PR DESCRIPTION
We add some tests with the jemalloc size classes and add them to the
metamorphic test as well. We will update the crdb code to use
`pebble.JemallocSizeClasses`.