### PR TITLE
internal/manifest: maintain BlobFileMetadata references

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1324,17 +1324,15 @@ func (d *DB) newIngestedFlushableEntry(
 	// to.
 	entry := d.newFlushableEntry(f, logNum, seqNum)
 	// The flushable entry starts off with a single reader ref, so increment
-	// the FileBacking.Refs.
+	// the TableMetadata.Refs.
 	for _, file := range f.files {
-		file.FileBacking.Ref()
+		file.Ref()
 	}
 	entry.unrefFiles = func(of *manifest.ObsoleteFiles) {
-		// Invoke Unref on each table. If any files become obsolete, add them to
-		// the obsolete files list.
+		// Invoke Unref on each table. If any files become obsolete, they'll be
+		// added to the set of obsolete files.
 		for _, file := range f.files {
-			if file.FileBacking.Unref() == 0 {
-				of.AddBacking(file.FileBacking)
-			}
+			file.Unref(of)
 		}
 	}
 

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -5,16 +5,31 @@
 package manifest
 
 import (
+	"sync/atomic"
+
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/redact"
 )
 
 // A BlobReference describes a sstable's reference to a blob value file.
 type BlobReference struct {
-	FileNum   base.DiskFileNum
+	// FileNum identifies the referenced blob file.
+	FileNum base.DiskFileNum
+	// ValueSize is the sum of the lengths of the uncompressed values within the
+	// blob file for which there exists a reference in the sstable.
+	//
+	// INVARIANT: ValueSize <= Metadata.ValueSize
 	ValueSize uint64
+
+	// Metadata is the metadata for the blob file. It is non-nil for blob
+	// references contained within active Versions. It is expected to initially
+	// be nil when decoding a version edit as a part of manfiest replay. When
+	// the version edit is accumulated into a bulk version edit, the metadata
+	// is populated.
+	Metadata *BlobFileMetadata
 }
 
 // BlobFileMetadata is metadata describing a blob value file.
@@ -29,6 +44,65 @@ type BlobFileMetadata struct {
 	// File creation time in seconds since the epoch (1970-01-01 00:00:00
 	// UTC).
 	CreationTime uint64
+
+	// Mutable state
+
+	// refs holds the reference count for the blob file. Each ref is from a
+	// TableMetadata in a Version with a positive reference count. Each
+	// TableMetadata can refer to multiple blob files and will count as 1 ref
+	// for each of those blob files. The ref count is incremented when a new
+	// referencing TableMetadata is installed in a Version and decremented when
+	// that TableMetadata becomes obsolete.
+	refs atomic.Int32
+
+	// ActiveRefs holds state that describes the latest (the 'live') Version
+	// containing this blob file and the references to the file within that
+	// version.
+	ActiveRefs BlobFileActiveRefs
+}
+
+// BlobFileActiveRefs describes the state of a blob file within the latest
+// Version and the references to the file within that version.
+type BlobFileActiveRefs struct {
+	// count holds the number of tables in the latest version that reference
+	// this blob file. When this reference count falls to zero, the blob file is
+	// either a zombie file (if BlobFileMetadata.refs > 0), or obsolete and
+	// ready to be deleted.
+	//
+	// INVARIANT: BlobFileMetadata.refs > BlobFileMetadata.ActiveRefs.count
+	count int32
+	// valueSize is the sum of the length of uncompressed values in this blob
+	// file that are still live (i.e., referred to by sstables in the latest
+	// version).
+	valueSize uint64
+}
+
+// AddRef records a new reference to the blob file from a sstable in the latest
+// Version. The provided valueSize should be the value of the sstable's
+// BlobReference.ValueSize.
+//
+// Requires the manifest logLock be held.
+func (r *BlobFileActiveRefs) AddRef(valueSize uint64) {
+	r.count++
+	r.valueSize += valueSize
+}
+
+// RemoveRef removes a reference that no longer exists in the latest Version.
+// The provided valueSize should be the value of the removed sstable's
+// BlobReference.ValueSize.
+//
+// Requires the manifest logLock be held.
+func (r *BlobFileActiveRefs) RemoveRef(valueSize uint64) {
+	if invariants.Enabled {
+		if r.count <= 0 {
+			panic(errors.AssertionFailedf("pebble: negative active ref count"))
+		}
+		if valueSize > r.valueSize {
+			panic(errors.AssertionFailedf("pebble: negative active value size"))
+		}
+	}
+	r.count--
+	r.valueSize -= valueSize
 }
 
 // SafeFormat implements redact.SafeFormatter.
@@ -41,6 +115,21 @@ func (m *BlobFileMetadata) SafeFormat(w redact.SafePrinter, _ rune) {
 // String implements fmt.Stringer.
 func (m *BlobFileMetadata) String() string {
 	return redact.StringWithoutMarkers(m)
+}
+
+// ref increments the reference count for the blob file.
+func (m *BlobFileMetadata) ref() {
+	m.refs.Add(+1)
+}
+
+// unref decrements the reference count for the blob file. It returns the
+// resulting reference count.
+func (m *BlobFileMetadata) unref() int32 {
+	refs := m.refs.Add(-1)
+	if refs < 0 {
+		panic(errors.AssertionFailedf("pebble: refs for blob file %d equal to %d", m.FileNum, refs))
+	}
+	return refs
 }
 
 // ParseBlobFileMetadataDebug parses a BlobFileMetadata from its string

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -141,6 +141,9 @@ type ObsoleteFilesSet interface {
 	// AddBacking appends the provided FileBacking to the list of obsolete
 	// files.
 	AddBacking(*FileBacking)
+	// AddBlob appends the provided BlobFileMetadata to the list of obsolete
+	// files.
+	AddBlob(*BlobFileMetadata)
 }
 
 // assertNoObsoleteFiles is an obsoleteFiles implementation that panics if its
@@ -159,6 +162,11 @@ func (assertNoObsoleteFiles) AddBacking(fb *FileBacking) {
 	panic(errors.AssertionFailedf("file backing %s dereferenced to zero during tree mutation", fb.DiskFileNum))
 }
 
+// AddBlob appends the provided BlobFileMetadata to the list of obsolete files.
+func (assertNoObsoleteFiles) AddBlob(bm *BlobFileMetadata) {
+	panic(errors.AssertionFailedf("blob file %s dereferenced to zero during tree mutation", bm.FileNum))
+}
+
 // ignoreObsoleteFiles is an ObsoleteFilesSet implementation that ignores
 // obsolete files. It's used in some contexts where we construct ephemeral
 // B-Trees which do not need to track obsolete files and in tests.
@@ -169,6 +177,9 @@ var _ ObsoleteFilesSet = ignoreObsoleteFiles{}
 
 // AddBacking appends the provided FileBacking to the list of obsolete files.
 func (ignoreObsoleteFiles) AddBacking(fb *FileBacking) {}
+
+// AddBlob appends the provided BlobFileMetadata to the list of obsolete files.
+func (ignoreObsoleteFiles) AddBlob(bm *BlobFileMetadata) {}
 
 // incRef acquires a reference to the node.
 func (n *node) incRef() {

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -37,7 +37,7 @@ func (lm *LevelMetadata) clone() LevelMetadata {
 	}
 }
 
-func (lm *LevelMetadata) release(of obsoleteFiles) {
+func (lm *LevelMetadata) release(of ObsoleteFilesSet) {
 	lm.tree.Release(of)
 }
 

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -215,3 +215,90 @@ apply v7
 ----
 L2:
   000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+define v8
+L1:
+  000001:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET]
+----
+L1:
+  000001:[a#2,SET-e#2,SET] seqnums:[0-0] points:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+# Accumulate should error if we attempt to add a sstable referencing a blob file
+# that is unknown.
+
+apply v8
+  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935)]
+----
+error during Accumulate: blob file 000003 referenced by L0.000004 not found
+
+# Apply a version edit that introduces a new blob file and a corresponding table
+# that references its entirety.
+
+apply v8 name=v9
+  add-blob-file: 000003 size:[20535 (20KB)] vals:[25935 (25KB)]
+  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935)]
+----
+L0.0:
+  000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935)]
+L1:
+  000001:[a#2,SET-e#2,SET] seqnums:[0-0] points:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+# Try to add another table referencing the blob file. Since the file is not
+# added in the same version edit, and no referencing table is deleted in the
+# same version edit, accumulate will error.
+
+apply v8
+  add-table:     L0 000005:[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] blobrefs:[(000003: 205)]
+----
+error during Accumulate: blob file 000003 referenced by L0.000005 not found
+
+# We can add new tables referencing the blob file if we delete an existing table
+# with a reference to the file.
+
+apply v9
+  del-table:     L0 000004
+  del-table:     L1 000001
+  add-table:     L1 000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205)]
+  add-table:     L1 000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192)]
+----
+L1:
+  000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205)]
+  000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192)]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+# Repeat the above but this time applying the entire lifecycle of a blob file in
+# a single bulk version edit. This simulates a manifest replay during startup.
+
+define v10
+L1:
+  000001:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET]
+----
+L1:
+  000001:[a#2,SET-e#2,SET] seqnums:[0-0] points:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+apply v10
+  add-blob-file: 000003 size:[20535 (20KB)] vals:[25935 (25KB)]
+  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935)]
+new version edit
+  del-table:     L0 000004
+  del-table:     L1 000001
+  add-table:     L1 000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205)]
+  add-table:     L1 000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192)]
+new version edit
+  del-table:     L1 000005
+  del-table:     L1 000006
+  del-blob-file: 000003
+----
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -404,6 +404,8 @@ func TestVersionEditApply(t *testing.T) {
 				return v.DebugString()
 
 			case "apply":
+				var saveName string
+				d.MaybeScanArgs(t, "name", &saveName)
 				// Apply an edit to the given version.
 				name := d.CmdArgs[0].String()
 				v := versions[name]
@@ -444,6 +446,9 @@ func TestVersionEditApply(t *testing.T) {
 				newv, err := bve.Apply(v, base.DefaultComparer, flushSplitBytes, readCompactionRate)
 				if err != nil {
 					return err.Error()
+				}
+				if saveName != "" {
+					versions[saveName] = newv
 				}
 
 				// Reinitialize the L0 sublevels in the original version; otherwise we


### PR DESCRIPTION
Extend the BlobReference type with a pointer to a shared BlobFileMetadata
struct describing the blob file. Apply reference counting to these
BlobFileMetadata to track the lifecycle of a blob file.

Informs #112.