### PR TITLE
compact: cap overlap ratio of tombstone density compactions

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -586,7 +586,6 @@ func newCompactionPickerByScore(
 		virtualBackings: virtualBackings,
 	}
 	p.initLevelMaxBytes(inProgressCompactions)
-	p.initTombstoneDensityAnnotator(opts)
 	return p
 }
 
@@ -667,11 +666,6 @@ type compactionPickerByScore struct {
 	// levelMaxBytes holds the dynamically adjusted max bytes setting for each
 	// level.
 	levelMaxBytes [numLevels]int64
-	// tombstoneDensityAnnotator holds the annotator for choosing tombstone
-	// density compactions.
-	// NB: This is declared here rather than globally because
-	// options.Experimental.MinTombstoneDenseRatio is not known until runtime.
-	tombstoneDensityAnnotator *manifest.Annotator[fileMetadata]
 }
 
 var _ compactionPicker = &compactionPickerByScore{}
@@ -1506,25 +1500,6 @@ func (p *compactionPickerByScore) pickRewriteCompaction(env compactionEnv) (pc *
 	return nil
 }
 
-func (p *compactionPickerByScore) initTombstoneDensityAnnotator(opts *Options) {
-	p.tombstoneDensityAnnotator = &manifest.Annotator[fileMetadata]{
-		Aggregator: manifest.PickFileAggregator{
-			Filter: func(f *fileMetadata) (eligible bool, cacheOK bool) {
-				if f.IsCompacting() {
-					return false, true
-				}
-				if !f.StatsValid() {
-					return false, false
-				}
-				return f.Stats.TombstoneDenseBlocksRatio > opts.Experimental.TombstoneDenseCompactionThreshold, true
-			},
-			Compare: func(a, b *fileMetadata) bool {
-				return a.Stats.TombstoneDenseBlocksRatio > b.Stats.TombstoneDenseBlocksRatio
-			},
-		},
-	}
-}
-
 // pickTombstoneDensityCompaction looks for a compaction that eliminates
 // regions of extremely high point tombstone density. For each level, it picks
 // a file where the ratio of tombstone-dense blocks is at least
