### PR TITLE
sstable: reconcile out-of-order key error messages

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -534,8 +534,13 @@ func (w *RawColumnWriter) evaluatePoint(
 
 	if !w.disableKeyOrderChecks && (eval.kcmp.UserKeyComparison < 0 ||
 		(eval.kcmp.UserKeyComparison == 0 && w.prevPointKey.trailer <= key.Trailer)) {
+		previousKey := base.InternalKey{
+			UserKey: w.dataBlock.MaterializeLastUserKey(nil),
+			Trailer: w.prevPointKey.trailer,
+		}
 		return eval, errors.Errorf(
-			"pebble: keys must be added in strictly increasing order: %s",
+			"pebble: keys must be added in strictly increasing order: %s, %s",
+			previousKey.Pretty(w.comparer.FormatKey),
 			key.Pretty(w.comparer.FormatKey))
 	}
 

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -142,13 +142,13 @@ build
 a.SET.1:b
 a.SET.2:c
 ----
-pebble: keys must be added in strictly increasing order: a#2,SET
+pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
 
 build
 b.SET.1:a
 a.SET.2:b
 ----
-pebble: keys must be added in strictly increasing order: a#2,SET
+pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
 
 build
 b.RANGEDEL.1:c


### PR DESCRIPTION
When keys are written to a sstable writer out-of-order, the writer returns an error message. The error messages returned from the row-based and column-based writers varied, in part because the columnar writer did not readily have the previous key at hand. This commit adapts the column writer to synthesize the previous user key for the purpose of embedding it within the returned error message.

This will ensure cockroach unit tests that assert on these errors behave correctly when metamorphically switching between row and column blocks.