### PR TITLE
metamorphic: deduplicate prefixes in key_manager for external objs

### DIFF
--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1397,23 +1397,6 @@ func (g *generator) writerIngestExternalFiles() {
 				continue
 			}
 
-			// We can only use a synthetic suffix if we don't have multiple keys with
-			// the same prefix.
-			hasDuplicatePrefix := func() bool {
-				var prevPrefix []byte
-				for _, k := range g.keyManager.KeysForExternalIngest(objs[i]) {
-					prefix := g.prefix(k.key)
-					if g.cmp(prefix, prevPrefix) == 0 {
-						return true
-					}
-					prevPrefix = append(prevPrefix[:0], prefix...)
-				}
-				return false
-			}()
-			if hasDuplicatePrefix {
-				continue
-			}
-
 			// We can only use a synthetic suffix if we don't have overlapping range
 			// key sets (because they will become logically conflicting when we
 			// replace their suffixes with the synthetic one).

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -651,9 +651,9 @@ func RandomOptions(
 	opts.Experimental.ValidateOnIngest = rng.IntN(2) != 0
 	opts.L0CompactionThreshold = 1 + rng.IntN(100)     // 1 - 100
 	opts.L0CompactionFileThreshold = 1 << rng.IntN(11) // 1 - 1024
-	opts.L0StopWritesThreshold = 1 + rng.IntN(100)     // 1 - 100
-	if opts.L0StopWritesThreshold < opts.L0CompactionThreshold {
-		opts.L0StopWritesThreshold = opts.L0CompactionThreshold
+	opts.L0StopWritesThreshold = 50 + rng.IntN(100)    // 50 - 150
+	if opts.L0StopWritesThreshold < 2*opts.L0CompactionThreshold {
+		opts.L0StopWritesThreshold = 2 * opts.L0CompactionThreshold
 	}
 	opts.LBaseMaxBytes = 1 << uint(rng.IntN(30)) // 1B - 1GB
 	maxConcurrentCompactions := rng.IntN(3) + 1  // 1-3


### PR DESCRIPTION
Previously we assumed that external objects would keep keys with different suffixes but the same prefix when doing key tracking in the key manager. This wasn't in line with what newExternalObjOp was doing, and led to cases of keys being marked as eligible for singledel when they were not.

Fixes #4047.