### PR TITLE
crl-release-24.3: valblk: fix Writer.Size() performance

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -204,9 +204,7 @@ func (w *RawColumnWriter) EstimatedSize() uint64 {
 		sz += uint64(w.rangeKeyBlock.Size())
 	}
 	if w.valueBlock != nil {
-		for _, blk := range w.valueBlock.blocks {
-			sz += uint64(blk.block.LengthWithTrailer())
-		}
+		sz += w.valueBlock.totalBlockBytes
 		if w.valueBlock.buf != nil {
 			sz += uint64(len(w.valueBlock.buf.b))
 		}


### PR DESCRIPTION
#### sstable: improve writer benchmark

Add varying `vals-per-key` parameter and add an `EstimatedSize()` call
per key (which happens during compactions).

#### crl-release-24.3: valblk: fix Writer.Size() performance

`Writer.Size()` unnecessarily loops through all the blocks instead of
using `totalBlockBytes`. This seems like an oversight: we only append
to `blocks` in `compressAndFlush` where we also update
`totalBlockBytes`. I verified that in all Pebble tests these values are
the same, using `if sz != w.totalBlockBytes { panic() }`.