### PR TITLE
crl-release-24.1: db: avoid loading later files for a level in SeekPrefixGE

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -59,6 +59,9 @@ type levelIter struct {
 	// recent call to SetBounds.
 	lower []byte
 	upper []byte
+	// prefix holds the iteration prefix when the most recent absolute
+	// positioning method was a SeekPrefixGE.
+	prefix []byte
 	// The iterator options for the currently open table. If
 	// tableOpts.{Lower,Upper}Bound are nil, the corresponding iteration boundary
 	// does not lie within the table bounds.
@@ -235,6 +238,7 @@ func (l *levelIter) init(
 	l.err = nil
 	l.level = level
 	l.logger = opts.getLogger()
+	l.prefix = nil
 	l.lower = opts.LowerBound
 	l.upper = opts.UpperBound
 	l.tableOpts.TableFilter = opts.TableFilter
@@ -641,6 +645,18 @@ func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicato
 			file = l.files.Prev()
 			continue
 		}
+		// If we're in prefix iteration, it's possible this file's smallest
+		// boundary is large enough to prove the file cannot possibly contain
+		// any keys within the iteration prefix. Loading the next file is
+		// unnecessary. This has been observed in practice on slow shared
+		// storage. See #3575.
+		if l.prefix != nil && l.cmp(file.SmallestPointKey.UserKey[:l.split(file.SmallestPointKey.UserKey)], l.prefix) > 0 {
+			// Note that because l.iter is nil, a subsequent call to
+			// SeekPrefixGE with TrySeekUsingNext()=true will load the file
+			// (returning newFileLoaded) and disable TrySeekUsingNext before
+			// performing a seek in the file.
+			return noFileLoaded
+		}
 
 		var rangeDelIter keyspan.FragmentIterator
 		var iter internalIterator
@@ -694,6 +710,7 @@ func (l *levelIter) SeekGE(key []byte, flags base.SeekGEFlags) (*InternalKey, ba
 		l.boundaryContext.isSyntheticIterBoundsKey = false
 		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
+	l.prefix = nil
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
 	loadFileIndicator := l.loadFile(l.findFileGE(key, flags), +1)
@@ -719,6 +736,7 @@ func (l *levelIter) SeekPrefixGE(
 		l.boundaryContext.isSyntheticIterBoundsKey = false
 		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
+	l.prefix = prefix
 
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.LowerBound.
@@ -785,6 +803,7 @@ func (l *levelIter) SeekLT(key []byte, flags base.SeekLTFlags) (*InternalKey, ba
 		l.boundaryContext.isSyntheticIterBoundsKey = false
 		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
+	l.prefix = nil
 
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.UpperBound.
@@ -803,6 +822,7 @@ func (l *levelIter) First() (*InternalKey, base.LazyValue) {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
 		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
+	l.prefix = nil
 
 	// NB: the top-level Iterator will call SeekGE if IterOptions.LowerBound is
 	// set.
@@ -821,6 +841,7 @@ func (l *levelIter) Last() (*InternalKey, base.LazyValue) {
 		l.boundaryContext.isSyntheticIterBoundsKey = false
 		l.boundaryContext.isIgnorableBoundaryKey = false
 	}
+	l.prefix = nil
 
 	// NB: the top-level Iterator will call SeekLT if IterOptions.UpperBound is
 	// set.
@@ -1053,6 +1074,24 @@ func (l *levelIter) skipEmptyFileForward() (*InternalKey, base.LazyValue) {
 					l.boundaryContext.isIgnorableBoundaryKey = true
 				}
 				return l.largestBoundary, base.LazyValue{}
+			}
+		}
+		// If the iterator is in prefix iteration mode, it's possible that we
+		// are here because bloom filter matching failed. In that case it is
+		// likely that all keys matching the prefix are wholly within the
+		// current file and cannot be in a subsequent file. In that case we
+		// don't want to go to the next file, since loading and seeking in there
+		// has some cost.
+		//
+		// This is not just an optimization. We must not advance to the next
+		// file if the current file might possibly contain keys relevant to any
+		// prefix greater than our current iteration prefix. If we did, a
+		// subsequent SeekPrefixGE with TrySeekUsingNext could mistakenly skip
+		// the file's relevant keys.
+		if l.prefix != nil {
+			fileLargestPrefix := l.iterFile.LargestPointKey.UserKey[:l.split(l.iterFile.LargestPointKey.UserKey)]
+			if l.cmp(fileLargestPrefix, l.prefix) > 0 {
+				return nil, base.LazyValue{}
 			}
 		}
 

--- a/testdata/iter_histories/prefix_iteration
+++ b/testdata/iter_histories/prefix_iteration
@@ -297,6 +297,55 @@ next
 b@4: (b@4, .)
 .
 
+# Regression test for #3610.
+#
+# Similar to the above case, this test consists of two SeekPrefixGEs for
+# ascending keys, resulting in TrySeekUsingNext()=true for the second seek.
+# Previously, during the first SeekPrefixGE the mergingIter could Next the
+# levelIter beyond the file containing point keys relevant to both seeks.
+
+reset bloom-bits-per-key=100
+----
+
+define bloom-bits-per-key=100
+L4
+  b@0.SET.10:b@0
+L5
+  b@8.RANGEDEL.3:b@1
+  c@3.SET.0:c@3
+----
+L4:
+  000004:[b@0#10,SET-b@0#10,SET]
+L5:
+  000005:[b@8#3,RANGEDEL-c@3#0,SET]
+
+combined-iter
+seek-prefix-ge b@10
+seek-prefix-ge c@10
+----
+b@0: (b@0, .)
+c@3: (c@3, .)
+
+# Test a seek for a prefix that falls entirely in the gap between file
+# boundaries. The iterator stats should indicate that no blocks are loaded.
+
+define bloom-bits-per-key=100
+L4
+  b@0.SET.10:b@0
+L4
+  d@3.SET.10:d@3
+----
+L4:
+  000004:[b@0#10,SET-b@0#10,SET]
+  000005:[d@3#10,SET-d@3#10,SET]
+
+combined-iter
+seek-prefix-ge c@10
+stats
+----
+.
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal)
+
 # Regression test for #2151.
 #
 # This test consists of two SeekPrefixGEs for ascending keys, which results in

--- a/testdata/iterator_seek_opt
+++ b/testdata/iterator_seek_opt
@@ -244,7 +244,7 @@ seek-prefix-ge d
 d: (2, .)
 stats: seeked 22 times (21 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # Shifting bounds, with non-overlapping and monotonic bounds, but using
 # SetOptions. A set-options sits between every two seeks. We don't call
@@ -260,7 +260,7 @@ seek-ge b
 b: (1, .)
 stats: seeked 23 times (22 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=c upper=e
@@ -270,7 +270,7 @@ seek-ge c
 c: (1, .)
 stats: seeked 24 times (23 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 8
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # NB: Equal bounds.
 
@@ -282,7 +282,7 @@ seek-ge d
 d: (2, .)
 stats: seeked 25 times (24 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=a upper=c
@@ -292,7 +292,7 @@ seek-prefix-ge b
 b: (1, .)
 stats: seeked 26 times (25 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 iter
 set-options lower=c upper=e
@@ -302,7 +302,7 @@ seek-prefix-ge c
 c: (1, .)
 stats: seeked 27 times (26 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 6
+SeekPrefixGEs with trySeekUsingNext: 5
 
 # NB: Equal bounds.
 
@@ -314,4 +314,4 @@ seek-prefix-ge d
 d: (2, .)
 stats: seeked 28 times (27 internal); stepped 2 times (1 fwd/1 rev, internal: 1 fwd/3 rev)
 SeekGEs with trySeekUsingNext: 10
-SeekPrefixGEs with trySeekUsingNext: 8
+SeekPrefixGEs with trySeekUsingNext: 6

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -124,7 +124,7 @@ next
 next
 ----
 d#4,SET:4
-dd#5,SET:5
+.
 .
 
 iter
@@ -141,9 +141,9 @@ prev
 prev
 ----
 d#4,SET:4
-dd#5,SET:5
-d#4,SET:4
-c#3,SET:3
+.
+.
+.
 
 iter
 seek-prefix-ge d
@@ -387,14 +387,14 @@ next
 next
 ----
 d#4,SET:4
-dd#5,SET:5
+.
 .
 
 iter lower=dd
 seek-prefix-ge d
 next
 ----
-dd#5,SET:5
+.
 .
 
 iter lower=d

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -725,8 +725,7 @@ err=injected error
 # L2.000029.Close() = nil <err="injected error">
 err=injected error
 # L1.000028.SeekPrefixGE("b") = (c#27,SET,"27")
-# L2.000029.SeekPrefixGE("b") = nil <err="injected error">
-err=injected error
+.
 
 # Inject errors during L1.{Next,NextPrefix,Prev}.
 


### PR DESCRIPTION
Don't load arbitrarily later files during levelIter.SeekPrefixGE. This avoids unnecessary IO and CPU overhead.

Close #3575.