### PR TITLE
tool: use MakeReaderOptions

### DIFF
--- a/tool/db.go
+++ b/tool/db.go
@@ -884,19 +884,15 @@ func (d *dbT) addProps(
 	if err != nil {
 		return err
 	}
-	opts := sstable.ReaderOptions{
-		Mergers:   d.mergers,
-		Comparers: d.comparers,
-	}
+	opts := d.opts.MakeReaderOptions()
+	opts.Mergers = d.mergers
+	opts.Comparers = d.comparers
 	opts.SetInternal(sstableinternal.ReaderOptions{
 		CacheOpts: sstableinternal.CacheOptions{
 			FileNum: m.FileBacking.DiskFileNum,
 		},
 	})
-	r, err := sstable.NewReader(ctx, f, sstable.ReaderOptions{
-		Mergers:   d.mergers,
-		Comparers: d.comparers,
-	})
+	r, err := sstable.NewReader(ctx, f, opts)
 	if err != nil {
 		_ = f.Close()
 		return err

--- a/tool/find.go
+++ b/tool/find.go
@@ -438,12 +438,9 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 				}
 			}()
 
-			opts := sstable.ReaderOptions{
-				Comparer:  f.opts.Comparer,
-				Filters:   f.opts.Filters,
-				Comparers: f.comparers,
-				Mergers:   f.mergers,
-			}
+			opts := f.opts.MakeReaderOptions()
+			opts.Comparers = f.comparers
+			opts.Mergers = f.mergers
 			opts.SetInternal(sstableinternal.ReaderOptions{
 				CacheOpts: sstableinternal.CacheOptions{
 					Cache:   cache,

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -147,13 +147,9 @@ func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	o := sstable.ReaderOptions{
-		Comparer:   s.opts.Comparer,
-		Comparers:  s.comparers,
-		KeySchemas: s.opts.KeySchemas,
-		Filters:    s.opts.Filters,
-		Mergers:    s.mergers,
-	}
+	o := s.opts.MakeReaderOptions()
+	o.Comparers = s.comparers
+	o.Mergers = s.mergers
 	c := pebble.NewCache(128 << 20 /* 128 MB */)
 	defer c.Unref()
 	o.SetInternal(sstableinternal.ReaderOptions{

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -56,6 +56,13 @@ func Comparers(cmps ...*Comparer) Option {
 	}
 }
 
+// KeySchema configures the name of the schema to use when writing sstables.
+func KeySchema(name string) Option {
+	return func(t *T) {
+		t.opts.KeySchema = name
+	}
+}
+
 // KeySchemas may be passed to New to register key schemas for use by the
 // introspection tools.
 func KeySchemas(schemas ...*colblk.KeySchema) Option {


### PR DESCRIPTION
Use MakeReaderOptions when constructing the sstable.ReaderOptions in individual subcommands. This is more maintainable and fixes a bug whereby the find command was unable to read columnar sstables written in a non-default KeySchema.