### PR TITLE
metamorphic: increase per-operation timeouts

### DIFF
--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -76,7 +76,7 @@ func initCommonFlags() *CommonFlags {
 
 	flag.IntVar(&c.NumInstances, "num-instances", 1, "number of pebble instances to create (default: 1)")
 
-	defaultOpTimeout := 1 * time.Minute
+	defaultOpTimeout := 2 * time.Minute
 	if invariants.RaceEnabled {
 		defaultOpTimeout *= 5
 	}

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -423,10 +423,12 @@ func (t *Test) runOp(idx int, h historyRecorder) {
 	if t.opTimeout > 0 {
 		opTimeout := t.opTimeout
 		switch op.(type) {
-		case *compactOp, *downloadOp, *newSnapshotOp, *ingestOp, *ingestAndExciseOp, *ingestExternalFilesOp:
+		case *compactOp, *newSnapshotOp, *ingestOp, *ingestAndExciseOp, *ingestExternalFilesOp:
 			// These ops can be very slow, especially if we end up with many tiny
 			// tables. Bump up the timout by a factor.
 			opTimeout *= 4
+		case *downloadOp:
+			opTimeout *= 8
 		}
 		timer = time.AfterFunc(opTimeout, func() {
 			panic(fmt.Sprintf("operation took longer than %s: %s", opTimeout, op.String()))


### PR DESCRIPTION
We've seen some operation timeouts being hit on teamcity agents with inexplicably slower runs than anywhere else. This change tries to quieten those failures by bumping up the default per-op timeout as well as the timeout for downloads which are especially susceptible to slowdowns in the presence of a lot of files.

Fixes #4114
Fixes #4120