### PR TITLE
buildtags: correct file names

### DIFF
--- a/internal/buildtags/invariants_off.go
+++ b/internal/buildtags/invariants_off.go
@@ -2,10 +2,10 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build invariants
+//go:build !invariants
 
 package buildtags
 
 // Invariants indicates if the invariants tag is used.
 // See invariants.Enabled.
-const Invariants = true
+const Invariants = false

--- a/internal/buildtags/invariants_on.go
+++ b/internal/buildtags/invariants_on.go
@@ -2,10 +2,10 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build !invariants
+//go:build invariants
 
 package buildtags
 
 // Invariants indicates if the invariants tag is used.
 // See invariants.Enabled.
-const Invariants = false
+const Invariants = true


### PR DESCRIPTION
The `off` and `on` file names were reversed (in https://github.com/cockroachdb/pebble/pull/4117). This leads to confusion
in the bazel build files and patches.