### PR TITLE
compact: save the resized valueBuf when saving values

### DIFF
--- a/internal/compact/iterator.go
+++ b/internal/compact/iterator.go
@@ -1294,7 +1294,8 @@ func (i *Iter) saveValue() {
 		i.err = err
 		i.value = base.LazyValue{}
 	} else if !callerOwned {
-		i.value = base.MakeInPlaceValue(append(i.valueBuf[:0], v...))
+		i.valueBuf = append(i.valueBuf[:0], v...)
+		i.value = base.MakeInPlaceValue(i.valueBuf)
 	} else {
 		i.value = base.MakeInPlaceValue(v)
 	}


### PR DESCRIPTION
Previously saveValue would copy the current iteration value into valueBuf, but if valueBuf was grown to accommodate a larger value, valueBuf wasn't stored. This lead to repeated re-allocations of buffers sufficiently large to hold the iteration value.