### PR TITLE
sstable/valblk: new package

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
+	"github.com/cockroachdb/pebble/sstable/valblk"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -71,7 +72,7 @@ type Reader struct {
 	filterBH     block.Handle
 	rangeDelBH   block.Handle
 	rangeKeyBH   block.Handle
-	valueBIH     valueBlocksIndexHandle
+	valueBIH     valblk.IndexHandle
 	propertiesBH block.Handle
 	metaindexBH  block.Handle
 	footerBH     block.Handle
@@ -664,7 +665,7 @@ func (r *Reader) Layout() (*Layout, error) {
 		Data:       make([]block.HandleWithProperties, 0, r.Properties.NumDataBlocks),
 		RangeDel:   r.rangeDelBH,
 		RangeKey:   r.rangeKeyBH,
-		ValueIndex: r.valueBIH.h,
+		ValueIndex: r.valueBIH.Handle,
 		Properties: r.propertiesBH,
 		MetaIndex:  r.metaindexBH,
 		Footer:     r.footerBH,
@@ -742,8 +743,8 @@ func (r *Reader) Layout() (*Layout, error) {
 			}
 		}
 	}
-	if r.valueBIH.h.Length != 0 {
-		vbiH, err := r.readValueBlock(context.Background(), noEnv, noReadHandle, r.valueBIH.h)
+	if r.valueBIH.Handle.Length != 0 {
+		vbiH, err := r.readValueBlock(context.Background(), noEnv, noReadHandle, r.valueBIH.Handle)
 		if err != nil {
 			return nil, err
 		}

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -235,19 +235,19 @@ sstable
  │    └── trailer [compression=none checksum=0x5fb0d551]
  ├── data  offset: 38  length: 29
  │    ├── 00000    record (21 = 3 [0] + 14 + 4) [restart]
- │    │            blue@8#18,SET:value handle {valueLen:5 blockNum:0 offsetInBlock:0}
+ │    │            blue@8#18,SET:value handle {ValueLen:5 BlockNum:0 OffsetInBlock:0}
  │    ├── restart points
  │    │    └── 00021 [restart 0]
  │    └── trailer [compression=none checksum=0x628e4a10]
  ├── data  offset: 72  length: 29
  │    ├── 00000    record (21 = 3 [0] + 14 + 4) [restart]
- │    │            blue@8#16,SET:value handle {valueLen:6 blockNum:0 offsetInBlock:5}
+ │    │            blue@8#16,SET:value handle {ValueLen:6 BlockNum:0 OffsetInBlock:5}
  │    ├── restart points
  │    │    └── 00021 [restart 0]
  │    └── trailer [compression=none checksum=0x4e65b9b6]
  ├── data  offset: 106  length: 29
  │    ├── 00000    record (21 = 3 [0] + 14 + 4) [restart]
- │    │            blue@6#16,SET:value handle {valueLen:15 blockNum:1 offsetInBlock:0}
+ │    │            blue@6#16,SET:value handle {ValueLen:15 BlockNum:1 OffsetInBlock:0}
  │    ├── restart points
  │    │    └── 00021 [restart 0]
  │    └── trailer [compression=none checksum=0x9f60e629]
@@ -478,7 +478,7 @@ sstable
  │    │    ├── data for column 6 (bool)
  │    │    │    └── 112-113: x 01 # zero bitmap encoding
  │    │    └── 113-114: x 00 # block padding byte
- │    ├── blue@8#18,SET:value handle {valueLen:5 blockNum:0 offsetInBlock:0}
+ │    ├── blue@8#18,SET:value handle {ValueLen:5 BlockNum:0 OffsetInBlock:0}
  │    └── trailer [compression=snappy checksum=0xceb8415d]
  ├── data  offset: 177  length: 95
  │    ├── data block header
@@ -545,7 +545,7 @@ sstable
  │    │    │    ├── 120-128: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap word 0
  │    │    │    └── 128-136: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
  │    │    └── 136-137: x 00 # block padding byte
- │    ├── blue@8#16,SET:value handle {valueLen:6 blockNum:0 offsetInBlock:5}
+ │    ├── blue@8#16,SET:value handle {ValueLen:6 BlockNum:0 OffsetInBlock:5}
  │    └── trailer [compression=snappy checksum=0xfb8462e1]
  ├── data  offset: 277  length: 91
  │    ├── data block header
@@ -609,7 +609,7 @@ sstable
  │    │    ├── data for column 6 (bool)
  │    │    │    └── 112-113: x 01 # zero bitmap encoding
  │    │    └── 113-114: x 00 # block padding byte
- │    ├── blue@6#16,SET:value handle {valueLen:15 blockNum:1 offsetInBlock:0}
+ │    ├── blue@6#16,SET:value handle {ValueLen:15 BlockNum:1 OffsetInBlock:0}
  │    └── trailer [compression=snappy checksum=0xa053f3eb]
  ├── index  offset: 373  length: 42
  │    ├── 00000    block:0/81

--- a/sstable/valblk/valblk.go
+++ b/sstable/valblk/valblk.go
@@ -1,0 +1,356 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package valblk implements value blocks for sstables.
+//
+// Value blocks are supported in TableFormatPebblev3.
+//
+// 1. Motivation and overview
+//
+// Value blocks are a mechanism designed for sstables storing MVCC data, where
+// there can be many versions of a key that need to be kept, but only the
+// latest value is typically read (see the documentation for Comparer.Split
+// regarding MVCC keys). The goal is faster reads. Unlike Pebble versions,
+// which can be eagerly thrown away (except when there are snapshots), MVCC
+// versions are long-lived (e.g. default CockroachDB garbage collection
+// threshold for older versions is 24 hours) and can significantly slow down
+// reads. We have seen CockroachDB production workloads with very slow reads
+// due to:
+// - 100s of versions for each key in a table.
+//
+//   - Tables with mostly MVCC garbage consisting of 2 versions per key -- a
+//     real key-value pair, followed by a key-value pair whose value (usually
+//     with zero byte length) indicates it is an MVCC tombstone.
+//
+// The value blocks mechanism attempts to improve read throughput in these
+// cases when the key size is smaller than the value sizes of older versions.
+// This is done by moving the value of an older version to a value block in a
+// different part of the sstable. This improves spatial locality of the data
+// being read by the workload, which increases caching effectiveness.
+//
+// Additionally, even when the key size is not smaller than the value of older
+// versions (e.g. secondary indexes in CockroachDB), TableFormatPebblev3
+// stores the result of key comparisons done at write time inside the sstable,
+// which makes stepping from one key prefix to the next prefix (i.e., skipping
+// over older versions of a MVCC key) more efficient by avoiding key
+// comparisons and key decoding. See the results in
+// https://github.com/cockroachdb/pebble/pull/2149 and more details in the
+// comment inside BenchmarkIteratorScanNextPrefix. These improvements are also
+// visible in end-to-end CockroachDB tests, as outlined in
+// https://github.com/cockroachdb/cockroach/pull/96652.
+//
+// In TableFormatPebblev3, each SET has a one byte value prefix that tells us
+// whether the value is in-place or in a value block. This 1 byte prefix
+// encodes additional information:
+//
+//   - ShortAttribute: This is an attribute of the value. Currently, CockroachDB
+//     uses it to represent whether the value is a tombstone or not. This avoids
+//     the need to fetch a value from the value block if the caller only wants
+//     to figure out whether it is an MVCC tombstone. The length of the value is
+//     another attribute that the caller can be interested in, and it is also
+//     accessible without reading the value in the value block (see the value
+//     handle in the details section).
+//
+//   - SET-same-prefix: this enables the aforementioned optimization when
+//     stepping from one key prefix to the next key prefix.
+//
+// We further optimize this iteration over prefixes by using the restart
+// points in a block to encode whether the SET at a restart point has the same
+// prefix since the last restart point. This allows us to skip over restart
+// points within the same block. See the comment in blockWriter, and how both
+// SET-same-prefix and the restart point information is used in
+// blockIter.nextPrefixV3.
+//
+// This flexibility of values that are in-place or in value blocks requires
+// flexibility in the iterator interface. The InternalIterator interface
+// returns a LazyValue instead of a byte slice. Additionally, pebble.Iterator
+// allows the caller to ask for a LazyValue. See lazy_value.go for details,
+// including the memory lifetime management.
+//
+// For historical discussions about this feature, see the issue
+// https://github.com/cockroachdb/pebble/issues/1170 and the prototype in
+// https://github.com/cockroachdb/pebble/pull/1443.
+//
+// The code in this file mainly covers value block and related encodings. We
+// discuss these in the next section.
+//
+// 2. Details
+//
+// Note that the notion of the latest value is local to the sstable. It is
+// possible that that latest value has been deleted by a sstable in a higher
+// level, and what is the latest value from the perspective of the whole LSM
+// is an older MVCC version. This only affects performance and not
+// correctness. This local knowledge is also why we continue to store these
+// older versions in the same sstable -- we need to be able to conveniently
+// read them. The code in this file is agnostic to the policy regarding what
+// should be stored in value blocks -- it allows even the latest MVCC version
+// to be stored in a value block. The policy decision in made in the
+// sstable.Writer. See Writer.makeAddPointDecisionV3.
+//
+// Data blocks contain two kinds of SET keys: those with in-place values and
+// those with a value handle. To distinguish these two cases we use a single
+// byte prefix (ValuePrefix). This single byte prefix is split into multiple
+// parts, where nb represents information that is encoded in n bits.
+//
+// +---------------+--------------------+-----------+--------------------+
+// | value-kind 2b | SET-same-prefix 1b | unused 2b | short-attribute 3b |
+// +---------------+--------------------+-----------+--------------------+
+//
+// The 2 bit value-kind specifies whether this is an in-place value or a value
+// handle pointing to a value block. We use 2 bits here for future
+// representation of values that are in separate files. The 1 bit
+// SET-same-prefix is true if this key is a SET and is immediately preceded by
+// a SET that shares the same prefix. The 3 bit short-attribute is described
+// in base.ShortAttribute -- it stores user-defined attributes about the
+// value. It is unused for in-place values.
+//
+// Value Handle and Value Blocks:
+// valueHandles refer to values in value blocks. Value blocks are simpler than
+// normal data blocks (that contain key-value pairs, and allow for binary
+// search), which makes them cheap for value retrieval purposes. A valueHandle
+// is a tuple (valueLen, blockNum, offsetInBlock), where blockNum is the 0
+// indexed value block number and offsetInBlock is the byte offset in that
+// block containing the value. The valueHandle.valueLen is included since
+// there are multiple use cases in CockroachDB that need the value length but
+// not the value, for which we can avoid reading the value in the value block
+// (see
+// https://github.com/cockroachdb/pebble/issues/1170#issuecomment-958203245).
+//
+// A value block has a checksum like other blocks, and is optionally
+// compressed. An uncompressed value block is a sequence of values with no
+// separator or length (we rely on the valueHandle to demarcate). The
+// valueHandle.offsetInBlock points to the value, of length
+// valueHandle.valueLen. While writing a sstable, all the (possibly
+// compressed) value blocks need to be held in-memory until they can be
+// written. Value blocks are placed after the "meta rangedel" and "meta range
+// key" blocks since value blocks are considered less likely to be read.
+//
+// Meta Value Index Block:
+// Since the (key, valueHandle) pair are written before there is any knowledge
+// of the byte offset of the value block in the file, or its compressed
+// length, we need another lookup to map the valueHandle.blockNum to the
+// information needed to read it from the file. This information is provided
+// by the "value index block". The "value index block" is referred to by the
+// metaindex block. The design intentionally avoids making the "value index
+// block" a general purpose key-value block, since each caller wants to lookup
+// the information for a particular blockNum (there is no need for SeekGE
+// etc.). Instead, this index block stores a sequence of (blockNum,
+// blockOffset, blockLength) tuples, where the blockNums are consecutive
+// integers, and the tuples are encoded with a fixed width encoding. This
+// allows a reader to find the tuple for block K by looking at the offset
+// K*fixed-width. The fixed width for each field is decided by looking at the
+// maximum value of each of these fields. As a concrete example of a large
+// sstable with many value blocks, we constructed a 100MB sstable with many
+// versions and had 2475 value blocks (~32KB each). This sstable had this
+// tuple encoded using 2+4+2=8 bytes, which means the uncompressed value index
+// block was 2475*8=~19KB, which is modest. Therefore, we don't support more
+// than one value index block. Consider the example of 2 byte blockNum, 4 byte
+// blockOffset and 2 byte blockLen. The value index block will look like:
+//
+//	+---------------+------------------+---------------+
+//	| blockNum (2B) | blockOffset (4B) | blockLen (2B) |
+//	+---------------+------------------+---------------+
+//	|       0       |    7,123,456     |  30,000       |
+//	+---------------+------------------+---------------+
+//	|       1       |    7,153,456     |  20,000       |
+//	+---------------+------------------+---------------+
+//	|       2       |    7,173,456     |  25,567       |
+//	+---------------+------------------+---------------+
+//	|     ....      |      ...         |    ...        |
+//
+// The metaindex block contains the valueBlocksIndexHandle which in addition
+// to the BlockHandle also specifies the widths of these tuple fields. In the
+// above example, the
+// valueBlockIndexHandle.{blockNumByteLength,blockOffsetByteLength,blockLengthByteLength}
+// will be (2,4,2).
+package valblk
+
+import (
+	"encoding/binary"
+	"unsafe"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/sstable/block"
+)
+
+// Handle is stored with a key when the value is in a value block. This
+// handle is the pointer to that value.
+type Handle struct {
+	ValueLen      uint32
+	BlockNum      uint32
+	OffsetInBlock uint32
+}
+
+// HandleMaxLen is the maximum length of a variable-width encoded Handle.
+//
+// Handle fields are varint encoded, so maximum 5 bytes each, plus 1 byte for
+// the valuePrefix. This could alternatively be group varint encoded, but
+// experiments were inconclusive
+// (https://github.com/cockroachdb/pebble/pull/1443#issuecomment-1270298802).
+const HandleMaxLen = 5*3 + 1
+
+// EncodeHandle encodes the Handle into dst in a variable-width encoding and
+// returns the number of bytes encoded.
+func EncodeHandle(dst []byte, v Handle) int {
+	n := 0
+	n += binary.PutUvarint(dst[n:], uint64(v.ValueLen))
+	n += binary.PutUvarint(dst[n:], uint64(v.BlockNum))
+	n += binary.PutUvarint(dst[n:], uint64(v.OffsetInBlock))
+	return n
+}
+
+// DecodeLenFromHandle decodes the value length from the beginning of a
+// variaible-width encoded Handle.
+func DecodeLenFromHandle(src []byte) (uint32, []byte) {
+	ptr := unsafe.Pointer(&src[0])
+	var v uint32
+	if a := *((*uint8)(ptr)); a < 128 {
+		v = uint32(a)
+		src = src[1:]
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		v = uint32(b)<<7 | uint32(a)
+		src = src[2:]
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[3:]
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[4:]
+	} else {
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[5:]
+	}
+	return v, src
+}
+
+// DecodeRemainingHandle decodes the BlockNum and OffsetInBlock from a
+// variable-width encoded Handle, assuming the ValueLen prefix has already been
+// stripped from src.
+func DecodeRemainingHandle(src []byte) Handle {
+	var vh Handle
+	ptr := unsafe.Pointer(&src[0])
+	// Manually inlined uvarint decoding. Saves ~25% in benchmarks. Unrolling
+	// a loop for i:=0; i<2; i++, saves ~6%.
+	var v uint32
+	if a := *((*uint8)(ptr)); a < 128 {
+		v = uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 1)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		v = uint32(b)<<7 | uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 2)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 3)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+	} else {
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+	}
+	vh.BlockNum = v
+
+	if a := *((*uint8)(ptr)); a < 128 {
+		v = uint32(a)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		v = uint32(b)<<7 | uint32(a)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+	} else {
+		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+	}
+	vh.OffsetInBlock = v
+
+	return vh
+}
+
+// DecodeHandle decodes a Handle from a variable-length encoding.
+func DecodeHandle(src []byte) Handle {
+	valLen, src := DecodeLenFromHandle(src)
+	vh := DecodeRemainingHandle(src)
+	vh.ValueLen = valLen
+	return vh
+}
+
+// IndexHandle is placed in the metaindex if there are any value blocks. If
+// there are no value blocks, there is no value blocks index, and no entry in
+// the metaindex. Note that the lack of entry in the metaindex should not be
+// used to ascertain whether the values are prefixed, since the former is an
+// emergent property of the data that was written and not known until all the
+// key-value pairs in the sstable are written.
+type IndexHandle struct {
+	Handle                block.Handle
+	BlockNumByteLength    uint8
+	BlockOffsetByteLength uint8
+	BlockLengthByteLength uint8
+}
+
+// EncodeIndexHandle encodes the IndexHandle into dst and returns the number of
+// bytes written.
+func EncodeIndexHandle(dst []byte, v IndexHandle) int {
+	n := v.Handle.EncodeVarints(dst)
+	dst[n] = v.BlockNumByteLength
+	n++
+	dst[n] = v.BlockOffsetByteLength
+	n++
+	dst[n] = v.BlockLengthByteLength
+	n++
+	return n
+}
+
+// DecodeIndexHandle decodes an IndexHandle from src and returns the number of
+// bytes read.
+func DecodeIndexHandle(src []byte) (IndexHandle, int, error) {
+	var vbih IndexHandle
+	var n int
+	vbih.Handle, n = block.DecodeHandle(src)
+	if n <= 0 {
+		return vbih, 0, errors.Errorf("bad BlockHandle %x", src)
+	}
+	if len(src) != n+3 {
+		return vbih, 0, errors.Errorf("bad BlockHandle %x", src)
+	}
+	vbih.BlockNumByteLength = src[n]
+	vbih.BlockOffsetByteLength = src[n+1]
+	vbih.BlockLengthByteLength = src[n+2]
+	return vbih, n + 3, nil
+}
+
+// littleEndianPut writes v to b using little endian encoding, under the
+// assumption that v can be represented using n bytes.
+func littleEndianPut(v uint64, b []byte, n int) {
+	_ = b[n-1] // bounds check
+	for i := 0; i < n; i++ {
+		b[i] = byte(v)
+		v = v >> 8
+	}
+}
+
+// lenLittleEndian returns the minimum number of bytes needed to encode v
+// using little endian encoding.
+func lenLittleEndian(v uint64) int {
+	n := 0
+	for i := 0; i < 8; i++ {
+		n++
+		v = v >> 8
+		if v == 0 {
+			break
+		}
+	}
+	return n
+}
+
+func littleEndianGet(b []byte, n int) uint64 {
+	_ = b[n-1] // bounds check
+	v := uint64(b[0])
+	for i := 1; i < n; i++ {
+		v |= uint64(b[i]) << (8 * i)
+	}
+	return v
+}

