### PR TITLE
sstable: remove iterstatsaccumulator and refactor

### DIFF
--- a/level_iter.go
+++ b/level_iter.go
@@ -26,7 +26,7 @@ type internalIterOpts struct {
 	compaction           bool
 	bufferPool           *block.BufferPool
 	stats                *base.InternalIteratorStats
-	iterStatsAccumulator block.IterStatsAccumulator
+	iterStatsAccumulator *block.CategoryStatsShard
 	boundLimitedFilter   sstable.BoundLimitedBlockPropertyFilter
 }
 

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -323,7 +323,7 @@ type ReadEnv struct {
 	// iterator is closed. In the important code paths, the CategoryStatsCollector
 	// is managed by the fileCacheContainer.
 	Stats     *base.InternalIteratorStats
-	IterStats IterStatsAccumulator
+	IterStats *CategoryStatsShard
 
 	// BufferPool is not-nil if we read blocks into a buffer pool and not into the
 	// cache. This is used during compactions.

--- a/sstable/block/category_stats.go
+++ b/sstable/block/category_stats.go
@@ -6,6 +6,7 @@ package block
 
 import (
 	"cmp"
+	"runtime"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -31,6 +32,15 @@ const CategoryUnknown Category = 0
 // CategoryMax is the maximum value of a category, and is also the maximum
 // number of categories that can be registered.
 const CategoryMax = 30
+
+// shardPadding pads each shard to 64 bytes so they don't share a cache line.
+const shardPadding = 64 - unsafe.Sizeof(CategoryStatsShard{})
+
+// paddedCategoryStatsShard is a single shard of a category's statistics.
+type paddedCategoryStatsShard struct {
+	CategoryStatsShard
+	_ [shardPadding]byte
+}
 
 func (c Category) String() string {
 	return categories[c].name
@@ -169,20 +179,32 @@ type CategoryStatsAggregate struct {
 	CategoryStats CategoryStats
 }
 
-const numCategoryStatsShards = 16
+// numCategoryStatsShards must be a power of 2. We initialize it to GOMAXPROCS
+// (rounded up to the nearest power of 2) or 16, whichever is larger.
+var numCategoryStatsShards = func() int {
+	p := runtime.GOMAXPROCS(0)
+	n := 16
+	for n < p {
+		n *= 2
+	}
+	return n
+}()
 
-type categoryStatsWithMu struct {
-	mu sync.Mutex
-	// Protected by mu.
-	stats CategoryStats
+// CategoryStatsShard holds CategoryStats with a mutex
+// to ensure safe access.
+type CategoryStatsShard struct {
+	mu struct {
+		sync.Mutex
+		stats CategoryStats
+	}
 }
 
 // Accumulate implements the IterStatsAccumulator interface.
-func (c *categoryStatsWithMu) Accumulate(
+func (c *CategoryStatsShard) Accumulate(
 	blockBytes, blockBytesInCache uint64, blockReadDuration time.Duration,
 ) {
 	c.mu.Lock()
-	c.stats.aggregate(blockBytes, blockBytesInCache, blockReadDuration)
+	c.mu.stats.aggregate(blockBytes, blockBytesInCache, blockReadDuration)
 	c.mu.Unlock()
 }
 
@@ -199,11 +221,7 @@ type CategoryStatsCollector struct {
 // contention on the category stats mutex has been observed.
 type shardedCategoryStats struct {
 	Category Category
-	shards   [numCategoryStatsShards]struct {
-		categoryStatsWithMu
-		// Pad each shard to 64 bytes so they don't share a cache line.
-		_ [64 - unsafe.Sizeof(categoryStatsWithMu{})]byte
-	}
+	shards   []paddedCategoryStatsShard
 }
 
 // getStats retrieves the aggregated stats for the category, summing across all
@@ -214,7 +232,7 @@ func (s *shardedCategoryStats) getStats() CategoryStatsAggregate {
 	}
 	for i := range s.shards {
 		s.shards[i].mu.Lock()
-		agg.CategoryStats.aggregate(s.shards[i].stats.BlockBytes, s.shards[i].stats.BlockBytesInCache, s.shards[i].stats.BlockReadDuration)
+		agg.CategoryStats.aggregate(s.shards[i].mu.stats.BlockBytes, s.shards[i].mu.stats.BlockBytesInCache, s.shards[i].mu.stats.BlockReadDuration)
 		s.shards[i].mu.Unlock()
 	}
 	return agg
@@ -222,20 +240,21 @@ func (s *shardedCategoryStats) getStats() CategoryStatsAggregate {
 
 // Accumulator returns a stats accumulator for the given category. The provided
 // p is used to detrmine which shard to write stats to.
-func (c *CategoryStatsCollector) Accumulator(p uint64, category Category) IterStatsAccumulator {
+func (c *CategoryStatsCollector) Accumulator(p uint64, category Category) *CategoryStatsShard {
 	v, ok := c.statsMap.Load(category)
 	if !ok {
 		c.mu.Lock()
 		v, _ = c.statsMap.LoadOrStore(category, &shardedCategoryStats{
 			Category: category,
+			shards:   make([]paddedCategoryStatsShard, numCategoryStatsShards),
 		})
 		c.mu.Unlock()
 	}
 	s := v.(*shardedCategoryStats)
 	// This equation is taken from:
 	// https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use
-	shard := ((p * 25214903917) >> 32) & (numCategoryStatsShards - 1)
-	return &s.shards[shard].categoryStatsWithMu
+	shard := ((p * 25214903917) >> 32) & uint64(numCategoryStatsShards-1)
+	return &s.shards[shard].CategoryStatsShard
 }
 
 // GetStats returns the aggregated stats.
@@ -250,9 +269,4 @@ func (c *CategoryStatsCollector) GetStats() []CategoryStatsAggregate {
 		return cmp.Compare(a.Category, b.Category)
 	})
 	return stats
-}
-
-type IterStatsAccumulator interface {
-	// Accumulate accumulates the provided stats.
-	Accumulate(blockBytes, blockBytesInCache uint64, blockReadDuration time.Duration)
 }


### PR DESCRIPTION
Removed block.IterStatsAccumulator since there is only one implementation of the interface. Refactored usages of block.IterStatsAccumulator to use CategoryStatsWithMu. Also, increased numCategoryStatsShards to be runtime.GOMAXPROCS(0).