### PR TITLE
*: prefer InternalKV value helpers

### DIFF
--- a/cockroachkvs/cockroachkvs_test.go
+++ b/cockroachkvs/cockroachkvs_test.go
@@ -421,8 +421,8 @@ func testCockroachDataColBlock(t *testing.T, seed uint64, keyCfg keyGenConfig) {
 		if !bytes.Equal(kv.K.UserKey, keys[i]) {
 			t.Fatalf("expected %q, but found %q", keys[i], kv.K.UserKey)
 		}
-		if !bytes.Equal(kv.V.InPlaceValue(), values[i]) {
-			t.Fatalf("expected %x, but found %x", values[i], kv.V.InPlaceValue())
+		if !bytes.Equal(kv.InPlaceValue(), values[i]) {
+			t.Fatalf("expected %x, but found %x", values[i], kv.InPlaceValue())
 		}
 	}
 	require.Equal(t, len(keys), i)
@@ -440,7 +440,7 @@ func testCockroachDataColBlock(t *testing.T, seed uint64, keyCfg keyGenConfig) {
 			)
 		}
 		// Search for the correct value among all keys that are equal.
-		for !bytes.Equal(kv.V.InPlaceValue(), values[i]) {
+		for !bytes.Equal(kv.InPlaceValue(), values[i]) {
 			kv = it.Next()
 			if kv == nil || Compare(kv.K.UserKey, keys[i]) != 0 {
 				t.Fatalf("could not find correct value for %s", formatUserKey(keys[i]))
@@ -645,7 +645,7 @@ func formatInternalKey(key base.InternalKey) string {
 //
 //	foo @ 0001020304050607 #1,SET
 func formatInternalKV(kv base.InternalKV) string {
-	val, _, err := kv.V.Value(nil)
+	val, _, err := kv.Value(nil)
 	if err != nil {
 		panic(err)
 	}

--- a/cockroachkvs/key_schema_test.go
+++ b/cockroachkvs/key_schema_test.go
@@ -164,7 +164,7 @@ func TestKeySchema_RandomKeys(t *testing.T) {
 		validateEngineKey.MustValidate(kv.K.UserKey)
 
 		// We write keys[k] as the value too, so check that it's verbatim equal.
-		value, callerOwned, err := kv.V.Value(valBuf)
+		value, callerOwned, err := kv.Value(valBuf)
 		require.NoError(t, err)
 		require.Equal(t, keys[k], value)
 		if callerOwned {
@@ -191,7 +191,7 @@ func TestKeySchema_RandomKeys(t *testing.T) {
 		require.Equal(t, 0, Compare(keys[i], kv.K.UserKey))
 
 		// We write keys[k] as the value too, so check that it's verbatim equal.
-		value, callerOwned, err := kv.V.Value(valBuf)
+		value, callerOwned, err := kv.Value(valBuf)
 		require.NoError(t, err)
 		require.Equal(t, keys[i], value)
 		if callerOwned {

--- a/internal/compact/iterator.go
+++ b/internal/compact/iterator.go
@@ -588,7 +588,7 @@ func (i *Iter) Next() (*base.InternalKey, base.LazyValue) {
 			origSnapshotIdx := i.curSnapshotIdx
 			var valueMerger base.ValueMerger
 			// MERGE values are always stored in-place.
-			valueMerger, i.err = i.cfg.Merge(i.iterKV.K.UserKey, i.iterKV.V.InPlaceValue())
+			valueMerger, i.err = i.cfg.Merge(i.iterKV.K.UserKey, i.iterKV.InPlaceValue())
 			if i.err == nil {
 				i.mergeNext(valueMerger)
 			}
@@ -1115,7 +1115,7 @@ func (i *Iter) deleteSizedNext() (*base.InternalKey, base.LazyValue) {
 	// In this case, we still peek forward in case there's another DELSIZED key
 	// with a lower sequence number, in which case we'll adopt its value.
 	// If the DELSIZED does have a value, it must be in-place.
-	i.valueBuf = append(i.valueBuf[:0], i.iterKV.V.InPlaceValue()...)
+	i.valueBuf = append(i.valueBuf[:0], i.iterKV.InPlaceValue()...)
 	i.value = base.MakeInPlaceValue(i.valueBuf)
 
 	// Loop through all the keys within this stripe that are skippable.
@@ -1289,7 +1289,7 @@ func (i *Iter) saveValue() {
 	// TODO(jackson): With the introduction of values stored in separate
 	// physical blob files, this should begin to Clone LazyValues that are
 	// stored in blob reference files when non-rewriting blob files.
-	v, callerOwned, err := i.iterKV.V.Value(i.valueBuf[:0])
+	v, callerOwned, err := i.iterKV.Value(i.valueBuf[:0])
 	if err != nil {
 		i.err = err
 		i.value = base.LazyValue{}

--- a/sstable/copier_test.go
+++ b/sstable/copier_test.go
@@ -130,8 +130,8 @@ func TestCopySpan(t *testing.T) {
 			}
 			defer iter.Close()
 			var result strings.Builder
-			for key := iter.First(); key != nil; key = iter.Next() {
-				fmt.Fprintf(&result, "%s: %s\n", key.K, key.V.InPlaceValue())
+			for kv := iter.First(); kv != nil; kv = iter.Next() {
+				fmt.Fprintf(&result, "%s: %s\n", kv.K, kv.InPlaceValue())
 			}
 			return result.String()
 

--- a/sstable/rowblk/rowblk_index_iter.go
+++ b/sstable/rowblk/rowblk_index_iter.go
@@ -79,7 +79,7 @@ func (i *IndexIter) SeparatorGT(key []byte, inclusively bool) bool {
 // BlockHandleWithProperties decodes the block handle with any encoded
 // properties at the iterator's current position.
 func (i *IndexIter) BlockHandleWithProperties() (block.HandleWithProperties, error) {
-	return block.DecodeHandleWithProperties(i.iter.ikv.V.ValueOrHandle)
+	return block.DecodeHandleWithProperties(i.iter.ikv.InPlaceValue())
 }
 
 // SeekGE seeks the index iterator to the first block entry with a separator key

--- a/sstable/rowblk/rowblk_iter_test.go
+++ b/sstable/rowblk/rowblk_iter_test.go
@@ -501,7 +501,7 @@ func TestSingularKVBlockRestartsOverflow(t *testing.T) {
 	// Ensure that SeekGE() finds the correct KV
 	require.NotNil(t, kv, "failed to find the key")
 	require.Equal(t, largeKey, kv.K.UserKey, "unexpected key")
-	require.Equal(t, largeValue, kv.V.ValueOrHandle, "unexpected value")
+	require.Equal(t, largeValue, kv.InPlaceValue(), "unexpected value")
 
 	// Ensure that SeekGE() does not raise panic due to integer overflow
 	// indexing problems.
@@ -510,7 +510,7 @@ func TestSingularKVBlockRestartsOverflow(t *testing.T) {
 	// Ensure that SeekLT() finds the correct KV
 	require.NotNil(t, kv, "failed to find the key")
 	require.Equal(t, largeKey, kv.K.UserKey, "unexpected key")
-	require.Equal(t, largeValue, kv.V.ValueOrHandle, "unexpected value")
+	require.Equal(t, largeValue, kv.InPlaceValue(), "unexpected value")
 }
 
 func TestBufferExceeding256MBShouldPanic(t *testing.T) {
@@ -625,7 +625,7 @@ func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
 		kv := iter.SeekGE(key, base.SeekGEFlagsNone)
 		require.NotNil(t, kv, "failed to find the large key")
 		require.Equal(t, key, kv.K.UserKey, "unexpected key")
-		require.Equal(t, value, kv.V.ValueOrHandle, "unexpected value")
+		require.Equal(t, value, kv.InPlaceValue(), "unexpected value")
 	}
 }
 


### PR DESCRIPTION
When applicable, prefer InternalKV's value helpers over directly accessing the InternalKV's V field. This is in preparation for refactorings surrounding the LazyValue that will be easier with fewer direct accesses.