### PR TITLE
sstable: cache DataBlockDecoder alongside data blocks

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -831,8 +831,8 @@ func TestMemTableReservation(t *testing.T) {
 		t.Fatalf("expected 2 refs, but found %d", refs)
 	}
 	// Verify the memtable reservation has caused our test block to be evicted.
-	if h := opts.Cache.Get(tmpID, base.DiskFileNum(0), 0); h.Get() != nil {
-		t.Fatalf("expected failure, but found success: %s", h.Get())
+	if h := opts.Cache.Get(tmpID, base.DiskFileNum(0), 0); h.Valid() {
+		t.Fatalf("expected failure, but found success: %#v", h)
 	}
 
 	// Flush the memtable. The memtable reservation should double because old

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -683,7 +683,9 @@ type Cache struct {
 	}
 }
 
-// TODO
+// ID is a namespace for file numbers. It allows a single Cache to be shared
+// among multiple Pebble instances. NewID can be used to generate a new ID that
+// is unique in the context of this cache.
 type ID uint64
 
 // New creates a new cache of the specified size. Memory for the cache is

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -59,14 +59,19 @@ type Handle struct {
 	value *Value
 }
 
-// Get returns the value stored in handle.
-func (h Handle) Get() []byte {
-	if h.value != nil {
-		// NB: We don't increment shard.hits in this code path because we only want
-		// to record a hit when the handle is retrieved from the cache.
-		return h.value.buf
-	}
-	return nil
+// Valid returns true if the handle holds a value.
+func (h Handle) Valid() bool {
+	return h.value != nil
+}
+
+// RawBuffer returns the value buffer. Note that this buffer holds the block
+// metadata and the data and should be used through a block.BufferHandle.
+//
+// RawBuffer can only be called if the handle is Valid().
+func (h Handle) RawBuffer() []byte {
+	// NB: We don't increment shard.hits in this code path because we only want
+	// to record a hit when the handle is retrieved from the cache.
+	return h.value.buf
 }
 
 // Release releases the reference to the cache entry.

--- a/internal/crdbtest/crdbtest_test.go
+++ b/internal/crdbtest/crdbtest_test.go
@@ -6,6 +6,7 @@ package crdbtest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/rand/v2"
 	"slices"
@@ -15,7 +16,12 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/cache"
+	"github.com/cockroachdb/pebble/internal/sstableinternal"
 	"github.com/cockroachdb/pebble/internal/testutils"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/stretchr/testify/require"
 )
 
 func TestComparer(t *testing.T) {
@@ -121,4 +127,123 @@ func TestDataDriven(t *testing.T) {
 		}
 		return buf.String()
 	})
