### PR TITLE
metamorphic: add KeyGenerator.RecordPrecedingKey

### DIFF
--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -482,7 +482,7 @@ func (y *ycsb) insert(db DB, buf *ycsbBuf) {
 			log.Fatal(err)
 		}
 		if delta > 0 {
-			y.keyDist.IncMax(delta)
+			y.keyDist.IncMax(uint64(delta))
 		}
 	}
 }

--- a/internal/randvar/randvar.go
+++ b/internal/randvar/randvar.go
@@ -18,7 +18,7 @@ type Dynamic interface {
 	Static
 
 	// Increment the max value the variable will return.
-	IncMax(delta int)
+	IncMax(delta uint64)
 
 	// Read the current max value the variable will return.
 	Max() uint64

--- a/internal/randvar/skewed_latest.go
+++ b/internal/randvar/skewed_latest.go
@@ -52,7 +52,7 @@ func NewSkewedLatest(min, max uint64, theta float64) (*SkewedLatest, error) {
 }
 
 // IncMax increments max.
-func (z *SkewedLatest) IncMax(delta int) {
+func (z *SkewedLatest) IncMax(delta uint64) {
 	z.mu.Lock()
 	z.mu.zipf.IncMax(delta)
 	z.mu.max += uint64(delta)

--- a/internal/randvar/uniform.go
+++ b/internal/randvar/uniform.go
@@ -37,8 +37,8 @@ func NewUniform(min, max uint64) *Uniform {
 }
 
 // IncMax increments max.
-func (g *Uniform) IncMax(delta int) {
-	g.max.Add(uint64(delta))
+func (g *Uniform) IncMax(delta uint64) {
+	g.max.Add(delta)
 }
 
 // Max returns the max value of the distribution.

--- a/internal/randvar/zipf.go
+++ b/internal/randvar/zipf.go
@@ -111,10 +111,10 @@ func computeZetaFromScratch(n uint64, theta float64) float64 {
 
 // IncMax increments max and recomputes the internal values that depend on
 // it. Returns an error if the recomputation failed.
-func (z *Zipf) IncMax(delta int) {
+func (z *Zipf) IncMax(delta uint64) {
 	z.mu.Lock()
 	oldMax := z.mu.max
-	z.mu.max += uint64(delta)
+	z.mu.max += delta
 	z.mu.zetaN = computeZetaIncrementally(oldMax+1-z.min, z.mu.max+1-z.min, z.theta, z.mu.zetaN)
 	z.mu.eta = (1 - math.Pow(2.0/float64(z.mu.max+1-z.min), 1.0-z.theta)) / (1.0 - z.zeta2/z.mu.zetaN)
 	z.mu.Unlock()

--- a/metamorphic/generator_test.go
+++ b/metamorphic/generator_test.go
@@ -133,7 +133,8 @@ func TestGeneratorRandom(t *testing.T) {
 		rng := rand.New(rand.NewPCG(0, seed))
 		count := ops.Uint64(rng)
 		km := newKeyManager(cfg.numInstances)
-		return formatOps(km.kf, generate(rng, count, cfg, km))
+		g := newGenerator(rng, cfg, km)
+		return formatOps(km.kf, g.generate(count))
 	}
 
 	for i := range cfgs {

--- a/metamorphic/key_manager_test.go
+++ b/metamorphic/key_manager_test.go
@@ -158,11 +158,13 @@ func TestLoadPrecedingKeys(t *testing.T) {
 	rng := randvar.NewRand()
 	cfg := DefaultOpConfig()
 	km := newKeyManager(1 /* numInstances */)
-	ops := generate(rng, 1000, cfg, km)
+	g := newGenerator(rng, cfg, km)
+	ops := g.generate(1000)
 
 	cfg2 := DefaultOpConfig()
 	km2 := newKeyManager(1 /* numInstances */)
-	loadPrecedingKeys(t, ops, &cfg2, km2)
+	g2 := newGenerator(rng, cfg2, km2)
+	loadPrecedingKeys(ops, g2.keyGenerator, km2)
 
 	// NB: We can't assert equality, because the original run may not have
 	// ever used the max of the distribution.

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -175,7 +175,8 @@ func TestBlockPropertiesParse(t *testing.T) {
 
 	rng := rand.New(rand.NewPCG(0, fixedSeed))
 	km := newKeyManager(1 /* numInstances */)
-	ops := generate(rng, numOps, presetConfigs[0], km)
+	g := newGenerator(rng, presetConfigs[0], km)
+	ops := g.generate(numOps)
 	opsPath := filepath.Join(metaDir, "ops")
 	formattedOps := formatOps(km.kf, ops)
 	require.NoError(t, os.WriteFile(opsPath, []byte(formattedOps), 0644))

--- a/metamorphic/parser_test.go
+++ b/metamorphic/parser_test.go
@@ -42,7 +42,8 @@ func TestParserRandom(t *testing.T) {
 				cfg.numInstances = 2
 			}
 			km := newKeyManager(cfg.numInstances)
-			ops := generate(randvar.NewRand(), 10000, cfg, km)
+			g := newGenerator(randvar.NewRand(), cfg, km)
+			ops := g.generate(10000)
 			src := formatOps(km.kf, ops)
 
 			parsedOps, err := parse([]byte(src), parserOpts{})

--- a/metamorphic/testkeys.go
+++ b/metamorphic/testkeys.go
@@ -65,7 +65,7 @@ func (kg *testkeyKeyGenerator) RecordPrecedingKey(key []byte) {
 			panic(err)
 		}
 		if uint64(s) > kg.cfg.writeSuffixDist.Max() {
-			diff := int(uint64(s) - kg.cfg.writeSuffixDist.Max())
+			diff := uint64(s) - kg.cfg.writeSuffixDist.Max()
 			kg.cfg.writeSuffixDist.IncMax(diff)
 		}
 	}


### PR DESCRIPTION
Add a method to the KeyGenerator interface for informing a key generator of the existence of a previously-used key. Use this for updating the distribution of suffixes generated by the testkey generator.

In future work, the Cockroach key generator will use it to parse keys and update its distribution of MVCC suffixes as well.