### PR TITLE
sstable: assert KeyComparison correctness under invariants

### DIFF
--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -27,3 +27,18 @@ func (d *CloseChecker) AssertClosed() {}
 
 // AssertNotClosed panics in invariant builds if Close was called.
 func (d *CloseChecker) AssertNotClosed() {}
+
+// Value is a generic container for a value that should only exist in invariant
+// builds. In non-invariant builds, storing a value is a no-op, retrieving a
+// value returns the type parameter's zero value, and the Value struct takes up
+// no space.
+type Value[V any] struct{}
+
+// Get returns the current value, or the zero-value if invariants are disabled.
+func (*Value[V]) Get() V {
+	var v V // zero value
+	return v
+}
+
+// Store stores the value.
+func (*Value[V]) Store(v V) {}

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -40,3 +40,21 @@ func (d *CloseChecker) AssertNotClosed() {
 		panic("closed")
 	}
 }
+
+// Value is a generic container for a value that should only exist in invariant
+// builds. In non-invariant builds, storing a value is a no-op, retrieving a
+// value returns the type parameter's zero value, and the Value struct takes up
+// no space.
+type Value[V any] struct {
+	v V
+}
+
+// Get returns the current value, or the zero-value if invariants are disabled.
+func (v *Value[V]) Get() V {
+	return v.v
+}
+
+// Store stores the value.
+func (v *Value[V]) Store(inner V) {
+	v.v = inner
+}

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -95,6 +96,7 @@ type RawColumnWriter struct {
 
 	separatorBuf          []byte
 	tmp                   [blockHandleLikelyMaxLen]byte
+	previousUserKey       invariants.Value[[]byte]
 	disableKeyOrderChecks bool
 }
 
@@ -469,6 +471,13 @@ func (w *RawColumnWriter) evaluatePoint(
 	key base.InternalKey, valueLen int,
 ) (eval pointKeyEvaluation, err error) {
 	eval.kcmp = w.dataBlock.KeyWriter.ComparePrev(key.UserKey)
+
+	// When invariants are enabled, validate kcmp.
+	if invariants.Enabled {
+		colblk.AssertKeyCompare(w.comparer, key.UserKey, w.previousUserKey.Get(), eval.kcmp)
+		w.previousUserKey.Store(append(w.previousUserKey.Get()[:0], key.UserKey...))
+	}
+
 	if !w.meta.HasPointKeys {
 		return eval, nil
 	}


### PR DESCRIPTION
When the invariants build tag is enabled, assert that the KeyComparison returned by the columnar data block writer is accurate by computing the KeyComparison from a buffered user key.

Informs #4103.