### PR TITLE
compact: set minimum score for tombstone density compactions

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/invalidating"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
@@ -2963,6 +2964,7 @@ func runBenchmarkQueueWorkload(b *testing.B, deleteRatio float32, initOps int, v
 	}
 
 	o := (&Options{
+		Cache:              cache.New(0), // disable cache
 		DisableWAL:         true,
 		FS:                 vfs.NewMem(),
 		Comparer:           testkeys.Comparer,
@@ -3036,13 +3038,15 @@ func runBenchmarkQueueWorkload(b *testing.B, deleteRatio float32, initOps int, v
 
 	// Seek to the start of each queue.
 	b.Run("seek", func(b *testing.B) {
+		iter, _ := d.NewIter(nil)
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			for q := 0; q < queueCount; q++ {
-				iter, _ := d.NewIter(nil)
 				iter.SeekGE(getKey(q, 0))
-				require.NoError(b, iter.Close())
 			}
 		}
+		b.StopTimer()
+		require.NoError(b, iter.Close())
 	})
 
 	require.NoError(b, d.Close())
@@ -3064,7 +3068,7 @@ func BenchmarkQueueWorkload(b *testing.B) {
 	var deleteRatios = []float32{0.1, 0.3, 0.5}
 	// The number of times queues will be processed before running each
 	// subbenchmark.
-	var initOps = []int{400_000, 800_000, 1_200_000, 2_000_000, 3_500_000, 5_000_000, 7_500_000, 10_000_000, 50_000_000}
+	var initOps = []int{400_000, 800_000, 1_200_000, 2_000_000, 3_500_000, 5_000_000, 7_500_000}
 	// We vary the value size to identify how compaction behaves when the
 	// relative sizes of tombstones and the keys they delete are different.
 	var valueSizes = []int{128, 2048}

--- a/options.go
+++ b/options.go
@@ -1351,7 +1351,7 @@ func (o *Options) EnsureDefaults() *Options {
 		o.Experimental.DeletionSizeRatioThreshold = sstable.DefaultDeletionSizeRatioThreshold
 	}
 	if o.Experimental.TombstoneDenseCompactionThreshold == 0 {
-		o.Experimental.TombstoneDenseCompactionThreshold = 0.05
+		o.Experimental.TombstoneDenseCompactionThreshold = 0.10
 	}
 	if o.Experimental.TableCacheShards <= 0 {
 		o.Experimental.TableCacheShards = runtime.GOMAXPROCS(0)

--- a/options_test.go
+++ b/options_test.go
@@ -110,7 +110,7 @@ func TestOptionsString(t *testing.T) {
   read_sampling_multiplier=16
   num_deletions_threshold=100
   deletion_size_ratio_threshold=0.500000
-  tombstone_dense_compaction_threshold=0.050000
+  tombstone_dense_compaction_threshold=0.100000
   strict_wal_tail=true
   table_cache_shards=8
   validate_on_ingest=false

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -61,7 +61,7 @@ cat build/OPTIONS-000003
   read_sampling_multiplier=16
   num_deletions_threshold=100
   deletion_size_ratio_threshold=0.500000
-  tombstone_dense_compaction_threshold=0.050000
+  tombstone_dense_compaction_threshold=0.100000
   strict_wal_tail=true
   table_cache_shards=2
   validate_on_ingest=false


### PR DESCRIPTION
Previously, the heuristic to pick tombstone-density compactions did not account for level sizes at all; it solely looked at how tombstone-dense some sstables were. This resulted in cases where if a large part of the LSM was tombstone-dense, we would needlessly spend CPU and IO compacting everything all the way to L6.

This change adds a minimum uncompensated score that a level must meet before we consider a tombstone-density compaction out of that level. This change also bumps up the tombstone dense blocks threshold to 10% of data blocks in an sstable, up from 5%, before an sstable is chosen for a tombstone density compaction.

Fixes #4052.