### PR TITLE
record: refactor chunk types, errors, logNum EOF handling

### DIFF
--- a/open.go
+++ b/open.go
@@ -941,8 +941,11 @@ func (d *DB) replayWAL(
 			// to otherwise treat them like EOF.
 			if err == io.EOF {
 				break
-			} else if record.IsInvalidRecord(err) && !strictWALTail {
-				break
+			} else if record.IsInvalidRecord(err) {
+				if !strictWALTail {
+					break
+				}
+				err = errors.Mark(err, ErrCorruption)
 			}
 			return nil, 0, errors.Wrap(err, "pebble: error when replaying WAL")
 		}

--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -961,7 +961,7 @@ func (w *LogWriter) emitEOFTrailer() {
 	i := b.written.Load()
 	binary.LittleEndian.PutUint32(b.buf[i+0:i+4], 0) // CRC
 	binary.LittleEndian.PutUint16(b.buf[i+4:i+6], 0) // Size
-	b.buf[i+6] = recyclableFullChunkType
+	b.buf[i+6] = recyclableFullChunkEncoding
 	binary.LittleEndian.PutUint32(b.buf[i+7:i+11], w.logNum+1) // Log number
 	b.written.Store(i + int32(recyclableHeaderSize))
 }
@@ -974,15 +974,15 @@ func (w *LogWriter) emitFragment(n int, p []byte) (remainingP []byte) {
 
 	if last {
 		if first {
-			b.buf[i+6] = recyclableFullChunkType
+			b.buf[i+6] = recyclableFullChunkEncoding
 		} else {
-			b.buf[i+6] = recyclableLastChunkType
+			b.buf[i+6] = recyclableLastChunkEncoding
 		}
 	} else {
 		if first {
-			b.buf[i+6] = recyclableFirstChunkType
+			b.buf[i+6] = recyclableFirstChunkEncoding
 		} else {
-			b.buf[i+6] = recyclableMiddleChunkType
+			b.buf[i+6] = recyclableMiddleChunkEncoding
 		}
 	}
 

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -828,8 +828,8 @@ func TestInvalidLogNum(t *testing.T) {
 
 	{
 		r := NewReader(bytes.NewReader(buf.Bytes()), 2)
-		if _, err := r.Next(); err != io.EOF {
-			t.Fatalf("expected %s, but found %s\n", io.EOF, err)
+		if _, err := r.Next(); err != ErrInvalidChunk {
+			t.Fatalf("expected %s, but found %s\n", ErrInvalidChunk, err)
 		}
 	}
 }


### PR DESCRIPTION
Previously, record.go used and manipulated chunkType (the "Type" byte in the chunk header) clumsily to branch in record nextChunk(). The calculations make adding future wire formats difficult. This PR introduces a mapping from the encoded "Type" byte to the corresponding chunk type, wire format, and header size for simplicity and ease of updates in the future.

ErrZeroedChunk and ErrInvalidChunk are updated to be initialized using errors.New() instead of base.CorruptionErrorf due to a bug in using errors.Is() to check propagated errors (like in tools/wal.go). The errors are marked as ErrCorruption in replayWal().

Nonmatching log numbers are handled more precisely in record.go. Previously any nonmatching log number could be marked as an EOF as long as wantFirst == true. EmitEOFTrailer, however, will only write a log number that is 1 greater than the current log number. An update is added to strengthen the requriements to return EOF from nextChunk() in the event of a nonmatching log number, exactly when the decoded logNum is equal to the reader's log number + 1.