### PR TITLE
sstable: pass KeySchema by pointer

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -63,7 +63,7 @@ func newPebbleDB(dir string) DB {
 		DisableWAL:                  disableWAL,
 		FormatMajorVersion:          pebble.FormatNewest,
 		KeySchema:                   crdbtest.KeySchema.Name,
-		KeySchemas:                  sstable.MakeKeySchemas(crdbtest.KeySchema),
+		KeySchemas:                  sstable.MakeKeySchemas(&crdbtest.KeySchema),
 		L0CompactionThreshold:       2,
 		L0StopWritesThreshold:       1000,
 		LBaseMaxBytes:               64 << 20, // 64 MB

--- a/internal/compact/spans_test.go
+++ b/internal/compact/spans_test.go
@@ -123,9 +123,10 @@ func TestSplitAndEncodeSpan(t *testing.T) {
 			}
 
 			obj := &objstorage.MemObj{}
+			keySchema := colblk.DefaultKeySchema(testkeys.Comparer, 16)
 			wo := sstable.WriterOptions{
 				Comparer:    testkeys.Comparer,
-				KeySchema:   colblk.DefaultKeySchema(testkeys.Comparer, 16),
+				KeySchema:   &keySchema,
 				TableFormat: sstable.TableFormatMax,
 			}
 			tw := sstable.NewRawWriter(obj, wo)

--- a/internal/crdbtest/crdbtest_test.go
+++ b/internal/crdbtest/crdbtest_test.go
@@ -176,7 +176,7 @@ func BenchmarkRandSeekInSST(b *testing.B) {
 			AllocatorSizeClasses: sstable.JemallocSizeClasses,
 			TableFormat:          cfg.version,
 			Comparer:             &Comparer,
-			KeySchema:            KeySchema,
+			KeySchema:            &KeySchema,
 		}
 		b.Run(cfg.name, func(b *testing.B) {
 			benchmarkRandSeekInSST(b, rng, cfg.numKeys, keyCfg, cfg.valueLen, o)
@@ -207,7 +207,7 @@ func benchmarkRandSeekInSST(
 	ctx := context.Background()
 	readerOpts := sstable.ReaderOptions{
 		Comparer:   writerOpts.Comparer,
-		KeySchemas: sstable.MakeKeySchemas(KeySchema),
+		KeySchemas: sstable.MakeKeySchemas(&KeySchema),
 	}
 	readerOpts.SetInternalCacheOpts(sstableinternal.CacheOptions{
 		Cache:   c,

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -176,9 +176,10 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 						return fmt.Sprintf("unknown arg: %s", arg.Key)
 					}
 				}
+				keySchema := colblk.DefaultKeySchema(testkeys.Comparer, 16)
 				writerOpts := sstable.WriterOptions{
 					Comparer:    testkeys.Comparer,
-					KeySchema:   colblk.DefaultKeySchema(testkeys.Comparer, 16),
+					KeySchema:   &keySchema,
 					TableFormat: FormatNewest.MaxTableFormat(),
 				}
 				writerOpts.SetInternal(sstableinternal.WriterOptions{

--- a/sstable/colblk/cockroach_test.go
+++ b/sstable/colblk/cockroach_test.go
@@ -36,10 +36,10 @@ func TestCockroachDataBlock(t *testing.T) {
 
 	var decoder colblk.DataBlockDecoder
 	var it colblk.DataBlockIter
-	it.InitOnce(crdbtest.KeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(&crdbtest.KeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
-	decoder.Init(crdbtest.KeySchema, serializedBlock)
+	decoder.Init(&crdbtest.KeySchema, serializedBlock)
 	if err := it.Init(&decoder, block.IterTransforms{}); err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func generateDataBlock(
 	keys, values = crdbtest.RandomKVs(rng, targetBlockSize/valueLen, cfg, valueLen)
 
 	var w colblk.DataBlockEncoder
-	w.Init(crdbtest.KeySchema)
+	w.Init(&crdbtest.KeySchema)
 	count := 0
 	for w.Size() < targetBlockSize {
 		ik := base.MakeInternalKey(keys[count], base.SeqNum(rng.Uint64N(uint64(base.SeqNumMax))), base.InternalKeyKindSet)
@@ -124,7 +124,7 @@ func benchmarkCockroachDataBlockWriter(b *testing.B, keyConfig crdbtest.KeyConfi
 	_, keys, values := generateDataBlock(rng, targetBlockSize, keyConfig, valueLen)
 
 	var w colblk.DataBlockEncoder
-	w.Init(crdbtest.KeySchema)
+	w.Init(&crdbtest.KeySchema)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -262,10 +262,10 @@ func benchmarkCockroachDataBlockIter(
 
 	var decoder colblk.DataBlockDecoder
 	var it colblk.DataBlockIter
-	it.InitOnce(crdbtest.KeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(&crdbtest.KeySchema, crdbtest.Compare, crdbtest.Split, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
-	decoder.Init(crdbtest.KeySchema, serializedBlock)
+	decoder.Init(&crdbtest.KeySchema, serializedBlock)
 	if err := it.Init(&decoder, transforms); err != nil {
 		b.Fatal(err)
 	}

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -423,7 +423,7 @@ func (ks *defaultKeySeeker) MaterializeUserKeyWithSyntheticSuffix(
 
 // DataBlockEncoder encodes columnar data blocks using a user-defined schema.
 type DataBlockEncoder struct {
-	Schema    KeySchema
+	Schema    *KeySchema
 	KeyWriter KeyWriter
 	// trailers is the column writer for InternalKey uint64 trailers.
 	trailers UintBuilder
@@ -467,7 +467,7 @@ const (
 const dataBlockCustomHeaderSize = 4
 
 // Init initializes the data block writer.
-func (w *DataBlockEncoder) Init(schema KeySchema) {
+func (w *DataBlockEncoder) Init(schema *KeySchema) {
 	w.Schema = schema
 	w.KeyWriter = schema.NewKeyWriter()
 	w.trailers.Init()
@@ -631,7 +631,7 @@ func (w *DataBlockEncoder) Finish(rows, size int) (finished []byte, lastKey base
 
 // DataBlockRewriter rewrites data blocks. See RewriteSuffixes.
 type DataBlockRewriter struct {
-	KeySchema KeySchema
+	KeySchema *KeySchema
 
 	encoder   DataBlockEncoder
 	decoder   DataBlockDecoder
@@ -648,7 +648,7 @@ type DataBlockRewriter struct {
 
 // NewDataBlockRewriter creates a block rewriter.
 func NewDataBlockRewriter(
-	keySchema KeySchema, compare base.Compare, split base.Split,
+	keySchema *KeySchema, compare base.Compare, split base.Split,
 ) *DataBlockRewriter {
 	return &DataBlockRewriter{
 		KeySchema: keySchema,
@@ -767,7 +767,7 @@ const _ uint = block.MetadataSize - uint(dataBlockDecoderSize) - KeySeekerMetada
 const _ uint = block.MetadataSize - uint(unsafe.Sizeof(IndexBlockDecoder{}))
 
 // InitDataBlockMetadata initializes the metadata for a data block.
-func InitDataBlockMetadata(schema KeySchema, md *block.Metadata, data []byte) (err error) {
+func InitDataBlockMetadata(schema *KeySchema, md *block.Metadata, data []byte) (err error) {
 	if uintptr(unsafe.Pointer(md))%8 != 0 {
 		return errors.AssertionFailedf("metadata is not 8-byte aligned")
 	}
@@ -845,7 +845,7 @@ func (d *DataBlockDecoder) PrefixChanged() Bitmap {
 }
 
 // Init initializes the data block reader with the given serialized data block.
-func (d *DataBlockDecoder) Init(schema KeySchema, data []byte) {
+func (d *DataBlockDecoder) Init(schema *KeySchema, data []byte) {
 	if uintptr(unsafe.Pointer(unsafe.SliceData(data)))&7 != 0 {
 		panic("data buffer not 8-byte aligned")
 	}
@@ -890,7 +890,7 @@ type DataBlockIter struct {
 	// keySchema configures the DataBlockIterConfig to use the provided
 	// KeySchema when initializing the DataBlockIter for iteration over a new
 	// block.
-	keySchema KeySchema
+	keySchema *KeySchema
 	cmp       base.Compare
 	split     base.Split
 	// getLazyValuer configures the DataBlockIterConfig to initialize the
@@ -926,7 +926,7 @@ type DataBlockIter struct {
 // handler. The iterator must be initialized with a block before it can be used.
 // It may be reinitialized with new blocks without calling InitOnce again.
 func (i *DataBlockIter) InitOnce(
-	keySchema KeySchema,
+	keySchema *KeySchema,
 	cmp base.Compare,
 	split base.Split,
 	getLazyValuer block.GetLazyValueForPrefixAndValueHandler,

--- a/sstable/colblk_writer_test.go
+++ b/sstable/colblk_writer_test.go
@@ -39,7 +39,7 @@ func TestColumnarWriter(t *testing.T) {
 				writerOpts.Comparer = testkeys.Comparer
 				writerOpts.Compression = block.NoCompression
 				writerOpts.TableFormat = TableFormatPebblev5
-				writerOpts.KeySchema = keySchema
+				writerOpts.KeySchema = &keySchema
 				writerOpts.BlockPropertyCollectors = []func() BlockPropertyCollector{NewTestKeysBlockPropertyCollector}
 				if err := optsFromArgs(td, &writerOpts); err != nil {
 					require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestColumnarWriter(t *testing.T) {
 				var err error
 				r, err = NewReader(context.Background(), obj, ReaderOptions{
 					Comparer:   testkeys.Comparer,
-					KeySchemas: KeySchemas{keySchema.Name: keySchema},
+					KeySchemas: KeySchemas{keySchema.Name: &keySchema},
 				})
 				require.NoError(t, err)
 				return "ok"

--- a/sstable/copier_test.go
+++ b/sstable/copier_test.go
@@ -66,7 +66,7 @@ func TestCopySpan(t *testing.T) {
 				IndexBlockSize: indexBlockSize,
 				TableFormat:    tableFormat,
 				Comparer:       testkeys.Comparer,
-				KeySchema:      keySchema,
+				KeySchema:      &keySchema,
 			})
 			for _, key := range strings.Split(d.Input, "\n") {
 				j := strings.Index(key, ":")
@@ -94,7 +94,7 @@ func TestCopySpan(t *testing.T) {
 			}
 			r, err := NewReader(context.TODO(), readable, ReaderOptions{
 				Comparer:   testkeys.Comparer,
-				KeySchemas: KeySchemas{keySchema.Name: keySchema},
+				KeySchemas: KeySchemas{keySchema.Name: &keySchema},
 			})
 			defer r.Close()
 			if err != nil {
@@ -137,7 +137,7 @@ func TestCopySpan(t *testing.T) {
 			}
 			rOpts := ReaderOptions{
 				Comparer:   testkeys.Comparer,
-				KeySchemas: KeySchemas{keySchema.Name: keySchema},
+				KeySchemas: KeySchemas{keySchema.Name: &keySchema},
 			}
 			rOpts.internal.CacheOpts.Cache = blockCache
 			r, err := NewReader(context.TODO(), readable, rOpts)
@@ -147,7 +147,7 @@ func TestCopySpan(t *testing.T) {
 			defer r.Close()
 			wOpts := WriterOptions{
 				Comparer:  testkeys.Comparer,
-				KeySchema: colblk.DefaultKeySchema(testkeys.Comparer, 16),
+				KeySchema: &keySchema,
 			}
 			// CopySpan closes readable but not reader. We need to open a new readable for it.
 			f2, err := fs.Open(inputFile)
@@ -175,7 +175,7 @@ func TestCopySpan(t *testing.T) {
 			}
 			r, err := NewReader(context.TODO(), readable, ReaderOptions{
 				Comparer:   testkeys.Comparer,
-				KeySchemas: KeySchemas{keySchema.Name: keySchema},
+				KeySchemas: KeySchemas{keySchema.Name: &keySchema},
 			})
 			if err != nil {
 				return err.Error()

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -69,8 +69,9 @@ func optsFromArgs(td *datadriven.TestData, writerOpts *WriterOptions) error {
 	if writerOpts.Comparer == nil {
 		writerOpts.Comparer = testkeys.Comparer
 	}
-	if len(writerOpts.KeySchema.ColumnTypes) == 0 {
-		writerOpts.KeySchema = colblk.DefaultKeySchema(writerOpts.Comparer, 16)
+	if writerOpts.KeySchema == nil {
+		s := colblk.DefaultKeySchema(writerOpts.Comparer, 16)
+		writerOpts.KeySchema = &s
 	}
 	return nil
 }

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -276,7 +276,7 @@ type randomTableConfig struct {
 func (cfg *randomTableConfig) readerOpts() ReaderOptions {
 	rOpts := ReaderOptions{
 		Comparer:   testkeys.Comparer,
-		KeySchemas: map[string]colblk.KeySchema{cfg.wopts.KeySchema.Name: cfg.wopts.KeySchema},
+		KeySchemas: map[string]*colblk.KeySchema{cfg.wopts.KeySchema.Name: cfg.wopts.KeySchema},
 		Filters:    map[string]FilterPolicy{},
 	}
 	if cfg.wopts.FilterPolicy != nil {
@@ -284,6 +284,8 @@ func (cfg *randomTableConfig) readerOpts() ReaderOptions {
 	}
 	return rOpts
 }
+
+var testkeysSchema = colblk.DefaultKeySchema(testkeys.Comparer, 16 /* bundle size */)
 
 func (cfg *randomTableConfig) randomize() {
 	if cfg.wopts == nil {
@@ -296,7 +298,7 @@ func (cfg *randomTableConfig) randomize() {
 			BlockSize:               (1 << cfg.rng.IntN(18)),            // {1, 2, 4, ..., 128 KiB}
 			IndexBlockSize:          (1 << cfg.rng.IntN(20)),            // {1, 2, 4, ..., 512 KiB}
 			BlockPropertyCollectors: nil,
-			KeySchema:               colblk.DefaultKeySchema(testkeys.Comparer, 16 /* bundle size */),
+			KeySchema:               &testkeysSchema,
 			WritingToLowestLevel:    cfg.rng.IntN(2) == 1,
 			Parallelism:             cfg.rng.IntN(2) == 1,
 		}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -51,7 +51,7 @@ type Reader struct {
 
 	// The following fields are copied from the ReadOptions.
 	cacheOpts            sstableinternal.CacheOptions
-	keySchema            colblk.KeySchema
+	keySchema            *colblk.KeySchema
 	loadBlockSema        *fifo.Semaphore
 	deniedUserProperties map[string]struct{}
 	filterMetricsTracker *FilterMetricsTracker

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
-	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/stretchr/testify/require"
@@ -1678,7 +1677,7 @@ func TestReader_TableFormat(t *testing.T) {
 
 		opts := WriterOptions{
 			Comparer:    testkeys.Comparer,
-			KeySchema:   colblk.DefaultKeySchema(testkeys.Comparer, 16),
+			KeySchema:   &testkeysSchema,
 			TableFormat: want,
 		}
 		w := NewRawWriter(objstorageprovider.NewFileWritable(f), opts)

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable/block"
-	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +45,7 @@ func TestRewriteSuffixProps(t *testing.T) {
 			wOpts := WriterOptions{
 				FilterPolicy:     bloom.FilterPolicy(10),
 				Comparer:         testkeys.Comparer,
-				KeySchema:        colblk.DefaultKeySchema(testkeys.Comparer, 16),
+				KeySchema:        &testkeysSchema,
 				TableFormat:      format,
 				IsStrictObsolete: format >= TableFormatPebblev3,
 			}

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -204,7 +204,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 			}
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{
 				Comparer:    cmp,
-				KeySchema:   keySchema,
+				KeySchema:   &keySchema,
 				TableFormat: sstable.TableFormatMax,
 			})
 			m = &fileMetadata{}
@@ -243,7 +243,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 			}
 			r, err = sstable.NewReader(context.Background(), readable, sstable.ReaderOptions{
 				Comparer:   cmp,
-				KeySchemas: sstable.KeySchemas{keySchema.Name: keySchema},
+				KeySchemas: sstable.KeySchemas{keySchema.Name: &keySchema},
 			})
 			if err != nil {
 				return err.Error()

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -54,7 +54,7 @@ Virtual tables: 0 (0B)
 Local tables size: 569B
 Compression types: snappy: 1
 Block cache: 3 entries (1.0KB)  hit rate: 18.2%
-Table cache: 1 entries (816B)  hit rate: 50.0%
+Table cache: 1 entries (760B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -76,7 +76,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 1
 Block cache: 2 entries (700B)  hit rate: 0.0%
-Table cache: 1 entries (816B)  hit rate: 0.0%
+Table cache: 1 entries (760B)  hit rate: 0.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -133,7 +133,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (700B)  hit rate: 33.3%
-Table cache: 2 entries (1.6KB)  hit rate: 66.7%
+Table cache: 2 entries (1.5KB)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
@@ -177,7 +177,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (700B)  hit rate: 33.3%
-Table cache: 2 entries (1.6KB)  hit rate: 66.7%
+Table cache: 2 entries (1.5KB)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
@@ -218,7 +218,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (700B)  hit rate: 33.3%
-Table cache: 1 entries (816B)  hit rate: 66.7%
+Table cache: 1 entries (760B)  hit rate: 66.7%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -496,7 +496,7 @@ Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 7
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (816B)  hit rate: 53.8%
+Table cache: 1 entries (760B)  hit rate: 53.8%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -560,7 +560,7 @@ Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Compression types: snappy: 10
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (816B)  hit rate: 53.8%
+Table cache: 1 entries (760B)  hit rate: 53.8%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -835,7 +835,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 1 entries (816B)  hit rate: 0.0%
+Table cache: 1 entries (760B)  hit rate: 0.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -883,7 +883,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 2
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (816B)  hit rate: 50.0%
+Table cache: 1 entries (760B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -932,7 +932,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 3
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (816B)  hit rate: 50.0%
+Table cache: 1 entries (760B)  hit rate: 50.0%
 Secondary cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -58,7 +58,7 @@ func Comparers(cmps ...*Comparer) Option {
 
 // KeySchemas may be passed to New to register key schemas for use by the
 // introspection tools.
-func KeySchemas(schemas ...colblk.KeySchema) Option {
+func KeySchemas(schemas ...*colblk.KeySchema) Option {
 	return func(t *T) {
 		for _, s := range schemas {
 			t.opts.KeySchemas[s.Name] = s


### PR DESCRIPTION
We pass and store `KeySchema` by value in many places; this struct is
~64 bytes in size, so it adds a bit of size to various structs.

Switch to using `*KeySchema`, which is also consistent with how we use
the `Comparer`.

RabdSeekInSST benchmark is unaffected:
```
name                              old time/op  new time/op  delta
RandSeekInSST/v5/single-level-10   505ns ± 2%   504ns ± 0%   ~     (p=0.718 n=7+8)
RandSeekInSST/v5/two-level-10     1.02µs ± 3%  1.01µs ± 2%   ~     (p=0.591 n=8+8)
```