### PR TITLE
db: rework fileCache to use genericcache

### DIFF
--- a/file_cache.go
+++ b/file_cache.go
@@ -108,17 +108,20 @@ type fileCacheHandle struct {
 // handles.
 // TODO(radu): don't pass entire options.
 func (c *FileCache) newHandle(
-	cacheHandle *cache.Handle, objProvider objstorage.Provider, opts *Options,
+	cacheHandle *cache.Handle,
+	objProvider objstorage.Provider,
+	loggerAndTracer LoggerAndTracer,
+	readerOpts sstable.ReaderOptions,
 ) *fileCacheHandle {
 	c.Ref()
 
 	t := &fileCacheHandle{
 		fileCache:        c,
-		loggerAndTracer:  opts.LoggerAndTracer,
+		loggerAndTracer:  loggerAndTracer,
 		blockCacheHandle: cacheHandle,
 		objProvider:      objProvider,
 	}
-	t.readerOpts = opts.MakeReaderOptions()
+	t.readerOpts = readerOpts
 	t.readerOpts.FilterMetricsTracker = &sstable.FilterMetricsTracker{}
 	return t
 }

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -225,7 +225,7 @@ func (t *fileCacheTest) newTestHandle() (*fileCacheHandle, *fileCacheTestFS) {
 		FileCache: t.fileCache,
 	}
 	opts.EnsureDefaults()
-	h := t.fileCache.newHandle(t.blockCacheHandle, objProvider, opts)
+	h := t.fileCache.newHandle(t.blockCacheHandle, objProvider, opts.LoggerAndTracer, opts.MakeReaderOptions())
 	return h, fs
 }
 
@@ -1055,7 +1055,7 @@ func TestFileCacheErrorBadMagicNumber(t *testing.T) {
 		FileCache: fcs.fileCache,
 	}
 	opts.EnsureDefaults()
-	c := opts.FileCache.newHandle(fcs.blockCacheHandle, objProvider, opts)
+	c := opts.FileCache.newHandle(fcs.blockCacheHandle, objProvider, opts.LoggerAndTracer, opts.MakeReaderOptions())
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -1129,7 +1129,7 @@ func TestFileCacheClockPro(t *testing.T) {
 		LoggerAndTracer: &base.LoggerWithNoopTracer{Logger: base.DefaultLogger},
 	}
 	opts.EnsureDefaults()
-	h := fcs.fileCache.newHandle(fcs.blockCacheHandle, objProvider, opts)
+	h := fcs.fileCache.newHandle(fcs.blockCacheHandle, objProvider, opts.LoggerAndTracer, opts.MakeReaderOptions())
 	defer h.Close()
 
 	scanner := bufio.NewScanner(f)
@@ -1265,7 +1265,7 @@ func BenchmarkFileCacheHotPath(b *testing.B) {
 		LoggerAndTracer: &base.LoggerWithNoopTracer{Logger: base.DefaultLogger},
 	}
 	opts.EnsureDefaults()
-	h := fcs.fileCache.newHandle(fcs.blockCacheHandle, objProvider, opts)
+	h := fcs.fileCache.newHandle(fcs.blockCacheHandle, objProvider, opts.LoggerAndTracer, opts.MakeReaderOptions())
 	defer h.Close()
 
 	shard := fcs.fileCache.shards[0]

