### PR TITLE
db: add an interface for a slot-based compaction limiter

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -265,6 +265,8 @@ type compaction struct {
 	metrics map[int]*LevelMetrics
 
 	pickerMetrics compactionPickerMetrics
+
+	slot base.CompactionSlot
 }
 
 // inputLargestSeqNumAbsolute returns the maximum LargestSeqNumAbsolute of any
@@ -346,12 +348,17 @@ func newCompaction(
 		maxOutputFileSize: pc.maxOutputFileSize,
 		maxOverlapBytes:   pc.maxOverlapBytes,
 		pickerMetrics:     pc.pickerMetrics,
+		slot:              pc.slot,
 	}
 	c.startLevel = &c.inputs[0]
 	if pc.startLevel.l0SublevelInfo != nil {
 		c.startLevel.l0SublevelInfo = pc.startLevel.l0SublevelInfo
 	}
 	c.outputLevel = &c.inputs[1]
+	if c.slot == nil {
+		c.slot = opts.Experimental.CompactionLimiter.TookWithoutPermission(context.TODO())
+		c.slot.CompactionSelected(c.startLevel.level, c.outputLevel.level, c.startLevel.files.SizeSum())
+	}
 
 	if len(pc.extraLevels) > 0 {
 		c.extraLevels = pc.extraLevels
@@ -517,6 +524,18 @@ func newFlush(
 	}
 	c.startLevel = &c.inputs[0]
 	c.outputLevel = &c.inputs[1]
+
+	// Flush slots are always taken without permission.
+	//
+	// NB: CompactionLimiter defaults to a no-op limiter unless one is implemented
+	// and passed-in as an option during Open.
+	slot := opts.Experimental.CompactionLimiter.TookWithoutPermission(context.TODO())
+	var flushingSize uint64
+	for i := range flushing {
+		flushingSize += flushing[i].totalBytes()
+	}
+	slot.CompactionSelected(-1, 0, flushingSize)
+	c.slot = slot
 
 	if len(flushing) > 0 {
 		if _, ok := flushing[0].flushable.(*ingestedFlushable); ok {
@@ -765,6 +784,7 @@ func (c *compaction) newInputIters(
 				iterOpts, c.comparer, newIters, level.files.Iter(), l, internalIterOpts{
 					compaction: true,
 					bufferPool: &c.bufferPool,
+					stats:      &c.stats,
 				}))
 			// TODO(jackson): Use keyspanimpl.LevelIter to avoid loading all the range
 			// deletions into memory upfront. (See #2015, which reverted this.) There
@@ -2900,6 +2920,8 @@ func (d *DB) compactAndWrite(
 		Grandparents:               c.grandparents,
 		MaxGrandparentOverlapBytes: c.maxOverlapBytes,
 		TargetOutputFileSize:       c.maxOutputFileSize,
+		Slot:                       c.slot,
+		IteratorStats:              &c.stats,
 	}
 	runner := compact.NewRunner(runnerCfg, iter)
 	for runner.MoreDataToWrite() {

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -220,6 +221,10 @@ type pickedCompaction struct {
 	// overlap in its output level with. If the overlap is greater than
 	// maxReadCompaction bytes, then we don't proceed with the compaction.
 	maxReadCompactionBytes uint64
+
+	// slot is the compaction slot used up by this compaction. Encapsulates any
+	// limiting/pacing logic.
+	slot base.CompactionSlot
 	// The boundaries of the input data.
 	smallest      InternalKey
 	largest       InternalKey
@@ -1177,6 +1182,37 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 			return nil
 		}
 	}
+
+	// NB: CompactionLimiter defaults to a no-op limiter unless one is implemented
+	// and passed-in as an option during Open.
+	limiter := p.opts.Experimental.CompactionLimiter
+	var slot base.CompactionSlot
+	if n := len(env.inProgressCompactions); n == 0 {
+		// We are not running a compaction at the moment. We should take a compaction slot
+		// without permission.
+		slot = limiter.TookWithoutPermission(context.TODO())
+	} else {
+		var err error
+		slot, err = limiter.RequestSlot(context.TODO())
+		if err != nil {
+			p.opts.EventListener.BackgroundError(err)
+			return nil
+		}
+		if slot == nil {
+			// The limiter is denying us a compaction slot. Yield to other work.
+			return nil
+		}
+	}
+	defer func() {
+		if pc != nil {
+			var inputSize uint64
+			for i := range pc.inputs {
+				inputSize += pc.inputs[i].files.SizeSum()
+			}
+			slot.CompactionSelected(pc.startLevel.level, pc.outputLevel.level, inputSize)
+			pc.slot = slot
+		}
+	}()
 
 	scores := p.calculateLevelScores(env.inProgressCompactions)
 

--- a/internal/base/compaction.go
+++ b/internal/base/compaction.go
@@ -1,0 +1,62 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import "context"
+
+type CompactionSlot interface {
+	// CompactionSelected is called when a compaction is selected for execution in
+	// this compaction slot. The firstInputLevel is the highest input level participating
+	// in this compaction, and the outputLevel is the level that outputs are being
+	// written to from this compaction. inputSize is the cumulative size of inputs participating
+	// in this compaction, including the size of the memtable for flushes.
+	CompactionSelected(firstInputLevel, outputLevel int, inputSize uint64)
+	// UpdateMetrics is called periodically to update the number of disk bytes read and written
+	// for this compaction slot. The metrics passed in are cumulative, not incremental
+	// since the last UpdateMetrics call. The implementation of this method could
+	// calculate deltas as necessary. For flushes, bytesRead will be bytes read from
+	// the memtable.
+	UpdateMetrics(bytesRead, bytesWritten uint64)
+	// Release returns a compaction slot. Must be called once a compaction is
+	// complete. After this method, no more calls must be made to other interface
+	// methods on CompactionSlot.
+	Release(totalBytesWritten uint64)
+}
+
+type CompactionLimiter interface {
+	// TookWithoutPermission is called when a compaction is performed without
+	// asking for permission. Pebble calls into this method for flushes as well
+	// as for the first compaction in an instance, as those slots will always be
+	// granted even in the case of slot exhaustion or overload.
+	TookWithoutPermission(ctx context.Context) CompactionSlot
+	// RequestSlot is called when a compaction is about to be scheduled. If the
+	// compaction is allowed, the method returns a non-nil slot that must be released
+	// after the compaction is complete. If a nil value is returned, the compaction is
+	// disallowed due to possible overload.
+	RequestSlot(ctx context.Context) (CompactionSlot, error)
+}
+
+type DefaultCompactionSlot struct{}
+
+func (d *DefaultCompactionSlot) CompactionSelected(
+	firstInputLevel, outputLevel int, inputSize uint64,
+) {
+}
+
+func (d *DefaultCompactionSlot) UpdateMetrics(bytesRead, bytesWritten uint64) {
+}
+
+func (d *DefaultCompactionSlot) Release(totalBytesWritten uint64) {
+}
+
+type DefaultCompactionLimiter struct{}
+
+func (d *DefaultCompactionLimiter) TookWithoutPermission(ctx context.Context) CompactionSlot {
+	return &DefaultCompactionSlot{}
+}
+
+func (d *DefaultCompactionLimiter) RequestSlot(ctx context.Context) (CompactionSlot, error) {
+	return &DefaultCompactionSlot{}, nil
+}

--- a/options.go
+++ b/options.go
@@ -77,6 +77,12 @@ type ShortAttributeExtractor = base.ShortAttributeExtractor
 // UserKeyPrefixBound exports the sstable.UserKeyPrefixBound type.
 type UserKeyPrefixBound = sstable.UserKeyPrefixBound
 
+// CompactionLimiter exports the base.CompactionLimiter type.
+type CompactionLimiter = base.CompactionLimiter
+
+// CompactionSlot exports the base.CompactionSlot type.
+type CompactionSlot = base.CompactionSlot
+
 // IterKeyType configures which types of keys an iterator should surface.
 type IterKeyType int8
 
@@ -847,6 +853,12 @@ type Options struct {
 		// with it. This application happens through an excise, similar to
 		// the excise phase of IngestAndExcise.
 		EnableDeleteOnlyCompactionExcises func() bool
+
+		// CompactionLimiter, if set, is used to limit concurrent compactions as well
+		// as to pace compactions and flushing compactions already chosen. If nil,
+		// no limiting or pacing happens other than that controlled by other options
+		// like L0CompactionConcurrency and CompactionDebtConcurrency.
+		CompactionLimiter CompactionLimiter
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for
@@ -1228,6 +1240,9 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 	if o.Experimental.CompactionDebtConcurrency <= 0 {
 		o.Experimental.CompactionDebtConcurrency = 1 << 30 // 1 GB
+	}
+	if o.Experimental.CompactionLimiter == nil {
+		o.Experimental.CompactionLimiter = &base.DefaultCompactionLimiter{}
 	}
 	if o.Experimental.KeyValidationFunc == nil {
 		o.Experimental.KeyValidationFunc = func([]byte) error { return nil }


### PR DESCRIPTION
This change adds an interface that users of Pebble can implement to integrate a compaction limiter that gets information about compaction bytes read and bytes written. This change also threads that interface (and a simple no-op implementation by default) through the compaction and flush code paths.

Informs #1329.