### PR TITLE
sstable: copy filter block during suffix rewriting

### DIFF
--- a/objstorage/test_utils.go
+++ b/objstorage/test_utils.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/pkg/errors"
 )
 
@@ -32,6 +33,13 @@ func (f *MemObj) Abort() { f.buf.Reset() }
 // Write is part of the Writable interface.
 func (f *MemObj) Write(p []byte) error {
 	_, err := f.buf.Write(p)
+	// Write is allowed to mangle the buffer. Do it sometimes in invariant
+	// builds to catch callers that don't handle this.
+	if invariants.Enabled && invariants.Sometimes(1) {
+		for i := range p {
+			p[i] = 0xFF
+		}
+	}
 	return err
 }
 

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1066,7 +1066,9 @@ func (w *RawColumnWriter) rewriteSuffixes(
 			w.filterBlock = copyFilterWriter{
 				origPolicyName: w.filterBlock.policyName(),
 				origMetaName:   w.filterBlock.metaName(),
-				data:           filterBlock,
+				// Clone the filter block, because readBlockBuf allows the
+				// returned byte slice to point directly into sst.
+				data: slices.Clone(filterBlock),
 			}
 		}
 	}

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/cockroachdb/errors"
@@ -1903,7 +1904,11 @@ func (w *RawRowWriter) rewriteSuffixes(
 				return errors.Wrap(err, "reading filter")
 			}
 			w.filter = copyFilterWriter{
-				origPolicyName: w.filter.policyName(), origMetaName: w.filter.metaName(), data: filterBlock,
+				origPolicyName: w.filter.policyName(),
+				origMetaName:   w.filter.metaName(),
+				// Clone the filter block, because readBlockBuf allows the
+				// returned byte slice to point directly into sst.
+				data: slices.Clone(filterBlock),
 			}
 		}
 	}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -351,6 +351,10 @@ func NewMemReader(sst []byte, o ReaderOptions) (*Reader, error) {
 	return NewReader(context.Background(), newMemReader(sst), o)
 }
 
+// readBlockBuf may return a byte slice that points directly into sstBytes. If
+// the caller is going to expect that sstBytes remain stable, it should copy the
+// returned slice before writing it out to a objstorage.Writable which may
+// mangle it.
 func readBlockBuf(
 	sstBytes []byte, bh block.Handle, checksumType block.ChecksumType, buf []byte,
 ) ([]byte, []byte, error) {


### PR DESCRIPTION
Previously, during suffix rewriting, both row and columnar sstable writers
could pass the input sstable's filter block into objstorage.Writable.Write by
passing a subslice of the original input sstables byte slice. The Write method
is permitted to mangle the input buffer, which in this case would corrupt the
original input sstable.