--- a/internal/genericcache/cache.go
+++ b/internal/genericcache/cache.go
@@ -1,0 +1,184 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package genericcache
+
+import (
+	"context"
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
+
+// Cache implements a generic cache that associates arbitrary keys with values.
+// It uses multiple shards to reduce contention and uses the CLOCK-Pro
+// algorithm.
+//
+// Values are initialized on demand and are automatically released when they are
+// evicted.
+type Cache[K Key, V any] struct {
+	shards []shard[K, V]
+}
+
+// Key must be implemented by the key type used with a Cache.
+type Key interface {
+	comparable
+
+	// Shard maps the key to a shard index between 0 and numShards-1.
+	Shard(numShards int) int
+}
+
+// InitValueFn is called to initialize a new value that is being added to the cache.
+//
+// The function passes a ValueRef instead of *V only for special cases where we
+// need to store the ValueRef in a closure (to Unref() it after a later
+// FindOrCreate() call).
+//
+// It is guaranteed that there will be no concurrent calls to InitValueFn() with
+// the same key.
+type InitValueFn[K Key, V any] func(context.Context, K, ValueRef[K, V]) error
+
+// ReleaseValueFn is called to release a value that is no longer used
+// (specifically: it was evicted from the cache AND there are no outstanding
+// ValueRefs on it).
+type ReleaseValueFn[V any] func(*V)
+
+// New creates a Cache with the given capacity and number of shards.
+//
+// initValue is used to initialize a new value when it is added to the cache.
+// releaseValueFn is used to close a V when it is no longer needed.
+func New[K Key, V any](
+	capacity int, numShards int, initValueFn InitValueFn[K, V], releaseValueFn ReleaseValueFn[V],
+) *Cache[K, V] {
+	c := &Cache[K, V]{}
+	c.Init(capacity, numShards, initValueFn, releaseValueFn)
+	return c
+}
+
+// Init can be used instead of New when the cache is embedded in another struct.
+func (c *Cache[K, V]) Init(
+	capacity int, numShards int, initValueFn InitValueFn[K, V], releaseValueFn ReleaseValueFn[V],
+) {
+	c.shards = make([]shard[K, V], numShards)
+	shardCapacity := (capacity + numShards - 1) / numShards
+	for i := range c.shards {
+		c.shards[i].Init(shardCapacity, initValueFn, releaseValueFn)
+	}
+}
+
+// Close the cache, releasing all live values. There must not be any outstanding
+// references on any of the values.
+func (c *Cache[K, V]) Close() {
+	for i := range c.shards {
+		c.shards[i].Close()
+	}
+	c.shards = nil
+}
+
+// FindOrCreate retrieves an existing value or creates a new value for the given
+// key. The result can be accessed via ValueRef.Value(). The caller must call
+// ValueRef.Close() when it no longer needs the value.
+func (c *Cache[K, V]) FindOrCreate(ctx context.Context, key K) (ValueRef[K, V], error) {
+	shard := c.getShard(key)
+	value := shard.findOrCreateValue(ctx, key)
+	if err := value.err; err != nil {
+		shard.UnrefValue(value)
+		return ValueRef[K, V]{}, err
+	}
+	return ValueRef[K, V]{shard: shard, value: value}, nil
+}
+
+// ValueRef is returned by FindOrCreate. It holds a reference on a value; the
+// value will be kept "alive" even if the cache decides to evict the value to
+// make room for another one.
+// The ValueRef is identical to the one passed to InitValueFn for this value.
+type ValueRef[K Key, V any] struct {
+	shard *shard[K, V]
+	value *value[V]
+}
+
+// Value returns the value. This method and the returned value can only be used
+// until ref.Close() is called.
+func (ref ValueRef[K, V]) Value() *V {
+	if invariants.Enabled && ref.value.err != nil {
+		panic("ValueRef with error")
+	}
+	return &ref.value.v
+}
+
+// Unref releases the reference. This must be called or the underlying value
+// will never be cleaned up.
+func (ref ValueRef[K, V]) Unref() {
+	ref.shard.UnrefValue(ref.value)
+}
+
+// Evict any entry associated with the given key. If there is a corresponding
+// value in the cache, it is cleaned up before the function returns. There must
+// not be any outstanding references on the value.
+func (c *Cache[K, V]) Evict(key K) {
+	c.getShard(key).Evict(key)
+}
+
+// EvictAll evicts all entries in the cache with a key that satisfies the given
+// predicate. Any corresponding values are released before the function returns.
+// There must not be any outstanding references on the values, and no keys that
+// satisfy the predicate should be inserted while the method is running.
+//
+// It should be used sparingly as it is an O(n) operation. Returns the list of
+// keys that were evicted (note that some may have been "ghost" entries without
+// an associated value in the cache).
+func (c *Cache[K, V]) EvictAll(predicate func(K) bool) []K {
+	var keys []K
+	for i := range c.shards {
+		keys = append(keys, c.shards[i].EvictAll(predicate)...)
+	}
+	return keys
+}
+
+func (c *Cache[K, V]) getShard(key K) *shard[K, V] {
+	return &c.shards[key.Shard(len(c.shards))]
+}
+
+// Metrics holds metrics for the cache.
+type Metrics struct {
+	// The number of bytes inuse by the cache. This includes the internal metadata
+	// and storage for the V values present in the cache. Note that if V values
+	// point to other objects, it is the caller's responsibility to account for
+	// those as necessary.
+	Size int64
+	// The count of objects in the cache.
+	Count int64
+	// The number of cache hits.
+	Hits int64
+	// The number of cache misses.
+	Misses int64
+}
+
+// Metrics retrieves metrics for the cache.
+func (c *Cache[K, V]) Metrics() Metrics {
+	var numHotOrCold, numTest int64
+	var m Metrics
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.mu.RLock()
+		numHotOrCold += int64(s.mu.sizeHot) + int64(s.mu.sizeCold)
+		numTest += int64(s.mu.sizeTest)
+		s.mu.RUnlock()
+		m.Hits += s.hits.Load()
+		m.Misses += s.misses.Load()
+	}
+	// Only hot and cold entries actually contain an object.
+	m.Count = numHotOrCold
+
+	// All entries have a node and a key in the map.
+	var k K
+	m.Size = (numHotOrCold + numTest) * int64(
+		unsafe.Sizeof(node[K, V]{})+ // nodes
+			unsafe.Sizeof(k)+ // key in nodes map.
+			unsafe.Sizeof((*node[K, V])(nil))) // value in nodes map (pointer).
+
+	// Only hot or cold entries have an associated value.
+	m.Size += numHotOrCold * int64(unsafe.Sizeof(value[V]{}))
+	return m
+}

