### PR TITLE
colblk: optimizations to PrefixBytesBuilder.Put and DetermineUintEncoding

### DIFF
--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -821,7 +821,7 @@ func (b *PrefixBytesBuilder) Put(key []byte, bytesSharedWithPrev int) {
 			currentBundlePrefixOffset: 1,
 			completedBundleLen:        0,
 			compressedDataLen:         len(key),
-			offsetEncoding:            DetermineUintEncoding(0, uint64(len(key)), UintEncodingRowThreshold),
+			offsetEncoding:            DetermineUintEncodingNoDelta(uint64(len(key))),
 		}
 	case b.nKeys&(b.bundleSize-1) == 0:
 		// We're starting a new bundle.
@@ -854,7 +854,7 @@ func (b *PrefixBytesBuilder) Put(key []byte, bytesSharedWithPrev int) {
 			currentBundleDistinctKeys: 1,
 			compressedDataLen:         completedBundleSize + len(key) - (b.bundleCount(b.nKeys)-1)*blockPrefixLen,
 		}
-		curr.offsetEncoding = DetermineUintEncoding(0, uint64(curr.compressedDataLen), UintEncodingRowThreshold)
+		curr.offsetEncoding = DetermineUintEncodingNoDelta(uint64(curr.compressedDataLen))
 		b.data = append(b.data, key...)
 		b.addOffset(0) // Placeholder for bundle prefix.
 		b.addOffset(uint32(len(b.data)))
@@ -896,7 +896,7 @@ func (b *PrefixBytesBuilder) Put(key []byte, bytesSharedWithPrev int) {
 		curr.compressedDataLen -= (b.bundleCount(b.nKeys) - 1) * curr.blockPrefixLen
 		// The compressedDataLen is the largest offset we'll need to encode in the
 		// offset table.
-		curr.offsetEncoding = DetermineUintEncoding(0, uint64(curr.compressedDataLen), UintEncodingRowThreshold)
+		curr.offsetEncoding = DetermineUintEncodingNoDelta(uint64(curr.compressedDataLen))
 		b.data = append(b.data, key...)
 		b.addOffset(uint32(len(b.data)))
 	}

--- a/sstable/colblk/uints.go
+++ b/sstable/colblk/uints.go
@@ -110,6 +110,13 @@ func DetermineUintEncoding(minValue, maxValue uint64, numRows int) UintEncoding 
 	return makeUintEncoding(b, isDelta)
 }
 
+// DetermineUintEncodingNoDelta is a more efficient variant of
+// DetermineUintEncoding when minValue is zero (or we don't need a delta
+// encoding).
+func DetermineUintEncodingNoDelta(maxValue uint64) UintEncoding {
+	return makeUintEncoding(byteWidth(maxValue), false /* isDelta */)
+}
+
 // byteWidthTable maps a number’s bit‐length to the number of bytes needed.
 var byteWidthTable = [65]uint8{
 	// 0 bits => 0 bytes

--- a/sstable/colblk/uints.go
+++ b/sstable/colblk/uints.go
@@ -110,16 +110,27 @@ func DetermineUintEncoding(minValue, maxValue uint64, numRows int) UintEncoding 
 	return makeUintEncoding(b, isDelta)
 }
 
+// byteWidthTable maps a number’s bit‐length to the number of bytes needed.
+var byteWidthTable = [65]uint8{
+	// 0 bits => 0 bytes
+	0,
+	// 1..8 bits => 1 byte
+	1, 1, 1, 1, 1, 1, 1, 1,
+	// 9..16 bits => 2 bytes
+	2, 2, 2, 2, 2, 2, 2, 2,
+	// 17..32 bits => 4 bytes
+	4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	// 33..64 bits => 8 bytes
+	8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+	8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+}
+
 // byteWidth returns the number of bytes necessary to represent the given value,
 // either 0, 1, 2, 4, or 8.
 func byteWidth(maxValue uint64) uint8 {
-	// b the number of bytes necessary to represent maxValue.
-	b := (uint8(bits.Len64(maxValue)) + 7) >> 3
-	// Round up to the nearest power of 2 by subtracting one and filling out all bits.
-	b--
-	b |= b >> 1
-	b |= b >> 2
-	return b + 1
+	// bits.Len64 returns 0 for 0, 1..64 for others.
+	// We then simply return the precomputed result.
+	return byteWidthTable[bits.Len64(maxValue)]
 }
 
 func makeUintEncoding(width uint8, isDelta bool) UintEncoding {

--- a/sstable/colblk/uints_test.go
+++ b/sstable/colblk/uints_test.go
@@ -111,6 +111,9 @@ func TestUintEncoding(t *testing.T) {
 		if actual != tc.expected {
 			t.Errorf("%d/%d/%d expected %s, but got %s", tc.min, tc.max, tc.numRows, tc.expected, actual)
 		}
+		if !actual.IsDelta() {
+			require.Equal(t, actual, DetermineUintEncodingNoDelta(tc.max))
+		}
 	}
 }
 

--- a/sstable/colblk/uints_test.go
+++ b/sstable/colblk/uints_test.go
@@ -49,6 +49,25 @@ func TestByteWidth(t *testing.T) {
 	}
 }
 
+func BenchmarkByteWidth(b *testing.B) {
+	for _, n := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			vals := make([]uint64, 128)
+			for i := range vals {
+				vals[i] = (1 << (8 * (n - 1))) + rand.Uint64N((1<<(8*n))-(1<<(8*(n-1))))
+			}
+			b.ResetTimer()
+			var x int
+			for i := 0; i < b.N; i++ {
+				x += int(byteWidth(vals[i&127]))
+			}
+			if x != n*b.N {
+				b.Fatal("unexpected result")
+			}
+		})
+	}
+}
+
 func TestUintEncoding(t *testing.T) {
 	for _, r := range interestingIntRanges {
 		actual := DetermineUintEncoding(r.Min, r.Max, UintEncodingRowThreshold)

--- a/sstable/colblk/uints_test.go
+++ b/sstable/colblk/uints_test.go
@@ -112,7 +112,6 @@ func TestUintEncoding(t *testing.T) {
 			t.Errorf("%d/%d/%d expected %s, but got %s", tc.min, tc.max, tc.numRows, tc.expected, actual)
 		}
 	}
-
 }
 
 func TestUints(t *testing.T) {


### PR DESCRIPTION

#### colblk: add benchmark for byteWidth


#### colblk: improved byteWidth implementation

```
name              old time/op  new time/op  delta
ByteWidth/n=1-10  1.06ns ± 1%  0.63ns ± 0%  -40.84%  (p=0.001 n=7+7)
ByteWidth/n=2-10  1.05ns ± 0%  0.63ns ± 0%  -40.60%  (p=0.000 n=8+8)
ByteWidth/n=4-10  1.06ns ± 0%  0.63ns ± 0%  -40.71%  (p=0.000 n=8+7)
ByteWidth/n=8-10  1.05ns ± 0%  0.63ns ± 0%  -40.61%  (p=0.000 n=8+8)
```

#### colblk: add DetermineUintEncodingNoDelta

Add a more efficient variant used for offsets, where the minimum value
is always 0.

#### colblk: minor optimizations to PrefixBytesBuilder.Put

Reorganize the code so that we only check one `if` in the common path.
Benchmark shows a slight improvement (I expect it to be a higher when
the keys are very small).

```
PrefixBytes/alphaLen=2/building-10    710µs ± 0%   708µs ± 0%  -0.34%  (p=0.029 n=4+4)
```

#### colblk: move completedBundleLen out of sizings

This value is not used outside of `Put` so we don't need to keep two
of its values around.

----

Fixes #4322