### PR TITLE
db: relax type of fileCache's closeHook

### DIFF
--- a/file_cache.go
+++ b/file_cache.go
@@ -338,8 +338,6 @@ type fileCacheShard struct {
 	mu struct {
 		sync.RWMutex
 		nodes map[fileCacheKey]*fileCacheNode
-		// The iters map is only created and populated in race builds.
-		iters map[io.Closer][]byte
 
 		handHot  *fileCacheNode
 		handCold *fileCacheNode
@@ -349,6 +347,11 @@ type fileCacheShard struct {
 		sizeHot    int
 		sizeCold   int
 		sizeTest   int
+
+		race struct {
+			// The iters map is only created and populated in race builds.
+			iters map[any][]byte
+		}
 	}
 	releasing       sync.WaitGroup
 	releasingCh     chan *fileCacheValue
@@ -365,7 +368,7 @@ func (c *fileCacheShard) init(size int) {
 	go c.releaseLoop()
 
 	if invariants.RaceEnabled {
-		c.mu.iters = make(map[io.Closer][]byte)
+		c.mu.race.iters = make(map[any][]byte)
 	}
 }
 
@@ -564,7 +567,7 @@ func (c *fileCacheShard) newPointIter(
 	handle.iterCount.Add(1)
 	if invariants.RaceEnabled {
 		c.mu.Lock()
-		c.mu.iters[iter] = debug.Stack()
+		c.mu.race.iters[iter] = debug.Stack()
 		c.mu.Unlock()
 	}
 	return iter, nil
@@ -890,16 +893,15 @@ func (c *fileCacheShard) findNodeInternal(
 	v.refCount.Store(2)
 	// Cache the closure invoked when an iterator is closed. This avoids an
 	// allocation on every call to newIters.
-	v.closeHook = func(i sstable.Iterator) error {
+	v.closeHook = func(i any) {
 		if invariants.RaceEnabled {
 			c.mu.Lock()
-			delete(c.mu.iters, i)
+			delete(c.mu.race.iters, i)
 			c.mu.Unlock()
 		}
 		c.unrefValue(v)
 		c.iterCount.Add(-1)
 		handle.iterCount.Add(-1)
-		return nil
 	}
 	n.value = v
 
@@ -1080,7 +1082,7 @@ func (c *fileCacheShard) Close() error {
 			err = errors.Errorf("leaked iterators: %d", errors.Safe(v))
 		} else {
 			var buf bytes.Buffer
-			for _, stack := range c.mu.iters {
+			for _, stack := range c.mu.race.iters {
 				fmt.Fprintf(&buf, "%s\n", stack)
 			}
 			err = errors.Errorf("leaked iterators: %d\n%s", errors.Safe(v), buf.String())
@@ -1120,7 +1122,7 @@ func (c *fileCacheShard) Close() error {
 }
 
 type fileCacheValue struct {
-	closeHook func(i sstable.Iterator) error
+	closeHook func(i any)
 	reader    io.Closer // *sstable.Reader
 	err       error
 	loaded    chan struct{}

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -49,7 +49,12 @@ type Iterator interface {
 	// NextPrefix implements (base.InternalIterator).NextPrefix.
 	NextPrefix(succKey []byte) *base.InternalKV
 
-	SetCloseHook(fn func(i Iterator) error)
+	// SetCloseHook sets a function that will be called when the iterator is
+	// closed.  This is used by the file cache to release the reference count on
+	// the open sstable.Reader when the iterator is closed. The closures takes
+	// the iterator as a parameter to enable invariant-build tracking of leaked
+	// iterators.
+	SetCloseHook(fn func(any))
 }
 
 // Iterator positioning optimizations and singleLevelIterator and

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -71,7 +71,7 @@ type singleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIte
 	vbRH         objstorage.ReadHandle
 	vbRHPrealloc objstorageprovider.PreallocatedReadHandle
 	err          error
-	closeHook    func(i Iterator) error
+	closeHook    func(i any)
 
 	readBlockEnv block.ReadEnv
 
@@ -1513,9 +1513,11 @@ func (i *singleLevelIterator[I, PI, D, PD]) Error() error {
 	return i.err
 }
 
-// SetCloseHook sets a function that will be called when the iterator is
-// closed.
-func (i *singleLevelIterator[I, PI, D, PD]) SetCloseHook(fn func(i Iterator) error) {
+// SetCloseHook sets a function that will be called when the iterator is closed.
+// This is used by the file cache to release the reference count on the open
+// sstable.Reader when the iterator is closed. The closures takes the iterator
+// as a parameter to enable invariant-build tracking of leaked iterators.
+func (i *singleLevelIterator[I, PI, D, PD]) SetCloseHook(fn func(i any)) {
 	i.closeHook = fn
 }
 
@@ -1543,10 +1545,10 @@ func (i *singleLevelIterator[I, PI, D, PD]) closeInternal() error {
 		panic("Close called on interator in pool")
 	}
 
-	var err error
 	if i.closeHook != nil {
-		err = firstError(err, i.closeHook(i))
+		i.closeHook(i)
 	}
+	var err error
 	err = firstError(err, PD(&i.data).Close())
 	err = firstError(err, PI(&i.index).Close())
 	if i.indexFilterRH != nil {

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -1015,7 +1015,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) SetContext(ctx context.Context) {
 	i.secondLevel.SetContext(ctx)
 }
 
-func (i *twoLevelIterator[I, PI, D, PD]) SetCloseHook(fn func(i Iterator) error) {
+func (i *twoLevelIterator[I, PI, D, PD]) SetCloseHook(fn func(i any)) {
 	i.secondLevel.SetCloseHook(fn)
 }
 


### PR DESCRIPTION
The file cache implements a closure it calls the 'closeHook' which is propagated to opened iterators to be invoked when the iterators are closed. This hook is responsible for releasing hte ref count on the open sstable Reader. In race builds, it's also used to track the stack traces of iterator opens to aid debugging leaks of open iterators. This closeHook previously required the iterator pass in itself as a sstable.Iterator interface value, but the closeHook really only required its pointer and none of the interface methods. It also returned an error that was never non-nil. This commit removes the error return value and updates the iterator parameter to be any type.

This ensures that other usages of the file cache, such as blob files, can use close hooks with non-sstable.Iterator types.