--- a/internal/genericcache/cache_test.go
+++ b/internal/genericcache/cache_test.go
@@ -1,0 +1,229 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package genericcache
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"slices"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+type intKey int
+
+// Randomly distribute small key values to shards.
+var randPerm = rand.Perm(50)
+
+func (k intKey) Shard(numShards int) int {
+	if int(k) < len(randPerm) {
+		return randPerm[k] % numShards
+	}
+	return int(k) % numShards
+}
+
+func TestBasic(t *testing.T) {
+	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, string]) error {
+		*v.Value() = fmt.Sprint(k)
+		return nil
+	}
+	releaseFn := func(v *string) {
+		*v = "bogus"
+	}
+	c := New[intKey, string](10, 1, initFn, releaseFn)
+	ctx := context.Background()
+
+	for i := range 100 {
+		k := intKey(i % 10)
+		ref, err := c.FindOrCreate(ctx, k)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprint(k), *ref.Value())
+		ref.Unref()
+	}
+	m := c.Metrics()
+	require.Equal(t, int64(10), m.Misses)
+
+	for i := range 100 {
+		k := intKey(i % 10)
+		ref, err := c.FindOrCreate(ctx, k)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprint(k), *ref.Value())
+		ref.Unref()
+	}
+
+	c.Close()
+}
+
+func TestFileCacheClockPro(t *testing.T) {
+	// Reuse the data from the block cache. See
+	// internal/cache/clockpro_test.go:TestCache.
+	f, err := os.Open("../cache/testdata/cache")
+	require.NoError(t, err)
+
+	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, string]) error {
+		*v.Value() = fmt.Sprint(k)
+		return nil
+	}
+	releaseFn := func(v *string) {
+		*v = "bogus"
+	}
+	// The cache must have a single shard of size 200 is required for the expected
+	// test values.
+	c := New[intKey, string](200, 1, initFn, releaseFn)
+	defer c.Close()
+
+	scanner := bufio.NewScanner(f)
+
+	for line := 1; scanner.Scan(); line++ {
+		fields := bytes.Fields(scanner.Bytes())
+
+		key, err := strconv.Atoi(string(fields[0]))
+		require.NoError(t, err)
+
+		oldHits := c.shards[0].hits.Load()
+
+		ref, err := c.FindOrCreate(context.Background(), intKey(key))
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprint(key), *ref.Value())
+		ref.Unref()
+
+		hit := c.shards[0].hits.Load() != oldHits
+		wantHit := fields[1][0] == 'h'
+		if hit != wantHit {
+			t.Errorf("%d: cache hit mismatch: got %v, want %v\n", line, hit, wantHit)
+		}
+	}
+}
+
+func TestEvict(t *testing.T) {
+	var initialized []int
+	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, int]) error {
+		initialized = append(initialized, int(k))
+		*v.Value() = int(k)
+		return nil
+	}
+	expectInitialized := func(vals ...int) {
+		t.Helper()
+		slices.Sort(initialized)
+		slices.Sort(vals)
+		require.Equal(t, initialized, vals)
+		initialized = nil
+	}
+	var released []int
+	expectReleased := func(vals ...int) {
+		t.Helper()
+		slices.Sort(released)
+		slices.Sort(vals)
+		require.Equal(t, released, vals)
+		released = nil
+	}
+	releaseFn := func(v *int) {
+		released = append(released, *v)
+		*v = -1
+	}
+	c := New[intKey, int](20, 1+rand.IntN(4), initFn, releaseFn)
+	ctx := context.Background()
+	testutils.CheckErr(c.FindOrCreate(ctx, 1)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 2)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 3)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 4)).Unref()
+	expectInitialized(1, 2, 3, 4)
+	expectReleased()
+	c.Evict(2)
+	expectReleased(2)
+	testutils.CheckErr(c.FindOrCreate(ctx, 2)).Unref()
+	expectInitialized(2)
+	c.EvictAll(func(k intKey) bool {
+		return k%2 == 1
+	})
+	expectReleased(1, 3)
+	testutils.CheckErr(c.FindOrCreate(ctx, 2)).Unref()
+	expectInitialized()
+	testutils.CheckErr(c.FindOrCreate(ctx, 3)).Unref()
+	expectInitialized(3)
+
+	c.Close()
+	expectReleased(2, 3, 4)
+}
+
+func TestEvictPanic(t *testing.T) {
+	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, int]) error {
+		*v.Value() = int(k)
+		return nil
+	}
+	releaseFn := func(v *int) {
+		*v = -1
+	}
+	// The cache must have a single shard of size 200 is required for the expected
+	// test values.
+	c := New[intKey, int](20, 4, initFn, releaseFn)
+	ctx := context.Background()
+	testutils.CheckErr(c.FindOrCreate(ctx, 1)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 2)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 3)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 4)).Unref()
+
+	ref := testutils.CheckErr(c.FindOrCreate(ctx, 3))
+	require.Panics(t, func() {
+		c.Evict(3)
+	})
+	ref.Unref()
+	_, _ = c.FindOrCreate(ctx, 2)
+	require.Panics(t, func() {
+		c.Close()
+	})
+}
+
+func TestErrorHandling(t *testing.T) {
+	var fail atomic.Int32
+	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, int]) error {
+		if errVal := fail.Load(); errVal != 0 {
+			time.Sleep(10 * time.Millisecond)
+			return errors.Newf("%d", errVal)
+		}
+		*v.Value() = int(k)
+		return nil
+	}
+	releaseFn := func(v *int) {
+		*v = -1
+	}
+	c := New[intKey, int](20, 4, initFn, releaseFn)
+	ctx := context.Background()
+
+	fail.Store(1)
+	var wg sync.WaitGroup
+	wg.Add(3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := c.FindOrCreate(ctx, 1)
+			require.ErrorContains(t, err, "1")
+		}()
+	}
+	wg.Wait()
+
+	fail.Store(2)
+	// A new attempt should try again and return the new error.
+	_, err := c.FindOrCreate(ctx, 1)
+	require.ErrorContains(t, err, "2")
+
+	fail.Store(0)
+	// A new attempt should succeed.
+	v, err := c.FindOrCreate(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, *v.Value(), 1)
+	v.Unref()
+}

