### PR TITLE
metamorphic: ignore rangedels for deduplicating point prefixes

### DIFF
--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -1922,9 +1922,9 @@ func (o *dbRatchetFormatMajorVersionOp) run(t *Test, h historyRecorder) {
 	// versions, making the presence of an error and the error message itself
 	// non-deterministic if we attempt to upgrade to an older version.
 	//
-	//Regardless, subsequent operations should behave identically, which is what
-	//we're really aiming to test by including this format major version ratchet
-	//operation.
+	// Regardless, subsequent operations should behave identically, which is
+	// what we're really aiming to test by including this format major version
+	// ratchet operation.
 	if t.getDB(o.dbID).FormatMajorVersion() < o.vers {
 		err = t.getDB(o.dbID).RatchetFormatMajorVersion(o.vers)
 	}

--- a/metamorphic/testdata/key_manager
+++ b/metamorphic/testdata/key_manager
@@ -475,3 +475,31 @@ conflicts merging batch1 into db1: "foo"
 conflicts merging batch1 (collapsed) into db1: (none)
 [db1.Merge("foo", "foo")]
 can singledel on db1: (none)
+
+# Regression test for #4267. In the below example, foo@3 must not be eligible
+# for single delete on db1 at the end of the test. The external object will end
+# up containing the point key foo@3 (NOT foo@5).
+
+reset
+----
+
+run
+add-new-key foo@5
+op db1.Set("foo@5", "foo5")
+add-new-key foo@3
+op db1.Set("foo@3", "foo3")
+op batch1.DeleteRange("a", "foo@3")
+op batch1.Set("foo@3", "foo3batch1")
+op external1 = batch1.NewExternalObj()
+op db1.IngestExternalFiles(external1, "a", "z", "", "")
+singledel-keys db1
+----
+"foo@5" is new
+[db1.Set("foo@5", "foo5")]
+"foo@3" is new
+[db1.Set("foo@3", "foo3")]
+[batch1.DeleteRange("a", "foo@3")]
+[batch1.Set("foo@3", "foo3batch1")]
+[external1 = batch1.NewExternalObj()]
+[db1.IngestExternalFiles(external1, "a" /* start */, "z" /* end */, "" /* syntheticSuffix */, "" /* syntheticPrefix */)]
+can singledel on db1: "foo@5"


### PR DESCRIPTION
When constructing an external object, only the first point key with each unique prefix is added to the sstable. The key manager strives to maintain consistency with this behavior to ensure that the it maintains correct key histories after an ingestion of an external object. The key manager however also will discretize range deletions, sometimes creating keyMetas for keys that do not exist as point keys on the associated writer. The presence of these was confusing the key manager's calculation of which keys would end up in the external object.

This commit updates the external object calculation to account for the existence of the range deletions. Future work may refactor the tracking of range deletions to track range deletions separately from point keys and as continuous spans.

Fix #4267.