### PR TITLE
colblk: fix a few errant uses of CompareRangeSuffixes

### DIFF
--- a/internal/compact/iterator.go
+++ b/internal/compact/iterator.go
@@ -148,8 +148,8 @@ import (
 // exported function, and before a subsequent call to Next advances the iterator
 // and mutates the contents of the returned key and value.
 type Iter struct {
-	cmp       base.Compare
-	suffixCmp base.CompareRangeSuffixes
+	cmp            base.Compare
+	cmpRangeSuffix base.CompareRangeSuffixes
 
 	cfg IterConfig
 
@@ -309,9 +309,9 @@ func NewIter(
 ) *Iter {
 	cfg.ensureDefaults()
 	i := &Iter{
-		cmp:       cfg.Comparer.Compare,
-		suffixCmp: cfg.Comparer.CompareRangeSuffixes,
-		cfg:       cfg,
+		cmp:            cfg.Comparer.Compare,
+		cmpRangeSuffix: cfg.Comparer.CompareRangeSuffixes,
+		cfg:            cfg,
 		// We don't want a nil keyBuf because if the first key we encounter is
 		// empty, it would become nil.
 		keyBuf: make([]byte, 8),
@@ -331,7 +331,7 @@ func NewIter(
 	i.frontiers.Init(i.cmp)
 	i.delElider.Init(i.cmp, cfg.TombstoneElision)
 	i.rangeDelCompactor = MakeRangeDelSpanCompactor(i.cmp, i.cfg.Comparer.Equal, cfg.Snapshots, cfg.TombstoneElision)
-	i.rangeKeyCompactor = MakeRangeKeySpanCompactor(i.cmp, i.suffixCmp, cfg.Snapshots, cfg.RangeKeyElision)
+	i.rangeKeyCompactor = MakeRangeKeySpanCompactor(i.cmp, i.cmpRangeSuffix, cfg.Snapshots, cfg.RangeKeyElision)
 	i.lastRangeDelSpanFrontier.Init(&i.frontiers, nil, i.lastRangeDelSpanFrontierReached)
 	return i
 }

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -252,7 +252,7 @@ func (w *defaultKeyWriter) ComparePrev(key []byte) KeyComparison {
 	// CommonPrefixLen, it would sort after [key].)
 	if cmpv.CommonPrefixLen == cmpv.PrefixLen {
 		// The keys share the same MVCC prefix. Compare the suffixes.
-		cmpv.UserKeyComparison = int32(w.comparer.CompareRangeSuffixes(key[cmpv.PrefixLen:],
+		cmpv.UserKeyComparison = int32(w.comparer.ComparePointSuffixes(key[cmpv.PrefixLen:],
 			w.suffixes.UnsafeGet(w.suffixes.rows-1)))
 		if invariants.Enabled {
 			if !w.comparer.Equal(lp, key[:cmpv.PrefixLen]) {
@@ -396,7 +396,7 @@ func (ks *defaultKeySeeker) SeekGE(
 func (ks *defaultKeySeeker) seekGEOnSuffix(index int, suffix []byte) (row int) {
 	// The search key's prefix exactly matches the prefix of the row at index.
 	// If the row at index has a suffix >= [suffix], then return the row.
-	if ks.comparer.CompareRangeSuffixes(ks.suffixes.At(index), suffix) >= 0 {
+	if ks.comparer.ComparePointSuffixes(ks.suffixes.At(index), suffix) >= 0 {
 		return index
 	}
 	// Otherwise, the row at [index] sorts before the search key and we need to
@@ -409,7 +409,7 @@ func (ks *defaultKeySeeker) seekGEOnSuffix(index int, suffix []byte) (row int) {
 	for l < u {
 		h := int(uint(l+u) >> 1) // avoid overflow when computing h
 		// l ≤ h < u
-		if ks.comparer.CompareRangeSuffixes(ks.suffixes.At(h), suffix) >= 0 {
+		if ks.comparer.ComparePointSuffixes(ks.suffixes.At(h), suffix) >= 0 {
 			u = h // preserves f(u) == true
 		} else {
 			l = h + 1 // preserves f(l-1) == false


### PR DESCRIPTION
In #4070, CompareSuffixes was split into CompareRangeSuffixes and ComparePointSuffixes. This commit fixes a few errant uses of CompareRangeSuffixes on point key suffixes.