### PR TITLE
metamorphic: allow KeyFormat to specify a KeySchema

### DIFF
--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -356,6 +356,7 @@ var keyFormatsByName = func() map[string]KeyFormat {
 type KeyFormat struct {
 	Name                         string
 	Comparer                     *base.Comparer
+	KeySchema                    *pebble.KeySchema
 	FormatKey                    func(UserKey) string
 	FormatKeySuffix              func(UserKeySuffix) string
 	ParseFormattedKey            func(string) (UserKey, error)

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -358,7 +358,7 @@ func (k *keyManager) getSetOfVisibleKeys(readerID objID) [][]byte {
 			keys = append(keys, unsafe.Slice(unsafe.StringData(k), len(k)))
 		}
 	}
-	slices.SortFunc(keys, testkeys.Comparer.Compare)
+	slices.SortFunc(keys, k.kf.Comparer.Compare)
 	return keys
 }
 

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -48,7 +48,7 @@ func TestSetupInitialState(t *testing.T) {
 	// setupInitialState with an initial state path set to the test's TempDir
 	// should populate opts.opts.FS with the directory's contents.
 	opts := &TestOptions{
-		Opts:             defaultOptions(),
+		Opts:             defaultOptions(TestkeysKeyFormat),
 		initialStatePath: initialStatePath,
 		initialStateDesc: "test",
 	}

--- a/metamorphic/testkeys.go
+++ b/metamorphic/testkeys.go
@@ -13,10 +13,15 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/colblk"
 )
 
 var TestkeysKeyFormat = KeyFormat{
-	Comparer:        testkeys.Comparer,
+	Comparer: testkeys.Comparer,
+	KeySchema: func() *colblk.KeySchema {
+		kf := colblk.DefaultKeySchema(testkeys.Comparer, 16 /* bundle size */)
+		return &kf
+	}(),
 	FormatKey:       func(k UserKey) string { return string(k) },
 	FormatKeySuffix: func(s UserKeySuffix) string { return string(s) },
 	NewGenerator: func(km *keyManager, rng *rand.Rand, cfg OpConfig) KeyGenerator {


### PR DESCRIPTION
Allow KeyFormat to specify a KeySchema that should be used by the metamorphic tests for columnar block sstables. This is in preparation for use of the cockroachkvs package within the metamorphic test.

Informs #4167.