### PR TITLE
sstable: fix nil pointer with DisableValueBlocks set

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -203,11 +203,13 @@ func (w *RawColumnWriter) EstimatedSize() uint64 {
 	if w.rangeKeyBlock.KeyCount() > 0 {
 		sz += uint64(w.rangeKeyBlock.Size())
 	}
-	for _, blk := range w.valueBlock.blocks {
-		sz += uint64(blk.block.LengthWithTrailer())
-	}
-	if w.valueBlock.buf != nil {
-		sz += uint64(len(w.valueBlock.buf.b))
+	if w.valueBlock != nil {
+		for _, blk := range w.valueBlock.blocks {
+			sz += uint64(blk.block.LengthWithTrailer())
+		}
+		if w.valueBlock.buf != nil {
+			sz += uint64(len(w.valueBlock.buf.b))
+		}
 	}
 	// TODO(jackson): Include an estimate of the properties, filter and meta
 	// index blocks sizes.

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -327,3 +327,18 @@ rocksdb.property.collectors: [obsolete-key]
 pebble.raw.range-key.key.size: 6
 pebble.raw.range-key.value.size: 9
 obsolete-key: hex:0074
+
+open-writer disable-value-blocks
+----
+
+write-kvs
+a@2.SET.1:a2
+a@1.SET.1:a1
+b@2.SET.1:b2
+----
+EstimatedSize()=53
+
+close
+----
+point:    [a@2#1,SET-b@2#1,SET]
+seqnums:  [1-1]


### PR DESCRIPTION
Previously, the EstimatedSize method of the columnar sstable writer would panic when the writer was configured with DisableValueBlocks enabled.