### PR TITLE
objstorage: add FileTypeBlob

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2320,7 +2320,7 @@ func (d *DB) cleanupVersionEdit(ve *versionEdit) {
 		// Add this file to zombie tables as well, as the versionSet
 		// asserts on whether every obsolete file was at one point
 		// marked zombie.
-		d.mu.versions.zombieTables[obsoleteFiles[i].DiskFileNum] = tableInfo{
+		d.mu.versions.zombieTables[obsoleteFiles[i].DiskFileNum] = objectInfo{
 			fileInfo: fileInfo{
 				FileNum:  obsoleteFiles[i].DiskFileNum,
 				FileSize: obsoleteFiles[i].Size,
@@ -2936,7 +2936,7 @@ func (d *DB) runCompaction(
 			// Add this file to zombie tables as well, as the versionSet
 			// asserts on whether every obsolete file was at one point
 			// marked zombie.
-			d.mu.versions.zombieTables[backing.DiskFileNum] = tableInfo{
+			d.mu.versions.zombieTables[backing.DiskFileNum] = objectInfo{
 				fileInfo: fileInfo{
 					FileNum:  backing.DiskFileNum,
 					FileSize: backing.Size,

--- a/internal/base/cleaner.go
+++ b/internal/base/cleaner.go
@@ -40,7 +40,7 @@ var _ NeedsFileContents = ArchiveCleaner{}
 // also write to the secondary. We should consider archiving to the primary.
 func (ArchiveCleaner) Clean(fs vfs.FS, fileType FileType, path string) error {
 	switch fileType {
-	case FileTypeLog, FileTypeManifest, FileTypeTable:
+	case FileTypeLog, FileTypeManifest, FileTypeTable, FileTypeBlob:
 		destDir := fs.PathJoin(fs.PathDir(path), "archive")
 
 		if err := fs.MkdirAll(destDir, 0755); err != nil {

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -61,7 +61,43 @@ const (
 	FileTypeOptions
 	FileTypeOldTemp
 	FileTypeTemp
+	FileTypeBlob
 )
+
+var fileTypeStrings = [...]string{
+	FileTypeLog:      "log",
+	FileTypeLock:     "lock",
+	FileTypeTable:    "sstable",
+	FileTypeManifest: "manifest",
+	FileTypeOptions:  "options",
+	FileTypeOldTemp:  "old-temp",
+	FileTypeTemp:     "temp",
+	FileTypeBlob:     "blob",
+}
+
+// FileTypeFromName parses a FileType from its string representation.
+func FileTypeFromName(name string) FileType {
+	for i, s := range fileTypeStrings {
+		if s == name {
+			return FileType(i)
+		}
+	}
+	panic(fmt.Sprintf("unknown file type: %q", name))
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (ft FileType) SafeFormat(w redact.SafePrinter, _ rune) {
+	if ft < 0 || int(ft) >= len(fileTypeStrings) {
+		w.Print(redact.SafeString("unknown"))
+		return
+	}
+	w.Print(redact.SafeString(fileTypeStrings[ft]))
+}
+
+// String implements fmt.Stringer.
+func (ft FileType) String() string {
+	return redact.StringWithoutMarkers(ft)
+}
 
 // MakeFilename builds a filename from components.
 func MakeFilename(fileType FileType, dfn DiskFileNum) string {
@@ -80,6 +116,8 @@ func MakeFilename(fileType FileType, dfn DiskFileNum) string {
 		return fmt.Sprintf("CURRENT.%s.dbtmp", dfn)
 	case FileTypeTemp:
 		return fmt.Sprintf("temporary.%s.dbtmp", dfn)
+	case FileTypeBlob:
+		return fmt.Sprintf("%s.blob", dfn)
 	}
 	panic("unreachable")
 }
@@ -130,10 +168,11 @@ func ParseFilename(fs vfs.FS, filename string) (fileType FileType, dfn DiskFileN
 		if !ok {
 			break
 		}
-		// TODO(sumeer): stop handling FileTypeLog in this function.
 		switch filename[i+1:] {
 		case "sst":
 			return FileTypeTable, dfn, true
+		case "blob":
+			return FileTypeBlob, dfn, true
 		}
 	}
 	return 0, dfn, false

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -45,6 +45,10 @@ func TestParseFilename(t *testing.T) {
 		"CURRENT.dbtmp":          false,
 		"CURRENT.123456.dbtmp":   true,
 		"temporary.123456.dbtmp": true,
+		"foo.blob":               false,
+		"000000.blob":            true,
+		"000001.blob":            true,
+		"935203523.blob":         true,
 	}
 	fs := vfs.NewMem()
 	for tc, want := range testCases {
@@ -65,6 +69,7 @@ func TestFilenameRoundTrip(t *testing.T) {
 		FileTypeOptions:  true,
 		FileTypeOldTemp:  true,
 		FileTypeTemp:     true,
+		FileTypeBlob:     true,
 		// NB: Log filenames are created and parsed elsewhere in the wal/
 		// package.
 		// FileTypeLog:      true,

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -488,13 +488,13 @@ func (p *provider) Lookup(
 	if !ok {
 		return objstorage.ObjectMetadata{}, errors.Wrapf(
 			os.ErrNotExist,
-			"file %s (type %d) unknown to the objstorage provider",
-			fileNum, errors.Safe(fileType),
+			"file %s (type %s) unknown to the objstorage provider",
+			fileNum, fileType,
 		)
 	}
 	if meta.FileType != fileType {
 		return objstorage.ObjectMetadata{}, base.AssertionFailedf(
-			"file %s type mismatch (known type %d, expected type %d)",
+			"file %s type mismatch (known type %s, expected type %s)",
 			fileNum, errors.Safe(meta.FileType), errors.Safe(fileType),
 		)
 	}
@@ -549,8 +549,8 @@ func (p *provider) CheckpointState(
 		if _, ok := p.mu.knownObjects[fileNums[i]]; !ok {
 			return errors.Wrapf(
 				os.ErrNotExist,
-				"file %s (type %d) unknown to the objstorage provider",
-				fileNums[i], errors.Safe(fileType),
+				"file %s (type %s) unknown to the objstorage provider",
+				fileNums[i], fileType,
 			)
 		}
 		// Prevent this object from deletion, at least for the life of this instance.

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -110,6 +110,11 @@ func TestProvider(t *testing.T) {
 				opts := objstorage.CreateOptions{
 					SharedCleanupMethod: objstorage.SharedRefTracking,
 				}
+				ft := base.FileTypeTable
+				if len(d.CmdArgs) > 0 && d.CmdArgs[0].Key == "file-type" {
+					ft = base.FileTypeFromName(d.CmdArgs[0].FirstVal(t))
+					d.CmdArgs = d.CmdArgs[1:]
+				}
 				if len(d.CmdArgs) == 5 && d.CmdArgs[4].Key == "no-ref-tracking" {
 					d.CmdArgs = d.CmdArgs[:4]
 					opts.SharedCleanupMethod = objstorage.SharedNoCleanup
@@ -117,7 +122,7 @@ func TestProvider(t *testing.T) {
 				var fileNum base.DiskFileNum
 				var typ string
 				var salt, size int
-				scanArgs("<file-num> <local|shared> <salt> <size> [no-ref-tracking]", &fileNum, &typ, &salt, &size)
+				scanArgs("[file-type=sstable|blob] <file-num> <local|shared> <salt> <size> [no-ref-tracking]", &fileNum, &typ, &salt, &size)
 				switch typ {
 				case "local":
 				case "shared":
@@ -125,7 +130,7 @@ func TestProvider(t *testing.T) {
 				default:
 					d.Fatalf(t, "'%s' should be 'local' or 'shared'", typ)
 				}
-				w, _, err := curProvider.Create(ctx, base.FileTypeTable, fileNum, opts)
+				w, _, err := curProvider.Create(ctx, ft, fileNum, opts)
 				if err != nil {
 					return err.Error()
 				}
@@ -141,6 +146,11 @@ func TestProvider(t *testing.T) {
 				opts := objstorage.CreateOptions{
 					SharedCleanupMethod: objstorage.SharedRefTracking,
 				}
+				ft := base.FileTypeTable
+				if len(d.CmdArgs) > 0 && d.CmdArgs[0].Key == "file-type" {
+					ft = base.FileTypeFromName(d.CmdArgs[0].FirstVal(t))
+					d.CmdArgs = d.CmdArgs[1:]
+				}
 				if len(d.CmdArgs) == 5 && d.CmdArgs[4].Key == "no-ref-tracking" {
 					d.CmdArgs = d.CmdArgs[:4]
 					opts.SharedCleanupMethod = objstorage.SharedNoCleanup
@@ -148,7 +158,7 @@ func TestProvider(t *testing.T) {
 				var fileNum base.DiskFileNum
 				var typ string
 				var salt, size int
-				scanArgs("<file-num> <local|shared> <salt> <size> [no-ref-tracking]", &fileNum, &typ, &salt, &size)
+				scanArgs("[file-type=sstable|blob] <file-num> <local|shared> <salt> <size> [no-ref-tracking]", &fileNum, &typ, &salt, &size)
 				switch typ {
 				case "local":
 				case "shared":
@@ -168,9 +178,7 @@ func TestProvider(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 
-				_, err = curProvider.LinkOrCopyFromLocal(
-					ctx, fs, tmpFilename, base.FileTypeTable, fileNum, opts,
-				)
+				_, err = curProvider.LinkOrCopyFromLocal(ctx, fs, tmpFilename, ft, fileNum, opts)
 				require.NoError(t, err)
 				return log.String()
 
@@ -195,10 +203,15 @@ func TestProvider(t *testing.T) {
 					}
 				}
 
+				ft := base.FileTypeTable
+				if len(d.CmdArgs) > 0 && d.CmdArgs[0].Key == "file-type" {
+					ft = base.FileTypeFromName(d.CmdArgs[0].FirstVal(t))
+					d.CmdArgs = d.CmdArgs[1:]
+				}
 				d.CmdArgs = d.CmdArgs[:1]
 				var fileNum base.DiskFileNum
-				scanArgs("<file-num> [for-compaction] [readahead|speculative-overhead=off|sys-readahead|fadvise-sequential]", &fileNum)
-				r, err := curProvider.OpenForReading(ctx, base.FileTypeTable, fileNum, objstorage.OpenOptions{})
+				scanArgs("[file-type=sstable|blob] <file-num> [for-compaction] [readahead|speculative-overhead=off|sys-readahead|fadvise-sequential]", &fileNum)
+				r, err := curProvider.OpenForReading(ctx, ft, fileNum, objstorage.OpenOptions{})
 				if err != nil {
 					return err.Error()
 				}
@@ -231,9 +244,14 @@ func TestProvider(t *testing.T) {
 				return log.String()
 
 			case "remove":
+				ft := base.FileTypeTable
+				if len(d.CmdArgs) > 0 && d.CmdArgs[0].Key == "file-type" {
+					ft = base.FileTypeFromName(d.CmdArgs[0].FirstVal(t))
+					d.CmdArgs = d.CmdArgs[1:]
+				}
 				var fileNum base.DiskFileNum
-				scanArgs("<file-num>", &fileNum)
-				if err := curProvider.Remove(base.FileTypeTable, fileNum); err != nil {
+				scanArgs("[file-type=sstable|blob] <file-num>", &fileNum)
+				if err := curProvider.Remove(ft, fileNum); err != nil {
 					return err.Error()
 				}
 				return log.String()

--- a/objstorage/objstorageprovider/testdata/provider/local
+++ b/objstorage/objstorageprovider/testdata/provider/local
@@ -62,7 +62,7 @@ list
 
 read 1
 ----
-file 000001 (type 2) unknown to the objstorage provider: file does not exist
+file 000001 (type sstable) unknown to the objstorage provider: file does not exist
 
 link-or-copy 3 local 3 100
 ----
@@ -93,6 +93,38 @@ size: 1234
 <local fs> read-at(0, 1234): p0/000004.sst
 0 1234: ok (salt 4)
 <local fs> close: p0/000004.sst
+
+create file-type=blob 000005 local 1 4096
+----
+<local fs> create: p0/000005.blob
+<local fs> sync-data: p0/000005.blob
+<local fs> close: p0/000005.blob
+
+read file-type=blob 000005
+0 1024
+2048 1024
+----
+<local fs> open: p0/000005.blob (options: *vfs.randomReadsOption)
+size: 4096
+<local fs> read-at(0, 1024): p0/000005.blob
+0 1024: ok (salt 1)
+<local fs> read-at(2048, 1024): p0/000005.blob
+2048 1024: ok (salt 1)
+<local fs> close: p0/000005.blob
+
+link-or-copy file-type=blob 000006 shared 6 1234
+----
+<local fs> create: temp-file-3
+<local fs> close: temp-file-3
+<local fs> link: temp-file-3 -> p0/000006.blob
+
+list
+----
+000002 -> p0/000002.sst
+000003 -> p0/000003.sst
+000004 -> p0/000004.sst
+000005 -> p0/000005.blob
+000006 -> p0/000006.blob
 
 close
 ----

--- a/objstorage/objstorageprovider/vfs.go
+++ b/objstorage/objstorageprovider/vfs.go
@@ -73,12 +73,15 @@ func (p *provider) vfsInit() error {
 
 	for _, filename := range listing {
 		fileType, fileNum, ok := base.ParseFilename(p.st.FS, filename)
-		if ok && fileType == base.FileTypeTable {
-			o := objstorage.ObjectMetadata{
-				FileType:    fileType,
-				DiskFileNum: fileNum,
+		if ok {
+			switch fileType {
+			case base.FileTypeTable, base.FileTypeBlob:
+				o := objstorage.ObjectMetadata{
+					FileType:    fileType,
+					DiskFileNum: fileNum,
+				}
+				p.mu.knownObjects[o.DiskFileNum] = o
 			}
-			p.mu.knownObjects[o.DiskFileNum] = o
 		}
 	}
 	return nil

--- a/open.go
+++ b/open.go
@@ -403,7 +403,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 
 	if manifestExists && !opts.DisableConsistencyCheck {
 		curVersion := d.mu.versions.currentVersion()
-		if err := checkConsistency(curVersion, dirname, d.objProvider); err != nil {
+		if err := checkConsistency(curVersion, d.objProvider); err != nil {
 			return nil, err
 		}
 	}
@@ -1238,7 +1238,7 @@ func IsCorruptionError(err error) bool {
 	return errors.Is(err, base.ErrCorruption)
 }
 
-func checkConsistency(v *manifest.Version, dirname string, objProvider objstorage.Provider) error {
+func checkConsistency(v *manifest.Version, objProvider objstorage.Provider) error {
 	var errs []error
 	dedup := make(map[base.DiskFileNum]struct{})
 	for level, files := range v.Levels {

--- a/open_test.go
+++ b/open_test.go
@@ -1417,7 +1417,7 @@ func TestCheckConsistency(t *testing.T) {
 				}
 
 				v := manifest.NewVersion(base.DefaultComparer, 0, filesByLevel)
-				err := checkConsistency(v, dir, provider)
+				err := checkConsistency(v, provider)
 				if err != nil {
 					if redactErr {
 						redacted := redact.Sprint(err).Redact()

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -206,6 +206,19 @@ create: db1/000456.sst
 sync: db1/000456.sst
 close: db1/000456.sst
 
+create-bogus-file db1/000234.blob
+----
+create: db1/000234.blob
+sync: db1/000234.blob
+close: db1/000234.blob
+
+create-bogus-file db1/000345.blob
+----
+create: db1/000345.blob
+sync: db1/000345.blob
+close: db1/000345.blob
+
+
 open db1
 ----
 mkdir-all: db1 0755
@@ -249,6 +262,8 @@ rename: db1/temporary.000460.dbtmp -> db1/OPTIONS-000460
 sync: db1
 remove: db1/000123.sst
 remove: db1/000456.sst
+remove: db1/000234.blob
+remove: db1/000345.blob
 remove: db1/OPTIONS-000003
 
 list db1

--- a/testdata/version_check_consistency
+++ b/testdata/version_check_consistency
@@ -13,25 +13,25 @@ check-consistency
 L0
   000005:10
 ----
-L0: 000005: file 000005 (type 2) unknown to the objstorage provider: file does not exist
+L0: 000005: file 000005 (type sstable) unknown to the objstorage provider: file does not exist
 
 check-consistency
 L0
   000001:10
 ----
-L0: 000001: file 000001 (type 2) unknown to the objstorage provider: file does not exist
+L0: 000001: file 000001 (type sstable) unknown to the objstorage provider: file does not exist
 
 check-consistency
 L0
   000001:11
 ----
-L0: 000001: file 000001 (type 2) unknown to the objstorage provider: file does not exist
+L0: 000001: file 000001 (type sstable) unknown to the objstorage provider: file does not exist
 
 check-consistency redact
 L0
   000001:11
 ----
-L0: 000001: file 000001 (type 2) unknown to the objstorage provider: file does not exist
+L0: 000001: file 000001 (type sstable) unknown to the objstorage provider: file does not exist
 
 check-consistency
 L0
@@ -41,9 +41,9 @@ L1
 L2
   000003:30
 ----
-L0: 000001: file 000001 (type 2) unknown to the objstorage provider: file does not exist
-L1: 000002: file 000002 (type 2) unknown to the objstorage provider: file does not exist
-L2: 000003: file 000003 (type 2) unknown to the objstorage provider: file does not exist
+L0: 000001: file 000001 (type sstable) unknown to the objstorage provider: file does not exist
+L1: 000002: file 000002 (type sstable) unknown to the objstorage provider: file does not exist
+L2: 000003: file 000003 (type sstable) unknown to the objstorage provider: file does not exist
 
 check-consistency
 L0
@@ -53,9 +53,9 @@ L1
 L2
   000003:33
 ----
-L0: 000001: file 000001 (type 2) unknown to the objstorage provider: file does not exist
-L1: 000002: file 000002 (type 2) unknown to the objstorage provider: file does not exist
-L2: 000003: file 000003 (type 2) unknown to the objstorage provider: file does not exist
+L0: 000001: file 000001 (type sstable) unknown to the objstorage provider: file does not exist
+L1: 000002: file 000002 (type sstable) unknown to the objstorage provider: file does not exist
+L2: 000003: file 000003 (type sstable) unknown to the objstorage provider: file does not exist
 
 check-consistency redact
 L0
@@ -65,6 +65,6 @@ L1
 L2
   000004:30
 ----
-L0: 000001: file 000001 (type 2) unknown to the objstorage provider: file does not exist
-L1: 000002: file 000002 (type 2) unknown to the objstorage provider: file does not exist
-L2: 000004: file 000004 (type 2) unknown to the objstorage provider: file does not exist
+L0: 000001: file 000001 (type sstable) unknown to the objstorage provider: file does not exist
+L1: 000002: file 000002 (type sstable) unknown to the objstorage provider: file does not exist
+L2: 000004: file 000004 (type sstable) unknown to the objstorage provider: file does not exist

--- a/tool/testdata/db_excise
+++ b/tool/testdata/db_excise
@@ -52,7 +52,7 @@ scanned 2 records in 1.0s
 
 db scan testdata/broken-external-db
 ----
-L0: 000008: file 000008 (type 2) unknown to the objstorage provider: file does not exist
+L0: 000008: file 000008 (type sstable) unknown to the objstorage provider: file does not exist
 
 # The database LSM is as follows:
 #   L0.0:


### PR DESCRIPTION
  Introduce a new file type for blob files. These files will contain the values
  for keys stored in separate sstables. This commit introduces the new file type
  and plumbs some simple machinery, including around deleting obsolete blob files
  subject to the same deletion pacing as sstables.


Informs #112.