### PR TITLE
*: fix up comments lingering references to file metadata

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -489,7 +489,7 @@ func adjustGrandparentOverlapBytesForFlush(c *compaction, flushingBytes uint64) 
 	// TODO(sumeer): we don't have compression info for the data being
 	// flushed, but it is likely that existing files that overlap with
 	// this flush in Lbase are representative wrt compression ratio. We
-	// could store the uncompressed size in FileMetadata and estimate
+	// could store the uncompressed size in TableMetadata and estimate
 	// the compression ratio.
 	const approxCompressionRatio = 0.2
 	approxOutputBytes := approxCompressionRatio * float64(flushingBytes)
@@ -1085,7 +1085,7 @@ func (d *DB) clearCompactingState(c *compaction, rollback bool) {
 		// happening in parallel with it, i.e. we're not in the midst of installing
 		// another version. Otherwise, it's possible that we've created another
 		// L0Sublevels instance, but not added it to the versions list, causing
-		// all the indices in FileMetadata to be inaccurate. To ensure this,
+		// all the indices in TableMetadata to be inaccurate. To ensure this,
 		// grab the manifest lock.
 		d.mu.versions.logLock()
 		defer d.mu.versions.logUnlock()

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -642,7 +642,7 @@ var compensatedSizeAnnotator = manifest.SumAnnotator(func(f *tableMetadata) (uin
 	return compensatedSize(f), f.StatsValid()
 })
 
-// totalCompensatedSize computes the compensated size over a file metadata
+// totalCompensatedSize computes the compensated size over a table metadata
 // iterator. Note that this function is linear in the files available to the
 // iterator. Use the compensatedSizeAnnotator if querying the total
 // compensated size of a level.
@@ -1330,7 +1330,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 	// units" within the code). Rewrite them in-place.
 	//
 	// It's also possible that a file may have been marked for compaction by
-	// even earlier versions of Pebble code, since FileMetadata's
+	// even earlier versions of Pebble code, since TableMetadata's
 	// MarkedForCompaction field is persisted in the manifest. That's okay. We
 	// previously would've ignored the designation, whereas now we'll re-compact
 	// the file in place.

--- a/data_test.go
+++ b/data_test.go
@@ -1144,8 +1144,8 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	var file int
 	td.ScanArgs(t, "file", &file)
 
-	// See if we can grab the FileMetadata associated with the file. This is needed
-	// to easily construct virtual sstable properties.
+	// See if we can grab the TableMetadata associated with the file. This is
+	// needed to easily construct virtual sstable properties.
 	var m *tableMetadata
 	d.mu.Lock()
 	currVersion := d.mu.versions.currentVersion()

--- a/db.go
+++ b/db.go
@@ -2191,7 +2191,7 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 	defer readState.unref()
 
 	// TODO(peter): This is somewhat expensive, especially on a large
-	// database. It might be worthwhile to unify TableInfo and FileMetadata and
+	// database. It might be worthwhile to unify TableInfo and TableMetadata and
 	// then we could simply return current.Files. Note that RocksDB is doing
 	// something similar to the current code, so perhaps it isn't too bad.
 	srcLevels := readState.current.Levels

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -230,7 +230,7 @@ func finishInitializingExternal(ctx context.Context, it *Iterator) error {
 			// warrant it.
 			//
 			// TODO(bilal): Explore adding a simpleRangeKeyLevelIter that does not
-			// operate on FileMetadatas (similar to simpleLevelIter), and implements
+			// operate on TableMetadatas (similar to simpleLevelIter), and implements
 			// this optimization.
 			// We set a synthetic sequence number, with lower levels having higer numbers.
 			seqNum := 0

--- a/file_cache.go
+++ b/file_cache.go
@@ -33,7 +33,7 @@ var emptyIter = &errorIter{err: nil}
 var emptyKeyspanIter = &errorKeyspanIter{err: nil}
 
 // tableNewIters creates new iterators (point, range deletion and/or range key)
-// for the given file metadata. Which of the various iterator kinds the user is
+// for the given table metadata. Which of the various iterator kinds the user is
 // requesting is specified with the iterKinds bitmap.
 //
 // On success, the requested subset of iters.{point,rangeDel,rangeKey} are

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -566,10 +566,10 @@ func (d *DB) markFilesLocked(findFn findFilesFunc) error {
 	}
 
 	// The 'marked-for-compaction' bit is persisted in the MANIFEST file
-	// metadata. We've already modified the in-memory file metadata, but the
+	// metadata. We've already modified the in-memory table metadata, but the
 	// manifest hasn't been updated. Force rotation to a new MANIFEST file,
-	// which will write every file metadata to the new manifest file and ensure
-	// that the now marked-for-compaction file metadata are persisted as marked.
+	// which will write every table metadata to the new manifest file and ensure
+	// that the now marked-for-compaction table metadata are persisted as marked.
 	// NB: This call to logAndApply will unlockthe MANIFEST, which we locked up
 	// above before obtaining `vers`.
 	return d.mu.versions.logAndApply(

--- a/ingest.go
+++ b/ingest.go
@@ -211,8 +211,8 @@ func ingestLoad1External(
 		Size:         e.Size,
 	}
 
-	// In the name of keeping this ingestion as fast as possible, we avoid
-	// *all* existence checks and synthesize a file metadata with smallest/largest
+	// In the name of keeping this ingestion as fast as possible, we avoid *all*
+	// existence checks and synthesize a table metadata with smallest/largest
 	// keys that overlap whatever the passed-in span was.
 	smallestCopy := slices.Clone(e.StartKey)
 	largestCopy := slices.Clone(e.EndKey)
@@ -293,7 +293,7 @@ func (r *rangeKeyIngestValidator) Validate(nextFileSmallestKey *keyspan.Span) er
 	return nil
 }
 
-// ingestLoad1 creates the FileMetadata for one file. This file will be owned
+// ingestLoad1 creates the TableMetadata for one file. This file will be owned
 // by this store.
 //
 // prevLastRangeKey is the last range key from the previous file. It is used to
@@ -1324,7 +1324,7 @@ func (d *DB) newIngestedFlushableEntry(
 	// to.
 	entry := d.newFlushableEntry(f, logNum, seqNum)
 	// The flushable entry starts off with a single reader ref, so increment
-	// the FileMetadata.Refs.
+	// the FileBacking.Refs.
 	for _, file := range f.files {
 		file.FileBacking.Ref()
 	}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -2359,7 +2359,7 @@ func TestIngestTargetLevel(t *testing.T) {
 				}
 			}
 			for _, target := range strings.Split(td.Input, "\n") {
-				meta, err := manifest.ParseFileMetadataDebug(target)
+				meta, err := manifest.ParseTableMetadataDebug(target)
 				require.NoError(t, err)
 				overlapChecker := &overlapChecker{
 					comparer: d.opts.Comparer,
@@ -3341,7 +3341,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 				return key
 			}
 
-			// Construct the file metadata from the writer metadata.
+			// Construct the table metadata from the writer metadata.
 			m := &tableMetadata{
 				SmallestSeqNum: 0, // Simulate an ingestion.
 				LargestSeqNum:  0,

--- a/internal/compact/splitting_test.go
+++ b/internal/compact/splitting_test.go
@@ -27,7 +27,7 @@ func TestOutputSplitter(t *testing.T) {
 			var files [manifest.NumLevels][]*manifest.TableMetadata
 			if d.Input != "" {
 				for _, l := range strings.Split(d.Input, "\n") {
-					f, err := manifest.ParseFileMetadataDebug(l)
+					f, err := manifest.ParseTableMetadataDebug(l)
 					if err != nil {
 						d.Fatalf(t, "error parsing %q: %v", l, err)
 					}

--- a/internal/manifest/annotator.go
+++ b/internal/manifest/annotator.go
@@ -24,17 +24,17 @@ import (
 // on the node, ensuring that future queries for the annotation will recompute
 // the value.
 
-// An Annotator defines a computation over a level's FileMetadata. If the
-// computation is stable and uses inputs that are fixed for the lifetime of
-// a FileMetadata, the LevelMetadata's internal data structures are annotated
+// An Annotator defines a computation over a level's TableMetadata. If the
+// computation is stable and uses inputs that are fixed for the lifetime of a
+// TableMetadata, the LevelMetadata's internal data structures are annotated
 // with the intermediary computations. This allows the computation to be
 // computed incrementally as edits are applied to a level.
 type Annotator[T any] struct {
 	Aggregator AnnotationAggregator[T]
 }
 
-// An AnnotationAggregator defines how an annotation should be accumulated
-// from a single FileMetadata and merged with other annotated values.
+// An AnnotationAggregator defines how an annotation should be accumulated from
+// a single TableMetadata and merged with other annotated values.
 type AnnotationAggregator[T any] interface {
 	// Zero returns the zero value of an annotation. This value is returned
 	// when a LevelMetadata is empty. The dst argument, if non-nil, is an
@@ -372,7 +372,7 @@ func (sa SumAggregator) Merge(src *uint64, dst *uint64) *uint64 {
 }
 
 // SumAnnotator takes a function that computes a uint64 value from a single
-// FileMetadata and returns an Annotator that sums together the values across
+// TableMetadata and returns an Annotator that sums together the values across
 // files.
 func SumAnnotator(accumulate func(f *TableMetadata) (v uint64, cacheOK bool)) *Annotator[uint64] {
 	return &Annotator[uint64]{
@@ -393,13 +393,13 @@ var NumFilesAnnotator = SumAnnotator(func(f *TableMetadata) (uint64, bool) {
 // PickFileAggregator implements the AnnotationAggregator interface. It defines
 // an aggregator that picks a single file from a set of eligible files.
 type PickFileAggregator struct {
-	// Filter takes a FileMetadata and returns whether it is eligible to be
+	// Filter takes a TableMetadata and returns whether it is eligible to be
 	// picked by this PickFileAggregator. The second return value indicates
 	// whether this eligibility is stable and thus cacheable.
 	Filter func(f *TableMetadata) (eligible bool, cacheOK bool)
-	// Compare compares two instances of FileMetadata and returns true if
-	// the first one should be picked over the second one. It may assume
-	// that both arguments are non-nil.
+	// Compare compares two instances of TableMetadata and returns true if the
+	// first one should be picked over the second one. It may assume that both
+	// arguments are non-nil.
 	Compare func(f1 *TableMetadata, f2 *TableMetadata) bool
 }
 

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -30,9 +30,9 @@ func btreeCmpSmallestKey(cmp Compare) btreeCmp {
 	}
 }
 
-// btreeCmpSpecificOrder is used in tests to construct a B-Tree with a
-// specific ordering of FileMetadata within the tree. It's typically used to
-// test consistency checking code that needs to construct a malformed B-Tree.
+// btreeCmpSpecificOrder is used in tests to construct a B-Tree with a specific
+// ordering of TableMetadata within the tree. It's typically used to test
+// consistency checking code that needs to construct a malformed B-Tree.
 func btreeCmpSpecificOrder(files []*TableMetadata) btreeCmp {
 	m := map[*TableMetadata]int{}
 	for i, f := range files {
@@ -655,10 +655,10 @@ func (n *node) verifyInvariants() {
 
 // btree is an implementation of a B-Tree.
 //
-// btree stores FileMetadata in an ordered structure, allowing easy insertion,
+// btree stores TableMetadata in an ordered structure, allowing easy insertion,
 // removal, and iteration. The B-Tree stores items in order based on cmp. The
 // first level of the LSM uses a cmp function that compares sequence numbers.
-// All other levels compare using the FileMetadata.Smallest.
+// All other levels compare using the TableMetadata.Smallest.
 //
 // Write operations are not safe for concurrent mutation by multiple
 // goroutines, but Read operations are.
@@ -890,7 +890,7 @@ type iterator struct {
 	// n may be nil iff i.r is nil.
 	n   *node
 	pos int16
-	// cmp dictates the ordering of the FileMetadata.
+	// cmp dictates the ordering of the TableMetadata.
 	cmp func(*TableMetadata, *TableMetadata) int
 	// a stack of n's ancestors within the B-Tree, alongside the position
 	// taken to arrive at n. If non-empty, the bottommost frame of the stack

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -285,7 +285,7 @@ func (sl sublevelSorter) Swap(i, j int) {
 // split key is added.
 //
 // This method can be called without DB.mu being held, so any DB.mu protected
-// fields in FileMetadata cannot be accessed here, such as Compacting and
+// fields in TableMetadata cannot be accessed here, such as Compacting and
 // IsIntraL0Compacting. Those fields are accessed in InitCompactingFileInfo
 // instead.
 func NewL0Sublevels(
@@ -730,11 +730,11 @@ func (s *L0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 	for f := iter.First(); f != nil; f = iter.Next() {
 		if invariants.Enabled {
 			if !bytes.Equal(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest.UserKey) {
-				panic(fmt.Sprintf("f.minIntervalIndex in FileMetadata out of sync with intervals in L0Sublevels: %s != %s",
+				panic(fmt.Sprintf("f.minIntervalIndex in TableMetadata out of sync with intervals in L0Sublevels: %s != %s",
 					s.formatKey(s.orderedIntervals[f.minIntervalIndex].startKey.key), s.formatKey(f.Smallest.UserKey)))
 			}
 			if !bytes.Equal(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest.UserKey) {
-				panic(fmt.Sprintf("f.maxIntervalIndex in FileMetadata out of sync with intervals in L0Sublevels: %s != %s",
+				panic(fmt.Sprintf("f.maxIntervalIndex in TableMetadata out of sync with intervals in L0Sublevels: %s != %s",
 					s.formatKey(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key), s.formatKey(f.Smallest.UserKey)))
 			}
 		}

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -553,9 +553,10 @@ func TestAddL0FilesEquivalence(t *testing.T) {
 			s2, err = NewL0Sublevels(&levelMetadata, testkeys.Comparer.Compare, testkeys.Comparer.FormatKey, flushSplitMaxBytes)
 			require.NoError(t, err)
 		} else {
-			// AddL0Files relies on the indices in FileMetadatas pointing to that of
-			// the previous L0Sublevels. So it must be called before NewL0Sublevels;
-			// calling it the other way around results in out-of-bounds panics.
+			// AddL0Files relies on the indices in TableMetadatas pointing to
+			// that of the previous L0Sublevels. So it must be called before
+			// NewL0Sublevels; calling it the other way around results in
+			// out-of-bounds panics.
 			SortBySeqNum(filesToAdd)
 			s2, err = s2.AddL0Files(filesToAdd, flushSplitMaxBytes, &levelMetadata)
 			require.NoError(t, err)

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -618,7 +618,7 @@ func (i *LevelIterator) assertNotL0Cmp() {
 	}
 }
 
-// skipFilteredForward takes the file metadata at the iterator's current
+// skipFilteredForward takes the table metadata at the iterator's current
 // position, and skips forward if the current key-type filter (i.filter)
 // excludes the file. It skips until it finds an unfiltered file or exhausts the
 // level. If lower is != nil, skipFilteredForward skips any files that do not
@@ -642,7 +642,7 @@ func (i *LevelIterator) skipFilteredForward(meta *TableMetadata) *TableMetadata 
 	return meta
 }
 
-// skipFilteredBackward takes the file metadata at the iterator's current
+// skipFilteredBackward takes the table metadata at the iterator's current
 // position, and skips backward if the current key-type filter (i.filter)
 // excludes the file. It skips until it finds an unfiltered file or exhausts the
 // level. If upper is != nil, skipFilteredBackward skips any files that do not

--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -80,7 +80,7 @@ func TestLevelIteratorFiltered(t *testing.T) {
 			case "define":
 				var files []*TableMetadata
 				for _, metaStr := range strings.Split(d.Input, "\n") {
-					m, err := ParseFileMetadataDebug(metaStr)
+					m, err := ParseTableMetadataDebug(metaStr)
 					require.NoError(t, err)
 					files = append(files, m)
 				}

--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -1,6 +1,6 @@
 # Note: when specifying test cases with tables in L0, the L0 files should be
 # specified in seqnum descending order, as the test case input is parsed as the
-# inverse of `(*FileMetadata).DebugString`.
+# inverse of `(*TableMetadata).DebugString`.
 
 check-ordering
 L0:

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -636,7 +636,7 @@ func ParseVersionEditDebug(s string) (_ *VersionEdit, err error) {
 		switch field {
 		case "add-table":
 			level := p.Level()
-			meta, err := ParseFileMetadataDebug(p.Remaining())
+			meta, err := ParseTableMetadataDebug(p.Remaining())
 			if err != nil {
 				return nil, err
 			}
@@ -921,15 +921,15 @@ type BulkVersionEdit struct {
 	AddedFileBacking   map[base.DiskFileNum]*FileBacking
 	RemovedFileBacking []base.DiskFileNum
 
-	// AddedTablesByFileNum maps file number to file metadata for all added
-	// files from accumulated version edits. AddedTablesByFileNum is only
+	// AddedTablesByFileNum maps file number to table metadata for all added
+	// sstables from accumulated version edits. AddedTablesByFileNum is only
 	// populated if set to non-nil by a caller. It must be set to non-nil when
 	// replaying version edits read from a MANIFEST (as opposed to VersionEdits
 	// constructed in-memory).  While replaying a MANIFEST file,
 	// VersionEdit.DeletedFiles map entries have nil values, because the on-disk
 	// deletion record encodes only the file number. Accumulate uses
 	// AddedTablesByFileNum to correctly populate the BulkVersionEdit's Deleted
-	// field with non-nil *FileMetadata.
+	// field with non-nil *TableMetadata.
 	AddedTablesByFileNum map[base.FileNum]*TableMetadata
 
 	// MarkedForCompactionCountDiff holds the aggregated count of files

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -383,7 +383,7 @@ func TestExtendBounds(t *testing.T) {
 	})
 }
 
-func TestFileMetadata_ParseRoundTrip(t *testing.T) {
+func TestTableMetadata_ParseRoundTrip(t *testing.T) {
 	testCases := []struct {
 		name   string
 		input  string
@@ -421,7 +421,7 @@ func TestFileMetadata_ParseRoundTrip(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := ParseFileMetadataDebug(tc.input)
+			m, err := ParseTableMetadataDebug(tc.input)
 			require.NoError(t, err)
 			err = m.Validate(base.DefaultComparer.Compare, base.DefaultFormatter)
 			require.NoError(t, err)

--- a/level_iter.go
+++ b/level_iter.go
@@ -254,7 +254,7 @@ func (l *levelIter) findFileGE(key []byte, flags base.SeekGEFlags) *tableMetadat
 	//      much later the seek key is, so it's possible there are many sstables
 	//      between the current position and the seek key. However in most real-
 	//      world use cases, the seek key is likely to be nearby. Rather than
-	//      performing a log(N) seek through the file metadata, we next a few
+	//      performing a log(N) seek through the table metadata, we next a few
 	//      times from our existing location. If we don't find a file whose
 	//      largest is >= key within a few nexts, we fall back to seeking.
 	//

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -202,9 +202,9 @@ func TestMergingIterDataDriven(t *testing.T) {
 					d.Fatalf(t, "top-level strings should be L")
 				}
 				for _, file := range levels[l].Children() {
-					m, err := manifest.ParseFileMetadataDebug(file.Value())
+					m, err := manifest.ParseTableMetadataDebug(file.Value())
 					if err != nil {
-						d.Fatalf(t, "file metadata: %s", err)
+						d.Fatalf(t, "table metadata: %s", err)
 					}
 					files[l+1] = append(files[l+1], m)
 

--- a/options.go
+++ b/options.go
@@ -580,7 +580,7 @@ type Options struct {
 		IngestSplit func() bool
 
 		// ReadCompactionRate controls the frequency of read triggered
-		// compactions by adjusting `AllowedSeeks` in manifest.FileMetadata:
+		// compactions by adjusting `AllowedSeeks` in manifest.TableMetadata:
 		//
 		// AllowedSeeks = FileSize / ReadCompactionRate
 		//

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -743,9 +743,9 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 			rr := record.NewReader(f, 0 /* logNum */)
 			// A manifest's first record always holds the initial version state.
 			// If this is the first manifest we're examining, we load it in
-			// order to seed `metas` with the file metadata of the existing
+			// order to seed `metas` with the table metadata of the existing
 			// files. Otherwise, we can skip it because we already know all the
-			// file metadatas up to this point.
+			// table metadatas up to this point.
 			rec, err := rr.Next()
 			if err != nil {
 				return err

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -46,7 +46,7 @@ var ErrInvalidSkipSharedIteration = errors.New("pebble: cannot use skip-shared i
 // by another pebble instance. This struct must contain all fields that are
 // required for a Pebble instance to ingest a foreign sstable on shared storage,
 // including constructing any relevant objstorage.Provider / remoteobjcat.Catalog
-// data structures, as well as creating virtual FileMetadatas.
+// data structures, as well as creating virtual TableMetadatas.
 //
 // Note that the Pebble instance creating and returning a SharedSSTMeta might
 // not be the one that created the underlying sstable on shared storage to begin

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -264,7 +264,7 @@ close-snapshot
 # In the current code, the hint remains but when the hint is resolved the hint
 # will not apply to any sstables containing keys that previously had sequence
 # numbers higher than the hint's lowest tombstone sequence number. We use
-# FileMetadata.LargestSeqNumAbsolute for this purpose.
+# TableMetadata.LargestSeqNumAbsolute for this purpose.
 
 get-hints
 ----

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -373,7 +373,7 @@ c@4: (c@4, .)
 # Regression test for #2084.
 #
 # The optimization added in #2058 began using an enabled TrySeekUsingNext flag
-# to avoid re-seeking within a level's file metadata. This optimization was
+# to avoid re-seeking within a level's table metadata. This optimization was
 # dependent on the invariant that the iterator remained positioned at the
 # previous seek key, so that a subsequent seek to a larger key does not need to
 # backtrack.
@@ -449,7 +449,7 @@ L0.0:
 # see that level 0.0's synthetic boundary key at d@1 was at the top of the heap
 # and move to the next file in 0.0. The subsequent call to SeekPrefixGE(d@1,
 # TrySeekUsingNext=true) would incorrectly use the current position within the
-# 0.0 file metadata (nil), and miss the d@1 key.
+# 0.0 table metadata (nil), and miss the d@1 key.
 
 combined-iter
 seek-prefix-ge b@3

--- a/testdata/merging_iter
+++ b/testdata/merging_iter
@@ -12,7 +12,7 @@
 #
 # Levels are ordered from higher to lower, and each new level starts with an L
 # For each level, one or more files are defined. A file definition starts with
-# the file metadata representation, at one indentation level. Followed are KVs
+# the table metadata representation, at one indentation level. Followed are KVs
 # arbitrarily spread over one or more lines, at two indentation levels. Point
 # KVs should be ordered relative to each other, and rangedels should be ordered
 # relative to each other.

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -23,7 +23,7 @@ import (
 
 //go:generate ./make_lsm_data.sh
 
-type lsmFileMetadata struct {
+type lsmTableMetadata struct {
 	Size           uint64
 	Smallest       int // ID of smallest key
 	Largest        int // ID of largest key
@@ -51,9 +51,9 @@ type lsmKey struct {
 
 type lsmState struct {
 	Manifest  string
-	Edits     []lsmVersionEdit                 `json:",omitempty"`
-	Files     map[base.FileNum]lsmFileMetadata `json:",omitempty"`
-	Keys      []lsmKey                         `json:",omitempty"`
+	Edits     []lsmVersionEdit                  `json:",omitempty"`
+	Files     map[base.FileNum]lsmTableMetadata `json:",omitempty"`
+	Keys      []lsmKey                          `json:",omitempty"`
 	StartEdit int64
 }
 
@@ -274,7 +274,7 @@ func (l *lsmT) buildKeys(edits []*manifest.VersionEdit) {
 func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 	l.state.Edits = nil
 	l.state.StartEdit = l.startEdit
-	l.state.Files = make(map[base.FileNum]lsmFileMetadata)
+	l.state.Files = make(map[base.FileNum]lsmTableMetadata)
 	var currentFiles [manifest.NumLevels][]*manifest.TableMetadata
 
 	backings := make(map[base.DiskFileNum]*manifest.FileBacking)
@@ -299,7 +299,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 				nf.Meta.FileBacking = b
 			}
 			if _, ok := l.state.Files[nf.Meta.FileNum]; !ok {
-				l.state.Files[nf.Meta.FileNum] = lsmFileMetadata{
+				l.state.Files[nf.Meta.FileNum] = lsmTableMetadata{
 					Size:           nf.Meta.Size,
 					Smallest:       l.findKey(nf.Meta.Smallest),
 					Largest:        l.findKey(nf.Meta.Largest),

--- a/tool/make_incorrect_manifests.go
+++ b/tool/make_incorrect_manifests.go
@@ -38,14 +38,14 @@ func makeManifest1() {
 	ve.MinUnflushedLogNum = 2
 	ve.NextFileNum = 5
 	ve.LastSeqNum = 20
-	ve.NewFiles = []manifest.NewFileEntry{
-		{Level: 6, Meta: &manifest.FileMetadata{
+	ve.NewFiles = []manifest.NewTableEntry{
+		{Level: 6, Meta: &manifest.TableMetadata{
 			FileNum: 1, SmallestSeqNum: 2, LargestSeqNum: 5}}}
 	writeVE(writer, &ve)
 
 	ve.MinUnflushedLogNum = 3
-	ve.NewFiles = []manifest.NewFileEntry{
-		{Level: 6, Meta: &manifest.FileMetadata{
+	ve.NewFiles = []manifest.NewTableEntry{
+		{Level: 6, Meta: &manifest.TableMetadata{
 			FileNum: 2, SmallestSeqNum: 1, LargestSeqNum: 4}}}
 	writeVE(writer, &ve)
 

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -574,7 +574,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 			var v *manifest.Version
 			var cmp *base.Comparer
 			rr := record.NewReader(f, 0 /* logNum */)
-			// Contains the FileMetadata needed by BulkVersionEdit.Apply.
+			// Contains the TableMetadata needed by BulkVersionEdit.Apply.
 			// It accumulates the additions since later edits contain
 			// deletions of earlier added files.
 			addedByFileNum := make(map[base.FileNum]*manifest.TableMetadata)


### PR DESCRIPTION
In 6f32adb the manifest.FileMetadata type was renamed to TableMetadata to disambiguate it with manfiest metadata tracking non-sstable files. This commit cleans up some lingering references to 'file metadata,' particularly in comments.