### PR TITLE
valblk: move reader, fetcher

### DIFF
--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -7,6 +7,7 @@ package sstable
 import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/sstable/valblk"
 )
 
 // These constants are part of the file format, and should not be changed.
@@ -28,3 +29,11 @@ type InternalKey = base.InternalKey
 
 // Span exports the keyspan.Span type.
 type Span = keyspan.Span
+
+const valueBlocksIndexHandleMaxLen = blockHandleMaxLenWithoutProperties + 3
+
+// Assert blockHandleLikelyMaxLen >= valueBlocksIndexHandleMaxLen.
+const _ = uint(blockHandleLikelyMaxLen - valueBlocksIndexHandleMaxLen)
+
+// Assert blockHandleLikelyMaxLen >= valblk.HandleMaxLen.
+const _ = uint(blockHandleLikelyMaxLen - valblk.HandleMaxLen)

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -301,6 +301,21 @@ type WriterOptions struct {
 	disableObsoleteCollector bool
 }
 
+// UserKeyPrefixBound represents a [Lower,Upper) bound of user key prefixes.
+// If both are nil, there is no bound specified. Else, Compare(Lower,Upper)
+// must be < 0.
+type UserKeyPrefixBound struct {
+	// Lower is a lower bound user key prefix.
+	Lower []byte
+	// Upper is an upper bound user key prefix.
+	Upper []byte
+}
+
+// IsEmpty returns true iff the bound is empty.
+func (ukb *UserKeyPrefixBound) IsEmpty() bool {
+	return len(ukb.Lower) == 0 && len(ukb.Upper) == 0
+}
+
 // JemallocSizeClasses are a subset of available size classes in jemalloc[1],
 // suitable for the AllocatorSizeClasses option.
 //

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/valblk"
 )
 
 // CommonReader abstracts functionality over a Reader or a VirtualReader. This
@@ -33,13 +34,13 @@ type CommonReader interface {
 		filterBlockSizeLimit FilterBlockSizeLimit,
 		stats *base.InternalIteratorStats,
 		statsAccum IterStatsAccumulator,
-		rp ReaderProvider,
+		rp valblk.ReaderProvider,
 	) (Iterator, error)
 
 	NewCompactionIter(
 		transforms IterTransforms,
 		statsAccum IterStatsAccumulator,
-		rp ReaderProvider,
+		rp valblk.ReaderProvider,
 		bufferPool *block.BufferPool,
 	) (Iterator, error)
 

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/valblk"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/stretchr/testify/require"
@@ -230,7 +231,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 				return "virtualize must be called before creating compaction iters"
 			}
 
-			var rp ReaderProvider
+			var rp valblk.ReaderProvider
 			transforms := IterTransforms{
 				SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(nil, syntheticSuffix),
 			}

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/valblk"
 )
 
 // VirtualReader wraps Reader. Its purpose is to restrict functionality of the
@@ -95,7 +96,7 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 func (v *VirtualReader) NewCompactionIter(
 	transforms IterTransforms,
 	statsAccum IterStatsAccumulator,
-	rp ReaderProvider,
+	rp valblk.ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (Iterator, error) {
 	return v.reader.newCompactionIter(
@@ -119,7 +120,7 @@ func (v *VirtualReader) NewPointIter(
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
 	statsAccum IterStatsAccumulator,
-	rp ReaderProvider,
+	rp valblk.ReaderProvider,
 ) (Iterator, error) {
 	return v.reader.newPointIter(
 		ctx, transforms, lower, upper, filterer, filterBlockSizeLimit,

--- a/sstable/value_block.go
+++ b/sstable/value_block.go
@@ -25,21 +25,6 @@ const _ = uint(blockHandleLikelyMaxLen - valueBlocksIndexHandleMaxLen)
 // Assert blockHandleLikelyMaxLen >= valblk.HandleMaxLen.
 const _ = uint(blockHandleLikelyMaxLen - valblk.HandleMaxLen)
 
-// UserKeyPrefixBound represents a [Lower,Upper) bound of user key prefixes.
-// If both are nil, there is no bound specified. Else, Compare(Lower,Upper)
-// must be < 0.
-type UserKeyPrefixBound struct {
-	// Lower is a lower bound user key prefix.
-	Lower []byte
-	// Upper is an upper bound user key prefix.
-	Upper []byte
-}
-
-// IsEmpty returns true iff the bound is empty.
-func (ukb *UserKeyPrefixBound) IsEmpty() bool {
-	return len(ukb.Lower) == 0 && len(ukb.Upper) == 0
-}
-
 type blockProviderWhenOpen interface {
 	readBlockForVBR(
 		h block.Handle, stats *base.InternalIteratorStats,

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -419,7 +419,7 @@ func TestWriterWithValueBlocks(t *testing.T) {
 				return err.Error()
 			}
 			forceRowIterIgnoreValueBlocks := func(i *singleLevelIteratorRowBlocks) {
-				i.vbReader = valueBlockReader{}
+				i.vbReader = valblk.Reader{}
 				i.data.SetGetLazyValuer(nil)
 				i.data.SetHasValuePrefix(false)
 			}

--- a/table_cache.go
+++ b/table_cache.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/valblk"
 )
 
 var emptyIter = &errorIter{err: nil}
@@ -666,7 +667,7 @@ type tableCacheShardReaderProvider struct {
 	}
 }
 
-var _ sstable.ReaderProvider = &tableCacheShardReaderProvider{}
+var _ valblk.ReaderProvider = &tableCacheShardReaderProvider{}
 
 func (rp *tableCacheShardReaderProvider) init(
 	c *tableCacheShard, dbOpts *tableCacheOpts, backingFileNum base.DiskFileNum,
@@ -692,7 +693,9 @@ func (rp *tableCacheShardReaderProvider) init(
 //
 // TODO(bananabrick): We could return a wrapper over the Reader to ensure
 // that the reader isn't used for other purposes.
-func (rp *tableCacheShardReaderProvider) GetReader(ctx context.Context) (*sstable.Reader, error) {
+func (rp *tableCacheShardReaderProvider) GetReader(
+	ctx context.Context,
+) (valblk.ExternalBlockReader, error) {
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 


### PR DESCRIPTION
Move the facilities around reading value blocks into the valblk package.