### PR TITLE
sstable: validate index separator keys before writing

### DIFF
--- a/cockroachkvs/cockroachkvs.go
+++ b/cockroachkvs/cockroachkvs.go
@@ -1013,7 +1013,10 @@ func memmove(to, from unsafe.Pointer, n uintptr)
 
 var validateEngineKey base.ValidateKey = func(k []byte) error {
 	if len(k) == 0 {
-		return errors.AssertionFailedf("empty key")
+		// It would be nice to assert that the key is not empty, but
+		// unfortunately separator keys within index blocks may be empty in the
+		// case that a sstable (and its single data block) has no keys.
+		return nil
 	}
 	if int(k[len(k)-1]) >= len(k) {
 		return errors.AssertionFailedf("malformed key terminator byte: %x", k)


### PR DESCRIPTION
**cockroachkvs: allow empty keys in ValidateKey**

Previously (cockroachkvs.Comparer).ValidateKey considered an empty key to be
invalid. Empty keys are possible in some circumstances (notably in an index
block in a sstable that contains no point keys). Adapt ValidateKey to allow
these keys so that we can apply ValidateKey to separator keys.

**sstable: validate separator keys before writing**

Validate separator keys before writing them out to an index block by calling
Comparer.ValidateKey.