### PR TITLE
objstorage: optimize MemObj.NewReadHandle

### DIFF
--- a/objstorage/test_utils.go
+++ b/objstorage/test_utils.go
@@ -59,5 +59,20 @@ func (f *MemObj) Size() int64 {
 
 // NewReadHandle is part of the Readable interface.
 func (f *MemObj) NewReadHandle(readBeforeSize ReadBeforeSize) ReadHandle {
-	return &NoopReadHandle{readable: f}
+	return (*memObjReadHandle)(f)
 }
+
+// memObjReadHandle implements ReadHandle for MemObj.
+type memObjReadHandle MemObj
+
+var _ ReadHandle = (*memObjReadHandle)(nil)
+
+func (h *memObjReadHandle) ReadAt(ctx context.Context, p []byte, off int64) error {
+	return (*MemObj)(h).ReadAt(ctx, p, off)
+}
+
+func (h *memObjReadHandle) Close() error { return nil }
+
+func (h *memObjReadHandle) SetupForCompaction() {}
+
+func (h *memObjReadHandle) RecordCacheHit(ctx context.Context, offset, size int64) {}


### PR DESCRIPTION
Better implementation for `MemObj.NewReadHandle` which doesn't
allocate (the allocation shows up in microbenchmark profiles and is a
red-herring as the production path would use a preallocated handle).