### PR TITLE
crl-release-23.2: sstable: fix restarts integer overflow

### DIFF
--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -7,6 +7,9 @@ package sstable
 import (
 	"bytes"
 	"fmt"
+	"math"
+	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -389,6 +392,168 @@ func TestBlockIterReverseDirections(t *testing.T) {
 				t.Fatalf("expected %s, but found %s", keys[pos], key.UserKey)
 			}
 		})
+	}
+}
+func TestSingularKVBlockRestartsOverflow(t *testing.T) {
+
+	_, isCI := os.LookupEnv("CI")
+	if isCI {
+		t.Skip("Skipping test: requires too much memory for CI now.")
+	}
+
+	// Test that SeekGE() and SeekLT() function correctly
+	// with a singular large KV > 2GB.
+
+	// Skip this test on 32-bit architectures because they may not
+	// have sufficient memory to reliably execute this test.
+	if runtime.GOARCH == "386" || runtime.GOARCH == "arm" || strconv.IntSize == 32 {
+		t.Skip("Skipping test: not supported on 32-bit architecture")
+	}
+
+	var largeKeySize int64 = 2 << 30   // 2GB key size
+	var largeValueSize int64 = 2 << 30 // 2GB value size
+
+	largeKey := bytes.Repeat([]byte("k"), int(largeKeySize))
+	largeValue := bytes.Repeat([]byte("v"), int(largeValueSize))
+
+	writer := &blockWriter{restartInterval: 1}
+	writer.add(base.InternalKey{UserKey: largeKey}, largeValue)
+	blockData := writer.finish()
+	iter, err := newBlockIter(bytes.Compare, blockData)
+	require.NoError(t, err, "failed to create iterator for block")
+
+	// Ensure that SeekGE() does not raise panic due to integer overflow
+	// indexing problems.
+	key, value := iter.SeekGE(largeKey, base.SeekGEFlagsNone)
+
+	// Ensure that SeekGE() finds the correct KV
+	require.NotNil(t, key, "failed to find the key")
+	require.Equal(t, largeKey, key.UserKey, "unexpected key")
+	require.Equal(t, largeValue, value.ValueOrHandle, "unexpected value")
+
+	// Ensure that SeekGE() does not raise panic due to integer overflow
+	// indexing problems.
+	key, value = iter.SeekLT([]byte("z"), base.SeekLTFlagsNone)
+
+	// Ensure that SeekLT() finds the correct KV
+	require.NotNil(t, key, "failed to find the key")
+	require.Equal(t, largeKey, key.UserKey, "unexpected key")
+	require.Equal(t, largeValue, value.ValueOrHandle, "unexpected value")
+}
+
+func TestBufferExceeding256MBShouldPanic(t *testing.T) {
+
+	_, isCI := os.LookupEnv("CI")
+	if isCI {
+		t.Skip("Skipping test: requires too much memory for CI now.")
+	}
+
+	// Test that writing to a block that is already >= 256MiB
+	// causes a panic to occur.
+
+	// Skip this test on 32-bit architectures because they may not
+	// have sufficient memory to reliably execute this test.
+	if runtime.GOARCH == "386" || runtime.GOARCH == "arm" || strconv.IntSize == 32 {
+		t.Skip("Skipping test: not supported on 32-bit architecture")
+	}
+
+	// Adding 64 KVs each with size 4MiB will create a block
+	// size of >= ~256MiB
+	const numKVs = 64
+	const valueSize = (1 << 20) * 4
+
+	type KVTestPair struct {
+		key   []byte
+		value []byte
+	}
+
+	KVTestPairs := make([]KVTestPair, numKVs)
+	value4MB := bytes.Repeat([]byte("a"), valueSize)
+	for i := 0; i < numKVs; i++ {
+		key := fmt.Sprintf("key-%04d", i)
+		KVTestPairs[i] = KVTestPair{key: []byte(key), value: value4MB}
+	}
+
+	writer := &blockWriter{restartInterval: 1}
+	for _, KVPair := range KVTestPairs {
+		writer.add(base.InternalKey{UserKey: KVPair.key}, KVPair.value)
+	}
+
+	// Check that buffer is larger than 256MiB
+	require.Greater(t, len(writer.buf), MaximumBlockSize)
+
+	// Check that a panic has occurred after the final write after the 256MiB
+	// threshold has been crossed
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on the last write, but none occurred")
+		}
+	}()
+	writer.add(base.InternalKey{UserKey: []byte("arbitrary-last-key")}, []byte("arbitrary-last-value"))
+}
+
+func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
+
+	_, isCI := os.LookupEnv("CI")
+	if isCI {
+		t.Skip("Skipping test: requires too much memory for CI now.")
+	}
+
+	// Tests that SeekGE() works when iter.restarts is
+	// greater than math.MaxUint32 for multiple KVs.
+	// Test writes < 256MiB to the block and then 4GiB
+	// causing iter.restarts will be an int > math.MaxUint32.
+	// Reaching just shy of 256MiB before adding 4GiB allows
+	// the final write to succeed without surpassing 256MiB
+	// limit.  Then test whether SeekGE() will return valid
+	// output without integer overflow.
+
+	// Skip this test on 32-bit architectures because they may not
+	// have sufficient memory to reliably execute this test.
+	if runtime.GOARCH == "386" || runtime.GOARCH == "arm" || strconv.IntSize == 32 {
+		t.Skip("Skipping test: not supported on 32-bit architecture")
+	}
+
+	// Write just shy of 256MiB to the block 63 * 4MiB < 256MiB
+	const numKVs = 63
+	const valueSize = 4 * (1 << 20)
+	var FourGB int64 = 4 * (1 << 30)
+
+	type KVTestPair struct {
+		key   []byte
+		value []byte
+	}
+
+	KVTestPairs := make([]KVTestPair, numKVs)
+	value4MB := bytes.Repeat([]byte("a"), valueSize)
+	for i := 0; i < numKVs; i++ {
+		key := fmt.Sprintf("key-%04d", i)
+		KVTestPairs[i] = KVTestPair{key: []byte(key), value: value4MB}
+	}
+
+	writer := &blockWriter{restartInterval: 1}
+	for _, KVPair := range KVTestPairs {
+		writer.add(base.InternalKey{UserKey: KVPair.key}, KVPair.value)
+	}
+
+	// Add the 4GiB KV, causing iter.restarts >= math.MaxUint32.
+	// Ensure that SeekGE() works thereafter without integer
+	// overflows.
+	writer.add(base.InternalKey{UserKey: []byte("large-kv")}, []byte(strings.Repeat("v", int(FourGB))))
+
+	blockData := writer.finish()
+	iter, err := newBlockIter(bytes.Compare, blockData)
+	require.NoError(t, err, "failed to create iterator for block")
+	require.Greater(t, int64(iter.restarts), int64(MaximumBlockSize), "check iter.restarts > 256MiB")
+	require.Greater(t, int64(iter.restarts), int64(math.MaxUint32), "check iter.restarts > 2^32-1")
+
+	for i := 0; i < numKVs; i++ {
+		expectedKey := []byte(fmt.Sprintf("key-%04d", i))
+		expectedValue := []byte(strings.Repeat("a", valueSize))
+		key, value := iter.SeekGE(expectedKey, base.SeekGEFlagsNone)
+		require.NotNil(t, key, "failed to find the large key")
+		require.Equal(t, expectedKey, key.UserKey, "unexpected key")
+		require.Equal(t, expectedValue, value.ValueOrHandle, "unexpected value")
 	}
 }
 

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -150,11 +150,11 @@ func (l *Layout) Describe(
 			continue
 		}
 
