### PR TITLE
metamorphic: skip non-suffixed keys on time-bound iterators

### DIFF
--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1401,8 +1401,12 @@ func iterOptions(kf KeyFormat, o iterOpts) *pebble.IterOptions {
 		opts.SkipPoint = func(k []byte) (skip bool) {
 			n := kf.Comparer.Split(k)
 			if n == len(k) {
-				// No suffix, don't skip it.
-				return false
+				// No suffix, skip it. We adopt these semantics because the MVCC
+				// timestamp block-property collector used by CockroachDB just
+				// ignores keys without suffixes, meaning that filtering on the
+				// property results in nondeterministic presence of
+				// non-timestamped keys.
+				return true
 			}
 			if kf.Comparer.ComparePointSuffixes(k[n:], o.filterMin) < 0 {
 				return true


### PR DESCRIPTION
The metamorphic tests sometimes generates iterators with block-property filters constraining the set of MVCC timestamps that should be observed. Previously keys that were not suffixed were guaranteed to always be surfaced. The testkeys block-property collector would map an unsuffixed key to the maximal interval, ensuring any block containing an unsuffixed key would be visited by all time-bound iterators.

The cockroachdb block-property collector does not give non-MVCC keys the same treatment. Instead, it simply ignores non-timestamped keys for the purpose of calculating block-property collectors. This results in non-deterministic presence of non-MVCC keys in a time-bound iterators iteration. With the introduction of cockroach kvs in the metamorphic test, we'll need consistent, deterministic behavior. Skipping non-MVCC keys on time-bound iterators ensures the iterator observes the same keys regardless of the behavior of the underlying block property collector.