### PR TITLE
crdbtest: fix MaterializeUserKey

### DIFF
--- a/internal/crdbtest/crdbtest.go
+++ b/internal/crdbtest/crdbtest.go
@@ -833,10 +833,10 @@ func (ks *cockroachKeySeeker) MaterializeUserKey(
 	}
 
 	// Inline binary.BigEndian.PutUint32.
-	*(*byte)(ptr) = byte(mvccWall >> 24)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccWall >> 16)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccWall >> 8)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccWall)
+	*(*byte)(ptr) = byte(mvccLogical >> 24)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccLogical >> 16)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccLogical >> 8)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccLogical)
 	*(*byte)(unsafe.Pointer(uintptr(ptr) + 4)) = 13
 	return ki.Buf[:len(ki.Buf)+14]
 }

--- a/sstable/colblk/cockroach_test.go
+++ b/sstable/colblk/cockroach_test.go
@@ -29,6 +29,7 @@ func TestCockroachDataBlock(t *testing.T) {
 	serializedBlock, keys, values := generateDataBlock(rng, targetBlockSize, crdbtest.KeyConfig{
 		PrefixAlphabetLen: 26,
 		PrefixLen:         12,
+		PercentLogical:    rng.IntN(25),
 		AvgKeysPerPrefix:  2,
 		BaseWallTime:      seed,
 	}, valueLen)


### PR DESCRIPTION
The KeySeeker implementation accidentally materialized four bytes of the wall time as the logical time when encoding a MVCC timestamp with a non-zero logical time.