### PR TITLE
colblk: reduce allocations when validating data blocks

### DIFF
--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -28,6 +28,7 @@ func TestDataBlock(t *testing.T) {
 	var buf bytes.Buffer
 	var w DataBlockEncoder
 	var r DataBlockDecoder
+	var v DataBlockValidator
 	var it DataBlockIter
 	rw := NewDataBlockRewriter(&testKeysSchema, testkeys.Comparer.EnsureDefaults())
 	var sizes []int
@@ -111,7 +112,7 @@ func TestDataBlock(t *testing.T) {
 				tp := treeprinter.New()
 				r.Describe(f, tp)
 				fmt.Fprintf(&buf, "LastKey: %s\n%s", lastKey.Pretty(testkeys.Comparer.FormatKey), tp.String())
-				if err := r.Validate(testkeys.Comparer, &testKeysSchema); err != nil {
+				if err := v.Validate(block, testkeys.Comparer, &testKeysSchema); err != nil {
 					fmt.Fprintln(&buf, err)
 				}
 				return buf.String()


### PR DESCRIPTION
In invariant builds, we validate all columnar data blocks as they're constructed. Previously, every Validate call would perform multiple allocations. During an IMPORT on a CockroachDB node running with runtime assertions, these allocations made up 15% of all recent allocations. This commit addresses an existing TODO to address these allocations by reusing allocations within an individual sstable.RawColumnWriter.

```
  34253026   34253026 (flat, cum) 15.14% of Total
         .          .    946:func (d *DataBlockDecoder) Validate(comparer *base.Comparer, keySchema *KeySchema) error {
         .          .    947:	// TODO(jackson): Consider avoiding these allocations, even if this is only
         .          .    948:	// called in invariants builds.
         .          .    949:	n := d.d.header.Rows
   8345320    8345320    950:	meta := &KeySeekerMetadata{}
         .          .    951:	keySchema.InitKeySeekerMetadata(meta, d)
         .          .    952:	keySeeker := keySchema.KeySeeker(meta)
   8665692    8665692    953:	prevKey := base.InternalKey{UserKey: make([]byte, 0, d.maximumKeyLength+1)}
   8651145    8651145    954:	var curKey PrefixBytesIter
   8590869    8590869    955:	curKey.Init(int(d.maximumKeyLength), nil)
         .          .    956:
         .          .    957:	for i := 0; i < int(n); i++ {
         .          .    958:		k := base.InternalKey{
         .          .    959:			UserKey: keySeeker.MaterializeUserKey(&curKey, i-1, i),
         .          .    960:			Trailer: base.InternalKeyTrailer(d.trailers.At(i)),
```

Informs cockroachdb/cockroach#139424.
Informs cockroachdb/cockroach#139396.
Informs cockroachdb/cockroach#139485.
Informs cockroachdb/cockroach#139401.
Informs cockroachdb/cockroach#139446.