--- a/sstable/valblk/valblk_test.go
+++ b/sstable/valblk/valblk_test.go
@@ -1,8 +1,8 @@
-// Copyright 2022 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package sstable
+package valblk
 
 import (
 	"fmt"
@@ -15,17 +15,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValueHandleEncodeDecode(t *testing.T) {
+func TestHandleEncodeDecode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	testCases := []valueHandle{
-		{valueLen: 23, blockNum: 100003, offsetInBlock: 2300},
-		{valueLen: math.MaxUint32 - 1, blockNum: math.MaxUint32 / 2, offsetInBlock: math.MaxUint32 - 2},
+	testCases := []Handle{
+		{ValueLen: 23, BlockNum: 100003, OffsetInBlock: 2300},
+		{ValueLen: math.MaxUint32 - 1, BlockNum: math.MaxUint32 / 2, OffsetInBlock: math.MaxUint32 - 2},
 	}
-	var buf [valueHandleMaxLen]byte
+	var buf [HandleMaxLen]byte
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
-			n := encodeValueHandle(buf[:], tc)
-			vh := decodeValueHandle(buf[:n])
+			n := EncodeHandle(buf[:], tc)
+			vh := DecodeHandle(buf[:n])
 			require.Equal(t, tc, vh)
 		})
 	}
