### PR TITLE
metamorphic: move block property collectors into KeyFormat

### DIFF
--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -361,6 +361,7 @@ type KeyFormat struct {
 	Name                         string
 	Comparer                     *base.Comparer
 	KeySchema                    *pebble.KeySchema
+	BlockPropertyCollectors      []func() pebble.BlockPropertyCollector
 	FormatKey                    func(UserKey) string
 	FormatKeySuffix              func(UserKeySuffix) string
 	ParseFormattedKey            func(string) (UserKey, error)

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -318,7 +318,7 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 		Levels: []pebble.LevelOptions{{
 			FilterPolicy: bloom.FilterPolicy(10),
 		}},
-		BlockPropertyCollectors: blockPropertyCollectorConstructors,
+		BlockPropertyCollectors: kf.BlockPropertyCollectors,
 	}
 	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 
@@ -938,10 +938,6 @@ func setupInitialState(dataDir string, testOpts *TestOptions) error {
 		})
 	}
 	return nil
-}
-
-var blockPropertyCollectorConstructors = []func() pebble.BlockPropertyCollector{
-	sstable.NewTestKeysBlockPropertyCollector,
 }
 
 // testingFilterPolicy is used to allow bloom filter policies with non-default

--- a/metamorphic/testkeys.go
+++ b/metamorphic/testkeys.go
@@ -22,6 +22,9 @@ var TestkeysKeyFormat = KeyFormat{
 		kf := colblk.DefaultKeySchema(testkeys.Comparer, 16 /* bundle size */)
 		return &kf
 	}(),
+	BlockPropertyCollectors: []func() pebble.BlockPropertyCollector{
+		sstable.NewTestKeysBlockPropertyCollector,
+	},
 	FormatKey:       func(k UserKey) string { return string(k) },
 	FormatKeySuffix: func(s UserKeySuffix) string { return string(s) },
 	NewGenerator: func(km *keyManager, rng *rand.Rand, cfg OpConfig) KeyGenerator {


### PR DESCRIPTION
Move the configuration of block-property collectors into the KeyFormat, since it's dependent on the key format used.