### PR TITLE
sstable: make Category an enum

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -733,11 +733,8 @@ func (c *compaction) newInputIters(
 		}
 	}()
 	iterOpts := IterOptions{
-		CategoryAndQoS: sstable.CategoryAndQoS{
-			Category: "pebble-compaction",
-			QoSLevel: sstable.NonLatencySensitiveQoSLevel,
-		},
-		logger: c.logger,
+		Category: categoryCompaction,
+		logger:   c.logger,
 	}
 
 	// Populate iters, rangeDelIters and rangeKeyIters with the appropriate
@@ -1246,11 +1243,8 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 		comparer: d.opts.Comparer,
 		newIters: d.newIters,
 		opts: IterOptions{
-			logger: d.opts.Logger,
-			CategoryAndQoS: sstable.CategoryAndQoS{
-				Category: "pebble-ingest",
-				QoSLevel: sstable.LatencySensitiveQoSLevel,
-			},
+			logger:   d.opts.Logger,
+			Category: categoryIngest,
 		},
 		v: c.version,
 	}

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/sstable"
 )
 
 func TestGetIter(t *testing.T) {
@@ -455,10 +454,7 @@ func TestGetIter(t *testing.T) {
 			get.version = v
 			get.snapshot = ikey.SeqNum() + 1
 			get.iterOpts = IterOptions{
-				CategoryAndQoS: sstable.CategoryAndQoS{
-					Category: "pebble-get",
-					QoSLevel: sstable.LatencySensitiveQoSLevel,
-				},
+				Category:                      categoryGet,
 				logger:                        testLogger{t},
 				snapshotForHideObsoletePoints: get.snapshot,
 			}

--- a/ingest.go
+++ b/ingest.go
@@ -1752,11 +1752,8 @@ func (d *DB) excise(
 		}
 		var err error
 		iters, err = d.newIters(ctx, m, &IterOptions{
-			CategoryAndQoS: sstable.CategoryAndQoS{
-				Category: "pebble-ingest",
-				QoSLevel: sstable.LatencySensitiveQoSLevel,
-			},
-			layer: manifest.Level(level),
+			Category: categoryIngest,
+			layer:    manifest.Level(level),
 		}, internalIterOpts{}, iterPointKeys|iterRangeDeletions|iterRangeKeys)
 		itersLoaded = true
 		return err
@@ -2154,11 +2151,8 @@ func (d *DB) ingestApply(
 		comparer: d.opts.Comparer,
 		newIters: d.newIters,
 		opts: IterOptions{
-			logger: d.opts.Logger,
-			CategoryAndQoS: sstable.CategoryAndQoS{
-				Category: "pebble-ingest",
-				QoSLevel: sstable.LatencySensitiveQoSLevel,
-			},
+			logger:   d.opts.Logger,
+			Category: categoryIngest,
 		},
 		v: current,
 	}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1133,7 +1133,7 @@ func testIngestSharedImpl(
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writeOpts)
 
 			var sharedSSTs []SharedSSTMeta
-			err = from.ScanInternal(context.TODO(), sstable.CategoryAndQoS{}, startKey, endKey,
+			err = from.ScanInternal(context.TODO(), sstable.CategoryUnknown, startKey, endKey,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
@@ -1634,7 +1634,7 @@ func TestConcurrentExcise(t *testing.T) {
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writeOpts)
 
 			var sharedSSTs []SharedSSTMeta
-			err = from.ScanInternal(context.TODO(), sstable.CategoryAndQoS{}, startKey, endKey,
+			err = from.ScanInternal(context.TODO(), sstable.CategoryUnknown, startKey, endKey,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
@@ -2071,7 +2071,7 @@ func TestIngestExternal(t *testing.T) {
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writeOpts)
 
 			var externalFiles []ExternalFile
-			err = from.ScanInternal(context.TODO(), sstable.CategoryAndQoS{}, startKey, endKey,
+			err = from.ScanInternal(context.TODO(), sstable.CategoryUnknown, startKey, endKey,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
@@ -2356,11 +2356,8 @@ func TestIngestTargetLevel(t *testing.T) {
 					comparer: d.opts.Comparer,
 					newIters: d.newIters,
 					opts: IterOptions{
-						logger: d.opts.Logger,
-						CategoryAndQoS: sstable.CategoryAndQoS{
-							Category: "pebble-ingest",
-							QoSLevel: sstable.LatencySensitiveQoSLevel,
-						},
+						logger:   d.opts.Logger,
+						Category: categoryIngest,
 					},
 					v: d.mu.versions.currentVersion(),
 				}

--- a/level_iter.go
+++ b/level_iter.go
@@ -169,7 +169,7 @@ func (l *levelIter) init(
 		l.tableOpts.PointKeyFilters = l.filtersBuf[:0:1]
 	}
 	l.tableOpts.UseL6Filters = opts.UseL6Filters
-	l.tableOpts.CategoryAndQoS = opts.CategoryAndQoS
+	l.tableOpts.Category = opts.Category
 	l.tableOpts.layer = l.layer
 	l.tableOpts.snapshotForHideObsoletePoints = opts.snapshotForHideObsoletePoints
 	l.comparer = comparer

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1914,7 +1914,7 @@ func (r *replicateOp) runSharedReplicate(
 ) {
 	var sharedSSTs []pebble.SharedSSTMeta
 	var err error
-	err = source.ScanInternal(context.TODO(), sstable.CategoryAndQoS{}, r.start, r.end,
+	err = source.ScanInternal(context.TODO(), sstable.CategoryUnknown, r.start, r.end,
 		func(key *pebble.InternalKey, value pebble.LazyValue, _ pebble.IteratorLevel) error {
 			val, _, err := value.Value(nil)
 			if err != nil {
@@ -1977,7 +1977,7 @@ func (r *replicateOp) runExternalReplicate(
 ) {
 	var externalSSTs []pebble.ExternalFile
 	var err error
-	err = source.ScanInternal(context.TODO(), sstable.CategoryAndQoS{}, r.start, r.end,
+	err = source.ScanInternal(context.TODO(), sstable.CategoryUnknown, r.start, r.end,
 		func(key *pebble.InternalKey, value pebble.LazyValue, _ pebble.IteratorLevel) error {
 			val, _, err := value.Value(nil)
 			if err != nil {

--- a/metrics.go
+++ b/metrics.go
@@ -147,6 +147,10 @@ func (m *LevelMetrics) WriteAmp() float64 {
 	return float64(m.BytesFlushed+m.BytesCompacted) / float64(m.BytesIn)
 }
 
+var categoryCompaction = sstable.RegisterCategory("pebble-compaction", sstable.NonLatencySensitiveQoSLevel)
+var categoryIngest = sstable.RegisterCategory("pebble-ingest", sstable.LatencySensitiveQoSLevel)
+var categoryGet = sstable.RegisterCategory("pebble-get", sstable.LatencySensitiveQoSLevel)
+
 // Metrics holds metrics for various subsystems of the DB such as the Cache,
 // Compactions, WAL, and per-Level metrics.
 //

--- a/options.go
+++ b/options.go
@@ -188,9 +188,9 @@ type IterOptions struct {
 	// existing is not low or if we just expect a one-time Seek (where loading the
 	// data block directly is better).
 	UseL6Filters bool
-	// CategoryAndQoS is used for categorized iterator stats. This should not be
+	// Category is used for categorized iterator stats. This should not be
 	// changed by calling SetOptions.
-	sstable.CategoryAndQoS
+	Category sstable.Category
 
 	DebugRangeKeyStack bool
 
@@ -261,8 +261,9 @@ func (o *IterOptions) SpanIterOptions() keyspan.SpanIterOptions {
 // scanInternalOptions is similar to IterOptions, meant for use with
 // scanInternalIterator.
 type scanInternalOptions struct {
-	sstable.CategoryAndQoS
 	IterOptions
+
+	category sstable.Category
 
 	visitPointKey     func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error
 	visitRangeDel     func(start, end []byte, seqNum SeqNum) error

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -830,7 +830,7 @@ func (opts *scanInternalOptions) skipLevelForOpts() int {
 
 // constructPointIter constructs a merging iterator and sets i.iter to it.
 func (i *scanInternalIterator) constructPointIter(
-	categoryAndQoS sstable.CategoryAndQoS, memtables flushableList, buf *iterAlloc,
+	category sstable.Category, memtables flushableList, buf *iterAlloc,
 ) error {
 	// Merging levels and levels from iterAlloc.
 	mlevels := buf.mlevels[:0]
@@ -897,7 +897,7 @@ func (i *scanInternalIterator) constructPointIter(
 	levels = levels[:numLevelIters]
 	rangeDelLevels = rangeDelLevels[:numLevelIters]
 	i.opts.IterOptions.snapshotForHideObsoletePoints = i.seqNum
-	i.opts.IterOptions.CategoryAndQoS = categoryAndQoS
+	i.opts.IterOptions.Category = category
 	addLevelIterForFiles := func(files manifest.LevelIterator, level manifest.Layer) {
 		li := &levels[levelsIndex]
 		rli := &rangeDelLevels[levelsIndex]

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -213,7 +213,7 @@ func TestScanInternal(t *testing.T) {
 	type scanInternalReader interface {
 		ScanInternal(
 			ctx context.Context,
-			categoryAndQoS sstable.CategoryAndQoS,
+			category sstable.Category,
 			lower, upper []byte,
 			visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
 			visitRangeDel func(start, end []byte, seqNum base.SeqNum) error,
@@ -561,7 +561,7 @@ func TestScanInternal(t *testing.T) {
 					}
 				}
 			}
-			err := reader.ScanInternal(context.TODO(), sstable.CategoryAndQoS{}, lower, upper,
+			err := reader.ScanInternal(context.TODO(), sstable.CategoryUnknown, lower, upper,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					v := value.InPlaceValue()
 					fmt.Fprintf(&b, "%s (%s)\n", key, v)

--- a/snapshot.go
+++ b/snapshot.go
@@ -75,7 +75,7 @@ func (s *Snapshot) NewIterWithContext(ctx context.Context, o *IterOptions) (*Ite
 // point keys deleted by range dels and keys masked by range keys.
 func (s *Snapshot) ScanInternal(
 	ctx context.Context,
-	categoryAndQoS sstable.CategoryAndQoS,
+	category sstable.Category,
 	lower, upper []byte,
 	visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
 	visitRangeDel func(start, end []byte, seqNum base.SeqNum) error,
@@ -87,7 +87,7 @@ func (s *Snapshot) ScanInternal(
 		panic(ErrClosed)
 	}
 	scanInternalOpts := &scanInternalOptions{
-		CategoryAndQoS:    categoryAndQoS,
+		category:          category,
 		visitPointKey:     visitPointKey,
 		visitRangeDel:     visitRangeDel,
 		visitRangeKey:     visitRangeKey,
@@ -473,7 +473,7 @@ func (es *EventuallyFileOnlySnapshot) NewIterWithContext(
 // point keys deleted by range dels and keys masked by range keys.
 func (es *EventuallyFileOnlySnapshot) ScanInternal(
 	ctx context.Context,
-	categoryAndQoS sstable.CategoryAndQoS,
+	category sstable.Category,
 	lower, upper []byte,
 	visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
 	visitRangeDel func(start, end []byte, seqNum base.SeqNum) error,
@@ -486,7 +486,7 @@ func (es *EventuallyFileOnlySnapshot) ScanInternal(
 	}
 	var sOpts snapshotIterOpts
 	opts := &scanInternalOptions{
-		CategoryAndQoS: categoryAndQoS,
+		category: category,
 		IterOptions: IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			LowerBound: lower,

--- a/table_cache.go
+++ b/table_cache.go
@@ -574,7 +574,7 @@ func (c *tableCacheShard) newPointIter(
 	iterStatsAccum := internalOpts.iterStatsAccumulator
 	if iterStatsAccum == nil && opts != nil && dbOpts.sstStatsCollector != nil {
 		iterStatsAccum = dbOpts.sstStatsCollector.Accumulator(
-			uint64(uintptr(unsafe.Pointer(v.reader))), opts.CategoryAndQoS)
+			uint64(uintptr(unsafe.Pointer(v.reader))), opts.Category)
 	}
 	if internalOpts.compaction {
 		iter, err = cr.NewCompactionIter(transforms, iterStatsAccum, rp, internalOpts.bufferPool)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -38,7 +38,7 @@ batch
 set a 1
 ----
 
-iter-new a category=a qos=non-latency
+iter-new a category=a
 ----
 
 flush
@@ -48,7 +48,7 @@ L0.0:
 
 # iter b references both a memtable and sstable 5.
 
-iter-new b category=b qos=latency
+iter-new b category=b
 ----
 
 metrics
@@ -103,7 +103,7 @@ L0.0:
 
 # iter c references both a memtable and sstables 5 and 7.
 
-iter-new c category=c qos=non-latency
+iter-new c category=c
 ----
 
 compact a-z
@@ -144,10 +144,10 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    c, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -191,10 +191,10 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    c, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 # Closing iter c will release one of the zombie sstables. The other
 # zombie sstable is still referenced by iter b.
@@ -235,10 +235,10 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -282,10 +282,10 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 disk-usage
 ----
@@ -355,10 +355,10 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
 
 additional-metrics
 ----
@@ -412,10 +412,10 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
 
 additional-metrics
 ----
@@ -518,11 +518,11 @@ Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
+       pebble-ingest,     latency: {BlockBytes:64 BlockBytesInCache:0 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
-       pebble-ingest,     latency: {BlockBytes:64 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 batch
 set g g
@@ -583,11 +583,11 @@ Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
+       pebble-ingest,     latency: {BlockBytes:64 BlockBytesInCache:0 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
-       pebble-ingest,     latency: {BlockBytes:64 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 build ext1
 set z z
@@ -662,11 +662,11 @@ Filter utility: 0.0%
 Ingestions: 3  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
+       pebble-ingest,     latency: {BlockBytes:200 BlockBytesInCache:0 BlockReadDuration:30ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
-       pebble-ingest,     latency: {BlockBytes:200 BlockBytesInCache:0 BlockReadDuration:30ms}
 
 # Virtualize a virtual sstable.
 build ext1
@@ -766,11 +766,11 @@ Filter utility: 0.0%
 Ingestions: 4  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:677 BlockBytesInCache:376 BlockReadDuration:70ms}
+       pebble-ingest,     latency: {BlockBytes:272 BlockBytesInCache:72 BlockReadDuration:30ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
-   pebble-compaction, non-latency: {BlockBytes:677 BlockBytesInCache:376 BlockReadDuration:70ms}
-       pebble-ingest,     latency: {BlockBytes:272 BlockBytesInCache:72 BlockReadDuration:30ms}
 
 # Create a DB where lower levels are written as shared tables. All ingests also
 # become shared tables.


### PR DESCRIPTION
Instead of using arbitrary strings, we use an enum. Categories must
now be registered upfront (from an `init` function). We also associate
the QoS level upon registration, simplifying the plumbing.