### PR TITLE
sstable: shard categorized iterator stats

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -134,6 +134,11 @@ func createExternalPointIter(ctx context.Context, it *Iterator) (topLevelIterato
 	}
 	mlevels := it.alloc.mlevels[:0]
 
+	// TODO(jackson): External iterators never provide categorized iterator
+	// stats today because they exist outside the context of a *DB. If the
+	// sstables being read are on the physical filesystem, we may still want to
+	// thread a CategoryStatsCollector through so that we collect their stats.
+
 	if len(it.externalReaders) > cap(mlevels) {
 		mlevels = make([]mergingIterLevel, 0, len(it.externalReaders))
 	}
@@ -159,7 +164,7 @@ func createExternalPointIter(ctx context.Context, it *Iterator) (topLevelIterato
 			pointIter, err = r.NewPointIter(
 				ctx, transforms, it.opts.LowerBound, it.opts.UpperBound, nil, /* BlockPropertiesFilterer */
 				sstable.NeverUseFilterBlock,
-				&it.stats.InternalStats, it.opts.CategoryAndQoS, nil,
+				&it.stats.InternalStats, nil,
 				sstable.MakeTrivialReaderProvider(r))
 			if err != nil {
 				return nil, err

--- a/internal/crdbtest/crdb_bench_test.go
+++ b/internal/crdbtest/crdb_bench_test.go
@@ -117,7 +117,7 @@ func benchmarkRandSeekInSST(
 	rp := sstable.MakeTrivialReaderProvider(reader)
 	iter, err := reader.NewPointIter(
 		ctx, sstable.NoTransforms, nil, nil, nil, sstable.NeverUseFilterBlock,
-		&stats, sstable.CategoryAndQoS{}, nil, rp)
+		&stats, nil, rp)
 	require.NoError(b, err)
 	n := 0
 	for kv := iter.First(); kv != nil; kv = iter.Next() {
@@ -133,7 +133,7 @@ func benchmarkRandSeekInSST(
 		key := queryKeys[i%numQueryKeys]
 		iter, err := reader.NewPointIter(
 			ctx, sstable.NoTransforms, nil, nil, nil, sstable.NeverUseFilterBlock,
-			&stats, sstable.CategoryAndQoS{}, nil, rp)
+			&stats, nil, rp)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/iterator.go
+++ b/iterator.go
@@ -245,6 +245,7 @@ type Iterator struct {
 	// and SetOptions or when re-fragmenting a batch's range keys/range dels.
 	// Non-nil if this Iterator includes a Batch.
 	batch            *Batch
+	tc               *tableCacheContainer
 	newIters         tableNewIters
 	newIterRangeKey  keyspanimpl.TableNewSpanIter
 	lazyCombinedIter lazyCombinedIter
@@ -2866,6 +2867,7 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 		boundsBuf:           buf.boundsBuf,
 		batch:               i.batch,
 		batchSeqNum:         i.batchSeqNum,
+		tc:                  i.tc,
 		newIters:            i.newIters,
 		newIterRangeKey:     i.newIterRangeKey,
 		seqNum:              i.seqNum,

--- a/level_iter.go
+++ b/level_iter.go
@@ -22,10 +22,11 @@ type internalIterOpts struct {
 	// if compaction is set, sstable-level iterators will be created using
 	// NewCompactionIter; these iterators have a more constrained interface
 	// and are optimized for the sequential scan of a compaction.
-	compaction         bool
-	bufferPool         *sstable.BufferPool
-	stats              *base.InternalIteratorStats
-	boundLimitedFilter sstable.BoundLimitedBlockPropertyFilter
+	compaction           bool
+	bufferPool           *sstable.BufferPool
+	stats                *base.InternalIteratorStats
+	iterStatsAccumulator sstable.IterStatsAccumulator
+	boundLimitedFilter   sstable.BoundLimitedBlockPropertyFilter
 }
 
 // levelIter provides a merged view of the sstables in a level.

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -184,7 +184,7 @@ func (lt *levelIterTest) newIters(
 	if kinds.Point() {
 		iter, err := lt.readers[file.FileNum].NewPointIter(
 			ctx, transforms,
-			opts.LowerBound, opts.UpperBound, nil, sstable.AlwaysUseFilterBlock, iio.stats, sstable.CategoryAndQoS{},
+			opts.LowerBound, opts.UpperBound, nil, sstable.AlwaysUseFilterBlock, iio.stats,
 			nil, sstable.MakeTrivialReaderProvider(lt.readers[file.FileNum]))
 		if err != nil {
 			return iterSet{}, errors.CombineErrors(err, set.CloseAll())

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -179,7 +179,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 					context.Background(),
 					sstable.NoTransforms,
 					opts.GetLowerBound(), opts.GetUpperBound(), nil, sstable.AlwaysUseFilterBlock, iio.stats,
-					sstable.CategoryAndQoS{}, nil, sstable.MakeTrivialReaderProvider(r))
+					nil, sstable.MakeTrivialReaderProvider(r))
 				if err != nil {
 					return iterSet{}, errors.CombineErrors(err, set.CloseAll())
 				}

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -988,7 +988,7 @@ func TestBlockProperties(t *testing.T) {
 			iter, err := r.NewPointIter(
 				context.Background(),
 				NoTransforms, lower, upper, filterer, NeverUseFilterBlock, &stats,
-				CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r))
+				nil, MakeTrivialReaderProvider(r))
 			if err != nil {
 				return err.Error()
 			}
@@ -1072,7 +1072,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 			iter, err := r.NewPointIter(
 				context.Background(),
 				NoTransforms, lower, upper, filterer, NeverUseFilterBlock, &stats,
-				CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r))
+				nil, MakeTrivialReaderProvider(r))
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/category_stats.go
+++ b/sstable/category_stats.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -96,45 +97,75 @@ type CategoryStatsAggregate struct {
 	CategoryStats CategoryStats
 }
 
+const numCategoryStatsShards = 16
+
 type categoryStatsWithMu struct {
 	mu sync.Mutex
 	// Protected by mu.
-	stats CategoryStatsAggregate
+	stats CategoryStats
 }
 
 // CategoryStatsCollector collects and aggregates the stats per category.
 type CategoryStatsCollector struct {
 	// mu protects additions to statsMap.
 	mu sync.Mutex
-	// Category => categoryStatsWithMu.
+	// Category => *shardedCategoryStats.
 	statsMap sync.Map
 }
 
+// shardedCategoryStats accumulates stats for a category, splitting its stats
+// across multiple shards to prevent mutex contention. In high-read workloads,
+// contention on the category stats mutex has been observed.
+type shardedCategoryStats struct {
+	Category Category
+	QoSLevel QoSLevel
+	shards   [numCategoryStatsShards]struct {
+		categoryStatsWithMu
+		// Pad each shard to 64 bytes so they don't share a cache line.
+		_ [64 - unsafe.Sizeof(categoryStatsWithMu{})]byte
+	}
+}
+
+// getStats retrieves the aggregated stats for the category, summing across all
+// shards.
+func (s *shardedCategoryStats) getStats() CategoryStatsAggregate {
+	agg := CategoryStatsAggregate{
+		Category: s.Category,
+		QoSLevel: s.QoSLevel,
+	}
+	for i := range s.shards {
+		s.shards[i].mu.Lock()
+		agg.CategoryStats.aggregate(s.shards[i].stats)
+		s.shards[i].mu.Unlock()
+	}
+	return agg
+}
+
 func (c *CategoryStatsCollector) reportStats(
-	category Category, qosLevel QoSLevel, stats CategoryStats,
+	p uint64, category Category, qosLevel QoSLevel, stats CategoryStats,
 ) {
 	v, ok := c.statsMap.Load(category)
 	if !ok {
 		c.mu.Lock()
-		v, _ = c.statsMap.LoadOrStore(category, &categoryStatsWithMu{
-			stats: CategoryStatsAggregate{Category: category, QoSLevel: qosLevel},
+		v, _ = c.statsMap.LoadOrStore(category, &shardedCategoryStats{
+			Category: category,
+			QoSLevel: qosLevel,
 		})
 		c.mu.Unlock()
 	}
-	aggStats := v.(*categoryStatsWithMu)
-	aggStats.mu.Lock()
-	aggStats.stats.CategoryStats.aggregate(stats)
-	aggStats.mu.Unlock()
+
+	shardedStats := v.(*shardedCategoryStats)
+	s := ((p * 25214903917) >> 32) & (numCategoryStatsShards - 1)
+	shardedStats.shards[s].mu.Lock()
+	shardedStats.shards[s].stats.aggregate(stats)
+	shardedStats.shards[s].mu.Unlock()
 }
 
 // GetStats returns the aggregated stats.
 func (c *CategoryStatsCollector) GetStats() []CategoryStatsAggregate {
 	var stats []CategoryStatsAggregate
 	c.statsMap.Range(func(_, v any) bool {
-		aggStats := v.(*categoryStatsWithMu)
-		aggStats.mu.Lock()
-		s := aggStats.stats
-		aggStats.mu.Unlock()
+		s := v.(*shardedCategoryStats).getStats()
 		if len(s.Category) == 0 {
 			s.Category = "_unknown"
 		}
@@ -175,6 +206,6 @@ func (accum *iterStatsAccumulator) reportStats(
 
 func (accum *iterStatsAccumulator) close() {
 	if accum.collector != nil {
-		accum.collector.reportStats(accum.Category, accum.QoSLevel, accum.stats)
+		accum.collector.reportStats(uint64(uintptr(unsafe.Pointer(accum))), accum.Category, accum.QoSLevel, accum.stats)
 	}
 }

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -111,8 +111,7 @@ func runErrorInjectionTest(t *testing.T, seed int64) {
 		filterer,
 		filterBlockSizeLimit,
 		&stats,
-		CategoryAndQoS{},
-		nil, /* CategoryStatsCollector */
+		nil, /* IterStatsAccumulator */
 		MakeTrivialReaderProvider(r),
 	)
 	require.NoError(t, err)

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -32,15 +32,13 @@ type CommonReader interface {
 		filterer *BlockPropertiesFilterer,
 		filterBlockSizeLimit FilterBlockSizeLimit,
 		stats *base.InternalIteratorStats,
-		categoryAndQoS CategoryAndQoS,
-		statsCollector *CategoryStatsCollector,
+		statsAccum IterStatsAccumulator,
 		rp ReaderProvider,
 	) (Iterator, error)
 
 	NewCompactionIter(
 		transforms IterTransforms,
-		categoryAndQoS CategoryAndQoS,
-		statsCollector *CategoryStatsCollector,
+		statsAccum IterStatsAccumulator,
 		rp ReaderProvider,
 		bufferPool *block.BufferPool,
 	) (Iterator, error)

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -210,8 +210,7 @@ func newColumnBlockSingleLevelIterator(
 	filterer *BlockPropertiesFilterer,
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
-	categoryAndQoS CategoryAndQoS,
-	statsCollector *CategoryStatsCollector,
+	statsAccum IterStatsAccumulator,
 	rp ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (*singleLevelIteratorColumnBlocks, error) {
@@ -225,7 +224,7 @@ func newColumnBlockSingleLevelIterator(
 	useFilterBlock := shouldUseFilterBlock(r, filterBlockSizeLimit)
 	i.init(
 		ctx, r, v, transforms, lower, upper, filterer, useFilterBlock,
-		stats, categoryAndQoS, statsCollector, bufferPool,
+		stats, statsAccum, bufferPool,
 	)
 	var getLazyValuer block.GetLazyValueForPrefixAndValueHandler
 	if r.Properties.NumValueBlocks > 0 {
@@ -275,8 +274,7 @@ func newRowBlockSingleLevelIterator(
 	filterer *BlockPropertiesFilterer,
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
-	categoryAndQoS CategoryAndQoS,
-	statsCollector *CategoryStatsCollector,
+	statsAccum IterStatsAccumulator,
 	rp ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (*singleLevelIteratorRowBlocks, error) {
@@ -290,7 +288,7 @@ func newRowBlockSingleLevelIterator(
 	useFilterBlock := shouldUseFilterBlock(r, filterBlockSizeLimit)
 	i.init(
 		ctx, r, v, transforms, lower, upper, filterer, useFilterBlock,
-		stats, categoryAndQoS, statsCollector, bufferPool,
+		stats, statsAccum, bufferPool,
 	)
 	if r.tableFormat >= TableFormatPebblev3 {
 		if r.Properties.NumValueBlocks > 0 {
@@ -336,8 +334,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) init(
 	filterer *BlockPropertiesFilterer,
 	useFilterBlock bool,
 	stats *base.InternalIteratorStats,
-	categoryAndQoS CategoryAndQoS,
-	statsCollector *CategoryStatsCollector,
+	statsAccum IterStatsAccumulator,
 	bufferPool *block.BufferPool,
 ) {
 	i.inPool = false
@@ -353,8 +350,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) init(
 		i.vState = v
 		i.endKeyInclusive, i.lower, i.upper = v.constrainBounds(lower, upper, false /* endInclusive */)
 	}
-
-	i.iterStats.init(categoryAndQoS, statsCollector)
+	i.iterStats.init(statsAccum)
 	i.readBlockEnv = readBlockEnv{
 		Stats:      stats,
 		IterStats:  &i.iterStats,

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -64,8 +64,7 @@ func TestIteratorErrorOnInit(t *testing.T) {
 				nil /* lower */, nil, /* upper */
 				nil /* filterer */, NeverUseFilterBlock,
 				&stats,
-				CategoryAndQoS{},
-				nil, /* statsCollector */
+				nil, /* statsAccum */
 				MakeTrivialReaderProvider(r),
 				&pool,
 			)
@@ -79,8 +78,7 @@ func TestIteratorErrorOnInit(t *testing.T) {
 				nil /* lower */, nil, /* upper */
 				nil /* filterer */, NeverUseFilterBlock,
 				&stats,
-				CategoryAndQoS{},
-				nil, /* statsCollector */
+				nil, /* statsAccum */
 				MakeTrivialReaderProvider(r),
 				&pool,
 			)

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -161,8 +161,7 @@ func newColumnBlockTwoLevelIterator(
 	filterer *BlockPropertiesFilterer,
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
-	categoryAndQoS CategoryAndQoS,
-	statsCollector *CategoryStatsCollector,
+	statsAccum IterStatsAccumulator,
 	rp ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (*twoLevelIteratorColumnBlocks, error) {
@@ -175,7 +174,7 @@ func newColumnBlockTwoLevelIterator(
 	i := twoLevelIterColumnBlockPool.Get().(*twoLevelIteratorColumnBlocks)
 	i.secondLevel.init(ctx, r, v, transforms, lower, upper, filterer,
 		false, // Disable the use of the filter block in the second level.
-		stats, categoryAndQoS, statsCollector, bufferPool)
+		stats, statsAccum, bufferPool)
 	var getLazyValuer block.GetLazyValueForPrefixAndValueHandler
 	if r.Properties.NumValueBlocks > 0 {
 		// NB: we cannot avoid this ~248 byte allocation, since valueBlockReader
@@ -225,8 +224,7 @@ func newRowBlockTwoLevelIterator(
 	filterer *BlockPropertiesFilterer,
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
-	categoryAndQoS CategoryAndQoS,
-	statsCollector *CategoryStatsCollector,
+	statsAccum IterStatsAccumulator,
 	rp ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (*twoLevelIteratorRowBlocks, error) {
@@ -239,7 +237,7 @@ func newRowBlockTwoLevelIterator(
 	i := twoLevelIterRowBlockPool.Get().(*twoLevelIteratorRowBlocks)
 	i.secondLevel.init(ctx, r, v, transforms, lower, upper, filterer,
 		false, // Disable the use of the filter block in the second level.
-		stats, categoryAndQoS, statsCollector, bufferPool)
+		stats, statsAccum, bufferPool)
 	if r.tableFormat >= TableFormatPebblev3 {
 		if r.Properties.NumValueBlocks > 0 {
 			// NB: we cannot avoid this ~248 byte allocation, since valueBlockReader

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -234,7 +234,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 			transforms := IterTransforms{
 				SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(nil, syntheticSuffix),
 			}
-			iter, err := v.NewCompactionIter(transforms, CategoryAndQoS{}, nil, rp, &bp)
+			iter, err := v.NewCompactionIter(transforms, nil, rp, &bp)
 			if err != nil {
 				return err.Error()
 			}
@@ -361,7 +361,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 			}
 			iter, err := v.NewPointIter(
 				context.Background(), transforms, lower, upper, filterer, NeverUseFilterBlock,
-				&stats, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r))
+				&stats, nil, MakeTrivialReaderProvider(r))
 			if err != nil {
 				return err.Error()
 			}
@@ -755,7 +755,6 @@ func runTestReader(t *testing.T, o WriterOptions, dir string, r *Reader, printVa
 					filterer,
 					AlwaysUseFilterBlock,
 					&stats,
-					CategoryAndQoS{},
 					nil,
 					MakeTrivialReaderProvider(r),
 				)
@@ -899,7 +898,7 @@ func TestCompactionIteratorSetupForCompaction(t *testing.T) {
 				var pool block.BufferPool
 				pool.Init(5)
 				citer, err := r.NewCompactionIter(
-					NoTransforms, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r), &pool)
+					NoTransforms, nil, MakeTrivialReaderProvider(r), &pool)
 				require.NoError(t, err)
 				switch i := citer.(type) {
 				case *singleLevelIteratorRowBlocks:
@@ -957,7 +956,7 @@ func TestReadaheadSetupForV3TablesWithMultipleVersions(t *testing.T) {
 		pool.Init(5)
 		defer pool.Release()
 		citer, err := r.NewCompactionIter(
-			NoTransforms, CategoryAndQoS{}, nil, MakeTrivialReaderProvider(r), &pool)
+			NoTransforms, nil, MakeTrivialReaderProvider(r), &pool)
 		require.NoError(t, err)
 		defer citer.Close()
 		i := citer.(*singleLevelIteratorRowBlocks)
@@ -1254,7 +1253,7 @@ func TestRandomizedPrefixSuffixRewriter(t *testing.T) {
 				SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
 			},
 			nil, nil, nil,
-			AlwaysUseFilterBlock, nil, CategoryAndQoS{}, nil,
+			AlwaysUseFilterBlock, nil, nil,
 			MakeTrivialReaderProvider(eReader), &virtualState{
 				lower: base.MakeInternalKey([]byte("_"), base.SeqNumMax, base.InternalKeyKindSet),
 				upper: base.MakeRangeDeleteSentinelKey([]byte("~~~~~~~~~~~~~~~~")),
@@ -2401,7 +2400,7 @@ func BenchmarkIteratorScanObsolete(b *testing.B) {
 								transforms := IterTransforms{HideObsoletePoints: hideObsoletePoints}
 								iter, err := r.NewPointIter(
 									context.Background(), transforms, nil, nil, filterer,
-									AlwaysUseFilterBlock, nil, CategoryAndQoS{}, nil,
+									AlwaysUseFilterBlock, nil, nil,
 									MakeTrivialReaderProvider(r))
 								require.NoError(b, err)
 								b.ResetTimer()

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -94,13 +94,12 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 // NewCompactionIter is the compaction iterator function for virtual readers.
 func (v *VirtualReader) NewCompactionIter(
 	transforms IterTransforms,
-	categoryAndQoS CategoryAndQoS,
-	statsCollector *CategoryStatsCollector,
+	statsAccum IterStatsAccumulator,
 	rp ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (Iterator, error) {
 	return v.reader.newCompactionIter(
-		transforms, categoryAndQoS, statsCollector, rp, &v.vState, bufferPool)
+		transforms, statsAccum, rp, &v.vState, bufferPool)
 }
 
 // NewPointIter returns an iterator for the point keys in the table.
@@ -119,13 +118,12 @@ func (v *VirtualReader) NewPointIter(
 	filterer *BlockPropertiesFilterer,
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
-	categoryAndQoS CategoryAndQoS,
-	statsCollector *CategoryStatsCollector,
+	statsAccum IterStatsAccumulator,
 	rp ReaderProvider,
 ) (Iterator, error) {
 	return v.reader.newPointIter(
 		ctx, transforms, lower, upper, filterer, filterBlockSizeLimit,
-		stats, categoryAndQoS, statsCollector, rp, &v.vState)
+		stats, statsAccum, rp, &v.vState)
 }
 
 // ValidateBlockChecksumsOnBacking will call ValidateBlockChecksumsOnBacking on the underlying reader.

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -83,6 +83,9 @@ Table iters: 1
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
+Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
 
 disk-usage
 ----
@@ -141,6 +144,9 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
+                   c, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 disk-usage
@@ -185,6 +191,9 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
+                   c, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 # Closing iter c will release one of the zombie sstables. The other
@@ -226,6 +235,8 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
@@ -271,6 +282,7 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
@@ -343,6 +355,7 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
@@ -399,6 +412,7 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
@@ -504,6 +518,7 @@ Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
@@ -568,6 +583,7 @@ Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
@@ -646,6 +662,7 @@ Filter utility: 0.0%
 Ingestions: 3  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
@@ -749,6 +766,7 @@ Filter utility: 0.0%
 Ingestions: 4  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+                   a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
    pebble-compaction, non-latency: {BlockBytes:677 BlockBytesInCache:376 BlockReadDuration:70ms}


### PR DESCRIPTION
Shard the categorized iterator stats to avoid mutex contention in high-read workloads that are frequently closing sstable iterators.