### PR TITLE
db: minor file cache cleanup

### DIFF
--- a/db.go
+++ b/db.go
@@ -305,7 +305,7 @@ type DB struct {
 	fileLock *Lock
 	dataDir  vfs.File
 
-	fileCache            *fileCacheContainer
+	fileCache            *fileCacheHandle
 	newIters             tableNewIters
 	tableNewRangeKeyIter keyspanimpl.TableNewSpanIter
 

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -80,7 +80,7 @@ func (fs *fileCacheTestFS) validate(
 		t.Error(err)
 		return
 	}
-	c.close()
+	c.Close()
 	if err := fs.validateNoneStillOpen(); err != nil {
 		t.Error(err)
 		return
@@ -919,7 +919,7 @@ func TestFileCacheIterLeak(t *testing.T) {
 	iters, err := c.newIters(context.Background(), m, nil, internalIterOpts{}, iterPointKeys)
 	require.NoError(t, err)
 
-	if err := c.close(); err == nil {
+	if err := c.Close(); err == nil {
 		t.Fatalf("expected failure, but found success")
 	} else if !strings.HasPrefix(err.Error(), "leaked iterators:") {
 		t.Fatalf("expected leaked iterators, but found %+v", err)
@@ -946,7 +946,7 @@ func TestSharedFileCacheIterLeak(t *testing.T) {
 	iters, err := c1.newIters(context.Background(), m, nil, internalIterOpts{}, iterPointKeys)
 	require.NoError(t, err)
 
-	if err := c1.close(); err == nil {
+	if err := c1.Close(); err == nil {
 		t.Fatalf("expected failure, but found success")
 	} else if !strings.HasPrefix(err.Error(), "leaked iterators:") {
 		t.Fatalf("expected leaked iterators, but found %+v", err)
@@ -955,12 +955,12 @@ func TestSharedFileCacheIterLeak(t *testing.T) {
 	}
 
 	// Closing c2 shouldn't error out since c2 isn't leaking any iterators.
-	require.NoError(t, c2.close())
+	require.NoError(t, c2.Close())
 
 	// Closing c3 should error out since c3 holds the last reference to the
 	// FileCache, and when the FileCache closes, it will detect that there was a
 	// leaked iterator.
-	if err := c3.close(); err == nil {
+	if err := c3.Close(); err == nil {
 		t.Fatalf("expected failure, but found success")
 	} else if !strings.HasPrefix(err.Error(), "leaked iterators:") {
 		t.Fatalf("expected leaked iterators, but found %+v", err)
@@ -1018,7 +1018,7 @@ func TestFileCacheErrorBadMagicNumber(t *testing.T) {
 	defer opts.FileCache.Unref()
 	c := opts.FileCache.newHandle(opts.Cache.NewID(), objProvider, opts)
 	require.NoError(t, err)
-	defer c.close()
+	defer c.Close()
 
 	m := &fileMetadata{FileNum: testFileNum}
 	m.InitPhysicalBacking()

--- a/iterator.go
+++ b/iterator.go
@@ -243,7 +243,7 @@ type Iterator struct {
 	// and SetOptions or when re-fragmenting a batch's range keys/range dels.
 	// Non-nil if this Iterator includes a Batch.
 	batch            *Batch
-	fc               *fileCacheContainer
+	fc               *fileCacheHandle
 	newIters         tableNewIters
 	newIterRangeKey  keyspanimpl.TableNewSpanIter
 	lazyCombinedIter lazyCombinedIter

--- a/open.go
+++ b/open.go
@@ -246,7 +246,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 			opts.Cache.Unref()
 
 			if d.fileCache != nil {
-				_ = d.fileCache.close()
+				_ = d.fileCache.Close()
 			}
 
 			for _, mem := range d.mu.mem.queue {


### PR DESCRIPTION
#### db: minor file cache cleanup

This change renames `fileCacheContainer` to a more appropriate
`fileCacheHandle`. The function to create a handle is now a method on
`FileCache` and the "create new file cache if nil" logic is pulled out
into the caller.

#### db: clear fileCacheHandle on close


#### db: clean up file cache tests

Some cleanup of the fileCache tests, which makes it more clear how the
caches are initialized.
