### PR TITLE
cache: Load before Store

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -251,13 +251,14 @@ func TestCacheStressSetExisting(t *testing.T) {
 func BenchmarkCacheGet(b *testing.B) {
 	const size = 100000
 
-	cache := newCache(size, 1)
+	n := runtime.GOMAXPROCS(0)
+	cache := newCache(size*int64(n), n)
 	defer cache.Unref()
 	h := cache.NewHandle()
 	defer h.Close()
 
 	for i := 0; i < size; i++ {
-		setTestValue(h, 0, 0, "a", 1)
+		setTestValue(h, 0, uint64(i), "a", 1)
 	}
 
 	b.ResetTimer()

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -140,7 +140,8 @@ func (c *shard) getWithMaybeReadEntry(k key, desireReadEntry bool) (*Value, *rea
 	var value *Value
 	if e, _ := c.blocks.Get(k); e != nil {
 		value = e.acquireValue()
-		if value != nil {
+		// Note: we Load first to avoid an atomic XCHG when not necessary.
+		if value != nil && !e.referenced.Load() {
 			e.referenced.Store(true)
 		}
 	}


### PR DESCRIPTION
#### cache: fix and improve Get benchmark


#### cache: Load before Store

On x86 an atomic.Load is a simple load, whereas a Store is an atomic
`XCHG` operation which involves a memory barrier. Frequently accessed
blocks are likely to be accessed many times between two sweeps of the
clockpro hand.

On a gceworker:
```
name         old time/op    new time/op    delta
CacheGet-24    20.1ns ± 4%    18.9ns ± 5%  -5.82%  (p=0.002 n=10+10)
```

Fixes #4328