+}
+
+func BenchmarkRandSeekInSST(b *testing.B) {
+	configs := []struct {
+		name     string
+		numKeys  int
+		valueLen int
+		version  sstable.TableFormat
+	}{
+		{
+			name:     "v4/single-level",
+			numKeys:  200 * 100, // ~100 data blocks.
+			valueLen: 128,       // ~200 KVs per data block
+			version:  sstable.TableFormatPebblev4,
+		},
+		{
+			name:     "v4/two-level",
+			numKeys:  200 * 5000, // ~5000 data blocks
+			valueLen: 128,        // ~200 KVs per data block
+			version:  sstable.TableFormatPebblev4,
+		},
+		{
+			name:     "v5/single-level",
+			numKeys:  200 * 100, // ~100 data blocks.
+			valueLen: 128,       // ~200 KVs per data block
+			version:  sstable.TableFormatPebblev5,
+		},
+		{
+			name:     "v5/two-level",
+			numKeys:  200 * 5000, // ~5000 data blocks
+			valueLen: 128,        // ~200 KVs per data block
+			version:  sstable.TableFormatPebblev5,
+		},
+	}
+	keyCfg := KeyConfig{
+		PrefixAlphabetLen: 26,
+		PrefixLen:         12,
+		PrefixLenShared:   4,
+		AvgKeysPerPrefix:  1,
+		BaseWallTime:      uint64(time.Now().UnixNano()),
+	}
+	rng := rand.New(rand.NewPCG(0, rand.Uint64()))
+	for _, cfg := range configs {
+		o := sstable.WriterOptions{
+			BlockSize:            32 * 1024,
+			IndexBlockSize:       128 * 1024,
+			AllocatorSizeClasses: sstable.JemallocSizeClasses,
+			TableFormat:          cfg.version,
+			Comparer:             &Comparer,
+			KeySchema:            KeySchema,
+		}
+		b.Run(cfg.name, func(b *testing.B) {
+			benchmarkRandSeekInSST(b, rng, cfg.numKeys, keyCfg, cfg.valueLen, o)
+		})
+
+	}
+}
+
+func benchmarkRandSeekInSST(
+	b *testing.B,
+	rng *rand.Rand,
+	numKeys int,
+	keyCfg KeyConfig,
+	valueLen int,
+	writerOpts sstable.WriterOptions,
+) {
+	keys, values := RandomKVs(rng, numKeys, keyCfg, valueLen)
+	obj := &objstorage.MemObj{}
+	w := sstable.NewWriter(obj, writerOpts)
+	for i := range keys {
+		require.NoError(b, w.Set(keys[i], values[i]))
+	}
+	require.NoError(b, w.Close())
+	// Make the cache twice the size of the object, to allow for decompression and
+	// overhead.
+	c := cache.New(obj.Size() * 2)
+	defer c.Unref()
+	ctx := context.Background()
+	readerOpts := sstable.ReaderOptions{
+		Comparer:   writerOpts.Comparer,
+		KeySchemas: sstable.MakeKeySchemas(KeySchema),
+	}
+	readerOpts.SetInternalCacheOpts(sstableinternal.CacheOptions{
+		Cache:   c,
+		CacheID: c.NewID(),
+		FileNum: 1,
+	})
+	reader, err := sstable.NewReader(ctx, obj, readerOpts)
+	require.NoError(b, err)
+	defer reader.Close()
+
+	// Iterate through the entire table to warm up the cache.
+	var stats base.InternalIteratorStats
+	rp := sstable.MakeTrivialReaderProvider(reader)
+	iter, err := reader.NewPointIter(
+		ctx, sstable.NoTransforms, nil, nil, nil, sstable.NeverUseFilterBlock,
+		&stats, sstable.CategoryAndQoS{}, nil, rp)
+	require.NoError(b, err)
+	n := 0
+	for kv := iter.First(); kv != nil; kv = iter.Next() {
+		n++
+	}
+	require.Equal(b, len(keys), n)
+	require.NoError(b, iter.Close())
+
+	const numQueryKeys = 65536
+	queryKeys := RandomQueryKeys(rng, numQueryKeys, keys, keyCfg.BaseWallTime)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := queryKeys[i%numQueryKeys]
+		iter, err := reader.NewPointIter(
+			ctx, sstable.NoTransforms, nil, nil, nil, sstable.NeverUseFilterBlock,
+			&stats, sstable.CategoryAndQoS{}, nil, rp)
+		require.NoError(b, err)
+		iter.SeekGE(key, base.SeekGEFlagsNone)
+		require.NoError(b, iter.Close())
+	}
+	// Stop the timer before any deferred cleanup.
+	b.StopTimer()
 }

--- a/sstable/block/flush_governor.go
+++ b/sstable/block/flush_governor.go
@@ -38,7 +38,7 @@ const maxFlushBoundaries = 4
 // within a 1024B class. However, when loaded into the block cache we also
 // allocate space for the cache entry metadata. The new allocation may now only
 // fit within a 2048B class, which increases internal fragmentation.
-const blockAllocationOverhead = cache.ValueMetadataSize
+const blockAllocationOverhead = cache.ValueMetadataSize + MetadataSize
 
 // MakeFlushGovernor initializes a flush controller.
 //

--- a/sstable/block/testdata/flush_governor
+++ b/sstable/block/testdata/flush_governor
@@ -25,14 +25,14 @@ should-flush size-before=899 size-after=10000
 ----
 should not flush
 
-# Size classes. Note that the block allocation overhead is 32.
-init target-block-size=1000 size-class-aware-threshold=60 size-classes=(500, 700, 1000, 1500)
+# Size classes. Note that the block allocation overhead is 360.
+init target-block-size=1000 size-class-aware-threshold=60 size-classes=(820, 1020, 1320, 1820)
 ----
 low watermark: 600
-high watermark: 1468
-boundaries: [668 968]
+high watermark: 1460
+boundaries: [660 960]
 
-# Should not flush at 600 if the after" block fits in the same size class
+# Should not flush when the "after" block fits in the same size class.
 should-flush size-before=600 size-after=650
 ----
 should not flush
@@ -53,12 +53,12 @@ should-flush size-before=600 size-after=1450
 ----
 should not flush
 
-# Should flush if the after size is above the high watermark.
+# Should flush when the after size is above the high watermark.
 should-flush size-before=600 size-after=1500
 ----
 should flush
 
