### PR TITLE
*: add InternalValue

### DIFF
--- a/cockroachkvs/cockroachkvs_bench_test.go
+++ b/cockroachkvs/cockroachkvs_bench_test.go
@@ -320,8 +320,8 @@ func benchmarkCockroachDataBlockIter(
 
 	var decoder colblk.DataBlockDecoder
 	var it colblk.DataBlockIter
-	it.InitOnce(&KeySchema, &Comparer, getLazyValuer(func([]byte) base.LazyValue {
-		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
+	it.InitOnce(&KeySchema, &Comparer, getInternalValuer(func([]byte) base.InternalValue {
+		return base.MakeInPlaceValue([]byte("mock external value"))
 	}))
 	decoder.Init(&KeySchema, serializedBlock)
 	if err := it.Init(&decoder, transforms); err != nil {

--- a/cockroachkvs/cockroachkvs_test.go
+++ b/cockroachkvs/cockroachkvs_test.go
@@ -408,8 +408,8 @@ func testCockroachDataColBlock(t *testing.T, seed uint64, keyCfg keyGenConfig) {
 
 	var decoder colblk.DataBlockDecoder
 	var it colblk.DataBlockIter
-	it.InitOnce(&KeySchema, &Comparer, getLazyValuer(func([]byte) base.LazyValue {
-		return base.LazyValue{ValueOrHandle: []byte("mock external value")}
+	it.InitOnce(&KeySchema, &Comparer, getInternalValuer(func([]byte) base.InternalValue {
+		return base.MakeInPlaceValue([]byte("mock external value"))
 	}))
 	decoder.Init(&KeySchema, serializedBlock)
 	if err := it.Init(&decoder, block.IterTransforms{}); err != nil {
@@ -470,9 +470,11 @@ func generateDataBlock(
 	return data, keys[:count], values[:count]
 }
 
-type getLazyValuer func([]byte) base.LazyValue
+type getInternalValuer func([]byte) base.InternalValue
 
-func (g getLazyValuer) GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue {
+func (g getInternalValuer) GetInternalValueForPrefixAndValueHandle(
+	handle []byte,
+) base.InternalValue {
 	return g(handle)
 }
 

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -104,7 +104,7 @@ func TestFull(t *testing.T) {
 	require.Equal(t, ErrArenaFull, err)
 }
 
-func mustGetValue(t *testing.T, lv base.LazyValue) []byte {
+func mustGetValue(t *testing.T, lv base.InternalValue) []byte {
 	v, _, err := lv.Value(nil)
 	require.NoError(t, err)
 	return v

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -610,7 +610,7 @@ func MakeInternalKV(k InternalKey, v []byte) InternalKV {
 // InternalKV represents a single internal key-value pair.
 type InternalKV struct {
 	K InternalKey
-	V LazyValue
+	V InternalValue
 }
 
 // Kind returns the KV's internal key kind.
@@ -628,7 +628,12 @@ func (kv *InternalKV) InPlaceValue() []byte {
 	return kv.V.InPlaceValue()
 }
 
-// Value return's the KV's underlying value.
+// LazyValue returns a LazyValue containing the KV's value.
+func (kv *InternalKV) LazyValue() LazyValue {
+	return kv.V.LazyValue()
+}
+
+// Value returns the KV's underlying value.
 func (kv *InternalKV) Value(buf []byte) (val []byte, callerOwned bool, err error) {
 	return kv.V.Value(buf)
 }

--- a/internal/base/lazy_value.go
+++ b/internal/base/lazy_value.go
@@ -4,11 +4,7 @@
 
 package base
 
-import (
-	"context"
-
-	"github.com/cockroachdb/pebble/internal/invariants"
-)
+import "context"
 
 // A value can have user-defined attributes that are a function of the value
 // byte slice. For now, we only support "short attributes", which can be
@@ -222,21 +218,6 @@ func (lv *LazyValue) fetchValue(
 	return f.value, f.callerOwned, f.err
 }
 
-// IsInPlaceValue returns true iff the value was stored in-place and does not
-// need to be fetched externally.
-func (lv *LazyValue) IsInPlaceValue() bool {
-	return lv.Fetcher == nil
-}
-
-// InPlaceValue returns the value under the assumption that it is in-place.
-// This is for Pebble-internal code.
-func (lv *LazyValue) InPlaceValue() []byte {
-	if invariants.Enabled && lv.Fetcher != nil {
-		panic("value must be in-place")
-	}
-	return lv.ValueOrHandle
-}
-
 // Len returns the length of the value.
 func (lv *LazyValue) Len() int {
 	if lv.Fetcher == nil {
@@ -292,9 +273,4 @@ func (lv *LazyValue) Clone(buf []byte, fetcher *LazyFetcher) (LazyValue, []byte)
 	buf = append(buf, lv.ValueOrHandle...)
 	lvCopy.ValueOrHandle = buf[bufLen : bufLen+vLen]
 	return lvCopy, buf
-}
-
-// MakeInPlaceValue constructs an in-place value.
-func MakeInPlaceValue(val []byte) LazyValue {
-	return LazyValue{ValueOrHandle: val}
 }

--- a/internal/base/lazy_value_test.go
+++ b/internal/base/lazy_value_test.go
@@ -29,7 +29,7 @@ func TestLazyValue(t *testing.T) {
 	require.True(t, unsafe.Sizeof(LazyValue{}) <= 32)
 
 	fooBytes1 := []byte("foo")
-	fooLV1 := MakeInPlaceValue(fooBytes1)
+	fooLV1 := LazyValue{ValueOrHandle: fooBytes1}
 	require.Equal(t, 3, fooLV1.Len())
 	_, hasAttr := fooLV1.TryGetShortAttribute()
 	require.False(t, hasAttr)
@@ -37,7 +37,7 @@ func TestLazyValue(t *testing.T) {
 	require.Equal(t, 3, fooLV2.Len())
 	_, hasAttr = fooLV2.TryGetShortAttribute()
 	require.False(t, hasAttr)
-	require.Equal(t, fooLV1.InPlaceValue(), fooLV2.InPlaceValue())
+	require.Equal(t, fooLV1.ValueOrHandle, fooLV2.ValueOrHandle)
 	getValue := func(lv LazyValue, expectedCallerOwned bool) []byte {
 		v, callerOwned, err := lv.Value(nil)
 		require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestLazyValue(t *testing.T) {
 	}
 	require.Equal(t, getValue(fooLV1, false), getValue(fooLV2, false))
 	fooBytes2[0] = 'b'
-	require.False(t, bytes.Equal(fooLV1.InPlaceValue(), fooLV2.InPlaceValue()))
+	require.False(t, bytes.Equal(fooLV1.ValueOrHandle, fooLV2.ValueOrHandle))
 
 	for _, callerOwned := range []bool{false, true} {
 		numCalls := 0

--- a/internal/base/value.go
+++ b/internal/base/value.go
@@ -1,0 +1,76 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import "github.com/cockroachdb/pebble/internal/invariants"
+
+// An InternalValue represents a value. The value may be in-memory, immediately
+// accessible, or it may be stored out-of-band and need to be fetched when
+// required.
+//
+// InternalValue is distinct from LazyValue. The LazyValue type is used within
+// Pebble's public interface, while InternalValue is an intermediary
+// representation of a value used only internally within Pebble.
+type InternalValue struct {
+	lazyValue LazyValue
+}
+
+// MakeLazyValue constructs an IntrenalValue from a LazyValue.
+func MakeLazyValue(v LazyValue) InternalValue {
+	return InternalValue{lazyValue: v}
+}
+
+// MakeInPlaceValue constructs an in-place value.
+func MakeInPlaceValue(val []byte) InternalValue {
+	return InternalValue{lazyValue: LazyValue{ValueOrHandle: val}}
+}
+
+// IsInPlaceValue returns true iff the value was stored in-place and does not
+// need to be fetched externally.
+func (v *InternalValue) IsInPlaceValue() bool {
+	return v.lazyValue.Fetcher == nil
+}
+
+// InPlaceValue returns the value under the assumption that it is in-place.
+// This is for Pebble-internal code.
+func (v *InternalValue) InPlaceValue() []byte {
+	if invariants.Enabled && v.lazyValue.Fetcher != nil {
+		panic("value must be in-place")
+	}
+	return v.lazyValue.ValueOrHandle
+}
+
+// LazyValue returns the InternalValue as a LazyValue.
+func (v *InternalValue) LazyValue() LazyValue {
+	return v.lazyValue
+}
+
+// Len returns the length of the value. This is the length of the logical value
+// (i.e., the length of the byte slice returned by .Value())
+func (v *InternalValue) Len() int {
+	return v.lazyValue.Len()
+}
+
+// InternalLen returns the length of the value, if the value is in-place, or the
+// length of the handle describing the location of the value if the value is
+// stored out-of-band.
+func (v *InternalValue) InternalLen() int {
+	return len(v.lazyValue.ValueOrHandle)
+}
+
+// Value returns the KV's underlying value.
+func (v *InternalValue) Value(buf []byte) (val []byte, callerOwned bool, err error) {
+	return v.lazyValue.Value(buf)
+}
+
+// Clone creates a stable copy of the value, by appending bytes to buf.  The
+// fetcher parameter must be non-nil and may be over-written and used inside the
+// returned InternalValue -- this is needed to avoid an allocation.
+//
+// See LazyValue.Clone for more details.
+func (v *InternalValue) Clone(buf []byte, fetcher *LazyFetcher) (InternalValue, []byte) {
+	lv, buf := v.lazyValue.Clone(buf, fetcher)
+	return InternalValue{lazyValue: lv}, buf
+}

--- a/iterator.go
+++ b/iterator.go
@@ -217,7 +217,7 @@ type Iterator struct {
 	// is backed by keyBuf.
 	key    []byte
 	keyBuf []byte
-	value  LazyValue
+	value  base.InternalValue
 	// For use in LazyValue.Clone.
 	valueBuf []byte
 	fetcher  base.LazyFetcher
@@ -576,7 +576,7 @@ func (i *Iterator) findNextEntry(limit []byte) {
 			// Save the current key.
 			i.keyBuf = append(i.keyBuf[:0], key.UserKey...)
 			i.key = i.keyBuf
-			i.value = LazyValue{}
+			i.value = base.InternalValue{}
 			// There may also be a live point key at this userkey that we have
 			// not yet read. We need to find the next entry with this user key
 			// to find it. Save the range key so we don't lose it when we Next
@@ -946,7 +946,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 						// a range key boundary at this key, we still want to
 						// return. Otherwise, we need to continue looking for
 						// a live key.
-						i.value = LazyValue{}
+						i.value = base.InternalValue{}
 						if rangeKeyBoundary {
 							i.rangeKey.rangeKeyOnly = true
 						} else {
@@ -1020,7 +1020,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			rangeKeyBoundary = true
 
 		case InternalKeyKindDelete, InternalKeyKindSingleDelete, InternalKeyKindDeleteSized:
-			i.value = LazyValue{}
+			i.value = base.InternalValue{}
 			i.iterValidityState = IterExhausted
 			valueMerger = nil
 			i.stats.ReverseStepCount[InternalIterCall]++
@@ -1139,7 +1139,7 @@ func (i *Iterator) findPrevEntry(limit []byte) {
 			i.value = base.MakeInPlaceValue(value)
 			if i.err == nil && needDelete {
 				i.key = nil
-				i.value = LazyValue{}
+				i.value = base.InternalValue{}
 				i.iterValidityState = IterExhausted
 			}
 		}
@@ -2292,7 +2292,7 @@ func (i *Iterator) ValueAndErr() ([]byte, error) {
 // LazyValue returns the LazyValue. Only for advanced use cases.
 // REQUIRES: i.Error()==nil and HasPointAndRange() returns true for hasPoint.
 func (i *Iterator) LazyValue() LazyValue {
-	return i.value
+	return i.value.LazyValue()
 }
 
 // RangeKeys returns the range key values and their suffixes covering the

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -1373,7 +1373,7 @@ func (m *mergingIter) ForEachLevelIter(fn func(li *levelIter) bool) {
 func (m *mergingIter) addItemStats(l *mergingIterLevel) {
 	m.stats.PointCount++
 	m.stats.KeyBytes += uint64(len(l.iterKV.K.UserKey))
-	m.stats.ValueBytes += uint64(len(l.iterKV.V.ValueOrHandle))
+	m.stats.ValueBytes += uint64(l.iterKV.V.InternalLen())
 }
 
 var _ internalIterator = &mergingIter{}

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -85,7 +85,7 @@ func writeSSTForIngestion(
 		k := *kv
 		k.K.SetSeqNum(base.SeqNumZero)
 		k.K.UserKey = outputKey(k.K.UserKey, syntheticSuffix)
-		value := kv.V
+		value := kv.LazyValue()
 		// It's possible that we wrote the key on a batch from a db that supported
 		// DeleteSized, but will be ingesting into a db that does not. Detect this
 		// case and translate the key to an InternalKeyKindDelete.

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -1087,7 +1087,7 @@ func (i *scanInternalIterator) unsafeKey() *InternalKey {
 // position. Behaviour undefined if unsafeKey() returns a Range key or Rangedel
 // kind key.
 func (i *scanInternalIterator) lazyValue() LazyValue {
-	return i.iterKV.V
+	return i.iterKV.LazyValue()
 }
 
 // unsafeRangeDel returns a range key span. Behaviour undefined if UnsafeKey returns

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -564,7 +564,10 @@ func TestScanInternal(t *testing.T) {
 			}
 			err := reader.ScanInternal(context.TODO(), block.CategoryUnknown, lower, upper,
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
-					v := value.InPlaceValue()
+					v, _, err := value.Value(nil)
+					if err != nil {
+						return err
+					}
 					fmt.Fprintf(&b, "%s (%s)\n", key, v)
 					return nil
 				},

--- a/sstable/block/kv.go
+++ b/sstable/block/kv.go
@@ -69,15 +69,15 @@ func InPlaceValuePrefix(setHasSameKeyPrefix bool) ValuePrefix {
 	return prefix
 }
 
-// GetLazyValueForPrefixAndValueHandler is an interface for getting a LazyValue
-// from a value prefix and value.
-type GetLazyValueForPrefixAndValueHandler interface {
-	// GetLazyValueForPrefixAndValueHandle returns a LazyValue for the given value
-	// prefix and value.
+// GetInternalValueForPrefixAndValueHandler is an interface for getting an
+// InternalValue from a value prefix and value.
+type GetInternalValueForPrefixAndValueHandler interface {
+	// GetInternalValueForPrefixAndValueHandle returns a InternalValue for the
+	// given value prefix and value.
 	//
 	// The result is only valid until the next call to
-	// GetLazyValueForPrefixAndValueHandle. Use LazyValue.Clone if the lifetime of
-	// the LazyValue needs to be extended. For more details, see the "memory
-	// management" comment where LazyValue is declared.
-	GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue
+	// GetInternalValueForPrefixAndValueHandle. Use InternalValue.Clone if the
+	// lifetime of the InternalValue needs to be extended. For more details, see
+	// the "memory management" comment where LazyValue is declared.
+	GetInternalValueForPrefixAndValueHandle(handle []byte) base.InternalValue
 }

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -694,9 +694,11 @@ func NewDataBlockRewriter(keySchema *KeySchema, comparer *base.Comparer) *DataBl
 
 type assertNoExternalValues struct{}
 
-var _ block.GetLazyValueForPrefixAndValueHandler = assertNoExternalValues{}
+var _ block.GetInternalValueForPrefixAndValueHandler = assertNoExternalValues{}
 
-func (assertNoExternalValues) GetLazyValueForPrefixAndValueHandle(value []byte) base.LazyValue {
+func (assertNoExternalValues) GetInternalValueForPrefixAndValueHandle(
+	value []byte,
+) base.InternalValue {
 	panic(errors.AssertionFailedf("pebble: sstable contains values in value blocks"))
 }
 
@@ -762,12 +764,12 @@ func (rw *DataBlockRewriter) RewriteSuffixes(
 
 	// Rewrite each key-value pair one-by-one.
 	for i, kv := 0, rw.iter.First(); kv != nil; i, kv = i+1, rw.iter.Next() {
-		value := kv.V.ValueOrHandle
+		value := kv.V.LazyValue().ValueOrHandle
 		valuePrefix := block.InPlaceValuePrefix(false /* setHasSamePrefix (unused) */)
 		isValueExternal := rw.decoder.isValueExternal.At(i)
 		if isValueExternal {
-			valuePrefix = block.ValuePrefix(kv.V.ValueOrHandle[0])
-			value = kv.V.ValueOrHandle[1:]
+			valuePrefix = block.ValuePrefix(value[0])
+			value = value[1:]
 		}
 		kcmp := rw.encoder.KeyWriter.ComparePrev(kv.K.UserKey)
 		if !bytes.Equal(kv.K.UserKey[kcmp.PrefixLen:], from) {
@@ -1019,7 +1021,7 @@ type DataBlockIter struct {
 	split     base.Split
 	// getLazyValuer configures the DataBlockIterConfig to initialize the
 	// DataBlockIter to use the provided handler for retrieving lazy values.
-	getLazyValuer block.GetLazyValueForPrefixAndValueHandler
+	getLazyValuer block.GetInternalValueForPrefixAndValueHandler
 
 	// -- Fields that are initialized for each block --
 	// For any changes to these fields, InitHandle should be updated.
@@ -1052,7 +1054,7 @@ type DataBlockIter struct {
 func (i *DataBlockIter) InitOnce(
 	keySchema *KeySchema,
 	comparer *base.Comparer,
-	getLazyValuer block.GetLazyValueForPrefixAndValueHandler,
+	getLazyValuer block.GetInternalValueForPrefixAndValueHandler,
 ) {
 	i.keySchema = keySchema
 	i.suffixCmp = comparer.ComparePointSuffixes
@@ -1337,7 +1339,7 @@ func (i *DataBlockIter) Next() *base.InternalKV {
 	// Inline i.d.values.At(row).
 	v := i.d.values.slice(i.d.values.offsets.At2(i.row))
 	if i.d.isValueExternal.At(i.row) {
-		i.kv.V = i.getLazyValuer.GetLazyValueForPrefixAndValueHandle(v)
+		i.kv.V = i.getLazyValuer.GetInternalValueForPrefixAndValueHandle(v)
 	} else {
 		i.kv.V = base.MakeInPlaceValue(v)
 	}
@@ -1506,7 +1508,7 @@ func (i *DataBlockIter) decodeRow() *base.InternalKV {
 		startOffset := i.d.values.offsets.At(i.row)
 		v := unsafe.Slice((*byte)(i.d.values.ptr(startOffset)), i.d.values.offsets.At(i.row+1)-startOffset)
 		if i.d.isValueExternal.At(i.row) {
-			i.kv.V = i.getLazyValuer.GetLazyValueForPrefixAndValueHandle(v)
+			i.kv.V = i.getLazyValuer.GetInternalValueForPrefixAndValueHandle(v)
 		} else {
 			i.kv.V = base.MakeInPlaceValue(v)
 		}

--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -33,8 +33,8 @@ func TestDataBlock(t *testing.T) {
 	rw := NewDataBlockRewriter(&testKeysSchema, testkeys.Comparer.EnsureDefaults())
 	var sizes []int
 	it.InitOnce(&testKeysSchema, testkeys.Comparer,
-		getLazyValuer(func([]byte) base.LazyValue {
-			return base.LazyValue{ValueOrHandle: []byte("mock external value")}
+		getInternalValuer(func([]byte) base.InternalValue {
+			return base.MakeInPlaceValue([]byte("mock external value"))
 		}))
 
 	datadriven.Walk(t, "testdata/data_block", func(t *testing.T, path string) {
@@ -207,8 +207,10 @@ func randTestKey(rng *rand.Rand, buf []byte, prefixLen int) []byte {
 	return buf
 }
 
-type getLazyValuer func([]byte) base.LazyValue
+type getInternalValuer func([]byte) base.InternalValue
 
-func (g getLazyValuer) GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue {
+func (g getInternalValuer) GetInternalValueForPrefixAndValueHandle(
+	handle []byte,
+) base.InternalValue {
 	return g(handle)
 }

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -359,25 +359,25 @@ func formatColblkDataBlock(
 		}
 		defer iter.Close()
 		for kv := iter.First(); kv != nil; kv = iter.Next() {
-			tp.Child(fmtKV(&kv.K, kv.V.ValueOrHandle))
+			tp.Child(fmtKV(&kv.K, kv.V.LazyValue().ValueOrHandle))
 		}
 	}
 	return nil
 }
 
-// describingLazyValueHandler is a block.GetLazyValueForPrefixAndValueHandler
+// describingLazyValueHandler is a block.GetInternalValueForPrefixAndValueHandler
 // that replaces a value handle with an in-place value describing the handle.
 type describingLazyValueHandler struct{}
 
 // Assert that debugLazyValueHandler implements the
-// block.GetLazyValueForPrefixAndValueHandler interface.
-var _ block.GetLazyValueForPrefixAndValueHandler = describingLazyValueHandler{}
+// block.GetInternalValueForPrefixAndValueHandler interface.
+var _ block.GetInternalValueForPrefixAndValueHandler = describingLazyValueHandler{}
 
-func (describingLazyValueHandler) GetLazyValueForPrefixAndValueHandle(
+func (describingLazyValueHandler) GetInternalValueForPrefixAndValueHandle(
 	handle []byte,
-) base.LazyValue {
+) base.InternalValue {
 	vh := valblk.DecodeHandle(handle[1:])
-	return base.LazyValue{ValueOrHandle: []byte(fmt.Sprintf("value handle %+v", vh))}
+	return base.MakeInPlaceValue([]byte(fmt.Sprintf("value handle %+v", vh)))
 }
 
 func formatColblkKeyspanBlock(

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -224,7 +224,7 @@ func newColumnBlockSingleLevelIterator(
 		ctx, r, v, transforms, lower, upper, filterer, useFilterBlock,
 		env,
 	)
-	var getLazyValuer block.GetLazyValueForPrefixAndValueHandler
+	var getLazyValuer block.GetInternalValueForPrefixAndValueHandler
 	if r.Properties.NumValueBlocks > 0 {
 		i.vbReader = valblk.MakeReader(i, rp, r.valueBIH, env.Stats)
 		getLazyValuer = &i.vbReader

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -173,7 +173,7 @@ func newColumnBlockTwoLevelIterator(
 	i.secondLevel.init(ctx, r, v, transforms, lower, upper, filterer,
 		false, // Disable the use of the filter block in the second level.
 		env)
-	var getLazyValuer block.GetLazyValueForPrefixAndValueHandler
+	var getLazyValuer block.GetInternalValueForPrefixAndValueHandler
 	if r.Properties.NumValueBlocks > 0 {
 		// NB: we cannot avoid this ~248 byte allocation, since valueBlockReader
 		// can outlive the singleLevelIterator due to be being embedded in a

--- a/sstable/valblk/reader.go
+++ b/sstable/valblk/reader.go
@@ -96,16 +96,16 @@ func MakeReader(
 	}
 }
 
-var _ block.GetLazyValueForPrefixAndValueHandler = (*Reader)(nil)
+var _ block.GetInternalValueForPrefixAndValueHandler = (*Reader)(nil)
 
-// GetLazyValueForPrefixAndValueHandle returns a LazyValue for the given value
-// prefix and value.
+// GetInternalValueForPrefixAndValueHandle returns an InternalValue for the
+// given value prefix and value.
 //
 // The result is only valid until the next call to
-// GetLazyValueForPrefixAndValueHandle. Use LazyValue.Clone if the lifetime of
-// the LazyValue needs to be extended. For more details, see the "memory
-// management" comment where LazyValue is declared.
-func (r *Reader) GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyValue {
+// GetInternalValueForPrefixAndValueHandle. Use InternalValue.Clone if the
+// lifetime of the InternalValue needs to be extended. For more details, see the
+// "memory management" comment where LazyValue is declared.
+func (r *Reader) GetInternalValueForPrefixAndValueHandle(handle []byte) base.InternalValue {
 	if r.fetcher == nil {
 		// NB: we cannot avoid this allocation, since the valueBlockFetcher
 		// can outlive the singleLevelIterator due to be being embedded in a
@@ -129,10 +129,10 @@ func (r *Reader) GetLazyValueForPrefixAndValueHandle(handle []byte) base.LazyVal
 		r.stats.SeparatedPointValue.Count++
 		r.stats.SeparatedPointValue.ValueBytes += uint64(valLen)
 	}
-	return base.LazyValue{
+	return base.MakeLazyValue(base.LazyValue{
 		ValueOrHandle: h,
 		Fetcher:       lazyFetcher,
-	}
+	})
 }
 
 // Close closes the Reader.


### PR DESCRIPTION
Add an InternalValue type as an internal-only type representing a value or instructions on how to retrieve the value. For now, InternalValue is a simple wrapper around a LazyValue. Separating the two allows us to extend the interval value type without expanding the public API unnecessarily. With the introduction of values externalized in blob files (#112), we expect to further modify the InternalValue.