### PR TITLE
crl-release-24.3: sstable: fix row writer mangling of cache block

### DIFF
--- a/objstorage/objstorageprovider/vfs_writable.go
+++ b/objstorage/objstorageprovider/vfs_writable.go
@@ -7,6 +7,7 @@ package objstorageprovider
 import (
 	"bufio"
 
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -35,6 +36,14 @@ func (w *fileBufferedWritable) Write(p []byte) error {
 	// Ignoring the length written since bufio.Writer.Write is guaranteed to
 	// return an error if the length written is < len(p).
 	_, err := w.bw.Write(p)
+
+	// Write is allowed to mangle the buffer. Do it sometimes in invariant builds
+	// to catch callers that don't handle this.
+	if invariants.Enabled && invariants.Sometimes(1) {
+		for i := range p {
+			p[i] = 0xFF
+		}
+	}
 	return err
 }
 

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/golang/snappy"
 )
@@ -221,6 +222,14 @@ func (b *PhysicalBlock) WriteTo(w objstorage.Writable) (n int, err error) {
 	}
 	if err := w.Write(b.trailer[:]); err != nil {
 		return 0, err
+	}
+
+	// WriteTo is allowed to mangle the data. Mangle it ourselves some of the time
+	// in invariant builds to catch callers that don't handle this.
+	if invariants.Enabled && invariants.Sometimes(1) {
+		for i := range b.data {
+			b.data[i] = 0xFF
+		}
 	}
 	return len(b.data) + len(b.trailer), nil
 }

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/binfmt"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 	"github.com/cockroachdb/pebble/objstorage"
@@ -798,12 +799,23 @@ func (w *layoutWriter) WriteValueIndexBlock(
 func (w *layoutWriter) writeBlock(
 	b []byte, compression block.Compression, buf *blockBuf,
 ) (block.Handle, error) {
-	return w.writePrecompressedBlock(block.CompressAndChecksum(
-		&buf.compressedBuf, b, compression, &buf.checksummer))
+	pb := block.CompressAndChecksum(&buf.compressedBuf, b, compression, &buf.checksummer)
+	h, err := w.writePrecompressedBlock(pb)
+	// This method is allowed to mangle b, but that only happens when the block
+	// data is not compressible. Mangle it anyway in invariant builds to catch
+	// callers that don't handle this.
+	if invariants.Enabled && invariants.Sometimes(1) {
+		for i := range b {
+			b[i] = 0xFF
+		}
+	}
+	return h, err
 }
 
 // writePrecompressedBlock writes a pre-compressed block and its
-// pre-computed trailer to the writer, returning it's block handle.
+// pre-computed trailer to the writer, returning its block handle.
+//
+// writePrecompressedBlock might mangle the block data.
 func (w *layoutWriter) writePrecompressedBlock(blk block.PhysicalBlock) (block.Handle, error) {
 	w.clearFromCache(w.offset)
 	// Write the bytes to the file.


### PR DESCRIPTION
#### sstable, objstorageprovider: mangle the buffer when writing blocks

Pepper in some invariant-only buffer mangling on block write paths.
With this we can repro the failure in
https://github.com/cockroachdb/cockroach/issues/138662 with the meta
test.

#### sstable: fix row writer mangling of cache block

Fix `RawRowWriter.addDataBlock` to make a copy of the block data when
it's not compressed (similar to the columnar writer), because in that
case the writing out can mangle the buffer.

The sstable copier (during Download) uses `addDataBlock` with a buffer
from the cache, which we are not allowed to modify.

Informs https://github.com/cockroachdb/cockroach/issues/138662