### PR TITLE
*: use crtime.NowMono instead of time.Now

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/batchrepr"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -1655,12 +1656,12 @@ func (b *Batch) Reader() batchrepr.Reader {
 
 // SyncWait is to be used in conjunction with DB.ApplyNoSyncWait.
 func (b *Batch) SyncWait() error {
-	now := time.Now()
+	now := crtime.NowMono()
 	b.fsyncWait.Wait()
 	if b.commitErr != nil {
 		b.db = nil // prevent batch reuse on error
 	}
-	waitDuration := time.Since(now)
+	waitDuration := now.Elapsed()
 	b.commitStats.CommitWaitDuration += waitDuration
 	b.commitStats.TotalDuration += waitDuration
 	return b.commitErr

--- a/compaction.go
+++ b/compaction.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/compact"
@@ -1174,7 +1175,7 @@ func (d *DB) maybeScheduleDelayedFlush(tbl *memTable, dur time.Duration) {
 
 func (d *DB) flush() {
 	pprof.Do(context.Background(), flushLabels, func(context.Context) {
-		flushingWorkStart := time.Now()
+		flushingWorkStart := crtime.NowMono()
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		idleDuration := flushingWorkStart.Sub(d.mu.compact.noOngoingFlushStartTime)
@@ -1185,7 +1186,7 @@ func (d *DB) flush() {
 			d.opts.EventListener.BackgroundError(err)
 		}
 		d.mu.compact.flushing = false
-		d.mu.compact.noOngoingFlushStartTime = time.Now()
+		d.mu.compact.noOngoingFlushStartTime = crtime.NowMono()
 		workDuration := d.mu.compact.noOngoingFlushStartTime.Sub(flushingWorkStart)
 		d.mu.compact.flushWriteThroughput.Bytes += int64(bytesFlushed)
 		d.mu.compact.flushWriteThroughput.WorkDuration += workDuration

--- a/db.go
+++ b/db.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -456,7 +457,7 @@ type DB struct {
 			flushWriteThroughput ThroughputMetric
 			// The idle start time for the flush "loop", i.e., when the flushing
 			// bool above transitions to false.
-			noOngoingFlushStartTime time.Time
+			noOngoingFlushStartTime crtime.Mono
 		}
 
 		// Non-zero when file cleaning is disabled. The disabled count acts as a
@@ -2477,10 +2478,10 @@ func (d *DB) maybeInduceWriteStall(b *Batch) {
 					Reason: "memtable count limit reached",
 				})
 			}
-			now := time.Now()
+			beforeWait := crtime.NowMono()
 			d.mu.compact.cond.Wait()
 			if b != nil {
-				b.commitStats.MemTableWriteStallDuration += time.Since(now)
+				b.commitStats.MemTableWriteStallDuration += beforeWait.Elapsed()
 			}
 			continue
 		}
@@ -2493,10 +2494,10 @@ func (d *DB) maybeInduceWriteStall(b *Batch) {
 					Reason: "L0 file count limit exceeded",
 				})
 			}
-			now := time.Now()
+			beforeWait := crtime.NowMono()
 			d.mu.compact.cond.Wait()
 			if b != nil {
-				b.commitStats.L0ReadAmpWriteStallDuration += time.Since(now)
+				b.commitStats.L0ReadAmpWriteStallDuration += beforeWait.Elapsed()
 			}
 			continue
 		}
