### PR TITLE
db: clean up Checkpoint collection of WALs

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -383,8 +383,7 @@ func TestLargeBatch(t *testing.T) {
 	getLatestLog := func() wal.LogicalLog {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		logs, err := d.mu.log.manager.List()
-		require.NoError(t, err)
+		logs := d.mu.log.manager.List()
 		return logs[len(logs)-1]
 	}
 	memTableCreationSeqNum := func() base.SeqNum {
@@ -1996,15 +1995,13 @@ func TestRecycleLogs(t *testing.T) {
 	logNum := func() base.DiskFileNum {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		walNums, err := d.mu.log.manager.List()
-		require.NoError(t, err)
+		walNums := d.mu.log.manager.List()
 		return base.DiskFileNum(walNums[len(walNums)-1].Num)
 	}
 	logCount := func() int {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		walNums, err := d.mu.log.manager.List()
-		require.NoError(t, err)
+		walNums := d.mu.log.manager.List()
 		return len(walNums)
 	}
 

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -530,7 +530,7 @@ func (wm *failoverManager) init(o Options, initial Logs) error {
 }
 
 // List implements Manager.
-func (wm *failoverManager) List() (Logs, error) {
+func (wm *failoverManager) List() Logs {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
 	n := len(wm.mu.closedWALs)
@@ -554,7 +554,7 @@ func (wm *failoverManager) List() (Logs, error) {
 	if wm.mu.ww != nil {
 		setLogicalLog(n-1, wm.mu.ww.getLog())
 	}
-	return wals, nil
+	return wals
 }
 
 // Obsolete implements Manager.

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -424,10 +424,7 @@ func TestManagerFailover(t *testing.T) {
 				return b.String()
 
 			case "list-and-stats":
-				logs, err := fm.List()
-				if err != nil {
-					return err.Error()
-				}
+				logs := fm.List()
 				stats := fm.Stats()
 				var b strings.Builder
 				if len(logs) > 0 {

--- a/wal/standalone_manager.go
+++ b/wal/standalone_manager.go
@@ -78,7 +78,7 @@ func (m *StandaloneManager) init(o Options, initial Logs) error {
 }
 
 // List implements Manager.
-func (m *StandaloneManager) List() (Logs, error) {
+func (m *StandaloneManager) List() Logs {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	wals := make(Logs, len(m.mu.queue))
@@ -88,7 +88,7 @@ func (m *StandaloneManager) List() (Logs, error) {
 			segments: []segment{{dir: m.o.Primary}},
 		}
 	}
-	return wals, nil
+	return wals
 }
 
 // Obsolete implements Manager.

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -322,8 +322,9 @@ type Manager interface {
 	// init initializes the Manager. init is called during DB initialization.
 	init(o Options, initial Logs) error
 
-	// List returns the virtual WALs in ascending order.
-	List() (Logs, error)
+	// List returns the virtual WALs in ascending order. List must not perform
+	// I/O.
+	List() Logs
 	// Obsolete informs the manager that all virtual WALs less than
 	// minUnflushedNum are obsolete. The callee can choose to recycle some
 	// underlying log files, if !noRecycle. The log files that are not recycled,


### PR DESCRIPTION
Copy all the WALs provided by the wal.Manager. This is guaranteed to be a superset of the WALs in the flushable queue. Additionally, collect the WALs while holding DB.mu to ensure the DB can't complete a flush and mark a relevant WAL as obsolete before the call to (wal.Manager).List acquires the WAL manager's mutex.