### PR TITLE
sstable: revert change to binary search calculation

### DIFF
--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -583,7 +583,7 @@ func (i *Iter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 		// Invariant: f(index-1) == false, f(upper) == true.
 		upper := i.numRestarts
 		for index < upper {
-			h := index + ((upper - index) >> 1) // avoid overflow when computing h
+			h := int32(uint(index+upper) >> 1) // avoid overflow when computing h
 
 			// index ≤ h < upper
 			offset := decodeRestart(i.data[i.restarts+4*offsetInBlock(h):])
@@ -766,7 +766,7 @@ func (i *Iter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 		// Invariant: f(index-1) == false, f(upper) == true.
 		upper := i.numRestarts
 		for index < upper {
-			h := index + ((upper - index) >> 1) // avoid overflow when computing h
+			h := int32(uint(index+upper) >> 1) // avoid overflow when computing h
 
 			// index ≤ h < upper
 			offset := decodeRestart(i.data[i.restarts+4*offsetInBlock(h):])
@@ -1293,7 +1293,7 @@ func (i *Iter) nextPrefixV3(succKey []byte) *base.InternalKV {
 						// Invariant: f(index-1) == false, f(upper) == true.
 						upper := i.numRestarts
 						for index < upper {
-							h := index + ((upper - index) >> 1) // avoid overflow when computing h
+							h := int32(uint(index+upper) >> 1) // avoid overflow when computing h
 
 							// index ≤ h < upper
 							offset := decodeRestart(i.data[i.restarts+4*offsetInBlock(h):])
@@ -1496,7 +1496,7 @@ start:
 		// Invariant: f(index-1) == false, f(upper) == true.
 		upper := i.numRestarts
 		for index < upper {
-			h := index + ((upper - index) >> 1) // avoid overflow when computing h
+			h := int32(uint(index+upper) >> 1) // avoid overflow when computing h
 
 			// index ≤ h < upper
 			offset := decodeRestart(i.data[i.restarts+4*offsetInBlock(h):])


### PR DESCRIPTION
Revert index calculation for binary search in rowblk_iter.go to use casting (like in old iterations).
Binary search was originally modified to factor for int32 overflow, however this is not relevant
because a cast to uint will fix the overflow error. Reverting back to old calculation for
consistency with other of binary search calculations and (presumably) less instructions.