### PR TITLE
internal/manifest: extend version edits for blob metadata

### DIFF
--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -1,0 +1,93 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/redact"
+)
+
+// A BlobReference describes a sstable's reference to a blob value file.
+type BlobReference struct {
+	FileNum   base.DiskFileNum
+	ValueSize uint64
+}
+
+// BlobFileMetadata is metadata describing a blob value file.
+type BlobFileMetadata struct {
+	// FileNum is the file number.
+	FileNum base.DiskFileNum
+	// Size is the size of the file, in bytes.
+	Size uint64
+	// ValueSize is the sum of the length of the uncompressed values stored in
+	// this blob file.
+	ValueSize uint64
+	// File creation time in seconds since the epoch (1970-01-01 00:00:00
+	// UTC).
+	CreationTime uint64
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (m *BlobFileMetadata) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%s size:[%d (%s)] vals:[%d (%s)]",
+		m.FileNum, redact.Safe(m.Size), humanize.Bytes.Uint64(m.Size),
+		redact.Safe(m.ValueSize), humanize.Bytes.Uint64(m.ValueSize))
+}
+
+// String implements fmt.Stringer.
+func (m *BlobFileMetadata) String() string {
+	return redact.StringWithoutMarkers(m)
+}
+
+// ParseBlobFileMetadataDebug parses a BlobFileMetadata from its string
+// representation. This function is intended for use in tests. It's the inverse
+// of BlobFileMetadata.String().
+//
+// In production code paths, the BlobFileMetadata is serialized in a binary
+// format within a version edit under the tag tagNewBlobFile.
+func ParseBlobFileMetadataDebug(s string) (_ *BlobFileMetadata, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.CombineErrors(err, errFromPanic(r))
+		}
+	}()
+
+	// Input format:
+	//  000000: size:[206536 (201KiB)], vals:[393256 (384KiB)]
+	m := &BlobFileMetadata{}
+	p := makeDebugParser(s)
+	m.FileNum = base.DiskFileNum(p.FileNum())
+
+	maybeSkipParens := func() {
+		if p.Peek() != "(" {
+			return
+		}
+		for p.Next() != ")" {
+			// Skip.
+		}
+	}
+
+	for !p.Done() {
+		field := p.Next()
+		p.Expect(":")
+		switch field {
+		case "size":
+			p.Expect("[")
+			m.Size = p.Uint64()
+			maybeSkipParens()
+			p.Expect("]")
+		case "vals":
+			p.Expect("[")
+			m.ValueSize = p.Uint64()
+			maybeSkipParens()
+			p.Expect("]")
+		default:
+			p.Errf("unknown field %q", field)
+		}
+	}
+	return m, nil
+}

--- a/internal/manifest/blob_metadata_test.go
+++ b/internal/manifest/blob_metadata_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlobFileMetadata_ParseRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name:  "verbatim",
+			input: "000001 size:[903530 (882KB)] vals:[39531 (39KB)]",
+		},
+		{
+			name:   "whitespace is insignificant",
+			input:  "000001   size  : [ 903530 (882KB )] vals: [ 39531 ( 39KB ) ]",
+			output: "000001 size:[903530 (882KB)] vals:[39531 (39KB)]",
+		},
+		{
+			name:   "humanized sizes are optional",
+			input:  "000001 size:[903530] vals:[39531]",
+			output: "000001 size:[903530 (882KB)] vals:[39531 (39KB)]",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := ParseBlobFileMetadataDebug(tc.input)
+			require.NoError(t, err)
+			got := m.String()
+			want := tc.input
+			if tc.output != "" {
+				want = tc.output
+			}
+			require.Equal(t, want, got)
+		})
+	}
+}

