### PR TITLE
sstable/block: move block reading, loading into new Reader type

### DIFF
--- a/db.go
+++ b/db.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
 	"github.com/cockroachdb/pebble/wal"
@@ -1260,7 +1261,7 @@ func finishInitializingIter(ctx context.Context, buf *iterAlloc) *Iterator {
 // iteration is invalid in those cases.
 func (d *DB) ScanInternal(
 	ctx context.Context,
-	category sstable.Category,
+	category block.Category,
 	lower, upper []byte,
 	visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
 	visitRangeDel func(start, end []byte, seqNum SeqNum) error,

--- a/db_test.go
+++ b/db_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/cockroachdb/pebble/wal"
@@ -1417,7 +1418,7 @@ func (t *testTracer) IsTracingEnabled(ctx context.Context) bool {
 }
 
 func TestTracing(t *testing.T) {
-	defer sstable.DeterministicReadBlockDurationForTesting()()
+	defer block.DeterministicReadBlockDurationForTesting()()
 
 	var tracer testTracer
 	buf := &tracer.buf

--- a/file_cache.go
+++ b/file_cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/valblk"
 )
 
@@ -101,7 +102,7 @@ type fileCacheOpts struct {
 	cacheID           cache.ID
 	objProvider       objstorage.Provider
 	readerOpts        sstable.ReaderOptions
-	sstStatsCollector *sstable.CategoryStatsCollector
+	sstStatsCollector *block.CategoryStatsCollector
 }
 
 // fileCacheContainer contains the file cache and fields which are unique to the
@@ -122,7 +123,7 @@ func newFileCacheContainer(
 	objProvider objstorage.Provider,
 	opts *Options,
 	size int,
-	sstStatsCollector *sstable.CategoryStatsCollector,
+	sstStatsCollector *block.CategoryStatsCollector,
 ) *fileCacheContainer {
 	// We will release a ref to the file cache acquired here when
 	// fileCacheContainer.close is called.

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -202,7 +203,7 @@ func newFileCacheContainerTest(
 	}
 
 	c := newFileCacheContainer(tc, opts.Cache.NewID(), objProvider, opts, fileCacheTestCacheSize,
-		&sstable.CategoryStatsCollector{})
+		&block.CategoryStatsCollector{})
 	return c, fs, nil
 }
 
@@ -1014,7 +1015,7 @@ func TestFileCacheErrorBadMagicNumber(t *testing.T) {
 	opts.Cache = NewCache(8 << 20) // 8 MB
 	defer opts.Cache.Unref()
 	c := newFileCacheContainer(nil, opts.Cache.NewID(), objProvider, opts, fileCacheTestCacheSize,
-		&sstable.CategoryStatsCollector{})
+		&block.CategoryStatsCollector{})
 	require.NoError(t, err)
 	defer c.close()
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1133,7 +1133,7 @@ func testIngestSharedImpl(
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writeOpts)
 
 			var sharedSSTs []SharedSSTMeta
-			err = from.ScanInternal(context.TODO(), sstable.CategoryUnknown, startKey, endKey,
+			err = from.ScanInternal(context.TODO(), block.CategoryUnknown, startKey, endKey,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
@@ -1634,7 +1634,7 @@ func TestConcurrentExcise(t *testing.T) {
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writeOpts)
 
 			var sharedSSTs []SharedSSTMeta
-			err = from.ScanInternal(context.TODO(), sstable.CategoryUnknown, startKey, endKey,
+			err = from.ScanInternal(context.TODO(), block.CategoryUnknown, startKey, endKey,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
@@ -2071,7 +2071,7 @@ func TestIngestExternal(t *testing.T) {
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writeOpts)
 
 			var externalFiles []ExternalFile
-			err = from.ScanInternal(context.TODO(), sstable.CategoryUnknown, startKey, endKey,
+			err = from.ScanInternal(context.TODO(), block.CategoryUnknown, startKey, endKey,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)

--- a/level_iter.go
+++ b/level_iter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 )
 
 type internalIterOpts struct {
@@ -23,9 +24,9 @@ type internalIterOpts struct {
 	// NewCompactionIter; these iterators have a more constrained interface
 	// and are optimized for the sequential scan of a compaction.
 	compaction           bool
-	bufferPool           *sstable.BufferPool
+	bufferPool           *block.BufferPool
 	stats                *base.InternalIteratorStats
-	iterStatsAccumulator sstable.IterStatsAccumulator
+	iterStatsAccumulator block.IterStatsAccumulator
 	boundLimitedFilter   sstable.BoundLimitedBlockPropertyFilter
 }
 

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 )
@@ -1980,7 +1981,7 @@ func (r *replicateOp) runSharedReplicate(
 ) {
 	var sharedSSTs []pebble.SharedSSTMeta
 	var err error
-	err = source.ScanInternal(context.TODO(), sstable.CategoryUnknown, r.start, r.end,
+	err = source.ScanInternal(context.TODO(), block.CategoryUnknown, r.start, r.end,
 		func(key *pebble.InternalKey, value pebble.LazyValue, _ pebble.IteratorLevel) error {
 			val, _, err := value.Value(nil)
 			if err != nil {
@@ -2043,7 +2044,7 @@ func (r *replicateOp) runExternalReplicate(
 ) {
 	var externalSSTs []pebble.ExternalFile
 	var err error
-	err = source.ScanInternal(context.TODO(), sstable.CategoryUnknown, r.start, r.end,
+	err = source.ScanInternal(context.TODO(), block.CategoryUnknown, r.start, r.end,
 		func(key *pebble.InternalKey, value pebble.LazyValue, _ pebble.IteratorLevel) error {
 			val, _, err := value.Value(nil)
 			if err != nil {

--- a/metrics.go
+++ b/metrics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/wal"
 	"github.com/cockroachdb/redact"
 	"github.com/prometheus/client_golang/prometheus"
@@ -147,9 +148,9 @@ func (m *LevelMetrics) WriteAmp() float64 {
 	return float64(m.BytesFlushed+m.BytesCompacted) / float64(m.BytesIn)
 }
 
-var categoryCompaction = sstable.RegisterCategory("pebble-compaction", sstable.NonLatencySensitiveQoSLevel)
-var categoryIngest = sstable.RegisterCategory("pebble-ingest", sstable.LatencySensitiveQoSLevel)
-var categoryGet = sstable.RegisterCategory("pebble-get", sstable.LatencySensitiveQoSLevel)
+var categoryCompaction = block.RegisterCategory("pebble-compaction", block.NonLatencySensitiveQoSLevel)
+var categoryIngest = block.RegisterCategory("pebble-ingest", block.LatencySensitiveQoSLevel)
+var categoryGet = block.RegisterCategory("pebble-get", block.LatencySensitiveQoSLevel)
 
 // Metrics holds metrics for various subsystems of the DB such as the Cache,
 // Compactions, WAL, and per-Level metrics.
@@ -338,7 +339,7 @@ type Metrics struct {
 		record.LogWriterMetrics
 	}
 
-	CategoryStats []sstable.CategoryStatsAggregate
+	CategoryStats []block.CategoryStatsAggregate
 
 	SecondaryCacheMetrics SecondaryCacheMetrics
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/remote"
-	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
@@ -119,7 +118,7 @@ func TestMetrics(t *testing.T) {
 	if runtime.GOARCH == "386" {
 		t.Skip("skipped on 32-bit due to slightly varied output")
 	}
-	defer sstable.DeterministicReadBlockDurationForTesting()()
+	defer block.DeterministicReadBlockDurationForTesting()()
 
 	var d *DB
 	var iters map[string]*Iterator

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/cockroachdb/redact"
@@ -109,9 +110,9 @@ func exampleMetrics() Metrics {
 
 func init() {
 	// Register some categories for the purposes of the test.
-	sstable.RegisterCategory("a", sstable.NonLatencySensitiveQoSLevel)
-	sstable.RegisterCategory("b", sstable.LatencySensitiveQoSLevel)
-	sstable.RegisterCategory("c", sstable.NonLatencySensitiveQoSLevel)
+	block.RegisterCategory("a", block.NonLatencySensitiveQoSLevel)
+	block.RegisterCategory("b", block.LatencySensitiveQoSLevel)
+	block.RegisterCategory("c", block.NonLatencySensitiveQoSLevel)
 }
 
 func TestMetrics(t *testing.T) {
@@ -313,11 +314,11 @@ func TestMetrics(t *testing.T) {
 					return err.Error()
 				}
 			}
-			category := sstable.CategoryUnknown
+			category := block.CategoryUnknown
 			if td.HasArg("category") {
 				var s string
 				td.ScanArgs(t, "category", &s)
-				category = sstable.StringToCategoryForTesting(s)
+				category = block.StringToCategoryForTesting(s)
 			}
 			iter, _ := d.NewIter(&IterOptions{Category: category})
 			// Some iterators (eg. levelIter) do not instantiate the underlying
@@ -344,8 +345,8 @@ func TestMetrics(t *testing.T) {
 				m.FileCache = cache.Metrics{}
 				m.BlockCache = cache.Metrics{}
 				// Empirically, the unknown stats are also non-deterministic.
-				if len(m.CategoryStats) > 0 && m.CategoryStats[0].Category == sstable.CategoryUnknown {
-					m.CategoryStats[0].CategoryStats = sstable.CategoryStats{}
+				if len(m.CategoryStats) > 0 && m.CategoryStats[0].Category == block.CategoryUnknown {
+					m.CategoryStats[0].CategoryStats = block.CategoryStats{}
 				}
 			}
 			var buf strings.Builder

--- a/open.go
+++ b/open.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/record"
-	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/wal"
 	"github.com/prometheus/client_golang/prometheus"
@@ -411,7 +411,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	fileCacheSize := FileCacheSize(opts.MaxOpenFiles)
 	d.fileCache = newFileCacheContainer(
 		opts.FileCache, d.cacheID, d.objProvider, d.opts, fileCacheSize,
-		&sstable.CategoryStatsCollector{})
+		&block.CategoryStatsCollector{})
 	d.newIters = d.fileCache.newIters
 	d.tableNewRangeKeyIter = tableNewRangeKeyIter(d.newIters)
 

--- a/options.go
+++ b/options.go
@@ -197,7 +197,7 @@ type IterOptions struct {
 	UseL6Filters bool
 	// Category is used for categorized iterator stats. This should not be
 	// changed by calling SetOptions.
-	Category sstable.Category
+	Category block.Category
 
 	DebugRangeKeyStack bool
 
@@ -270,7 +270,7 @@ func (o *IterOptions) SpanIterOptions() keyspan.SpanIterOptions {
 type scanInternalOptions struct {
 	IterOptions
 
-	category sstable.Category
+	category block.Category
 
 	visitPointKey     func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error
 	visitRangeDel     func(start, end []byte, seqNum SeqNum) error

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/remote"
-	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 )
 
 const (
@@ -830,7 +830,7 @@ func (opts *scanInternalOptions) skipLevelForOpts() int {
 
 // constructPointIter constructs a merging iterator and sets i.iter to it.
 func (i *scanInternalIterator) constructPointIter(
-	category sstable.Category, memtables flushableList, buf *iterAlloc,
+	category block.Category, memtables flushableList, buf *iterAlloc,
 ) error {
 	// Merging levels and levels from iterAlloc.
 	mlevels := buf.mlevels[:0]

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -213,7 +214,7 @@ func TestScanInternal(t *testing.T) {
 	type scanInternalReader interface {
 		ScanInternal(
 			ctx context.Context,
-			category sstable.Category,
+			category block.Category,
 			lower, upper []byte,
 			visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
 			visitRangeDel func(start, end []byte, seqNum base.SeqNum) error,
@@ -561,7 +562,7 @@ func TestScanInternal(t *testing.T) {
 					}
 				}
 			}
-			err := reader.ScanInternal(context.TODO(), sstable.CategoryUnknown, lower, upper,
+			err := reader.ScanInternal(context.TODO(), block.CategoryUnknown, lower, upper,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					v := value.InPlaceValue()
 					fmt.Fprintf(&b, "%s (%s)\n", key, v)

--- a/snapshot.go
+++ b/snapshot.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/rangekey"
-	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
 )
 
 // Snapshot provides a read-only point-in-time view of the DB state.
@@ -75,7 +75,7 @@ func (s *Snapshot) NewIterWithContext(ctx context.Context, o *IterOptions) (*Ite
 // point keys deleted by range dels and keys masked by range keys.
 func (s *Snapshot) ScanInternal(
 	ctx context.Context,
-	category sstable.Category,
+	category block.Category,
 	lower, upper []byte,
 	visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
 	visitRangeDel func(start, end []byte, seqNum base.SeqNum) error,
@@ -473,7 +473,7 @@ func (es *EventuallyFileOnlySnapshot) NewIterWithContext(
 // point keys deleted by range dels and keys masked by range keys.
 func (es *EventuallyFileOnlySnapshot) ScanInternal(
 	ctx context.Context,
-	category sstable.Category,
+	category block.Category,
 	lower, upper []byte,
 	visitPointKey func(key *InternalKey, value LazyValue, iterInfo IteratorLevel) error,
 	visitRangeDel func(start, end []byte, seqNum base.SeqNum) error,

--- a/sstable/block/category_stats.go
+++ b/sstable/block/category_stats.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package sstable
+package block
 
 import (
 	"cmp"
@@ -253,19 +253,21 @@ type IterStatsAccumulator interface {
 	Accumulate(cas CategoryStats)
 }
 
-// iterStatsAccumulator is a helper for a sstable iterator to accumulate stats,
-// which are reported to the CategoryStatsCollector when the accumulator is
-// closed.
-type iterStatsAccumulator struct {
+// ChildIterStatsAccumulator is a helper for a sstable iterator to accumulate
+// stats, which are reported to the CategoryStatsCollector when the accumulator
+// is closed.
+type ChildIterStatsAccumulator struct {
 	stats  CategoryStats
 	parent IterStatsAccumulator
 }
 
-func (a *iterStatsAccumulator) init(parent IterStatsAccumulator) {
+// Init initializes the accumulator with the parent accumulator.
+func (a *ChildIterStatsAccumulator) Init(parent IterStatsAccumulator) {
 	a.parent = parent
 }
 
-func (a *iterStatsAccumulator) reportStats(
+// Accumulate accumulates the provided stats.
+func (a *ChildIterStatsAccumulator) Accumulate(
 	blockBytes, blockBytesInCache uint64, blockReadDuration time.Duration,
 ) {
 	a.stats.BlockBytes += blockBytes
@@ -273,7 +275,8 @@ func (a *iterStatsAccumulator) reportStats(
 	a.stats.BlockReadDuration += blockReadDuration
 }
 
-func (a *iterStatsAccumulator) close() {
+// Close closes the accumulator, accumulating the stats to the parent.
+func (a *ChildIterStatsAccumulator) Close() {
 	if a.parent != nil {
 		a.parent.Accumulate(a.stats)
 	}

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/stretchr/testify/require"
 )
 
@@ -902,7 +903,7 @@ func TestBlockProperties(t *testing.T) {
 
 				// Enumerate point key data blocks encoded into the index.
 				if f != nil {
-					indexH, err := r.readTopLevelIndexBlock(context.Background(), noEnv, noReadHandle)
+					indexH, err := r.readTopLevelIndexBlock(context.Background(), block.NoReadEnv, noReadHandle)
 					if err != nil {
 						return err.Error()
 					}
@@ -1271,7 +1272,7 @@ func runBlockPropertiesBuildCmd(td *datadriven.TestData) (r *Reader, out string)
 }
 
 func runBlockPropsCmd(r *Reader) string {
-	bh, err := r.readTopLevelIndexBlock(context.Background(), noEnv, noReadHandle)
+	bh, err := r.readTopLevelIndexBlock(context.Background(), block.NoReadEnv, noReadHandle)
 	if err != nil {
 		return err.Error()
 	}
@@ -1320,7 +1321,7 @@ func runBlockPropsCmd(r *Reader) string {
 		// If the table has a two-level index, also decode the index
 		// block that bhp points to, along with its block properties.
 		if twoLevelIndex {
-			subIndex, err := r.readIndexBlock(context.Background(), noEnv, noReadHandle, bhp.Handle)
+			subIndex, err := r.readIndexBlock(context.Background(), block.NoReadEnv, noReadHandle, bhp.Handle)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1059,7 +1059,7 @@ func (w *RawColumnWriter) rewriteSuffixes(
 	// Copy over the filter block if it exists.
 	if w.filterBlock != nil {
 		if filterBlockBH, ok := l.FilterByName(w.filterBlock.metaName()); ok {
-			filterBlock, _, err := readBlockBuf(sstBytes, filterBlockBH, r.checksumType, nil)
+			filterBlock, _, err := readBlockBuf(sstBytes, filterBlockBH, r.blockReader.ChecksumType(), nil)
 			if err != nil {
 				return errors.Wrap(err, "reading filter")
 			}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -89,7 +89,7 @@ func CopySpan(
 		r.readable, objstorage.ReadBeforeForIndexAndFilter, &preallocRH)
 	defer rh.Close()
 	rh.SetupForCompaction()
-	indexH, err := r.readTopLevelIndexBlock(ctx, noEnv, rh)
+	indexH, err := r.readTopLevelIndexBlock(ctx, block.NoReadEnv, rh)
 	if err != nil {
 		return 0, err
 	}
@@ -99,7 +99,7 @@ func CopySpan(
 	// positives for keys in blocks of the original file that we don't copy, but
 	// filters can always have false positives, so this is fine.
 	if r.tableFilter != nil {
-		filterBlock, err := r.readFilterBlock(ctx, noEnv, rh, r.filterBH)
+		filterBlock, err := r.readFilterBlock(ctx, block.NoReadEnv, rh, r.filterBH)
 		if err != nil {
 			return 0, errors.Wrap(err, "reading filter")
 		}
@@ -228,7 +228,7 @@ func intersectingIndexEntries(
 			alloc, entry.sep = alloc.Copy(entry.sep)
 			res = append(res, entry)
 		} else {
-			subBlk, err := r.readIndexBlock(ctx, noEnv, rh, bh.Handle)
+			subBlk, err := r.readIndexBlock(ctx, block.NoReadEnv, rh, bh.Handle)
 			if err != nil {
 				return nil, err
 			}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -85,8 +85,8 @@ func CopySpan(
 	var preallocRH objstorageprovider.PreallocatedReadHandle
 	// ReadBeforeForIndexAndFilter attempts to read the top-level index, filter
 	// and lower-level index blocks with one read.
-	rh := objstorageprovider.UsePreallocatedReadHandle(
-		r.readable, objstorage.ReadBeforeForIndexAndFilter, &preallocRH)
+	rh := r.blockReader.UsePreallocatedReadHandle(
+		objstorage.ReadBeforeForIndexAndFilter, &preallocRH)
 	defer rh.Close()
 	rh.SetupForCompaction()
 	indexH, err := r.readTopLevelIndexBlock(ctx, block.NoReadEnv, rh)
@@ -131,7 +131,7 @@ func CopySpan(
 	var blocksNotInCache []indexEntry
 
 	for i := range blocks {
-		cv := r.cacheOpts.Cache.Get(r.cacheOpts.CacheID, r.cacheOpts.FileNum, blocks[i].bh.Offset)
+		cv := r.blockReader.GetFromCache(blocks[i].bh.Handle)
 		if cv == nil {
 			// Cache miss. Add this block to the list of blocks that are not in cache.
 			blocksNotInCache = blocks[i-len(blocksNotInCache) : i+1]

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -492,7 +492,7 @@ func runIterCmd(
 }
 
 func runRewriteCmd(
-	td *datadriven.TestData, r *Reader, writerOpts WriterOptions,
+	td *datadriven.TestData, r *Reader, sst []byte, writerOpts WriterOptions,
 ) (*WriterMetadata, *Reader, error) {
 	var from, to []byte
 	for _, arg := range td.CmdArgs {
@@ -513,7 +513,6 @@ func runRewriteCmd(
 	}
 
 	f := &objstorage.MemObj{}
-	sst := r.readable.(*memReader).b
 	meta, _, err := rewriteKeySuffixesInBlocks(r, sst, f, opts, from, to, 2)
 	if err != nil {
 		return nil, r, errors.Wrap(err, "rewrite failed")

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -138,7 +138,7 @@ func (l *Layout) Describe(
 
 		if b.Name == "footer" || b.Name == "leveldb-footer" {
 			trailer, offset := make([]byte, b.Length), 0
-			_ = r.readable.ReadAt(ctx, trailer, int64(b.Offset))
+			_ = r.blockReader.Readable().ReadAt(ctx, trailer, int64(b.Offset))
 
 			if b.Name == "footer" {
 				checksumType := block.ChecksumType(trailer[0])
@@ -231,7 +231,7 @@ func (l *Layout) Describe(
 				formatting.formatIndexBlock(tpNode, r, *b, h.BlockData())
 
 			case "properties":
-				h, err = r.readBlockInternal(ctx, block.NoReadEnv, noReadHandle, b.Handle, noInitBlockMetadataFn)
+				h, err = r.blockReader.Read(ctx, block.NoReadEnv, noReadHandle, b.Handle, noInitBlockMetadataFn)
 				if err != nil {
 					return err
 				}
@@ -284,7 +284,7 @@ func (l *Layout) Describe(
 
 			// Format the trailer.
 			trailer := make([]byte, block.TrailerLen)
-			_ = r.readable.ReadAt(ctx, trailer, int64(b.Offset+b.Length))
+			_ = r.blockReader.Readable().ReadAt(ctx, trailer, int64(b.Offset+b.Length))
 			algo := block.CompressionIndicator(trailer[0])
 			checksum := binary.LittleEndian.Uint32(trailer[1:])
 			tpNode.Childf("trailer [compression=%s checksum=0x%04x]", algo, checksum)

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -186,7 +186,7 @@ func (l *Layout) Describe(
 
 			switch b.Name {
 			case "data":
-				h, err = r.readDataBlock(ctx, noEnv, noReadHandle, b.Handle)
+				h, err = r.readDataBlock(ctx, block.NoReadEnv, noReadHandle, b.Handle)
 				if err != nil {
 					return err
 				}
@@ -206,7 +206,7 @@ func (l *Layout) Describe(
 				}
 
 			case "range-del":
-				h, err = r.readRangeDelBlock(ctx, noEnv, noReadHandle, b.Handle)
+				h, err = r.readRangeDelBlock(ctx, block.NoReadEnv, noReadHandle, b.Handle)
 				if err != nil {
 					return err
 				}
@@ -215,7 +215,7 @@ func (l *Layout) Describe(
 				formatting.formatKeyspanBlock(tpNode, r, *b, h.BlockData(), fmtKV)
 
 			case "range-key":
-				h, err = r.readRangeKeyBlock(ctx, noEnv, noReadHandle, b.Handle)
+				h, err = r.readRangeKeyBlock(ctx, block.NoReadEnv, noReadHandle, b.Handle)
 				if err != nil {
 					return err
 				}
@@ -224,14 +224,14 @@ func (l *Layout) Describe(
 				formatting.formatKeyspanBlock(tpNode, r, *b, h.BlockData(), fmtKV)
 
 			case "index", "top-index":
-				h, err = r.readIndexBlock(ctx, noEnv, noReadHandle, b.Handle)
+				h, err = r.readIndexBlock(ctx, block.NoReadEnv, noReadHandle, b.Handle)
 				if err != nil {
 					return err
 				}
 				formatting.formatIndexBlock(tpNode, r, *b, h.BlockData())
 
 			case "properties":
-				h, err = r.readBlockInternal(ctx, noEnv, noReadHandle, b.Handle, noInitBlockMetadataFn)
+				h, err = r.readBlockInternal(ctx, block.NoReadEnv, noReadHandle, b.Handle, noInitBlockMetadataFn)
 				if err != nil {
 					return err
 				}
@@ -244,7 +244,7 @@ func (l *Layout) Describe(
 				if b.Handle != r.metaindexBH {
 					return base.AssertionFailedf("range-del block handle does not match rangeDelBH")
 				}
-				h, err = r.readMetaindexBlock(ctx, noEnv, noReadHandle)
+				h, err = r.readMetaindexBlock(ctx, block.NoReadEnv, noReadHandle)
 				if err != nil {
 					return err
 				}

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -33,13 +33,13 @@ type CommonReader interface {
 		filterer *BlockPropertiesFilterer,
 		filterBlockSizeLimit FilterBlockSizeLimit,
 		stats *base.InternalIteratorStats,
-		statsAccum IterStatsAccumulator,
+		statsAccum block.IterStatsAccumulator,
 		rp valblk.ReaderProvider,
 	) (Iterator, error)
 
 	NewCompactionIter(
 		transforms IterTransforms,
-		statsAccum IterStatsAccumulator,
+		statsAccum block.IterStatsAccumulator,
 		rp valblk.ReaderProvider,
 		bufferPool *block.BufferPool,
 	) (Iterator, error)

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -231,7 +231,7 @@ func newColumnBlockSingleLevelIterator(
 	if r.Properties.NumValueBlocks > 0 {
 		i.vbReader = valblk.MakeReader(i, rp, r.valueBIH, stats)
 		getLazyValuer = &i.vbReader
-		i.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.vbRHPrealloc)
+		i.vbRH = r.blockReader.UsePreallocatedReadHandle(objstorage.NoReadBefore, &i.vbRHPrealloc)
 	}
 	i.data.InitOnce(r.keySchema, r.Comparer, getLazyValuer)
 	indexH, err := r.readTopLevelIndexBlock(ctx, i.readBlockEnv, i.indexFilterRH)
@@ -281,7 +281,7 @@ func newRowBlockSingleLevelIterator(
 		if r.Properties.NumValueBlocks > 0 {
 			i.vbReader = valblk.MakeReader(i, rp, r.valueBIH, stats)
 			(&i.data).SetGetLazyValuer(&i.vbReader)
-			i.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.vbRHPrealloc)
+			i.vbRH = r.blockReader.UsePreallocatedReadHandle(objstorage.NoReadBefore, &i.vbRHPrealloc)
 		}
 		i.data.SetHasValuePrefix(true)
 	}
@@ -330,10 +330,10 @@ func (i *singleLevelIterator[I, PI, D, PD]) init(
 		BufferPool: bufferPool,
 	}
 
-	i.indexFilterRH = objstorageprovider.UsePreallocatedReadHandle(
-		r.readable, objstorage.ReadBeforeForIndexAndFilter, &i.indexFilterRHPrealloc)
-	i.dataRH = objstorageprovider.UsePreallocatedReadHandle(
-		r.readable, objstorage.NoReadBefore, &i.dataRHPrealloc)
+	i.indexFilterRH = r.blockReader.UsePreallocatedReadHandle(
+		objstorage.ReadBeforeForIndexAndFilter, &i.indexFilterRHPrealloc)
+	i.dataRH = r.blockReader.UsePreallocatedReadHandle(
+		objstorage.NoReadBefore, &i.dataRHPrealloc)
 }
 
 // Helper function to check if keys returned from iterator are within virtual bounds.
@@ -1585,7 +1585,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) String() string {
 	if i.vState != nil {
 		return i.vState.fileNum.String()
 	}
-	return i.reader.cacheOpts.FileNum.String()
+	return i.reader.blockReader.FileNum().String()
 }
 
 // DebugTree is part of the InternalIterator interface.

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -162,7 +162,7 @@ func newColumnBlockTwoLevelIterator(
 	filterer *BlockPropertiesFilterer,
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
-	statsAccum IterStatsAccumulator,
+	statsAccum block.IterStatsAccumulator,
 	rp valblk.ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (*twoLevelIteratorColumnBlocks, error) {
@@ -220,7 +220,7 @@ func newRowBlockTwoLevelIterator(
 	filterer *BlockPropertiesFilterer,
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
-	statsAccum IterStatsAccumulator,
+	statsAccum block.IterStatsAccumulator,
 	rp valblk.ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (*twoLevelIteratorRowBlocks, error) {

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 	"github.com/cockroachdb/pebble/objstorage"
-	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/valblk"
 )
@@ -189,7 +188,8 @@ func newColumnBlockTwoLevelIterator(
 		// sync.Pool.
 		i.secondLevel.vbReader = valblk.MakeReader(&i.secondLevel, rp, r.valueBIH, stats)
 		getLazyValuer = &i.secondLevel.vbReader
-		i.secondLevel.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
+		i.secondLevel.vbRH = r.blockReader.UsePreallocatedReadHandle(
+			objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
 	i.secondLevel.data.InitOnce(r.keySchema, r.Comparer, getLazyValuer)
 	i.useFilterBlock = shouldUseFilterBlock(r, filterBlockSizeLimit)
@@ -247,7 +247,8 @@ func newRowBlockTwoLevelIterator(
 			// sync.Pool.
 			i.secondLevel.vbReader = valblk.MakeReader(&i.secondLevel, rp, r.valueBIH, stats)
 			i.secondLevel.data.SetGetLazyValuer(&i.secondLevel.vbReader)
-			i.secondLevel.vbRH = objstorageprovider.UsePreallocatedReadHandle(r.readable, objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
+			i.secondLevel.vbRH = r.blockReader.UsePreallocatedReadHandle(
+				objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 		}
 		i.secondLevel.data.SetHasValuePrefix(true)
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -47,7 +47,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 	}
 
 	if r.tableFilter != nil {
-		dataH, err := r.readFilterBlock(context.Background(), noEnv, noReadHandle, r.filterBH)
+		dataH, err := r.readFilterBlock(context.Background(), block.NoReadEnv, noReadHandle, r.filterBH)
 		if err != nil {
 			return nil, err
 		}
@@ -637,7 +637,7 @@ func TestInvalidReader(t *testing.T) {
 }
 
 func indexLayoutString(t *testing.T, r *Reader) string {
-	indexH, err := r.readTopLevelIndexBlock(context.Background(), noEnv, noReadHandle)
+	indexH, err := r.readTopLevelIndexBlock(context.Background(), block.NoReadEnv, noReadHandle)
 	require.NoError(t, err)
 	defer indexH.Release()
 	var buf strings.Builder
@@ -654,7 +654,7 @@ func indexLayoutString(t *testing.T, r *Reader) string {
 		require.NoError(t, err)
 		fmt.Fprintf(&buf, " %s: size %d\n", string(iter.Separator()), bh.Length)
 		if twoLevelIndex {
-			b, err := r.readIndexBlock(context.Background(), noEnv, noReadHandle, bh.Handle)
+			b, err := r.readIndexBlock(context.Background(), block.NoReadEnv, noReadHandle, bh.Handle)
 			require.NoError(t, err)
 			defer b.Release()
 			iter2 := r.tableFormat.newIndexIter()

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -95,7 +95,7 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 // NewCompactionIter is the compaction iterator function for virtual readers.
 func (v *VirtualReader) NewCompactionIter(
 	transforms IterTransforms,
-	statsAccum IterStatsAccumulator,
+	statsAccum block.IterStatsAccumulator,
 	rp valblk.ReaderProvider,
 	bufferPool *block.BufferPool,
 ) (Iterator, error) {
@@ -119,7 +119,7 @@ func (v *VirtualReader) NewPointIter(
 	filterer *BlockPropertiesFilterer,
 	filterBlockSizeLimit FilterBlockSizeLimit,
 	stats *base.InternalIteratorStats,
-	statsAccum IterStatsAccumulator,
+	statsAccum block.IterStatsAccumulator,
 	rp valblk.ReaderProvider,
 ) (Iterator, error) {
 	return v.reader.newPointIter(

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -1898,7 +1898,7 @@ func (w *RawRowWriter) rewriteSuffixes(
 	// already have ensured this is valid if it exists).
 	if w.filter != nil {
 		if filterBlockBH, ok := l.FilterByName(w.filter.metaName()); ok {
-			filterBlock, _, err := readBlockBuf(sst, filterBlockBH, r.checksumType, nil)
+			filterBlock, _, err := readBlockBuf(sst, filterBlockBH, r.blockReader.ChecksumType(), nil)
 			if err != nil {
 				return errors.Wrap(err, "reading filter")
 			}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -168,7 +168,7 @@ func rewriteDataBlocksInParallel(
 				for i := worker; i < len(input); i += concurrency {
 					bh := input[i]
 					var err error
-					inputBlock, inputBlockBuf, err = readBlockBuf(sstBytes, bh.Handle, r.checksumType, inputBlockBuf)
+					inputBlock, inputBlockBuf, err = readBlockBuf(sstBytes, bh.Handle, r.blockReader.ChecksumType(), inputBlockBuf)
 					if err != nil {
 						return err
 					}
@@ -355,7 +355,7 @@ func readBlockBuf(
 	sstBytes []byte, bh block.Handle, checksumType block.ChecksumType, buf []byte,
 ) ([]byte, []byte, error) {
 	raw := sstBytes[bh.Offset : bh.Offset+bh.Length+block.TrailerLen]
-	if err := checkChecksum(checksumType, raw, bh, 0); err != nil {
+	if err := block.ValidateChecksum(checksumType, raw, bh); err != nil {
 		return nil, buf, err
 	}
 	algo := block.CompressionIndicator(raw[bh.Length])

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -246,7 +246,7 @@ func BenchmarkRewriteSST(b *testing.B) {
 				sst := sstBytes[comp][sz]
 				b.Run(fmt.Sprintf("keys=%d", sizes[sz]), func(b *testing.B) {
 					b.Run("ReaderWriterLoop", func(b *testing.B) {
-						b.SetBytes(r.readable.Size())
+						b.SetBytes(int64(len(sst)))
 						for i := 0; i < b.N; i++ {
 							if _, err := RewriteKeySuffixesViaWriter(r, &discardFile{}, writerOpts, from, to); err != nil {
 								b.Fatal(err)
@@ -255,7 +255,7 @@ func BenchmarkRewriteSST(b *testing.B) {
 					})
 					for _, concurrency := range []int{1, 2, 4, 8, 16} {
 						b.Run(fmt.Sprintf("RewriteKeySuffixes,concurrency=%d", concurrency), func(b *testing.B) {
-							b.SetBytes(r.readable.Size())
+							b.SetBytes(int64(len(sst)))
 							for i := 0; i < b.N; i++ {
 								if _, _, err := rewriteKeySuffixesInBlocks(r, sst, &discardFile{}, writerOpts, []byte("_123"), []byte("_456"), concurrency); err != nil {
 									b.Fatal(err)

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -532,7 +532,7 @@ func TestMetaIndexEntriesSorted(t *testing.T) {
 	r, err := newReader(f, ReaderOptions{})
 	require.NoError(t, err)
 
-	b, err := r.readMetaindexBlock(context.Background(), noEnv, noReadHandle)
+	b, err := r.readMetaindexBlock(context.Background(), block.NoReadEnv, noReadHandle)
 	require.NoError(t, err)
 	defer b.Release()
 

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -311,7 +311,8 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 		case "rewrite":
 			var meta *WriterMetadata
 			var err error
-			meta, r, err = runRewriteCmd(td, r, WriterOptions{
+			sst := r.blockReader.Readable().(*memReader).b
+			meta, r, err = runRewriteCmd(td, r, sst, WriterOptions{
 				TableFormat: tableFormat,
 			})
 			if err != nil {

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -54,7 +54,7 @@ Virtual tables: 0 (0B)
 Local tables size: 569B
 Compression types: snappy: 1
 Block cache: 3 entries (1.1KB)  hit rate: 18.2%
-Table cache: 1 entries (912B)  hit rate: 50.0%
+Table cache: 1 entries (920B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -75,7 +75,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 0.0%
-Table cache: 1 entries (912B)  hit rate: 0.0%
+Table cache: 1 entries (920B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -223,7 +223,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 33.3%
-Table cache: 1 entries (912B)  hit rate: 66.7%
+Table cache: 1 entries (920B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -502,7 +502,7 @@ Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 7
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (912B)  hit rate: 53.8%
+Table cache: 1 entries (920B)  hit rate: 53.8%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -566,7 +566,7 @@ Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Compression types: snappy: 10
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (912B)  hit rate: 53.8%
+Table cache: 1 entries (920B)  hit rate: 53.8%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -840,7 +840,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 1 entries (912B)  hit rate: 0.0%
+Table cache: 1 entries (920B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -887,7 +887,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 2
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (912B)  hit rate: 50.0%
+Table cache: 1 entries (920B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -935,7 +935,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 3
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (912B)  hit rate: 50.0%
+Table cache: 1 entries (920B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/tool/testdata/sstable_check
+++ b/tool/testdata/sstable_check
@@ -45,7 +45,7 @@ sstable check
 testdata/corrupted.sst
 ----
 corrupted.sst
-pebble/table: invalid table 000000 (checksum mismatch at 87/465)
+pebble/table: table 000000: block 87/465: crc32c checksum mismatch c8539ba5 != b972e324
 
 sstable check
 testdata/bad-magic.sst


### PR DESCRIPTION
**sstable: use errorfs in TestIteratorErrorOnInit**

Use errorfs to test sstable iterator error propogation instead of swapping a
objstorage.Readable out from underneath an open sstable.Reader.

**sstable/block: move category stats, read env**

**sstable/block: add Reader type**

Move block-reading logic into a block.Reader type. This is in preparation for
use of the block.Reader type within blob file readers.

Informs #112.