### PR TITLE
db: add a LowDiskSpace event

### DIFF
--- a/db.go
+++ b/db.go
@@ -280,7 +280,8 @@ type DB struct {
 	logBytesIn atomic.Uint64
 
 	// The number of bytes available on disk.
-	diskAvailBytes atomic.Uint64
+	diskAvailBytes       atomic.Uint64
+	lowDiskSpaceReporter lowDiskSpaceReporter
 
 	cacheID        cache.ID
 	dirname        string


### PR DESCRIPTION
Add an event when the low disk space runs low. We post an event when
we go below each threshold (10%, 5%, 2%, 1%) and we keep posting the
event periodically.

Informs https://github.com/cockroachdb/cockroach/issues/129319