### PR TITLE
record: add WAL read ahead usage, new chunk format, and major version

### DIFF
--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -25,11 +25,12 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatVirtualSSTables, FormatMajorVersion(16))
 	require.Equal(t, FormatSyntheticPrefixSuffix, FormatMajorVersion(17))
 	require.Equal(t, FormatFlushableIngestExcises, FormatMajorVersion(18))
+	require.Equal(t, FormatColumnarBlocks, FormatMajorVersion(19))
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
-	require.Equal(t, FormatNewest, FormatMajorVersion(19))
-	require.Equal(t, internalFormatNewest, FormatMajorVersion(19))
+	require.Equal(t, FormatNewest, FormatMajorVersion(20))
+	require.Equal(t, internalFormatNewest, FormatMajorVersion(20))
 }
 
 func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
@@ -60,6 +61,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatFlushableIngestExcises, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatColumnarBlocks))
 	require.Equal(t, FormatColumnarBlocks, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatWALSyncChunks))
+	require.Equal(t, FormatWALSyncChunks, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -217,6 +220,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatSyntheticPrefixSuffix:      {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
 		FormatFlushableIngestExcises:     {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
 		FormatColumnarBlocks:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
+		FormatWALSyncChunks:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
 	}
 
 	// Valid versions.

--- a/open.go
+++ b/open.go
@@ -366,6 +366,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		QueueSemChan:         d.commit.logSyncQSem,
 		Logger:               opts.Logger,
 		EventListener:        walEventListenerAdaptor{l: opts.EventListener},
+		WriteWALSyncOffsets:  FormatMajorVersion(d.mu.formatVers.vers.Load()) >= FormatWALSyncChunks,
 	}
 	if opts.WALFailover != nil {
 		walOpts.Secondary = opts.WALFailover.Secondary
@@ -930,18 +931,31 @@ func (d *DB) replayWAL(
 		}
 		if err != nil {
 			// It is common to encounter a zeroed or invalid chunk due to WAL
-			// preallocation and WAL recycling. We need to distinguish these
-			// errors from EOF in order to recognize that the record was
-			// truncated and to avoid replaying subsequent WALs, but want
-			// to otherwise treat them like EOF.
-			if err == io.EOF {
+			// preallocation and WAL recycling. However zeroed or invalid chunks
+			// can also be a consequence of corruption / disk rot. When the log
+			// reader encounters one of these cases, it attempts to disambiguate
+			// by reading ahead looking for a future record. If a future chunk
+			// indicates the chunk at the original offset should've been valid, it
+			// surfaces record.ErrInvalidChunk or record.ErrZeroedChunk. These
+			// errors are always indicative of corruption and data loss.
+			//
+			// Otherwise, the reader surfaces io.ErrUnexpectedEOF indicating that
+			// the WAL terminated uncleanly and ambiguously. If the WAL is the
+			// most recent logical WAL, the caller passes in (strictWALTail=false),
+			// indicating we should tolerate the unclean ending. If the WAL is an
+			// older WAL, the caller passes in (strictWALTail=true), indicating that
+			// the WAL should have been closed cleanly, and we should interpret
+			// the `io.ErrUnexpectedEOF` as corruption and stop recovery.
+			if errors.Is(err, io.EOF) {
 				break
-			} else if record.IsInvalidRecord(err) {
-				if !strictWALTail {
-					break
-				}
+			} else if errors.Is(err, io.ErrUnexpectedEOF) && !strictWALTail {
+				break
+			} else if errors.Is(err, record.ErrInvalidChunk) || errors.Is(err, record.ErrZeroedChunk) {
+				// If a read-ahead returns one of these errors, they should be marked with corruption.
+				// Other I/O related errors should not be marked with corruption and simply returned.
 				err = errors.Mark(err, ErrCorruption)
 			}
+
 			return nil, 0, errors.Wrap(err, "pebble: error when replaying WAL")
 		}
 

--- a/open_test.go
+++ b/open_test.go
@@ -332,7 +332,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000006.019",
+			"marker.format-version.000007.020",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/record/record.go
+++ b/record/record.go
@@ -276,26 +276,58 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 			chunkEncoding := r.buf[r.end+6]
 
 			if int(chunkEncoding) >= len(headerFormatMappings) {
+				r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 				return ErrInvalidChunk
 			}
 			headerFormat := headerFormatMappings[chunkEncoding]
 			chunkPosition, wireFormat, headerSize := headerFormat.chunkPosition, headerFormat.wireFormat, headerFormat.headerSize
 
 			if checksum == 0 && length == 0 && chunkPosition == invalidChunkPosition {
+				// remaining bytes < 11
+				// The remaining bytes in the block is < 11 so regardless of which chunk format is
+				// being written (Recyclable or walSync), we should skip to the next block.
 				if r.end+recyclableHeaderSize > r.n {
 					// Skip the rest of the block if the recyclable header size does not
-					// fit within it.
+					// fit within it. The end of a block will be zeroed out if the log writer
+					// cannot fit another chunk into it, even a chunk with no payload like
+					// the EOF Trailer.
 					r.end = r.n
 					continue
 				}
+
+				// check if 11 <= remaining bytes < 19
+				// If so, the remaining bytes in the block can fit a recyclable header but not a
+				// walSync header. In this case, check if the remainder of the chunk is all zeroes.
+				//
+				// If the remainder was all zeroes, then we tolerate this and continue to
+				// the next block. However, if there was non-zero content in the remaining chunk,
+				// then was possibly an artifact of corruption found and ErrZeroedChunk should be
+				// returned.
+				if r.end+walSyncHeaderSize > r.n {
+					// Check that the remainder of the chunk is all zeroes.
+					for i := r.end; i < r.n; i++ {
+						if r.buf[i] != 0 {
+							r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
+							return ErrZeroedChunk
+						}
+					}
+					r.end = r.n
+					continue
+				}
+
+				// The last case is when there was more than 19 bytes which means there shouldn't be
+				// a zeroed header. Thus, this case should also return ErrZeroedChunk.
+				r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 				return ErrZeroedChunk
 			}
 
 			if wireFormat == invalidWireFormat {
+				r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 				return ErrInvalidChunk
 			}
-			if wireFormat == recyclableWireFormat {
+			if wireFormat == recyclableWireFormat || wireFormat == walSyncWireFormat {
 				if r.end+headerSize > r.n {
+					r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 					return ErrInvalidChunk
 				}
 
@@ -308,6 +340,7 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 					}
 					// Otherwise, treat this chunk as invalid in order to prevent reading
 					// of a partial record.
+					r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 					return ErrInvalidChunk
 				}
 			}
@@ -316,9 +349,11 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 			r.end = r.begin + int(length)
 			if r.end > r.n {
 				// The chunk straddles a 32KB boundary (or the end of file).
+				r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 				return ErrInvalidChunk
 			}
 			if checksum != crc.New(r.buf[r.begin-headerSize+6:r.end]).Value() {
+				r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 				return ErrInvalidChunk
 			}
 			if wantFirst {
@@ -334,6 +369,7 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 				// This can happen if the previous instance of the log ended with a
 				// partial block at the same blockNum as the new log but extended
 				// beyond the partial block of the new log.
+				r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 				return ErrInvalidChunk
 			}
 			return io.EOF
@@ -341,6 +377,7 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 		n, err := io.ReadFull(r.r, r.buf[:])
 		if err != nil && err != io.ErrUnexpectedEOF {
 			if err == io.EOF && !wantFirst {
+				r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)
 				return io.ErrUnexpectedEOF
 			}
 			return err
@@ -360,11 +397,10 @@ func (r *Reader) Next() (io.Reader, error) {
 	}
 	r.begin = r.end
 	r.err = r.nextChunk(true)
-	// TODO(edward) usage of readAheadForCorruption; uncomment in follow PR
-	// if r.err == ErrInvalidChunk || r.err == ErrZeroedChunk {
-	// 	readAheadResult := r.readAheadForCorruption()
-	// 	return nil, readAheadResult
-	// }
+	if errors.Is(r.err, ErrInvalidChunk) || errors.Is(r.err, ErrZeroedChunk) {
+		readAheadResult := r.readAheadForCorruption()
+		return nil, readAheadResult
+	}
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -389,6 +425,9 @@ func (r *Reader) readAheadForCorruption() error {
 	for {
 		// Load the next block into r.buf.
 		n, err := io.ReadFull(r.r, r.buf[:])
+		r.begin, r.end, r.n = 0, 0, n
+		r.blockNum++
+
 		if errors.Is(err, io.EOF) {
 			// io.ErrUnexpectedEOF is returned instead of
 			// io.EOF because io library functions clear
@@ -411,9 +450,6 @@ func (r *Reader) readAheadForCorruption() error {
 			return err
 		}
 
-		r.begin, r.end, r.n = 0, 0, n
-		r.blockNum++
-
 		for r.end+legacyHeaderSize <= r.n {
 			checksum := binary.LittleEndian.Uint32(r.buf[r.end+0 : r.end+4])
 			length := binary.LittleEndian.Uint16(r.buf[r.end+4 : r.end+6])
@@ -431,7 +467,7 @@ func (r *Reader) readAheadForCorruption() error {
 				break
 			}
 			if wireFormat == recyclableWireFormat || wireFormat == walSyncWireFormat {
-				if r.begin+headerSize > r.n {
+				if r.end+headerSize > r.n {
 					break
 				}
 				logNum := binary.LittleEndian.Uint32(r.buf[r.end+7 : r.end+11])
@@ -533,15 +569,14 @@ func (x singleReader) Read(p []byte) (int, error) {
 		if r.last {
 			return 0, io.EOF
 		}
-		if r.err = r.nextChunk(false); r.err != nil {
+		r.err = r.nextChunk(false)
+		if errors.Is(r.err, ErrInvalidChunk) || errors.Is(r.err, ErrZeroedChunk) {
+			readAheadResult := r.readAheadForCorruption()
+			return 0, readAheadResult
+		}
+		if r.err != nil {
 			return 0, r.err
 		}
-		// TODO(edward) usage of readAheadForCorruption; uncomment in follow PR
-		// r.err = r.nextChunk(false)
-		// if r.err == ErrInvalidChunk || r.err == ErrZeroedChunk {
-		// 	readAheadResult := r.readAheadForCorruption()
-		// 	return 0, readAheadResult
-		// }
 	}
 	n := copy(p, r.buf[r.begin:r.end])
 	r.begin += n

--- a/record/testdata/walSync
+++ b/record/testdata/walSync
@@ -1,0 +1,1191 @@
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+EOF logNum=2
+----
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    ├── Chunk #0 (offset 0)
+ │    │    ├── Checksum: 3699662224
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 0
+ │    └── Chunk #1 (offset 20)
+ │         └── EOF
+ └── 
+
+read
+----
+error reading next: EOF
+final blockNum: 0
+bytes read: 1
+
+
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=true
+EOF logNum=2
+----
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    ├── Chunk #0 (offset 0, corrupt)
+ │    │    ├── Checksum: 3716504721
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 0
+ │    └── Chunk #1 (offset 20)
+ │         └── EOF
+ └── 
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 1
+bytes read: 0
+
+###########################
+##### CRC Error Cases #####
+###########################
+
+# Simple corruption in single block with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=true
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 1
+bytes read: 0
+
+# Simple corruption spanning the entire block with no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 2
+bytes read: 0
+
+# Multiple corruption with no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Multiple corruption but large offset is also corrupt, no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100000 corrupt=true
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Simple corruption with confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=30000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Corrupt the first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a confirmation chunk. Observe that final blockNum == 1
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Corrupt the first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a corrupt chunk, leading to EOF
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=true
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Complex multiple corruption with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=32000 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=32000 corrupt=true
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=64000 corrupt=true
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 0
+
+# Complex multiple corruption with confirmation in blockNum 3
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=true
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 3
+bytes read: 0
+
+# Complex multiple corruption with confirmation offset too small
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=true
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=true
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=100 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 32749
+
+###########################
+###### log num cases ######
+###########################
+# NOTE: reader logNum == 1
+###########################
+
+
+# Simple logNum issues in single block with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 1
+bytes read: 0
+
+# Simple logNum issues spanning the entire block with no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 2
+bytes read: 0
+
+# Multiple logNum issues with no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Multiple logNum issues but large offset is also has issues, no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=100 offset=100000 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Simple logNum issues with confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=30000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a confirmation chunk. Observe that final blockNum == 1
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a logNum issue chunk, leading to EOF
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Complex multiple logNum issues with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=32000 corrupt=false
+
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=32000 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=32000 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=32000 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=64000 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 0
+
+
+# Complex multiple logNum issues with confirmation in blockNum 3
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=32000 corrupt=false
+
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 3
+bytes read: 0
+
+
+# Complex multiple logNum issue with confirmation offset too small
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=0 corrupt=false
+
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=100 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 32749
+
+#######################################
+###### invalid wire format cases ######
+#######################################
+# Encoding == 0 leads to a wireFormat error
+
+
+# Simple wire issues in single block with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 1
+bytes read: 0
+
+# Simple wire issues spanning the entire block with no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 2
+bytes read: 0
+
+# Multiple wire issues with no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Multiple wire issues but large offset is also has issues, no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=100000 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Simple wire issues with confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
+
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=30000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a confirmation chunk. Observe that final blockNum == 1
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a wire issue chunk, leading to EOF
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=32000 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Complex multiple wire issues with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=32000 corrupt=false
+
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=32000 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=64000 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 0
+
+
+# Complex multiple wire issues with confirmation in blockNum 3
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=32000 corrupt=false
+
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 3
+bytes read: 0
+
+
+# Complex multiple wire issue with confirmation offset too small
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
+
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=100 corrupt=false
+
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 32749
+
+###########################
+###### zeroed chunk  ######
+###########################
+# Zeroed chunk has checksum, encodedLength, and chunkEncoding == 0; minimum 7 zeroes
+
+# Simple zeroed issues in single block with no confirmation
+init
+writeChunk encodedLength=32730 chunkLength=32730 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 19 0x00's
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 2
+bytes read: 32730
+
+# Multiple zeroed issues with no confirmation
+init
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 19 0x00's
+writeChunk encodedLength=32730 chunkLength=32730 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=32730 chunkLength=32730 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 19 0x00's
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Multiple zeroed issues but large offset is also has issues, no confirmation
+init
+writeChunk encodedLength=32730 chunkLength=32730 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 19 0x00's
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 19 0x00's
+writeChunk encodedLength=32730 chunkLength=32730 encoding=9 logNum=1 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 32730
+
+# Simple zeroed issues with confirmation
+init
+writeChunk encodedLength=32730 chunkLength=32730 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 19 0x00's
+
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=100000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: zeroed chunk
+final blockNum: 1
+bytes read: 32730
+
+init
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 11 0x00's
+writeChunk encodedLength=32738 chunkLength=32738 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=100000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: zeroed chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a confirmation chunk. Observe that final blockNum == 1
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 11 0x00's
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=1000000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: zeroed chunk
+final blockNum: 1
+bytes read: 1
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a zeroed chunk, leading to EOF
+init
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 11 0x00's
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=60 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 11 0x00's
+writeChunk encodedLength=32738 chunkLength=32738 encoding=0 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Multiple zeroed chunk issues with confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=1 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=64000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: zeroed chunk
+final blockNum: 2
+bytes read: 1
+
+# Complex multiple zeroed chunks with confirmation offset too small
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 11 0x00's
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=1 corrupt=false
+raw 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 # 11 0x00's
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 32750
+
+#####################################
+###### encodedLength too long  ######
+#####################################
+# if r.end > r.n {
+
+init
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Simple encodedLength issues in single block with no confirmation
+init
+writeChunk encodedLength=64000 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 1
+bytes read: 0
+
+# Simple encodedLength issues spanning the entire block with no confirmation
+init
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 2
+bytes read: 0
+
+# Multiple encodedLength issues with no confirmation
+init
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Multiple encodedLength issues but large offset is also has issues, no confirmation
+init
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=1000 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Simple encodedLength issues with confirmation
+init
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=30000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a confirmation chunk. Observe that final blockNum == 1
+init
+writeChunk encodedLength=200 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=1000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a encodedLength issue chunk, leading to EOF
+init
+writeChunk encodedLength=200 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Complex multiple encodedLength issues with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=32000 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=32000 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=32000 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=64000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 0
+
+# Complex multiple encodedLength issues with confirmation in blockNum 3
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=200 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=200 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 3
+bytes read: 1
+
+# Complex multiple encodedLength issues with confirmation offset too small
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=200 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=64000 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=200 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 6
+bytes read: 32750
+
+###########################
+#### Encoding too Large ###
+###########################
+# if int(chunkEncoding) >= len(headerFormatMappings) {
+
+# Simple encoding issues in single block with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 1
+bytes read: 0
+
+# Simple encoding issues spanning the entire block with no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 2
+bytes read: 0
+
+# Multiple encoding issues with no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=0 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Multiple encoding issues but large offset is also has issues, no confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=100000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Simple encoding issues with confirmation
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=30000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a confirmation chunk. Observe that final blockNum == 1
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 0
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a encoding issue chunk, leading to EOF
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 0
+
+# Complex multiple encoding issues with no confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=64000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 0
+
+# Complex multiple encoding issues with confirmation in blockNum 3
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 3
+bytes read: 0
+
+# Complex multiple encoding issue with confirmation offset too small
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=100 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=100 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 32749
+
+###########################
+## header format too big ##
+###########################
+# if r.end+headerSize > r.n {
+
+# large header chunk
+init
+writeChunk encodedLength=32738 chunkLength=32738 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=60000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 32738
+
+# Simple large header issues in single block with no confirmation
+init
+writeChunk encodedLength=32738 chunkLength=32738 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 2
+bytes read: 32738
+
+# Multiple large header issues with no confirmation
+init
+writeChunk encodedLength=32738 chunkLength=32738 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32738 chunkLength=32738 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 32738
+
+# Multiple large header issues but large offset is also has issues, no confirmation
+init
+writeChunk encodedLength=32738 chunkLength=32738 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32738 chunkLength=32738 encoding=9 logNum=1 offset=1000000 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 32738
+
+# Simple large header issues with confirmation
+init
+writeChunk encodedLength=32738 chunkLength=32738 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=100000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 32738
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a confirmation chunk. Observe that final blockNum == 1
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=1000000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 1
+bytes read: 1
+
+# Issues in first block with confirming chunks after. However, these next chunks
+# in the same block cannot be used to confirm because reading ahead jumps to the next
+# block which has a zeroed chunk, leading to EOF
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=32738 chunkLength=32738 encoding=0 logNum=1 offset=32000 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 3
+bytes read: 1
+
+# Multiple large header issues with confirmation
+init
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=1 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=64000 corrupt=false
+EOF logNum=2
+----
+
+read
+----
+error reading next: pebble/record: invalid chunk
+final blockNum: 2
+bytes read: 1
+
+# Complex multiple large header chunks with confirmation offset too small
+init
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=0 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=60 corrupt=false
+writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=1 corrupt=false
+raw 0x01 0x01 0x01 0x01 0x01 0x01 0x09 0x00 0x00 0x00 0x00 # length 11, 0x09 encodes a wal sync type, which is 19 bytes header
+writeChunk encodedLength=32718 chunkLength=32718 encoding=9 logNum=1 offset=32000 corrupt=false
+writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100 corrupt=false
+
+EOF logNum=2
+----
+
+read
+----
+error reading next: unexpected EOF
+final blockNum: 5
+bytes read: 32750

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -43,6 +43,10 @@ create: db/marker.format-version.000006.019
 close: db/marker.format-version.000006.019
 remove: db/marker.format-version.000005.018
 sync: db
+create: db/marker.format-version.000007.020
+close: db/marker.format-version.000007.020
+remove: db/marker.format-version.000006.019
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -109,9 +113,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.019
-close: checkpoints/checkpoint1/marker.format-version.000001.019
+create: checkpoints/checkpoint1/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.020
+close: checkpoints/checkpoint1/marker.format-version.000001.020
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -153,9 +157,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.019
-close: checkpoints/checkpoint2/marker.format-version.000001.019
+create: checkpoints/checkpoint2/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.020
+close: checkpoints/checkpoint2/marker.format-version.000001.020
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -192,9 +196,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.019
-close: checkpoints/checkpoint3/marker.format-version.000001.019
+create: checkpoints/checkpoint3/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.020
+close: checkpoints/checkpoint3/marker.format-version.000001.020
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -278,7 +282,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -288,7 +292,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.019
+marker.format-version.000001.020
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -355,7 +359,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.019
+marker.format-version.000001.020
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -397,7 +401,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.019
+marker.format-version.000001.020
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -516,9 +520,9 @@ sync-data: checkpoints/checkpoint4/OPTIONS-000003
 close: checkpoints/checkpoint4/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.019
-close: checkpoints/checkpoint4/marker.format-version.000001.019
+create: checkpoints/checkpoint4/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.020
+close: checkpoints/checkpoint4/marker.format-version.000001.020
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -606,7 +610,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -625,9 +629,9 @@ sync-data: checkpoints/checkpoint5/OPTIONS-000003
 close: checkpoints/checkpoint5/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.019
-close: checkpoints/checkpoint5/marker.format-version.000001.019
+create: checkpoints/checkpoint5/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.020
+close: checkpoints/checkpoint5/marker.format-version.000001.020
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -727,9 +731,9 @@ sync-data: checkpoints/checkpoint6/OPTIONS-000003
 close: checkpoints/checkpoint6/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.019
-close: checkpoints/checkpoint6/marker.format-version.000001.019
+create: checkpoints/checkpoint6/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.020
+close: checkpoints/checkpoint6/marker.format-version.000001.020
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -31,6 +31,10 @@ create: db/marker.format-version.000003.019
 close: db/marker.format-version.000003.019
 remove: db/marker.format-version.000002.018
 sync: db
+create: db/marker.format-version.000004.020
+close: db/marker.format-version.000004.020
+remove: db/marker.format-version.000003.019
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -97,9 +101,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.019
-close: checkpoints/checkpoint1/marker.format-version.000001.019
+create: checkpoints/checkpoint1/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.020
+close: checkpoints/checkpoint1/marker.format-version.000001.020
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -150,9 +154,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.019
-close: checkpoints/checkpoint2/marker.format-version.000001.019
+create: checkpoints/checkpoint2/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.020
+close: checkpoints/checkpoint2/marker.format-version.000001.020
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -199,9 +203,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.019
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.019
-close: checkpoints/checkpoint3/marker.format-version.000001.019
+create: checkpoints/checkpoint3/marker.format-version.000001.020
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.020
+close: checkpoints/checkpoint3/marker.format-version.000001.020
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -258,7 +262,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000003.019
+marker.format-version.000004.020
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -268,7 +272,7 @@ list checkpoints/checkpoint1
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.019
+marker.format-version.000001.020
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -320,7 +324,7 @@ list checkpoints/checkpoint2
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.019
+marker.format-version.000001.020
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -56,6 +56,11 @@ close: db/marker.format-version.000006.019
 remove: db/marker.format-version.000005.018
 sync: db
 upgraded to format version: 019
+create: db/marker.format-version.000007.020
+close: db/marker.format-version.000007.020
+remove: db/marker.format-version.000006.019
+sync: db
+upgraded to format version: 020
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -365,9 +370,9 @@ sync-data: checkpoint/OPTIONS-000003
 close: checkpoint/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.019
-sync-data: checkpoint/marker.format-version.000001.019
-close: checkpoint/marker.format-version.000001.019
+create: checkpoint/marker.format-version.000001.020
+sync-data: checkpoint/marker.format-version.000001.020
+close: checkpoint/marker.format-version.000001.020
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -60,7 +60,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -81,7 +81,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -390,7 +390,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -410,7 +410,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -443,7 +443,7 @@ MANIFEST-000001
 MANIFEST-000011
 OPTIONS-000014
 ext
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000002.MANIFEST-000011
 
 # Make sure that the new mutable memtable can accept writes.
@@ -586,7 +586,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -605,7 +605,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext1
-marker.format-version.000006.019
+marker.format-version.000007.020
 marker.manifest.000001.MANIFEST-000001
 
 open

--- a/tool/testdata/db_upgrade
+++ b/tool/testdata/db_upgrade
@@ -27,7 +27,7 @@ db get foo yellow
 db upgrade foo
 ----
 ----
-Upgrading DB from internal version 16 to 19.
+Upgrading DB from internal version 16 to 20.
 WARNING!!!
 This DB will not be usable with older versions of Pebble!
 
@@ -43,7 +43,7 @@ Continue? [Y/N] Error: EOF
 
 db upgrade foo --yes
 ----
-Upgrading DB from internal version 16 to 19.
+Upgrading DB from internal version 16 to 20.
 Upgrade complete.
 
 db get foo blue
@@ -56,4 +56,4 @@ db get foo yellow
 
 db upgrade foo
 ----
-DB is already at internal version 19.
+DB is already at internal version 20.

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -631,6 +631,7 @@ func (wm *failoverManager) Create(wn NumWAL, jobID int) (Writer, error) {
 		failoverWriteAndSyncLatency: wm.opts.FailoverWriteAndSyncLatency,
 		writerClosed:                wm.writerClosed,
 		writerCreatedForTest:        wm.opts.logWriterCreatedForTesting,
+		writeWALSyncOffsets:         wm.opts.WriteWALSyncOffsets,
 	}
 	var err error
 	var ww *failoverWriter

--- a/wal/failover_writer.go
+++ b/wal/failover_writer.go
@@ -463,6 +463,9 @@ type failoverWriterOpts struct {
 	writerClosed                func(logicalLogWithSizesEtc)
 
 	writerCreatedForTest chan<- struct{}
+
+	// writeWALSyncOffsets represents whether to write the WAL sync chunk format.
+	writeWALSyncOffsets bool
 }
 
 func simpleLogCreator(
@@ -633,6 +636,7 @@ func (ww *failoverWriter) switchToNewDir(dir dirAndFileHandle) error {
 				WALFsyncLatency:           ww.opts.fsyncLatency,
 				QueueSemChan:              ww.opts.queueSemChan,
 				ExternalSyncQueueCallback: ww.doneSyncCallback,
+				WriteWALSyncOffsets:       ww.opts.writeWALSyncOffsets,
 			})
 		closeWriter := func() bool {
 			ww.mu.Lock()

--- a/wal/standalone_manager.go
+++ b/wal/standalone_manager.go
@@ -194,9 +194,10 @@ func (m *StandaloneManager) Create(wn NumWAL, jobID int) (Writer, error) {
 		PreallocateSize: m.o.PreallocateSize(),
 	})
 	w := record.NewLogWriter(newLogFile, newLogNum, record.LogWriterConfig{
-		WALFsyncLatency:    m.o.FsyncLatency,
-		WALMinSyncInterval: m.o.MinSyncInterval,
-		QueueSemChan:       m.o.QueueSemChan,
+		WALFsyncLatency:     m.o.FsyncLatency,
+		WALMinSyncInterval:  m.o.MinSyncInterval,
+		QueueSemChan:        m.o.QueueSemChan,
+		WriteWALSyncOffsets: m.o.WriteWALSyncOffsets,
 	})
 	m.w = &standaloneWriter{
 		m: m,

--- a/wal/testdata/reader
+++ b/wal/testdata/reader
@@ -90,7 +90,7 @@ r.NextRecord() = (rr, (000002.log: 111), <nil>)
 r.NextRecord() = (rr, (000002.log: 272), <nil>)
   io.ReadAll(rr) = ("2a0000000000000001000000ec8367c42ebf0ffad5c57ece37b18559ba95ad78... <64000-byte record>", <nil>)
   BatchHeader: [seqNum=42,count=1]
-r.NextRecord() = (rr, (000002.log: 64294), pebble/record: invalid chunk)
+r.NextRecord() = (rr, (000002.log: 64294), unexpected EOF)
 
 # Test a typical failure scenario. Start off with a recycled log file (000003)
 # that would be on the primary device. It closes "unclean" because we're unable
@@ -253,7 +253,7 @@ r.NextRecord() = (rr, (000005-001.log: 55), 6022 from previous files, <nil>)
 r.NextRecord() = (rr, (000005-001.log: 482), 6022 from previous files, <nil>)
   io.ReadAll(rr) = ("12750100000000001d0000007575c6296b096226e5e78b9760aa7c2ecfa913b6... <199-byte record>", <nil>)
   BatchHeader: [seqNum=95506,count=29]
-r.NextRecord() = (rr, (000005-001.log: 692), 6022 from previous files, pebble/record: invalid chunk)
+r.NextRecord() = (rr, (000005-001.log: 692), 6022 from previous files, unexpected EOF)
 
 # Read again, this time pretending we found a third segment with the
 # logNameIndex=002. This helps exercise error conditions switching to a new

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -146,6 +146,10 @@ type Options struct {
 	// FailoverWriteAndSyncLatency is only populated when WAL failover is
 	// configured.
 	FailoverWriteAndSyncLatency prometheus.Histogram
+
+	// WriteWALSyncOffsets represents whether to write the WAL sync chunk format.
+	// It is plumbed down from wal.Options to record.newLogWriter.
+	WriteWALSyncOffsets bool
 }
 
 // Init constructs and initializes a WAL manager from the provided options and


### PR DESCRIPTION
Add usages of WAL readAheadForCorruption to record.Next() and record.Read(). Write a new chunk format to include sync offsets for reading ahead. Add a new format major version for the new chunk format.

Followup to: https://github.com/cockroachdb/pebble/pull/4331
Fixes: https://github.com/cockroachdb/pebble/issues/453