### PR TITLE
crl-release-24.3: block: improve FlushGovernor logic

### DIFF
--- a/sstable/block/flush_governor_internal_test.go
+++ b/sstable/block/flush_governor_internal_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package block
+
+import "testing"
+
+func TestFindClosestClass(t *testing.T) {
+	vals := []int{10, 20, 30, 50}
+	testCases := [][2]int{
+		{0, 10},
+		{9, 10},
+		{10, 10},
+		{11, 10},
+		{14, 10},
+		{16, 20},
+		{18, 20},
+		{20, 20},
+		{24, 20},
+		{26, 30},
+		{39, 30},
+		{41, 50},
+		{60, 50},
+		{1000, 50},
+	}
+	for _, tc := range testCases {
+		res := vals[findClosestClass(vals, tc[0])]
+		if res != tc[1] {
+			t.Errorf("expected %d, but got %d", tc[1], res)
+		}
+	}
+}

--- a/sstable/block/testdata/flush_governor
+++ b/sstable/block/testdata/flush_governor
@@ -3,7 +3,7 @@ init target-block-size=1000 block-size-threshold=90
 ----
 low watermark: 900
 high watermark: 1000
-boundaries: []
+targetBoundary: 1000
 
 should-flush size-before=800 size-after=900
 ----
@@ -26,11 +26,11 @@ should-flush size-before=899 size-after=10000
 should not flush
 
 # Size classes. Note that the block allocation overhead is 360.
-init target-block-size=1000 size-class-aware-threshold=60 size-classes=(820, 1020, 1320, 1820)
+init target-block-size=800 size-class-aware-threshold=60 size-classes=(820, 1020, 1320, 1820)
 ----
-low watermark: 600
-high watermark: 1452
-boundaries: [652 952]
+low watermark: 480
+high watermark: 952
+targetBoundary: 652
 
 # Should not flush when the "after" block fits in the same size class.
 should-flush size-before=600 size-after=650
@@ -49,9 +49,9 @@ should-flush size-before=600 size-after=950
 ----
 should not flush
 
-should-flush size-before=600 size-after=1450
+should-flush size-before=600 size-after=960
 ----
-should not flush
+should flush
 
 # Should flush when the after size is above the high watermark.
 should-flush size-before=600 size-after=1500
@@ -60,7 +60,7 @@ should flush
 
 # Should not flush when the "before" size is below the low watermark (even when
 # the "after" size is greater than the high watermark).
-should-flush size-before=500 size-after=1500
+should-flush size-before=400 size-after=1500
 ----
 should not flush
 
@@ -69,28 +69,26 @@ init target-block-size=1000 size-class-aware-threshold=60 size-classes=(1500, 20
 ----
 low watermark: 900
 high watermark: 1000
-boundaries: []
+targetBoundary: 1000
 
 # Size classes should be ignored when they're all below the target block size.
 init target-block-size=1000 size-class-aware-threshold=60 size-classes=(500, 800, 900)
 ----
 low watermark: 900
 high watermark: 1000
-boundaries: []
-
-# Verify we limit the number of boundaries to 4.
-init target-block-size=1000 size-class-aware-threshold=60 size-classes=(500, 600, 650, 700, 750, 800, 850, 900, 950, 1000, 1050)
-----
-low watermark: 900
-high watermark: 1000
-boundaries: []
+targetBoundary: 1000
 
 # Test with jemalloc boundaries.
 init target-block-size=32768 jemalloc-size-classes
 ----
 low watermark: 19661
 high watermark: 40592
-boundaries: [20112 24208 28304 32400]
+targetBoundary: 32400
+
+# We should not flush until exceeding the boundary.
+should-flush size-before=30000 size-after=31000
+----
+should not flush
 
 # We should flush to avoid exceeding the boundary.
 should-flush size-before=32000 size-after=32766

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -316,6 +316,7 @@ var JemallocSizeClasses = []int{
 	40 * 1024, 48 * 1024, 56 * 1024, 64 * 1024, // 8KiB spacing
 	80 * 1024, 96 * 1024, 112 * 1024, 128 * 1024, // 16KiB spacing.
 	160 * 1024, 192 * 1024, 224 * 1024, 256 * 1024, // 32KiB spacing.
+	320 * 1024,
 }
 
 // SetInternal sets the internal writer options. Note that even though this


### PR DESCRIPTION
Currently the FlushGovernor logic results in blocks that are too small
(about 60% of the target). This was a result of a misinterpretation of
the previous code.

We now find the allocation size boundary that is closest to our target
and consider that boundary and the following one. For the 32KB
cockroach default block size, the boundaries are 32KB and 40KB. We
will flush right before exceeding the 32KB boundary, unless we have a
large enough KV that fits better in the 40KB class.

Informs https://github.com/cockroachdb/cockroach/issues/134420