### PR TITLE
cockroachkvs: add FormatKey, ParseFormattedKey

### DIFF
--- a/cockroachkvs/cockroachkvs_test.go
+++ b/cockroachkvs/cockroachkvs_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/olekukonko/tablewriter"
+	testify "github.com/stretchr/testify/require"
 )
 
 func TestComparer(t *testing.T) {
@@ -702,4 +703,31 @@ func splitStringAt(str string, sep string) (before, after string) {
 		return s[0], s[1]
 	}
 	return str, ""
+}
+
+func TestFormatKey(t *testing.T) {
+	formattedKeys := []string{
+		"foo",                     // Bare key
+		"bar",                     // Bare key
+		"foo@1000000,0",           // MVCC key, only wall time in seconds
+		"foo@1000000.000051212,0", // MVCC key, wall time with subsecond nanos
+		"foo@1000000,8",           // MVCC key, with logical time
+		"foo@1000000.000051212,7", // MVCC key, wall time with subsecond nanos and logical time
+		"foo@01,cf379e85-6371-42e6-acc8-ed5259fa177a", // Lock table key
+	}
+	for _, formattedKey := range formattedKeys {
+		k := ParseFormattedKey(formattedKey)
+		t.Logf("ParseFormattedKey(%s) = %x", formattedKey, k)
+		reformatted := fmt.Sprint(FormatKey(k))
+		require.Equal(t, formattedKey, reformatted)
+	}
+
+	invalidFormattedKeys := []string{
+		"foo@01000000",                              // Missing logical
+		"foo@1000000.000051212",                     // Missing logical
+		"foo@01,cf379e85-6371-42e6-acc8-ed5259fa17", // Invalid UUID
+	}
+	for _, formattedKey := range invalidFormattedKeys {
+		testify.Panics(t, func() { ParseFormattedKey(formattedKey) })
+	}
 }


### PR DESCRIPTION
Add functions to format cockroach keys into human-readable strings and parse the human-readable strings back out into the binary format. This will be used by the metamorphic test when it serializes operations.

For parity with the Cockroach repo's key pretty-printing, timestamps use a formatting matching the hlc timestamp's pretty printing format.