### PR TITLE
crl-release-24.3: sstable: order range keys consistently in colblk and rowblk encodings

### DIFF
--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -470,9 +470,14 @@ func SortKeysByTrailer(keys []Key) {
 	})
 }
 
-// SortKeysBySuffix sorts a Keys slice by suffix.
-func SortKeysBySuffix(suffixCmp base.CompareRangeSuffixes, keys []Key) {
+// SortKeysByTrailerAndSuffix sorts a Keys slice by trailer, and among keys with
+// equal trailers, by suffix.
+func SortKeysByTrailerAndSuffix(suffixCmp base.CompareRangeSuffixes, keys []Key) {
 	slices.SortFunc(keys, func(a, b Key) int {
+		// Trailer are ordered in decreasing number order.
+		if v := cmp.Compare(b.Trailer, a.Trailer); v != 0 {
+			return v
+		}
 		return suffixCmp(a.Suffix, b.Suffix)
 	})
 }

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -227,6 +227,10 @@ func (i *fragmentIter) gatherForward(kv *base.InternalKV) (*keyspan.Span, error)
 	if err := i.applySpanTransforms(); err != nil {
 		return nil, err
 	}
+
+	// Apply a consistent ordering.
+	keyspan.SortKeysByTrailer(i.span.Keys)
+
 	// i.blockIter is positioned over the first internal key for the next span.
 	return &i.span, nil
 }
@@ -264,7 +268,7 @@ func (i *fragmentIter) gatherBackward(kv *base.InternalKV) (*keyspan.Span, error
 	// i.blockIter is positioned over the last internal key for the previous
 	// span.
 
-	// Backwards iteration encounters internal keys in the wrong order.
+	// Apply a consistent ordering.
 	keyspan.SortKeysByTrailer(i.span.Keys)
 
 	i.applySpanTransforms()


### PR DESCRIPTION
24.3 backport of #4160.

----

Previously the ordering of range keys within a range key block was a bit muddled and undefined. Before encoding a Span of range keys to the underlying RawWriter, the sstable.Writer type previously sorted the span's keys by suffix. However, the row-based sstable writer always serializes RANGEKEYSETs of a Span first, followed by RANGEKEYUNSETs and then RANGEKEYDELs.

Confusingly, the rowblk fragment iterator also sorted keys by trailer when iterating backwards, but not forwards. The columnar RawWriter preserved the order of keys in the span passed to EncodeSpan, and this order was preserved during iteration.

This commit adapts the sstable.Writer type to sort a range key Span's keys by trailer and then suffix before encoding. This provides determinism and matches the ordering of keys produced by compactions which sort the keys by trailer. Additionally, the rowblk fragment iterator is updated to always sort the returned keys by trailer.