### PR TITLE
internal/metamorphic: fix bugs in KeyFormat abstraction

### DIFF
--- a/external_test.go
+++ b/external_test.go
@@ -34,7 +34,8 @@ func TestIteratorErrors(t *testing.T) {
 	// Generate a random database by running the metamorphic test with the
 	// WriteOpConfig. We'll perform ~10,000 random operations that mutate the
 	// state of the database.
-	testOpts := metamorphic.RandomOptions(rng, nil /* custom opt parsers */)
+	kf := metamorphic.TestkeysKeyFormat
+	testOpts := metamorphic.RandomOptions(rng, kf, nil /* custom opt parsers */)
 	// With even a very small injection probability, it's relatively
 	// unlikely that pebble.DebugCheckLevels will successfully complete
 	// without being interrupted by an ErrInjected. Omit these checks.
@@ -50,8 +51,8 @@ func TestIteratorErrors(t *testing.T) {
 
 	testOpts.Opts.Cache.Ref()
 	{
-		test, err := metamorphic.New(
-			metamorphic.GenerateOps(rng, 10000, metamorphic.WriteOpConfig()),
+		test, err := metamorphic.New(metamorphic.GenerateOps(
+			rng, 10000, kf, metamorphic.WriteOpConfig()),
 			testOpts, "" /* dir */, io.Discard)
 		require.NoError(t, err)
 		require.NoError(t, metamorphic.Execute(test))
@@ -72,7 +73,7 @@ func TestIteratorErrors(t *testing.T) {
 		testOpts.Opts.ReadOnly = true
 
 		test, err := metamorphic.New(
-			metamorphic.GenerateOps(rng, 5000, metamorphic.ReadOpConfig()),
+			metamorphic.GenerateOps(rng, 5000, metamorphic.TestkeysKeyFormat, metamorphic.ReadOpConfig()),
 			testOpts, "" /* dir */, &testWriter{t: t})
 		require.NoError(t, err)
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -31,7 +31,7 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 	rng := rand.New(rand.NewPCG(0, seed))
 
 	// Generate a random database by running the metamorphic test.
-	testOpts := metamorphic.RandomOptions(rng, nil /* custom opt parsers */)
+	testOpts := metamorphic.RandomOptions(rng, metamorphic.TestkeysKeyFormat, nil /* custom opt parsers */)
 	testOpts.Opts.Cache.Ref()
 	defer testOpts.Opts.Cache.Unref()
 	{
@@ -41,7 +41,7 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 			// we are unlucky).
 			nOps = 2000
 		}
-		ops := metamorphic.GenerateOps(rng, uint64(nOps), metamorphic.WriteOpConfig())
+		ops := metamorphic.GenerateOps(rng, uint64(nOps), metamorphic.TestkeysKeyFormat, metamorphic.WriteOpConfig())
 		test, err := metamorphic.New(ops, testOpts, "" /* dir */, io.Discard)
 		require.NoError(t, err)
 		require.NoError(t, metamorphic.Execute(test))

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -70,7 +70,8 @@ func runTestMeta(t *testing.T, multiInstance bool) {
 			tryToReduceCompare(t, runOnceFlags.Dir, testRootDir, runSubdirs, runOnceFlags.ReduceAttempts)
 			return
 		}
-		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs, onceOpts...)
+		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs,
+			runOnceFlags.KeyFormat(), onceOpts...)
 
 	case runOnceFlags.RunDir != "":
 		// The --run-dir flag is specified either in the child process (see
@@ -84,7 +85,8 @@ func runTestMeta(t *testing.T, multiInstance bool) {
 			tryToReduce(t, runOnceFlags.Dir, runOnceFlags.RunDir, runOnceFlags.ReduceAttempts)
 			return
 		}
-		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
+		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed,
+			filepath.Join(runOnceFlags.RunDir, "history"), runOnceFlags.KeyFormat(), onceOpts...)
 
 	default:
 		opts := runFlags.MakeRunOptions()

--- a/internal/metamorphic/metarunner/main.go
+++ b/internal/metamorphic/metarunner/main.go
@@ -27,13 +27,16 @@ func main() {
 	switch {
 	case runOnceFlags.Compare != "":
 		testRootDir, runSubdirs := runOnceFlags.ParseCompare()
-		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs, onceOpts...)
+		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs,
+			runOnceFlags.KeyFormat(), onceOpts...)
 
 	case runOnceFlags.RunDir != "":
 		// The --run-dir flag is specified either in the child process (see
 		// runOptions() below) or the user specified it manually in order to re-run
 		// a test.
-		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
+		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed,
+			filepath.Join(runOnceFlags.RunDir, "history"),
+			runOnceFlags.KeyFormat(), onceOpts...)
 
 	default:
 		t.Errorf("--compare or --run-dir must be used")

--- a/metamorphic/example_test.go
+++ b/metamorphic/example_test.go
@@ -16,9 +16,10 @@ func ExampleExecute() {
 	const seed = 1698702489658104000
 	rng := rand.New(rand.NewPCG(0, seed))
 
+	kf := metamorphic.TestkeysKeyFormat
 	// Generate a random database by running the metamorphic test.
-	testOpts := metamorphic.RandomOptions(rng, nil /* custom opt parsers */)
-	ops := metamorphic.GenerateOps(rng, 10000, metamorphic.DefaultOpConfig())
+	testOpts := metamorphic.RandomOptions(rng, kf, nil /* custom opt parsers */)
+	ops := metamorphic.GenerateOps(rng, 10000, kf, metamorphic.DefaultOpConfig())
 	test, err := metamorphic.New(ops, testOpts, "" /* dir */, io.Discard)
 	if err != nil {
 		panic(err)

--- a/metamorphic/generator_test.go
+++ b/metamorphic/generator_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGenerator(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
+	g := newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */, TestkeysKeyFormat))
 
 	g.newBatch()
 	g.newBatch()
@@ -62,7 +62,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
+	g = newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */, TestkeysKeyFormat))
 
 	g.newSnapshot()
 	g.newSnapshot()
