### PR TITLE
cmd/pebble: populate common KeySchemas

### DIFF
--- a/tool/tool.go
+++ b/tool/tool.go
@@ -60,6 +60,9 @@ func Comparers(cmps ...*Comparer) Option {
 // introspection tools.
 func KeySchemas(schemas ...*colblk.KeySchema) Option {
 	return func(t *T) {
+		if t.opts.KeySchemas == nil {
+			t.opts.KeySchemas = make(map[string]*colblk.KeySchema)
+		}
 		for _, s := range schemas {
 			t.opts.KeySchemas[s.Name] = s
 		}


### PR DESCRIPTION
Update the cmd/pebble CLI tool to populate opts.KeySchemas with commonly used KeySchemas. This was motivated by a desire to use the cmd/pebble CLI tool with a sstable constructed by the metamorphic tests.