### PR TITLE
crl-release-23.2: db: avoid loading later files for a level in SeekPrefixGE

### DIFF
--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -210,6 +210,10 @@ var DefaultComparer = &Comparer{
 		return append(dst, a...)
 	},
 
+	Split: func(a []byte) int {
+		return len(a)
+	},
+
 	ImmediateSuccessor: func(dst, a []byte) (ret []byte) {
 		return append(append(dst, a...), 0x00)
 	},

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -362,6 +362,12 @@ func build(
 	}
 	tmpFileCount++
 
+	if comparer == nil {
+		cmp := *base.DefaultComparer
+		// runTestFixtures relies on split not being defined.
+		cmp.Split = nil
+		comparer = &cmp
+	}
 	writerOpts := WriterOptions{
 		BlockSize:      blockSize,
 		Comparer:       comparer,

--- a/testdata/iter_histories/prefix_iteration
+++ b/testdata/iter_histories/prefix_iteration
@@ -224,7 +224,7 @@ c@10: (., [c-"c\x00") @1=bar UPDATED)
 #      b. In L6, the level iterator seeks to 000004 which contains a key with
 #         the prefix, returning 'b@4'.
 #   2. Next():
-#      a. Next advances the the L6 iterator to file 000005. This file contains a
+#      a. Next advances the L6 iterator to file 000005. This file contains a
 #         range key [e,f)@1=bar, which updates the lazy-combined iterator's
 #         state, recording the earliest observed range key as 'e'. The L6 level
 #         iterator then returns the file single point key 'c'.
@@ -296,6 +296,55 @@ next
 ----
 b@4: (b@4, .)
 .
+
+# Regression test for #3610.
+#
+# Similar to the above case, this test consists of two SeekPrefixGEs for
+# ascending keys, resulting in TrySeekUsingNext()=true for the second seek.
+# Previously, during the first SeekPrefixGE the mergingIter could Next the
+# levelIter beyond the file containing point keys relevant to both seeks.
+
+reset bloom-bits-per-key=100
+----
+
+define bloom-bits-per-key=100
+L4
+  b@0.SET.10:b@0
+L5
+  b@8.RANGEDEL.3:b@1
+  c@3.SET.0:c@3
+----
+4:
+  000004:[b@0#10,SET-b@0#10,SET]
+5:
+  000005:[b@8#3,RANGEDEL-c@3#0,SET]
+
+combined-iter
+seek-prefix-ge b@10
+seek-prefix-ge c@10
+----
+b@0: (b@0, .)
+c@3: (c@3, .)
+
+# Test a seek for a prefix that falls entirely in the gap between file
+# boundaries. The iterator stats should indicate that no blocks are loaded.
+
+define bloom-bits-per-key=100
+L4
+  b@0.SET.10:b@0
+L4
+  d@3.SET.10:d@3
+----
+4:
+  000004:[b@0#10,SET-b@0#10,SET]
+  000005:[d@3#10,SET-d@3#10,SET]
+
+combined-iter
+seek-prefix-ge c@10
+stats
+----
+.
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal)
 
 # Regression test for #2151.
 #

--- a/testdata/iterator_seek_opt
+++ b/testdata/iterator_seek_opt
@@ -244,7 +244,7 @@ seek-prefix-ge d
 d: (2, .)
 stats: seeked 22 times (21 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # Shifting bounds, with non-overlapping and monotonic bounds, but using
 # SetOptions. A set-options sits between every two seeks. We don't call
@@ -260,7 +260,7 @@ seek-ge b
 b: (1, .)
 stats: seeked 23 times (22 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=c upper=e
@@ -270,7 +270,7 @@ seek-ge c
 c: (1, .)
 stats: seeked 24 times (23 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # NB: Equal bounds.
 
@@ -282,7 +282,7 @@ seek-ge d
 d: (2, .)
 stats: seeked 25 times (24 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=a upper=c
@@ -292,7 +292,7 @@ seek-prefix-ge b
 b: (1, .)
 stats: seeked 26 times (25 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=c upper=e
@@ -302,7 +302,7 @@ seek-prefix-ge c
 c: (1, .)
 stats: seeked 27 times (26 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # NB: Equal bounds.
 
@@ -314,4 +314,4 @@ seek-prefix-ge d
 d: (2, .)
 stats: seeked 28 times (27 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -124,7 +124,7 @@ next
 next
 ----
 d#4,1:4
-dd#5,1:5
+.
 .
 
 iter
@@ -141,9 +141,9 @@ prev
 prev
 ----
 d#4,1:4
-dd#5,1:5
-d#4,1:4
-c#3,1:3
+.
+.
+.
 
 iter
 seek-prefix-ge d
@@ -387,14 +387,14 @@ next
 next
 ----
 d#4,1:4
-dd#5,1:5
+.
 .
 
 iter lower=dd
 seek-prefix-ge d
 next
 ----
-dd#5,1:5
+.
 .
 
 iter lower=d


### PR DESCRIPTION
Don't load arbitrarily later files during levelIter.SeekPrefixGE. This avoids unnecessary IO and CPU overhead.

Close #3575.