@@ -95,7 +95,7 @@ func TestGenerator(t *testing.T) {
 		t.Logf("\n%s", g)
 	}
 
-	g = newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
+	g = newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */, TestkeysKeyFormat))
 
 	g.newIndexedBatch()
 	g.newIndexedBatch()
@@ -132,7 +132,7 @@ func TestGeneratorRandom(t *testing.T) {
 	generateFromSeed := func(cfg OpConfig) string {
 		rng := rand.New(rand.NewPCG(0, seed))
 		count := ops.Uint64(rng)
-		km := newKeyManager(cfg.numInstances)
+		km := newKeyManager(cfg.numInstances, TestkeysKeyFormat)
 		g := newGenerator(rng, cfg, km)
 		return formatOps(km.kf, g.generate(count))
 	}
@@ -171,7 +171,7 @@ func TestGeneratorRandom(t *testing.T) {
 
 func TestGenerateDisjointKeyRanges(t *testing.T) {
 	rng := randvar.NewRand()
-	g := newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */))
+	g := newGenerator(rng, DefaultOpConfig(), newKeyManager(1 /* numInstances */, TestkeysKeyFormat))
 
 	for i := 0; i < 10; i++ {
 		keyRanges := g.generateDisjointKeyRanges(5)

--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -362,9 +362,9 @@ func (k *keyManager) getSetOfVisibleKeys(readerID objID) [][]byte {
 
 // newKeyManager returns a pointer to a new keyManager. Callers should
 // interact with this using addNewKey, knownKeys, update methods only.
-func newKeyManager(numInstances int) *keyManager {
+func newKeyManager(numInstances int, kf KeyFormat) *keyManager {
 	m := &keyManager{
-		kf:                   TestkeysKeyFormat,
+		kf:                   kf,
 		byObj:                make(map[objID]*objKeyMeta),
 		globalKeysMap:        make(map[string]bool),
 		globalKeyPrefixesMap: make(map[string]struct{}),

--- a/metamorphic/key_manager_test.go
+++ b/metamorphic/key_manager_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestKeyManager_AddKey(t *testing.T) {
-	m := newKeyManager(1 /* numInstances */)
+	m := newKeyManager(1 /* numInstances */, TestkeysKeyFormat)
 	require.Empty(t, m.globalKeys)
 
 	k1 := []byte("foo")
@@ -77,12 +77,12 @@ func printKeys(w io.Writer, keys [][]byte) {
 
 func TestKeyManager(t *testing.T) {
 	var buf bytes.Buffer
-	km := newKeyManager(1 /* numInstances */)
+	km := newKeyManager(1 /* numInstances */, TestkeysKeyFormat)
 	kf := TestkeysKeyFormat
 	datadriven.RunTest(t, "testdata/key_manager", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "reset":
-			km = newKeyManager(1 /* numInstances */)
+			km = newKeyManager(1 /* numInstances */, TestkeysKeyFormat)
 			return ""
 		case "run":
 			buf.Reset()
@@ -157,12 +157,12 @@ func TestOpWrittenKeys(t *testing.T) {
 func TestLoadPrecedingKeys(t *testing.T) {
 	rng := randvar.NewRand()
 	cfg := DefaultOpConfig()
-	km := newKeyManager(1 /* numInstances */)
+	km := newKeyManager(1 /* numInstances */, TestkeysKeyFormat)
 	g := newGenerator(rng, cfg, km)
 	ops := g.generate(1000)
 
 	cfg2 := DefaultOpConfig()
-	km2 := newKeyManager(1 /* numInstances */)
+	km2 := newKeyManager(1 /* numInstances */, TestkeysKeyFormat)
 	g2 := newGenerator(rng, cfg2, km2)
 	loadPrecedingKeys(ops, g2.keyGenerator, km2)
 
@@ -181,7 +181,7 @@ func TestGenerateRandKeyInRange(t *testing.T) {
 
 	for _, kf := range knownKeyFormats {
 		t.Run(kf.Name, func(t *testing.T) {
-			km := newKeyManager(1 /* numInstances */)
+			km := newKeyManager(1 /* numInstances */, kf)
 			g := kf.NewGenerator(km, rng, DefaultOpConfig())
 			// Seed 100 initial keys.
 			for i := 0; i < 100; i++ {

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -504,8 +504,8 @@ func (o *setOp) diagramKeyRanges() []pebble.KeyRange {
 // rangeKeyDeleteOp models a Write.RangeKeyDelete operation.
 type rangeKeyDeleteOp struct {
 	writerID objID
-	start    []byte
-	end      []byte
+	start    UserKey
+	end      UserKey
 }
 
 func (o *rangeKeyDeleteOp) run(t *Test, h historyRecorder) {
@@ -534,9 +534,9 @@ func (o *rangeKeyDeleteOp) diagramKeyRanges() []pebble.KeyRange {
 // rangeKeySetOp models a Write.RangeKeySet operation.
 type rangeKeySetOp struct {
 	writerID objID
-	start    []byte
-	end      []byte
-	suffix   []byte
+	start    UserKey
+	end      UserKey
+	suffix   UserKeySuffix
 	value    []byte
 }
 
@@ -1081,9 +1081,11 @@ func (o *ingestExternalFilesOp) syncObjs() objIDSlice {
 func (o *ingestExternalFilesOp) formattedString(kf KeyFormat) string {
 	strs := make([]string, len(o.objs))
 	for i, obj := range o.objs {
+		// NB: The syntheticPrefix is intentionally not formatted, because it's
+		// not a valid key itself. It is printed as a simple quoted Go string.
 		strs[i] = fmt.Sprintf("%s, %q /* start */, %q /* end */, %q /* syntheticSuffix */, %q /* syntheticPrefix */",
 			obj.externalObjID, kf.FormatKey(obj.bounds.Start), kf.FormatKey(obj.bounds.End),
-			kf.FormatKeySuffix(UserKeySuffix(obj.syntheticSuffix)), kf.FormatKey(UserKey(obj.syntheticPrefix)),
+			kf.FormatKeySuffix(UserKeySuffix(obj.syntheticSuffix)), obj.syntheticPrefix,
 		)
 	}
 	return fmt.Sprintf("%s.IngestExternalFiles(%s)", o.dbID, strings.Join(strs, ", "))
@@ -1761,7 +1763,7 @@ func (o *iterCanSingleDelOp) diagramKeyRanges() []pebble.KeyRange { return nil }
 // iterPrevOp models an Iterator.Prev[WithLimit] operation.
 type iterPrevOp struct {
 	iterID objID
-	limit  []byte
+	limit  UserKey
 
 	derivedReaderID objID
 }

--- a/metamorphic/parser_test.go
+++ b/metamorphic/parser_test.go
@@ -41,7 +41,7 @@ func TestParserRandom(t *testing.T) {
 				cfg = multiInstanceConfig()
 				cfg.numInstances = 2
 			}
-			km := newKeyManager(cfg.numInstances)
+			km := newKeyManager(cfg.numInstances, TestkeysKeyFormat)
 			g := newGenerator(randvar.NewRand(), cfg, km)
 			ops := g.generate(10000)
 			src := formatOps(km.kf, ops)


### PR DESCRIPTION
This commit fixes a handful of bugs in the abstraction of the KeyFormat (today only the testkeys KeyFormat exists). It also introduces a --key-format= CLI flag for configuring the key format to use in a particular run of the metamorphic test.