### PR TITLE
internal/manifest: rename uses of 'file' to refer to sstables

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -262,7 +262,7 @@ func (d *DB) Checkpoint(
 		}
 	}
 
-	var excludedFiles map[deletedFileEntry]*fileMetadata
+	var excludedTables map[deletedFileEntry]*fileMetadata
 	var remoteFiles []base.DiskFileNum
 	// Set of FileBacking.DiskFileNum which will be required by virtual sstables
 	// in the checkpoint.
@@ -272,10 +272,10 @@ func (d *DB) Checkpoint(
 		iter := current.Levels[l].Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
 			if excludeFromCheckpoint(f, opt, d.cmp) {
-				if excludedFiles == nil {
-					excludedFiles = make(map[deletedFileEntry]*fileMetadata)
+				if excludedTables == nil {
+					excludedTables = make(map[deletedFileEntry]*fileMetadata)
 				}
-				excludedFiles[deletedFileEntry{
+				excludedTables[deletedFileEntry{
 					Level:   l,
 					FileNum: f.FileNum,
 				}] = f
@@ -325,7 +325,7 @@ func (d *DB) Checkpoint(
 
 	ckErr = d.writeCheckpointManifest(
 		fs, formatVers, destDir, dir, manifestFileNum, manifestSize,
-		excludedFiles, removeBackingTables,
+		excludedTables, removeBackingTables,
 	)
 	if ckErr != nil {
 		return ckErr
@@ -480,7 +480,7 @@ func (d *DB) writeCheckpointManifest(
 		if len(excludedFiles) > 0 {
 			// Write out an additional VersionEdit that deletes the excluded SST files.
 			ve := versionEdit{
-				DeletedFiles:         excludedFiles,
+				DeletedTables:        excludedFiles,
 				RemovedBackingTables: removeBackingTables,
 			}
 

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -69,7 +69,7 @@ type CheckpointSpan struct {
 // excludeFromCheckpoint returns true if an SST file should be excluded from the
 // checkpoint because it does not overlap with the spans of interest
 // (opt.restrictToSpans).
-func excludeFromCheckpoint(f *fileMetadata, opt *checkpointOptions, cmp Compare) bool {
+func excludeFromCheckpoint(f *tableMetadata, opt *checkpointOptions, cmp Compare) bool {
 	if len(opt.restrictToSpans) == 0 {
 		// Option not set; don't exclude anything.
 		return false
@@ -262,7 +262,7 @@ func (d *DB) Checkpoint(
 		}
 	}
 
-	var excludedTables map[deletedFileEntry]*fileMetadata
+	var excludedTables map[deletedFileEntry]*tableMetadata
 	var remoteFiles []base.DiskFileNum
 	// Set of FileBacking.DiskFileNum which will be required by virtual sstables
 	// in the checkpoint.
@@ -273,7 +273,7 @@ func (d *DB) Checkpoint(
 		for f := iter.First(); f != nil; f = iter.Next() {
 			if excludeFromCheckpoint(f, opt, d.cmp) {
 				if excludedTables == nil {
-					excludedTables = make(map[deletedFileEntry]*fileMetadata)
+					excludedTables = make(map[deletedFileEntry]*tableMetadata)
 				}
 				excludedTables[deletedFileEntry{
 					Level:   l,
@@ -427,7 +427,7 @@ func (d *DB) writeCheckpointManifest(
 	destDir vfs.File,
 	manifestFileNum base.DiskFileNum,
 	manifestSize int64,
-	excludedFiles map[deletedFileEntry]*fileMetadata,
+	excludedTables map[deletedFileEntry]*tableMetadata,
 	removeBackingTables []base.DiskFileNum,
 ) error {
 	// Copy the MANIFEST, and create a pointer to it. We copy rather
@@ -477,10 +477,10 @@ func (d *DB) writeCheckpointManifest(
 			}
 		}
 
-		if len(excludedFiles) > 0 {
+		if len(excludedTables) > 0 {
 			// Write out an additional VersionEdit that deletes the excluded SST files.
 			ve := versionEdit{
-				DeletedTables:        excludedFiles,
+				DeletedTables:        excludedTables,
 				RemovedBackingTables: removeBackingTables,
 			}
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -768,7 +768,7 @@ func TestValidateVersionEdit(t *testing.T) {
 		{
 			desc: "single new file; start key",
 			ve: &versionEdit{
-				NewFiles: []manifest.NewFileEntry{
+				NewTables: []manifest.NewTableEntry{
 					{
 						Meta: newFileMeta(
 							manifest.InternalKey{UserKey: []byte(badKey)},
@@ -783,7 +783,7 @@ func TestValidateVersionEdit(t *testing.T) {
 		{
 			desc: "single new file; end key",
 			ve: &versionEdit{
-				NewFiles: []manifest.NewFileEntry{
+				NewTables: []manifest.NewTableEntry{
 					{
 						Meta: newFileMeta(
 							manifest.InternalKey{UserKey: []byte("a")},
@@ -798,7 +798,7 @@ func TestValidateVersionEdit(t *testing.T) {
 		{
 			desc: "multiple new files",
 			ve: &versionEdit{
-				NewFiles: []manifest.NewFileEntry{
+				NewTables: []manifest.NewTableEntry{
 					{
 						Meta: newFileMeta(
 							manifest.InternalKey{UserKey: []byte("a")},
@@ -819,7 +819,7 @@ func TestValidateVersionEdit(t *testing.T) {
 		{
 			desc: "single deleted file; start key",
 			ve: &versionEdit{
-				DeletedFiles: map[manifest.DeletedFileEntry]*manifest.FileMetadata{
+				DeletedTables: map[manifest.DeletedTableEntry]*manifest.FileMetadata{
 					deletedFileEntry{Level: 0, FileNum: 0}: newFileMeta(
 						manifest.InternalKey{UserKey: []byte(badKey)},
 						manifest.InternalKey{UserKey: []byte("z")},
@@ -832,7 +832,7 @@ func TestValidateVersionEdit(t *testing.T) {
 		{
 			desc: "single deleted file; end key",
 			ve: &versionEdit{
-				DeletedFiles: map[manifest.DeletedFileEntry]*manifest.FileMetadata{
+				DeletedTables: map[manifest.DeletedTableEntry]*manifest.FileMetadata{
 					deletedFileEntry{Level: 0, FileNum: 0}: newFileMeta(
 						manifest.InternalKey{UserKey: []byte("a")},
 						manifest.InternalKey{UserKey: []byte(badKey)},
@@ -845,7 +845,7 @@ func TestValidateVersionEdit(t *testing.T) {
 		{
 			desc: "multiple deleted files",
 			ve: &versionEdit{
-				DeletedFiles: map[manifest.DeletedFileEntry]*manifest.FileMetadata{
+				DeletedTables: map[manifest.DeletedTableEntry]*manifest.FileMetadata{
 					deletedFileEntry{Level: 0, FileNum: 0}: newFileMeta(
 						manifest.InternalKey{UserKey: []byte("a")},
 						manifest.InternalKey{UserKey: []byte("c")},
@@ -862,7 +862,7 @@ func TestValidateVersionEdit(t *testing.T) {
 		{
 			desc: "no errors",
 			ve: &versionEdit{
-				NewFiles: []manifest.NewFileEntry{
+				NewTables: []manifest.NewTableEntry{
 					{
 						Level: 0,
 						Meta: newFileMeta(
@@ -878,7 +878,7 @@ func TestValidateVersionEdit(t *testing.T) {
 						),
 					},
 				},
-				DeletedFiles: map[manifest.DeletedFileEntry]*manifest.FileMetadata{
+				DeletedTables: map[manifest.DeletedTableEntry]*manifest.FileMetadata{
 					deletedFileEntry{Level: 6, FileNum: 0}: newFileMeta(
 						manifest.InternalKey{UserKey: []byte("a")},
 						manifest.InternalKey{UserKey: []byte("d")},
@@ -2043,19 +2043,19 @@ func TestCompactionErrorOnUserKeyOverlap(t *testing.T) {
 					comparer:  DefaultComparer,
 					formatKey: DefaultComparer.FormatKey,
 				}
-				var files []manifest.NewFileEntry
+				var files []manifest.NewTableEntry
 				fileNum := base.FileNum(1)
 
 				for _, data := range strings.Split(d.Input, "\n") {
 					meta := parseMeta(data)
 					meta.FileNum = fileNum
 					fileNum++
-					files = append(files, manifest.NewFileEntry{Level: 1, Meta: meta})
+					files = append(files, manifest.NewTableEntry{Level: 1, Meta: meta})
 				}
 
 				result := "OK"
 				ve := &versionEdit{
-					NewFiles: files,
+					NewTables: files,
 				}
 				if err := c.errorOnUserKeyOverlap(ve); err != nil {
 					result = fmt.Sprint(err)

--- a/data_test.go
+++ b/data_test.go
@@ -886,7 +886,7 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 			return err
 		}
 		largestSeqNum := d.mu.versions.logSeqNum.Load()
-		for _, f := range newVE.NewFiles {
+		for _, f := range newVE.NewTables {
 			if start != nil {
 				f.Meta.SmallestPointKey = *start
 				f.Meta.Smallest = *start
@@ -898,7 +898,7 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 			if largestSeqNum <= f.Meta.LargestSeqNum {
 				largestSeqNum = f.Meta.LargestSeqNum + 1
 			}
-			ve.NewFiles = append(ve.NewFiles, newFileEntry{
+			ve.NewTables = append(ve.NewTables, newTableEntry{
 				Level: level,
 				Meta:  f.Meta,
 			})
@@ -1043,16 +1043,16 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 		return nil, err
 	}
 
-	if len(ve.NewFiles) > 0 {
+	if len(ve.NewTables) > 0 {
 		jobID := d.newJobIDLocked()
 		d.mu.versions.logLock()
-		if err := d.mu.versions.logAndApply(jobID, ve, newFileMetrics(ve.NewFiles), false, func() []compactionInfo {
+		if err := d.mu.versions.logAndApply(jobID, ve, newFileMetrics(ve.NewTables), false, func() []compactionInfo {
 			return nil
 		}); err != nil {
 			return nil, err
 		}
 		d.updateReadStateLocked(nil)
-		d.updateTableStatsLocked(ve.NewFiles)
+		d.updateTableStatsLocked(ve.NewTables)
 	}
 
 	return d, nil

--- a/data_test.go
+++ b/data_test.go
@@ -919,12 +919,12 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 	}
 
 	// Example, a-c.
-	parseMeta := func(s string) (*fileMetadata, error) {
+	parseMeta := func(s string) (*tableMetadata, error) {
 		parts := strings.Split(s, "-")
 		if len(parts) != 2 {
 			return nil, errors.Errorf("malformed table spec: %s", s)
 		}
-		m := (&fileMetadata{}).ExtendPointKeyBounds(
+		m := (&tableMetadata{}).ExtendPointKeyBounds(
 			opts.Comparer.Compare,
 			InternalKey{UserKey: []byte(parts[0])},
 			InternalKey{UserKey: []byte(parts[1])},
@@ -1121,7 +1121,7 @@ func runVersionFileSizes(v *version) string {
 func runMetadataCommand(t *testing.T, td *datadriven.TestData, d *DB) string {
 	var file int
 	td.ScanArgs(t, "file", &file)
-	var m *fileMetadata
+	var m *tableMetadata
 	d.mu.Lock()
 	currVersion := d.mu.versions.currentVersion()
 	for _, level := range currVersion.Levels {
@@ -1146,7 +1146,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 
 	// See if we can grab the FileMetadata associated with the file. This is needed
 	// to easily construct virtual sstable properties.
-	var m *fileMetadata
+	var m *tableMetadata
 	d.mu.Lock()
 	currVersion := d.mu.versions.currentVersion()
 	for _, level := range currVersion.Levels {

--- a/db.go
+++ b/db.go
@@ -2265,16 +2265,16 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 
 // makeFileSizeAnnotator returns an annotator that computes the total size of
 // files that meet some criteria defined by filter.
-func (d *DB) makeFileSizeAnnotator(filter func(f *fileMetadata) bool) *manifest.Annotator[uint64] {
+func (d *DB) makeFileSizeAnnotator(filter func(f *tableMetadata) bool) *manifest.Annotator[uint64] {
 	return &manifest.Annotator[uint64]{
 		Aggregator: manifest.SumAggregator{
-			AccumulateFunc: func(f *fileMetadata) (uint64, bool) {
+			AccumulateFunc: func(f *tableMetadata) (uint64, bool) {
 				if filter(f) {
 					return f.Size, true
 				}
 				return 0, true
 			},
-			AccumulatePartialOverlapFunc: func(f *fileMetadata, bounds base.UserKeyBounds) uint64 {
+			AccumulatePartialOverlapFunc: func(f *tableMetadata, bounds base.UserKeyBounds) uint64 {
 				if filter(f) {
 					size, err := d.fileCache.estimateSize(f, bounds.Start, bounds.End.Key)
 					if err != nil {
@@ -2910,7 +2910,7 @@ func (d *DB) ObjProvider() objstorage.Provider {
 	return d.objProvider
 }
 
-func (d *DB) checkVirtualBounds(m *fileMetadata) {
+func (d *DB) checkVirtualBounds(m *tableMetadata) {
 	if !invariants.Enabled {
 		return
 	}

--- a/db.go
+++ b/db.go
@@ -492,7 +492,7 @@ type DB struct {
 			// Compactions, ingests, flushes append files to be processed. An
 			// active stat collection goroutine clears the list and processes
 			// them.
-			pending []manifest.NewFileEntry
+			pending []manifest.NewTableEntry
 		}
 
 		tableValidation struct {
@@ -502,7 +502,7 @@ type DB struct {
 			// pending is a slice of metadata for sstables waiting to be
 			// validated. Only physical sstables should be added to the pending
 			// queue.
-			pending []newFileEntry
+			pending []newTableEntry
 			// validating is set to true when validation is running.
 			validating bool
 		}

--- a/download_test.go
+++ b/download_test.go
@@ -172,7 +172,7 @@ func TestDownloadTask(t *testing.T) {
 			var buf strings.Builder
 			maxConcurrentDownloads := 1
 			td.MaybeScanArgs(t, "max-concurrent-downloads", &maxConcurrentDownloads)
-			task.testing.launchDownloadCompaction = func(f *fileMetadata) (chan error, bool) {
+			task.testing.launchDownloadCompaction = func(f *tableMetadata) (chan error, bool) {
 				ch := make(chan error, 1)
 				if td.HasArg("fail") {
 					fmt.Fprintf(&buf, "launching download for %s and cancelling it\n", f.FileNum)

--- a/event.go
+++ b/event.go
@@ -451,7 +451,7 @@ func (i TableStatsInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 // on an sstable.
 type TableValidatedInfo struct {
 	JobID int
-	Meta  *fileMetadata
+	Meta  *tableMetadata
 }
 
 func (i TableValidatedInfo) String() string {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -79,7 +79,7 @@ func NewExternalIterWithContext(
 		// Add the external iter state to the Iterator so that Close closes it,
 		// and SetOptions can re-construct iterators using its state.
 		externalIter: &externalIterState{readers: readers},
-		newIters: func(context.Context, *manifest.FileMetadata, *IterOptions,
+		newIters: func(context.Context, *manifest.TableMetadata, *IterOptions,
 			internalIterOpts, iterKinds) (iterSet, error) {
 			// NB: External iterators are currently constructed without any
 			// `levelIters`. newIters should never be called. When we support

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -372,8 +372,8 @@ func TestVirtualReadsWiring(t *testing.T) {
 
 	// Write the version edit.
 	fileMetrics := func(ve *versionEdit) map[int]*LevelMetrics {
-		metrics := newFileMetrics(ve.NewFiles)
-		for de, f := range ve.DeletedFiles {
+		metrics := newFileMetrics(ve.NewTables)
+		for de, f := range ve.DeletedTables {
 			lm := metrics[de.Level]
 			if lm == nil {
 				lm = &LevelMetrics{}
@@ -397,14 +397,14 @@ func TestVirtualReadsWiring(t *testing.T) {
 	}
 
 	ve := manifest.VersionEdit{}
-	d1 := manifest.DeletedFileEntry{Level: 6, FileNum: parentFile.FileNum}
-	n1 := manifest.NewFileEntry{Level: 6, Meta: v1}
-	n2 := manifest.NewFileEntry{Level: 6, Meta: v2}
+	d1 := manifest.DeletedTableEntry{Level: 6, FileNum: parentFile.FileNum}
+	n1 := manifest.NewTableEntry{Level: 6, Meta: v1}
+	n2 := manifest.NewTableEntry{Level: 6, Meta: v2}
 
-	ve.DeletedFiles = make(map[manifest.DeletedFileEntry]*manifest.FileMetadata)
-	ve.DeletedFiles[d1] = parentFile
-	ve.NewFiles = append(ve.NewFiles, n1)
-	ve.NewFiles = append(ve.NewFiles, n2)
+	ve.DeletedTables = make(map[manifest.DeletedTableEntry]*manifest.FileMetadata)
+	ve.DeletedTables[d1] = parentFile
+	ve.NewTables = append(ve.NewTables, n1)
+	ve.NewTables = append(ve.NewTables, n2)
 	ve.CreatedBackingTables = append(ve.CreatedBackingTables, parentFile.FileBacking)
 
 	require.NoError(t, applyVE(&ve))

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -323,7 +323,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	seqNumRangeUnset := seqNumA + 5
 	seqNumZ := seqNumA + 6
 
-	v1 := &manifest.FileMetadata{
+	v1 := &manifest.TableMetadata{
 		FileBacking:           parentFile.FileBacking,
 		FileNum:               f1,
 		CreationTime:          time.Now().Unix(),
@@ -340,7 +340,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	}
 	v1.Stats.NumEntries = 1
 
-	v2 := &manifest.FileMetadata{
+	v2 := &manifest.TableMetadata{
 		FileBacking:           parentFile.FileBacking,
 		FileNum:               f2,
 		CreationTime:          time.Now().Unix(),
@@ -401,7 +401,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	n1 := manifest.NewTableEntry{Level: 6, Meta: v1}
 	n2 := manifest.NewTableEntry{Level: 6, Meta: v2}
 
-	ve.DeletedTables = make(map[manifest.DeletedTableEntry]*manifest.FileMetadata)
+	ve.DeletedTables = make(map[manifest.DeletedTableEntry]*manifest.TableMetadata)
 	ve.DeletedTables[d1] = parentFile
 	ve.NewTables = append(ve.NewTables, n1)
 	ve.NewTables = append(ve.NewTables, n2)
@@ -643,7 +643,7 @@ func testFileCacheRandomAccess(t *testing.T, concurrent bool) {
 			rngMu.Lock()
 			fileNum, sleepTime := rng.IntN(fileCacheTestNumTables), rng.IntN(1000)
 			rngMu.Unlock()
-			m := &fileMetadata{FileNum: base.FileNum(fileNum)}
+			m := &tableMetadata{FileNum: base.FileNum(fileNum)}
 			m.InitPhysicalBacking()
 			m.FileBacking.Ref()
 			defer m.FileBacking.Unref()
@@ -708,7 +708,7 @@ func testFileCacheFrequentlyUsedInternal(t *testing.T, rangeIter bool) {
 		for _, j := range [...]int{pinned0, i % fileCacheTestNumTables, pinned1} {
 			var iters iterSet
 			var err error
-			m := &fileMetadata{FileNum: base.FileNum(j)}
+			m := &tableMetadata{FileNum: base.FileNum(j)}
 			m.InitPhysicalBacking()
 			m.FileBacking.Ref()
 			if rangeIter {
@@ -757,7 +757,7 @@ func TestSharedFileCacheFrequentlyUsed(t *testing.T) {
 
 	for i := 0; i < N; i++ {
 		for _, j := range [...]int{pinned0, i % fileCacheTestNumTables, pinned1} {
-			m := &fileMetadata{FileNum: base.FileNum(j)}
+			m := &tableMetadata{FileNum: base.FileNum(j)}
 			m.InitPhysicalBacking()
 			m.FileBacking.Ref()
 			iters1, err := h1.newIters(context.Background(), m, nil, internalIterOpts{}, iterPointKeys)
@@ -811,7 +811,7 @@ func testFileCacheEvictionsInternal(t *testing.T, rangeIter bool) {
 		j := rng.IntN(fileCacheTestNumTables)
 		var iters iterSet
 		var err error
-		m := &fileMetadata{FileNum: base.FileNum(j)}
+		m := &tableMetadata{FileNum: base.FileNum(j)}
 		m.InitPhysicalBacking()
 		m.FileBacking.Ref()
 		if rangeIter {
@@ -876,7 +876,7 @@ func TestSharedFileCacheEvictions(t *testing.T) {
 	rng := rand.New(rand.NewPCG(0, 0))
 	for i := 0; i < N; i++ {
 		j := rng.IntN(fileCacheTestNumTables)
-		m := &fileMetadata{FileNum: base.FileNum(j)}
+		m := &tableMetadata{FileNum: base.FileNum(j)}
 		m.InitPhysicalBacking()
 		m.FileBacking.Ref()
 		iters1, err := h1.newIters(context.Background(), m, nil, internalIterOpts{}, iterPointKeys)
@@ -944,7 +944,7 @@ func TestFileCacheIterLeak(t *testing.T) {
 	defer fct.cleanup()
 	h, _ := fct.newTestHandle()
 
-	m := &fileMetadata{FileNum: 0}
+	m := &tableMetadata{FileNum: 0}
 	m.InitPhysicalBacking()
 	m.FileBacking.Ref()
 	defer m.FileBacking.Unref()
@@ -972,7 +972,7 @@ func TestSharedFileCacheIterLeak(t *testing.T) {
 	h2, _ := fct.newTestHandle()
 	h3, _ := fct.newTestHandle()
 
-	m := &fileMetadata{FileNum: 0}
+	m := &tableMetadata{FileNum: 0}
 	m.InitPhysicalBacking()
 	m.FileBacking.Ref()
 	defer m.FileBacking.Unref()
@@ -1013,7 +1013,7 @@ func TestFileCacheRetryAfterFailure(t *testing.T) {
 	h, fs := fct.newTestHandle()
 
 	fs.setOpenError(true /* enabled */)
-	m := &fileMetadata{FileNum: 0}
+	m := &tableMetadata{FileNum: 0}
 	m.InitPhysicalBacking()
 	m.FileBacking.Ref()
 	defer m.FileBacking.Unref()
@@ -1059,7 +1059,7 @@ func TestFileCacheErrorBadMagicNumber(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	m := &fileMetadata{FileNum: testFileNum}
+	m := &tableMetadata{FileNum: testFileNum}
 	m.InitPhysicalBacking()
 	m.FileBacking.Ref()
 	defer m.FileBacking.Unref()
@@ -1151,7 +1151,7 @@ func TestFileCacheClockPro(t *testing.T) {
 
 		shard := fcs.fileCache.shards[0]
 		oldHits := shard.hits.Load()
-		m := &fileMetadata{FileNum: base.FileNum(key)}
+		m := &tableMetadata{FileNum: base.FileNum(key)}
 		m.InitPhysicalBacking()
 		m.FileBacking.Ref()
 		v := shard.findNode(context.Background(), m.FileBacking, h)
@@ -1272,7 +1272,7 @@ func BenchmarkFileCacheHotPath(b *testing.B) {
 
 	makeTable(1)
 
-	m := &fileMetadata{FileNum: 1}
+	m := &tableMetadata{FileNum: 1}
 	m.InitPhysicalBacking()
 	m.FileBacking.Ref()
 

--- a/flushable.go
+++ b/flushable.go
@@ -54,7 +54,7 @@ type bounded interface {
 	UserKeyBounds() base.UserKeyBounds
 }
 
-var _ bounded = (*fileMetadata)(nil)
+var _ bounded = (*tableMetadata)(nil)
 var _ bounded = KeyRange{}
 
 func sliceAsBounded[B bounded](s []B) []bounded {
@@ -168,7 +168,7 @@ type ingestedFlushable struct {
 }
 
 func newIngestedFlushable(
-	files []*fileMetadata,
+	files []*tableMetadata,
 	comparer *Comparer,
 	newIters tableNewIters,
 	newRangeKeyIters keyspanimpl.TableNewSpanIter,
@@ -232,7 +232,7 @@ func (s *ingestedFlushable) newFlushIter(*IterOptions) internalIterator {
 }
 
 func (s *ingestedFlushable) constructRangeDelIter(
-	ctx context.Context, file *manifest.FileMetadata, _ keyspan.SpanIterOptions,
+	ctx context.Context, file *manifest.TableMetadata, _ keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error) {
 	iters, err := s.newIters(ctx, file, nil, internalIterOpts{}, iterRangeDeletions)
 	if err != nil {

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -48,7 +48,7 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 	}
 	reset()
 
-	loadFileMeta := func(paths []string, exciseSpan KeyRange, seqNum base.SeqNum) []*fileMetadata {
+	loadFileMeta := func(paths []string, exciseSpan KeyRange, seqNum base.SeqNum) []*tableMetadata {
 		pendingOutputs := make([]base.FileNum, len(paths))
 		for i := range paths {
 			pendingOutputs[i] = d.mu.versions.getNextFileNum()
@@ -61,12 +61,12 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		meta := make([]*fileMetadata, len(lr.local))
+		meta := make([]*tableMetadata, len(lr.local))
 		if exciseSpan.Valid() {
 			seqNum++
 		}
 		for i := range meta {
-			meta[i] = lr.local[i].fileMetadata
+			meta[i] = lr.local[i].tableMetadata
 			if err := setSeqNumInMetadata(meta[i], seqNum+base.SeqNum(i), d.cmp, d.opts.Comparer.FormatKey); err != nil {
 				t.Fatal(err)
 			}

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -487,7 +487,7 @@ func (d *DB) compactMarkedFilesLocked() error {
 // findFilesFunc scans the LSM for files, returning true if at least one
 // file was found. The returned array contains the matched files, if any, per
 // level.
-type findFilesFunc func(v *version) (found bool, files [numLevels][]*fileMetadata, _ error)
+type findFilesFunc func(v *version) (found bool, files [numLevels][]*tableMetadata, _ error)
 
 // This method is not used currently, but it will be useful the next time we need
 // to mark files for compaction.
@@ -505,7 +505,7 @@ func (d *DB) markFilesLocked(findFn findFilesFunc) error {
 	rs := d.loadReadState()
 	var (
 		found bool
-		files [numLevels][]*fileMetadata
+		files [numLevels][]*tableMetadata
 		err   error
 	)
 	func() {

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -386,7 +386,7 @@ func TestGetIter(t *testing.T) {
 		// m is a map from file numbers to DBs.
 		m := map[base.FileNum]*memTable{}
 		newIter := func(
-			_ context.Context, file *manifest.FileMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds,
+			_ context.Context, file *manifest.TableMetadata, _ *IterOptions, _ internalIterOpts, _ iterKinds,
 		) (iterSet, error) {
 			d, ok := m[file.FileNum]
 			if !ok {
@@ -395,12 +395,12 @@ func TestGetIter(t *testing.T) {
 			return iterSet{point: d.newIter(nil)}, nil
 		}
 
-		var files [numLevels][]*fileMetadata
+		var files [numLevels][]*tableMetadata
 		for _, tt := range tc.tables {
 			d := newMemTable(memTableOptions{})
 			m[tt.fileNum] = d
 
-			meta := &fileMetadata{
+			meta := &tableMetadata{
 				FileNum: tt.fileNum,
 			}
 			meta.InitPhysicalBacking()

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -867,7 +867,7 @@ func TestExcise(t *testing.T) {
 
 		case "excise":
 			ve := &versionEdit{
-				DeletedFiles: map[deletedFileEntry]*fileMetadata{},
+				DeletedTables: map[deletedFileEntry]*fileMetadata{},
 			}
 			var exciseSpan KeyRange
 			if len(td.CmdArgs) != 2 {
@@ -893,7 +893,7 @@ func TestExcise(t *testing.T) {
 			d.mu.Lock()
 			d.mu.versions.logUnlock()
 			d.mu.Unlock()
-			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedFiles), ve.DebugString(base.DefaultFormatter))
+			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedTables), ve.DebugString(base.DefaultFormatter))
 
 		case "confirm-backing":
 			// Confirms that the files have the same FileBacking.
@@ -1219,7 +1219,7 @@ func testIngestSharedImpl(
 
 		case "excise":
 			ve := &versionEdit{
-				DeletedFiles: map[deletedFileEntry]*fileMetadata{},
+				DeletedTables: map[deletedFileEntry]*fileMetadata{},
 			}
 			var exciseSpan KeyRange
 			if len(td.CmdArgs) != 2 {
@@ -1247,7 +1247,7 @@ func testIngestSharedImpl(
 			d.mu.Lock()
 			d.mu.versions.logUnlock()
 			d.mu.Unlock()
-			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedFiles), ve.String())
+			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedTables), ve.String())
 
 		case "file-only-snapshot":
 			if len(td.CmdArgs) != 1 {
@@ -1721,7 +1721,7 @@ func TestConcurrentExcise(t *testing.T) {
 
 		case "excise":
 			ve := &versionEdit{
-				DeletedFiles: map[deletedFileEntry]*fileMetadata{},
+				DeletedTables: map[deletedFileEntry]*fileMetadata{},
 			}
 			var exciseSpan KeyRange
 			if len(td.CmdArgs) != 2 {
@@ -1749,7 +1749,7 @@ func TestConcurrentExcise(t *testing.T) {
 			d.mu.Lock()
 			d.mu.versions.logUnlock()
 			d.mu.Unlock()
-			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedFiles), ve.String())
+			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedTables), ve.String())
 
 		case "file-only-snapshot":
 			if len(td.CmdArgs) != 1 {
@@ -3156,7 +3156,7 @@ func TestIngestMemtableOverlapRace(t *testing.T) {
 		var ve manifest.VersionEdit
 		require.NoError(t, ve.Decode(r))
 		t.Log(ve.String())
-		for _, f := range ve.NewFiles {
+		for _, f := range ve.NewTables {
 			if largest != nil {
 				require.Equal(t, 0, f.Level)
 				if largest.LargestSeqNum > f.Meta.LargestSeqNum {

--- a/internal/compact/splitting.go
+++ b/internal/compact/splitting.go
@@ -179,7 +179,7 @@ func (s *OutputSplitter) boundaryReached(key []byte) (nextBoundary []byte) {
 	return s.nextBoundary.key
 }
 
-func (s *OutputSplitter) setNextBoundary(nextGrandparent *manifest.FileMetadata) {
+func (s *OutputSplitter) setNextBoundary(nextGrandparent *manifest.TableMetadata) {
 	if nextGrandparent != nil && (s.limit == nil || s.cmp(nextGrandparent.Smallest.UserKey, s.limit) < 0) {
 		s.nextBoundary = splitterBoundary{
 			key:           nextGrandparent.Smallest.UserKey,

--- a/internal/compact/splitting_test.go
+++ b/internal/compact/splitting_test.go
@@ -24,7 +24,7 @@ func TestOutputSplitter(t *testing.T) {
 		switch d.Cmd {
 		case "init-grandparents":
 			// We create a version with all tables in L1.
-			var files [manifest.NumLevels][]*manifest.FileMetadata
+			var files [manifest.NumLevels][]*manifest.TableMetadata
 			if d.Input != "" {
 				for _, l := range strings.Split(d.Input, "\n") {
 					f, err := manifest.ParseFileMetadataDebug(l)

--- a/internal/keyspan/keyspanimpl/level_iter.go
+++ b/internal/keyspan/keyspanimpl/level_iter.go
@@ -18,7 +18,7 @@ import (
 // TableNewSpanIter creates a new iterator for range key spans for the given
 // file.
 type TableNewSpanIter func(
-	ctx context.Context, file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions,
+	ctx context.Context, file *manifest.TableMetadata, iterOptions keyspan.SpanIterOptions,
 ) (keyspan.FragmentIterator, error)
 
 // LevelIter provides a merged view of spans from sstables in an L1+ level or an
@@ -56,7 +56,7 @@ type LevelIter struct {
 	files manifest.LevelIterator
 
 	// file always corresponds to the current position of LevelIter.files.
-	file *manifest.FileMetadata
+	file *manifest.TableMetadata
 	pos  levelIterPos
 	// fileIter is the iterator for LevelIter.file when pos is atFile; it is nil
 	// otherwise.
@@ -66,7 +66,7 @@ type LevelIter struct {
 	// need an iterator it is for the same file. When fileIter is not nil,
 	// fileIter is the same with lastIter and file is the same with lastIterFile.
 	lastIter     keyspan.FragmentIterator
-	lastIterFile *manifest.FileMetadata
+	lastIterFile *manifest.TableMetadata
 
 	wrapFn       keyspan.WrapFn
 	straddleSpan keyspan.Span
@@ -436,17 +436,17 @@ func (l *LevelIter) DebugTree(tp treeprinter.Node) {
 	}
 }
 
-func (l *LevelIter) setPosBeforeFile(f *manifest.FileMetadata) {
+func (l *LevelIter) setPosBeforeFile(f *manifest.TableMetadata) {
 	l.setPosInternal(f, beforeFile)
 }
 
-func (l *LevelIter) setPosAfterFile(f *manifest.FileMetadata) {
+func (l *LevelIter) setPosAfterFile(f *manifest.TableMetadata) {
 	l.setPosInternal(f, afterFile)
 }
 
 // setPosAtFile sets the current position and opens an iterator for the file (if
 // necessary).
-func (l *LevelIter) setPosAtFile(f *manifest.FileMetadata) error {
+func (l *LevelIter) setPosAtFile(f *manifest.TableMetadata) error {
 	l.setPosInternal(f, atFile)
 	// See if the last iterator was for the same file; if not, close it and open a
 	// new one.
@@ -472,7 +472,7 @@ func (l *LevelIter) setPosAtFile(f *manifest.FileMetadata) error {
 }
 
 // setPos sets l.file and l.pos (and closes the iteris for the new file).
-func (l *LevelIter) setPosInternal(f *manifest.FileMetadata, pos levelIterPos) {
+func (l *LevelIter) setPosInternal(f *manifest.TableMetadata, pos levelIterPos) {
 	l.file = f
 	l.fileIter = nil
 	l.pos = pos
@@ -485,7 +485,7 @@ func (l *LevelIter) straddleSpansEnabled() bool {
 // needStraddleSpan returns true if straddle spans are enabled and there is a
 // gap between the bounds of the files. file and nextFile are assumed to be
 // consecutive files in the level, in the order they appear in the level.
-func (l *LevelIter) needStraddleSpan(file, nextFile *manifest.FileMetadata) bool {
+func (l *LevelIter) needStraddleSpan(file, nextFile *manifest.TableMetadata) bool {
 	// We directly use range key bounds because that is the current condition for
 	// straddleSpansEnabled.
 	return l.straddleSpansEnabled() && l.cmp(file.LargestRangeKey.UserKey, nextFile.SmallestRangeKey.UserKey) < 0
@@ -493,7 +493,7 @@ func (l *LevelIter) needStraddleSpan(file, nextFile *manifest.FileMetadata) bool
 
 // makeStraddleSpan returns a straddle span that covers the gap between file and
 // nextFile.
-func (l *LevelIter) makeStraddleSpan(file, nextFile *manifest.FileMetadata) *keyspan.Span {
+func (l *LevelIter) makeStraddleSpan(file, nextFile *manifest.TableMetadata) *keyspan.Span {
 	l.straddleSpan = keyspan.Span{
 		Start: file.LargestRangeKey.UserKey,
 		End:   nextFile.SmallestRangeKey.UserKey,

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -311,7 +311,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 			for i := range metas {
 				amap[metas[i].FileNum] = metas[i]
 			}
-			b.Added[6] = amap
+			b.AddedTables[6] = amap
 			v, err := b.Apply(nil, base.DefaultComparer, 0, 0)
 			require.NoError(t, err)
 			levelIter.Init(

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -283,10 +283,10 @@ func TestLevelIterEquivalence(t *testing.T) {
 		for j, level := range tc.levels {
 			j := j // Copy for use in closures down below.
 			var levelIter LevelIter
-			var metas []*manifest.FileMetadata
+			var metas []*manifest.TableMetadata
 			for k, file := range level {
 				fileIters = append(fileIters, keyspan.NewIter(base.DefaultComparer.Compare, file))
-				meta := &manifest.FileMetadata{
+				meta := &manifest.TableMetadata{
 					FileNum:               base.FileNum(k + 1),
 					Size:                  1024,
 					SmallestSeqNum:        2,
@@ -302,12 +302,12 @@ func TestLevelIterEquivalence(t *testing.T) {
 				metas = append(metas, meta)
 			}
 
-			tableNewIters := func(ctx context.Context, file *manifest.FileMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+			tableNewIters := func(ctx context.Context, file *manifest.TableMetadata, iterOptions keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
 				return keyspan.NewIter(base.DefaultComparer.Compare, tc.levels[j][file.FileNum-1]), nil
 			}
 			// Add all the fileMetadatas to L6.
 			b := &manifest.BulkVersionEdit{}
-			amap := make(map[base.FileNum]*manifest.FileMetadata)
+			amap := make(map[base.FileNum]*manifest.TableMetadata)
 			for i := range metas {
 				amap[metas[i].FileNum] = metas[i]
 			}
@@ -354,7 +354,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 func TestLevelIter(t *testing.T) {
 	var cmp = base.DefaultComparer.Compare
 	type file struct {
-		meta      *manifest.FileMetadata
+		meta      *manifest.TableMetadata
 		rangeDels []keyspan.Span
 		rangeKeys []keyspan.Span
 	}
@@ -366,7 +366,7 @@ func TestLevelIter(t *testing.T) {
 			files = nil
 			for _, key := range strings.Split(d.Input, "\n") {
 				if strings.HasPrefix(key, "file") {
-					meta := &manifest.FileMetadata{
+					meta := &manifest.TableMetadata{
 						FileNum: base.FileNum(len(files) + 1),
 					}
 					meta.InitPhysicalBacking()
@@ -416,14 +416,14 @@ func TestLevelIter(t *testing.T) {
 					keyType = manifest.KeyTypePoint
 				}
 			}
-			tableNewIters := func(ctx context.Context, file *manifest.FileMetadata, _ keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
+			tableNewIters := func(ctx context.Context, file *manifest.TableMetadata, _ keyspan.SpanIterOptions) (keyspan.FragmentIterator, error) {
 				f := files[file.FileNum-1]
 				if keyType == manifest.KeyTypePoint {
 					return keyspan.NewIter(cmp, f.rangeDels), nil
 				}
 				return keyspan.NewIter(cmp, f.rangeKeys), nil
 			}
-			metas := make([]*manifest.FileMetadata, len(files))
+			metas := make([]*manifest.TableMetadata, len(files))
 			for i := range files {
 				metas[i] = files[i].meta
 			}

--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -13,17 +13,17 @@ import (
 )
 
 // Creates a version with numFiles files in level 6.
-func makeTestVersion(numFiles int) (*Version, []*FileMetadata) {
-	files := make([]*FileMetadata, numFiles)
+func makeTestVersion(numFiles int) (*Version, []*TableMetadata) {
+	files := make([]*TableMetadata, numFiles)
 	for i := 0; i < numFiles; i++ {
 		// Each file spans 10 keys, e.g. [0->9], [10->19], etc.
-		files[i] = (&FileMetadata{}).ExtendPointKeyBounds(
+		files[i] = (&TableMetadata{}).ExtendPointKeyBounds(
 			base.DefaultComparer.Compare, key(i*10), key(i*10+9),
 		)
 		files[i].InitPhysicalBacking()
 	}
 
-	var levelFiles [7][]*FileMetadata
+	var levelFiles [7][]*TableMetadata
 	levelFiles[6] = files
 
 	v := NewVersion(base.DefaultComparer, 0, levelFiles)
@@ -52,12 +52,12 @@ func BenchmarkNumFilesAnnotator(b *testing.B) {
 
 func TestPickFileAggregator(t *testing.T) {
 	const count = 1000
-	a := Annotator[FileMetadata]{
+	a := Annotator[TableMetadata]{
 		Aggregator: PickFileAggregator{
-			Filter: func(f *FileMetadata) (eligible bool, cacheOK bool) {
+			Filter: func(f *TableMetadata) (eligible bool, cacheOK bool) {
 				return true, true
 			},
-			Compare: func(f1 *FileMetadata, f2 *FileMetadata) bool {
+			Compare: func(f1 *TableMetadata, f2 *TableMetadata) bool {
 				return base.DefaultComparer.Compare(f1.Smallest.UserKey, f2.Smallest.UserKey) < 0
 			},
 		},

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -20,15 +20,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newItem(k InternalKey) *FileMetadata {
-	m := (&FileMetadata{}).ExtendPointKeyBounds(
+func newItem(k InternalKey) *TableMetadata {
+	m := (&TableMetadata{}).ExtendPointKeyBounds(
 		base.DefaultComparer.Compare, k, k,
 	)
 	m.InitPhysicalBacking()
 	return m
 }
 
-func cmp(a, b *FileMetadata) int {
+func cmp(a, b *TableMetadata) int {
 	return cmpKey(a.Smallest, b.Smallest)
 }
 
@@ -114,7 +114,7 @@ func (t *btree) isSorted(tt *testing.T) {
 	t.root.isSorted(tt, t.bcmp)
 }
 
-func (n *node) isSorted(t *testing.T, cmp func(*FileMetadata, *FileMetadata) int) {
+func (n *node) isSorted(t *testing.T, cmp func(*TableMetadata, *TableMetadata) int) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
@@ -477,7 +477,7 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 
 	t.Log("Checking all values again")
 	for i, tree := range trees {
-		var wantpart []*FileMetadata
+		var wantpart []*TableMetadata
 		if i < len(trees)/2 {
 			wantpart = want[:cloneTestSize/2]
 		} else {
@@ -551,7 +551,7 @@ func TestRandomizedBTree(t *testing.T) {
 		numOps = 10_000 + rng.IntN(40_000)
 	}
 
-	var metadataAlloc [maxFileNum]FileMetadata
+	var metadataAlloc [maxFileNum]TableMetadata
 	for i := 0; i < len(metadataAlloc); i++ {
 		metadataAlloc[i].FileNum = base.FileNum(i)
 		metadataAlloc[i].InitPhysicalBacking()
@@ -560,7 +560,7 @@ func TestRandomizedBTree(t *testing.T) {
 	// Use a btree comparator that sorts by file number to make it easier to
 	// prevent duplicates or overlaps.
 	tree := btree{
-		bcmp: func(a *FileMetadata, b *FileMetadata) int {
+		bcmp: func(a *TableMetadata, b *TableMetadata) int {
 			return stdcmp.Compare(a.FileNum, b.FileNum)
 		},
 	}
@@ -635,7 +635,7 @@ func TestRandomizedBTree(t *testing.T) {
 //////////////////////////////////////////
 
 // perm returns a random permutation of items with keys in the range [0, n).
-func perm(n int) (out []*FileMetadata) {
+func perm(n int) (out []*TableMetadata) {
 	for _, i := range rand.Perm(n) {
 		out = append(out, newItem(key(i)))
 	}
@@ -643,14 +643,14 @@ func perm(n int) (out []*FileMetadata) {
 }
 
 // rang returns an ordered list of items with keys in the range [m, n].
-func rang(m, n int) (out []*FileMetadata) {
+func rang(m, n int) (out []*TableMetadata) {
 	for i := m; i <= n; i++ {
 		out = append(out, newItem(key(i)))
 	}
 	return out
 }
 
-func strReprs(items []*FileMetadata) []string {
+func strReprs(items []*TableMetadata) []string {
 	s := make([]string, len(items))
 	for i := range items {
 		s[i] = items[i].String()
@@ -659,7 +659,7 @@ func strReprs(items []*FileMetadata) []string {
 }
 
 // all extracts all items from a tree in order as a slice.
-func all(tr *btree) (out []*FileMetadata) {
+func all(tr *btree) (out []*TableMetadata) {
 	it := tr.Iter()
 	it.first()
 	for it.valid() {

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -47,7 +47,7 @@ func readManifest(filename string) (*Version, error) {
 			return nil, err
 		}
 		var bve BulkVersionEdit
-		bve.AddedByFileNum = addedByFileNum
+		bve.AddedTablesByFileNum = addedByFileNum
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}

--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -21,7 +21,7 @@ func TestLevelIterator(t *testing.T) {
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "define":
-				var files []*FileMetadata
+				var files []*TableMetadata
 				var startReslice int
 				var endReslice int
 				for _, metaStr := range strings.Split(d.Input, " ") {
@@ -39,7 +39,7 @@ func TestLevelIterator(t *testing.T) {
 						if len(parts) != 2 {
 							t.Fatalf("malformed table spec: %q", metaStr)
 						}
-						m := &FileMetadata{FileNum: base.FileNum(len(files) + 1)}
+						m := &TableMetadata{FileNum: base.FileNum(len(files) + 1)}
 						m.ExtendPointKeyBounds(
 							base.DefaultComparer.Compare,
 							base.ParseInternalKey(strings.TrimSpace(parts[0])),
@@ -78,7 +78,7 @@ func TestLevelIteratorFiltered(t *testing.T) {
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "define":
-				var files []*FileMetadata
+				var files []*TableMetadata
 				for _, metaStr := range strings.Split(d.Input, "\n") {
 					m, err := ParseFileMetadataDebug(metaStr)
 					require.NoError(t, err)
@@ -114,7 +114,7 @@ func runIterCmd(t *testing.T, d *datadriven.TestData, iter LevelIterator, verbos
 		if len(parts) == 0 {
 			continue
 		}
-		var m *FileMetadata
+		var m *TableMetadata
 		switch parts[0] {
 		case "first":
 			m = iter.First()

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -114,7 +114,7 @@ func replayManifest(t *testing.T, opts *pebble.Options, dirname string) *manifes
 
 	cmp := opts.Comparer
 	var bve manifest.BulkVersionEdit
-	bve.AddedByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+	bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
 	rr := record.NewReader(f, 0 /* logNum */)
 	for {
 		r, err := rr.Next()

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -114,7 +114,7 @@ func replayManifest(t *testing.T, opts *pebble.Options, dirname string) *manifes
 
 	cmp := opts.Comparer
 	var bve manifest.BulkVersionEdit
-	bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+	bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.TableMetadata)
 	rr := record.NewReader(f, 0 /* logNum */)
 	for {
 		r, err := rr.Next()

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -50,7 +50,7 @@ func checkRoundTrip(e0 VersionEdit) error {
 // FileBacking should be set.
 func TestVERoundTripAndAccumulate(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
-	m1 := (&FileMetadata{
+	m1 := (&TableMetadata{
 		FileNum:                  810,
 		Size:                     8090,
 		CreationTime:             809060,
@@ -69,7 +69,7 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 	)
 	m1.InitPhysicalBacking()
 
-	m2 := (&FileMetadata{
+	m2 := (&TableMetadata{
 		FileNum:               812,
 		Size:                  8090,
 		CreationTime:          809060,
@@ -120,7 +120,7 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 
 func TestVersionEditRoundTrip(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
-	m1 := (&FileMetadata{
+	m1 := (&TableMetadata{
 		FileNum:      805,
 		Size:         8050,
 		CreationTime: 805030,
@@ -131,7 +131,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	)
 	m1.InitPhysicalBacking()
 
-	m2 := (&FileMetadata{
+	m2 := (&TableMetadata{
 		FileNum:                  806,
 		Size:                     8060,
 		CreationTime:             806040,
@@ -147,7 +147,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	)
 	m2.InitPhysicalBacking()
 
-	m3 := (&FileMetadata{
+	m3 := (&TableMetadata{
 		FileNum:      807,
 		Size:         8070,
 		CreationTime: 807050,
@@ -158,7 +158,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	)
 	m3.InitPhysicalBacking()
 
-	m4 := (&FileMetadata{
+	m4 := (&TableMetadata{
 		FileNum:               809,
 		Size:                  8090,
 		CreationTime:          809060,
@@ -176,7 +176,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	)
 	m4.InitPhysicalBacking()
 
-	m5 := (&FileMetadata{
+	m5 := (&TableMetadata{
 		FileNum:               810,
 		Size:                  8090,
 		CreationTime:          809060,
@@ -194,7 +194,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	)
 	m5.InitPhysicalBacking()
 
-	m6 := (&FileMetadata{
+	m6 := (&TableMetadata{
 		FileNum:               811,
 		Size:                  8090,
 		CreationTime:          809060,
@@ -224,7 +224,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			LastSeqNum:           55,
 			RemovedBackingTables: []base.DiskFileNum{10, 11},
 			CreatedBackingTables: []*FileBacking{m5.FileBacking, m6.FileBacking},
-			DeletedTables: map[DeletedTableEntry]*FileMetadata{
+			DeletedTables: map[DeletedTableEntry]*TableMetadata{
 				{
 					Level:   3,
 					FileNum: 703,
@@ -413,7 +413,7 @@ func TestVersionEditApply(t *testing.T) {
 				}
 
 				bve := BulkVersionEdit{}
-				bve.AddedTablesByFileNum = make(map[base.FileNum]*FileMetadata)
+				bve.AddedTablesByFileNum = make(map[base.FileNum]*TableMetadata)
 				for _, l := range v.Levels {
 					it := l.Iter()
 					for f := it.First(); f != nil; f = it.Next() {

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -91,7 +91,7 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 		NextFileNum:          44,
 		LastSeqNum:           55,
 		CreatedBackingTables: []*FileBacking{m1.FileBacking},
-		NewFiles: []NewFileEntry{
+		NewTables: []NewTableEntry{
 			{
 				Level: 4,
 				Meta:  m2,
@@ -224,7 +224,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			LastSeqNum:           55,
 			RemovedBackingTables: []base.DiskFileNum{10, 11},
 			CreatedBackingTables: []*FileBacking{m5.FileBacking, m6.FileBacking},
-			DeletedFiles: map[DeletedFileEntry]*FileMetadata{
+			DeletedTables: map[DeletedTableEntry]*FileMetadata{
 				{
 					Level:   3,
 					FileNum: 703,
@@ -234,7 +234,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					FileNum: 704,
 				}: nil,
 			},
-			NewFiles: []NewFileEntry{
+			NewTables: []NewTableEntry{
 				{
 					Level: 4,
 					Meta:  m1,
@@ -413,11 +413,11 @@ func TestVersionEditApply(t *testing.T) {
 				}
 
 				bve := BulkVersionEdit{}
-				bve.AddedByFileNum = make(map[base.FileNum]*FileMetadata)
+				bve.AddedTablesByFileNum = make(map[base.FileNum]*FileMetadata)
 				for _, l := range v.Levels {
 					it := l.Iter()
 					for f := it.First(); f != nil; f = it.Next() {
-						bve.AddedByFileNum[f.FileNum] = f
+						bve.AddedTablesByFileNum[f.FileNum] = f
 					}
 				}
 

--- a/internal/manifest/virtual_backings.go
+++ b/internal/manifest/virtual_backings.go
@@ -133,7 +133,7 @@ func (bv *VirtualBackings) Remove(n base.DiskFileNum) {
 
 // AddTable is used when a new table is using an exiting backing. The backing
 // must be in the set already.
-func (bv *VirtualBackings) AddTable(m *FileMetadata) {
+func (bv *VirtualBackings) AddTable(m *TableMetadata) {
 	if !m.Virtual {
 		panic(errors.AssertionFailedf("table %s not virtual", m.FileNum))
 	}
@@ -148,7 +148,7 @@ func (bv *VirtualBackings) AddTable(m *FileMetadata) {
 
 // RemoveTable is used when a table using a backing is removed. The backing is
 // not removed from the set, even if it becomes unused.
-func (bv *VirtualBackings) RemoveTable(m *FileMetadata) {
+func (bv *VirtualBackings) RemoveTable(m *TableMetadata) {
 	if !m.Virtual {
 		panic(errors.AssertionFailedf("table %s not virtual", m.FileNum))
 	}

--- a/internal/manifest/virtual_backings_test.go
+++ b/internal/manifest/virtual_backings_test.go
@@ -37,14 +37,14 @@ func TestVirtualBackings(t *testing.T) {
 			bv.Remove(n)
 
 		case "add-table":
-			bv.AddTable(&FileMetadata{
+			bv.AddTable(&TableMetadata{
 				Virtual:     true,
 				FileBacking: &FileBacking{DiskFileNum: n},
 				Size:        size,
 			})
 
 		case "remove-table":
-			bv.RemoveTable(&FileMetadata{
+			bv.RemoveTable(&TableMetadata{
 				Virtual:     true,
 				FileBacking: &FileBacking{DiskFileNum: n},
 				Size:        size,

--- a/internal/overlap/checker.go
+++ b/internal/overlap/checker.go
@@ -24,7 +24,7 @@ type WithLevel struct {
 	Result Kind
 	// SplitFile can be set only when result is OnlyBoundary. If it is set, this
 	// file can be split to free up the range of interest.
-	SplitFile *manifest.FileMetadata
+	SplitFile *manifest.TableMetadata
 }
 
 // Kind indicates the kind of overlap detected between a key range and a level.
@@ -59,9 +59,9 @@ type Checker struct {
 // IteratorFactory is an interface that is used by the Checker to create
 // iterators for a given table. All methods can return nil as an empty iterator.
 type IteratorFactory interface {
-	Points(ctx context.Context, m *manifest.FileMetadata) (base.InternalIterator, error)
-	RangeDels(ctx context.Context, m *manifest.FileMetadata) (keyspan.FragmentIterator, error)
-	RangeKeys(ctx context.Context, m *manifest.FileMetadata) (keyspan.FragmentIterator, error)
+	Points(ctx context.Context, m *manifest.TableMetadata) (base.InternalIterator, error)
+	RangeDels(ctx context.Context, m *manifest.TableMetadata) (keyspan.FragmentIterator, error)
+	RangeKeys(ctx context.Context, m *manifest.TableMetadata) (keyspan.FragmentIterator, error)
 }
 
 // MakeChecker initializes a new Checker.
@@ -151,7 +151,7 @@ func (c *Checker) LevelOverlap(
 // EmptyRegion returns true if the given region doesn't overlap with any keys or
 // ranges in the given table.
 func (c *Checker) EmptyRegion(
-	ctx context.Context, region base.UserKeyBounds, m *manifest.FileMetadata,
+	ctx context.Context, region base.UserKeyBounds, m *manifest.TableMetadata,
 ) (bool, error) {
 	empty, err := c.emptyRegionPointsAndRangeDels(ctx, region, m)
 	if err != nil || !empty {
@@ -163,7 +163,7 @@ func (c *Checker) EmptyRegion(
 // emptyRegionPointsAndRangeDels returns true if the file doesn't contain any
 // point keys or range del spans that overlap with region.
 func (c *Checker) emptyRegionPointsAndRangeDels(
-	ctx context.Context, region base.UserKeyBounds, m *manifest.FileMetadata,
+	ctx context.Context, region base.UserKeyBounds, m *manifest.TableMetadata,
 ) (bool, error) {
 	if !m.HasPointKeys {
 		return true, nil
@@ -210,7 +210,7 @@ func (c *Checker) emptyRegionPointsAndRangeDels(
 // emptyRegionRangeKeys returns true if the file doesn't contain any range key
 // spans that overlap with region.
 func (c *Checker) emptyRegionRangeKeys(
-	ctx context.Context, region base.UserKeyBounds, m *manifest.FileMetadata,
+	ctx context.Context, region base.UserKeyBounds, m *manifest.TableMetadata,
 ) (bool, error) {
 	if !m.HasRangeKeys {
 		return true, nil

--- a/internal/overlap/checker_test.go
+++ b/internal/overlap/checker_test.go
@@ -21,14 +21,14 @@ import (
 
 func TestChecker(t *testing.T) {
 	tables := newTestTables()
-	byName := make(map[string]*manifest.FileMetadata)
+	byName := make(map[string]*manifest.TableMetadata)
 
 	datadriven.RunTest(t, "testdata/checker", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "define":
 			tt := testTable{
 				name: d.CmdArgs[0].String(),
-				meta: &manifest.FileMetadata{
+				meta: &manifest.TableMetadata{
 					FileNum: base.FileNum(1 + len(tables.tables)),
 				},
 			}
@@ -99,7 +99,7 @@ func TestChecker(t *testing.T) {
 			tables.tables[tt.meta] = tt
 
 		case "overlap":
-			var metas []*manifest.FileMetadata
+			var metas []*manifest.TableMetadata
 			lines := strings.Split(d.Input, "\n")
 			for _, arg := range d.CmdArgs {
 				name := arg.String()
@@ -143,7 +143,7 @@ func TestChecker(t *testing.T) {
 
 type testTable struct {
 	name      string
-	meta      *manifest.FileMetadata
+	meta      *manifest.TableMetadata
 	points    []base.InternalKV
 	rangeDels []keyspan.Span
 	rangeKeys []keyspan.Span
@@ -153,7 +153,7 @@ var _ IteratorFactory = (*testTables)(nil)
 
 // testTables implements the IteratorFactory interface for testing purposes.
 type testTables struct {
-	tables map[*manifest.FileMetadata]testTable
+	tables map[*manifest.TableMetadata]testTable
 	// openedIterators keeps track of the iterators we opened. It is reset before
 	// every overlap check.
 	openedIterators []string
@@ -161,7 +161,7 @@ type testTables struct {
 
 func newTestTables() *testTables {
 	return &testTables{
-		tables: make(map[*manifest.FileMetadata]testTable),
+		tables: make(map[*manifest.TableMetadata]testTable),
 	}
 }
 
@@ -175,7 +175,7 @@ func (tt *testTables) OpenedIterators() string {
 }
 
 func (tt *testTables) Points(
-	ctx context.Context, m *manifest.FileMetadata,
+	ctx context.Context, m *manifest.TableMetadata,
 ) (base.InternalIterator, error) {
 	t := tt.get(m)
 	tt.openedIterators = append(tt.openedIterators, fmt.Sprintf("%s/points", t.name))
@@ -186,7 +186,7 @@ func (tt *testTables) Points(
 }
 
 func (tt *testTables) RangeDels(
-	ctx context.Context, m *manifest.FileMetadata,
+	ctx context.Context, m *manifest.TableMetadata,
 ) (keyspan.FragmentIterator, error) {
 	t := tt.get(m)
 	tt.openedIterators = append(tt.openedIterators, fmt.Sprintf("%s/range-del", t.name))
@@ -197,7 +197,7 @@ func (tt *testTables) RangeDels(
 }
 
 func (tt *testTables) RangeKeys(
-	ctx context.Context, m *manifest.FileMetadata,
+	ctx context.Context, m *manifest.TableMetadata,
 ) (keyspan.FragmentIterator, error) {
 	t := tt.get(m)
 	tt.openedIterators = append(tt.openedIterators, fmt.Sprintf("%s/range-key", t.name))
@@ -207,7 +207,7 @@ func (tt *testTables) RangeKeys(
 	return keyspan.NewIter(bytes.Compare, t.rangeKeys), nil
 }
 
-func (tt *testTables) get(m *manifest.FileMetadata) testTable {
+func (tt *testTables) get(m *manifest.TableMetadata) testTable {
 	t, ok := tt.tables[m]
 	if !ok {
 		panic("table not found")

--- a/iterator.go
+++ b/iterator.go
@@ -828,7 +828,7 @@ func (i *Iterator) maybeSampleRead() {
 }
 
 func (i *Iterator) sampleRead() {
-	var topFile *manifest.FileMetadata
+	var topFile *manifest.TableMetadata
 	topLevel, numOverlappingLevels := numLevels, 0
 	mi := i.merging
 	if mi == nil {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -368,7 +368,7 @@ func TestReadSampling(t *testing.T) {
 
 			d.mu.Lock()
 			for _, l := range d.mu.versions.currentVersion().Levels {
-				l.Slice().Each(func(f *fileMetadata) {
+				l.Slice().Each(func(f *tableMetadata) {
 					f.AllowedSeeks.Store(allowedSeeks)
 				})
 			}
@@ -398,7 +398,7 @@ func TestReadSampling(t *testing.T) {
 			var foundAllowedSeeks int64 = -1
 			d.mu.Lock()
 			for _, l := range d.mu.versions.currentVersion().Levels {
-				l.Slice().Each(func(f *fileMetadata) {
+				l.Slice().Each(func(f *tableMetadata) {
 					if f.FileNum == base.FileNum(fileNum) {
 						actualAllowedSeeks := f.AllowedSeeks.Load()
 						foundAllowedSeeks = actualAllowedSeeks
@@ -721,7 +721,7 @@ func TestIteratorSeekOpt(t *testing.T) {
 			d.mu.Unlock()
 			oldNewIters := d.newIters
 			d.newIters = func(
-				ctx context.Context, file *manifest.FileMetadata, opts *IterOptions,
+				ctx context.Context, file *manifest.TableMetadata, opts *IterOptions,
 				internalOpts internalIterOpts, kinds iterKinds) (iterSet, error) {
 				iters, err := oldNewIters(ctx, file, opts, internalOpts, kinds)
 				iters.point = &iterSeekOptWrapper{

--- a/level_checker.go
+++ b/level_checker.go
@@ -401,7 +401,7 @@ func checkRangeTombstones(c *checkConfig) error {
 		for f := files.First(); f != nil; f = files.Next() {
 			lf := files.Take()
 			iters, err := c.newIters(
-				context.Background(), lf.FileMetadata, &IterOptions{layer: manifest.Level(lsmLevel)},
+				context.Background(), lf.TableMetadata, &IterOptions{layer: manifest.Level(lsmLevel)},
 				internalIterOpts{}, iterRangeDeletions)
 			if err != nil {
 				return err

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -91,7 +91,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 	}
 
 	memFS := vfs.NewMem()
-	var levels [][]*fileMetadata
+	var levels [][]*tableMetadata
 	formatKey := testkeys.Comparer.FormatKey
 	// Indexed by fileNum
 	var readers []*sstable.Reader
@@ -103,7 +103,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 
 	var fileNum base.FileNum
 	newIters :=
-		func(_ context.Context, file *manifest.FileMetadata, _ *IterOptions, iio internalIterOpts, _ iterKinds) (iterSet, error) {
+		func(_ context.Context, file *manifest.TableMetadata, _ *IterOptions, iio internalIterOpts, _ iterKinds) (iterSet, error) {
 			r := readers[file.FileNum]
 			rangeDelIter, err := r.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms, iio.readEnv)
 			if err != nil {
@@ -149,7 +149,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				keys := strings.Fields(line)
 				smallestKey := base.ParseInternalKey(keys[0])
 				largestKey := base.ParseInternalKey(keys[1])
-				m := (&fileMetadata{
+				m := (&tableMetadata{
 					FileNum: fileNum,
 				}).ExtendPointKeyBounds(testkeys.Comparer.Compare, smallestKey, largestKey)
 				m.InitPhysicalBacking()
@@ -274,7 +274,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				}
 			}
 
-			var files [numLevels][]*fileMetadata
+			var files [numLevels][]*tableMetadata
 			for i := range levels {
 				// Start from level 1 in this test.
 				files[i+1] = levels[i]

--- a/level_iter.go
+++ b/level_iter.go
@@ -69,7 +69,7 @@ type levelIter struct {
 	//   be relevant to the iteration.
 	iter internalIterator
 	// iterFile holds the current file. It is always equal to l.files.Current().
-	iterFile *fileMetadata
+	iterFile *tableMetadata
 	newIters tableNewIters
 	files    manifest.LevelIterator
 	err      error
@@ -184,7 +184,7 @@ func (l *levelIter) initCombinedIterState(state *combinedIterState) {
 	l.combinedIterState = state
 }
 
-func (l *levelIter) maybeTriggerCombinedIteration(file *fileMetadata, dir int) {
+func (l *levelIter) maybeTriggerCombinedIteration(file *tableMetadata, dir int) {
 	// If we encounter a file that contains range keys, we may need to
 	// trigger a switch to combined range-key and point-key iteration,
 	// if the *pebble.Iterator is configured for it. This switch is done
@@ -238,7 +238,7 @@ func (l *levelIter) maybeTriggerCombinedIteration(file *fileMetadata, dir int) {
 	}
 }
 
-func (l *levelIter) findFileGE(key []byte, flags base.SeekGEFlags) *fileMetadata {
+func (l *levelIter) findFileGE(key []byte, flags base.SeekGEFlags) *tableMetadata {
 	// Find the earliest file whose largest key is >= key.
 
 	// NB: if flags.TrySeekUsingNext()=true, the levelIter must respect it. If
@@ -298,7 +298,7 @@ func (l *levelIter) findFileGE(key []byte, flags base.SeekGEFlags) *fileMetadata
 		nextsUntilSeek = -1
 	}
 
-	var m *fileMetadata
+	var m *tableMetadata
 	if nextInsteadOfSeek {
 		m = l.iterFile
 	} else {
@@ -372,7 +372,7 @@ func (l *levelIter) findFileGE(key []byte, flags base.SeekGEFlags) *fileMetadata
 	return m
 }
 
-func (l *levelIter) findFileLT(key []byte, flags base.SeekLTFlags) *fileMetadata {
+func (l *levelIter) findFileLT(key []byte, flags base.SeekLTFlags) *tableMetadata {
 	// Find the last file whose smallest key is < ikey.
 
 	// Ordinarily we seek the LevelIterator using SeekLT.
@@ -389,7 +389,7 @@ func (l *levelIter) findFileLT(key []byte, flags base.SeekLTFlags) *fileMetadata
 	// one file at a time, checking each for range keys.
 	prevInsteadOfSeek := flags.RelativeSeek() && l.combinedIterState != nil && !l.combinedIterState.initialized
 
-	var m *fileMetadata
+	var m *tableMetadata
 	if prevInsteadOfSeek {
 		m = l.iterFile
 	} else {
@@ -440,7 +440,7 @@ func (l *levelIter) findFileLT(key []byte, flags base.SeekLTFlags) *fileMetadata
 // Init the iteration bounds for the current table. Returns -1 if the table
 // lies fully before the lower bound, +1 if the table lies fully after the
 // upper bound, and 0 if the table overlaps the iteration bounds.
-func (l *levelIter) initTableBounds(f *fileMetadata) int {
+func (l *levelIter) initTableBounds(f *tableMetadata) int {
 	l.tableOpts.LowerBound = l.lower
 	if l.tableOpts.LowerBound != nil {
 		if l.cmp(f.LargestPointKey.UserKey, l.tableOpts.LowerBound) < 0 {
@@ -480,7 +480,7 @@ const (
 	newFileLoaded
 )
 
-func (l *levelIter) loadFile(file *fileMetadata, dir int) loadFileReturnIndicator {
+func (l *levelIter) loadFile(file *tableMetadata, dir int) loadFileReturnIndicator {
 	if l.iterFile == file {
 		if l.err != nil {
 			return noFileLoaded

--- a/lsm_view.go
+++ b/lsm_view.go
@@ -50,7 +50,7 @@ type lsmViewBuilder struct {
 	fmtKey base.FormatKey
 
 	levelNames []string
-	levels     [][]*fileMetadata
+	levels     [][]*tableMetadata
 
 	// The keys that appear as Smallest/Largest, sorted and formatted.
 	sortedKeys []string
@@ -66,10 +66,10 @@ type lsmViewBuilder struct {
 // levelNames and levels.
 func (b *lsmViewBuilder) InitLevels(v *version) {
 	var levelNames []string
-	var levels [][]*fileMetadata
+	var levels [][]*tableMetadata
 	for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
-		var files []*fileMetadata
-		v.L0SublevelFiles[sublevel].Each(func(f *fileMetadata) {
+		var files []*tableMetadata
+		v.L0SublevelFiles[sublevel].Each(func(f *tableMetadata) {
 			files = append(files, f)
 		})
 
@@ -81,8 +81,8 @@ func (b *lsmViewBuilder) InitLevels(v *version) {
 		levels = append(levels, nil)
 	}
 	for level := 1; level < len(v.Levels); level++ {
-		var files []*fileMetadata
-		v.Levels[level].Slice().Each(func(f *fileMetadata) {
+		var files []*tableMetadata
+		v.Levels[level].Slice().Each(func(f *tableMetadata) {
 			files = append(files, f)
 		})
 		levelNames = append(levelNames, fmt.Sprintf("L%d", level))
@@ -158,7 +158,7 @@ func (b *lsmViewBuilder) Build(
 }
 
 func (b *lsmViewBuilder) tableDetails(
-	m *fileMetadata, objProvider objstorage.Provider, newIters tableNewIters,
+	m *tableMetadata, objProvider objstorage.Provider, newIters tableNewIters,
 ) []string {
 	res := make([]string, 0, 10)
 	outf := func(format string, args ...any) {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -164,7 +164,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 		fileNum        base.FileNum
 	)
 	newIters :=
-		func(_ context.Context, file *manifest.FileMetadata, opts *IterOptions, iio internalIterOpts, kinds iterKinds,
+		func(_ context.Context, file *manifest.TableMetadata, opts *IterOptions, iio internalIterOpts, kinds iterKinds,
 		) (iterSet, error) {
 			var set iterSet
 			var err error
@@ -196,7 +196,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 			if err != nil {
 				d.Fatalf(t, "%v", err)
 			}
-			var files [numLevels][]*fileMetadata
+			var files [numLevels][]*tableMetadata
 			for l := range levels {
 				if levels[l].Value() != "L" {
 					d.Fatalf(t, "top-level strings should be L")
@@ -647,12 +647,12 @@ func buildLevelsForMergingIterSeqSeek(
 	}
 	levelSlices = make([]manifest.LevelSlice, levelCount)
 	for i := range readers {
-		meta := make([]*fileMetadata, len(readers[i]))
+		meta := make([]*tableMetadata, len(readers[i]))
 		for j := range readers[i] {
 			iter, err := readers[i][j].NewIter(sstable.NoTransforms, nil /* lower */, nil /* upper */)
 			require.NoError(b, err)
 			smallest := iter.First()
-			meta[j] = &fileMetadata{}
+			meta[j] = &tableMetadata{}
 			// The same FileNum is being reused across different levels, which
 			// is harmless for the benchmark since each level has its own iterator
 			// creation func.
@@ -672,7 +672,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 		levelIndex := i
 		level := len(readers) - 1 - i
 		newIters := func(
-			_ context.Context, file *manifest.FileMetadata, opts *IterOptions, iio internalIterOpts, _ iterKinds,
+			_ context.Context, file *manifest.TableMetadata, opts *IterOptions, iio internalIterOpts, _ iterKinds,
 		) (iterSet, error) {
 			iter, err := readers[levelIndex][file.FileNum].NewIter(
 				sstable.NoTransforms, opts.LowerBound, opts.UpperBound)

--- a/open.go
+++ b/open.go
@@ -409,17 +409,17 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	d.newIters = d.fileCache.newIters
 	d.tableNewRangeKeyIter = tableNewRangeKeyIter(d.newIters)
 
-	d.mu.annotators.totalSize = d.makeFileSizeAnnotator(func(f *manifest.FileMetadata) bool {
+	d.mu.annotators.totalSize = d.makeFileSizeAnnotator(func(f *manifest.TableMetadata) bool {
 		return true
 	})
-	d.mu.annotators.remoteSize = d.makeFileSizeAnnotator(func(f *manifest.FileMetadata) bool {
+	d.mu.annotators.remoteSize = d.makeFileSizeAnnotator(func(f *manifest.TableMetadata) bool {
 		meta, err := d.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
 		if err != nil {
 			return false
 		}
 		return meta.IsRemote()
 	})
-	d.mu.annotators.externalSize = d.makeFileSizeAnnotator(func(f *manifest.FileMetadata) bool {
+	d.mu.annotators.externalSize = d.makeFileSizeAnnotator(func(f *manifest.TableMetadata) bool {
 		meta, err := d.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
 		if err != nil {
 			return false
@@ -804,7 +804,7 @@ func (d *DB) replayIngestedFlushable(
 		panic("pebble: invalid number of entries in batch")
 	}
 
-	meta := make([]*fileMetadata, len(fileNums))
+	meta := make([]*tableMetadata, len(fileNums))
 	var lastRangeKey keyspan.Span
 	for i, n := range fileNums {
 		readable, err := d.objProvider.OpenForReading(context.TODO(), base.FileTypeTable, n,

--- a/open_test.go
+++ b/open_test.go
@@ -1396,7 +1396,7 @@ func TestCheckConsistency(t *testing.T) {
 	require.NoError(t, err)
 	defer provider.Close()
 
-	parseMeta := func(s string) (*manifest.FileMetadata, error) {
+	parseMeta := func(s string) (*manifest.TableMetadata, error) {
 		if len(s) == 0 {
 			return nil, nil
 		}
@@ -1412,7 +1412,7 @@ func TestCheckConsistency(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		m := &manifest.FileMetadata{
+		m := &manifest.TableMetadata{
 			FileNum: base.FileNum(fileNum),
 			Size:    uint64(size),
 		}
@@ -1424,8 +1424,8 @@ func TestCheckConsistency(t *testing.T) {
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "check-consistency":
-				var filesByLevel [manifest.NumLevels][]*manifest.FileMetadata
-				var files *[]*manifest.FileMetadata
+				var filesByLevel [manifest.NumLevels][]*manifest.TableMetadata
+				var files *[]*manifest.TableMetadata
 
 				for _, data := range strings.Split(d.Input, "\n") {
 					switch data {

--- a/overlap.go
+++ b/overlap.go
@@ -35,7 +35,7 @@ var _ overlap.IteratorFactory = (*overlapChecker)(nil)
 
 // Points is part of the overlap.IteratorFactory implementation.
 func (c *overlapChecker) Points(
-	ctx context.Context, m *manifest.FileMetadata,
+	ctx context.Context, m *manifest.TableMetadata,
 ) (base.InternalIterator, error) {
 	iters, err := c.newIters(ctx, m, &c.opts, internalIterOpts{}, iterPointKeys)
 	if err != nil {
@@ -46,7 +46,7 @@ func (c *overlapChecker) Points(
 
 // RangeDels is part of the overlap.IteratorFactory implementation.
 func (c *overlapChecker) RangeDels(
-	ctx context.Context, m *manifest.FileMetadata,
+	ctx context.Context, m *manifest.TableMetadata,
 ) (keyspan.FragmentIterator, error) {
 	iters, err := c.newIters(ctx, m, &c.opts, internalIterOpts{}, iterRangeDeletions)
 	if err != nil {
@@ -57,7 +57,7 @@ func (c *overlapChecker) RangeDels(
 
 // RangeKeys is part of the overlap.IteratorFactory implementation.
 func (c *overlapChecker) RangeKeys(
-	ctx context.Context, m *manifest.FileMetadata,
+	ctx context.Context, m *manifest.TableMetadata,
 ) (keyspan.FragmentIterator, error) {
 	iters, err := c.newIters(ctx, m, &c.opts, internalIterOpts{}, iterRangeKeys)
 	if err != nil {

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -713,7 +713,7 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 	var v *manifest.Version
 	var previousVersion *manifest.Version
 	var bve manifest.BulkVersionEdit
-	bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+	bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.TableMetadata)
 	applyVE := func(ve *manifest.VersionEdit) error {
 		return bve.Accumulate(ve)
 	}

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -89,7 +89,7 @@ type SharedSSTMeta struct {
 	fileNum base.FileNum
 }
 
-func (s *SharedSSTMeta) cloneFromFileMeta(f *fileMetadata) {
+func (s *SharedSSTMeta) cloneFromFileMeta(f *tableMetadata) {
 	*s = SharedSSTMeta{
 		Smallest:         f.Smallest.Clone(),
 		Largest:          f.Largest.Clone(),
@@ -459,7 +459,7 @@ func (d *DB) truncateExternalFile(
 	ctx context.Context,
 	lower, upper []byte,
 	level int,
-	file *fileMetadata,
+	file *tableMetadata,
 	objMeta objstorage.ObjectMetadata,
 ) (*ExternalFile, error) {
 	cmp := d.cmp
@@ -514,7 +514,7 @@ func (d *DB) truncateSharedFile(
 	ctx context.Context,
 	lower, upper []byte,
 	level int,
-	file *fileMetadata,
+	file *tableMetadata,
 	objMeta objstorage.ObjectMetadata,
 ) (sst *SharedSSTMeta, shouldSkip bool, err error) {
 	cmp := d.cmp
@@ -935,7 +935,7 @@ func (i *scanInternalIterator) constructPointIter(
 		i.iterLevels[mlevelsIndex] = IteratorLevel{Kind: IteratorLevelLSM, Level: level}
 		levIter := current.Levels[level].Iter()
 		if level == skipStart {
-			nonRemoteFiles := make([]*manifest.FileMetadata, 0)
+			nonRemoteFiles := make([]*manifest.TableMetadata, 0)
 			for f := levIter.First(); f != nil; f = levIter.Next() {
 				meta, err := i.db.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
 				if err != nil {
@@ -1047,7 +1047,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() error {
 		spanIterOpts := i.opts.SpanIterOptions()
 		levIter := current.RangeKeyLevels[level].Iter()
 		if level == skipStart {
-			nonRemoteFiles := make([]*manifest.FileMetadata, 0)
+			nonRemoteFiles := make([]*manifest.TableMetadata, 0)
 			for f := levIter.First(); f != nil; f = levIter.Next() {
 				meta, err := i.db.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
 				if err != nil {

--- a/table_stats.go
+++ b/table_stats.go
@@ -55,9 +55,9 @@ func (d *DB) maybeCollectTableStatsLocked() {
 // updateTableStatsLocked is called when new files are introduced, after the
 // read state has been updated. It may trigger a new stat collection.
 // DB.mu must be locked when calling.
-func (d *DB) updateTableStatsLocked(newFiles []manifest.NewFileEntry) {
+func (d *DB) updateTableStatsLocked(newTables []manifest.NewTableEntry) {
 	var needStats bool
-	for _, nf := range newFiles {
+	for _, nf := range newTables {
 		if !nf.Meta.StatsValid() {
 			needStats = true
 			break
@@ -67,7 +67,7 @@ func (d *DB) updateTableStatsLocked(newFiles []manifest.NewFileEntry) {
 		return
 	}
 
-	d.mu.tableStats.pending = append(d.mu.tableStats.pending, newFiles...)
+	d.mu.tableStats.pending = append(d.mu.tableStats.pending, newTables...)
 	d.maybeCollectTableStatsLocked()
 }
 
@@ -169,7 +169,7 @@ type collectedStats struct {
 }
 
 func (d *DB) loadNewFileStats(
-	rs *readState, pending []manifest.NewFileEntry,
+	rs *readState, pending []manifest.NewTableEntry,
 ) ([]collectedStats, []deleteCompactionHint) {
 	var hints []deleteCompactionHint
 	collected := make([]collectedStats, 0, len(pending))

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -191,7 +191,7 @@ func TestTableStats(t *testing.T) {
 }
 
 func TestTableRangeDeletionIter(t *testing.T) {
-	var m *fileMetadata
+	var m *tableMetadata
 	cmp := testkeys.Comparer
 	keySchema := colblk.DefaultKeySchema(cmp, 16)
 	fs := vfs.NewMem()
@@ -207,7 +207,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 				KeySchema:   &keySchema,
 				TableFormat: sstable.TableFormatMax,
 			})
-			m = &fileMetadata{}
+			m = &tableMetadata{}
 			for _, line := range strings.Split(td.Input, "\n") {
 				err = w.EncodeSpan(keyspan.ParseSpan(line))
 				if err != nil {

--- a/tool/db.go
+++ b/tool/db.go
@@ -690,7 +690,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 
 		cmp := base.DefaultComparer
 		var bve manifest.BulkVersionEdit
-		bve.AddedByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+		bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
 		rr := record.NewReader(f, 0 /* logNum */)
 		for {
 			r, err := rr.Next()

--- a/tool/db.go
+++ b/tool/db.go
@@ -690,7 +690,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 
 		cmp := base.DefaultComparer
 		var bve manifest.BulkVersionEdit
-		bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+		bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.TableMetadata)
 		rr := record.NewReader(f, 0 /* logNum */)
 		for {
 			r, err := rr.Next()
@@ -953,7 +953,7 @@ func (p *props) update(o props) {
 }
 
 func (d *dbT) addProps(
-	objProvider objstorage.Provider, m manifest.PhysicalFileMeta, p *props,
+	objProvider objstorage.Provider, m manifest.PhysicalTableMeta, p *props,
 ) error {
 	ctx := context.Background()
 	f, err := objProvider.OpenForReading(ctx, base.FileTypeTable, m.FileBacking.DiskFileNum, objstorage.OpenOptions{})

--- a/tool/find.go
+++ b/tool/find.go
@@ -70,7 +70,7 @@ type findT struct {
 	// Set of tables that contains references to the search key.
 	tableRefs map[base.FileNum]bool
 	// Map from file num to table metadata.
-	tableMeta map[base.FileNum]*manifest.FileMetadata
+	tableMeta map[base.FileNum]*manifest.TableMetadata
 	// List of error messages for SSTables that could not be decoded.
 	errors []string
 }
@@ -174,7 +174,7 @@ func (f *findT) findFiles(stdout, stderr io.Writer, dir string) error {
 	f.logs = nil
 	f.manifests = nil
 	f.tables = nil
-	f.tableMeta = make(map[base.FileNum]*manifest.FileMetadata)
+	f.tableMeta = make(map[base.FileNum]*manifest.TableMetadata)
 
 	if _, err := f.opts.FS.Stat(dir); err != nil {
 		return err

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -275,7 +275,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 	l.state.Edits = nil
 	l.state.StartEdit = l.startEdit
 	l.state.Files = make(map[base.FileNum]lsmFileMetadata)
-	var currentFiles [manifest.NumLevels][]*manifest.FileMetadata
+	var currentFiles [manifest.NumLevels][]*manifest.TableMetadata
 
 	backings := make(map[base.DiskFileNum]*manifest.FileBacking)
 
@@ -351,7 +351,7 @@ func (l *lsmT) coalesceEdits(edits []*manifest.VersionEdit) ([]*manifest.Version
 	}
 
 	be := manifest.BulkVersionEdit{}
-	be.AddedTablesByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+	be.AddedTablesByFileNum = make(map[base.FileNum]*manifest.TableMetadata)
 
 	// Coalesce all edits from [0, l.startEdit) into a BulkVersionEdit.
 	for _, ve := range edits[:l.startEdit] {
@@ -363,7 +363,7 @@ func (l *lsmT) coalesceEdits(edits []*manifest.VersionEdit) ([]*manifest.Version
 
 	startingEdit := edits[l.startEdit]
 	var beNewFiles []manifest.NewTableEntry
-	beDeletedFiles := make(map[manifest.DeletedTableEntry]*manifest.FileMetadata)
+	beDeletedFiles := make(map[manifest.DeletedTableEntry]*manifest.TableMetadata)
 
 	for level, deletedFiles := range be.DeletedTables {
 		for _, file := range deletedFiles {

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -105,7 +105,7 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 		if level == 0 && len(v.L0SublevelFiles) > 0 && !v.Levels[level].Empty() {
 			for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
 				fmt.Fprintf(stdout, "--- L0.%d ---\n", sublevel)
-				v.L0SublevelFiles[sublevel].Each(func(f *manifest.FileMetadata) {
+				v.L0SublevelFiles[sublevel].Each(func(f *manifest.TableMetadata) {
 					if !anyOverlapFile(cmp, f, m.filterStart, m.filterEnd) {
 						return
 					}
@@ -151,7 +151,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(stdout, "%s\n", arg)
 
 			var bve manifest.BulkVersionEdit
-			bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+			bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.TableMetadata)
 			var comparer *base.Comparer
 			var editIdx int
 			rr := record.NewReader(f, 0 /* logNum */)
@@ -273,7 +273,7 @@ func anyOverlap(cmp base.Compare, ve *manifest.VersionEdit, start, end key) bool
 	return false
 }
 
-func anyOverlapFile(cmp base.Compare, f *manifest.FileMetadata, start, end key) bool {
+func anyOverlapFile(cmp base.Compare, f *manifest.TableMetadata, start, end key) bool {
 	if f == nil {
 		return true
 	}
@@ -321,9 +321,9 @@ func (m *manifestT) runSummarizeOne(stdout io.Writer, arg string) error {
 		newestOverall time.Time
 		oldestOverall time.Time // oldest after initial version edit
 		buckets       = map[time.Time]*summaryBucket{}
-		metadatas     = map[base.FileNum]*manifest.FileMetadata{}
+		metadatas     = map[base.FileNum]*manifest.TableMetadata{}
 	)
-	bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.FileMetadata)
+	bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.TableMetadata)
 	rr := record.NewReader(f, 0 /* logNum */)
 	numHistErrors := 0
 	for i := 0; ; i++ {
@@ -577,7 +577,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 			// Contains the FileMetadata needed by BulkVersionEdit.Apply.
 			// It accumulates the additions since later edits contain
 			// deletions of earlier added files.
-			addedByFileNum := make(map[base.FileNum]*manifest.FileMetadata)
+			addedByFileNum := make(map[base.FileNum]*manifest.TableMetadata)
 			for {
 				offset := rr.Offset()
 				r, err := rr.Next()

--- a/version_set.go
+++ b/version_set.go
@@ -27,9 +27,9 @@ const manifestMarkerName = `manifest`
 // Provide type aliases for the various manifest structs.
 type bulkVersionEdit = manifest.BulkVersionEdit
 type deletedFileEntry = manifest.DeletedTableEntry
-type fileMetadata = manifest.FileMetadata
-type physicalMeta = manifest.PhysicalFileMeta
-type virtualMeta = manifest.VirtualFileMeta
+type tableMetadata = manifest.TableMetadata
+type physicalMeta = manifest.PhysicalTableMeta
+type virtualMeta = manifest.VirtualTableMeta
 type fileBacking = manifest.FileBacking
 type newTableEntry = manifest.NewTableEntry
 type version = manifest.Version
@@ -232,7 +232,7 @@ func (vs *versionSet) load(
 
 	// Read the versionEdits in the manifest file.
 	var bve bulkVersionEdit
-	bve.AddedTablesByFileNum = make(map[base.FileNum]*fileMetadata)
+	bve.AddedTablesByFileNum = make(map[base.FileNum]*tableMetadata)
 	manifest, err := vs.fs.Open(manifestPath)
 	if err != nil {
 		return errors.Wrapf(err, "pebble: could not open manifest file %q for DB %q",

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -57,7 +57,7 @@ func TestVersionSet(t *testing.T) {
 	))
 	vs.logSeqNum.Store(100)
 
-	metas := make(map[base.FileNum]*manifest.FileMetadata)
+	metas := make(map[base.FileNum]*manifest.TableMetadata)
 	backings := make(map[base.DiskFileNum]*manifest.FileBacking)
 	// When we parse VersionEdits, we get a new FileBacking each time. We need to
 	// deduplicate them, since they hold a ref count.
@@ -176,7 +176,7 @@ func TestVersionSet(t *testing.T) {
 			}
 
 			// Repopulate the maps.
-			metas = make(map[base.FileNum]*manifest.FileMetadata)
+			metas = make(map[base.FileNum]*manifest.TableMetadata)
 			backings = make(map[base.DiskFileNum]*manifest.FileBacking)
 			v := vs.currentVersion()
 			for _, l := range v.Levels {

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -88,7 +88,7 @@ func TestVersionSet(t *testing.T) {
 			if err != nil {
 				td.Fatalf(t, "%v", err)
 			}
-			for _, nf := range ve.NewFiles {
+			for _, nf := range ve.NewTables {
 				// Set a size that depends on FileNum.
 				nf.Meta.Size = uint64(nf.Meta.FileNum) * 100
 				nf.Meta.FileBacking = dedupBacking(nf.Meta.FileBacking)
@@ -97,20 +97,20 @@ func TestVersionSet(t *testing.T) {
 					createFile(nf.Meta.FileBacking.DiskFileNum)
 				}
 			}
-			for de := range ve.DeletedFiles {
+			for de := range ve.DeletedTables {
 				m := metas[de.FileNum]
 				if m == nil {
 					td.Fatalf(t, "unknown FileNum %s", de.FileNum)
 				}
-				ve.DeletedFiles[de] = m
+				ve.DeletedTables[de] = m
 			}
 			for i := range ve.CreatedBackingTables {
 				ve.CreatedBackingTables[i] = dedupBacking(ve.CreatedBackingTables[i])
 				createFile(ve.CreatedBackingTables[i].DiskFileNum)
 			}
 
-			fileMetrics := newFileMetrics(ve.NewFiles)
-			for de, f := range ve.DeletedFiles {
+			fileMetrics := newFileMetrics(ve.NewTables)
+			for de, f := range ve.DeletedTables {
 				lm := fileMetrics[de.Level]
 				if lm == nil {
 					lm = &LevelMetrics{}


### PR DESCRIPTION
With the introduction of blob files, the manifest and version edits will need
to account for the addition and removal of blob files. The term 'file' when
referring to a 'sstable' is vague and potentially confusing.