### PR TITLE
sstable: lift suffix rewriting in-memory requirement into type signature

### DIFF
--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -513,7 +513,8 @@ func runRewriteCmd(
 	}
 
 	f := &objstorage.MemObj{}
-	meta, _, err := rewriteKeySuffixesInBlocks(r, f, opts, from, to, 2)
+	sst := r.readable.(*memReader).b
+	meta, _, err := rewriteKeySuffixesInBlocks(r, sst, f, opts, from, to, 2)
 	if err != nil {
 		return nil, r, errors.Wrap(err, "rewrite failed")
 	}

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -342,7 +342,7 @@ type RawWriter interface {
 	// provided suffix. It's specifically used for the implementation of
 	// RewriteKeySuffixesAndReturnFormat. See that function's documentation for
 	// more details.
-	rewriteSuffixes(r *Reader, wo WriterOptions, from, to []byte, concurrency int) error
+	rewriteSuffixes(r *Reader, sst []byte, wo WriterOptions, from, to []byte, concurrency int) error
 
 	// copyDataBlocks copies data blocks to the table from the specified ReadHandle.
 	// It's specifically used by the sstable copier that can copy parts of an sstable


### PR DESCRIPTION
Previously the suffix rewriter required the sstable being rewritten be held entirely in memory but relied on a type assertion to a *sstable.memReader deep in a complicated call stack. This commit refactors this call stack to explicitly propagate the byte slice holding the in-memory sstable, making this requirement explicit and unambiguous.