### PR TITLE
db: add CacheSize option

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -55,10 +55,8 @@ type pebbleDB struct {
 }
 
 func newPebbleDB(dir string) DB {
-	cache := pebble.NewCache(cacheSize)
-	defer cache.Unref()
 	opts := &pebble.Options{
-		Cache:                       cache,
+		CacheSize:                   cacheSize,
 		Comparer:                    &cockroachkvs.Comparer,
 		DisableWAL:                  disableWAL,
 		FormatMajorVersion:          pebble.FormatNewest,

--- a/external_test.go
+++ b/external_test.go
@@ -49,7 +49,6 @@ func TestIteratorErrors(t *testing.T) {
 		testOpts.Opts.FS = vfs.NewMem()
 	}
 
-	testOpts.Opts.Cache.Ref()
 	{
 		test, err := metamorphic.New(metamorphic.GenerateOps(
 			rng, 10000, kf, metamorphic.WriteOpConfig()),

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -32,8 +32,6 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 
 	// Generate a random database by running the metamorphic test.
 	testOpts := metamorphic.RandomOptions(rng, metamorphic.TestkeysKeyFormat, nil /* custom opt parsers */)
-	testOpts.Opts.Cache.Ref()
-	defer testOpts.Opts.Cache.Unref()
 	{
 		nOps := 10000
 		if buildtags.Race {

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -48,7 +47,6 @@ func parseOptions(
 	opts *TestOptions, data string, customOptionParsers map[string]func(string) (CustomOption, bool),
 ) error {
 	hooks := &pebble.ParseHooks{
-		NewCache: pebble.NewCache,
 		NewComparer: func(name string) (*pebble.Comparer, error) {
 			for _, kf := range knownKeyFormats {
 				if kf.Comparer.Name == name {
@@ -671,8 +669,8 @@ func RandomOptions(
 		}
 	}
 
-	opts.BytesPerSync = 1 << uint(rng.IntN(28))     // 1B - 256MB
-	opts.Cache = cache.New(1 << uint(rng.IntN(30))) // 1B - 1GB
+	opts.BytesPerSync = 1 << uint(rng.IntN(28)) // 1B - 256MB
+	opts.CacheSize = 1 << uint(rng.IntN(30))    // 1B - 1GB
 	opts.DisableWAL = rng.IntN(2) == 0
 	opts.FlushDelayDeleteRange = time.Millisecond * time.Duration(5*rng.IntN(245)) // 5-250ms
 	opts.FlushDelayRangeKey = time.Millisecond * time.Duration(5*rng.IntN(245))    // 5-250ms

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -115,7 +115,9 @@ func (t *Test) init(
 
 	t.opsWaitOn, t.opsDone = computeSynchronizationPoints(t.ops)
 
-	defer t.opts.Cache.Unref()
+	if t.opts.Cache != nil {
+		defer t.opts.Cache.Unref()
+	}
 
 	// If an error occurs and we were using an in-memory FS, attempt to clone to
 	// on-disk in order to allow post-mortem debugging. Note that always using
@@ -285,7 +287,6 @@ func (t *Test) restartDB(dbID objID) error {
 	if len(t.dbs) > 1 {
 		return nil
 	}
-	t.opts.Cache.Ref()
 	fs := vfs.Root(t.opts.FS).(*vfs.MemFS)
 	crashFS := fs.CrashClone(vfs.CrashCloneCfg{UnsyncedDataPercent: 0})
 	if err := db.Close(); err != nil {
@@ -326,7 +327,6 @@ func (t *Test) restartDB(dbID objID) error {
 		}
 		return err
 	})
-	t.opts.Cache.Unref()
 	return err
 }
 

--- a/open.go
+++ b/open.go
@@ -206,7 +206,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	}
 
 	if opts.Cache == nil {
-		opts.Cache = cache.New(cacheDefaultSize)
+		opts.Cache = cache.New(opts.CacheSize)
 	} else {
 		opts.Cache.Ref()
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -240,13 +240,8 @@ func TestOptionsParse(t *testing.T) {
 	testComparer.Name = "test-comparer"
 	testMerger := *DefaultMerger
 	testMerger.Name = "test-merger"
-	var newCacheSize int64
 
 	hooks := &ParseHooks{
-		NewCache: func(size int64) *Cache {
-			newCacheSize = size
-			return nil
-		},
 		NewCleaner: func(name string) (Cleaner, error) {
 			if name == (testCleaner{}).String() {
 				return testCleaner{}, nil
@@ -306,7 +301,6 @@ func TestOptionsParse(t *testing.T) {
 			opts.EnsureDefaults()
 			str := opts.String()
 
-			newCacheSize = 0
 			var parsedOptions Options
 			require.NoError(t, parsedOptions.Parse(str, hooks))
 			parsedStr := parsedOptions.String()
@@ -314,7 +308,6 @@ func TestOptionsParse(t *testing.T) {
 				t.Fatalf("expected\n%s\nbut found\n%s", str, parsedStr)
 			}
 			require.Nil(t, parsedOptions.Cache)
-			require.NotEqual(t, newCacheSize, 0)
 		})
 	}
 }


### PR DESCRIPTION
Add a `CacheSize` option which is used when a `Cache` is not
specified. This removes the need for the awkward `NewCache` option
parsing hook, which creates a `Cache` that has to be `Unref`ed
elsewhere.