-# Should not flush if the "before" size is below the low watermark (even when
+# Should not flush when the "before" size is below the low watermark (even when
 # the "after" size is greater than the high watermark).
 should-flush size-before=500 size-after=1500
 ----
@@ -81,16 +81,16 @@ boundaries: []
 # Verify we limit the number of boundaries to 4.
 init target-block-size=1000 size-class-aware-threshold=60 size-classes=(500, 600, 650, 700, 750, 800, 850, 900, 950, 1000, 1050)
 ----
-low watermark: 600
-high watermark: 1018
-boundaries: [818 868 918 968]
+low watermark: 900
+high watermark: 1000
+boundaries: []
 
 # Test with jemalloc boundaries.
 init target-block-size=32768 jemalloc-size-classes
 ----
 low watermark: 19661
-high watermark: 40928
-boundaries: [20448 24544 28640 32736]
+high watermark: 40600
+boundaries: [20120 24216 28312 32408]
 
 # We should flush to avoid exceeding the boundary.
 should-flush size-before=32000 size-after=32766

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -913,7 +913,7 @@ func TestBlockProperties(t *testing.T) {
 					var blocks []int
 					var i int
 					iter := r.tableFormat.newIndexIter()
-					if err := iter.Init(r.Compare, r.Split, indexH.Get(), NoTransforms); err != nil {
+					if err := iter.Init(r.Compare, r.Split, indexH.BlockData(), NoTransforms); err != nil {
 						return err.Error()
 					}
 					for valid := iter.First(); valid; valid = iter.Next() {
@@ -1278,7 +1278,7 @@ func runBlockPropsCmd(r *Reader) string {
 	defer bh.Release()
 	twoLevelIndex := r.Properties.IndexPartitions > 0
 	i := r.tableFormat.newIndexIter()
-	if err := i.Init(r.Compare, r.Split, bh.Get(), NoTransforms); err != nil {
+	if err := i.Init(r.Compare, r.Split, bh.BlockData(), NoTransforms); err != nil {
 		return err.Error()
 	}
 	var sb strings.Builder
@@ -1327,7 +1327,7 @@ func runBlockPropsCmd(r *Reader) string {
 			err = func() error {
 				defer subIndex.Release()
 				subiter := r.tableFormat.newIndexIter()
-				if err := subiter.Init(r.Compare, r.Split, subIndex.Get(), NoTransforms); err != nil {
+				if err := subiter.Init(r.Compare, r.Split, subIndex.BlockData(), NoTransforms); err != nil {
 					return err
 				}
 				for valid := subiter.First(); valid; valid = subiter.Next() {

--- a/sstable/colblk/index_block.go
+++ b/sstable/colblk/index_block.go
@@ -240,7 +240,7 @@ func (i *IndexIter) InitHandle(
 	// overhead can be material.)
 	i.h.Release()
 	i.h = blk
-	i.allocDecoder.Init(i.h.Get())
+	i.allocDecoder.Init(i.h.BlockData())
 	i.InitWithDecoder(cmp, split, &i.allocDecoder, transforms)
 	return nil
 }

--- a/sstable/colblk/index_block_test.go
+++ b/sstable/colblk/index_block_test.go
@@ -125,7 +125,7 @@ func TestIndexIterInitHandle(t *testing.T) {
 
 	getBlockAndIterate := func(it *IndexIter) {
 		h := c.Get(cache.ID(1), base.DiskFileNum(1), 0)
-		require.NotNil(t, h.Get())
+		require.True(t, h.Valid())
 		require.NoError(t, it.InitHandle(
 			testkeys.Comparer.Compare,
 			testkeys.Comparer.Split,

--- a/sstable/colblk/keyspan_test.go
+++ b/sstable/colblk/keyspan_test.go
@@ -90,7 +90,7 @@ func TestKeyspanBlockPooling(t *testing.T) {
 
 	getBlockAndIterate := func() {
 		h := c.Get(cache.ID(1), base.DiskFileNum(1), 0)
-		require.NotNil(t, h.Get())
+		require.True(t, h.Valid())
 		it := NewKeyspanIter(testkeys.Comparer.Compare, block.CacheBufferHandle(h), block.NoFragmentTransforms)
 		defer it.Close()
 		s, err := it.First()

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -202,12 +202,12 @@ func checkSingleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlo
 	obj interface{},
 ) {
 	i := obj.(*singleLevelIterator[I, PI, D, PD])
-	if p := PD(&i.data).Handle().Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.handle is not nil: %p\n", p)
+	if h := PD(&i.data).Handle(); h.Valid() {
+		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.handle is not nil: %#v\n", h)
 		os.Exit(1)
 	}
-	if p := PI(&i.index).Handle().Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.handle is not nil: %p\n", p)
+	if h := PI(&i.index).Handle(); h.Valid() {
+		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.handle is not nil: %#v\n", h)
 		os.Exit(1)
 	}
 }
@@ -216,12 +216,12 @@ func checkTwoLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockI
 	obj interface{},
 ) {
 	i := obj.(*twoLevelIterator[I, PI, D, PD])
-	if p := PD(&i.secondLevel.data).Handle().Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.handle is not nil: %p\n", p)
+	if h := PD(&i.secondLevel.data).Handle(); h.Valid() {
+		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.handle is not nil: %#v\n", h)
 		os.Exit(1)
 	}
-	if p := PI(&i.secondLevel.index).Handle().Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.handle is not nil: %p\n", p)
+	if h := PI(&i.secondLevel.index).Handle(); h.Valid() {
+		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.handle is not nil: %#v\n", h)
 		os.Exit(1)
 	}
 }

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -951,12 +951,12 @@ func (i *singleLevelIterator[I, PI, D, PD]) bloomFilterMayContain(prefix []byte)
 		}
 	}
 
-	dataH, err := i.reader.readFilterBlock(i.ctx, i.readBlockEnv, i.indexFilterRH)
+	dataH, err := i.reader.readFilterBlock(i.ctx, i.readBlockEnv, i.indexFilterRH, i.reader.filterBH)
 	if err != nil {
 		return false, err
 	}
 	defer dataH.Release()
-	return i.reader.tableFilter.mayContain(dataH.Get(), prefixToCheck), nil
+	return i.reader.tableFilter.mayContain(dataH.BlockData(), prefixToCheck), nil
 }
 
 // virtualLast should only be called if i.vReader != nil.

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -47,7 +47,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 	}
 
 	if r.tableFilter != nil {
-		dataH, err := r.readFilterBlock(context.Background(), noEnv, noReadHandle)
+		dataH, err := r.readFilterBlock(context.Background(), noEnv, noReadHandle, r.filterBH)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +57,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 		} else {
 			lookupKey = key
 		}
-		mayContain := r.tableFilter.mayContain(dataH.Get(), lookupKey)
+		mayContain := r.tableFilter.mayContain(dataH.BlockData(), lookupKey)
 		dataH.Release()
 		if !mayContain {
 			return nil, base.ErrNotFound
@@ -636,7 +636,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 	twoLevelIndex := r.Properties.IndexType == twoLevelIndex
 	buf.WriteString("index entries:\n")
 	iter := r.tableFormat.newIndexIter()
-	require.NoError(t, iter.Init(r.Compare, r.Split, indexH.Get(), NoTransforms))
+	require.NoError(t, iter.Init(r.Compare, r.Split, indexH.BlockData(), NoTransforms))
 	defer func() {
 		require.NoError(t, iter.Close())
 	}()
@@ -650,7 +650,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 			require.NoError(t, err)
 			defer b.Release()
 			iter2 := r.tableFormat.newIndexIter()
-			require.NoError(t, iter2.Init(r.Compare, r.Split, b.Get(), NoTransforms))
+			require.NoError(t, iter2.Init(r.Compare, r.Split, b.BlockData(), NoTransforms))
 			defer func() {
 				require.NoError(t, iter2.Close())
 			}()

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -413,8 +413,8 @@ func (i *fragmentIter) DebugTree(tp treeprinter.Node) {
 
 func checkFragmentBlockIterator(obj interface{}) {
 	i := obj.(*fragmentIter)
-	if p := i.blockIter.Handle().Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "fragmentBlockIter.blockIter.handle is not nil: %p\n", p)
+	if h := i.blockIter.Handle(); h.Valid() {
+		fmt.Fprintf(os.Stderr, "fragmentBlockIter.blockIter.handle is not nil: %#v\n", h)
 		os.Exit(1)
 	}
 }

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -261,7 +261,7 @@ func (i *Iter) InitHandle(
 ) error {
 	i.handle.Release()
 	i.handle = block
-	return i.Init(cmp, split, block.Get(), transforms)
+	return i.Init(cmp, split, block.BlockData(), transforms)
 }
 
 // SetHasValuePrefix sets whether or not the block iterator should expect values

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -536,7 +536,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	require.NoError(t, err)
 	defer b.Release()
 
-	i, err := rowblk.NewRawIter(bytes.Compare, b.Get())
+	i, err := rowblk.NewRawIter(bytes.Compare, b.BlockData())
 	require.NoError(t, err)
 
 	var keys []string

--- a/sstable/testdata/columnar_writer/simple_binary
+++ b/sstable/testdata/columnar_writer/simple_binary
@@ -139,7 +139,7 @@ rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
 obsolete-key: hex:01
 pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
 
-build block-size=150
+build block-size=310
 a.SET.1:apple
 b.SET.1:banana
 c.SET.1:cantelope

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -840,7 +840,7 @@ func (r *valueBlockReader) getValueInternal(handle []byte, valLen int32) (val []
 			return nil, err
 		}
 		r.vbiCache = ch
-		r.vbiBlock = ch.Get()
+		r.vbiBlock = ch.BlockData()
 	}
 	if r.valueBlock == nil || r.valueBlockNum != vh.blockNum {
 		vbh, err := r.getBlockHandle(vh.blockNum)
@@ -854,7 +854,7 @@ func (r *valueBlockReader) getValueInternal(handle []byte, valLen int32) (val []
 		r.valueBlockNum = vh.blockNum
 		r.valueCache.Release()
 		r.valueCache = vbCacheHandle
-		r.valueBlock = vbCacheHandle.Get()
+		r.valueBlock = vbCacheHandle.BlockData()
 		r.valueBlockPtr = unsafe.Pointer(&r.valueBlock[0])
 	}
 	if r.stats != nil {

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -739,8 +739,8 @@ func TestWriterClearCache(t *testing.T) {
 	// Verify that the written blocks have been cleared from the cache.
 	check := func(bh block.Handle) {
 		h := cacheOpts.Cache.Get(cacheOpts.CacheID, cacheOpts.FileNum, bh.Offset)
-		if h.Get() != nil {
-			t.Fatalf("%d: expected cache to be cleared, but found %q", bh.Offset, h.Get())
+		if h.Valid() {
+			t.Fatalf("%d: expected cache to be cleared, but found %#v", bh.Offset, h)
 		}
 	}
 	foreachBH(layout, check)

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -232,7 +232,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 2.1KB
 Compression types: snappy: 3
-Block cache: 2 entries (112B)  hit rate: 0.0%
+Block cache: 2 entries (768B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -334,7 +334,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 6
-Block cache: 6 entries (336B)  hit rate: 0.0%
+Block cache: 6 entries (2.3KB)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -53,7 +53,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 569B
 Compression types: snappy: 1
-Block cache: 3 entries (84B)  hit rate: 18.2%
+Block cache: 3 entries (1.0KB)  hit rate: 18.2%
 Table cache: 1 entries (816B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -75,7 +75,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 1
-Block cache: 2 entries (44B)  hit rate: 0.0%
+Block cache: 2 entries (700B)  hit rate: 0.0%
 Table cache: 1 entries (816B)  hit rate: 0.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -132,7 +132,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
-Block cache: 2 entries (44B)  hit rate: 33.3%
+Block cache: 2 entries (700B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -176,7 +176,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
-Block cache: 2 entries (44B)  hit rate: 33.3%
+Block cache: 2 entries (700B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -217,7 +217,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
-Block cache: 2 entries (44B)  hit rate: 33.3%
+Block cache: 2 entries (700B)  hit rate: 33.3%
 Table cache: 1 entries (816B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -495,7 +495,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 7
-Block cache: 8 entries (204B)  hit rate: 9.1%
+Block cache: 8 entries (2.8KB)  hit rate: 9.1%
 Table cache: 1 entries (816B)  hit rate: 53.8%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -559,7 +559,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Compression types: snappy: 10
-Block cache: 8 entries (204B)  hit rate: 9.1%
+Block cache: 8 entries (2.8KB)  hit rate: 9.1%
 Table cache: 1 entries (816B)  hit rate: 53.8%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -882,7 +882,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 2
-Block cache: 4 entries (116B)  hit rate: 0.0%
+Block cache: 4 entries (1.4KB)  hit rate: 0.0%
 Table cache: 1 entries (816B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -931,7 +931,7 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 3
-Block cache: 4 entries (116B)  hit rate: 0.0%
+Block cache: 4 entries (1.4KB)  hit rate: 0.0%
 Table cache: 1 entries (816B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0


### PR DESCRIPTION
We reserve a chunk of each allocation in the cache as
`block.Metadata`. We use this to cache the `colblk.DataBlockDecoder`
so we don't have to reinitialize it each time we use the block.

In subsequent changes we will also cache the key seeker and the
`IndexBlockDecoder`.