### PR TITLE
db: fix Options.Parse handling of unrecognized comparer

### DIFF
--- a/options.go
+++ b/options.go
@@ -1667,7 +1667,11 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 					}
 				}
 			case "comparer":
-				o.Comparer, err = parseComparer(value)
+				var comparer *Comparer
+				comparer, err = parseComparer(value)
+				if comparer != nil {
+					o.Comparer = comparer
+				}
 			case "compaction_debt_concurrency":
 				o.Experimental.CompactionDebtConcurrency, err = strconv.ParseUint(value, 10, 64)
 			case "delete_range_flush_delay":

--- a/options_test.go
+++ b/options_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/wal"
 	"github.com/stretchr/testify/require"
@@ -315,6 +316,16 @@ func TestOptionsParse(t *testing.T) {
 			require.NotEqual(t, newCacheSize, 0)
 		})
 	}
+}
+
+func TestOptionsParseComparerOverwrite(t *testing.T) {
+	// Test that an unrecognized comparer in the OPTIONS file does not nil out
+	// the Comparer field.
+	o := &Options{Comparer: testkeys.Comparer}
+	err := o.Parse(`[Options]
+comparer=unrecognized`, nil)
+	require.NoError(t, err)
+	require.Equal(t, testkeys.Comparer, o.Comparer)
 }
 
 func TestOptionsValidate(t *testing.T) {


### PR DESCRIPTION
In b3993ff the behavior of Options.Parse when no NewComparer hook is provided changed. Parse began to nil out the Comparer field, clearing any existing Comparer.

Thanks @RaduBerinde for spotting this.