### PR TITLE
cache: remove Handle

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -812,8 +812,9 @@ func TestMemTableReservation(t *testing.T) {
 	tmpID := opts.Cache.NewID()
 	helloWorld := []byte("hello world")
 	value := cache.Alloc(len(helloWorld))
-	copy(value.Buf(), helloWorld)
-	opts.Cache.Set(tmpID, base.DiskFileNum(0), 0, value).Release()
+	copy(value.RawBuffer(), helloWorld)
+	opts.Cache.Set(tmpID, base.DiskFileNum(0), 0, value)
+	value.Release()
 
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -830,8 +831,8 @@ func TestMemTableReservation(t *testing.T) {
 		t.Fatalf("expected 2 refs, but found %d", refs)
 	}
 	// Verify the memtable reservation has caused our test block to be evicted.
-	if h := opts.Cache.Get(tmpID, base.DiskFileNum(0), 0); h.Valid() {
-		t.Fatalf("expected failure, but found success: %#v", h)
+	if cv := opts.Cache.Get(tmpID, base.DiskFileNum(0), 0); cv != nil {
+		t.Fatalf("expected failure, but found success: %#v", cv)
 	}
 
 	// Flush the memtable. The memtable reservation should double because old

--- a/internal/cache/entry.go
+++ b/internal/cache/entry.go
@@ -146,7 +146,7 @@ func (e *entry) setValue(v *Value) {
 	}
 	old := e.val
 	e.val = v
-	old.release()
+	old.Release()
 }
 
 func (e *entry) acquireValue() *Value {

--- a/internal/cache/read_shard.go
+++ b/internal/cache/read_shard.go
@@ -181,13 +181,13 @@ func newReadEntry(rs *readShard, k key) *readEntry {
 // latency due to context cancellation.
 func (e *readEntry) waitForReadPermissionOrHandle(
 	ctx context.Context,
-) (h Handle, errorDuration time.Duration, err error) {
-	constructHandleLocked := func() Handle {
+) (cv *Value, errorDuration time.Duration, err error) {
+	constructValueLocked := func() *Value {
 		if e.mu.v == nil {
 			panic("value is nil")
 		}
 		e.mu.v.acquire()
-		return Handle{value: e.mu.v}
+		return e.mu.v
 	}
 	becomeReaderLocked := func() {
 		if e.mu.v != nil {
@@ -222,9 +222,9 @@ func (e *readEntry) waitForReadPermissionOrHandle(
 		e.mu.Lock()
 		if e.mu.v != nil {
 			// Value has already been read.
-			h := constructHandleLocked()
+			cv := constructValueLocked()
 			errorDuration = unlockAndUnrefAndTryRemoveFromMap(false)
-			return h, errorDuration, nil
+			return cv, errorDuration, nil
 		}
 		// Not already read. Wait for turn to do the read or for someone else to do
 		// the read.
@@ -233,7 +233,7 @@ func (e *readEntry) waitForReadPermissionOrHandle(
 			becomeReaderLocked()
 			errorDuration = e.mu.errorDuration
 			e.mu.Unlock()
-			return Handle{}, errorDuration, nil
+			return nil, errorDuration, nil
 		}
 		if e.mu.ch == nil {
 			// Rare case when multiple readers are concurrently trying to read. If
@@ -246,7 +246,7 @@ func (e *readEntry) waitForReadPermissionOrHandle(
 		case <-ctx.Done():
 			e.mu.RLock()
 			errorDuration = unlockAndUnrefAndTryRemoveFromMap(true)
-			return Handle{}, errorDuration, ctx.Err()
+			return nil, errorDuration, ctx.Err()
 		case _, ok := <-ch:
 			if !ok {
 				// Channel closed, so value was read.
@@ -254,7 +254,7 @@ func (e *readEntry) waitForReadPermissionOrHandle(
 				if e.mu.v == nil {
 					panic("value is nil")
 				}
-				h := constructHandleLocked()
+				h := constructValueLocked()
 				errorDuration = unlockAndUnrefAndTryRemoveFromMap(true)
 				return h, errorDuration, nil
 			}
@@ -304,12 +304,12 @@ func (e *readEntry) unrefAndTryRemoveFromMap() {
 	rs.shard.mu.Unlock()
 
 	// Free s.e.
-	e.mu.v.release()
+	e.mu.v.Release()
 	*e = readEntry{}
 	readEntryPool.Put(e)
 }
 
-func (e *readEntry) setReadValue(v *Value) Handle {
+func (e *readEntry) setReadValue(v *Value) {
 	// Add to the cache before taking another ref for readEntry, since the cache
 	// expects ref=1 when it is called.
 	//
@@ -318,7 +318,7 @@ func (e *readEntry) setReadValue(v *Value) Handle {
 	// don't want to acquire e.mu twice, so one way to do this would be relax
 	// the invariant in shard.Set that requires Value.refs() == 1. Then we can
 	// do the work under e.mu before calling shard.Set.
-	h := e.readShard.shard.set(e.key, v)
+	e.readShard.shard.set(e.key, v)
 	e.mu.Lock()
 	// Acquire a ref for readEntry, since we are going to remember it in e.mu.v.
 	v.acquire()
@@ -338,7 +338,6 @@ func (e *readEntry) setReadValue(v *Value) Handle {
 	}
 	e.mu.Unlock()
 	e.unrefAndTryRemoveFromMap()
-	return h
 }
 
 func (e *readEntry) setReadError(err error) {
@@ -381,10 +380,13 @@ func (rh ReadHandle) Valid() bool {
 	return rh.entry != nil
 }
 
-// SetReadValue provides the Value that the caller has read. The caller is
-// responsible for releasing the returned Handle when it is no longer needed.
-func (rh ReadHandle) SetReadValue(v *Value) Handle {
-	return rh.entry.setReadValue(v)
+// SetReadValue provides the Value that the caller has read and sets it in the
+// block cache.
+//
+// The cache takes a reference on the Value and holds it until it is evicted and
+// no longer needed by other readers.
+func (rh ReadHandle) SetReadValue(v *Value) {
+	rh.entry.setReadValue(v)
 }
 
 // SetReadError specifies that the caller has encountered a read error.

--- a/internal/cache/value.go
+++ b/internal/cache/value.go
@@ -92,11 +92,11 @@ func (v *Value) free() {
 	manual.Free(manual.BlockCacheData, buf)
 }
 
-// Buf returns the buffer associated with the value. The contents of the buffer
+// RawBuffer returns the buffer associated with the value. The contents of the buffer
 // should not be changed once the value has been added to the cache. Instead, a
 // new Value should be created and added to the cache to replace the existing
 // value.
-func (v *Value) Buf() []byte {
+func (v *Value) RawBuffer() []byte {
 	if v == nil {
 		return nil
 	}
@@ -119,7 +119,9 @@ func (v *Value) acquire() {
 	v.ref.acquire()
 }
 
-func (v *Value) release() {
+// Release a ref count on the buffer. It is a no-op to call Release on a nil
+// Value.
+func (v *Value) Release() {
 	if v != nil && v.ref.release() {
 		v.free()
 	}

--- a/sstable/block/buffer_pool_test.go
+++ b/sstable/block/buffer_pool_test.go
@@ -22,7 +22,7 @@ func writeBufferPool(w io.Writer, bp *BufferPool) {
 			fmt.Fprint(w, "[    ]")
 			continue
 		}
-		sz := len(bp.pool[i].v.Buf())
+		sz := len(bp.pool[i].v.RawBuffer())
 		if bp.pool[i].b == nil {
 			fmt.Fprintf(w, "[%4d]", sz)
 		} else {

--- a/sstable/block/compression_test.go
+++ b/sstable/block/compression_test.go
@@ -40,7 +40,7 @@ func TestCompressionRoundtrip(t *testing.T) {
 			require.NoError(t, err)
 			got := payload
 			if v != nil {
-				got = v.Buf()
+				got = v.RawBuffer()
 				require.Equal(t, payload, got)
 				cache.Free(v)
 			}
@@ -85,7 +85,7 @@ func decompress(algo CompressionIndicator, b []byte) (*cache.Value, error) {
 	b = b[prefixLen:]
 	// Allocate sufficient space from the cache.
 	decoded := cache.Alloc(decodedLen)
-	decodedBuf := decoded.Buf()
+	decodedBuf := decoded.RawBuffer()
 	if err := DecompressInto(algo, b, decodedBuf); err != nil {
 		cache.Free(decoded)
 		return nil, err

--- a/sstable/colblk/index_block_test.go
+++ b/sstable/colblk/index_block_test.go
@@ -125,13 +125,12 @@ func TestIndexIterInitHandle(t *testing.T) {
 	d := (*IndexBlockDecoder)(unsafe.Pointer(v.BlockMetadata()))
 	d.Init(blockData)
 
-	h := v.SetInCacheForTesting(c, cache.ID(1), base.DiskFileNum(1), 0)
-	defer h.Release()
+	v.SetInCacheForTesting(c, cache.ID(1), base.DiskFileNum(1), 0)
 
 	getBlockAndIterate := func(it *IndexIter) {
-		h := c.Get(cache.ID(1), base.DiskFileNum(1), 0)
-		require.True(t, h.Valid())
-		require.NoError(t, it.InitHandle(testkeys.Comparer, block.CacheBufferHandle(h), block.NoTransforms))
+		cv := c.Get(cache.ID(1), base.DiskFileNum(1), 0)
+		require.NotNil(t, cv)
+		require.NoError(t, it.InitHandle(testkeys.Comparer, block.CacheBufferHandle(cv), block.NoTransforms))
 		defer it.Close()
 		require.True(t, it.First())
 		bh, err := it.BlockHandleWithProperties()

--- a/sstable/colblk/keyspan_test.go
+++ b/sstable/colblk/keyspan_test.go
@@ -88,12 +88,12 @@ func TestKeyspanBlockPooling(t *testing.T) {
 	copy(v.BlockData(), b)
 	d := (*KeyspanDecoder)(unsafe.Pointer(v.BlockMetadata()))
 	d.Init(v.BlockData())
-	v.SetInCacheForTesting(c, cache.ID(1), base.DiskFileNum(1), 0).Release()
+	v.SetInCacheForTesting(c, cache.ID(1), base.DiskFileNum(1), 0)
 
 	getBlockAndIterate := func() {
-		h := c.Get(cache.ID(1), base.DiskFileNum(1), 0)
-		require.True(t, h.Valid())
-		it := NewKeyspanIter(testkeys.Comparer.Compare, block.CacheBufferHandle(h), block.NoFragmentTransforms)
+		cv := c.Get(cache.ID(1), base.DiskFileNum(1), 0)
+		require.NotNil(t, cv)
+		it := NewKeyspanIter(testkeys.Comparer.Compare, block.CacheBufferHandle(cv), block.NoFragmentTransforms)
 		defer it.Close()
 		s, err := it.First()
 		require.NoError(t, err)

--- a/sstable/rowblk/rowblk_fragment_iter_test.go
+++ b/sstable/rowblk/rowblk_fragment_iter_test.go
@@ -73,7 +73,7 @@ func TestBlockFragmentIterator(t *testing.T) {
 				cache.Free(cacheVal)
 			}
 			cacheVal = cache.Alloc(block.MetadataSize + len(blockData))
-			copy(cacheVal.Buf()[block.MetadataSize:], blockData)
+			copy(cacheVal.RawBuffer()[block.MetadataSize:], blockData)
 			c.Set(1, 0, 0, cacheVal)
 
 			for _, s := range spans {


### PR DESCRIPTION
The cache `Handle` is just a `*Value` and the distinction is
confusing. In particular, functions like `Set` take a `*Value` and
return that same value as a `Handle` (and yet you can't make a
`Handle` yourself from a `*Value`).

This change removes the `Handle` and replaces its usage with `*Value`.