### PR TITLE
sstable: use ComparePointSuffix to compare against synthetic suffix

### DIFF
--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -177,7 +177,8 @@ type ImmediateSuccessor func(dst, a []byte) []byte
 //  3. Suffixes themselves must be valid keys and comparable, respecting the same
 //     ordering as within a key:
 //
-//     If Compare(prefix(a), prefix(b)) = 0, then Compare(a, b) = Compare(suffix(a), suffix(b)).
+//     If Compare(prefix(a), prefix(b)) = 0, then
+//     Compare(a, b) = ComparePointSuffixes(suffix(a), suffix(b))
 type Split func(a []byte) int
 
 // Prefix returns the prefix of the key k, using s to split the key.

--- a/internal/crdbtest/crdb_bench_test.go
+++ b/internal/crdbtest/crdb_bench_test.go
@@ -317,7 +317,7 @@ func benchmarkCockroachDataBlockIter(
 
 	var decoder colblk.DataBlockDecoder
 	var it colblk.DataBlockIter
-	it.InitOnce(&KeySchema, Compare, Split, getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(&KeySchema, &Comparer, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
 	decoder.Init(&KeySchema, serializedBlock)

--- a/internal/crdbtest/crdb_test.go
+++ b/internal/crdbtest/crdb_test.go
@@ -171,7 +171,7 @@ func testCockroachDataColBlock(t *testing.T, seed uint64, keyCfg keyGenConfig) {
 
 	var decoder colblk.DataBlockDecoder
 	var it colblk.DataBlockIter
-	it.InitOnce(&KeySchema, Compare, Split, getLazyValuer(func([]byte) base.LazyValue {
+	it.InitOnce(&KeySchema, &Comparer, getLazyValuer(func([]byte) base.LazyValue {
 		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
 	}))
 	decoder.Init(&KeySchema, serializedBlock)

--- a/internal/crdbtest/key_schema_test.go
+++ b/internal/crdbtest/key_schema_test.go
@@ -30,7 +30,7 @@ func runDataDrivenTest(t *testing.T, path string) {
 	var e colblk.DataBlockEncoder
 	e.Init(&KeySchema)
 	var iter colblk.DataBlockIter
-	iter.InitOnce(&KeySchema, Comparer.Compare, Comparer.Split, nil)
+	iter.InitOnce(&KeySchema, &Comparer, nil)
 
 	datadriven.RunTest(t, path, func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {

--- a/internal/crdbtest/rowblk_bench_test.go
+++ b/internal/crdbtest/rowblk_bench_test.go
@@ -115,7 +115,7 @@ func benchmarkCockroachDataRowBlockIter(b *testing.B, keyConfig keyGenConfig, va
 	}
 	serializedBlock := w.Finish()
 	var it rowblk.Iter
-	it.Init(Compare, Split, serializedBlock, block.NoTransforms)
+	it.Init(Compare, ComparePointSuffixes, Split, serializedBlock, block.NoTransforms)
 	avgRowSize := float64(len(serializedBlock)) / float64(count)
 
 	b.Run("Next", func(b *testing.B) {

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -175,7 +175,7 @@ type DataBlockIterator interface {
 	// The iterator takes ownership of the BufferHandle and releases it when it is
 	// closed (or re-initialized with another handle). This happens even in error
 	// cases.
-	InitHandle(base.Compare, base.Split, BufferHandle, IterTransforms) error
+	InitHandle(*base.Comparer, BufferHandle, IterTransforms) error
 	// Valid returns true if the iterator is currently positioned at a valid KV.
 	Valid() bool
 	// KV returns the key-value pair at the current iterator position. The
@@ -207,13 +207,13 @@ type DataBlockIterator interface {
 // *colblk.IndexBlockIter.
 type IndexBlockIterator interface {
 	// Init initializes the block iterator from the provided block.
-	Init(base.Compare, base.Split, []byte, IterTransforms) error
+	Init(*base.Comparer, []byte, IterTransforms) error
 	// InitHandle initializes an iterator from the provided block handle.
 	//
 	// The iterator takes ownership of the BufferHandle and releases it when it is
 	// closed (or re-initialized with another handle). This happens even in error
 	// cases.
-	InitHandle(base.Compare, base.Split, BufferHandle, IterTransforms) error
+	InitHandle(*base.Comparer, BufferHandle, IterTransforms) error
 	// Valid returns true if the iterator is currently positioned at a valid
 	// block handle.
 	Valid() bool

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -913,7 +913,7 @@ func TestBlockProperties(t *testing.T) {
 					var blocks []int
 					var i int
 					iter := r.tableFormat.newIndexIter()
-					if err := iter.Init(r.Compare, r.Split, indexH.BlockData(), NoTransforms); err != nil {
+					if err := iter.Init(r.Comparer, indexH.BlockData(), NoTransforms); err != nil {
 						return err.Error()
 					}
 					for valid := iter.First(); valid; valid = iter.Next() {
@@ -1278,7 +1278,7 @@ func runBlockPropsCmd(r *Reader) string {
 	defer bh.Release()
 	twoLevelIndex := r.Properties.IndexPartitions > 0
 	i := r.tableFormat.newIndexIter()
-	if err := i.Init(r.Compare, r.Split, bh.BlockData(), NoTransforms); err != nil {
+	if err := i.Init(r.Comparer, bh.BlockData(), NoTransforms); err != nil {
 		return err.Error()
 	}
 	var sb strings.Builder
@@ -1327,7 +1327,7 @@ func runBlockPropsCmd(r *Reader) string {
 			err = func() error {
 				defer subIndex.Release()
 				subiter := r.tableFormat.newIndexIter()
-				if err := subiter.Init(r.Compare, r.Split, subIndex.BlockData(), NoTransforms); err != nil {
+				if err := subiter.Init(r.Comparer, subIndex.BlockData(), NoTransforms); err != nil {
 					return err
 				}
 				for valid := subiter.First(); valid; valid = subiter.Next() {

--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -29,11 +29,12 @@ func TestDataBlock(t *testing.T) {
 	var w DataBlockEncoder
 	var r DataBlockDecoder
 	var it DataBlockIter
-	rw := NewDataBlockRewriter(&testKeysSchema, testkeys.Comparer.Compare, testkeys.Comparer.Split)
+	rw := NewDataBlockRewriter(&testKeysSchema, testkeys.Comparer.EnsureDefaults())
 	var sizes []int
-	it.InitOnce(&testKeysSchema, testkeys.Comparer.Compare, testkeys.Comparer.Split, getLazyValuer(func([]byte) base.LazyValue {
-		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
-	}))
+	it.InitOnce(&testKeysSchema, testkeys.Comparer,
+		getLazyValuer(func([]byte) base.LazyValue {
+			return base.LazyValue{ValueOrHandle: []byte("mock external value")}
+		}))
 
 	datadriven.Walk(t, "testdata/data_block", func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, td *datadriven.TestData) string {

--- a/sstable/colblk/index_block.go
+++ b/sstable/colblk/index_block.go
@@ -203,10 +203,10 @@ var _ block.IndexBlockIterator = (*IndexIter)(nil)
 
 // InitWithDecoder initializes an index iterator from the provided decoder.
 func (i *IndexIter) InitWithDecoder(
-	compare base.Compare, split base.Split, d *IndexBlockDecoder, transforms block.IterTransforms,
+	comparer *base.Comparer, d *IndexBlockDecoder, transforms block.IterTransforms,
 ) {
-	i.compare = compare
-	i.split = split
+	i.compare = comparer.Compare
+	i.split = comparer.Split
 	i.d = d
 	i.n = int(d.bd.header.Rows)
 	i.row = -1
@@ -216,23 +216,23 @@ func (i *IndexIter) InitWithDecoder(
 
 // Init initializes an iterator from the provided block data slice.
 func (i *IndexIter) Init(
-	cmp base.Compare, split base.Split, blk []byte, transforms block.IterTransforms,
+	comparer *base.Comparer, blk []byte, transforms block.IterTransforms,
 ) error {
 	i.h.Release()
 	i.h = block.BufferHandle{}
 	i.allocDecoder.Init(blk)
-	i.InitWithDecoder(cmp, split, &i.allocDecoder, transforms)
+	i.InitWithDecoder(comparer, &i.allocDecoder, transforms)
 	return nil
 }
 
 // InitHandle initializes an iterator from the provided block handle.
 func (i *IndexIter) InitHandle(
-	cmp base.Compare, split base.Split, blk block.BufferHandle, transforms block.IterTransforms,
+	comparer *base.Comparer, blk block.BufferHandle, transforms block.IterTransforms,
 ) error {
 	i.h.Release()
 	i.h = blk
 	d := (*IndexBlockDecoder)(unsafe.Pointer(blk.BlockMetadata()))
-	i.InitWithDecoder(cmp, split, d, transforms)
+	i.InitWithDecoder(comparer, d, transforms)
 	return nil
 }
 

--- a/sstable/colblk/index_block_test.go
+++ b/sstable/colblk/index_block_test.go
@@ -60,7 +60,7 @@ func TestIndexBlock(t *testing.T) {
 				SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix([]byte(syntheticPrefix), []byte(syntheticSuffix)),
 			}
 			var it IndexIter
-			it.InitWithDecoder(testkeys.Comparer.Compare, testkeys.Comparer.Split, &decoder, transforms)
+			it.InitWithDecoder(testkeys.Comparer, &decoder, transforms)
 			for _, line := range strings.Split(d.Input, "\n") {
 				fields := strings.Fields(line)
 				var valid bool
@@ -131,11 +131,7 @@ func TestIndexIterInitHandle(t *testing.T) {
 	getBlockAndIterate := func(it *IndexIter) {
 		h := c.Get(cache.ID(1), base.DiskFileNum(1), 0)
 		require.True(t, h.Valid())
-		require.NoError(t, it.InitHandle(
-			testkeys.Comparer.Compare,
-			testkeys.Comparer.Split,
-			block.CacheBufferHandle(h),
-			block.NoTransforms))
+		require.NoError(t, it.InitHandle(testkeys.Comparer, block.CacheBufferHandle(h), block.NoTransforms))
 		defer it.Close()
 		require.True(t, it.First())
 		bh, err := it.BlockHandleWithProperties()

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -988,7 +988,7 @@ func (w *RawColumnWriter) rewriteSuffixes(
 	}
 	// Copy data blocks in parallel, rewriting suffixes as we go.
 	blocks, err := rewriteDataBlocksInParallel(r, wo, l.Data, from, to, concurrency, func() blockRewriter {
-		return colblk.NewDataBlockRewriter(wo.KeySchema, w.comparer.Compare, w.comparer.Split)
+		return colblk.NewDataBlockRewriter(wo.KeySchema, w.comparer)
 	})
 	if err != nil {
 		return errors.Wrap(err, "rewriting data blocks")

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -209,7 +209,7 @@ func intersectingIndexEntries(
 	start, end InternalKey,
 ) ([]indexEntry, error) {
 	top := r.tableFormat.newIndexIter()
-	err := top.Init(r.Compare, r.Split, indexH.BlockData(), NoTransforms)
+	err := top.Init(r.Comparer, indexH.BlockData(), NoTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func intersectingIndexEntries(
 			defer subBlk.Release() // in-loop, but it is a short loop.
 
 			sub := r.tableFormat.newIndexIter()
-			err = sub.Init(r.Compare, r.Split, subBlk.BlockData(), NoTransforms)
+			err = sub.Init(r.Comparer, subBlk.BlockData(), NoTransforms)
 			if err != nil {
 				return nil, err
 			}

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -323,7 +323,7 @@ var (
 
 func formatColblkIndexBlock(tp treeprinter.Node, r *Reader, b NamedBlockHandle, data []byte) error {
 	var iter colblk.IndexIter
-	if err := iter.Init(r.Compare, r.Split, data, NoTransforms); err != nil {
+	if err := iter.Init(r.Comparer, data, NoTransforms); err != nil {
 		return err
 	}
 	defer iter.Close()
@@ -353,7 +353,7 @@ func formatColblkDataBlock(
 
 	if fmtKV != nil {
 		var iter colblk.DataBlockIter
-		iter.InitOnce(r.keySchema, r.Compare, r.Split, describingLazyValueHandler{})
+		iter.InitOnce(r.keySchema, r.Comparer, describingLazyValueHandler{})
 		if err := iter.Init(&decoder, block.IterTransforms{}); err != nil {
 			return err
 		}
@@ -395,7 +395,7 @@ func formatColblkKeyspanBlock(
 }
 
 func formatRowblkIndexBlock(tp treeprinter.Node, r *Reader, b NamedBlockHandle, data []byte) error {
-	iter, err := rowblk.NewIter(r.Compare, r.Split, data, NoTransforms)
+	iter, err := rowblk.NewIter(r.Compare, r.Comparer.ComparePointSuffixes, r.Split, data, NoTransforms)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func formatRowblkDataBlock(
 	data []byte,
 	fmtRecord func(key *base.InternalKey, value []byte) string,
 ) error {
-	iter, err := rowblk.NewIter(r.Compare, r.Split, data, NoTransforms)
+	iter, err := rowblk.NewIter(r.Compare, r.Comparer.ComparePointSuffixes, r.Split, data, NoTransforms)
 	if err != nil {
 		return err
 	}
@@ -561,10 +561,10 @@ func newIndexIter(
 	var err error
 	if tableFormat <= TableFormatPebblev4 {
 		iter = new(rowblk.IndexIter)
-		err = iter.Init(comparer.Compare, comparer.Split, data, block.NoTransforms)
+		err = iter.Init(comparer, data, block.NoTransforms)
 	} else {
 		iter = new(colblk.IndexIter)
-		err = iter.Init(comparer.Compare, comparer.Split, data, block.NoTransforms)
+		err = iter.Init(comparer, data, block.NoTransforms)
 	}
 	if err != nil {
 		return nil, err

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -233,10 +233,10 @@ func newColumnBlockSingleLevelIterator(
 		getLazyValuer = &i.vbReader
 		i.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.vbRHPrealloc)
 	}
-	i.data.InitOnce(r.keySchema, i.cmp, r.Split, getLazyValuer)
+	i.data.InitOnce(r.keySchema, r.Comparer, getLazyValuer)
 	indexH, err := r.readTopLevelIndexBlock(ctx, i.readBlockEnv, i.indexFilterRH)
 	if err == nil {
-		err = i.index.InitHandle(i.cmp, r.Split, indexH, transforms)
+		err = i.index.InitHandle(r.Comparer, indexH, transforms)
 	}
 	if err != nil {
 		_ = i.Close()
@@ -288,7 +288,7 @@ func newRowBlockSingleLevelIterator(
 
 	indexH, err := r.readTopLevelIndexBlock(ctx, i.readBlockEnv, i.indexFilterRH)
 	if err == nil {
-		err = i.index.InitHandle(i.cmp, r.Split, indexH, transforms)
+		err = i.index.InitHandle(r.Comparer, indexH, transforms)
 	}
 	if err != nil {
 		_ = i.Close()
@@ -542,7 +542,7 @@ func (i *singleLevelIterator[I, PI, P, PD]) loadDataBlock(dir int8) loadBlockRes
 		i.err = err
 		return loadBlockFailed
 	}
-	i.err = PD(&i.data).InitHandle(i.cmp, i.reader.Split, block, i.transforms)
+	i.err = PD(&i.data).InitHandle(i.reader.Comparer, block, i.transforms)
 	if i.err != nil {
 		// The block is partially loaded, and we don't want it to appear valid.
 		PD(&i.data).Invalidate()

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -74,7 +74,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) loadSecondLevelIndexBlock(dir int8) loa
 		i.secondLevel.err = err
 		return loadBlockFailed
 	}
-	err = PI(&i.secondLevel.index).InitHandle(i.secondLevel.cmp, i.secondLevel.reader.Split, indexBlock, i.secondLevel.transforms)
+	err = PI(&i.secondLevel.index).InitHandle(i.secondLevel.reader.Comparer, indexBlock, i.secondLevel.transforms)
 	if err != nil {
 		PI(&i.secondLevel.index).Invalidate()
 		i.secondLevel.err = err
@@ -191,11 +191,11 @@ func newColumnBlockTwoLevelIterator(
 		getLazyValuer = &i.secondLevel.vbReader
 		i.secondLevel.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
-	i.secondLevel.data.InitOnce(r.keySchema, r.Compare, r.Split, getLazyValuer)
+	i.secondLevel.data.InitOnce(r.keySchema, r.Comparer, getLazyValuer)
 	i.useFilterBlock = shouldUseFilterBlock(r, filterBlockSizeLimit)
 	topLevelIndexH, err := r.readTopLevelIndexBlock(ctx, i.secondLevel.readBlockEnv, i.secondLevel.indexFilterRH)
 	if err == nil {
-		err = i.topLevelIndex.InitHandle(i.secondLevel.cmp, i.secondLevel.reader.Split, topLevelIndexH, transforms)
+		err = i.topLevelIndex.InitHandle(r.Comparer, topLevelIndexH, transforms)
 	}
 	if err != nil {
 		_ = i.Close()
@@ -256,7 +256,7 @@ func newRowBlockTwoLevelIterator(
 
 	topLevelIndexH, err := r.readTopLevelIndexBlock(ctx, i.secondLevel.readBlockEnv, i.secondLevel.indexFilterRH)
 	if err == nil {
-		err = i.topLevelIndex.InitHandle(i.secondLevel.cmp, i.secondLevel.reader.Split, topLevelIndexH, transforms)
+		err = i.topLevelIndex.InitHandle(r.Comparer, topLevelIndexH, transforms)
 	}
 	if err != nil {
 		_ = i.Close()

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -644,7 +644,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 	twoLevelIndex := r.Properties.IndexType == twoLevelIndex
 	buf.WriteString("index entries:\n")
 	iter := r.tableFormat.newIndexIter()
-	require.NoError(t, iter.Init(r.Compare, r.Split, indexH.BlockData(), NoTransforms))
+	require.NoError(t, iter.Init(r.Comparer, indexH.BlockData(), NoTransforms))
 	defer func() {
 		require.NoError(t, iter.Close())
 	}()
@@ -658,7 +658,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 			require.NoError(t, err)
 			defer b.Release()
 			iter2 := r.tableFormat.newIndexIter()
-			require.NoError(t, iter2.Init(r.Compare, r.Split, b.BlockData(), NoTransforms))
+			require.NoError(t, iter2.Init(r.Comparer, b.BlockData(), NoTransforms))
 			defer func() {
 				require.NoError(t, iter2.Close())
 			}()

--- a/sstable/rowblk/rowblk_bench_test.go
+++ b/sstable/rowblk/rowblk_bench_test.go
@@ -22,8 +22,7 @@ var (
 
 	// Use testkeys.Comparer.Compare which approximates EngineCompare by ordering
 	// multiple keys with same prefix in descending suffix order.
-	benchCmp   = testkeys.Comparer.Compare
-	benchSplit = testkeys.Comparer.Split
+	benchComparer = testkeys.Comparer
 )
 
 // choosOrigSuffix randomly chooses a suffix that is either 1 or 2 bytes large.
@@ -89,9 +88,14 @@ func BenchmarkBlockIterSeekGE(b *testing.B) {
 
 						keys, syntheticPrefix, syntheticSuffix := createBenchBlock(blockSize, w, rng, withSyntheticPrefix, withSyntheticSuffix)
 
-						it, err := NewIter(benchCmp, benchSplit, w.Finish(), block.IterTransforms{
-							SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
-						})
+						it, err := NewIter(
+							benchComparer.Compare,
+							benchComparer.ComparePointSuffixes,
+							benchComparer.Split,
+							w.Finish(),
+							block.IterTransforms{
+								SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
+							})
 						if err != nil {
 							b.Fatal(err)
 						}
@@ -126,9 +130,14 @@ func BenchmarkBlockIterSeekLT(b *testing.B) {
 
 						keys, syntheticPrefix, syntheticSuffix := createBenchBlock(blockSize, w, rng, withSyntheticPrefix, withSyntheticSuffix)
 
-						it, err := NewIter(benchCmp, benchSplit, w.Finish(), block.IterTransforms{
-							SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
-						})
+						it, err := NewIter(
+							benchComparer.Compare,
+							benchComparer.ComparePointSuffixes,
+							benchComparer.Split,
+							w.Finish(),
+							block.IterTransforms{
+								SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
+							})
 						if err != nil {
 							b.Fatal(err)
 						}
@@ -170,9 +179,14 @@ func BenchmarkBlockIterNext(b *testing.B) {
 
 						_, syntheticPrefix, syntheticSuffix := createBenchBlock(blockSize, w, rng, withSyntheticPrefix, withSyntheticSuffix)
 
-						it, err := NewIter(benchCmp, benchSplit, w.Finish(), block.IterTransforms{
-							SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
-						})
+						it, err := NewIter(
+							benchComparer.Compare,
+							benchComparer.ComparePointSuffixes,
+							benchComparer.Split,
+							w.Finish(),
+							block.IterTransforms{
+								SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
+							})
 						if err != nil {
 							b.Fatal(err)
 						}
@@ -202,9 +216,14 @@ func BenchmarkBlockIterPrev(b *testing.B) {
 
 						_, syntheticPrefix, syntheticSuffix := createBenchBlock(blockSize, w, rng, withSyntheticPrefix, withSyntheticSuffix)
 
-						it, err := NewIter(benchCmp, benchSplit, w.Finish(), block.IterTransforms{
-							SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
-						})
+						it, err := NewIter(
+							benchComparer.Compare,
+							benchComparer.ComparePointSuffixes,
+							benchComparer.Split,
+							w.Finish(),
+							block.IterTransforms{
+								SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),
+							})
 						if err != nil {
 							b.Fatal(err)
 						}

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -74,15 +74,13 @@ var fragmentBlockIterPool = sync.Pool{
 // spans.
 func NewFragmentIter(
 	fileNum base.DiskFileNum,
-	cmp base.Compare,
-	suffixCmp base.CompareRangeSuffixes,
-	split base.Split,
+	comparer *base.Comparer,
 	blockHandle block.BufferHandle,
 	transforms block.FragmentIterTransforms,
 ) (keyspan.FragmentIterator, error) {
 	i := fragmentBlockIterPool.Get().(*fragmentIter)
 
-	i.suffixCmp = suffixCmp
+	i.suffixCmp = comparer.CompareRangeSuffixes
 	// Use the i.keyBuf array to back the Keys slice to prevent an allocation
 	// when the spans contain few keys.
 	i.span.Keys = i.keyBuf[:0]
@@ -93,7 +91,7 @@ func NewFragmentIter(
 	}
 	i.closeCheck = invariants.CloseChecker{}
 
-	if err := i.blockIter.InitHandle(cmp, split, blockHandle, block.IterTransforms{
+	if err := i.blockIter.InitHandle(comparer, blockHandle, block.IterTransforms{
 		SyntheticSeqNum: transforms.SyntheticSeqNum,
 		// We let the blockIter prepend the prefix to span start keys; the fragment
 		// iterator will prepend it for end keys. We could do everything in the

--- a/sstable/rowblk/rowblk_fragment_iter_test.go
+++ b/sstable/rowblk/rowblk_fragment_iter_test.go
@@ -96,7 +96,7 @@ func TestBlockFragmentIterator(t *testing.T) {
 
 			blockHandle := block.CacheBufferHandle(c.Get(1, 0, 0))
 			require.True(t, blockHandle.Valid())
-			i, err := NewFragmentIter(0, comparer.Compare, comparer.CompareRangeSuffixes, comparer.Split, blockHandle, transforms)
+			i, err := NewFragmentIter(0, comparer, blockHandle, transforms)
 			defer i.Close()
 			require.NoError(t, err)
 

--- a/sstable/rowblk/rowblk_index_iter.go
+++ b/sstable/rowblk/rowblk_index_iter.go
@@ -19,17 +19,15 @@ type IndexIter struct {
 var _ block.IndexBlockIterator = (*IndexIter)(nil)
 
 // Init initializes an iterator from the provided block data slice.
-func (i *IndexIter) Init(
-	cmp base.Compare, split base.Split, blk []byte, transforms block.IterTransforms,
-) error {
-	return i.iter.Init(cmp, split, blk, transforms)
+func (i *IndexIter) Init(c *base.Comparer, blk []byte, transforms block.IterTransforms) error {
+	return i.iter.Init(c.Compare, c.ComparePointSuffixes, c.Split, blk, transforms)
 }
 
 // InitHandle initializes an iterator from the provided block handle.
 func (i *IndexIter) InitHandle(
-	cmp base.Compare, split base.Split, block block.BufferHandle, transforms block.IterTransforms,
+	comparer *base.Comparer, block block.BufferHandle, transforms block.IterTransforms,
 ) error {
-	return i.iter.InitHandle(cmp, split, block, transforms)
+	return i.iter.InitHandle(comparer, block, transforms)
 }
 
 // Valid returns true if the iterator is currently positioned at a valid block

--- a/sstable/rowblk/rowblk_rewrite.go
+++ b/sstable/rowblk/rowblk_rewrite.go
@@ -40,7 +40,7 @@ type Rewriter struct {
 func (r *Rewriter) RewriteSuffixes(
 	input []byte, from []byte, to []byte,
 ) (start, end base.InternalKey, rewritten []byte, err error) {
-	if err := r.iter.Init(r.comparer.Compare, r.comparer.Split, input, block.NoTransforms); err != nil {
+	if err := r.iter.Init(r.comparer.Compare, r.comparer.ComparePointSuffixes, r.comparer.Split, input, block.NoTransforms); err != nil {
 		return base.InternalKey{}, base.InternalKey{}, nil, err
 	}
 	if cap(r.writer.restarts) < int(r.iter.restarts) {


### PR DESCRIPTION
This commit adapts colblk.DataBlockIter to use a base.ComparePointSuffixes func
to compare keys against the synthetic suffix. Previously we used base.Compare
which is no longer a valid use of the base.Compare contract.

Informs https://github.com/cockroachdb/cockroach/issues/136709.