### PR TITLE
sstable: perf improvement for ResetForReuse

### DIFF
--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -1009,13 +1009,9 @@ func (i *DataBlockIter) IsDataInvalidated() bool {
 
 // ResetForReuse resets the iterator for reuse, retaining buffers and
 // configuration supplied to InitOnce, to avoid future allocations.
-func (i *DataBlockIter) ResetForReuse() DataBlockIter {
-	return DataBlockIter{
-		keySchema:     i.keySchema,
-		getLazyValuer: i.getLazyValuer,
-		keyIter:       PrefixBytesIter{Buf: i.keyIter.Buf},
-		keySeeker:     i.keySeeker,
-	}
+func (i *DataBlockIter) ResetForReuse() {
+	i.d = nil
+	i.kv = base.InternalKV{}
 }
 
 // IsLowerBound implements the block.DataBlockIterator interface.

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -28,7 +28,7 @@ type dataBlockIterator[D any] interface {
 
 	// ResetForReuse resets the data block iterator for reuse, retaining buffers
 	// to avoid future allocations.
-	ResetForReuse() D
+	ResetForReuse()
 
 	*D // non-interface type constraint element
 }
@@ -45,7 +45,7 @@ type indexBlockIterator[I any] interface {
 
 	// ResetForReuse resets the index iterator for reuse, retaining buffers to
 	// avoid future allocations.
-	ResetForReuse() I
+	ResetForReuse()
 
 	*I // non-interface type constraint element
 }

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -1045,12 +1045,11 @@ func (i *twoLevelIterator[I, PI, D, PD]) Close() error {
 	}
 	pool := i.pool
 	err := i.secondLevel.closeInternal()
+	i.secondLevel.resetForReuse()
 	err = firstError(err, PI(&i.topLevelIndex).Close())
-	*i = twoLevelIterator[I, PI, D, PD]{
-		secondLevel:   i.secondLevel.resetForReuse(),
-		topLevelIndex: PI(&i.topLevelIndex).ResetForReuse(),
-		pool:          pool,
-	}
+	PI(&i.topLevelIndex).ResetForReuse()
+	i.useFilterBlock = false
+	i.lastBloomFilterMatched = false
 	if pool != nil {
 		pool.Put(i)
 	}

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -286,8 +286,9 @@ func (i *fragmentIter) Close() {
 		return
 	}
 
+	i.blockIter.ResetForReuse()
 	*i = fragmentIter{
-		blockIter:   i.blockIter.ResetForReuse(),
+		blockIter:   i.blockIter,
 		closeCheck:  i.closeCheck,
 		startKeyBuf: i.startKeyBuf[:0],
 		endKeyBuf:   i.endKeyBuf[:0],

--- a/sstable/rowblk/rowblk_index_iter.go
+++ b/sstable/rowblk/rowblk_index_iter.go
@@ -34,8 +34,8 @@ func (i *IndexIter) InitHandle(
 
 // ResetForReuse resets the index iterator for reuse, retaining buffers to avoid
 // future allocations.
-func (i *IndexIter) ResetForReuse() IndexIter {
-	return IndexIter{iter: i.iter.ResetForReuse()}
+func (i *IndexIter) ResetForReuse() {
+	i.iter.ResetForReuse()
 }
 
 // Valid returns true if the iterator is currently positioned at a valid block

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -303,13 +303,16 @@ func (i *Iter) IsDataInvalidated() bool {
 
 // ResetForReuse resets the blockIter for reuse, retaining buffers to avoid
 // future allocations.
-func (i *Iter) ResetForReuse() Iter {
-	return Iter{
-		fullKey:                   i.fullKey[:0],
-		cached:                    i.cached[:0],
-		cachedBuf:                 i.cachedBuf[:0],
-		firstUserKeyWithPrefixBuf: i.firstUserKeyWithPrefixBuf[:0],
-		data:                      nil,
+func (i *Iter) ResetForReuse() {
+	fullKey := i.fullKey[:0]
+	cached := i.cached[:0]
+	cachedBuf := i.cachedBuf[:0]
+	firstUserKeyWithPrefixBuf := i.firstUserKeyWithPrefixBuf[:0]
+	*i = Iter{
+		fullKey:                   fullKey,
+		cached:                    cached,
+		cachedBuf:                 cachedBuf,
+		firstUserKeyWithPrefixBuf: firstUserKeyWithPrefixBuf,
 	}
 }
 

--- a/sstable/rowblk/rowblk_rewrite.go
+++ b/sstable/rowblk/rowblk_rewrite.go
@@ -89,6 +89,6 @@ func (r *Rewriter) RewriteSuffixes(
 	end.Trailer = r.scratchKey.Trailer
 	r.keyAlloc, end.UserKey = r.keyAlloc.Copy(r.scratchKey.UserKey)
 
-	r.iter = r.iter.ResetForReuse()
+	r.iter.ResetForReuse()
 	return start, end, r.writer.Finish(), nil
 }


### PR DESCRIPTION
Resetting iterators takes a non-trivial amount of time (15% in the
RandSeekInSST benchmark). Most of it is because we're copying fairly
large structures by value.

We change `ResetForReuse` to reset the iterator in-place, and we use
an unsafe trick to clear out only a section of `singleLevelIterator`.

Benchmark (baseline includes a few other in-flight PRs):
```
name                              old time/op  new time/op  delta
RandSeekInSST/v4/single-level-10  1.15µs ± 0%  1.02µs ± 1%  -10.84%  (p=0.001 n=7+7)
RandSeekInSST/v4/two-level-10     1.99µs ± 2%  1.71µs ± 2%  -13.85%  (p=0.000 n=8+8)
RandSeekInSST/v5/single-level-10   944ns ± 1%   823ns ± 1%  -12.86%  (p=0.000 n=8+8)
RandSeekInSST/v5/two-level-10     1.44µs ± 1%  1.24µs ± 7%  -13.79%  (p=0.000 n=7+8)
```