### PR TITLE
sstable: fix use of incorrect iterator in CopySpan()

### DIFF
--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -246,7 +246,7 @@ func intersectingIndexEntries(
 				if err != nil {
 					return nil, err
 				}
-				entry := indexEntry{bh: bh, sep: top.Separator()}
+				entry := indexEntry{bh: bh, sep: sub.Separator()}
 				alloc, entry.bh.Props = alloc.Copy(entry.bh.Props)
 				alloc, entry.sep = alloc.Copy(entry.sep)
 				res = append(res, entry)

--- a/sstable/copier_test.go
+++ b/sstable/copier_test.go
@@ -7,6 +7,7 @@ package sstable
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -35,6 +36,8 @@ func TestCopySpan(t *testing.T) {
 				return err.Error()
 			}
 			tableFormat := TableFormatMax
+			blockSize := 1
+			var indexBlockSize int
 			for i := range d.CmdArgs[1:] {
 				switch d.CmdArgs[i+1].Key {
 				case "format":
@@ -44,13 +47,26 @@ func TestCopySpan(t *testing.T) {
 					case "pebblev5":
 						tableFormat = TableFormatPebblev5
 					}
+				case "block_size":
+					var err error
+					blockSize, err = strconv.Atoi(d.CmdArgs[i+1].FirstVal(t))
+					if err != nil {
+						return err.Error()
+					}
+				case "index_block_size":
+					var err error
+					indexBlockSize, err = strconv.Atoi(d.CmdArgs[i+1].FirstVal(t))
+					if err != nil {
+						return err.Error()
+					}
 				}
 			}
 			w := NewWriter(objstorageprovider.NewFileWritable(f), WriterOptions{
-				BlockSize:   1,
-				TableFormat: tableFormat,
-				Comparer:    testkeys.Comparer,
-				KeySchema:   keySchema,
+				BlockSize:      blockSize,
+				IndexBlockSize: indexBlockSize,
+				TableFormat:    tableFormat,
+				Comparer:       testkeys.Comparer,
+				KeySchema:      keySchema,
 			})
 			for _, key := range strings.Split(d.Input, "\n") {
 				j := strings.Index(key, ":")

--- a/sstable/testdata/copy_span
+++ b/sstable/testdata/copy_span
@@ -35,6 +35,54 @@ a#0,SET: foo
 b#0,SET: bar
 c#0,SET: baz
 
+
+# Try the above with small blocks.
+build test22 format=pebblev4 block_size=1 index_block_size=1
+a.SET.5:foo
+b.SET.3:bar
+c.SET.4:baz
+d.SET.5:foobar
+e.SET.5:foo
+f.SET.5:foo
+g.SET.5:foo
+h.SET.5:foo
+i.SET.5:foo
+j.SET.5:foo
+----
+
+iter test22
+----
+a#0,SET: foo
+b#0,SET: bar
+c#0,SET: baz
+d#0,SET: foobar
+e#0,SET: foo
+f#0,SET: foo
+g#0,SET: foo
+h#0,SET: foo
+i#0,SET: foo
+j#0,SET: foo
+
+copy-span test22 test23 b.SET.10 cc.SET.0
+----
+copied 661 bytes
+
+iter test23
+----
+b#0,SET: bar
+c#0,SET: baz
+d#0,SET: foobar
+
+copy-span test22 test24 a.SET.10 bb.SET.0
+----
+copied 658 bytes
+
+iter test24
+----
+a#0,SET: foo
+b#0,SET: bar
+c#0,SET: baz
+
 # Try the above with columnar blocks.
 
 build test3 format=pebblev5
@@ -66,6 +114,54 @@ copy-span test3 test5 a.SET.10 bb.SET.0
 copied 897 bytes
 
 iter test5
+----
+a#0,SET: foo
+b#0,SET: bar
+c#0,SET: baz
+
+
+# Try the above with small blocks.
+build test32 format=pebblev5 block_size=1 index_block_size=1
+a.SET.5:foo
+b.SET.3:bar
+c.SET.4:baz
+d.SET.5:foobar
+e.SET.5:foo
+f.SET.5:foo
+g.SET.5:foo
+h.SET.5:foo
+i.SET.5:foo
+j.SET.5:foo
+----
+
+iter test32
+----
+a#0,SET: foo
+b#0,SET: bar
+c#0,SET: baz
+d#0,SET: foobar
+e#0,SET: foo
+f#0,SET: foo
+g#0,SET: foo
+h#0,SET: foo
+i#0,SET: foo
+j#0,SET: foo
+
+copy-span test32 test33 b.SET.10 cc.SET.0
+----
+copied 889 bytes
+
+iter test33
+----
+b#0,SET: bar
+c#0,SET: baz
+d#0,SET: foobar
+
+copy-span test32 test34 a.SET.10 bb.SET.0
+----
+copied 897 bytes
+
+iter test34
 ----
 a#0,SET: foo
 b#0,SET: bar


### PR DESCRIPTION
Previously we were using the wrong index iterator's Separator when iterating over the entries of a two-level index sstable.