### PR TITLE
sstable: expand sstable iterator block stats

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -171,7 +171,7 @@ func createExternalPointIter(ctx context.Context, it *Iterator) (topLevelIterato
 			}
 			rangeDelIter, err = r.NewRawRangeDelIter(ctx, sstable.FragmentIterTransforms{
 				SyntheticSeqNum: sstable.SyntheticSeqNum(seqNum),
-			})
+			}, &it.stats.InternalStats, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -220,7 +220,7 @@ func finishInitializingExternal(ctx context.Context, it *Iterator) error {
 				for _, r := range readers {
 					transforms := sstable.FragmentIterTransforms{SyntheticSeqNum: sstable.SyntheticSeqNum(seqNum)}
 					seqNum--
-					if rki, err := r.NewRawRangeKeyIter(ctx, transforms); err != nil {
+					if rki, err := r.NewRawRangeKeyIter(ctx, transforms, &it.stats.InternalStats, nil); err != nil {
 						return err
 					} else if rki != nil {
 						rangeKeyIters = append(rangeKeyIters, rki)

--- a/ingest.go
+++ b/ingest.go
@@ -378,7 +378,7 @@ func ingestLoad1(
 		}
 	}
 
-	iter, err := r.NewRawRangeDelIter(ctx, sstable.NoFragmentTransforms)
+	iter, err := r.NewRawRangeDelIter(ctx, sstable.NoFragmentTransforms, nil, nil)
 	if err != nil {
 		return nil, keyspan.Span{}, err
 	}
@@ -408,7 +408,7 @@ func ingestLoad1(
 
 	// Update the range-key bounds for the table.
 	{
-		iter, err := r.NewRawRangeKeyIter(ctx, sstable.NoFragmentTransforms)
+		iter, err := r.NewRawRangeKeyIter(ctx, sstable.NoFragmentTransforms, nil, nil)
 		if err != nil {
 			return nil, keyspan.Span{}, err
 		}

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -103,9 +103,9 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 
 	var fileNum FileNum
 	newIters :=
-		func(_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds) (iterSet, error) {
+		func(_ context.Context, file *manifest.FileMetadata, _ *IterOptions, iio internalIterOpts, _ iterKinds) (iterSet, error) {
 			r := readers[file.FileNum]
-			rangeDelIter, err := r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms)
+			rangeDelIter, err := r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms, iio.stats, nil)
 			if err != nil {
 				return iterSet{}, err
 			}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -192,7 +192,7 @@ func (lt *levelIterTest) newIters(
 		set.point = iter
 	}
 	if kinds.RangeDeletion() {
-		rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(context.Background(), file.FragmentIterTransforms())
+		rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(context.Background(), file.FragmentIterTransforms(), nil, nil)
 		if err != nil {
 			return iterSet{}, errors.CombineErrors(err, set.CloseAll())
 		}

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -169,7 +169,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 			var err error
 			r := readers[file.FileNum]
 			if kinds.RangeDeletion() {
-				set.rangeDeletion, err = r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms)
+				set.rangeDeletion, err = r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms, iio.stats, nil)
 				if err != nil {
 					return iterSet{}, errors.CombineErrors(err, set.CloseAll())
 				}
@@ -671,14 +671,14 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 		levelIndex := i
 		level := len(readers) - 1 - i
 		newIters := func(
-			_ context.Context, file *manifest.FileMetadata, opts *IterOptions, _ internalIterOpts, _ iterKinds,
+			_ context.Context, file *manifest.FileMetadata, opts *IterOptions, iio internalIterOpts, _ iterKinds,
 		) (iterSet, error) {
 			iter, err := readers[levelIndex][file.FileNum].NewIter(
 				sstable.NoTransforms, opts.LowerBound, opts.UpperBound)
 			if err != nil {
 				return iterSet{}, err
 			}
-			rdIter, err := readers[levelIndex][file.FileNum].NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms)
+			rdIter, err := readers[levelIndex][file.FileNum].NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms, iio.stats, nil)
 			if err != nil {
 				iter.Close()
 				return iterSet{}, err

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -269,7 +269,7 @@ func openExternalObj(
 	pointIter, err = reader.NewIter(sstable.NoTransforms, start, end)
 	panicIfErr(err)
 
-	rangeDelIter, err = reader.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms)
+	rangeDelIter, err = reader.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms, nil, nil)
 	panicIfErr(err)
 	if rangeDelIter != nil {
 		rangeDelIter = keyspan.Truncate(
@@ -279,7 +279,7 @@ func openExternalObj(
 		)
 	}
 
-	rangeKeyIter, err = reader.NewRawRangeKeyIter(context.Background(), sstable.NoFragmentTransforms)
+	rangeKeyIter, err = reader.NewRawRangeKeyIter(context.Background(), sstable.NoFragmentTransforms, nil, nil)
 	panicIfErr(err)
 	if rangeKeyIter != nil {
 		rangeKeyIter = keyspan.Truncate(

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -1022,7 +1022,7 @@ func loadFlushedSSTableKeys(
 			}
 
 			// Load all the range tombstones.
-			if iter, err := r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms); err != nil {
+			if iter, err := r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms, nil, nil); err != nil {
 				return err
 			} else if iter != nil {
 				defer iter.Close()
@@ -1045,7 +1045,7 @@ func loadFlushedSSTableKeys(
 			}
 
 			// Load all the range keys.
-			if iter, err := r.NewRawRangeKeyIter(context.Background(), sstable.NoFragmentTransforms); err != nil {
+			if iter, err := r.NewRawRangeKeyIter(context.Background(), sstable.NoFragmentTransforms, nil, nil); err != nil {
 				return err
 			} else if iter != nil {
 				defer iter.Close()

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -19,11 +19,17 @@ import (
 // virtual reader.
 type CommonReader interface {
 	NewRawRangeKeyIter(
-		ctx context.Context, transforms FragmentIterTransforms,
+		ctx context.Context,
+		transforms FragmentIterTransforms,
+		stats *base.InternalIteratorStats,
+		statsAccum block.IterStatsAccumulator,
 	) (keyspan.FragmentIterator, error)
 
 	NewRawRangeDelIter(
-		ctx context.Context, transforms FragmentIterTransforms,
+		ctx context.Context,
+		transforms FragmentIterTransforms,
+		stats *base.InternalIteratorStats,
+		statsAccum block.IterStatsAccumulator,
 	) (keyspan.FragmentIterator, error)
 
 	NewPointIter(

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -555,7 +555,7 @@ func (i *singleLevelIterator[I, PI, P, PD]) loadDataBlock(dir int8) loadBlockRes
 // ReadValueBlock implements the valblk.BlockProviderWhenOpen interface for use
 // by the valblk.Reader.
 func (i *singleLevelIterator[I, PI, D, PD]) ReadValueBlock(
-	bh block.Handle, stats *base.InternalIteratorStats,
+	bh block.Handle, stats *base.InternalIteratorStats, statsAccum block.IterStatsAccumulator,
 ) (block.BufferHandle, error) {
 	env := i.readBlockEnv
 	env.Stats = stats

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -277,7 +277,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 			transforms := FragmentIterTransforms{
 				SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(nil, syntheticSuffix),
 			}
-			iter, err := v.NewRawRangeDelIter(context.Background(), transforms)
+			iter, err := v.NewRawRangeDelIter(context.Background(), transforms, nil, nil)
 			if err != nil {
 				return err.Error()
 			}
@@ -303,7 +303,7 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 			transforms := FragmentIterTransforms{
 				SyntheticPrefixAndSuffix: block.MakeSyntheticPrefixAndSuffix(nil, syntheticSuffix),
 			}
-			iter, err := v.NewRawRangeKeyIter(context.Background(), transforms)
+			iter, err := v.NewRawRangeKeyIter(context.Background(), transforms, nil, nil)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -135,9 +135,12 @@ func (v *VirtualReader) ValidateBlockChecksumsOnBacking() error {
 
 // NewRawRangeDelIter wraps Reader.NewRawRangeDelIter.
 func (v *VirtualReader) NewRawRangeDelIter(
-	ctx context.Context, transforms FragmentIterTransforms,
+	ctx context.Context,
+	transforms FragmentIterTransforms,
+	stats *base.InternalIteratorStats,
+	statsAccum block.IterStatsAccumulator,
 ) (keyspan.FragmentIterator, error) {
-	iter, err := v.reader.NewRawRangeDelIter(ctx, transforms)
+	iter, err := v.reader.NewRawRangeDelIter(ctx, transforms, stats, statsAccum)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +164,10 @@ func (v *VirtualReader) NewRawRangeDelIter(
 
 // NewRawRangeKeyIter wraps Reader.NewRawRangeKeyIter.
 func (v *VirtualReader) NewRawRangeKeyIter(
-	ctx context.Context, transforms FragmentIterTransforms,
+	ctx context.Context,
+	transforms FragmentIterTransforms,
+	stats *base.InternalIteratorStats,
+	statsAccum block.IterStatsAccumulator,
 ) (keyspan.FragmentIterator, error) {
 	syntheticSeqNum := transforms.SyntheticSeqNum
 	if v.vState.isSharedIngested {
@@ -170,7 +176,7 @@ func (v *VirtualReader) NewRawRangeKeyIter(
 		// appropriate sequence number substitution below.
 		transforms.SyntheticSeqNum = 0
 	}
-	iter, err := v.reader.NewRawRangeKeyIter(ctx, transforms)
+	iter, err := v.reader.NewRawRangeKeyIter(ctx, transforms, stats, statsAccum)
 	if err != nil {
 		return nil, err
 	}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -204,7 +204,7 @@ func rewriteDataBlocksInParallel(
 }
 
 func rewriteRangeKeyBlockToWriter(r *Reader, w RawWriter, from, to []byte) error {
-	iter, err := r.NewRawRangeKeyIter(context.TODO(), NoFragmentTransforms)
+	iter, err := r.NewRawRangeKeyIter(context.TODO(), NoFragmentTransforms, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -32,14 +32,14 @@ func ReadAll(
 	}
 
 	ctx := context.Background()
-	if rangeDelIter := testutils.CheckErr(reader.NewRawRangeDelIter(ctx, NoFragmentTransforms)); rangeDelIter != nil {
+	if rangeDelIter := testutils.CheckErr(reader.NewRawRangeDelIter(ctx, NoFragmentTransforms, nil, nil)); rangeDelIter != nil {
 		defer rangeDelIter.Close()
 		for s := testutils.CheckErr(rangeDelIter.First()); s != nil; s = testutils.CheckErr(rangeDelIter.Next()) {
 			rangeDels = append(rangeDels, s.Clone())
 		}
 	}
 
-	if rangeKeyIter := testutils.CheckErr(reader.NewRawRangeKeyIter(ctx, NoFragmentTransforms)); rangeKeyIter != nil {
+	if rangeKeyIter := testutils.CheckErr(reader.NewRawRangeKeyIter(ctx, NoFragmentTransforms, nil, nil)); rangeKeyIter != nil {
 		defer rangeKeyIter.Close()
 		for s := testutils.CheckErr(rangeKeyIter.First()); s != nil; s = testutils.CheckErr(rangeKeyIter.Next()) {
 			rangeKeys = append(rangeKeys, s.Clone())

--- a/sstable/writer_rangekey_test.go
+++ b/sstable/writer_rangekey_test.go
@@ -121,7 +121,7 @@ func TestWriter_RangeKeys(t *testing.T) {
 						return err.Error()
 					}
 
-					iter, err := r.NewRawRangeKeyIter(context.Background(), NoFragmentTransforms)
+					iter, err := r.NewRawRangeKeyIter(context.Background(), NoFragmentTransforms, nil, nil)
 					if err != nil {
 						return err.Error()
 					}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -239,7 +239,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			return buf.String()
 
 		case "scan-range-del":
-			iter, err := r.NewRawRangeDelIter(context.Background(), NoFragmentTransforms)
+			iter, err := r.NewRawRangeDelIter(context.Background(), NoFragmentTransforms, nil, nil)
 			if err != nil {
 				return err.Error()
 			}
@@ -259,7 +259,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat, paralleli
 			return buf.String()
 
 		case "scan-range-key":
-			iter, err := r.NewRawRangeKeyIter(context.Background(), NoFragmentTransforms)
+			iter, err := r.NewRawRangeKeyIter(context.Background(), NoFragmentTransforms, nil, nil)
 			if err != nil {
 				return err.Error()
 			}

--- a/table_stats.go
+++ b/table_stats.go
@@ -913,7 +913,7 @@ func newCombinedDeletionKeyspanIter(
 	})
 	mIter.Init(comparer, transform, new(keyspanimpl.MergingBuffers))
 
-	iter, err := cr.NewRawRangeDelIter(context.TODO(), m.FragmentIterTransforms())
+	iter, err := cr.NewRawRangeDelIter(context.TODO(), m.FragmentIterTransforms(), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -964,7 +964,7 @@ func newCombinedDeletionKeyspanIter(
 		mIter.AddLevel(iter)
 	}
 
-	iter, err = cr.NewRawRangeKeyIter(context.TODO(), m.FragmentIterTransforms())
+	iter, err = cr.NewRawRangeKeyIter(context.TODO(), m.FragmentIterTransforms(), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/find.go
+++ b/tool/find.go
@@ -478,7 +478,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			// bit more work here to put them in a form that can be iterated in
 			// parallel with the point records.
 			rangeDelIter, err := func() (keyspan.FragmentIterator, error) {
-				iter, err := r.NewRawRangeDelIter(context.Background(), fragTransforms)
+				iter, err := r.NewRawRangeDelIter(context.Background(), fragTransforms, nil, nil)
 				if err != nil {
 					return nil, err
 				}

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -408,7 +408,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		// bit more work here to put them in a form that can be iterated in
 		// parallel with the point records.
 		rangeDelIter, err := func() (keyspan.FragmentIterator, error) {
-			iter, err := r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms)
+			iter, err := r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms, nil, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -510,7 +510,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		}
 
 		// Handle range keys.
-		rkIter, err := r.NewRawRangeKeyIter(context.Background(), sstable.NoFragmentTransforms)
+		rkIter, err := r.NewRawRangeKeyIter(context.Background(), sstable.NoFragmentTransforms, nil, nil)
 		if err != nil {
 			fmt.Fprintf(stdout, "%s\n", err)
 			os.Exit(1)


### PR DESCRIPTION
Added iterator stats for rangekey, rangedel, and value blocks. Replaced noRead for NewRawRangeDelIter, NewRawRangeKeyIter, and ReadValueBlockExternal with InternalIteratorStats and IterStatsAccumulator. Updated function calls to reflect change.