### PR TITLE
block: remove unnecessary CompressAndChecksum allocation

### DIFF
--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -254,8 +254,7 @@ func CompressAndChecksum(
 
 	// Calculate the checksum.
 	pb := PhysicalBlock{data: block}
-	pb.trailer[0] = byte(algo)
-	checksum := checksummer.Checksum(block, pb.trailer[:1])
+	checksum := checksummer.Checksum(block, byte(algo))
 	pb.trailer = MakeTrailer(byte(algo), checksum)
 	return pb
 }

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -519,7 +519,7 @@ func (w *valueBlockWriter) compressAndFlush() {
 
 func (w *valueBlockWriter) computeChecksum(blk []byte) {
 	n := len(blk) - block.TrailerLen
-	checksum := w.checksummer.Checksum(blk[:n], blk[n:n+1])
+	checksum := w.checksummer.Checksum(blk[:n], blk[n])
 	binary.LittleEndian.PutUint32(blk[n+1:], checksum)
 }
 

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -1106,7 +1106,7 @@ func BenchmarkWriter(b *testing.B) {
 		binary.BigEndian.PutUint64(key[16:], uint64(i))
 		keys[i] = key
 	}
-	for _, format := range []TableFormat{TableFormatPebblev2, TableFormatPebblev3} {
+	for _, format := range []TableFormat{TableFormatPebblev2, TableFormatPebblev3, TableFormatPebblev5} {
 		b.Run(fmt.Sprintf("format=%s", format.String()), func(b *testing.B) {
 			runWriterBench(b, keys, nil, format)
 		})


### PR DESCRIPTION
This allocation snuck in during the block package refactors.

```
                                                                                │   old.txt    │                new.txt                │
                                                                                │  allocs/op   │  allocs/op   vs base                  │
Writer/format=(Pebble,v2)/block=4.0KB/filter=true/compression=NoCompression-10    18.985k ± 0%   9.533k ± 0%  -49.79% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=4.0KB/filter=true/compression=Snappy-10           18.991k ± 0%   9.536k ± 0%  -49.79% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=4.0KB/filter=true/compression=ZSTD-10              66.29k ± 0%   56.84k ± 0%  -14.25% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=4.0KB/filter=false/compression=NoCompression-10   18.974k ± 0%   9.521k ± 0%  -49.82% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=4.0KB/filter=false/compression=Snappy-10          18.978k ± 0%   9.525k ± 0%  -49.81% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=4.0KB/filter=false/compression=ZSTD-10             66.27k ± 0%   56.83k ± 0%  -14.26% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=32KB/filter=true/compression=NoCompression-10      2.377k ± 0%   1.218k ± 0%  -48.76% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=32KB/filter=true/compression=Snappy-10             2.379k ± 0%   1.220k ± 0%  -48.72% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=32KB/filter=true/compression=ZSTD-10               8.184k ± 0%   7.024k ± 0%  -14.17% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=32KB/filter=false/compression=NoCompression-10     2.365k ± 0%   1.207k ± 0%  -48.96% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=32KB/filter=false/compression=Snappy-10            2.366k ± 0%   1.208k ± 0%  -48.95% (p=0.000 n=10)
Writer/format=(Pebble,v2)/block=32KB/filter=false/compression=ZSTD-10              8.172k ± 0%   7.011k ± 0%  -14.21% (p=0.000 n=10)
```

Fix #4090.