### PR TITLE
.github: bump macos image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       matrix:
         go: ['1.22', '1.23']
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
   


### PR DESCRIPTION
The macOS-12 image is deprecated.

See https://github.com/actions/runner-images/issues/10721