### PR TITLE
internal: add SetFinalizerWithStack and fix test bug

### DIFF
--- a/internal/cache/entry.go
+++ b/internal/cache/entry.go
@@ -177,10 +177,10 @@ func entryAllocNew() *entry {
 		// We want to allocate each entry independently to check that it has been
 		// properly cleaned up.
 		e := &entry{}
-		invariants.SetFinalizer(e, func(obj interface{}) {
+		invariants.SetFinalizerWithStack(e, func(obj interface{}, stack []byte) {
 			e := obj.(*entry)
 			if *e != (entry{}) {
-				fmt.Fprintf(os.Stderr, "%p: entry was not freed", e)
+				fmt.Fprintf(os.Stderr, "%p: entry was not freed\n%s", e, stack)
 				os.Exit(1)
 			}
 		})

--- a/internal/cache/read_shard_test.go
+++ b/internal/cache/read_shard_test.go
@@ -109,11 +109,18 @@ func TestReadShard(t *testing.T) {
 	var c *shard
 	var readers map[string]*testReader
 	var mu sync.Mutex
-
+	freeShard := func() {
+		if c != nil {
+			c.Free()
+			c = nil
+		}
+	}
+	defer freeShard()
 	datadriven.RunTest(t, "testdata/read_shard",
 		func(t *testing.T, td *datadriven.TestData) string {
 			switch td.Cmd {
 			case "init":
+				freeShard()
 				var maxSize int64
 				td.ScanArgs(t, "max-size", &maxSize)
 				c = &shard{}

--- a/internal/cache/value.go
+++ b/internal/cache/value.go
@@ -53,11 +53,11 @@ func newValue(n int) *Value {
 		v.ref.init(1)
 		// Note: this is a no-op if invariants and tracing are disabled or race is
 		// enabled.
-		invariants.SetFinalizer(v, func(obj interface{}) {
+		invariants.SetFinalizerWithStack(v, func(obj interface{}, stack []byte) {
 			v := obj.(*Value)
 			if v.buf != nil {
-				fmt.Fprintf(os.Stderr, "%p: cache value was not freed: refs=%d\n%s",
-					v, v.refs(), v.ref.traces())
+				fmt.Fprintf(os.Stderr, "%p: cache value was not freed: refs=%d\n%s\n%s",
+					v, v.refs(), v.ref.traces(), stack)
 				os.Exit(1)
 			}
 		})

--- a/objstorage/objstorageprovider/vfs_readable.go
+++ b/objstorage/objstorageprovider/vfs_readable.go
@@ -49,9 +49,9 @@ func newFileReadable(
 		fs:              fs,
 		readaheadConfig: readaheadConfig,
 	}
-	invariants.SetFinalizer(r, func(obj interface{}) {
+	invariants.SetFinalizerWithStack(r, func(obj interface{}, stack []byte) {
 		if obj.(*fileReadable).file != nil {
-			fmt.Fprintf(os.Stderr, "Readable was not closed")
+			fmt.Fprintf(os.Stderr, "Readable was not closed\n%s", stack)
 			os.Exit(1)
 		}
 	})


### PR DESCRIPTION
SetFinalizerWithStack prints out the stack trace from when the finalizer was set. There was a bug in TestReadShard, in that it was not calling shard.Free, which is now fixed.