### PR TITLE
remove deprecated +build directives

### DIFF
--- a/internal/arenaskl/race_test.go
+++ b/internal/arenaskl/race_test.go
@@ -1,5 +1,4 @@
 //go:build race
-// +build race
 
 // Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved. Use
 // of this source code is governed by a BSD-style license that can be found in

--- a/internal/cache/clockpro_normal.go
+++ b/internal/cache/clockpro_normal.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !tracing
-// +build !tracing
 
 package cache
 

--- a/internal/cache/clockpro_tracing.go
+++ b/internal/cache/clockpro_tracing.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build tracing
-// +build tracing
 
 package cache
 

--- a/internal/cache/refcnt_normal.go
+++ b/internal/cache/refcnt_normal.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !tracing
-// +build !tracing
 
 package cache
 

--- a/internal/cache/refcnt_tracing.go
+++ b/internal/cache/refcnt_tracing.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build tracing
-// +build tracing
 
 package cache
 

--- a/internal/devtools/tools.go
+++ b/internal/devtools/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package tools
 

--- a/internal/manual/manual_nocgo.go
+++ b/internal/manual/manual_nocgo.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !cgo
-// +build !cgo
 
 package manual
 

--- a/internal/rawalloc/rawalloc_32bit.go
+++ b/internal/rawalloc/rawalloc_32bit.go
@@ -13,7 +13,6 @@
 // permissions and limitations under the License.
 
 //go:build 386 || amd64p32 || arm || armbe || ppc || sparc
-// +build 386 amd64p32 arm armbe ppc sparc
 
 package rawalloc
 

--- a/internal/rawalloc/rawalloc_64bit.go
+++ b/internal/rawalloc/rawalloc_64bit.go
@@ -13,7 +13,6 @@
 // permissions and limitations under the License.
 
 //go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64 || riscv64 || loong64
-// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64 riscv64 loong64
 
 package rawalloc
 

--- a/internal/rawalloc/rawalloc_gccgo.go
+++ b/internal/rawalloc/rawalloc_gccgo.go
@@ -13,7 +13,6 @@
 // permissions and limitations under the License.
 
 //go:build gccgo
-// +build gccgo
 
 package rawalloc
 

--- a/internal/rawalloc/rawalloc_go1.9.go
+++ b/internal/rawalloc/rawalloc_go1.9.go
@@ -13,7 +13,6 @@
 // permissions and limitations under the License.
 
 //go:build gc && go1.9
-// +build gc,go1.9
 
 package rawalloc
 

--- a/internal/rawalloc/rawalloc_mipsall.go
+++ b/internal/rawalloc/rawalloc_mipsall.go
@@ -13,7 +13,6 @@
 // permissions and limitations under the License.
 
 //go:build mips || mipsle || mips64p32 || mips64p32le
-// +build mips mipsle mips64p32 mips64p32le
 
 package rawalloc
 

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !pebble_obj_io_tracing
-// +build !pebble_obj_io_tracing
 
 package objiotracing
 

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_on.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build pebble_obj_io_tracing
-// +build pebble_obj_io_tracing
 
 package objiotracing
 

--- a/sstable/block/compression_cgo.go
+++ b/sstable/block/compression_cgo.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build cgo
-// +build cgo
 
 package block
 

--- a/sstable/block/compression_nocgo.go
+++ b/sstable/block/compression_nocgo.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !cgo
-// +build !cgo
 
 package block
 

--- a/tool/make_incorrect_manifests.go
+++ b/tool/make_incorrect_manifests.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build make_incorrect_manifests
-// +build make_incorrect_manifests
 
 // Run using: go run -tags make_incorrect_manifests ./tool/make_incorrect_manifests.go
 package main

--- a/tool/make_test_find_db.go
+++ b/tool/make_test_find_db.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build make_test_find_db
-// +build make_test_find_db
 
 // Run using: go run -tags make_test_find_db ./tool/make_test_find_db.go
 package main

--- a/tool/make_test_remotecat.go
+++ b/tool/make_test_remotecat.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build make_test_remotecat
-// +build make_test_remotecat
 
 // Run using: go run -tags make_test_remotecat ./tool/make_test_remotecat.go
 package main

--- a/tool/make_test_sstables.go
+++ b/tool/make_test_sstables.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build make_test_sstables
-// +build make_test_sstables
 
 // Run using: go run -tags make_test_sstables ./tool/make_test_sstables.go
 package main

--- a/vfs/default_linux.go
+++ b/vfs/default_linux.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package vfs
 

--- a/vfs/default_unix.go
+++ b/vfs/default_unix.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd netbsd openbsd solaris
 
 package vfs
 

--- a/vfs/default_windows.go
+++ b/vfs/default_windows.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package vfs
 

--- a/vfs/disk_usage_linux.go
+++ b/vfs/disk_usage_linux.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package vfs
 

--- a/vfs/disk_usage_netbsd.go
+++ b/vfs/disk_usage_netbsd.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build netbsd
-// +build netbsd
 
 package vfs
 

--- a/vfs/disk_usage_openbsd.go
+++ b/vfs/disk_usage_openbsd.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build openbsd
-// +build openbsd
 
 package vfs
 

--- a/vfs/disk_usage_unix.go
+++ b/vfs/disk_usage_unix.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd
-// +build darwin dragonfly freebsd
 
 package vfs
 

--- a/vfs/disk_usage_windows.go
+++ b/vfs/disk_usage_windows.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package vfs
 

--- a/vfs/errors_unix.go
+++ b/vfs/errors_unix.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || openbsd || netbsd
-// +build darwin dragonfly freebsd linux openbsd netbsd
 
 package vfs
 

--- a/vfs/errors_unix_test.go
+++ b/vfs/errors_unix_test.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || openbsd || netbsd
-// +build darwin dragonfly freebsd linux openbsd netbsd
 
 package vfs
 

--- a/vfs/errors_windows.go
+++ b/vfs/errors_windows.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package vfs
 

--- a/vfs/fadvise_generic.go
+++ b/vfs/fadvise_generic.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package vfs
 

--- a/vfs/fadvise_linux.go
+++ b/vfs/fadvise_linux.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package vfs
 

--- a/vfs/file_lock_generic.go
+++ b/vfs/file_lock_generic.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
-// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!windows
 
 package vfs
 

--- a/vfs/file_lock_unix.go
+++ b/vfs/file_lock_unix.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package vfs
 

--- a/vfs/file_lock_windows.go
+++ b/vfs/file_lock_windows.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build windows
-// +build windows
 
 package vfs
 

--- a/vfs/syncing_file_linux_test.go
+++ b/vfs/syncing_file_linux_test.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build linux && !arm
-// +build linux,!arm
 
 package vfs
 


### PR DESCRIPTION
The `+build` directive has been deprecated in favor of `go:build` many
Go releases ago.