### PR TITLE
pebble-release-1.1: db: fix Open issue with single-item relative paths

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -88,22 +88,19 @@ func mkdirAllAndSyncParents(fs vfs.FS, destDir string) (vfs.File, error) {
 	// Collect paths for all directories between destDir (excluded) and its
 	// closest existing ancestor (included).
 	var parentPaths []string
-	foundExistingAncestor := false
-	for parentPath := fs.PathDir(destDir); parentPath != "."; parentPath = fs.PathDir(parentPath) {
+	for parentPath := fs.PathDir(destDir); ; parentPath = fs.PathDir(parentPath) {
 		parentPaths = append(parentPaths, parentPath)
+		if fs.PathDir(parentPath) == parentPath {
+			break
+		}
 		_, err := fs.Stat(parentPath)
 		if err == nil {
 			// Exit loop at the closest existing ancestor.
-			foundExistingAncestor = true
 			break
 		}
 		if !oserror.IsNotExist(err) {
 			return nil, err
 		}
-	}
-	// Handle empty filesystem edge case.
-	if !foundExistingAncestor {
-		parentPaths = append(parentPaths, "")
 	}
 	// Create destDir and any of its missing parents.
 	if err := fs.MkdirAll(destDir, 0755); err != nil {

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -141,9 +141,9 @@ mkdir-all: checkpoints/checkpoint1 0755
 open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
-open-dir: 
-sync: 
-close: 
+open-dir: .
+sync: .
+close: .
 open-dir: checkpoints/checkpoint1
 link: db/OPTIONS-000003 -> checkpoints/checkpoint1/OPTIONS-000003
 open-dir: checkpoints/checkpoint1

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -409,9 +409,9 @@ sstables
 checkpoint
 ----
 mkdir-all: checkpoint 0755
-open-dir: 
-sync: 
-close: 
+open-dir: .
+sync: .
+close: .
 open-dir: checkpoint
 link: db/OPTIONS-000003 -> checkpoint/OPTIONS-000003
 open-dir: checkpoint

--- a/testdata/mkdir_all_and_sync_parents
+++ b/testdata/mkdir_all_and_sync_parents
@@ -1,0 +1,67 @@
+mkfs memfs fs=mem1
+----
+new memfs
+
+mkdir-all-and-sync-parents fs=mem1 path=foo/bar/baz/bax
+----
+mkdir-all: foo/bar/baz/bax 0755
+open-dir: foo/bar/baz
+sync: foo/bar/baz
+close: foo/bar/baz
+open-dir: foo/bar
+sync: foo/bar
+close: foo/bar
+open-dir: foo
+sync: foo
+close: foo
+open-dir: .
+sync: .
+close: .
+open-dir: foo/bar/baz/bax
+close: foo/bar/baz/bax
+
+# Repeating the same command should only sync the parent, and then the new data
+# directory itself.
+
+mkdir-all-and-sync-parents fs=mem1 path=foo/bar/baz/bax
+----
+mkdir-all: foo/bar/baz/bax 0755
+open-dir: foo/bar/baz
+sync: foo/bar/baz
+close: foo/bar/baz
+open-dir: foo/bar/baz/bax
+close: foo/bar/baz/bax
+
+mkfs fs=default1
+----
+new default fs
+
+mkdir-all-and-sync-parents fs=default1 path=foo/bar/baz/bax
+----
+mkdir-all: foo/bar/baz/bax 0755
+open-dir: foo/bar/baz
+sync: foo/bar/baz
+close: foo/bar/baz
+open-dir: foo/bar
+sync: foo/bar
+close: foo/bar
+open-dir: foo
+sync: foo
+close: foo
+open-dir: .
+sync: .
+close: .
+open-dir: foo/bar/baz/bax
+close: foo/bar/baz/bax
+
+# Repeating the same command should only sync the parent, and then the new data
+# directory itself.
+
+mkdir-all-and-sync-parents fs=default1 path=foo/bar/baz/bax
+----
+mkdir-all: foo/bar/baz/bax 0755
+open-dir: foo/bar/baz
+sync: foo/bar/baz
+close: foo/bar/baz
+open-dir: foo/bar/baz/bax
+close: foo/bar/baz/bax

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -164,6 +164,9 @@ func (y *MemFS) walk(fullname string, f func(dir *memNode, frag string, final bo
 	for len(fullname) > 0 && fullname[0] == sep[0] {
 		fullname = fullname[1:]
 	}
+	if fullname == "." {
+		fullname = ""
+	}
 	dir := y.root
 
 	for {


### PR DESCRIPTION
Previously Open with a relative path containing a single element would fail on real filesystems, because Open would attempt to open the empty path.

Backport of #3847 for #4268.