### PR TITLE
support build on loong64

### DIFF
--- a/internal/manual/manual_64bit.go
+++ b/internal/manual/manual_64bit.go
@@ -2,8 +2,8 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64 || riscv64
-// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64 riscv64
+//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64 || riscv64 || loong64
+// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64 riscv64 loong64
 
 package manual
 

--- a/internal/rawalloc/rawalloc_64bit.go
+++ b/internal/rawalloc/rawalloc_64bit.go
@@ -12,8 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64 || riscv64
-// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64 riscv64
+//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64 || riscv64 || loong64
+// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64 riscv64 loong64
 
 package rawalloc
 


### PR DESCRIPTION
This PR tris to support build on loong64 on the 1.1 branch

[Loongson](https://en.wikipedia.org/wiki/Loongson) ([simplified Chinese](https://en.wikipedia.org/wiki/Simplified_Chinese_characters): 龙芯; [traditional Chinese](https://en.wikipedia.org/wiki/Traditional_Chinese_characters): 龍芯; [pinyin](https://en.wikipedia.org/wiki/Pinyin): Lóngxīn; lit. 'Dragon Core') is the name of a family of general-purpose, [MIPS architecture](https://en.wikipedia.org/wiki/MIPS_architecture)-compatible, later in-house LoongArch architecture [microprocessors](https://en.wikipedia.org/wiki/Central_processing_unit)

see [loong64](https://wiki.debian.org/Ports/loong64) too.

I cannot find any contribution guide of pebble, so I create a PR directly to the 1.1 release branch