@@ -33,22 +33,22 @@ func TestValueHandleEncodeDecode(t *testing.T) {
 
 func TestValueBlocksIndexHandleEncodeDecode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	testCases := []valueBlocksIndexHandle{
+	testCases := []IndexHandle{
 		{
-			h: block.Handle{
+			Handle: block.Handle{
 				Offset: math.MaxUint64 / 2,
 				Length: math.MaxUint64 / 4,
 			},
-			blockNumByteLength:    53,
-			blockOffsetByteLength: math.MaxUint8,
-			blockLengthByteLength: math.MaxUint8 / 2,
+			BlockNumByteLength:    53,
+			BlockOffsetByteLength: math.MaxUint8,
+			BlockLengthByteLength: math.MaxUint8 / 2,
 		},
 	}
-	var buf [valueBlocksIndexHandleMaxLen]byte
+	var buf [100]byte
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
-			n := encodeValueBlocksIndexHandle(buf[:], tc)
-			vbih, n2, err := decodeValueBlocksIndexHandle(buf[:n])
+			n := EncodeIndexHandle(buf[:], tc)
+			vbih, n2, err := DecodeIndexHandle(buf[:n])
 			require.NoError(t, err)
 			require.Equal(t, n, n2)
 			require.Equal(t, tc, vbih)

--- a/sstable/valblk/writer.go
+++ b/sstable/valblk/writer.go
@@ -1,0 +1,328 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package valblk
+
+import (
+	"encoding/binary"
+	"math/rand/v2"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/sstable/block"
+)
+
+// Writer writes a sequence of value blocks, and the value blocks index, for a
+// sstable.
+type Writer struct {
+	flush block.FlushGovernor
+	// Configured compression.
+	compression block.Compression
+	// checksummer with configured checksum type.
+	checksummer block.Checksummer
+	// Block finished callback.
+	blockFinishedFunc func(compressedSize int)
+
+	// buf is the current block being written to (uncompressed).
+	buf *blockBuffer
+	// compressedBuf is used for compressing the block.
+	compressedBuf *blockBuffer
+	// Sequence of blocks that are finished.
+	blocks []bufferedValueBlock
+	// Cumulative value block bytes written so far.
+	totalBlockBytes uint64
+	numValues       uint64
+}
+
+type bufferedValueBlock struct {
+	block  block.PhysicalBlock
+	buffer *blockBuffer
+	handle block.Handle
+}
+
+type blockBuffer struct {
+	b []byte
+}
+
+// Pool of block buffers that should be roughly the blockSize.
+var uncompressedValueBlockBufPool = sync.Pool{
+	New: func() interface{} {
+		return &blockBuffer{}
+	},
+}
+
+// Pool of block buffers for compressed value blocks. These may widely vary in
+// size based on compression ratios.
+var compressedValueBlockBufPool = sync.Pool{
+	New: func() interface{} {
+		return &blockBuffer{}
+	},
+}
+
+func releaseToValueBlockBufPool(pool *sync.Pool, b *blockBuffer) {
+	// Don't pool buffers larger than 128KB, in case we had some rare large
+	// values.
+	if len(b.b) > 128*1024 {
+		return
+	}
+	if invariants.Enabled {
+		// Set the bytes to a random value. Cap the number of bytes being
+		// randomized to prevent test timeouts.
+		length := cap(b.b)
+		if length > 1000 {
+			length = 1000
+		}
+		b.b = b.b[:length:length]
+		for j := range b.b {
+			b.b[j] = byte(rand.Uint32())
+		}
+	}
+	pool.Put(b)
+}
+
+var valueBlockWriterPool = sync.Pool{
+	New: func() interface{} {
+		return &Writer{}
+	},
+}
+
+// NewWriter creates a new Writer of value blocks and value index blocks.
+func NewWriter(
+	flushGovernor block.FlushGovernor,
+	compression block.Compression,
+	checksumType block.ChecksumType,
+	// compressedSize should exclude the block trailer.
+	blockFinishedFunc func(compressedSize int),
+) *Writer {
+	w := valueBlockWriterPool.Get().(*Writer)
+	*w = Writer{
+		flush:       flushGovernor,
+		compression: compression,
+		checksummer: block.Checksummer{
+			Type: checksumType,
+		},
+		blockFinishedFunc: blockFinishedFunc,
+		buf:               uncompressedValueBlockBufPool.Get().(*blockBuffer),
+		compressedBuf:     compressedValueBlockBufPool.Get().(*blockBuffer),
+		blocks:            w.blocks[:0],
+	}
+	w.buf.b = w.buf.b[:0]
+	w.compressedBuf.b = w.compressedBuf.b[:0]
+	return w
+}
+
+// AddValue adds a value to the writer, returning a Handle referring to the
+// stored value.
+func (w *Writer) AddValue(v []byte) (Handle, error) {
+	if invariants.Enabled && len(v) == 0 {
+		return Handle{}, errors.Errorf("cannot write empty value to value block")
+	}
+	w.numValues++
+	blockLen := len(w.buf.b)
+	valueLen := len(v)
+	if w.flush.ShouldFlush(blockLen, blockLen+valueLen) {
+		// Block is not currently empty and adding this value will become too big,
+		// so finish this block.
+		w.compressAndFlush()
+		blockLen = len(w.buf.b)
+		if invariants.Enabled && blockLen != 0 {
+			panic("blockLen of new block should be 0")
+		}
+	}
+	vh := Handle{
+		ValueLen:      uint32(valueLen),
+		BlockNum:      uint32(len(w.blocks)),
+		OffsetInBlock: uint32(blockLen),
+	}
+	blockLen = int(vh.OffsetInBlock + vh.ValueLen)
+	if cap(w.buf.b) < blockLen {
+		size := 2 * cap(w.buf.b)
+		if size < 1024 {
+			size = 1024
+		}
+		for size < blockLen {
+			size *= 2
+		}
+		buf := make([]byte, blockLen, size)
+		_ = copy(buf, w.buf.b)
+		w.buf.b = buf
+	} else {
+		w.buf.b = w.buf.b[:blockLen]
+	}
+	buf := w.buf.b[vh.OffsetInBlock:]
+	n := copy(buf, v)
+	if n != len(buf) {
+		panic("incorrect length computation")
+	}
+	return vh, nil
+}
+
+// Size returns the total size of currently buffered value blocks.
+func (w *Writer) Size() uint64 {
+	var sz uint64
+	for _, blk := range w.blocks {
+		sz += uint64(blk.block.LengthWithTrailer())
+	}
+	if w.buf != nil {
+		sz += uint64(len(w.buf.b))
+	}
+	return sz
+}
+
+func (w *Writer) compressAndFlush() {
+	w.compressedBuf.b = w.compressedBuf.b[:cap(w.compressedBuf.b)]
+	physicalBlock := block.CompressAndChecksum(&w.compressedBuf.b, w.buf.b, w.compression, &w.checksummer)
+	bh := block.Handle{Offset: w.totalBlockBytes, Length: uint64(physicalBlock.LengthWithoutTrailer())}
+	w.totalBlockBytes += uint64(physicalBlock.LengthWithTrailer())
+	// blockFinishedFunc length excludes the block trailer.
+	w.blockFinishedFunc(physicalBlock.LengthWithoutTrailer())
+	b := bufferedValueBlock{
+		block:  physicalBlock,
+		handle: bh,
+	}
+
+	// We'll hand off a buffer to w.blocks and get a new one. Which buffer we're
+	// handing off depends on the outcome of compression.
+	if physicalBlock.IsCompressed() {
+		b.buffer = w.compressedBuf
+		w.compressedBuf = compressedValueBlockBufPool.Get().(*blockBuffer)
+	} else {
+		b.buffer = w.buf
+		w.buf = uncompressedValueBlockBufPool.Get().(*blockBuffer)
+	}
+	w.blocks = append(w.blocks, b)
+	w.buf.b = w.buf.b[:0]
+}
+
+func (w *Writer) computeChecksum(blk []byte) {
+	n := len(blk) - block.TrailerLen
+	checksum := w.checksummer.Checksum(blk[:n], blk[n])
+	binary.LittleEndian.PutUint32(blk[n+1:], checksum)
+}
+
+// Finish finishes writing the value blocks and value blocks index, writing the
+// buffered blocks out to the provider layout writer.
+func (w *Writer) Finish(layout LayoutWriter, fileOffset uint64) (IndexHandle, WriterStats, error) {
+	if len(w.buf.b) > 0 {
+		w.compressAndFlush()
+	}
+	n := len(w.blocks)
+	if n == 0 {
+		return IndexHandle{}, WriterStats{}, nil
+	}
+	largestOffset := uint64(0)
+	largestLength := uint64(0)
+	for i := range w.blocks {
+		_, err := layout.WriteValueBlock(w.blocks[i].block)
+		if err != nil {
+			return IndexHandle{}, WriterStats{}, err
+		}
+		w.blocks[i].handle.Offset += fileOffset
+		largestOffset = w.blocks[i].handle.Offset
+		if largestLength < w.blocks[i].handle.Length {
+			largestLength = w.blocks[i].handle.Length
+		}
+	}
+	vbihOffset := fileOffset + w.totalBlockBytes
+
+	vbih := IndexHandle{
+		Handle: block.Handle{
+			Offset: vbihOffset,
+		},
+		BlockNumByteLength:    uint8(lenLittleEndian(uint64(n - 1))),
+		BlockOffsetByteLength: uint8(lenLittleEndian(largestOffset)),
+		BlockLengthByteLength: uint8(lenLittleEndian(largestLength)),
+	}
+	var err error
+	if n > 0 {
+		if vbih, err = w.writeValueBlocksIndex(layout, vbih); err != nil {
+			return IndexHandle{}, WriterStats{}, err
+		}
+	}
+	stats := WriterStats{
+		NumValueBlocks:          uint64(n),
+		NumValuesInValueBlocks:  w.numValues,
+		ValueBlocksAndIndexSize: w.totalBlockBytes + vbih.Handle.Length + block.TrailerLen,
+	}
+	return vbih, stats, err
+}
+
+func (w *Writer) writeValueBlocksIndex(layout LayoutWriter, h IndexHandle) (IndexHandle, error) {
+	blockLen :=
+		int(h.BlockNumByteLength+h.BlockOffsetByteLength+h.BlockLengthByteLength) * len(w.blocks)
+	h.Handle.Length = uint64(blockLen)
+	blockLen += block.TrailerLen
+	var buf []byte
+	if cap(w.buf.b) < blockLen {
+		buf = make([]byte, blockLen)
+		w.buf.b = buf
+	} else {
+		buf = w.buf.b[:blockLen]
+	}
+	b := buf
+	for i := range w.blocks {
+		littleEndianPut(uint64(i), b, int(h.BlockNumByteLength))
+		b = b[int(h.BlockNumByteLength):]
+		littleEndianPut(w.blocks[i].handle.Offset, b, int(h.BlockOffsetByteLength))
+		b = b[int(h.BlockOffsetByteLength):]
+		littleEndianPut(w.blocks[i].handle.Length, b, int(h.BlockLengthByteLength))
+		b = b[int(h.BlockLengthByteLength):]
+	}
+	if len(b) != block.TrailerLen {
+		panic("incorrect length calculation")
+	}
+	b[0] = byte(block.NoCompressionIndicator)
+	w.computeChecksum(buf)
+	if _, err := layout.WriteValueIndexBlock(buf, h); err != nil {
+		return IndexHandle{}, err
+	}
+	return h, nil
+}
+
+// Release relinquishes the resources held by the writer and returns the Writer
+// to a pool.
+func (w *Writer) Release() {
+	for i := range w.blocks {
+		if w.blocks[i].block.IsCompressed() {
+			releaseToValueBlockBufPool(&compressedValueBlockBufPool, w.blocks[i].buffer)
+		} else {
+			releaseToValueBlockBufPool(&uncompressedValueBlockBufPool, w.blocks[i].buffer)
+		}
+		w.blocks[i].buffer = nil
+	}
+	if w.buf != nil {
+		releaseToValueBlockBufPool(&uncompressedValueBlockBufPool, w.buf)
+	}
+	if w.compressedBuf != nil {
+		releaseToValueBlockBufPool(&compressedValueBlockBufPool, w.compressedBuf)
+	}
+	*w = Writer{
+		blocks: w.blocks[:0],
+	}
+	valueBlockWriterPool.Put(w)
+}
+
+// WriterStats contains statistics about the value blocks and value index block
+// written by a Writer.
+type WriterStats struct {
+	NumValueBlocks         uint64
+	NumValuesInValueBlocks uint64
+	// Includes both value blocks and value index block.
+	ValueBlocksAndIndexSize uint64
+}
+
+// TODO(jackson): Refactor the Writer into an Encoder and move the onus of
+// calling into the sstable.layoutWriter onto the sstable.Writer.
+
+// LayoutWriter defines the interface for a writer that writes out serialized
+// value and value index blocks.
+type LayoutWriter interface {
+	// WriteValueBlock writes a pre-finished value block (with the trailer) to
+	// the writer.
+	WriteValueBlock(blk block.PhysicalBlock) (block.Handle, error)
+	// WriteValueBlockIndex writes a pre-finished value block index to the
+	// writer.
+	WriteValueIndexBlock(blk []byte, vbih IndexHandle) (block.Handle, error)
+}

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -6,9 +6,7 @@ package sstable
 
 import (
 	"context"
-	"encoding/binary"
 	"math/rand/v2"
-	"sync"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
@@ -16,626 +14,16 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/valblk"
 )
-
-// Value blocks are supported in TableFormatPebblev3.
-//
-// 1. Motivation and overview
-//
-// Value blocks are a mechanism designed for sstables storing MVCC data, where
-// there can be many versions of a key that need to be kept, but only the
-// latest value is typically read (see the documentation for Comparer.Split
-// regarding MVCC keys). The goal is faster reads. Unlike Pebble versions,
-// which can be eagerly thrown away (except when there are snapshots), MVCC
-// versions are long-lived (e.g. default CockroachDB garbage collection
-// threshold for older versions is 24 hours) and can significantly slow down
-// reads. We have seen CockroachDB production workloads with very slow reads
-// due to:
-// - 100s of versions for each key in a table.
-//
-// - Tables with mostly MVCC garbage consisting of 2 versions per key -- a
-//   real key-value pair, followed by a key-value pair whose value (usually
-//   with zero byte length) indicates it is an MVCC tombstone.
-//
-// The value blocks mechanism attempts to improve read throughput in these
-// cases when the key size is smaller than the value sizes of older versions.
-// This is done by moving the value of an older version to a value block in a
-// different part of the sstable. This improves spatial locality of the data
-// being read by the workload, which increases caching effectiveness.
-//
-// Additionally, even when the key size is not smaller than the value of older
-// versions (e.g. secondary indexes in CockroachDB), TableFormatPebblev3
-// stores the result of key comparisons done at write time inside the sstable,
-// which makes stepping from one key prefix to the next prefix (i.e., skipping
-// over older versions of a MVCC key) more efficient by avoiding key
-// comparisons and key decoding. See the results in
-// https://github.com/cockroachdb/pebble/pull/2149 and more details in the
-// comment inside BenchmarkIteratorScanNextPrefix. These improvements are also
-// visible in end-to-end CockroachDB tests, as outlined in
-// https://github.com/cockroachdb/cockroach/pull/96652.
-//
-// In TableFormatPebblev3, each SET has a one byte value prefix that tells us
-// whether the value is in-place or in a value block. This 1 byte prefix
-// encodes additional information:
-//
-// - ShortAttribute: This is an attribute of the value. Currently, CockroachDB
-//   uses it to represent whether the value is a tombstone or not. This avoids
-//   the need to fetch a value from the value block if the caller only wants
-//   to figure out whether it is an MVCC tombstone. The length of the value is
-//   another attribute that the caller can be interested in, and it is also
-//   accessible without reading the value in the value block (see the value
-//   handle in the details section).
-//
-// - SET-same-prefix: this enables the aforementioned optimization when
-//   stepping from one key prefix to the next key prefix.
-//
-// We further optimize this iteration over prefixes by using the restart
-// points in a block to encode whether the SET at a restart point has the same
-// prefix since the last restart point. This allows us to skip over restart
-// points within the same block. See the comment in blockWriter, and how both
-// SET-same-prefix and the restart point information is used in
-// blockIter.nextPrefixV3.
-//
-// This flexibility of values that are in-place or in value blocks requires
-// flexibility in the iterator interface. The InternalIterator interface
-// returns a LazyValue instead of a byte slice. Additionally, pebble.Iterator
-// allows the caller to ask for a LazyValue. See lazy_value.go for details,
-// including the memory lifetime management.
-//
-// For historical discussions about this feature, see the issue
-// https://github.com/cockroachdb/pebble/issues/1170 and the prototype in
-// https://github.com/cockroachdb/pebble/pull/1443.
-//
-// The code in this file mainly covers value block and related encodings. We
-// discuss these in the next section.
-//
-// 2. Details
-//
-// Note that the notion of the latest value is local to the sstable. It is
-// possible that that latest value has been deleted by a sstable in a higher
-// level, and what is the latest value from the perspective of the whole LSM
-// is an older MVCC version. This only affects performance and not
-// correctness. This local knowledge is also why we continue to store these
-// older versions in the same sstable -- we need to be able to conveniently
-// read them. The code in this file is agnostic to the policy regarding what
-// should be stored in value blocks -- it allows even the latest MVCC version
-// to be stored in a value block. The policy decision in made in the
-// sstable.Writer. See Writer.makeAddPointDecisionV3.
-//
-// Data blocks contain two kinds of SET keys: those with in-place values and
-// those with a value handle. To distinguish these two cases we use a single
-// byte prefix (ValuePrefix). This single byte prefix is split into multiple
-// parts, where nb represents information that is encoded in n bits.
-//
-// +---------------+--------------------+-----------+--------------------+
-// | value-kind 2b | SET-same-prefix 1b | unused 2b | short-attribute 3b |
-// +---------------+--------------------+-----------+--------------------+
-//
-// The 2 bit value-kind specifies whether this is an in-place value or a value
-// handle pointing to a value block. We use 2 bits here for future
-// representation of values that are in separate files. The 1 bit
-// SET-same-prefix is true if this key is a SET and is immediately preceded by
-// a SET that shares the same prefix. The 3 bit short-attribute is described
-// in base.ShortAttribute -- it stores user-defined attributes about the
-// value. It is unused for in-place values.
-//
-// Value Handle and Value Blocks:
-// valueHandles refer to values in value blocks. Value blocks are simpler than
-// normal data blocks (that contain key-value pairs, and allow for binary
-// search), which makes them cheap for value retrieval purposes. A valueHandle
-// is a tuple (valueLen, blockNum, offsetInBlock), where blockNum is the 0
-// indexed value block number and offsetInBlock is the byte offset in that
-// block containing the value. The valueHandle.valueLen is included since
-// there are multiple use cases in CockroachDB that need the value length but
-// not the value, for which we can avoid reading the value in the value block
-// (see
-// https://github.com/cockroachdb/pebble/issues/1170#issuecomment-958203245).
-//
-// A value block has a checksum like other blocks, and is optionally
-// compressed. An uncompressed value block is a sequence of values with no
-// separator or length (we rely on the valueHandle to demarcate). The
-// valueHandle.offsetInBlock points to the value, of length
-// valueHandle.valueLen. While writing a sstable, all the (possibly
-// compressed) value blocks need to be held in-memory until they can be
-// written. Value blocks are placed after the "meta rangedel" and "meta range
-// key" blocks since value blocks are considered less likely to be read.
-//
-// Meta Value Index Block:
-// Since the (key, valueHandle) pair are written before there is any knowledge
-// of the byte offset of the value block in the file, or its compressed
-// length, we need another lookup to map the valueHandle.blockNum to the
-// information needed to read it from the file. This information is provided
-// by the "value index block". The "value index block" is referred to by the
-// metaindex block. The design intentionally avoids making the "value index
-// block" a general purpose key-value block, since each caller wants to lookup
-// the information for a particular blockNum (there is no need for SeekGE
-// etc.). Instead, this index block stores a sequence of (blockNum,
-// blockOffset, blockLength) tuples, where the blockNums are consecutive
-// integers, and the tuples are encoded with a fixed width encoding. This
-// allows a reader to find the tuple for block K by looking at the offset
-// K*fixed-width. The fixed width for each field is decided by looking at the
-// maximum value of each of these fields. As a concrete example of a large
-// sstable with many value blocks, we constructed a 100MB sstable with many
-// versions and had 2475 value blocks (~32KB each). This sstable had this
-// tuple encoded using 2+4+2=8 bytes, which means the uncompressed value index
-// block was 2475*8=~19KB, which is modest. Therefore, we don't support more
-// than one value index block. Consider the example of 2 byte blockNum, 4 byte
-// blockOffset and 2 byte blockLen. The value index block will look like:
-//
-//   +---------------+------------------+---------------+
-//   | blockNum (2B) | blockOffset (4B) | blockLen (2B) |
-//   +---------------+------------------+---------------+
-//   |       0       |    7,123,456     |  30,000       |
-//   +---------------+------------------+---------------+
-//   |       1       |    7,153,456     |  20,000       |
-//   +---------------+------------------+---------------+
-//   |       2       |    7,173,456     |  25,567       |
-//   +---------------+------------------+---------------+
-//   |     ....      |      ...         |    ...        |
-//
-//
-// The metaindex block contains the valueBlocksIndexHandle which in addition
-// to the BlockHandle also specifies the widths of these tuple fields. In the
-// above example, the
-// valueBlockIndexHandle.{blockNumByteLength,blockOffsetByteLength,blockLengthByteLength}
-// will be (2,4,2).
-
-// valueHandle is stored with a key when the value is in a value block. This
-// handle is the pointer to that value.
-type valueHandle struct {
-	valueLen      uint32
-	blockNum      uint32
-	offsetInBlock uint32
-}
-
-// valueHandle fields are varint encoded, so maximum 5 bytes each, plus 1 byte
-// for the valuePrefix. This could alternatively be group varint encoded, but
-// experiments were inconclusive
-// (https://github.com/cockroachdb/pebble/pull/1443#issuecomment-1270298802).
-const valueHandleMaxLen = 5*3 + 1
-
-// Assert blockHandleLikelyMaxLen >= valueHandleMaxLen.
-const _ = uint(blockHandleLikelyMaxLen - valueHandleMaxLen)
-
-func encodeValueHandle(dst []byte, v valueHandle) int {
-	n := 0
-	n += binary.PutUvarint(dst[n:], uint64(v.valueLen))
-	n += binary.PutUvarint(dst[n:], uint64(v.blockNum))
-	n += binary.PutUvarint(dst[n:], uint64(v.offsetInBlock))
-	return n
-}
-
-func decodeLenFromValueHandle(src []byte) (uint32, []byte) {
-	ptr := unsafe.Pointer(&src[0])
-	var v uint32
-	if a := *((*uint8)(ptr)); a < 128 {
-		v = uint32(a)
-		src = src[1:]
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
-		v = uint32(b)<<7 | uint32(a)
-		src = src[2:]
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
-		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		src = src[3:]
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
-		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		src = src[4:]
-	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
-		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		src = src[5:]
-	}
-	return v, src
-}
-
-func decodeRemainingValueHandle(src []byte) valueHandle {
-	var vh valueHandle
-	ptr := unsafe.Pointer(&src[0])
-	// Manually inlined uvarint decoding. Saves ~25% in benchmarks. Unrolling
-	// a loop for i:=0; i<2; i++, saves ~6%.
-	var v uint32
-	if a := *((*uint8)(ptr)); a < 128 {
-		v = uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
-		v = uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
-		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
-		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
-	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
-		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 5)
-	}
-	vh.blockNum = v
-
-	if a := *((*uint8)(ptr)); a < 128 {
-		v = uint32(a)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
-		v = uint32(b)<<7 | uint32(a)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
-		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
-		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
-		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-	}
-	vh.offsetInBlock = v
-
-	return vh
-}
-
-func decodeValueHandle(src []byte) valueHandle {
-	valLen, src := decodeLenFromValueHandle(src)
-	vh := decodeRemainingValueHandle(src)
-	vh.valueLen = valLen
-	return vh
-}
-
-// valueBlocksIndexHandle is placed in the metaindex if there are any value
-// blocks. If there are no value blocks, there is no value blocks index, and
-// no entry in the metaindex. Note that the lack of entry in the metaindex
-// should not be used to ascertain whether the values are prefixed, since the
-// former is an emergent property of the data that was written and not known
-// until all the key-value pairs in the sstable are written.
-type valueBlocksIndexHandle struct {
-	h                     block.Handle
-	blockNumByteLength    uint8
-	blockOffsetByteLength uint8
-	blockLengthByteLength uint8
-}
 
 const valueBlocksIndexHandleMaxLen = blockHandleMaxLenWithoutProperties + 3
 
 // Assert blockHandleLikelyMaxLen >= valueBlocksIndexHandleMaxLen.
 const _ = uint(blockHandleLikelyMaxLen - valueBlocksIndexHandleMaxLen)
 
-func encodeValueBlocksIndexHandle(dst []byte, v valueBlocksIndexHandle) int {
-	n := v.h.EncodeVarints(dst)
-	dst[n] = v.blockNumByteLength
-	n++
-	dst[n] = v.blockOffsetByteLength
-	n++
-	dst[n] = v.blockLengthByteLength
-	n++
-	return n
-}
-
-func decodeValueBlocksIndexHandle(src []byte) (valueBlocksIndexHandle, int, error) {
-	var vbih valueBlocksIndexHandle
-	var n int
-	vbih.h, n = block.DecodeHandle(src)
-	if n <= 0 {
-		return vbih, 0, errors.Errorf("bad BlockHandle %x", src)
-	}
-	if len(src) != n+3 {
-		return vbih, 0, errors.Errorf("bad BlockHandle %x", src)
-	}
-	vbih.blockNumByteLength = src[n]
-	vbih.blockOffsetByteLength = src[n+1]
-	vbih.blockLengthByteLength = src[n+2]
-	return vbih, n + 3, nil
-}
-
-type valueBlocksAndIndexStats struct {
-	numValueBlocks         uint64
-	numValuesInValueBlocks uint64
-	// Includes both value blocks and value index block.
-	valueBlocksAndIndexSize uint64
-}
-
-// valueBlockWriter writes a sequence of value blocks, and the value blocks
-// index, for a sstable.
-type valueBlockWriter struct {
-	flush block.FlushGovernor
-	// Configured compression.
-	compression block.Compression
-	// checksummer with configured checksum type.
-	checksummer block.Checksummer
-	// Block finished callback.
-	blockFinishedFunc func(compressedSize int)
-
-	// buf is the current block being written to (uncompressed).
-	buf *blockBuffer
-	// compressedBuf is used for compressing the block.
-	compressedBuf *blockBuffer
-	// Sequence of blocks that are finished.
-	blocks []bufferedValueBlock
-	// Cumulative value block bytes written so far.
-	totalBlockBytes uint64
-	numValues       uint64
-}
-
-type bufferedValueBlock struct {
-	block  block.PhysicalBlock
-	buffer *blockBuffer
-	handle block.Handle
-}
-
-type blockBuffer struct {
-	b []byte
-}
-
-// Pool of block buffers that should be roughly the blockSize.
-var uncompressedValueBlockBufPool = sync.Pool{
-	New: func() interface{} {
-		return &blockBuffer{}
-	},
-}
-
-// Pool of block buffers for compressed value blocks. These may widely vary in
-// size based on compression ratios.
-var compressedValueBlockBufPool = sync.Pool{
-	New: func() interface{} {
-		return &blockBuffer{}
-	},
-}
-
-func releaseToValueBlockBufPool(pool *sync.Pool, b *blockBuffer) {
-	// Don't pool buffers larger than 128KB, in case we had some rare large
-	// values.
-	if len(b.b) > 128*1024 {
-		return
-	}
-	if invariants.Enabled {
-		// Set the bytes to a random value. Cap the number of bytes being
-		// randomized to prevent test timeouts.
-		length := cap(b.b)
-		if length > 1000 {
-			length = 1000
-		}
-		b.b = b.b[:length:length]
-		for j := range b.b {
-			b.b[j] = byte(rand.Uint32())
-		}
-	}
-	pool.Put(b)
-}
-
-var valueBlockWriterPool = sync.Pool{
-	New: func() interface{} {
-		return &valueBlockWriter{}
-	},
-}
-
-func newValueBlockWriter(
-	flushGovernor block.FlushGovernor,
-	compression block.Compression,
-	checksumType block.ChecksumType,
-	// compressedSize should exclude the block trailer.
-	blockFinishedFunc func(compressedSize int),
-) *valueBlockWriter {
-	w := valueBlockWriterPool.Get().(*valueBlockWriter)
-	*w = valueBlockWriter{
-		flush:       flushGovernor,
-		compression: compression,
-		checksummer: block.Checksummer{
-			Type: checksumType,
-		},
-		blockFinishedFunc: blockFinishedFunc,
-		buf:               uncompressedValueBlockBufPool.Get().(*blockBuffer),
-		compressedBuf:     compressedValueBlockBufPool.Get().(*blockBuffer),
-		blocks:            w.blocks[:0],
-	}
-	w.buf.b = w.buf.b[:0]
-	w.compressedBuf.b = w.compressedBuf.b[:0]
-	return w
-}
-
-func releaseValueBlockWriter(w *valueBlockWriter) {
-	for i := range w.blocks {
-		if w.blocks[i].block.IsCompressed() {
-			releaseToValueBlockBufPool(&compressedValueBlockBufPool, w.blocks[i].buffer)
-		} else {
-			releaseToValueBlockBufPool(&uncompressedValueBlockBufPool, w.blocks[i].buffer)
-		}
-		w.blocks[i].buffer = nil
-	}
-	if w.buf != nil {
-		releaseToValueBlockBufPool(&uncompressedValueBlockBufPool, w.buf)
-	}
-	if w.compressedBuf != nil {
-		releaseToValueBlockBufPool(&compressedValueBlockBufPool, w.compressedBuf)
-	}
-	*w = valueBlockWriter{
-		blocks: w.blocks[:0],
-	}
-	valueBlockWriterPool.Put(w)
-}
-
-func (w *valueBlockWriter) addValue(v []byte) (valueHandle, error) {
-	if invariants.Enabled && len(v) == 0 {
-		return valueHandle{}, errors.Errorf("cannot write empty value to value block")
-	}
-	w.numValues++
-	blockLen := len(w.buf.b)
-	valueLen := len(v)
-	if w.flush.ShouldFlush(blockLen, blockLen+valueLen) {
-		// Block is not currently empty and adding this value will become too big,
-		// so finish this block.
-		w.compressAndFlush()
-		blockLen = len(w.buf.b)
-		if invariants.Enabled && blockLen != 0 {
-			panic("blockLen of new block should be 0")
-		}
-	}
-	vh := valueHandle{
-		valueLen:      uint32(valueLen),
-		blockNum:      uint32(len(w.blocks)),
-		offsetInBlock: uint32(blockLen),
-	}
-	blockLen = int(vh.offsetInBlock + vh.valueLen)
-	if cap(w.buf.b) < blockLen {
-		size := 2 * cap(w.buf.b)
-		if size < 1024 {
-			size = 1024
-		}
-		for size < blockLen {
-			size *= 2
-		}
-		buf := make([]byte, blockLen, size)
-		_ = copy(buf, w.buf.b)
-		w.buf.b = buf
-	} else {
-		w.buf.b = w.buf.b[:blockLen]
-	}
-	buf := w.buf.b[vh.offsetInBlock:]
-	n := copy(buf, v)
-	if n != len(buf) {
-		panic("incorrect length computation")
-	}
-	return vh, nil
-}
-
-func (w *valueBlockWriter) compressAndFlush() {
-	w.compressedBuf.b = w.compressedBuf.b[:cap(w.compressedBuf.b)]
-	physicalBlock := block.CompressAndChecksum(&w.compressedBuf.b, w.buf.b, w.compression, &w.checksummer)
-	bh := block.Handle{Offset: w.totalBlockBytes, Length: uint64(physicalBlock.LengthWithoutTrailer())}
-	w.totalBlockBytes += uint64(physicalBlock.LengthWithTrailer())
-	// blockFinishedFunc length excludes the block trailer.
-	w.blockFinishedFunc(physicalBlock.LengthWithoutTrailer())
-	b := bufferedValueBlock{
-		block:  physicalBlock,
-		handle: bh,
-	}
-
-	// We'll hand off a buffer to w.blocks and get a new one. Which buffer we're
-	// handing off depends on the outcome of compression.
-	if physicalBlock.IsCompressed() {
-		b.buffer = w.compressedBuf
-		w.compressedBuf = compressedValueBlockBufPool.Get().(*blockBuffer)
-	} else {
-		b.buffer = w.buf
-		w.buf = uncompressedValueBlockBufPool.Get().(*blockBuffer)
-	}
-	w.blocks = append(w.blocks, b)
-	w.buf.b = w.buf.b[:0]
-}
-
-func (w *valueBlockWriter) computeChecksum(blk []byte) {
-	n := len(blk) - block.TrailerLen
-	checksum := w.checksummer.Checksum(blk[:n], blk[n])
-	binary.LittleEndian.PutUint32(blk[n+1:], checksum)
-}
-
-func (w *valueBlockWriter) finish(
-	layout *layoutWriter, fileOffset uint64,
-) (valueBlocksIndexHandle, valueBlocksAndIndexStats, error) {
-	if len(w.buf.b) > 0 {
-		w.compressAndFlush()
-	}
-	n := len(w.blocks)
-	if n == 0 {
-		return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, nil
-	}
-	largestOffset := uint64(0)
-	largestLength := uint64(0)
-	for i := range w.blocks {
-		_, err := layout.WriteValueBlock(w.blocks[i].block)
-		if err != nil {
-			return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, err
-		}
-		w.blocks[i].handle.Offset += fileOffset
-		largestOffset = w.blocks[i].handle.Offset
-		if largestLength < w.blocks[i].handle.Length {
-			largestLength = w.blocks[i].handle.Length
-		}
-	}
-	vbihOffset := fileOffset + w.totalBlockBytes
-
-	vbih := valueBlocksIndexHandle{
-		h: block.Handle{
-			Offset: vbihOffset,
-		},
-		blockNumByteLength:    uint8(lenLittleEndian(uint64(n - 1))),
-		blockOffsetByteLength: uint8(lenLittleEndian(largestOffset)),
-		blockLengthByteLength: uint8(lenLittleEndian(largestLength)),
-	}
-	var err error
-	if n > 0 {
-		if vbih, err = w.writeValueBlocksIndex(layout, vbih); err != nil {
-			return valueBlocksIndexHandle{}, valueBlocksAndIndexStats{}, err
-		}
-	}
-	stats := valueBlocksAndIndexStats{
-		numValueBlocks:          uint64(n),
-		numValuesInValueBlocks:  w.numValues,
-		valueBlocksAndIndexSize: w.totalBlockBytes + vbih.h.Length + block.TrailerLen,
-	}
-	return vbih, stats, err
-}
-
-func (w *valueBlockWriter) writeValueBlocksIndex(
-	layout *layoutWriter, h valueBlocksIndexHandle,
-) (valueBlocksIndexHandle, error) {
-	blockLen :=
-		int(h.blockNumByteLength+h.blockOffsetByteLength+h.blockLengthByteLength) * len(w.blocks)
-	h.h.Length = uint64(blockLen)
-	blockLen += block.TrailerLen
-	var buf []byte
-	if cap(w.buf.b) < blockLen {
-		buf = make([]byte, blockLen)
-		w.buf.b = buf
-	} else {
-		buf = w.buf.b[:blockLen]
-	}
-	b := buf
-	for i := range w.blocks {
-		littleEndianPut(uint64(i), b, int(h.blockNumByteLength))
-		b = b[int(h.blockNumByteLength):]
-		littleEndianPut(w.blocks[i].handle.Offset, b, int(h.blockOffsetByteLength))
-		b = b[int(h.blockOffsetByteLength):]
-		littleEndianPut(w.blocks[i].handle.Length, b, int(h.blockLengthByteLength))
-		b = b[int(h.blockLengthByteLength):]
-	}
-	if len(b) != block.TrailerLen {
-		panic("incorrect length calculation")
-	}
-	b[0] = byte(block.NoCompressionIndicator)
-	w.computeChecksum(buf)
-	if _, err := layout.WriteValueIndexBlock(buf, h); err != nil {
-		return valueBlocksIndexHandle{}, err
-	}
-	return h, nil
-}
-
-// littleEndianPut writes v to b using little endian encoding, under the
-// assumption that v can be represented using n bytes.
-func littleEndianPut(v uint64, b []byte, n int) {
-	_ = b[n-1] // bounds check
-	for i := 0; i < n; i++ {
-		b[i] = byte(v)
-		v = v >> 8
-	}
-}
-
-// lenLittleEndian returns the minimum number of bytes needed to encode v
-// using little endian encoding.
-func lenLittleEndian(v uint64) int {
-	n := 0
-	for i := 0; i < 8; i++ {
-		n++
-		v = v >> 8
-		if v == 0 {
-			break
-		}
-	}
-	return n
-}
-
-func littleEndianGet(b []byte, n int) uint64 {
-	_ = b[n-1] // bounds check
-	v := uint64(b[0])
-	for i := 1; i < n; i++ {
-		v |= uint64(b[i]) << (8 * i)
-	}
-	return v
-}
+// Assert blockHandleLikelyMaxLen >= valblk.HandleMaxLen.
+const _ = uint(blockHandleLikelyMaxLen - valblk.HandleMaxLen)
 
 // UserKeyPrefixBound represents a [Lower,Upper) bound of user key prefixes.
 // If both are nil, there is no bound specified. Else, Compare(Lower,Upper)
@@ -729,7 +117,7 @@ func (trp *trivialReaderProvider) Close() {}
 type valueBlockReader struct {
 	bpOpen blockProviderWhenOpen
 	rp     ReaderProvider
-	vbih   valueBlocksIndexHandle
+	vbih   valblk.IndexHandle
 	stats  *base.InternalIteratorStats
 
 	// fetcher is allocated lazily the first time we create a LazyValue, in order
@@ -752,7 +140,7 @@ func (r *valueBlockReader) GetLazyValueForPrefixAndValueHandle(handle []byte) ba
 		r.fetcher = newValueBlockFetcher(r.bpOpen, r.rp, r.vbih, r.stats)
 	}
 	lazyFetcher := &r.fetcher.lazyFetcher
-	valLen, h := decodeLenFromValueHandle(handle[1:])
+	valLen, h := valblk.DecodeLenFromHandle(handle[1:])
 	*lazyFetcher = base.LazyFetcher{
 		Fetcher: r.fetcher,
 		Attribute: base.AttributeAndLen{
@@ -784,7 +172,7 @@ func (r *valueBlockReader) close() {
 type valueBlockFetcher struct {
 	bpOpen blockProviderWhenOpen
 	rp     ReaderProvider
-	vbih   valueBlocksIndexHandle
+	vbih   valblk.IndexHandle
 	stats  *base.InternalIteratorStats
 	// The value blocks index is lazily retrieved the first time the reader
 	// needs to read a value that resides in a value block.
@@ -812,7 +200,7 @@ var _ base.ValueFetcher = (*valueBlockFetcher)(nil)
 func newValueBlockFetcher(
 	bpOpen blockProviderWhenOpen,
 	rp ReaderProvider,
-	vbih valueBlocksIndexHandle,
+	vbih valblk.IndexHandle,
 	stats *base.InternalIteratorStats,
 ) *valueBlockFetcher {
 	return &valueBlockFetcher{
@@ -886,18 +274,18 @@ func (f *valueBlockFetcher) doValueMangling(v []byte) []byte {
 }
 
 func (f *valueBlockFetcher) getValueInternal(handle []byte, valLen int32) (val []byte, err error) {
-	vh := decodeRemainingValueHandle(handle)
-	vh.valueLen = uint32(valLen)
+	vh := valblk.DecodeRemainingHandle(handle)
+	vh.ValueLen = uint32(valLen)
 	if f.vbiBlock == nil {
-		ch, err := f.bpOpen.readBlockForVBR(f.vbih.h, f.stats)
+		ch, err := f.bpOpen.readBlockForVBR(f.vbih.Handle, f.stats)
 		if err != nil {
 			return nil, err
 		}
 		f.vbiCache = ch
 		f.vbiBlock = ch.BlockData()
 	}
-	if f.valueBlock == nil || f.valueBlockNum != vh.blockNum {
-		vbh, err := f.getBlockHandle(vh.blockNum)
+	if f.valueBlock == nil || f.valueBlockNum != vh.BlockNum {
+		vbh, err := f.getBlockHandle(vh.BlockNum)
 		if err != nil {
 			return nil, err
 		}
@@ -905,7 +293,7 @@ func (f *valueBlockFetcher) getValueInternal(handle []byte, valLen int32) (val [
 		if err != nil {
 			return nil, err
 		}
-		f.valueBlockNum = vh.blockNum
+		f.valueBlockNum = vh.BlockNum
 		f.valueCache.Release()
 		f.valueCache = vbCacheHandle
 		f.valueBlock = vbCacheHandle.BlockData()
@@ -914,12 +302,12 @@ func (f *valueBlockFetcher) getValueInternal(handle []byte, valLen int32) (val [
 	if f.stats != nil {
 		f.stats.SeparatedPointValue.ValueBytesFetched += uint64(valLen)
 	}
-	return f.valueBlock[vh.offsetInBlock : vh.offsetInBlock+vh.valueLen], nil
+	return f.valueBlock[vh.OffsetInBlock : vh.OffsetInBlock+vh.ValueLen], nil
 }
 
 func (f *valueBlockFetcher) getBlockHandle(blockNum uint32) (block.Handle, error) {
 	indexEntryLen :=
-		int(f.vbih.blockNumByteLength + f.vbih.blockOffsetByteLength + f.vbih.blockLengthByteLength)
+		int(f.vbih.BlockNumByteLength + f.vbih.BlockOffsetByteLength + f.vbih.BlockLengthByteLength)
 	offsetInIndex := indexEntryLen * int(blockNum)
 	if len(f.vbiBlock) < offsetInIndex+indexEntryLen {
 		return block.Handle{}, base.AssertionFailedf(
@@ -927,17 +315,26 @@ func (f *valueBlockFetcher) getBlockHandle(blockNum uint32) (block.Handle, error
 			offsetInIndex, indexEntryLen, len(f.vbiBlock))
 	}
 	b := f.vbiBlock[offsetInIndex : offsetInIndex+indexEntryLen]
-	n := int(f.vbih.blockNumByteLength)
+	n := int(f.vbih.BlockNumByteLength)
 	bn := littleEndianGet(b, n)
 	if uint32(bn) != blockNum {
 		return block.Handle{},
 			errors.Errorf("expected block num %d but found %d", blockNum, bn)
 	}
 	b = b[n:]
-	n = int(f.vbih.blockOffsetByteLength)
+	n = int(f.vbih.BlockOffsetByteLength)
 	blockOffset := littleEndianGet(b, n)
 	b = b[n:]
-	n = int(f.vbih.blockLengthByteLength)
+	n = int(f.vbih.BlockLengthByteLength)
 	blockLen := littleEndianGet(b, n)
 	return block.Handle{Offset: blockOffset, Length: blockLen}, nil
+}
+
+func littleEndianGet(b []byte, n int) uint64 {
+	_ = b[n-1] // bounds check
+	v := uint64(b[0])
+	for i := 1; i < n; i++ {
+		v |= uint64(b[i]) << (8 * i)
+	}
+	return v
 }

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
+	"github.com/cockroachdb/pebble/sstable/valblk"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -441,9 +442,9 @@ func TestWriterWithValueBlocks(t *testing.T) {
 					setWithSamePrefix := prefix.SetHasSamePrefix()
 					if prefix.IsValueHandle() {
 						attribute := prefix.ShortAttribute()
-						vh := decodeValueHandle(kv.V.ValueOrHandle[1:])
+						vh := valblk.DecodeHandle(kv.V.ValueOrHandle[1:])
 						fmt.Fprintf(&buf, "%s:value-handle len %d block %d offset %d, att %d, same-pre %t\n",
-							kv.K, vh.valueLen, vh.blockNum, vh.offsetInBlock, attribute, setWithSamePrefix)
+							kv.K, vh.ValueLen, vh.BlockNum, vh.OffsetInBlock, attribute, setWithSamePrefix)
 					} else {
 						fmt.Fprintf(&buf, "%s:in-place %s, same-pre %t\n", kv.K, kv.V.ValueOrHandle[1:], setWithSamePrefix)
 					}


### PR DESCRIPTION
Move value-block Handle types, encoding/decoding routines and the value block Writer into a new valblk package. Add additionally commentary to document the new valblk package's interface.