### PR TITLE
internal/manifest: add BlobReferenceDepth and encode in manifest

### DIFF
--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -231,7 +231,7 @@ L2:
 # that is unknown.
 
 apply v8
-  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935)]
+  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935); depth:1]
 ----
 error during Accumulate: blob file 000003 referenced by L0.000004 not found
 
@@ -240,10 +240,10 @@ error during Accumulate: blob file 000003 referenced by L0.000004 not found
 
 apply v8 name=v9
   add-blob-file: 000003 size:[20535 (20KB)] vals:[25935 (25KB)]
-  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935)]
+  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935); depth:1]
 ----
 L0.0:
-  000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935)]
+  000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935); depth:1]
 L1:
   000001:[a#2,SET-e#2,SET] seqnums:[0-0] points:[a#2,SET-e#2,SET]
 L2:
@@ -254,7 +254,7 @@ L2:
 # same version edit, accumulate will error.
 
 apply v8
-  add-table:     L0 000005:[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] blobrefs:[(000003: 205)]
+  add-table:     L0 000005:[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] blobrefs:[(000003: 205); depth:1]
 ----
 error during Accumulate: blob file 000003 referenced by L0.000005 not found
 
@@ -264,12 +264,12 @@ error during Accumulate: blob file 000003 referenced by L0.000005 not found
 apply v9
   del-table:     L0 000004
   del-table:     L1 000001
-  add-table:     L1 000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205)]
-  add-table:     L1 000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192)]
+  add-table:     L1 000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205); depth:1]
+  add-table:     L1 000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192); depth:1]
 ----
 L1:
-  000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205)]
-  000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192)]
+  000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205); depth:1]
+  000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192); depth:1]
 L2:
   000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
 
@@ -289,12 +289,12 @@ L2:
 
 apply v10
   add-blob-file: 000003 size:[20535 (20KB)] vals:[25935 (25KB)]
-  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935)]
+  add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(000003: 25935); depth:1]
 new version edit
   del-table:     L0 000004
   del-table:     L1 000001
-  add-table:     L1 000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205)]
-  add-table:     L1 000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192)]
+  add-table:     L1 000005:[a#9,SET-d#9,SET] seqnums:[0-9] points:[a#9,SET-d#9,SET] blobrefs:[(000003: 12205); depth:1]
+  add-table:     L1 000006:[e#2,SET-z#9,SET] seqnums:[0-9] points:[e#2,SET-z#9,SET] blobrefs:[(000003: 14192); depth:1]
 new version edit
   del-table:     L1 000005
   del-table:     L1 000006

--- a/internal/manifest/testdata/version_edit_decode
+++ b/internal/manifest/testdata/version_edit_decode
@@ -69,22 +69,22 @@ f9a006                       #   . ValueSize    = 102521
   del-blob-file: 000033
 
 encode
-  add-table:     L6 000029:[bar#14,DEL-foo#13,SET] blobrefs:[(000041: 20952)]
+  add-table:     L6 000029:[bar#14,DEL-foo#13,SET] blobrefs:[(000041: 20952); depth:1]
   add-blob-file: 000041 size:[20952 (20KB)] vals:[102521 (100KB)]
   del-blob-file: 000033
 ----
 67061d000b626172000e0000000000000b666f6f010d0000000000000000
-450129d8a301016b29d8a301f9a006006c21
-  add-table:     L6 000029:[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(000041: 20952)]
+45010129d8a301016b29d8a301f9a006006c21
+  add-table:     L6 000029:[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(000041: 20952); depth:1]
   add-blob-file: 000041 size:[20952 (20KB)] vals:[102521 (100KB)]
   del-blob-file: 000033
 
 decode
 67061d000b626172000e0000000000000b666f6f010d0000000000000000
-450129d8a301016b29d8a301f9a006006c21
+45010129d8a301016b29d8a301f9a006006c21
 ----
 67061d000b626172000e0000000000000b666f6f010d0000000000000000
-450129d8a301016b29d8a301f9a006006c21
+45010129d8a301016b29d8a301f9a006006c21
   add-table:     L6 000029:[bar#14,DEL-foo#13,SET]
   add-blob-file: 000041 size:[20952 (20KB)] vals:[102521 (100KB)]
   del-blob-file: 000033

--- a/internal/manifest/testutils.go
+++ b/internal/manifest/testutils.go
@@ -30,7 +30,7 @@ type debugParser struct {
 	lastToken string
 }
 
-const debugParserSeparators = ":-[]()"
+const debugParserSeparators = ":-[]();"
 
 func makeDebugParser(s string) debugParser {
 	p := debugParser{

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -507,7 +507,7 @@ func TestParseVersionEditDebugRoundTrip(t *testing.T) {
 		{
 			input: strings.Join([]string{
 				`  add-table:     L1 000001:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:1`,
-				`  add-table:     L2 000002:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:2 blobrefs:[(002431: 3008533), (002432: 10534)]`,
+				`  add-table:     L2 000002:[a#0,SET-z#0,DEL] seqnums:[0-0] points:[a#0,SET-z#0,DEL] size:2 blobrefs:[(002431: 3008533), (002432: 10534); depth:2]`,
 			}, "\n"),
 		},
 	}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -416,7 +416,7 @@ func TestTableMetadata_ParseRoundTrip(t *testing.T) {
 		},
 		{
 			name:  "blobrefs",
-			input: "000196:[bar#0,SET-foo#0,SET] seqnums:[0-0] points:[bar#0,SET-foo#0,SET] blobrefs:[(000191: 2952), (000075: 108520)]",
+			input: "000196:[bar#0,SET-foo#0,SET] seqnums:[0-0] points:[bar#0,SET-foo#0,SET] blobrefs:[(000191: 2952), (000075: 108520); depth:2]",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Add TableMetadata.BlobReferenceDepth, which is an upper bound on the number of blob files that a reader scanning the table would need to keep open if they only open and close each referenced blob file once. The BlobReferenceDepth will be approximated in practice, by assigning the outputs of a compaction a blob reference depth equal to the sum of the highest blob reference depth in each input level of the compaction.

This commit introduces the field and adds it to the encoding and debug output of TableMetadata and VersionEdits.

Informs #112.