### PR TITLE
colblk: fix handle misuse in TestIndexIterInitHandle

### DIFF
--- a/sstable/colblk/index_block_test.go
+++ b/sstable/colblk/index_block_test.go
@@ -125,7 +125,8 @@ func TestIndexIterInitHandle(t *testing.T) {
 	d := (*IndexBlockDecoder)(unsafe.Pointer(v.BlockMetadata()))
 	d.Init(blockData)
 
-	v.MakeHandle(c, cache.ID(1), base.DiskFileNum(1), 0).Release()
+	h := v.MakeHandle(c, cache.ID(1), base.DiskFileNum(1), 0)
+	defer h.Release()
 
 	getBlockAndIterate := func(it *IndexIter) {
 		h := c.Get(cache.ID(1), base.DiskFileNum(1), 0)


### PR DESCRIPTION
This test TestIndexIterInitHandle relies on the test block remaining in the block cache. Hold on to a handle for the duration of the test to ensure it.

Fix #4172.