### PR TITLE
pebble-release-2.0: cmd/pebble: add version flag

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -5,10 +5,12 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"time"
 
+	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/crdbtest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
@@ -68,9 +70,13 @@ func main() {
 	)
 
 	rootCmd := &cobra.Command{
-		Use:   "pebble [command] (flags)",
-		Short: "pebble benchmarking/introspection tool",
+		Use:     "pebble [command] (flags)",
+		Short:   "pebble benchmarking/introspection tool",
+		Version: fmt.Sprintf("supported Pebble format versions: %d-%d", pebble.FormatMinSupported, pebble.FormatNewest),
 	}
+	rootCmd.SetVersionTemplate(`{{printf "%s" .Short}}
+{{printf "%s" .Version}}
+`)
 	rootCmd.AddCommand(benchCmd)
 
 	t := tool.New(

--- a/tool/db.go
+++ b/tool/db.go
@@ -90,9 +90,13 @@ func newDB(
 	d.fmtValue.mustSet("[%x]")
 
 	d.Root = &cobra.Command{
-		Use:   "db",
-		Short: "DB introspection tools",
+		Use:     "db",
+		Short:   "DB introspection tools",
+		Version: fmt.Sprintf("supported Pebble format versions: %d-%d", pebble.FormatMinSupported, pebble.FormatNewest),
 	}
+	d.Root.SetVersionTemplate(`{{printf "%s" .Short}}
+{{printf "%s" .Version}}
+`)
 	d.Check = &cobra.Command{
 		Use:   "check <dir>",
 		Short: "verify checksums and metadata",


### PR DESCRIPTION
Add a version flag to `pebble` and `pebble db` which prints the supported format versions.

```
$ go run ./cmd/pebble --version
pebble benchmarking/introspection tool
supported Pebble format versions: 13-19
$ go run ./cmd/pebble db --version
DB introspection tools
supported Pebble format versions: 13-19
```