-		getRestart := func(data []byte, restarts, i int32) int32 {
-			return decodeRestart(data[restarts+4*i:])
+		getRestart := func(data []byte, restarts offsetInBlock, i int32) offsetInBlock {
+			return decodeRestart(data[restarts+4*offsetInBlock(i):])
 		}
 
-		formatIsRestart := func(data []byte, restarts, numRestarts, offset int32) {
+		formatIsRestart := func(data []byte, restarts offsetInBlock, numRestarts int32, offset offsetInBlock) {
 			i := sort.Search(int(numRestarts), func(i int) bool {
 				return getRestart(data, restarts, int32(i)) >= offset
 			})
@@ -165,11 +165,11 @@ func (l *Layout) Describe(
 			}
 		}
 
-		formatRestarts := func(data []byte, restarts, numRestarts int32) {
+		formatRestarts := func(data []byte, restarts offsetInBlock, numRestarts int32) {
 			for i := int32(0); i < numRestarts; i++ {
 				offset := getRestart(data, restarts, i)
 				fmt.Fprintf(w, "%10d    [restart %d]\n",
-					b.Offset+uint64(restarts+4*i), b.Offset+uint64(offset))
+					b.Offset+uint64(restarts+4*offsetInBlock(i)), b.Offset+uint64(offset))
 			}
 		}
 
@@ -205,7 +205,7 @@ func (l *Layout) Describe(
 				// <value>    is the number of value bytes.
 				fmt.Fprintf(w, "%10d    record (%d = %d [%d] + %d + %d)",
 					b.Offset+uint64(iter.offset), total,
-					total-int32(unshared+value2), shared, unshared, value2)
+					total-offsetInBlock(unshared+value2), shared, unshared, value2)
 				formatIsRestart(iter.data, iter.restarts, iter.numRestarts, iter.offset)
 				if fmtRecord != nil {
 					fmt.Fprintf(w, "              ")


### PR DESCRIPTION
Fix bug with integer overflows while indexing into blocks with large KVs in SeekGE() and SeekLT() in block_iter. Updated members in blockEntry that represent offsets in blocks to be type offsetInBlock (alias for int64).

Added check in rowblk_writer to ensure that block sizes do not exceed MaximumBlockSize before writing more data to the block.
    
Wrote unit tests to verify correct behavior for SeekGE() and SeekLT() with large blocks >2GB.