### PR TITLE
arenaskl: remove node.allocSize field

### DIFF
--- a/internal/arenaskl/arena.go
+++ b/internal/arenaskl/arena.go
@@ -80,14 +80,14 @@ func (a *Arena) Capacity() uint32 {
 // If overflow is not 0, it also ensures that many bytes after the buffer are
 // inside the arena (this is used for structures that are larger than the
 // requested size but don't use those extra bytes).
-func (a *Arena) alloc(size, alignment, overflow uint32) (uint32, uint32, error) {
+func (a *Arena) alloc(size, alignment, overflow uint32) (uint32, error) {
 	if invariants.Enabled && (alignment&(alignment-1)) != 0 {
 		panic(errors.AssertionFailedf("invalid alignment %d", alignment))
 	}
 	// Verify that the arena isn't already full.
 	origSize := a.n.Load()
 	if int(origSize) > len(a.buf) {
-		return 0, 0, ErrArenaFull
+		return 0, ErrArenaFull
 	}
 
 	// Pad the allocation with enough bytes to ensure the requested alignment.
@@ -95,12 +95,12 @@ func (a *Arena) alloc(size, alignment, overflow uint32) (uint32, uint32, error) 
 
 	newSize := a.n.Add(padded)
 	if newSize+uint64(overflow) > uint64(len(a.buf)) {
-		return 0, 0, ErrArenaFull
+		return 0, ErrArenaFull
 	}
 
 	// Return the aligned offset.
 	offset := (uint32(newSize) - size) & ^(alignment - 1)
-	return offset, uint32(padded), nil
+	return offset, nil
 }
 
 func (a *Arena) getBytes(offset uint32, size uint32) []byte {

--- a/internal/arenaskl/arena_test.go
+++ b/internal/arenaskl/arena_test.go
@@ -35,19 +35,19 @@ func TestArenaSizeOverflow(t *testing.T) {
 	a := newArena(constants.MaxUint32OrInt)
 
 	// Allocating under the limit throws no error.
-	offset, _, err := a.alloc(math.MaxUint16, 1, 0)
+	offset, err := a.alloc(math.MaxUint16, 1, 0)
 	require.Nil(t, err)
 	require.Equal(t, uint32(1), offset)
 	require.Equal(t, uint32(math.MaxUint16)+1, a.Size())
 
 	// Allocating over the limit could cause an accounting
 	// overflow if 32-bit arithmetic was used. It shouldn't.
-	_, _, err = a.alloc(math.MaxUint32, 1, 0)
+	_, err = a.alloc(math.MaxUint32, 1, 0)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(constants.MaxUint32OrInt), a.Size())
 
 	// Continuing to allocate continues to throw an error.
-	_, _, err = a.alloc(math.MaxUint16, 1, 0)
+	_, err = a.alloc(math.MaxUint16, 1, 0)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(constants.MaxUint32OrInt), a.Size())
 }


### PR DESCRIPTION
The field was added in c34894c4 and has been unused since c34894c4.

The `node` struct remains the same size due to padding.

I found this while looking into cache misses in the memtable's arena-backed skiplist and exploring ways (e.g. value separation, value + key suffix separation) to improve memory locality. So far, I haven't found anything that shows promise on microbenchmarks.