@@ -2530,10 +2531,10 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 	var newLogNum base.DiskFileNum
 	var prevLogSize uint64
 	if !d.opts.DisableWAL {
-		now := time.Now()
+		beforeRotate := crtime.NowMono()
 		newLogNum, prevLogSize = d.rotateWAL()
 		if b != nil {
-			b.commitStats.WALRotationDuration += time.Since(now)
+			b.commitStats.WALRotationDuration += beforeRotate.Elapsed()
 		}
 	}
 	immMem := d.mu.mem.mutable

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/cespare/xxhash/v2 v2.2.0
-	github.com/cockroachdb/crlib v0.0.0-20241015224233-894974b3ad94
+	github.com/cockroachdb/crlib v0.0.0-20241030175859-ddcdee82a927
 	github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056
 	github.com/cockroachdb/errors v1.11.3
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/cockroachdb/crlib v0.0.0-20241015224233-894974b3ad94 h1:bvJv505UUfjzbaIPdNS4AEkHreDqQk6yuNpsdRHpwFA=
-github.com/cockroachdb/crlib v0.0.0-20241015224233-894974b3ad94/go.mod h1:Gq51ZeKaFCXk6QwuGM0w1dnaOqc/F5zKT2zA9D6Xeac=
+github.com/cockroachdb/crlib v0.0.0-20241030175859-ddcdee82a927 h1:KxHSDcEqwtVRnknERc+ao26hlGQuReg7hfsdQeNoomE=
+github.com/cockroachdb/crlib v0.0.0-20241030175859-ddcdee82a927/go.mod h1:Gq51ZeKaFCXk6QwuGM0w1dnaOqc/F5zKT2zA9D6Xeac=
 github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056 h1:slXychO2uDM6hYRu4c0pD0udNI8uObfeKN6UInWViS8=
 github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/cockroachdb/errors v1.11.3 h1:5bA+k2Y6r+oz/6Z/RFlNeVCesGARKuC6YymtcDrbC/I=

--- a/internal/batchskl/skl.go
+++ b/internal/batchskl/skl.go
@@ -59,7 +59,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand/v2"
-	"time"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
@@ -173,7 +172,7 @@ func (s *Skiplist) Init(storage *[]byte, cmp base.Compare, abbreviatedKey base.A
 		nodes:          s.nodes[:0],
 		height:         1,
 	}
