### PR TITLE
invariants: fix non-inlined empty function call

### DIFF
--- a/internal/invalidating/iter.go
+++ b/internal/invalidating/iter.go
@@ -15,7 +15,7 @@ import (
 // MaybeWrapIfInvariants wraps some iterators with an invalidating iterator.
 // MaybeWrapIfInvariants does nothing in non-invariant builds.
 func MaybeWrapIfInvariants(iter base.InternalIterator) base.InternalIterator {
-	if invariants.Sometimes(10) {
+	if invariants.Enabled && invariants.Sometimes(10) {
 		return NewIter(iter)
 	}
 	return iter

--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -6,6 +6,13 @@
 
 package invariants
 
+// Sometimes returns true percent% of the time if invariants are Enabled (i.e.
+// we were built with the "invariants" or "race" build tags). Otherwise, always
+// returns false.
+func Sometimes(percent int) bool {
+	return false
+}
+
 // CloseChecker is used to check that objects are closed exactly once. It is
 // empty and does nothing in non-invariant builds.
 //

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -6,6 +6,15 @@
 
 package invariants
 
+import "math/rand/v2"
+
+// Sometimes returns true percent% of the time if invariants are Enabled (i.e.
+// we were built with the "invariants" or "race" build tags). Otherwise, always
+// returns false.
+func Sometimes(percent int) bool {
+	return rand.Uint32N(100) < uint32(percent)
+}
+
 // CloseChecker is used to check that objects are closed exactly once. It is
 // empty and does nothing in non-invariant builds.
 //

--- a/sstable/colblk/keyspan.go
+++ b/sstable/colblk/keyspan.go
@@ -336,12 +336,14 @@ func NewKeyspanIter(
 var keyspanIterPool = sync.Pool{
 	New: func() interface{} {
 		i := &KeyspanIter{}
-		invariants.SetFinalizer(i, func(obj interface{}) {
-			if i := obj.(*KeyspanIter); i.handle.Valid() {
-				fmt.Fprintf(os.Stderr, "KeyspanIter.handle is not nil: %#v\n", i.handle)
-				os.Exit(1)
-			}
-		})
+		if invariants.UseFinalizers {
+			invariants.SetFinalizer(i, func(obj interface{}) {
+				if i := obj.(*KeyspanIter); i.handle.Valid() {
+					fmt.Fprintf(os.Stderr, "KeyspanIter.handle is not nil: %#v\n", i.handle)
+					os.Exit(1)
+				}
+			})
+		}
 		return i
 	},
 }

--- a/sstable/colblk/uints.go
+++ b/sstable/colblk/uints.go
@@ -221,7 +221,7 @@ func (b *UintBuilder) Reset() {
 		b.stats.maximum = 0
 		// We could reset all values as a precaution, but it has a visible cost
 		// in benchmarks.
-		if invariants.Sometimes(50) {
+		if invariants.Enabled && invariants.Sometimes(50) {
 			for i := 0; i < b.array.n; i++ {
 				b.array.elems.set(i, math.MaxUint64)
 			}
@@ -302,7 +302,7 @@ func (b *UintBuilder) determineEncoding(rows int) (_ UintEncoding, deltaBase uin
 		// Note that b.stats.minimum includes all rows set so far so it might be
 		// strictly smaller than all values up to [rows]; but it is still a suitable
 		// base for b.stats.encoding.
-		if invariants.Sometimes(1) && rows > 0 {
+		if invariants.Enabled && invariants.Sometimes(1) && rows > 0 {
 			if enc, _ := b.recalculateEncoding(rows); enc != b.stats.encoding {
 				panic(fmt.Sprintf("fast and slow paths don't agree: %s vs %s", b.stats.encoding, enc))
 			}

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -155,16 +155,18 @@ func init() {
 	singleLevelIterRowBlockPool = sync.Pool{
 		New: func() interface{} {
 			i := &singleLevelIteratorRowBlocks{pool: &singleLevelIterRowBlockPool}
-			// Note: this is a no-op if invariants are disabled or race is enabled.
-			invariants.SetFinalizer(i, checkSingleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
+			if invariants.UseFinalizers {
+				invariants.SetFinalizer(i, checkSingleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
+			}
 			return i
 		},
 	}
 	twoLevelIterRowBlockPool = sync.Pool{
 		New: func() interface{} {
 			i := &twoLevelIteratorRowBlocks{pool: &twoLevelIterRowBlockPool}
-			// Note: this is a no-op if invariants are disabled or race is enabled.
-			invariants.SetFinalizer(i, checkTwoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
+			if invariants.UseFinalizers {
+				invariants.SetFinalizer(i, checkTwoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
+			}
 			return i
 		},
 	}
@@ -173,8 +175,9 @@ func init() {
 			i := &singleLevelIteratorColumnBlocks{
 				pool: &singleLevelIterColumnBlockPool,
 			}
-			// Note: this is a no-op if invariants are disabled or race is enabled.
-			invariants.SetFinalizer(i, checkSingleLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.DataBlockIter, *colblk.DataBlockIter])
+			if invariants.UseFinalizers {
+				invariants.SetFinalizer(i, checkSingleLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.DataBlockIter, *colblk.DataBlockIter])
+			}
 			return i
 		},
 	}
@@ -183,8 +186,9 @@ func init() {
 			i := &twoLevelIteratorColumnBlocks{
 				pool: &twoLevelIterColumnBlockPool,
 			}
-			// Note: this is a no-op if invariants are disabled or race is enabled.
-			invariants.SetFinalizer(i, checkTwoLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.DataBlockIter, *colblk.DataBlockIter])
+			if invariants.UseFinalizers {
+				invariants.SetFinalizer(i, checkTwoLevelIterator[colblk.IndexIter, *colblk.IndexIter, colblk.DataBlockIter, *colblk.DataBlockIter])
+			}
 			return i
 		},
 	}

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -64,8 +64,9 @@ var _ keyspan.FragmentIterator = (*fragmentIter)(nil)
 var fragmentBlockIterPool = sync.Pool{
 	New: func() interface{} {
 		i := &fragmentIter{}
-		// Note: this is a no-op if invariants are disabled or race is enabled.
-		invariants.SetFinalizer(i, checkFragmentBlockIterator)
+		if invariants.UseFinalizers {
+			invariants.SetFinalizer(i, checkFragmentBlockIterator)
+		}
 		return i
 	},
 }


### PR DESCRIPTION
#### invariants: fix non-inlined empty function call

The `invariants.Sometimes()` was not being inlined even though it
resolves to a `return false` when invariants aren't on. It looks like
the inline decision happens before some phases of dead code
elimination. This function is called in some very hot paths inside the
columnar block builder.

This change moves `Sometimes()` into the `on.go/off.go` files where it
can be simplified for the `off` case. We also add some
`invariants.Enabled` and `invariants.UseFinalizers` checks (which are
constant, unlike function calls) in hot paths.

```
CockroachDataBlockWriter/AlphaLen=4,Prefix=8,Shared=2,KeysPerPrefix=2,valueLen=8-10  75.3µs ± 1%  74.4µs ± 0%  -1.19%  (p=0.000 n=8+8)
```