--- a/internal/manifest/testdata/version_edit_decode
+++ b/internal/manifest/testdata/version_edit_decode
@@ -48,3 +48,43 @@ c505                         #   . FileSize        = 709
   next-file-num: 6
   last-seq-num:  14
   add-table:     L0 000004:[bar#14,DEL-foo#13,SET] (2023-12-04T17:57:24Z)
+
+decode
+0219                         # <tagLogNumber>, 19
+0366                         # <tagNextFileNumber>, 42
+048410                       # <tagLastSequence>, 2052
+6b                           # <tagNewBlobFile>
+29                           #   . FileNum      = 000029
+d8a301                       #   . Size         = 20952
+f9a006                       #   . ValueSize    = 102521
+9f9485bd06                   #   . CreationTime = 1738623519
+6c                           # <tagDeleteBlobFile>
+21                           #   . FileNum      = 000021
+----
+021903660484106b29d8a301f9a0069f9485bd066c21
+  log-num:       25
+  next-file-num: 102
+  last-seq-num:  2052
+  add-blob-file: 000041 size:[20952 (20KB)] vals:[102521 (100KB)]
+  del-blob-file: 000033
+
+encode
+  add-table:     L6 000029:[bar#14,DEL-foo#13,SET] blobrefs:[(000041: 20952)]
+  add-blob-file: 000041 size:[20952 (20KB)] vals:[102521 (100KB)]
+  del-blob-file: 000033
+----
+67061d000b626172000e0000000000000b666f6f010d0000000000000000
+450129d8a301016b29d8a301f9a006006c21
+  add-table:     L6 000029:[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(000041: 20952)]
+  add-blob-file: 000041 size:[20952 (20KB)] vals:[102521 (100KB)]
+  del-blob-file: 000033
+
+decode
+67061d000b626172000e0000000000000b666f6f010d0000000000000000
+450129d8a301016b29d8a301f9a006006c21
+----
+67061d000b626172000e0000000000000b666f6f010d0000000000000000
+450129d8a301016b29d8a301f9a006006c21
+  add-table:     L6 000029:[bar#14,DEL-foo#13,SET]
+  add-blob-file: 000041 size:[20952 (20KB)] vals:[102521 (100KB)]
+  del-blob-file: 000033

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -268,6 +268,20 @@ func TestVersionEditDecode(t *testing.T) {
 			inputBuf.Reset()
 			outputBuf.Reset()
 			switch d.Cmd {
+			case "encode":
+				ve, err := ParseVersionEditDebug(d.Input)
+				require.NoError(t, err)
+				require.NoError(t, ve.Encode(&inputBuf))
+				serialized := inputBuf.Bytes()
+				for len(serialized) > 0 {
+					line := serialized[:min(30, len(serialized))]
+					serialized = serialized[len(line):]
+					outputBuf.WriteString(hex.EncodeToString(line))
+					outputBuf.WriteByte('\n')
+				}
+				fmt.Fprint(&outputBuf, ve.DebugString(base.DefaultFormatter))
+				return outputBuf.String()
+
 			case "decode":
 				for _, l := range crstrings.Lines(d.Input) {
 					i := strings.IndexByte(l, '#')
@@ -451,6 +465,12 @@ func TestParseVersionEditDebugRoundTrip(t *testing.T) {
 		output string
 	}{
 		{
+			input: `  del-blob-file: 000001`,
+		},
+		{
+			input: `  add-blob-file: 000005 size:[20535 (20KB)] vals:[25935 (25KB)]`,
+		},
+		{
 			input: `  add-table:     L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:1`,
 		},
 		{
@@ -466,6 +486,23 @@ func TestParseVersionEditDebugRoundTrip(t *testing.T) {
 				`  del-table:     L3 000003`,
 				`  add-table:     L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:1`,
 				`  add-table:     L2 000002:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:2`,
+			}, "\n"),
+		},
+		{
+			input: strings.Join([]string{
+				`  del-table:     L1 000002`,
+				`  del-table:     L3 000003`,
+				`  add-table:     L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:1`,
+				`  add-table:     L2 000002:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:2`,
+				`  add-blob-file: 000005 size:[20535 (20KB)] vals:[25935 (25KB)]`,
+				`  del-blob-file: 000004`,
+				`  del-blob-file: 000006`,
+			}, "\n"),
+		},
+		{
+			input: strings.Join([]string{
+				`  add-table:     L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:1`,
+				`  add-table:     L2 000002:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:2 blobrefs:[(002431: 3008533), (002432: 10534)]`,
 			}, "\n"),
 		},
 	}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -414,6 +414,10 @@ func TestFileMetadata_ParseRoundTrip(t *testing.T) {
 			name:  "virtual",
 			input: "000001(000008):[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL]",
 		},
+		{
+			name:  "blobrefs",
+			input: "000196:[bar#0,SET-foo#0,SET] seqnums:[0-0] points:[bar#0,SET-foo#0,SET] blobrefs:[(000191: 2952), (000075: 108520)]",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Extend the version edit binary encoding to support encoding the addition and removal of blob files and recording a sstable's reference to a blob file. This commit only introduces the binary serialization of this data and the corresponding Go structures. Future work will connect it to version edit application and the current Version.

Informs #112.