### PR TITLE
sstable: fix row writer mangling of cache block

### DIFF
--- a/objstorage/objstorageprovider/vfs_writable.go
+++ b/objstorage/objstorageprovider/vfs_writable.go
@@ -7,6 +7,7 @@ package objstorageprovider
 import (
 	"bufio"
 
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -35,6 +36,14 @@ func (w *fileBufferedWritable) Write(p []byte) error {
 	// Ignoring the length written since bufio.Writer.Write is guaranteed to
 	// return an error if the length written is < len(p).
 	_, err := w.bw.Write(p)
+
+	// Write is allowed to mangle the buffer. Do it sometimes in invariant builds
+	// to catch callers that don't handle this.
+	if invariants.Enabled && invariants.Sometimes(1) {
+		for i := range p {
+			p[i] = 0xFF
+		}
+	}
 	return err
 }
 

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -235,6 +235,14 @@ func (b *PhysicalBlock) WriteTo(w objstorage.Writable) (n int, err error) {
 	if err := w.Write(b.trailer[:]); err != nil {
 		return 0, err
 	}
+
+	// WriteTo is allowed to mangle the data. Mangle it ourselves some of the time
+	// in invariant builds to catch callers that don't handle this.
+	if invariants.Enabled && invariants.Sometimes(1) {
+		for i := range b.data {
+			b.data[i] = 0xFF
+		}
+	}
 	return len(b.data) + len(b.trailer), nil
 }
 

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -1941,8 +1941,21 @@ func (w *RawRowWriter) copyDataBlocks(
 
 // addDataBlock implements RawWriter.
 func (w *RawRowWriter) addDataBlock(b, sep []byte, bhp block.HandleWithProperties) error {
+	blockBuf := &w.dataBlockBuf.blockBuf
+	pb := block.CompressAndChecksum(
+		&blockBuf.dataBuf,
+		b,
+		w.layout.compression,
+		&blockBuf.checksummer,
+	)
+	if !pb.IsCompressed() {
+		// If the block isn't compressed, pb's underlying data points
+		// directly b. Clone it before writing it, as writing can mangle the buffer.
+		pb, blockBuf.dataBuf = pb.CloneUsingBuf(blockBuf.dataBuf)
+	}
+
 	// layout.WriteDataBlock keeps layout.offset up-to-date for us.
-	bh, err := w.layout.WriteDataBlock(b, &w.dataBlockBuf.blockBuf)
+	bh, err := w.layout.writePrecompressedBlock(pb)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### sstable, objstorageprovider: mangle the buffer when writing blocks

Pepper in some invariant-only buffer mangling on block write paths.
With this we can repro the failure in
https://github.com/cockroachdb/cockroach/issues/138662 with the meta
test.

#### sstable: fix row writer mangling of cache block

Fix `RawRowWriter.addDataBlock` to make a copy of the block data when
it's not compressed (similar to the columnar writer), because in that
case the writing out can mangle the buffer.

The sstable copier (during Download) uses `addDataBlock` with a buffer
from the cache, which we are not allowed to modify.

Informs https://github.com/cockroachdb/cockroach/issues/138662