### PR TITLE
crl-release-24.2: sstable: fix restarts integer overflow 

### DIFF
--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -115,10 +115,10 @@ type Iter struct {
 
 	// offset is the byte index that marks where the current key/value is
 	// encoded in the block.
-	offset int32
+	offset offsetInBlock
 	// nextOffset is the byte index where the next key/value is encoded in the
 	// block.
-	nextOffset int32
+	nextOffset offsetInBlock
 	// A "restart point" in a block is a point where the full key is encoded,
 	// instead of just having a suffix of the key encoded. See readEntry() for
 	// how prefix compression of keys works. Keys in between two restart points
@@ -131,7 +131,10 @@ type Iter struct {
 	// 4 bytes of the block as a uint32 (i.ptr[len(block)-4:]). i.restarts can
 	// therefore be seen as the point where data in the block ends, and a list
 	// of offsets of all restart points begins.
-	restarts int32
+	//
+	// int64 is used to prevent overflow and preserve signedness for binary
+	// search invariants.
+	restarts offsetInBlock
 	// Number of restart points in this block. Encoded at the end of the block
 	// as a uint32.
 	numRestarts int32
@@ -194,12 +197,25 @@ type Iter struct {
 	firstUserKeyWithPrefixBuf []byte
 }
 
+// offsetInBlock represents an offset in a block
+//
+// While restart points are serialized as uint32's, it is possible for offsets to
+// be greater than math.MaxUint32 since they may point to an offset after the KVs.
+//
+// Previously, offsets were represented as int32, which causes problems with
+// integer overflows while indexing into blocks (i.data) with large KVs in SeekGE()
+// and SeekLT(). Using an int64 solves the problem of overflows as wraparounds will
+// be prevented. Additionally, the signedness of int64 allows repsentation of
+// iterators that have conducted backward interation and allows for binary search
+// invariants in SeekGE() and SeekLT() to be preserved.
+type offsetInBlock int64
+
 type blockEntry struct {
-	offset   int32
-	keyStart int32
-	keyEnd   int32
-	valStart int32
-	valSize  int32
+	offset   offsetInBlock
+	keyStart offsetInBlock
+	keyEnd   offsetInBlock
+	valStart offsetInBlock
+	valSize  uint32
 }
 
 // blockIter implements the base.InternalIterator interface.
@@ -230,7 +246,7 @@ func (i *Iter) Init(
 	i.synthSuffixBuf = i.synthSuffixBuf[:0]
 	i.split = split
 	i.cmp = cmp
-	i.restarts = int32(len(blk)) - 4*(1+numRestarts)
+	i.restarts = offsetInBlock(len(blk)) - 4*(1+offsetInBlock(numRestarts))
 	i.numRestarts = numRestarts
 	i.ptr = unsafe.Pointer(&blk[0])
 	i.data = blk
@@ -395,7 +411,7 @@ func (i *Iter) readEntry() {
 	}
 	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(unshared))
 	i.val = getBytes(ptr, int(value))
-	i.nextOffset = int32(uintptr(ptr)-uintptr(i.ptr)) + int32(value)
+	i.nextOffset = offsetInBlock(uintptr(ptr)-uintptr(i.ptr)) + offsetInBlock(value)
 }
 
 func (i *Iter) readFirstKey() error {
@@ -504,16 +520,16 @@ func (i *Iter) clearCache() {
 }
 
 func (i *Iter) cacheEntry() {
-	var valStart int32
-	valSize := int32(len(i.val))
+	var valStart offsetInBlock
+	valSize := uint32(len(i.val))
 	if valSize > 0 {
-		valStart = int32(uintptr(unsafe.Pointer(&i.val[0])) - uintptr(i.ptr))
+		valStart = offsetInBlock(uintptr(unsafe.Pointer(&i.val[0])) - uintptr(i.ptr))
 	}
 
 	i.cached = append(i.cached, blockEntry{
 		offset:   i.offset,
-		keyStart: int32(len(i.cachedBuf)),
-		keyEnd:   int32(len(i.cachedBuf) + len(i.key)),
+		keyStart: offsetInBlock(len(i.cachedBuf)),
+		keyEnd:   offsetInBlock(len(i.cachedBuf) + len(i.key)),
 		valStart: valStart,
 		valSize:  valSize,
 	})
@@ -565,8 +581,9 @@ func (i *Iter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 		upper := i.numRestarts
 		for index < upper {
 			h := int32(uint(index+upper) >> 1) // avoid overflow when computing h
+
 			// index ≤ h < upper
-			offset := decodeRestart(i.data[i.restarts+4*h:])
+			offset := decodeRestart(i.data[i.restarts+4*offsetInBlock(h):])
 			// For a restart point, there are 0 bytes shared with the previous key.
 			// The varint encoding of 0 occupies 1 byte.
 			ptr := unsafe.Pointer(uintptr(i.ptr) + uintptr(offset+1))
@@ -638,7 +655,7 @@ func (i *Iter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	// could be equal to the search key.  If index == 0, then all keys in this
 	// block are larger than the key sought, and offset remains at zero.
 	if index > 0 {
-		i.offset = decodeRestart(i.data[i.restarts+4*(index-1):])
+		i.offset = decodeRestart(i.data[i.restarts+4*offsetInBlock(index-1):])
 	}
 	i.readEntry()
 	hiddenPoint := i.decodeInternalKey(i.key)
@@ -746,8 +763,9 @@ func (i *Iter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 		upper := i.numRestarts
 		for index < upper {
 			h := int32(uint(index+upper) >> 1) // avoid overflow when computing h
+
 			// index ≤ h < upper
-			offset := decodeRestart(i.data[i.restarts+4*h:])
+			offset := decodeRestart(i.data[i.restarts+4*offsetInBlock(h):])
 			// For a restart point, there are 0 bytes shared with the previous key.
 			// The varint encoding of 0 occupies 1 byte.
 			ptr := unsafe.Pointer(uintptr(i.ptr) + uintptr(offset+1))
@@ -848,9 +866,9 @@ func (i *Iter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	// i.Prev(). We need to know when we have hit the offset for index, since then
 	// we can stop searching. targetOffset encodes that offset for index.
 	targetOffset := i.restarts
-	i.offset = decodeRestart(i.data[i.restarts+4*(index-1):])
+	i.offset = decodeRestart(i.data[i.restarts+4*offsetInBlock(index-1):])
 	if index < i.numRestarts {
-		targetOffset = decodeRestart(i.data[i.restarts+4*(index):])
+		targetOffset = decodeRestart(i.data[i.restarts+4*offsetInBlock(index):])
 
 		if i.transforms.SyntheticSuffix.IsSet() {
 			// The binary search was conducted on keys without suffix replacement,
@@ -904,7 +922,7 @@ func (i *Iter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 				if index+1 < i.numRestarts {
 					// if index+1 is within the i.data bounds, use it to find the target
 					// offset.
-					targetOffset = decodeRestart(i.data[i.restarts+4*(index+1):])
+					targetOffset = decodeRestart(i.data[i.restarts+4*offsetInBlock(index+1):])
 				} else {
 					targetOffset = i.restarts
 				}
@@ -1007,9 +1025,9 @@ func (i *Iter) First() *base.InternalKV {
 const restartMaskLittleEndianHighByteWithoutSetHasSamePrefix byte = 0b0111_1111
 const restartMaskLittleEndianHighByteOnlySetHasSamePrefix byte = 0b1000_0000
 
-func decodeRestart(b []byte) int32 {
+func decodeRestart(b []byte) offsetInBlock {
 	_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
-	return int32(uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 |
+	return offsetInBlock(uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 |
 		uint32(b[3]&restartMaskLittleEndianHighByteWithoutSetHasSamePrefix)<<24)
 }
 
@@ -1020,7 +1038,7 @@ func (i *Iter) Last() *base.InternalKV {
 	}
 
 	// Seek forward from the last restart point.
-	i.offset = decodeRestart(i.data[i.restarts+4*(i.numRestarts-1):])
+	i.offset = decodeRestart(i.data[i.restarts+4*offsetInBlock(i.numRestarts-1):])
 	if !i.Valid() {
 		return nil
 	}
@@ -1228,7 +1246,7 @@ func (i *Iter) nextPrefixV3(succKey []byte) *base.InternalKV {
 		}
 		// The starting position of the value.
 		valuePtr := unsafe.Pointer(uintptr(ptr) + uintptr(unshared))
-		i.nextOffset = int32(uintptr(valuePtr)-uintptr(i.ptr)) + int32(value)
+		i.nextOffset = offsetInBlock(uintptr(valuePtr)-uintptr(i.ptr)) + offsetInBlock(value)
 		if invariants.Enabled && unshared < 8 {
 			// This should not happen since only the key prefix is shared, so even
 			// if the prefix length is the same as the user key length, the unshared
@@ -1274,8 +1292,9 @@ func (i *Iter) nextPrefixV3(succKey []byte) *base.InternalKV {
 						upper := i.numRestarts
 						for index < upper {
 							h := int32(uint(index+upper) >> 1) // avoid overflow when computing h
+
 							// index ≤ h < upper
-							offset := decodeRestart(i.data[i.restarts+4*h:])
+							offset := decodeRestart(i.data[i.restarts+4*offsetInBlock(h):])
 							if offset < targetOffset {
 								index = h + 1 // preserves f(index-1) == false
 							} else {
@@ -1302,7 +1321,7 @@ func (i *Iter) nextPrefixV3(succKey []byte) *base.InternalKV {
 						// most significant bit of the 3rd byte is what we use for
 						// encoding the set-has-same-prefix information, the indexing
 						// below has +3.
-						i.data[i.restarts+4*index+3]&restartMaskLittleEndianHighByteOnlySetHasSamePrefix != 0 {
+						i.data[i.restarts+4*offsetInBlock(index)+3]&restartMaskLittleEndianHighByteOnlySetHasSamePrefix != 0 {
 						// We still have the same prefix, so move to the next restart.
 						index++
 					}
@@ -1311,7 +1330,7 @@ func (i *Iter) nextPrefixV3(succKey []byte) *base.InternalKV {
 						// Managed to skip past at least one restart. Resume iteration
 						// from index-1. Since nextFastCount has been reset to 0, we
 						// should be able to iterate to the next prefix.
-						i.offset = decodeRestart(i.data[i.restarts+4*(index-1):])
+						i.offset = decodeRestart(i.data[i.restarts+4*offsetInBlock(index-1):])
 						i.readEntry()
 					}
 					// Else, unable to skip past any restart. Resume iteration. Since
@@ -1476,8 +1495,9 @@ start:
 		upper := i.numRestarts
 		for index < upper {
 			h := int32(uint(index+upper) >> 1) // avoid overflow when computing h
+
 			// index ≤ h < upper
-			offset := decodeRestart(i.data[i.restarts+4*h:])
+			offset := decodeRestart(i.data[i.restarts+4*offsetInBlock(h):])
 			if offset < targetOffset {
 				// Looking for the first restart that has offset >= targetOffset, so
 				// ignore h and earlier.
@@ -1498,7 +1518,7 @@ start:
 	// as the index).
 	i.offset = 0
 	if index > 0 {
-		i.offset = decodeRestart(i.data[i.restarts+4*(index-1):])
+		i.offset = decodeRestart(i.data[i.restarts+4*offsetInBlock(index-1):])
 	}
 	// TODO(sumeer): why is the else case not an error given targetOffset is a
 	// valid offset.
@@ -1591,8 +1611,8 @@ func (i *Iter) DebugTree(tp treeprinter.Node) {
 	tp.Childf("%T(%p)", i, i)
 }
 
-func (i *Iter) getRestart(idx int) int32 {
-	return int32(binary.LittleEndian.Uint32(i.data[i.restarts+4*int32(idx):]))
+func (i *Iter) getRestart(idx int) offsetInBlock {
+	return offsetInBlock(binary.LittleEndian.Uint32(i.data[i.restarts+4*offsetInBlock(idx):]))
 }
 
 func (i *Iter) isRestartPoint() bool {
@@ -1612,7 +1632,7 @@ type KVEncoding struct {
 	IsRestart bool
 	// Offset is the position within the block at which the key-value pair is
 	// encoded.
-	Offset int32
+	Offset offsetInBlock
 	// Length is the total length of the KV pair as it is encoded in the block
 	// format.
 	Length int32
@@ -1648,7 +1668,7 @@ func (i *Iter) Describe(w io.Writer, blkOffset uint64, fmtKV DescribeKV) {
 		// offset of the KV pair within the uncompressed block. We should just
 		// print offsets relative to the block start.
 		fmt.Fprintf(w, "%10d    [restart %d]\n",
-			blkOffset+uint64(i.restarts+4*int32(j)), blkOffset+uint64(offset))
+			blkOffset+uint64(i.restarts+4*offsetInBlock(j)), blkOffset+uint64(offset))
 	}
 }
 
@@ -1660,9 +1680,9 @@ func (i *Iter) Describe(w io.Writer, blkOffset uint64, fmtKV DescribeKV) {
 // stored together with the key.
 type RawIter struct {
 	cmp         base.Compare
-	offset      int32
-	nextOffset  int32
-	restarts    int32
+	offset      offsetInBlock
+	nextOffset  offsetInBlock
+	restarts    offsetInBlock
 	numRestarts int32
 	ptr         unsafe.Pointer
 	data        []byte
@@ -1685,7 +1705,7 @@ func (i *RawIter) Init(cmp base.Compare, blk []byte) error {
 		return base.CorruptionErrorf("pebble/table: invalid table (block has no restart points)")
 	}
 	i.cmp = cmp
-	i.restarts = int32(len(blk)) - 4*(1+numRestarts)
+	i.restarts = offsetInBlock(len(blk)) - 4*(1+offsetInBlock(numRestarts))
 	i.numRestarts = numRestarts
 	i.ptr = unsafe.Pointer(&blk[0])
 	i.data = blk
@@ -1708,7 +1728,7 @@ func (i *RawIter) readEntry() {
 	i.key = i.key[:len(i.key):len(i.key)]
 	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(unshared))
 	i.val = getBytes(ptr, int(value))
-	i.nextOffset = int32(uintptr(ptr)-uintptr(i.ptr)) + int32(value)
+	i.nextOffset = offsetInBlock(uintptr(ptr)-uintptr(i.ptr)) + offsetInBlock(value)
 }
 
 func (i *RawIter) loadEntry() {
@@ -1722,16 +1742,16 @@ func (i *RawIter) clearCache() {
 }
 
 func (i *RawIter) cacheEntry() {
-	var valStart int32
-	valSize := int32(len(i.val))
+	var valStart offsetInBlock
+	valSize := uint32(len(i.val))
 	if valSize > 0 {
-		valStart = int32(uintptr(unsafe.Pointer(&i.val[0])) - uintptr(i.ptr))
+		valStart = offsetInBlock(uintptr(unsafe.Pointer(&i.val[0])) - uintptr(i.ptr))
 	}
 
 	i.cached = append(i.cached, blockEntry{
 		offset:   i.offset,
-		keyStart: int32(len(i.cachedBuf)),
-		keyEnd:   int32(len(i.cachedBuf) + len(i.key)),
+		keyStart: offsetInBlock(len(i.cachedBuf)),
+		keyEnd:   offsetInBlock(len(i.cachedBuf) + len(i.key)),
 		valStart: valStart,
 		valSize:  valSize,
 	})
@@ -1761,7 +1781,7 @@ func (i *RawIter) SeekGE(key []byte) bool {
 	// 0, then all keys in this block are larger than the key sought, and offset
 	// remains at zero.
 	if index > 0 {
-		i.offset = int32(binary.LittleEndian.Uint32(i.data[int(i.restarts)+4*(index-1):]))
+		i.offset = offsetInBlock(binary.LittleEndian.Uint32(i.data[int(i.restarts)+4*(index-1):]))
 	}
 	i.loadEntry()
 
@@ -1785,7 +1805,7 @@ func (i *RawIter) First() bool {
 // Last implements internalIterator.Last, as documented in the pebble package.
 func (i *RawIter) Last() bool {
 	// Seek forward from the last restart point.
-	i.offset = int32(binary.LittleEndian.Uint32(i.data[i.restarts+4*(i.numRestarts-1):]))
+	i.offset = offsetInBlock(binary.LittleEndian.Uint32(i.data[i.restarts+4*offsetInBlock(i.numRestarts-1):]))
 
 	i.readEntry()
 	i.clearCache()
@@ -1833,12 +1853,12 @@ func (i *RawIter) Prev() bool {
 
 	targetOffset := i.offset
 	index := sort.Search(int(i.numRestarts), func(j int) bool {
-		offset := int32(binary.LittleEndian.Uint32(i.data[int(i.restarts)+4*j:]))
+		offset := offsetInBlock(binary.LittleEndian.Uint32(i.data[int(i.restarts)+4*j:]))
 		return offset >= targetOffset
 	})
 	i.offset = 0
 	if index > 0 {
-		i.offset = int32(binary.LittleEndian.Uint32(i.data[int(i.restarts)+4*(index-1):]))
+		i.offset = offsetInBlock(binary.LittleEndian.Uint32(i.data[int(i.restarts)+4*(index-1):]))
 	}
 
 	i.readEntry()
@@ -1890,8 +1910,8 @@ func (i *RawIter) DebugTree(tp treeprinter.Node) {
 	tp.Childf("%T(%p)", i, i)
 }
 
-func (i *RawIter) getRestart(idx int) int32 {
-	return int32(binary.LittleEndian.Uint32(i.data[i.restarts+4*int32(idx):]))
+func (i *RawIter) getRestart(idx int) offsetInBlock {
+	return offsetInBlock(binary.LittleEndian.Uint32(i.data[i.restarts+4*offsetInBlock(idx):]))
 }
 
 func (i *RawIter) isRestartPoint() bool {
@@ -1929,7 +1949,7 @@ func (i *RawIter) Describe(w io.Writer, blkOffset uint64, fmtKV DescribeKV) {
 		// offset of the KV pair within the uncompressed block. We should just
 		// print offsets relative to the block start.
 		fmt.Fprintf(w, "%10d    [restart %d]\n",
-			blkOffset+uint64(i.restarts+4*int32(j)), blkOffset+uint64(offset))
+			blkOffset+uint64(i.restarts+4*offsetInBlock(j)), blkOffset+uint64(offset))
 	}
 }
 

--- a/sstable/rowblk/rowblk_writer.go
+++ b/sstable/rowblk/rowblk_writer.go
@@ -127,6 +127,12 @@ func (w *Writer) storeWithOptionalValuePrefix(
 	valuePrefix block.ValuePrefix,
 	setHasSameKeyPrefix bool,
 ) {
+	// Ensure that the block size does not exceed rowblk.MaximumSize before writing more data
+	if len(w.buf) >= MaximumSize {
+		panic(errors.AssertionFailedf("rowblk: adding KV to %d-block; already exceeds %d-byte maximum",
+			len(w.buf), MaximumSize))
+	}
+
 	shared := 0
 	if !setHasSameKeyPrefix {
 		w.setHasSameKeyPrefixSinceLastRestart = false


### PR DESCRIPTION
Fix bug with integer overflows while indexing into blocks with large KVs in SeekGE() and SeekLT() in rowblk_iter. Updated members in blockEntry that represent  offsets in blocks to be type offsetInBlock (alias for int64).

Added check in rowblk_writer to ensure that block sizes do not exceed rowblk.MaximumSize before writing more data to the block.

Wrote unit tests to verify correct behavior for SeekGE() and SeekLT() with large blocks >2GB.