### PR TITLE
db: use BufferPool on external iterators

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -49,14 +49,8 @@ func NewExternalIterWithContext(
 	}
 
 	var readers [][]*sstable.Reader
-
-	seqNumOffset := 0
 	for _, levelFiles := range files {
-		seqNumOffset += len(levelFiles)
-	}
-	for _, levelFiles := range files {
-		seqNumOffset -= len(levelFiles)
-		subReaders, err := openExternalTables(ctx, o, levelFiles, seqNumOffset, o.MakeReaderOptions())
+		subReaders, err := openExternalTables(ctx, levelFiles, o.MakeReaderOptions())
 		readers = append(readers, subReaders)
 		if err != nil {
 			// Close all the opened readers.
@@ -258,9 +252,7 @@ func finishInitializingExternal(ctx context.Context, it *Iterator) error {
 
 func openExternalTables(
 	ctx context.Context,
-	o *Options,
 	files []sstable.ReadableFile,
-	seqNumOffset int,
 	readerOpts sstable.ReaderOptions,
 ) (readers []*sstable.Reader, err error) {
 	readers = make([]*sstable.Reader, 0, len(files))


### PR DESCRIPTION
Use a block.BufferPool to hold on to allocated block buffers during iteration
of external sstables. During external iteration, blocks read aren't inserted
into a shared block cache. Previously this meant that every block read
allocated a new buffer for the block. Using a small buffer pool allows block
reads to reuse buffers over the life of the external iterator, reducing CPU
from requesting memory from the memory allocator. Additionally, plumbing a
buffer pool means the block reader won't attempt to store the block in the
zero-sized, ephemeral block cache used by the external iterator.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble
cpu: Apple M1 Pro
                                                          │   old.txt   │               new.txt               │
                                                          │   sec/op    │   sec/op     vs base                │
ExternalIter_NonOverlapping_Scan/keys=100/files=1-10        34.05µ ± 1%   27.64µ ± 1%  -18.81% (p=0.000 n=10)
ExternalIter_NonOverlapping_Scan/keys=100/files=10-10       121.3µ ± 1%   112.8µ ± 1%   -6.96% (p=0.000 n=10)
ExternalIter_NonOverlapping_Scan/keys=100/files=100-10      1.045m ± 2%   1.016m ± 2%   -2.77% (p=0.000 n=10)
ExternalIter_NonOverlapping_Scan/keys=10000/files=1-10      2.413m ± 1%   1.754m ± 1%  -27.32% (p=0.000 n=10)
ExternalIter_NonOverlapping_Scan/keys=10000/files=10-10     2.756m ± 4%   2.172m ± 8%  -21.18% (p=0.000 n=10)
ExternalIter_NonOverlapping_Scan/keys=10000/files=100-10    4.068m ± 2%   3.671m ± 1%   -9.76% (p=0.000 n=10)
ExternalIter_NonOverlapping_Scan/keys=100000/files=1-10     24.42m ± 1%   17.72m ± 2%  -27.46% (p=0.000 n=10)
ExternalIter_NonOverlapping_Scan/keys=100000/files=10-10    27.39m ± 1%   21.11m ± 2%  -22.92% (p=0.000 n=10)
ExternalIter_NonOverlapping_Scan/keys=100000/files=100-10   32.01m ± 1%   27.68m ± 2%  -13.50% (p=0.000 n=10)
geomean                                                     2.385m        1.976m       -17.16%
```
