### PR TITLE
internal/manifest: add ObsoleteFiles type

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1328,14 +1328,14 @@ func (d *DB) newIngestedFlushableEntry(
 	for _, file := range f.files {
 		file.FileBacking.Ref()
 	}
-	entry.unrefFiles = func() []*fileBacking {
-		var obsolete []*fileBacking
+	entry.unrefFiles = func(of *manifest.ObsoleteFiles) {
+		// Invoke Unref on each table. If any files become obsolete, add them to
+		// the obsolete files list.
 		for _, file := range f.files {
 			if file.FileBacking.Unref() == 0 {
-				obsolete = append(obsolete, file.TableMetadata.FileBacking)
+				of.AddBacking(file.FileBacking)
 			}
 		}
-		return obsolete
 	}
 
 	entry.flushForced = true

--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -97,10 +97,10 @@ func TestNumFilesRangeAnnotationEmptyRanges(t *testing.T) {
 
 	// Delete files containing key ranges [0, 999] and [24_000, 25_999].
 	for i := 0; i < 100; i++ {
-		v.Levels[6].tree.Delete(files[i])
+		v.Levels[6].tree.Delete(files[i], ignoreObsoleteFiles{})
 	}
 	for i := 2400; i < 2600; i++ {
-		v.Levels[6].tree.Delete(files[i])
+		v.Levels[6].tree.Delete(files[i], ignoreObsoleteFiles{})
 	}
 
 	// Ranges that are completely empty.
@@ -147,7 +147,7 @@ func BenchmarkNumFilesRangeAnnotation(b *testing.B) {
 			// Randomly delete and reinsert a file to verify that range
 			// annotations are still fast despite small mutations.
 			toDelete := rng.IntN(count)
-			v.Levels[6].tree.Delete(files[toDelete])
+			v.Levels[6].tree.Delete(files[toDelete], ignoreObsoleteFiles{})
 
 			NumFilesAnnotator.LevelRangeAnnotation(v.Levels[6], b)
 
@@ -161,7 +161,7 @@ func BenchmarkNumFilesRangeAnnotation(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			b := randomBounds(rng, count*11)
 			toDelete := rng.IntN(count)
-			v.Levels[6].tree.Delete(files[toDelete])
+			v.Levels[6].tree.Delete(files[toDelete], ignoreObsoleteFiles{})
 
 			overlaps := v.Overlaps(6, b)
 			iter := overlaps.Iter()

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -339,7 +339,7 @@ func NewL0Sublevels(
 	for _, sublevelFiles := range s.levelFiles {
 		tr, ls := makeBTree(cmp, btreeCmpSmallestKey(cmp), sublevelFiles)
 		s.Levels = append(s.Levels, ls)
-		tr.Release()
+		tr.Release(ignoreObsoleteFiles{})
 	}
 
 	s.calculateFlushSplitKeys(flushSplitMaxBytes)
@@ -638,7 +638,7 @@ func (s *L0Sublevels) AddL0Files(
 			// populated correctly.
 			newVal.Levels[sublevel] = ls
 		}
-		tr.Release()
+		tr.Release(ignoreObsoleteFiles{})
 	}
 
 	newVal.flushSplitUserKeys = nil

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -278,7 +278,7 @@ func TestContains(t *testing.T) {
 func TestVersionUnref(t *testing.T) {
 	list := &VersionList{}
 	list.Init(&sync.Mutex{})
-	v := &Version{Deleted: func([]*FileBacking) {}}
+	v := &Version{Deleted: func(ObsoleteFiles) {}}
 	v.Ref()
 	list.PushBack(v)
 	v.Unref()


### PR DESCRIPTION
Rework the collection of obsolete files during a Version unref to accumulate the obsolete files into a new ObsoleteFiles type. This is in preparation for the introduction of blob files into manifest Versions. Unreferences will also need to unreference blob files and accumulate obsolete blob files.