--- a/internal/genericcache/node.go
+++ b/internal/genericcache/node.go
@@ -1,0 +1,82 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package genericcache
+
+import "sync/atomic"
+
+// node is an entry in the cache. Normally half the nodes in the cache have a
+// value, and half do not.
+type node[K Key, V any] struct {
+	key   K
+	value *value[V]
+
+	links struct {
+		next *node[K, V]
+		prev *node[K, V]
+	}
+	status nodeStatus
+	// referenced is atomically set to indicate that this entry has been accessed
+	// since the last time one of the clock hands swept it.
+	referenced atomic.Bool
+}
+
+type nodeStatus int8
+
+const (
+	test = iota
+	cold
+	hot
+)
+
+func (p nodeStatus) String() string {
+	switch p {
+	case test:
+		return "test"
+	case cold:
+		return "cold"
+	case hot:
+		return "hot"
+	}
+	return "unknown"
+}
+
+func (n *node[K, V]) next() *node[K, V] {
+	if n == nil {
+		return nil
+	}
+	return n.links.next
+}
+
+func (n *node[K, V]) prev() *node[K, V] {
+	if n == nil {
+		return nil
+	}
+	return n.links.prev
+}
+
+func (n *node[K, V]) link(s *node[K, V]) {
+	s.links.prev = n.links.prev
+	s.links.prev.links.next = s
+	s.links.next = n
+	s.links.next.links.prev = s
+}
+
+func (n *node[K, V]) unlink() *node[K, V] {
+	next := n.links.next
+	n.links.prev.links.next = n.links.next
+	n.links.next.links.prev = n.links.prev
+	n.links.prev = n
+	n.links.next = n
+	return next
+}
+
+type value[V any] struct {
+	// v and err can only be used after initialized is closed.
+	v   V
+	err error
+
+	initialized chan struct{}
+	refCount    atomic.Int32
+}

