### PR TITLE
tool: fix wal filename parsing to only work on filename

### DIFF
--- a/tool/wal.go
+++ b/tool/wal.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -107,7 +108,8 @@ func (w *walT) runDump(cmd *cobra.Command, args []string) {
 			// necessary in case WAL recycling was used (which it is usually is). If
 			// we can't parse the filename or it isn't a log file, we'll plow ahead
 			// anyways (which will likely fail when we try to read the file).
-			fileNum, _, ok := wal.ParseLogFilename(arg)
+			fileName := path.Base(arg)
+			fileNum, _, ok := wal.ParseLogFilename(fileName)
 			if !ok {
 				fileNum = 0
 			}


### PR DESCRIPTION
Previously, we treated the entirety of the cmd line argument passed in as a filename for figuring out the log file's number. This change updates that logic to split out the filename before parsing the file number, to better work in cases where the WAL file is not in the current directory and/or has a ./ before it.

Fixes #3863.