### PR TITLE
db: log additional WAL details during replay

### DIFF
--- a/open.go
+++ b/open.go
@@ -1022,7 +1022,7 @@ func (d *DB) replayWAL(
 	}
 
 	d.opts.Logger.Infof("[JOB %d] WAL %s stopped reading at offset: %s; replayed %d keys in %d batches",
-		jobID, base.DiskFileNum(ll.Num).String(), offset, keysReplayed, batchesReplayed)
+		jobID, ll.String(), offset, keysReplayed, batchesReplayed)
 	if !d.opts.ReadOnly {
 		flushMem()
 	}

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/redact"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -434,8 +435,15 @@ type Offset struct {
 // String implements fmt.Stringer, returning a string representation of the
 // offset.
 func (o Offset) String() string {
+	return redact.StringWithoutMarkers(o)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (o Offset) SafeFormat(w redact.SafePrinter, _ rune) {
 	if o.PreviousFilesBytes > 0 {
-		return fmt.Sprintf("(%s: %d), %d from previous files", o.PhysicalFile, o.Physical, o.PreviousFilesBytes)
+		w.Printf("(%s: %d), %d from previous files", o.PhysicalFile, o.Physical, o.PreviousFilesBytes)
+		return
 	}
-	return fmt.Sprintf("(%s: %d)", o.PhysicalFile, o.Physical)
+	w.Printf("(%s: %d)", o.PhysicalFile, o.Physical)
+
 }


### PR DESCRIPTION
When we finish replaying a WAL, log the logical log which will encode all the replayed segment files (if WAL failover resulted in multiple physical files).

```
[JOB 1] WAL 000002: {(data,000)} stopped reading at offset: (data/000002.log: 0); replayed 0 keys in 0 batches
```

Additionally, implement the SafeFormatter interface to ensure that relevant details are not redacted.

Informs #4162.