### PR TITLE
crdbtest: fix bug in cockroachKeyWriter.MaterializeKey

### DIFF
--- a/internal/crdbtest/crdb.go
+++ b/internal/crdbtest/crdb.go
@@ -533,7 +533,7 @@ func (kw *cockroachKeyWriter) MaterializeKey(dst []byte, i int) []byte {
 	dst = append(dst, 0)
 	if untypedVersion := kw.untypedVersions.UnsafeGet(i); len(untypedVersion) > 0 {
 		dst = append(dst, untypedVersion...)
-		dst = append(dst, byte(len(untypedVersion)))
+		dst = append(dst, byte(len(untypedVersion)+1))
 		return dst
 	}
 	return AppendTimestamp(dst, kw.wallTimes.Get(i), uint32(kw.logicalTimes.Get(i)))

--- a/internal/crdbtest/key_schema_test.go
+++ b/internal/crdbtest/key_schema_test.go
@@ -36,10 +36,15 @@ func runDataDrivenTest(t *testing.T, path string) {
 		switch td.Cmd {
 		case "init":
 			e.Reset()
+			var buf []byte
 			for _, l := range crstrings.Lines(td.Input) {
 				key, value := parseKV(l)
 				kcmp := e.KeyWriter.ComparePrev(key.UserKey)
 				e.Add(key, value, 0, kcmp, false /* isObsolete */)
+				buf = e.MaterializeLastUserKey(buf[:0])
+				if !Comparer.Equal(key.UserKey, buf) {
+					td.Fatalf(t, "incorect MaterializeLastKey: %s instead of %s", formatUserKey(buf), formatUserKey(key.UserKey))
+				}
 			}
 			numRows := e.Rows()
 			size := e.Size()

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -591,6 +591,11 @@ func (w *DataBlockEncoder) Size() int {
 	return int(off)
 }
 
+// MaterializeLastUserKey materializes the last added user key.
+func (w *DataBlockEncoder) MaterializeLastUserKey(appendTo []byte) []byte {
+	return w.KeyWriter.MaterializeKey(appendTo, w.rows-1)
+}
+
 // Finish serializes the pending data block, including the first [rows] rows.
 // The value of [rows] must be Rows() or Rows()-1. The provided size must be the
 // size of the data block with the provided row count (i.e., the return value of


### PR DESCRIPTION
We were writing the terminator length byte incorrectly.