--- a/internal/genericcache/shard.go
+++ b/internal/genericcache/shard.go
@@ -60,7 +60,7 @@ func (s *shard[K, V]) releaseLoop() {
 	defer s.releaseLoopExit.Done()
 	for v := range s.releasingCh {
 		<-v.initialized
-		if v.err != nil {
+		if v.err == nil {
 			s.releaseValueFn(&v.v)
 		}
 	}
@@ -322,7 +322,7 @@ func (s *shard[K, V]) Evict(key K) {
 			panic("element has outstanding references")
 		}
 		<-v.initialized
-		if v.err != nil {
+		if v.err == nil {
 			s.releaseValueFn(&v.v)
 		}
 	}

--- a/internal/genericcache/shard.go
+++ b/internal/genericcache/shard.go
@@ -1,0 +1,399 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package genericcache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
+
+type shard[K Key, V any] struct {
+	hits   atomic.Int64
+	misses atomic.Int64
+
+	capacity int
+
+	mu struct {
+		sync.RWMutex
+		nodes map[K]*node[K, V]
+
+		handHot  *node[K, V]
+		handCold *node[K, V]
+		handTest *node[K, V]
+
+		coldTarget int
+		sizeHot    int
+		sizeCold   int
+		sizeTest   int
+	}
+	releasingCh     chan *value[V]
+	releaseLoopExit sync.WaitGroup
+
+	initValueFn    InitValueFn[K, V]
+	releaseValueFn ReleaseValueFn[V]
+}
+
+func (s *shard[K, V]) Init(
+	capacity int, initValueFn InitValueFn[K, V], releaseValueFn ReleaseValueFn[V],
+) {
+	*s = shard[K, V]{
+		capacity:       capacity,
+		initValueFn:    initValueFn,
+		releaseValueFn: releaseValueFn,
+	}
+
+	s.mu.nodes = make(map[K]*node[K, V])
+	s.mu.coldTarget = capacity
+	s.releasingCh = make(chan *value[V], 100)
+	s.releaseLoopExit.Add(1)
+	go s.releaseLoop()
+}
+
+// releaseLoop runs in the background for each shard, releasing values that are
+// pushed to releasingCh.
+func (s *shard[K, V]) releaseLoop() {
+	defer s.releaseLoopExit.Done()
+	for v := range s.releasingCh {
+		<-v.initialized
+		if v.err != nil {
+			s.releaseValueFn(&v.v)
+		}
+	}
+}
+
+func (s *shard[K, V]) UnrefValue(v *value[V]) {
+	if v.refCount.Add(-1) == 0 {
+		s.releasingCh <- v
+	}
+}
+
+// unlinkNode removes a node from the shard[K,V], leaving the shard
+// reference in place.
+//
+// c.mu must be held when calling this.
+func (s *shard[K, V]) unlinkNode(n *node[K, V]) {
+	delete(s.mu.nodes, n.key)
+
+	switch n.status {
+	case hot:
+		s.mu.sizeHot--
+	case cold:
+		s.mu.sizeCold--
+	case test:
+		s.mu.sizeTest--
+	}
+
+	if n == s.mu.handHot {
+		s.mu.handHot = s.mu.handHot.prev()
+	}
+	if n == s.mu.handCold {
+		s.mu.handCold = s.mu.handCold.prev()
+	}
+	if n == s.mu.handTest {
+		s.mu.handTest = s.mu.handTest.prev()
+	}
+
+	if n.unlink() == n {
+		// This was the last entry in the cache.
+		s.mu.handHot = nil
+		s.mu.handCold = nil
+		s.mu.handTest = nil
+	}
+
+	n.links.prev = nil
+	n.links.next = nil
+}
+
+func (s *shard[K, V]) clearNode(n *node[K, V]) {
+	if v := n.value; v != nil {
+		n.value = nil
+		s.UnrefValue(v)
+	}
+}
+
+// findOrCreateValue returns an initialized value for the key, taking a
+// reference count on it. If the key is not already in the cache, a new value is
+// created and initialized (evicting as necessary).
+//
+// The caller is responsible for unrefing the value.
+func (s *shard[K, V]) findOrCreateValue(ctx context.Context, key K) *value[V] {
+	// Fast-path for a hit in the cache.
+	s.mu.RLock()
+	if n := s.mu.nodes[key]; n != nil && n.value != nil {
+		// Fast-path hit.
+		v := n.value
+		v.refCount.Add(1)
+		s.mu.RUnlock()
+		if !n.referenced.Load() {
+			n.referenced.Store(true)
+		}
+		s.hits.Add(1)
+		<-v.initialized
+		return v
+	}
+	s.mu.RUnlock()
+
+	s.mu.Lock()
+
+	n := s.mu.nodes[key]
+	switch {
+	case n == nil:
+		// Slow-path miss of a non-existent node.
+		n = &node[K, V]{}
+		s.addNode(n, key, cold)
+		s.mu.sizeCold++
+
+	case n.value != nil:
+		// Slow-path hit of a hot or cold node.
+		//
+		// The caller is responsible for decrementing the refCount.
+		v := n.value
+		v.refCount.Add(1)
+		n.referenced.Store(true)
+		s.hits.Add(1)
+		s.mu.Unlock()
+		<-v.initialized
+		return v
+
+	default:
+		// Slow-path miss of a test node.
+		s.unlinkNode(n)
+		s.mu.coldTarget++
+		if s.mu.coldTarget > s.capacity {
+			s.mu.coldTarget = s.capacity
+		}
+
+		n.referenced.Store(false)
+		s.addNode(n, key, hot)
+		s.mu.sizeHot++
+	}
+
+	v := &value[V]{
+		initialized: make(chan struct{}),
+	}
+	// One ref count for the shard, one for the caller.
+	v.refCount.Store(2)
+	n.value = v
+	s.misses.Add(1)
+
+	s.mu.Unlock()
+
+	vRef := ValueRef[K, V]{
+		shard: s,
+		value: v,
+	}
+
+	v.err = s.initValueFn(ctx, key, vRef)
+	if v.err != nil {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		// Lookup the node in the cache again as it might have already been
+		// removed.
+		if n := s.mu.nodes[key]; n != nil && n.value == v {
+			s.unlinkNode(n)
+			s.clearNode(n)
+		}
+	}
+	close(v.initialized)
+	return v
+}
+
+func (s *shard[K, V]) addNode(n *node[K, V], key K, status nodeStatus) {
+	n.key = key
+	n.status = status
+
+	s.evictNodes()
+	s.mu.nodes[n.key] = n
+
+	n.links.next = n
+	n.links.prev = n
+	if s.mu.handHot == nil {
+		// First element.
+		s.mu.handHot = n
+		s.mu.handCold = n
+		s.mu.handTest = n
+	} else {
+		s.mu.handHot.link(n)
+	}
+
+	if s.mu.handCold == s.mu.handHot {
+		s.mu.handCold = s.mu.handCold.prev()
+	}
+}
+
+func (s *shard[K, V]) evictNodes() {
+	for s.capacity <= s.mu.sizeHot+s.mu.sizeCold && s.mu.handCold != nil {
+		s.runHandCold()
+	}
+}
+
+func (s *shard[K, V]) runHandCold() {
+	n := s.mu.handCold
+	if n.status == cold {
+		if n.referenced.Load() {
+			n.referenced.Store(false)
+			n.status = hot
+			s.mu.sizeCold--
+			s.mu.sizeHot++
+		} else {
+			s.clearNode(n)
+			n.status = test
+			s.mu.sizeCold--
+			s.mu.sizeTest++
+			for s.capacity < s.mu.sizeTest && s.mu.handTest != nil {
+				s.runHandTest()
+			}
+		}
+	}
+
+	s.mu.handCold = s.mu.handCold.next()
+
+	for s.capacity-s.mu.coldTarget <= s.mu.sizeHot && s.mu.handHot != nil {
+		s.runHandHot()
+	}
+}
+
+func (s *shard[K, V]) runHandHot() {
+	if s.mu.handHot == s.mu.handTest && s.mu.handTest != nil {
+		s.runHandTest()
+		if s.mu.handHot == nil {
+			return
+		}
+	}
+
+	n := s.mu.handHot
+	if n.status == hot {
+		if n.referenced.Load() {
+			n.referenced.Store(false)
+		} else {
+			n.status = cold
+			s.mu.sizeHot--
+			s.mu.sizeCold++
+		}
+	}
+
+	s.mu.handHot = s.mu.handHot.next()
+}
+
+func (s *shard[K, V]) runHandTest() {
+	if s.mu.sizeCold > 0 && s.mu.handTest == s.mu.handCold && s.mu.handCold != nil {
+		s.runHandCold()
+		if s.mu.handTest == nil {
+			return
+		}
+	}
+
+	n := s.mu.handTest
+	if n.status == test {
+		s.mu.coldTarget--
+		if s.mu.coldTarget < 0 {
+			s.mu.coldTarget = 0
+		}
+		s.unlinkNode(n)
+		s.clearNode(n)
+	}
+
+	s.mu.handTest = s.mu.handTest.next()
+}
+
+// Evict any entry associated with the given key. If there is a corresponding
+// value in the shard, it is released before the function returns. There must
+// not be any outstanding references on the value.
+func (s *shard[K, V]) Evict(key K) {
+	s.mu.Lock()
+	n := s.mu.nodes[key]
+	var v *value[V]
+	if n != nil {
+		// NB: This is equivalent to UnrefValue, but we perform the releaseValueFn()
+		// call synchronously below to free up any associated resources before
+		// returning.
+		s.unlinkNode(n)
+		v = n.value
+	}
+	s.mu.Unlock()
+
+	if v != nil {
+		if v.refCount.Add(-1) != 0 {
+			panic("element has outstanding references")
+		}
+		<-v.initialized
+		if v.err != nil {
+			s.releaseValueFn(&v.v)
+		}
+	}
+}
+
+// EvictAll evicts all entries in the shard with a key that satisfies the given
+// predicate. Any corresponding values are released before the function returns.
+// There must not be any outstanding references on the values, and no keys that
+// satisfy the predicate should be inserted while the method is running.
+//
+// It should be used sparingly as it is an O(n) operation.
+func (s *shard[K, V]) EvictAll(predicate func(K) bool) []K {
+	// Collect the keys which need to be evicted.
+	var keys []K
+	s.mu.RLock()
+	s.forAllNodesLocked(func(n *node[K, V]) {
+		if predicate(n.key) {
+			keys = append(keys, n.key)
+		}
+	})
+	s.mu.RUnlock()
+
+	for i := range keys {
+		s.Evict(keys[i])
+	}
+
+	if invariants.Enabled {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		s.forAllNodesLocked(func(n *node[K, V]) {
+			if predicate(n.key) {
+				panic("evictable key added in shard")
+			}
+		})
+	}
+	return keys
+}
+
+func (s *shard[K, V]) forAllNodesLocked(f func(n *node[K, V])) {
+	if firstNode := s.mu.handHot; firstNode != nil {
+		for node := firstNode; ; {
+			f(node)
+			if node = node.next(); node == firstNode {
+				return
+			}
+		}
+	}
+}
+
+// Close the shard, releasing all live values. There must not be any outstanding
+// references on any of the values.
+func (s *shard[K, V]) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for s.mu.handHot != nil {
+		n := s.mu.handHot
+		if v := n.value; v != nil {
+			if v.refCount.Add(-1) != 0 {
+				panic("element has outstanding references")
+			}
+			s.releasingCh <- v
+		}
+		s.unlinkNode(n)
+	}
+
+	s.mu.nodes = nil
+	s.mu.handHot = nil
+	s.mu.handCold = nil
+	s.mu.handTest = nil
+
+	close(s.releasingCh)
+	s.releaseLoopExit.Wait()
+}

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -537,7 +537,7 @@ func (d *DB) deleteObsoleteFiles(jobID JobID) {
 		return cmp.Compare(a.FileNum, b.FileNum)
 	})
 	for _, f := range obsoleteTables {
-		d.fileCache.evict(f.FileNum)
+		d.fileCache.Evict(f.FileNum)
 		filesToDelete = append(filesToDelete, obsoleteFile{
 			fileType: base.FileTypeTable,
 			nonLogFile: deletableFile{
@@ -549,7 +549,7 @@ func (d *DB) deleteObsoleteFiles(jobID JobID) {
 		})
 	}
 	for _, f := range obsoleteBlobs {
-		d.fileCache.evict(f.FileNum)
+		d.fileCache.Evict(f.FileNum)
 		filesToDelete = append(filesToDelete, obsoleteFile{
 			fileType: base.FileTypeBlob,
 			nonLogFile: deletableFile{

--- a/open.go
+++ b/open.go
@@ -405,7 +405,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		opts.FileCache = NewFileCache(opts.Experimental.FileCacheShards, fileCacheSize)
 		defer opts.FileCache.Unref()
 	}
-	d.fileCache = opts.FileCache.newHandle(d.cacheHandle, d.objProvider, d.opts)
+	d.fileCache = opts.FileCache.newHandle(d.cacheHandle, d.objProvider, d.opts.LoggerAndTracer, d.opts.MakeReaderOptions())
 	d.newIters = d.fileCache.newIters
 	d.tableNewRangeKeyIter = tableNewRangeKeyIter(d.newIters)
 

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -799,6 +799,8 @@ func (r *Reader) TableFormat() (TableFormat, error) {
 //
 // The context is used for tracing any operations performed by NewReader; it is
 // NOT stored for future use.
+//
+// In error cases, the Readable is closed.
 func NewReader(ctx context.Context, f objstorage.Readable, o ReaderOptions) (*Reader, error) {
 	if f == nil {
 		return nil, errors.New("pebble/table: nil file")

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -54,7 +54,7 @@ Virtual tables: 0 (0B)
 Local tables size: 569B
 Compression types: snappy: 1
 Block cache: 3 entries (1.1KB)  hit rate: 18.2%
-Table cache: 1 entries (912B)  hit rate: 50.0%
+Table cache: 1 entries (952B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -75,7 +75,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 0.0%
-Table cache: 1 entries (912B)  hit rate: 0.0%
+Table cache: 1 entries (952B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -135,7 +135,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 33.3%
-Table cache: 2 entries (1.8KB)  hit rate: 66.7%
+Table cache: 2 entries (1.9KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
 Filter utility: 0.0%
@@ -181,7 +181,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 33.3%
-Table cache: 2 entries (1.8KB)  hit rate: 66.7%
+Table cache: 2 entries (1.9KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
 Filter utility: 0.0%
@@ -224,7 +224,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 33.3%
-Table cache: 1 entries (912B)  hit rate: 66.7%
+Table cache: 1 entries (952B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -503,7 +503,7 @@ Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 7
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (912B)  hit rate: 53.8%
+Table cache: 1 entries (952B)  hit rate: 53.8%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -567,7 +567,7 @@ Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Compression types: snappy: 10
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (912B)  hit rate: 53.8%
+Table cache: 1 entries (952B)  hit rate: 53.8%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -843,7 +843,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 1 entries (912B)  hit rate: 0.0%
+Table cache: 1 entries (952B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -892,7 +892,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 2
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (912B)  hit rate: 50.0%
+Table cache: 1 entries (952B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -941,7 +941,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 3
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (912B)  hit rate: 50.0%
+Table cache: 1 entries (952B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%


### PR DESCRIPTION
#### genericcache: extract the generic part of the file cache

This code extracts the internal logic of the file cache and makes it
into a generally useful type.

#### db: don't pass entire Options to file cache


#### db: rework fileCache to use genericcache

We no longer intermingle the cache infrastructure logic with the file
cache specifics. This will help when we extend the file cache to
support blob files.