### PR TITLE
sstable: optimize allocation of uncompressed buffers

### DIFF
--- a/sstable/block/compression_test.go
+++ b/sstable/block/compression_test.go
@@ -23,6 +23,9 @@ func TestCompressionRoundtrip(t *testing.T) {
 	rng := rand.New(rand.NewPCG(0, seed))
 
 	for compression := DefaultCompression + 1; compression < NCompression; compression++ {
+		if compression == NoCompression {
+			continue
+		}
 		t.Run(compression.String(), func(t *testing.T) {
 			payload := make([]byte, 1+rng.IntN(10<<10 /* 10 KiB */))
 			for i := range payload {

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -770,7 +770,7 @@ func (w *layoutWriter) writeBlock(
 	b []byte, compression block.Compression, buf *blockBuf,
 ) (block.Handle, error) {
 	return w.writePrecompressedBlock(block.CompressAndChecksum(
-		&buf.compressedBuf, b, compression, &buf.checksummer))
+		&buf.dataBuf, b, compression, &buf.checksummer))
 }
 
 // writePrecompressedBlock writes a pre-compressed block and its

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -531,7 +531,7 @@ func TestBlockBufClear(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	b1 := &blockBuf{}
 	b1.tmp[0] = 1
-	b1.compressedBuf = make([]byte, 1)
+	b1.dataBuf = make([]byte, 1)
 	b1.clear()
 	testBlockBufClear(t, b1, &blockBuf{})
 }
@@ -539,7 +539,7 @@ func TestBlockBufClear(t *testing.T) {
 func TestClearDataBlockBuf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	d := newDataBlockBuf(1, block.ChecksumTypeCRC32c)
-	d.blockBuf.compressedBuf = make([]byte, 1)
+	d.blockBuf.dataBuf = make([]byte, 1)
 	d.dataBlock.Add(ikey("apple"), nil)
 	d.dataBlock.Add(ikey("banana"), nil)
 


### PR DESCRIPTION
When we don't compress a data buffer, the `RawColumnWriter` makes a
clone of the data buffer. In the sysbench workload, we see this
allocation taking place for almost half of the blocks (suggesting that
the data isn't very compressible).

Use the buffer that we would have used for the compressed data instead
of allocating a new one.