@@ -1540,14 +1515,40 @@ func (p *compactionPickerByScore) pickTombstoneDensityCompaction(
 
 	var candidate *fileMetadata
 	var level int
+	// If a candidate file has a very high overlapping ratio, point tombstones
+	// in it are likely sparse in keyspace even if the sstable itself is tombstone
+	// dense. These tombstones likely wouldn't be slow to iterate over, so we exclude
+	// these files from tombstone density compactions. The threshold of 40.0 is
+	// chosen somewhat arbitrarily, after some observations around excessively large
+	// tombstone density compactions.
+	const maxOverlappingRatio = 40.0
 	// NB: we don't consider the lowest level because elision-only compactions
 	// handle that case.
-	for l := 0; l < numLevels-1; l++ {
-		f := p.tombstoneDensityAnnotator.LevelAnnotation(p.vers.Levels[l])
-		newCandidate := p.tombstoneDensityAnnotator.Aggregator.Merge(f, candidate)
-		if newCandidate != candidate {
-			candidate = newCandidate
-			level = l
+	lastNonEmptyLevel := numLevels - 1
+	for l := numLevels - 2; l >= 0; l-- {
+		iter := p.vers.Levels[l].Iter()
+		for f := iter.First(); f != nil; f = iter.Next() {
+			if f.IsCompacting() || !f.StatsValid() || f.Size == 0 {
+				continue
+			}
+			if f.Stats.TombstoneDenseBlocksRatio < p.opts.Experimental.TombstoneDenseCompactionThreshold {
+				continue
+			}
+			overlaps := p.vers.Overlaps(lastNonEmptyLevel, f.UserKeyBounds())
+			if float64(overlaps.SizeSum())/float64(f.Size) > maxOverlappingRatio {
+				continue
+			}
+			if candidate == nil || candidate.Stats.TombstoneDenseBlocksRatio < f.Stats.TombstoneDenseBlocksRatio {
+				candidate = f
+				level = l
+			}
+		}
+		// We prefer lower level (ie. L5) candidates over higher level (ie. L4) ones.
+		if candidate != nil {
+			break
+		}
+		if !p.vers.Levels[l].Empty() {
+			lastNonEmptyLevel = l
 		}
 	}
 

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -518,7 +518,6 @@ func TestCompactionPickerL0(t *testing.T) {
 			}
 			vs.picker = picker
 			picker.initLevelMaxBytes(inProgressCompactions)
-			picker.initTombstoneDensityAnnotator(opts)
 
 			var buf bytes.Buffer
 			fmt.Fprint(&buf, version.String())

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/invalidating"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
@@ -2963,6 +2964,7 @@ func runBenchmarkQueueWorkload(b *testing.B, deleteRatio float32, initOps int, v
 	}
 
 	o := (&Options{
+		Cache:              cache.New(0), // disable cache
 		DisableWAL:         true,
 		FS:                 vfs.NewMem(),
 		Comparer:           testkeys.Comparer,
@@ -3036,13 +3038,15 @@ func runBenchmarkQueueWorkload(b *testing.B, deleteRatio float32, initOps int, v
 
 	// Seek to the start of each queue.
 	b.Run("seek", func(b *testing.B) {
+		iter, _ := d.NewIter(nil)
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			for q := 0; q < queueCount; q++ {
-				iter, _ := d.NewIter(nil)
 				iter.SeekGE(getKey(q, 0))
-				require.NoError(b, iter.Close())
 			}
 		}
+		b.StopTimer()
+		require.NoError(b, iter.Close())
 	})
 
 	require.NoError(b, d.Close())
@@ -3064,7 +3068,7 @@ func BenchmarkQueueWorkload(b *testing.B) {
 	var deleteRatios = []float32{0.1, 0.3, 0.5}
 	// The number of times queues will be processed before running each
 	// subbenchmark.
-	var initOps = []int{400_000, 800_000, 1_200_000, 2_000_000, 3_500_000, 5_000_000, 7_500_000, 10_000_000, 50_000_000}
+	var initOps = []int{400_000, 800_000, 1_200_000, 2_000_000, 3_500_000, 5_000_000, 7_500_000}
 	// We vary the value size to identify how compaction behaves when the
 	// relative sizes of tombstones and the keys they delete are different.
 	var valueSizes = []int{128, 2048}

--- a/options.go
+++ b/options.go
@@ -627,7 +627,7 @@ type Options struct {
 		// TombstoneDenseCompactionThreshold is the minimum percent of data
 		// blocks in a table that must be tombstone-dense for that table to be
 		// eligible for a tombstone density compaction. It should be defined as a
-		// ratio out of 1. The default value is 0.05.
+		// ratio out of 1. The default value is 0.10.
 		//
 		// If multiple tables are eligible for a tombstone density compaction, then
 		// tables with a higher percent of tombstone-dense blocks are still
@@ -1351,7 +1351,7 @@ func (o *Options) EnsureDefaults() *Options {
 		o.Experimental.DeletionSizeRatioThreshold = sstable.DefaultDeletionSizeRatioThreshold
 	}
 	if o.Experimental.TombstoneDenseCompactionThreshold == 0 {
-		o.Experimental.TombstoneDenseCompactionThreshold = 0.05
+		o.Experimental.TombstoneDenseCompactionThreshold = 0.10
 	}
 	if o.Experimental.TableCacheShards <= 0 {
 		o.Experimental.TableCacheShards = runtime.GOMAXPROCS(0)

--- a/options_test.go
+++ b/options_test.go
@@ -110,7 +110,7 @@ func TestOptionsString(t *testing.T) {
   read_sampling_multiplier=16
   num_deletions_threshold=100
   deletion_size_ratio_threshold=0.500000
-  tombstone_dense_compaction_threshold=0.050000
+  tombstone_dense_compaction_threshold=0.100000
   strict_wal_tail=true
   table_cache_shards=8
   validate_on_ingest=false

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -61,7 +61,7 @@ cat build/OPTIONS-000003
   read_sampling_multiplier=16
   num_deletions_threshold=100
   deletion_size_ratio_threshold=0.500000
-  tombstone_dense_compaction_threshold=0.050000
+  tombstone_dense_compaction_threshold=0.100000
   strict_wal_tail=true
   table_cache_shards=2
   validate_on_ingest=false

--- a/table_stats.go
+++ b/table_stats.go
@@ -312,7 +312,9 @@ func (d *DB) loadTableStats(
 			stats.NumRangeKeySets = props.NumRangeKeySets
 			stats.ValueBlocksSize = props.ValueBlocksSize
 			stats.CompressionType = block.CompressionFromString(props.CompressionName)
-			stats.TombstoneDenseBlocksRatio = float64(props.NumTombstoneDenseBlocks) / float64(props.NumDataBlocks)
+			if props.NumDataBlocks > 0 {
+				stats.TombstoneDenseBlocksRatio = float64(props.NumTombstoneDenseBlocks) / float64(props.NumDataBlocks)
+			}
 
 			if props.NumPointDeletions() > 0 {
 				if err = d.loadTablePointKeyStats(props, v, level, meta, &stats); err != nil {


### PR DESCRIPTION
Previously, we didn't account for the overlapping ratio of a file when picking it for a tombstone density compaction. The overlap ratio likely tells us how sparse the tombstones are across the keyspace, and files with a high amount of overlap below them should likely be excluded from tombstone density compactions as these compactions are likely to be unnecessarily large, incurring extra write-amp.

Fixes #4052.