### PR TITLE
db: simplify EnsureDefaults

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -367,7 +367,7 @@ func TestCompactionPickerEstimatedCompactionDebt(t *testing.T) {
 }
 
 func TestCompactionPickerL0(t *testing.T) {
-	opts := (*Options)(nil).EnsureDefaults()
+	opts := DefaultOptions()
 	opts.Experimental.L0CompactionConcurrency = 1
 
 	parseMeta := func(s string) (*fileMetadata, error) {
@@ -585,7 +585,7 @@ func TestCompactionPickerL0(t *testing.T) {
 }
 
 func TestCompactionPickerConcurrency(t *testing.T) {
-	opts := (*Options)(nil).EnsureDefaults()
+	opts := DefaultOptions()
 	opts.Experimental.L0CompactionConcurrency = 1
 
 	parseMeta := func(s string) (*fileMetadata, error) {
@@ -780,7 +780,7 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 }
 
 func TestCompactionPickerPickReadTriggered(t *testing.T) {
-	opts := (*Options)(nil).EnsureDefaults()
+	opts := DefaultOptions()
 	var picker *compactionPickerByScore
 	var rcList readCompactionQueue
 	var vers *version
@@ -937,8 +937,7 @@ func (d alwaysMultiLevel) allowL0() bool  { return false }
 func (d alwaysMultiLevel) String() string { return "always" }
 
 func TestPickedCompactionSetupInputs(t *testing.T) {
-	opts := &Options{}
-	opts.EnsureDefaults()
+	opts := DefaultOptions()
 
 	parseMeta := func(s string) *fileMetadata {
 		parts := strings.Split(strings.TrimSpace(s), " ")
@@ -1117,8 +1116,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 }
 
 func TestPickedCompactionExpandInputs(t *testing.T) {
-	opts := &Options{}
-	opts.EnsureDefaults()
+	opts := DefaultOptions()
 	cmp := DefaultComparer.Compare
 	var files []*fileMetadata
 
@@ -1197,7 +1195,7 @@ func TestPickedCompactionExpandInputs(t *testing.T) {
 }
 
 func TestCompactionOutputFileSize(t *testing.T) {
-	opts := (*Options)(nil).EnsureDefaults()
+	opts := DefaultOptions()
 	var picker *compactionPickerByScore
 	var vers *version
 

--- a/data_test.go
+++ b/data_test.go
@@ -784,7 +784,10 @@ func runCompactCmd(td *datadriven.TestData, d *DB) error {
 // creation of invalid database states. If opts.DebugCheck is set, the
 // level checker should detect the invalid state.
 func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
-	opts = opts.EnsureDefaults()
+	if opts == nil {
+		opts = &Options{}
+	}
+	opts.EnsureDefaults()
 	opts.FS = vfs.NewMem()
 	return runDBDefineCmdReuseFS(td, opts)
 }
@@ -792,7 +795,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 // runDBDefineCmdReuseFS is like runDBDefineCmd, but does not set opts.FS, expecting
 // the caller to have set an appropriate FS already.
 func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) {
-	opts = opts.EnsureDefaults()
+	opts.EnsureDefaults()
 	if err := parseDBOptionsArgs(opts, td.CmdArgs); err != nil {
 		return nil, err
 	}

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -72,7 +72,8 @@ func TestExternalIterator(t *testing.T) {
 
 func BenchmarkExternalIter_NonOverlapping_Scan(b *testing.B) {
 	ks := testkeys.Alpha(6)
-	opts := (&Options{Comparer: testkeys.Comparer}).EnsureDefaults()
+	opts := &Options{Comparer: testkeys.Comparer}
+	opts.EnsureDefaults()
 	iterOpts := &IterOptions{
 		KeyTypes: IterKeyTypePointsAndRanges,
 	}

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -42,7 +42,9 @@ func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
 
 func TestRatchetFormat(t *testing.T) {
 	fs := vfs.NewMem()
-	d, err := Open("", (&Options{FS: fs}).WithFSDefaults())
+	opts := &Options{FS: fs}
+	opts.WithFSDefaults()
+	d, err := Open("", opts)
 	require.NoError(t, err)
 	require.NoError(t, d.Set([]byte("foo"), []byte("bar"), Sync))
 	require.Equal(t, FormatFlushableIngest, d.FormatMajorVersion())
@@ -63,7 +65,9 @@ func TestRatchetFormat(t *testing.T) {
 
 	// If we Open the database again, leaving the default format, the
 	// database should Open using the persisted FormatNewest.
-	d, err = Open("", (&Options{FS: fs, Logger: testLogger{t}}).WithFSDefaults())
+	opts = &Options{FS: fs, Logger: testLogger{t}}
+	opts.WithFSDefaults()
+	d, err = Open("", opts)
 	require.NoError(t, err)
 	require.Equal(t, internalFormatNewest, d.FormatMajorVersion())
 	require.NoError(t, d.Close())
@@ -74,10 +78,12 @@ func TestRatchetFormat(t *testing.T) {
 	require.NoError(t, m.Move("999999"))
 	require.NoError(t, m.Close())
 
-	_, err = Open("", (&Options{
+	opts = &Options{
 		FS:                 fs,
 		FormatMajorVersion: FormatMinSupported,
-	}).WithFSDefaults())
+	}
+	opts.WithFSDefaults()
+	_, err = Open("", opts)
 	require.Error(t, err)
 	require.EqualError(t, err, `pebble: database "" written in unknown format major version 999999`)
 }
@@ -108,11 +114,12 @@ func TestFormatMajorVersions(t *testing.T) {
 	for vers := FormatMinSupported; vers <= FormatNewest; vers++ {
 		t.Run(fmt.Sprintf("vers=%03d", vers), func(t *testing.T) {
 			fs := vfs.NewCrashableMem()
-			opts := (&Options{
+			opts := &Options{
 				FS:                 fs,
 				FormatMajorVersion: vers,
 				Logger:             testLogger{t},
-			}).WithFSDefaults()
+			}
+			opts.WithFSDefaults()
 
 			// Create a database at this format major version and perform
 			// some very basic operations.

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -125,10 +125,11 @@ func TestIngestLoad(t *testing.T) {
 				return err.Error()
 			}
 
-			opts := (&Options{
+			opts := &Options{
 				Comparer: DefaultComparer,
 				FS:       mem,
-			}).WithFSDefaults()
+			}
+			opts.WithFSDefaults()
 			lr, err := ingestLoad(context.Background(), opts, dbVersion, []string{"ext"}, nil, nil, 0, []base.FileNum{1})
 			if err != nil {
 				return err.Error()
@@ -216,10 +217,12 @@ func TestIngestLoadRand(t *testing.T) {
 		}()
 	}
 
-	opts := (&Options{
+	opts := &Options{
 		Comparer: base.DefaultComparer,
 		FS:       mem,
-	}).WithFSDefaults().EnsureDefaults()
+	}
+	opts.WithFSDefaults()
+	opts.EnsureDefaults()
 	lr, err := ingestLoad(context.Background(), opts, version, paths, nil, nil, 0, pending)
 	require.NoError(t, err)
 
@@ -236,10 +239,11 @@ func TestIngestLoadInvalid(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	opts := (&Options{
+	opts := &Options{
 		Comparer: DefaultComparer,
 		FS:       mem,
-	}).WithFSDefaults()
+	}
+	opts.WithFSDefaults()
 	if _, err := ingestLoad(context.Background(), opts, internalFormatNewest, []string{"invalid"}, nil, nil, 0, []base.FileNum{1}); err == nil {
 		t.Fatalf("expected error, but found success")
 	}
@@ -308,7 +312,8 @@ func TestIngestLink(t *testing.T) {
 	for i := 0; i <= count; i++ {
 		t.Run("", func(t *testing.T) {
 			opts := &Options{FS: vfs.NewMem()}
-			opts.EnsureDefaults().WithFSDefaults()
+			opts.EnsureDefaults()
+			opts.WithFSDefaults()
 			require.NoError(t, opts.FS.MkdirAll(dir, 0755))
 			objProvider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(opts.FS, dir))
 			require.NoError(t, err)
@@ -393,7 +398,8 @@ func TestIngestLinkFallback(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := &Options{FS: errorfs.Wrap(mem, errorfs.ErrInjected.If(errorfs.OnIndex(1)))}
-	opts.EnsureDefaults().WithFSDefaults()
+	opts.EnsureDefaults()
+	opts.WithFSDefaults()
 	objSettings := objstorageprovider.DefaultSettings(opts.FS, "")
 	// Prevent the provider from listing the dir (where we may get an injected error).
 	objSettings.FSDirInitialListing = []string{}
@@ -454,7 +460,7 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 		}
 
 		require.NoError(t, mem.MkdirAll("ext", 0755))
-		opts = (&Options{
+		opts = &Options{
 			FS: vfs.WithLogging(mem, func(format string, args ...interface{}) {
 				fsLog.Lock()
 				defer fsLog.Unlock()
@@ -467,7 +473,8 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 			DebugCheck:                  DebugCheckLevels,
 			FormatMajorVersion:          internalFormatNewest,
 			Logger:                      testLogger{t},
-		}).WithFSDefaults()
+		}
+		opts.WithFSDefaults()
 		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		if testing.Verbose() {
 			lel := MakeLoggingEventListener(DefaultLogger)
@@ -2174,7 +2181,8 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 					opts := &Options{
 						Comparer: &comparer,
 					}
-					opts.EnsureDefaults().WithFSDefaults()
+					opts.EnsureDefaults()
+					opts.WithFSDefaults()
 					if len(d.CmdArgs) > 1 {
 						return fmt.Sprintf("%s expects at most 1 argument", d.Cmd)
 					}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2715,11 +2715,12 @@ func buildFragmentedRangeKey(b testing.TB, seed uint64) (d *DB, keys [][]byte) {
 //
 // See cockroachdb/cockroach#89327.
 func BenchmarkSeekPrefixTombstones(b *testing.B) {
-	o := (&Options{
+	o := &Options{
 		FS:                 vfs.NewMem(),
 		Comparer:           testkeys.Comparer,
 		FormatMajorVersion: FormatNewest,
-	}).EnsureDefaults()
+	}
+	o.EnsureDefaults()
 	d, err := Open("", o)
 	require.NoError(b, err)
 	defer func() { require.NoError(b, d.Close()) }()
@@ -2777,11 +2778,13 @@ func BenchmarkPointDeletedSwath(b *testing.B) {
 	ks := testkeys.Alpha(maxKeyLen)
 
 	opts := func() *Options {
-		return (&Options{
+		o := &Options{
 			FS:                 vfs.NewMem(),
 			Comparer:           testkeys.Comparer,
 			FormatMajorVersion: FormatNewest,
-		}).EnsureDefaults()
+		}
+		o.EnsureDefaults()
+		return o
 	}
 	type iteratorOp struct {
 		name string
@@ -2963,13 +2966,14 @@ func runBenchmarkQueueWorkload(b *testing.B, deleteRatio float32, initOps int, v
 		queues[i] = &Queue{}
 	}
 
-	o := (&Options{
+	o := &Options{
 		Cache:              cache.New(0), // disable cache
 		DisableWAL:         true,
 		FS:                 vfs.NewMem(),
 		Comparer:           testkeys.Comparer,
 		FormatMajorVersion: FormatNewest,
-	}).EnsureDefaults()
+	}
+	o.EnsureDefaults()
 
 	d, err := Open("", o)
 	require.NoError(b, err)

--- a/mem_table.go
+++ b/mem_table.go
@@ -119,7 +119,10 @@ func checkMemTable(obj interface{}) {
 // newMemTable returns a new MemTable of the specified size. If size is zero,
 // Options.MemTableSize is used instead.
 func newMemTable(opts memTableOptions) *memTable {
-	opts.Options = opts.Options.EnsureDefaults()
+	if opts.Options == nil {
+		opts.Options = &Options{}
+	}
+	opts.Options.EnsureDefaults()
 	m := new(memTable)
 	m.init(opts)
 	return m

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -145,7 +145,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 	memFS := vfs.NewMem()
 	cmp := DefaultComparer.Compare
 	fmtKey := DefaultComparer.FormatKey
-	opts := (*Options)(nil).EnsureDefaults()
+	opts := DefaultOptions()
 	var v *version
 	var buf bytes.Buffer
 

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -93,7 +93,8 @@ func (t *Test) init(
 		t.writeOpts = pebble.NoSync
 	}
 	testOpts.Opts.WithFSDefaults()
-	t.opts = testOpts.Opts.EnsureDefaults()
+	t.opts = testOpts.Opts.Clone()
+	t.opts.EnsureDefaults()
 	t.opts.Logger = h
 	lel := pebble.MakeLoggingEventListener(t.opts.Logger)
 	t.opts.EventListener = &lel

--- a/obsolete_files_test.go
+++ b/obsolete_files_test.go
@@ -92,11 +92,12 @@ func TestCleaner(t *testing.T) {
 				return "open <dir> [archive] [readonly]"
 			}
 			dir := td.CmdArgs[0].String()
-			opts := (&Options{
+			opts := &Options{
 				FS:     fs,
 				WALDir: dir + "_wal",
 				Logger: testLogger{t},
-			}).WithFSDefaults()
+			}
+			opts.WithFSDefaults()
 
 			for i := 1; i < len(td.CmdArgs); i++ {
 				switch td.CmdArgs[i].String() {

--- a/open.go
+++ b/open.go
@@ -77,7 +77,7 @@ func FileCacheSize(maxOpenFiles int) int {
 func Open(dirname string, opts *Options) (db *DB, err error) {
 	// Make a copy of the options so that we don't mutate the passed in options.
 	opts = opts.Clone()
-	opts = opts.EnsureDefaults()
+	opts.EnsureDefaults()
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}

--- a/options.go
+++ b/options.go
@@ -449,10 +449,7 @@ type LevelOptions struct {
 // EnsureDefaults ensures that the default values for all of the options have
 // been initialized. It is valid to call EnsureDefaults on a nil receiver. A
 // non-nil result will always be returned.
-func (o *LevelOptions) EnsureDefaults() *LevelOptions {
-	if o == nil {
-		o = &LevelOptions{}
-	}
+func (o *LevelOptions) EnsureDefaults() {
 	if o.BlockRestartInterval <= 0 {
 		o.BlockRestartInterval = base.DefaultBlockRestartInterval
 	}
@@ -473,7 +470,6 @@ func (o *LevelOptions) EnsureDefaults() *LevelOptions {
 	if o.TargetFileSize <= 0 {
 		o.TargetFileSize = 2 << 20 // 2 MB
 	}
-	return o
 }
 
 // Options holds the optional parameters for configuring pebble. These options
@@ -1127,11 +1123,8 @@ func DebugCheckLevels(db *DB) error {
 }
 
 // EnsureDefaults ensures that the default values for all options are set if a
-// valid value was not already specified. Returns the new options.
-func (o *Options) EnsureDefaults() *Options {
-	if o == nil {
-		o = &Options{}
-	}
+// valid value was not already specified.
+func (o *Options) EnsureDefaults() {
 	if o.Cache == nil && o.CacheSize == 0 {
 		o.CacheSize = cacheDefaultSize
 	}
@@ -1289,12 +1282,18 @@ func (o *Options) EnsureDefaults() *Options {
 	}
 
 	o.initMaps()
+}
+
+// DefaultOptions returns a new Options object with the default values set.
+func DefaultOptions() *Options {
+	o := &Options{}
+	o.EnsureDefaults()
 	return o
 }
 
 // WithFSDefaults configures the Options to wrap the configured filesystem with
 // the default virtual file system middleware, like disk-health checking.
-func (o *Options) WithFSDefaults() *Options {
+func (o *Options) WithFSDefaults() {
 	if o.FS == nil {
 		o.FS = vfs.Default
 	}
@@ -1302,7 +1301,6 @@ func (o *Options) WithFSDefaults() *Options {
 		func(info vfs.DiskSlowInfo) {
 			o.EventListener.DiskSlow(info)
 		})
-	return o
 }
 
 // AddEventListener adds the provided event listener to the Options, in addition

--- a/tool/db.go
+++ b/tool/db.go
@@ -609,7 +609,8 @@ func (d *dbT) runExcise(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	dbOpts := d.opts.EnsureDefaults()
+	d.opts.EnsureDefaults()
+	dbOpts := d.opts
 	// Disable all processes that would try to open tables: table stats,
 	// consistency check, automatic compactions.
 	dbOpts.DisableTableStats = true


### PR DESCRIPTION
Simplify the awkward `EnsureDefaults` API; it no longer accepts a nil
receiver.