### PR TITLE
sstable: change load semaphore to limit bytes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/cespare/xxhash/v2 v2.2.0
-	github.com/cockroachdb/crlib v0.0.0-20241112164430-1264a2edc35b
+	github.com/cockroachdb/crlib v0.0.0-20250110162118-b7c9be99e911
 	github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056
 	github.com/cockroachdb/errors v1.11.3
 	github.com/cockroachdb/metamorphic v0.0.0-20231108215700-4ba948b56895

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/cockroachdb/crlib v0.0.0-20241112164430-1264a2edc35b h1:SHlYZ/bMx7frnmeqCu+xm0TCxXLzX3jQIVuFbnFGtFU=
-github.com/cockroachdb/crlib v0.0.0-20241112164430-1264a2edc35b/go.mod h1:Gq51ZeKaFCXk6QwuGM0w1dnaOqc/F5zKT2zA9D6Xeac=
+github.com/cockroachdb/crlib v0.0.0-20250110162118-b7c9be99e911 h1:X+r2Lb1qj0APqrxM8NhBD3X3JDM1Fe+u+WAvhvKuLdM=
+github.com/cockroachdb/crlib v0.0.0-20250110162118-b7c9be99e911/go.mod h1:Gq51ZeKaFCXk6QwuGM0w1dnaOqc/F5zKT2zA9D6Xeac=
 github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056 h1:slXychO2uDM6hYRu4c0pD0udNI8uObfeKN6UInWViS8=
 github.com/cockroachdb/datadriven v1.0.3-0.20240530155848-7682d40af056/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/cockroachdb/errors v1.11.3 h1:5bA+k2Y6r+oz/6Z/RFlNeVCesGARKuC6YymtcDrbC/I=

--- a/internal/cache/read_shard.go
+++ b/internal/cache/read_shard.go
@@ -34,7 +34,7 @@ import (
 // filesystem reads, where context cancellation is not respected. We do
 // introduce an error duration metric emitted in traces that can be used to
 // quantify such wasteful waiting. Note that this same risk extends to waiting
-// on the Options.LoadBlockSema, so the error duration metric includes the
+// on the Options.LoadBlockBytesSema, so the error duration metric includes the
 // case of an error when waiting on the semaphore (as a side effect of that
 // waiting happening in the caller, sstable.Reader).
 //
@@ -351,7 +351,7 @@ func (e *readEntry) setReadError(err error) {
 //
 // The caller must immediately start doing a read, or can first wait on a
 // shared resource that would also block a different reader if it was assigned
-// the turn instead (specifically, this refers to Options.LoadBlockSema).
+// the turn instead (specifically, this refers to Options.LoadBlockBytesSema).
 // After the read, it must either call SetReadValue or SetReadError depending
 // on whether the read succeeded or failed.
 type ReadHandle struct {

--- a/options.go
+++ b/options.go
@@ -494,10 +494,11 @@ type Options struct {
 	// The default cache size is 8 MB.
 	Cache *cache.Cache
 
-	// LoadBlockSema, if set, is used to limit the number of blocks that can be
-	// loaded (i.e. read from the filesystem) in parallel. Each load acquires one
-	// unit from the semaphore for the duration of the read.
-	LoadBlockSema *fifo.Semaphore
+	// LoadBlockBytesSema, if set, is used to limit the number of bytes that can
+	// be loaded (i.e. read from the filesystem) in parallel. Each block load
+	// acquires X units from the semaphore, where X is the on-disk size of the
+	// block.
+	LoadBlockBytesSema *fifo.Semaphore
 
 	// Cleaner cleans obsolete files.
 	//
@@ -510,7 +511,7 @@ type Options struct {
 		// consulted whenever a read handle is initialized.
 		ReadaheadConfig *ReadaheadConfig
 
-		// TODO(radu): move BytesPerSync, LoadBlockSema, Cleaner here.
+		// TODO(radu): move BytesPerSync, LoadBlockBytesSema, Cleaner here.
 	}
 
 	// Comparer defines a total ordering over the space of []byte keys: a 'less
@@ -2058,7 +2059,7 @@ func (o *Options) MakeReaderOptions() sstable.ReaderOptions {
 		readerOpts.Comparer = o.Comparer
 		readerOpts.Filters = o.Filters
 		readerOpts.KeySchemas = o.KeySchemas
-		readerOpts.LoadBlockSema = o.LoadBlockSema
+		readerOpts.LoadBlockBytesSema = o.LoadBlockBytesSema
 		readerOpts.LoggerAndTracer = o.LoggerAndTracer
 		readerOpts.Merger = o.Merger
 	}


### PR DESCRIPTION
I don't plan to merge until the crdb side is done and reviewed as well.

#### go.mod: update crlib


#### sstable: change load semaphore to limit bytes

Change the block load semaphore to limit the total number of bytes in
outstanding reads, instead of the number of reads. In practice there
shouldn't be a huge difference most of the time, but limiting bytes
protects against more cornercases: we did see cases where many reads
were trying to load the same huge block which led to memory
consumption issues (this particular case was addressed by
deduplicating reads but this mechanism would have saved us from OOMs).
