### PR TITLE
sstable: lazily allocate ValueFetcher

### DIFF
--- a/sstable/block/kv.go
+++ b/sstable/block/kv.go
@@ -72,5 +72,12 @@ func InPlaceValuePrefix(setHasSameKeyPrefix bool) ValuePrefix {
 // GetLazyValueForPrefixAndValueHandler is an interface for getting a LazyValue
 // from a value prefix and value.
 type GetLazyValueForPrefixAndValueHandler interface {
+	// GetLazyValueForPrefixAndValueHandle returns a LazyValue for the given value
+	// prefix and value.
+	//
+	// The result is only valid until the next call to
+	// GetLazyValueForPrefixAndValueHandle. Use LazyValue.Clone if the lifetime of
+	// the LazyValue needs to be extended. For more details, see the "memory
+	// management" comment where LazyValue is declared.
 	GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue
 }

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -186,13 +186,13 @@ func newColumnBlockTwoLevelIterator(
 		// versions of keys, and therefore never expose a LazyValue that is
 		// separated to their callers, they can put this valueBlockReader into a
 		// sync.Pool.
-		i.secondLevel.vbReader = &valueBlockReader{
+		i.secondLevel.vbReader = valueBlockReader{
 			bpOpen: &i.secondLevel,
 			rp:     rp,
 			vbih:   r.valueBIH,
 			stats:  stats,
 		}
-		getLazyValuer = i.secondLevel.vbReader
+		getLazyValuer = &i.secondLevel.vbReader
 		i.secondLevel.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
 	i.secondLevel.data.InitOnce(r.keySchema, r.Compare, r.Split, getLazyValuer)
@@ -249,13 +249,13 @@ func newRowBlockTwoLevelIterator(
 			// versions of keys, and therefore never expose a LazyValue that is
 			// separated to their callers, they can put this valueBlockReader into a
 			// sync.Pool.
-			i.secondLevel.vbReader = &valueBlockReader{
+			i.secondLevel.vbReader = valueBlockReader{
 				bpOpen: &i.secondLevel,
 				rp:     rp,
 				vbih:   r.valueBIH,
 				stats:  stats,
 			}
-			i.secondLevel.data.SetGetLazyValuer(i.secondLevel.vbReader)
+			i.secondLevel.data.SetGetLazyValuer(&i.secondLevel.vbReader)
 			i.secondLevel.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 		}
 		i.secondLevel.data.SetHasValuePrefix(true)

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -378,7 +378,7 @@ func TestWriterWithValueBlocks(t *testing.T) {
 				return err.Error()
 			}
 			forceRowIterIgnoreValueBlocks := func(i *singleLevelIteratorRowBlocks) {
-				i.vbReader = nil
+				i.vbReader = valueBlockReader{}
 				i.data.SetGetLazyValuer(nil)
 				i.data.SetHasValuePrefix(false)
 			}


### PR DESCRIPTION
Currently the type `valueBlockReader` implements both
`block.GetLazyValueForPrefixAndValueHandler` and `base.ValueFetcher`.
The lifetime of the `ValueFetcher` needs to extend beyond that
of the iterator.

This commit splits it into two objects - `valueBlockReader` continues
to implement `block.GetLazyValueForPrefixAndValueHandler` but the new
`valueBlockFetcher` now implements `base.ValueFetcher`. The
`valueBlockReader` lazily allocates the `valueBlockFetcher` the first
time it is asked to produce a `LazyValue`. The result is that we
should avoid the allocation if we are never positioned on a KV with
non-in-place value (which is the norm when we get the latest version
of a single key).

```
name                              old time/op    new time/op    delta
RandSeekInSST/v4/single-level-10     691ns ± 2%     668ns ± 3%    -3.38%  (p=0.000 n=8+7)
RandSeekInSST/v4/two-level-10       1.57µs ± 2%    1.54µs ± 4%      ~     (p=0.067 n=7+8)
RandSeekInSST/v5/single-level-10     479ns ± 1%     425ns ± 1%   -11.28%  (p=0.001 n=7+7)
RandSeekInSST/v5/two-level-10        967ns ± 4%     868ns ± 4%   -10.25%  (p=0.001 n=7+7)

name                              old alloc/op   new alloc/op   delta
RandSeekInSST/v4/single-level-10      288B ± 0%      122B ± 2%   -57.81%  (p=0.000 n=8+8)
RandSeekInSST/v4/two-level-10         288B ± 0%      122B ± 1%   -57.74%  (p=0.000 n=8+7)
RandSeekInSST/v5/single-level-10      288B ± 0%       11B ± 0%   -96.18%  (p=0.000 n=8+7)
RandSeekInSST/v5/two-level-10         288B ± 0%       11B ± 0%   -96.18%  (p=0.000 n=8+8)

name                              old allocs/op  new allocs/op  delta
RandSeekInSST/v4/single-level-10      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=8+8)
RandSeekInSST/v4/two-level-10         1.00 ± 0%      0.00       -100.00%  (p=0.000 n=8+8)
RandSeekInSST/v5/single-level-10      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=8+8)
RandSeekInSST/v5/two-level-10         1.00 ± 0%      0.00       -100.00%  (p=0.000 n=8+8)
```