### PR TITLE
record: add a WAL read ahead to disambiguate WAL replay errors

### DIFF
--- a/record/record_test.go
+++ b/record/record_test.go
@@ -897,3 +897,10 @@ func BenchmarkRecordWrite(b *testing.B) {
 		})
 	}
 }
+
+// TODO(edward) Suppresses linting warning.
+// Delete after readAheadForCorruption() is called in follow-up PRs.
+func TestReadAheadForCorruption(t *testing.T) {
+	r := NewReader(new(bytes.Buffer), 0)
+	r.readAheadForCorruption()
+}


### PR DESCRIPTION
readAheadForCorruption is a function added to record to disambiguate between errors when replaying WAL. The read ahead process scans ahead in the WAL to detect corruptions based a new promised offset wire format. When a potential corruption / garbage value is read in the WAL, this function reads ahead until it detects an offset that promises durability beyond the previous corruption offset. If the read ahead, finds a confirmation offset, then the original error will be returned. If reading ahead finds the end of file without corruption confirmation, then ErrUnexpectedEOF is returned to signify an abrupt end of the WAL. This helps to differenatiate between errors in replayWAL as ErrInvalidChunk and ErrZeroedChunk can be identified and are no longer silently ignored.