### PR TITLE
colblk: cache IndexBlockDecoder in block metadata

### DIFF
--- a/sstable/block/buffer_pool.go
+++ b/sstable/block/buffer_pool.go
@@ -38,13 +38,13 @@ func (b Value) getInternalBuf() []byte {
 	return b.v.Buf()
 }
 
-// Get returns the byte slice for the block data.
-func (b Value) Get() []byte {
+// BlockData returns the byte slice for the block data.
+func (b Value) BlockData() []byte {
 	return b.getInternalBuf()[MetadataSize:]
 }
 
 // GetMetadata returns the block metadata.
-func (b Value) GetMetadata() *Metadata {
+func (b Value) BlockMetadata() *Metadata {
 	return (*Metadata)(b.getInternalBuf())
 }
 

--- a/sstable/colblk/keyspan_test.go
+++ b/sstable/colblk/keyspan_test.go
@@ -85,7 +85,7 @@ func TestKeyspanBlockPooling(t *testing.T) {
 	c := cache.New(10 << 10)
 	defer c.Unref()
 	v := block.Alloc(len(b), nil)
-	copy(v.Get(), b)
+	copy(v.BlockData(), b)
 	v.MakeHandle(c, cache.ID(1), base.DiskFileNum(1), 0).Release()
 
 	getBlockAndIterate := func() {

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -321,7 +321,7 @@ var (
 )
 
 func formatColblkIndexBlock(tp treeprinter.Node, r *Reader, b NamedBlockHandle, data []byte) error {
-	iter := new(colblk.IndexIter)
+	var iter colblk.IndexIter
 	if err := iter.Init(r.Compare, r.Split, data, NoTransforms); err != nil {
 		return err
 	}


### PR DESCRIPTION
```
RandSeekInSST/v4/single-level-10  1.21µs ± 1%  1.25µs ± 5%   +3.40%  (p=0.005 n=8+8)
RandSeekInSST/v4/two-level-10     2.06µs ± 4%  2.06µs ± 1%     ~     (p=0.959 n=8+8)
RandSeekInSST/v5/single-level-10  1.11µs ± 1%  1.06µs ± 1%   -4.03%  (p=0.000 n=8+8)
RandSeekInSST/v5/two-level-10     1.79µs ± 5%  1.59µs ± 1%  -11.45%  (p=0.000 n=7+8)
```