-	s.rand.Seed(0, uint64(time.Now().UnixNano()))
+	s.rand.Seed(0, rand.Uint64())
 
 	const initBufSize = 256
 	if cap(s.nodes) < initBufSize {

--- a/internal/randvar/rand.go
+++ b/internal/randvar/rand.go
@@ -4,14 +4,11 @@
 
 package randvar
 
-import (
-	"math/rand/v2"
-	"time"
-)
+import "math/rand/v2"
 
-// NewRand creates a new random number generator seeded with the current time.
+// NewRand creates a new random number generator with a random seed.
 func NewRand() *rand.Rand {
-	return rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
+	return rand.New(rand.NewPCG(0, rand.Uint64()))
 }
 
 func ensureRand(rng *rand.Rand) *rand.Rand {

--- a/open.go
+++ b/open.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/batchrepr"
@@ -280,7 +281,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	}
 	d.mu.compact.cond.L = &d.mu.Mutex
 	d.mu.compact.inProgress = make(map[*compaction]struct{})
-	d.mu.compact.noOngoingFlushStartTime = time.Now()
+	d.mu.compact.noOngoingFlushStartTime = crtime.NowMono()
 	d.mu.snapshots.init()
 	// logSeqNum is the next sequence number that will be assigned.
 	// Start assigning sequence numbers from base.SeqNumStart to leave

--- a/pacer.go
+++ b/pacer.go
@@ -7,6 +7,8 @@ package pebble
 import (
 	"sync"
 	"time"
+
+	"github.com/cockroachdb/crlib/crtime"
 )
 
 // deletionPacerInfo contains any info from the db necessary to make deletion
@@ -58,7 +60,7 @@ const deletePacerHistory = 5 * time.Minute
 // normally limit deletes (when we are not falling behind or running out of
 // space). A value of 0.0 disables pacing.
 func newDeletionPacer(
-	now time.Time, targetByteDeletionRate int64, getInfo func() deletionPacerInfo,
+	now crtime.Mono, targetByteDeletionRate int64, getInfo func() deletionPacerInfo,
 ) *deletionPacer {
 	d := &deletionPacer{
 		freeSpaceThreshold: 16 << 30, // 16 GB
@@ -79,7 +81,7 @@ func newDeletionPacer(
 // deletion rate accordingly.
 //
 // ReportDeletion is thread-safe.
-func (p *deletionPacer) ReportDeletion(now time.Time, bytesToDelete uint64) {
+func (p *deletionPacer) ReportDeletion(now crtime.Mono, bytesToDelete uint64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.mu.history.Add(now, int64(bytesToDelete))
@@ -89,7 +91,7 @@ func (p *deletionPacer) ReportDeletion(now time.Time, bytesToDelete uint64) {
 // deleting the given number of bytes.
 //
 // PacingDelay is thread-safe.
-func (p *deletionPacer) PacingDelay(now time.Time, bytesToDelete uint64) (waitSeconds float64) {
+func (p *deletionPacer) PacingDelay(now crtime.Mono, bytesToDelete uint64) (waitSeconds float64) {
 	if p.targetByteDeletionRate == 0 {
 		// Pacing disabled.
 		return 0.0
@@ -136,7 +138,7 @@ func (p *deletionPacer) PacingDelay(now time.Time, bytesToDelete uint64) (waitSe
 // are effectively rounded down to the nearest epoch boundary.
 type history struct {
 	epochDuration time.Duration
-	startTime     time.Time
+	startTime     crtime.Mono
 	// currEpoch is the epoch of the most recent operation.
 	currEpoch int64
 	// val contains the recent epoch values.
@@ -151,7 +153,7 @@ const historyEpochs = 100
 
 // Init the history helper to keep track of data over the given number of
 // seconds.
-func (h *history) Init(now time.Time, timeframe time.Duration) {
+func (h *history) Init(now crtime.Mono, timeframe time.Duration) {
 	*h = history{
 		epochDuration: timeframe / time.Duration(historyEpochs),
 		startTime:     now,
@@ -161,7 +163,7 @@ func (h *history) Init(now time.Time, timeframe time.Duration) {
 }
 
 // Add adds a value for the current time.
-func (h *history) Add(now time.Time, val int64) {
+func (h *history) Add(now crtime.Mono, val int64) {
 	h.advance(now)
 	h.val[h.currEpoch%historyEpochs] += val
 	h.sum += val
@@ -169,17 +171,17 @@ func (h *history) Add(now time.Time, val int64) {
 
 // Sum returns the sum of recent values. The result is approximate in that the
 // cut-off time is within 1% of the exact one.
-func (h *history) Sum(now time.Time) int64 {
+func (h *history) Sum(now crtime.Mono) int64 {
 	h.advance(now)
 	return h.sum
 }
 
-func (h *history) epoch(t time.Time) int64 {
+func (h *history) epoch(t crtime.Mono) int64 {
 	return int64(t.Sub(h.startTime) / h.epochDuration)
 }
 
 // advance advances the time to the given time.
-func (h *history) advance(now time.Time) {
+func (h *history) advance(now crtime.Mono) {
 	epoch := h.epoch(now)
 	for h.currEpoch < epoch {
 		h.currEpoch++

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/fifo"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -1144,15 +1145,15 @@ func errCorruptIndexEntry(err error) error {
 }
 
 type deterministicStopwatchForTesting struct {
-	startTime time.Time
+	startTime crtime.Mono
 }
 
 func makeStopwatch() deterministicStopwatchForTesting {
-	return deterministicStopwatchForTesting{startTime: time.Now()}
+	return deterministicStopwatchForTesting{startTime: crtime.NowMono()}
 }
 
 func (w deterministicStopwatchForTesting) stop() time.Duration {
-	dur := time.Since(w.startTime)
+	dur := w.startTime.Elapsed()
 	if deterministicReadBlockDurationForTesting {
 		dur = slowReadTracingThreshold
 	}

--- a/wal/failover_writer.go
+++ b/wal/failover_writer.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/record"
@@ -19,16 +20,16 @@ import (
 
 // recordQueueEntry is an entry in recordQueue.
 type recordQueueEntry struct {
-	p                   []byte
-	opts                SyncOptions
-	refCount            RefCount
-	writeStartUnixNanos int64
+	p          []byte
+	opts       SyncOptions
+	refCount   RefCount
+	writeStart crtime.Mono
 }
 
 type poppedEntry struct {
-	opts                SyncOptions
-	refCount            RefCount
-	writeStartUnixNanos int64
+	opts       SyncOptions
+	refCount   RefCount
+	writeStart crtime.Mono
 }
 
 const initialBufferLen = 8192
@@ -152,7 +153,7 @@ func (q *recordQueue) push(
 	p []byte,
 	opts SyncOptions,
 	refCount RefCount,
-	writeStartUnixNanos int64,
+	writeStart crtime.Mono,
 	latestLogSizeInWriteRecord int64,
 	latestWriterInWriteRecord *record.LogWriter,
 ) (index uint32, writer *record.LogWriter, lastLogSize int64) {
@@ -173,10 +174,10 @@ func (q *recordQueue) push(
 	}
 	q.mu.RLock()
 	q.buffer[int(h)%m] = recordQueueEntry{
-		p:                   p,
-		opts:                opts,
-		refCount:            refCount,
-		writeStartUnixNanos: writeStartUnixNanos,
+		p:          p,
+		opts:       opts,
+		refCount:   refCount,
+		writeStart: writeStart,
 	}
 	// Reclaim memory for consumed entries. We couldn't do that in pop since
 	// multiple consumers are popping using CAS and that immediately transfers
@@ -223,7 +224,7 @@ func (q *recordQueue) popAll(err error) (numRecords int, numSyncsPopped int) {
 // pop. This would avoid the CAS below, but it seems better to reduce the
 // amount of queued work regardless of who has successfully written it.
 func (q *recordQueue) pop(index uint32, err error) (numSyncsPopped int) {
-	nowUnixNanos := time.Now().UnixNano()
+	now := crtime.NowMono()
 	var buf [512]poppedEntry
 	tailEntriesToPop := func() (t uint32, numEntriesToPop int) {
 		ht := q.headTail.Load()
@@ -254,9 +255,9 @@ func (q *recordQueue) pop(index uint32, err error) (numSyncsPopped int) {
 		// release those buffer slots to the producer.
 		idx := (i + int(tail)) % n
 		b[i] = poppedEntry{
-			opts:                q.buffer[idx].opts,
-			refCount:            q.buffer[idx].refCount,
-			writeStartUnixNanos: q.buffer[idx].writeStartUnixNanos,
+			opts:       q.buffer[idx].opts,
+			refCount:   q.buffer[idx].refCount,
+			writeStart: q.buffer[idx].writeStart,
 		}
 	}
 	// Since tail cannot change, we don't need to do a compare-and-swap.
@@ -264,7 +265,7 @@ func (q *recordQueue) pop(index uint32, err error) (numSyncsPopped int) {
 	q.mu.RUnlock()
 	q.consumerMu.Unlock()
 	addLatencySample := false
-	var maxLatencyNanos int64
+	var maxLatency time.Duration
 	for i := 0; i < numEntriesToPop; i++ {
 		// Now that we've synced the entry, we can unref it to signal that we
 		// will not read the written byte slice again.
@@ -277,20 +278,20 @@ func (q *recordQueue) pop(index uint32, err error) (numSyncsPopped int) {
 				*b[i].opts.Err = err
 			}
 			b[i].opts.Done.Done()
-			latency := nowUnixNanos - b[i].writeStartUnixNanos
+			latency := now.Sub(b[i].writeStart)
 			if !addLatencySample {
 				addLatencySample = true
-				maxLatencyNanos = latency
-			} else if maxLatencyNanos < latency {
-				maxLatencyNanos = latency
+				maxLatency = latency
+			} else if maxLatency < latency {
+				maxLatency = latency
 			}
 		}
 	}
 	if addLatencySample {
-		if maxLatencyNanos < 0 {
-			maxLatencyNanos = 0
+		if maxLatency < 0 {
+			maxLatency = 0
 		}
-		q.failoverWriteAndSyncLatency.Observe(float64(maxLatencyNanos))
+		q.failoverWriteAndSyncLatency.Observe(float64(maxLatency))
 	}
 	return numSyncsPopped
 }
@@ -504,15 +505,15 @@ func (ww *failoverWriter) WriteRecord(
 	if ref != nil {
 		ref.Ref()
 	}
-	var writeStartUnixNanos int64
+	var writeStart crtime.Mono
 	if opts.Done != nil {
-		writeStartUnixNanos = time.Now().UnixNano()
+		writeStart = crtime.NowMono()
 	}
 	recordIndex, writer, lastLogSize := ww.q.push(
 		p,
 		opts,
 		ref,
-		writeStartUnixNanos,
+		writeStart,
 		ww.logicalOffset.latestLogSizeInWriteRecord,
 		ww.logicalOffset.latestWriterInWriteRecord,
 	)


### PR DESCRIPTION
This commit updates crlib and changes the "production" parts of pebble
to use `crtime.Mono` instead of `time.Time` or unix nanos. `NowMono()`
is about 2x faster than `time.Now` (and is much cleaner than working
with unix nanos).

Informs https://github.com/cockroachdb/cockroach/issues/133315