### PR TITLE
sstable: refactor ReaderOptions

### DIFF
--- a/cockroachkvs/cockroachkvs_bench_test.go
+++ b/cockroachkvs/cockroachkvs_bench_test.go
@@ -100,14 +100,16 @@ func benchmarkRandSeekInSST(
 	defer c.Unref()
 	ctx := context.Background()
 	readerOpts := sstable.ReaderOptions{
+		ReaderOptions: block.ReaderOptions{
+			CacheOpts: sstableinternal.CacheOptions{
+				Cache:   c,
+				CacheID: c.NewID(),
+				FileNum: 1,
+			},
+		},
 		Comparer:   writerOpts.Comparer,
 		KeySchemas: sstable.MakeKeySchemas(&KeySchema),
 	}
-	readerOpts.SetInternalCacheOpts(sstableinternal.CacheOptions{
-		Cache:   c,
-		CacheID: c.NewID(),
-		FileNum: 1,
-	})
 	reader, err := sstable.NewReader(ctx, obj, readerOpts)
 	require.NoError(b, err)
 	defer reader.Close()

--- a/data_test.go
+++ b/data_test.go
@@ -1177,11 +1177,11 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	// TODO(bananabrick): cacheOpts is used to set the file number on a Reader,
 	// and virtual sstables expect this file number to be set. Split out the
 	// opts into fileNum opts, and cache opts.
-	readerOpts.SetInternalCacheOpts(sstableinternal.CacheOptions{
+	readerOpts.CacheOpts = sstableinternal.CacheOptions{
 		Cache:   d.opts.Cache,
 		CacheID: 0,
 		FileNum: backingFileNum,
-	})
+	}
 	r, err := sstable.NewReader(context.Background(), readable, readerOpts)
 	if err != nil {
 		return err.Error()

--- a/file_cache.go
+++ b/file_cache.go
@@ -1181,11 +1181,11 @@ func (v *fileCacheValue) load(
 	)
 	if err == nil {
 		o := dbOpts.readerOpts
-		o.SetInternalCacheOpts(sstableinternal.CacheOptions{
+		o.CacheOpts = sstableinternal.CacheOptions{
 			Cache:   dbOpts.cache,
 			CacheID: dbOpts.cacheID,
 			FileNum: backingFileNum,
-		})
+		}
 		r, err = sstable.NewReader(ctx, f, o)
 	}
 	if err == nil {

--- a/ingest.go
+++ b/ingest.go
@@ -305,11 +305,11 @@ func ingestLoad1(
 	rangeKeyValidator rangeKeyIngestValidator,
 ) (meta *fileMetadata, lastRangeKey keyspan.Span, err error) {
 	o := opts.MakeReaderOptions()
-	o.SetInternalCacheOpts(sstableinternal.CacheOptions{
+	o.CacheOpts = sstableinternal.CacheOptions{
 		Cache:   opts.Cache,
 		CacheID: cacheID,
 		FileNum: base.PhysicalTableDiskFileNum(fileNum),
-	})
+	}
 	r, err := sstable.NewReader(ctx, readable, o)
 	if err != nil {
 		return nil, keyspan.Span{}, err

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -241,7 +241,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 					Comparer:   testkeys.Comparer,
 					KeySchemas: sstable.KeySchemas{writerOpts.KeySchema.Name: writerOpts.KeySchema},
 				}
-				readerOpts.SetInternalCacheOpts(sstableinternal.CacheOptions{FileNum: base.DiskFileNum(fileNum - 1)})
+				readerOpts.CacheOpts = sstableinternal.CacheOptions{FileNum: base.DiskFileNum(fileNum - 1)}
 				r, err := sstable.NewReader(context.Background(), readable, readerOpts)
 				if err != nil {
 					return err.Error()

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -543,9 +543,7 @@ func buildLevelIterTables(
 	c := NewCache(128 << 20 /* 128MB */)
 	defer c.Unref()
 	opts := sstable.ReaderOptions{Comparer: DefaultComparer}
-	opts.SetInternalCacheOpts(sstableinternal.CacheOptions{
-		Cache: c,
-	})
+	opts.CacheOpts = sstableinternal.CacheOptions{Cache: c}
 	readers := make([]*sstable.Reader, len(files))
 	for i := range files {
 		f, err := mem.Open(fmt.Sprintf("bench%d", i))

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -372,9 +372,7 @@ func buildMergingIterTables(
 	defer c.Unref()
 
 	var opts sstable.ReaderOptions
-	opts.SetInternalCacheOpts(sstableinternal.CacheOptions{
-		Cache: c,
-	})
+	opts.CacheOpts = sstableinternal.CacheOptions{Cache: c}
 
 	readers := make([]*sstable.Reader, len(files))
 	for i := range files {
@@ -617,9 +615,7 @@ func buildLevelsForMergingIterSeqSeek(
 	defer c.Unref()
 
 	opts := sstable.ReaderOptions{Comparer: DefaultComparer}
-	opts.SetInternalCacheOpts(sstableinternal.CacheOptions{
-		Cache: c,
-	})
+	opts.CacheOpts = sstableinternal.CacheOptions{Cache: c}
 
 	if writeBloomFilters {
 		opts.Filters = make(map[string]FilterPolicy)

--- a/sstable/blob/blob_test.go
+++ b/sstable/blob/blob_test.go
@@ -58,10 +58,11 @@ func TestBlobWriter(t *testing.T) {
 			fmt.Fprintf(&buf, "  FileLen: %d\n", stats.FileLen)
 			return buf.String()
 		case "open":
-			r, err := NewFileReader(context.Background(), obj)
+			r, err := NewFileReader(context.Background(), obj, FileReaderOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer r.Close()
 			fmt.Fprintf(&buf, "TableFormat: %s\n", r.footer.format)
 			fmt.Fprintf(&buf, "ChecksumType: %s\n", r.footer.checksum)
 			fmt.Fprintf(&buf, "IndexHandle: %s\n", r.footer.indexHandle.String())

--- a/sstable/copier_test.go
+++ b/sstable/copier_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
+	"github.com/cockroachdb/pebble/internal/sstableinternal"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -107,12 +108,17 @@ func TestCopySpan(t *testing.T) {
 				}
 			}
 			rOpts := ReaderOptions{
+				ReaderOptions: block.ReaderOptions{
+					CacheOpts: sstableinternal.CacheOptions{
+						Cache:   blockCache,
+						CacheID: cacheID,
+						FileNum: base.DiskFileNum(fileNameToNum[d.CmdArgs[0].Key]),
+					},
+				},
 				Comparer:   testkeys.Comparer,
 				KeySchemas: KeySchemas{keySchema.Name: &keySchema},
 			}
-			rOpts.internal.CacheOpts.Cache = blockCache
-			rOpts.internal.CacheOpts.CacheID = cacheID
-			rOpts.internal.CacheOpts.FileNum = base.DiskFileNum(fileNameToNum[d.CmdArgs[0].Key])
+
 			r, err := NewReader(context.TODO(), readable, rOpts)
 			defer r.Close()
 			if err != nil {
@@ -156,12 +162,16 @@ func TestCopySpan(t *testing.T) {
 				return err.Error()
 			}
 			rOpts := ReaderOptions{
+				ReaderOptions: block.ReaderOptions{
+					CacheOpts: sstableinternal.CacheOptions{
+						Cache:   blockCache,
+						CacheID: cacheID,
+						FileNum: base.DiskFileNum(fileNameToNum[d.CmdArgs[0].Key]),
+					},
+				},
 				Comparer:   testkeys.Comparer,
 				KeySchemas: KeySchemas{keySchema.Name: &keySchema},
 			}
-			rOpts.internal.CacheOpts.Cache = blockCache
-			rOpts.internal.CacheOpts.CacheID = cacheID
-			rOpts.internal.CacheOpts.FileNum = base.DiskFileNum(fileNameToNum[inputFile])
 			r, err := NewReader(context.TODO(), readable, rOpts)
 			if err != nil {
 				return err.Error()

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -179,9 +179,7 @@ func openReader(obj *objstorage.MemObj, writerOpts *WriterOptions, cacheSize int
 	if cacheSize > 0 {
 		c := cache.New(int64(cacheSize))
 		defer c.Unref()
-		readerOpts.SetInternal(sstableinternal.ReaderOptions{
-			CacheOpts: sstableinternal.CacheOptions{Cache: c},
-		})
+		readerOpts.CacheOpts = sstableinternal.CacheOptions{Cache: c}
 	}
 	r, err := NewMemReader(obj.Data(), readerOpts)
 	if err != nil {

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -7,7 +7,6 @@ package sstable
 import (
 	"fmt"
 
-	"github.com/cockroachdb/crlib/fifo"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -81,10 +80,7 @@ func MakeKeySchemas(keySchemas ...*colblk.KeySchema) KeySchemas {
 
 // ReaderOptions holds the parameters needed for reading an sstable.
 type ReaderOptions struct {
-	// LoadBlockSema, if set, is used to limit the number of blocks that can be
-	// loaded (i.e. read from the filesystem) in parallel. Each load acquires one
-	// unit from the semaphore for the duration of the read.
-	LoadBlockSema *fifo.Semaphore
+	block.ReaderOptions
 
 	// User properties specified in this map will not be added to sst.Properties.UserProperties.
 	DeniedUserProperties map[string]struct{}
@@ -110,28 +106,8 @@ type ReaderOptions struct {
 	// policies that are not in this map will be ignored.
 	Filters map[string]FilterPolicy
 
-	// Logger is an optional logger and tracer.
-	LoggerAndTracer base.LoggerAndTracer
-
 	// FilterMetricsTracker is optionally used to track filter metrics.
 	FilterMetricsTracker *FilterMetricsTracker
-
-	// internal options can only be used from within the pebble package.
-	internal sstableinternal.ReaderOptions
-}
-
-// SetInternal sets the internal reader options. Note that even though this
-// method is public, a caller outside the pebble package can't construct a value
-// to pass to it.
-func (o *ReaderOptions) SetInternal(internalOpts sstableinternal.ReaderOptions) {
-	o.internal = internalOpts
-}
-
-// SetInternalCacheOpts sets the internal cache options. Note that even though
-// this method is public, a caller outside the pebble package can't construct a
-// value to pass to it.
-func (o *ReaderOptions) SetInternalCacheOpts(cacheOpts sstableinternal.CacheOptions) {
-	o.internal.CacheOpts = cacheOpts
 }
 
 func (o ReaderOptions) ensureDefaults() ReaderOptions {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -815,11 +815,11 @@ func NewReader(ctx context.Context, f objstorage.Readable, o ReaderOptions) (*Re
 		f, objstorage.ReadBeforeForNewReader, &preallocRH)
 	defer rh.Close()
 
-	footer, err := readFooter(ctx, f, rh, o.LoggerAndTracer, o.internal.CacheOpts.FileNum)
+	footer, err := readFooter(ctx, f, rh, o.LoggerAndTracer, o.CacheOpts.FileNum)
 	if err != nil {
 		return nil, errors.CombineErrors(err, f.Close())
 	}
-	r.blockReader.Init(f, o.internal.CacheOpts, o.LoadBlockSema, o.LoggerAndTracer, footer.checksum)
+	r.blockReader.Init(f, o.ReaderOptions, footer.checksum)
 	r.tableFormat = footer.format
 	r.indexBH = footer.indexBH
 	r.metaindexBH = footer.metaindexBH

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1751,7 +1751,7 @@ func buildTestTableWithProvider(
 	c := cache.New(128 << 20)
 	defer c.Unref()
 	r, err := NewReader(context.Background(), f1, ReaderOptions{
-		internal: sstableinternal.ReaderOptions{
+		ReaderOptions: block.ReaderOptions{
 			CacheOpts: sstableinternal.CacheOptions{
 				Cache: c,
 			},
@@ -1794,7 +1794,7 @@ func buildBenchmarkTable(
 	c := cache.New(128 << 20)
 	defer c.Unref()
 	r, err := newReader(f1, ReaderOptions{
-		internal: sstableinternal.ReaderOptions{
+		ReaderOptions: block.ReaderOptions{
 			CacheOpts: sstableinternal.CacheOptions{
 				Cache: c,
 			},
@@ -2081,7 +2081,7 @@ func BenchmarkIteratorScanManyVersions(b *testing.B) {
 		require.NoError(b, err)
 		r, err := newReader(f0, ReaderOptions{
 			Comparer: testkeys.Comparer,
-			internal: sstableinternal.ReaderOptions{
+			ReaderOptions: block.ReaderOptions{
 				CacheOpts: sstableinternal.CacheOptions{
 					Cache: c,
 				},
@@ -2201,7 +2201,7 @@ func BenchmarkIteratorScanNextPrefix(b *testing.B) {
 		require.NoError(b, err)
 		r, err = newReader(f0, ReaderOptions{
 			Comparer: testkeys.Comparer,
-			internal: sstableinternal.ReaderOptions{
+			ReaderOptions: block.ReaderOptions{
 				CacheOpts: sstableinternal.CacheOptions{
 					Cache: c,
 				},
@@ -2363,7 +2363,7 @@ func BenchmarkIteratorScanObsolete(b *testing.B) {
 		require.NoError(b, err)
 		r, err := newReader(f0, ReaderOptions{
 			Comparer: testkeys.Comparer,
-			internal: sstableinternal.ReaderOptions{
+			ReaderOptions: block.ReaderOptions{
 				CacheOpts: sstableinternal.CacheOptions{
 					Cache: c,
 				},

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -708,10 +708,8 @@ func TestWriterClearCache(t *testing.T) {
 	defer cacheOpts.Cache.Unref()
 
 	readerOpts := ReaderOptions{
-		Comparer: testkeys.Comparer,
-		internal: sstableinternal.ReaderOptions{
-			CacheOpts: cacheOpts,
-		},
+		ReaderOptions: block.ReaderOptions{CacheOpts: cacheOpts},
+		Comparer:      testkeys.Comparer,
 	}
 
 	writerOpts := WriterOptions{

--- a/tool/db.go
+++ b/tool/db.go
@@ -962,11 +962,9 @@ func (d *dbT) addProps(
 	opts := d.opts.MakeReaderOptions()
 	opts.Mergers = d.mergers
 	opts.Comparers = d.comparers
-	opts.SetInternal(sstableinternal.ReaderOptions{
-		CacheOpts: sstableinternal.CacheOptions{
-			FileNum: m.FileBacking.DiskFileNum,
-		},
-	})
+	opts.ReaderOptions.CacheOpts = sstableinternal.CacheOptions{
+		FileNum: m.FileBacking.DiskFileNum,
+	}
 	r, err := sstable.NewReader(ctx, f, opts)
 	if err != nil {
 		_ = f.Close()

--- a/tool/find.go
+++ b/tool/find.go
@@ -442,12 +442,10 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			opts := f.opts.MakeReaderOptions()
 			opts.Comparers = f.comparers
 			opts.Mergers = f.mergers
-			opts.SetInternal(sstableinternal.ReaderOptions{
-				CacheOpts: sstableinternal.CacheOptions{
-					Cache:   cache,
-					FileNum: fl.DiskFileNum,
-				},
-			})
+			opts.CacheOpts = sstableinternal.CacheOptions{
+				Cache:   cache,
+				FileNum: fl.DiskFileNum,
+			}
 			readable, err := sstable.NewSimpleReadable(tf)
 			if err != nil {
 				return err

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -153,11 +153,7 @@ func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
 	o.Mergers = s.mergers
 	c := pebble.NewCache(128 << 20 /* 128 MB */)
 	defer c.Unref()
-	o.SetInternal(sstableinternal.ReaderOptions{
-		CacheOpts: sstableinternal.CacheOptions{
-			Cache: c,
-		},
-	})
+	o.CacheOpts = sstableinternal.CacheOptions{Cache: c}
 	return sstable.NewReader(context.Background(), readable, o)
 }
 


### PR DESCRIPTION
Add block.ReaderOptions and refactor sstable.ReaderOptions to contain them, and the blob reader to also use block.Reader and block.ReaderOptions.