### PR TITLE
cache: only sometimes perform metaCheck invariant checks

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -486,7 +486,7 @@ func (c *shard) metaDel(e *entry) (deletedValue *Value) {
 
 // Check that the specified entry is not referenced by the cache.
 func (c *shard) metaCheck(e *entry) {
-	if invariants.Enabled {
+	if invariants.Enabled && invariants.Sometimes(1) {
 		if _, ok := c.entries[e]; ok {
 			fmt.Fprintf(os.Stderr, "%p: %s unexpectedly found in entries map\n%s",
 				e, e.key, debug.Stack())


### PR DESCRIPTION
In invariants builds, perform the invariant checks in metaCheck only 1% of the time. In a Cockroach runtime-assertion roachtest performing an import, these checks consumed 40% of CPU.

Informs cockroachdb/cockroach#139424.
Informs cockroachdb/cockroach#139396.
Informs cockroachdb/cockroach#139485.
Informs cockroachdb/cockroach#139401.
Informs cockroachdb/cockroach#139401.
Informs cockroachdb/cockroach#139446.
