### PR TITLE
colblk: don't require the header size for KeySchemaHeader

### DIFF
--- a/internal/crdbtest/crdb.go
+++ b/internal/crdbtest/crdb.go
@@ -633,7 +633,11 @@ func (ks *cockroachKeySeeker) init(d *colblk.DataBlockDecoder) {
 	ks.mvccWallTimes = bd.Uints(cockroachColMVCCWallTime)
 	ks.mvccLogical = bd.Uints(cockroachColMVCCLogical)
 	ks.untypedVersions = bd.RawBytes(cockroachColUntypedVersion)
-	ks.suffixTypes = suffixTypes(d.KeySchemaHeader(1)[0])
+	header := d.KeySchemaHeader()
+	if len(header) != 1 {
+		panic(errors.AssertionFailedf("invalid key schema-specific header %x", header))
+	}
+	ks.suffixTypes = suffixTypes(header[0])
 }
 
 // IsLowerBound is part of the KeySeeker interface.

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -874,9 +874,9 @@ func (d *DataBlockDecoder) PrefixChanged() Bitmap {
 	return d.prefixChanged
 }
 
-// KeySchemaHeader returns the KeySchema-specific header of fixed size.
-func (d *DataBlockDecoder) KeySchemaHeader(schemaHeaderSize uint32) []byte {
-	return d.d.data[:schemaHeaderSize]
+// KeySchemaHeader returns the KeySchema-specific header.
+func (d *DataBlockDecoder) KeySchemaHeader() []byte {
+	return d.d.data[:d.d.customHeaderSize-dataBlockCustomHeaderSize]
 }
 
 // Init initializes the data block reader with the given serialized data block.


### PR DESCRIPTION
`KeySchemaHeader` returns the header that was written instead of
relying on the caller to provide the correct size. This makes things
less error-prone and also allows for extending the header while
allowing backward compatibility.