### PR TITLE
sstable: reduce size of Reader struct

### DIFF
--- a/sstable/block/buffer_pool.go
+++ b/sstable/block/buffer_pool.go
@@ -177,8 +177,9 @@ func (p *BufferPool) Release() {
 			panic(errors.AssertionFailedf("Release called on a BufferPool with in-use buffers"))
 		}
 		cache.Free(p.pool[i].v)
+		p.pool[i].v = nil
 	}
-	*p = BufferPool{}
+	p.pool = p.pool[:0]
 }
 
 // Alloc allocates a new buffer of size n. If the pool already holds a buffer at

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -251,7 +251,7 @@ func intersectingIndexEntries(
 					alloc, entry.bh.Props = alloc.Copy(entry.bh.Props)
 					alloc, entry.sep = alloc.Copy(entry.sep)
 					res = append(res, entry)
-					if r.Compare(end.UserKey, entry.sep) <= 0 {
+					if r.Comparer.Compare(end.UserKey, entry.sep) <= 0 {
 						break
 					}
 				}

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -196,7 +196,7 @@ func (l *Layout) Describe(
 					var lastKey InternalKey
 					formatting.formatDataBlock(tpNode, r, *b, h.BlockData(), func(key *base.InternalKey, value []byte) string {
 						v := fmtKV(key, value)
-						if base.InternalCompare(r.Compare, lastKey, *key) >= 0 {
+						if base.InternalCompare(r.Comparer.Compare, lastKey, *key) >= 0 {
 							v += " WARNING: OUT OF ORDER KEYS!"
 						}
 						lastKey.Trailer = key.Trailer
@@ -235,7 +235,7 @@ func (l *Layout) Describe(
 				if err != nil {
 					return err
 				}
-				iter, _ := rowblk.NewRawIter(r.Compare, h.BlockData())
+				iter, _ := rowblk.NewRawIter(r.Comparer.Compare, h.BlockData())
 				iter.Describe(tpNode, func(w io.Writer, key *base.InternalKey, value []byte, enc rowblk.KVEncoding) {
 					fmt.Fprintf(w, "%05d    %s (%d)", enc.Offset, key.UserKey, enc.Length)
 				})
@@ -248,7 +248,7 @@ func (l *Layout) Describe(
 				if err != nil {
 					return err
 				}
-				iter, _ := rowblk.NewRawIter(r.Compare, h.BlockData())
+				iter, _ := rowblk.NewRawIter(r.Comparer.Compare, h.BlockData())
 				iter.Describe(tpNode, func(w io.Writer, key *base.InternalKey, value []byte, enc rowblk.KVEncoding) {
 					var bh block.Handle
 					var n int
@@ -395,7 +395,7 @@ func formatColblkKeyspanBlock(
 }
 
 func formatRowblkIndexBlock(tp treeprinter.Node, r *Reader, b NamedBlockHandle, data []byte) error {
-	iter, err := rowblk.NewIter(r.Compare, r.Comparer.ComparePointSuffixes, r.Split, data, NoTransforms)
+	iter, err := rowblk.NewIter(r.Comparer.Compare, r.Comparer.ComparePointSuffixes, r.Comparer.Split, data, NoTransforms)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func formatRowblkDataBlock(
 	data []byte,
 	fmtRecord func(key *base.InternalKey, value []byte) string,
 ) error {
-	iter, err := rowblk.NewIter(r.Compare, r.Comparer.ComparePointSuffixes, r.Split, data, NoTransforms)
+	iter, err := rowblk.NewIter(r.Comparer.Compare, r.Comparer.ComparePointSuffixes, r.Comparer.Split, data, NoTransforms)
 	if err != nil {
 		return err
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -43,13 +44,8 @@ type Reader struct {
 
 	// The following fields are copied from the ReadOptions.
 	keySchema            *colblk.KeySchema
-	deniedUserProperties map[string]struct{}
 	filterMetricsTracker *FilterMetricsTracker
-
-	Comparer *base.Comparer
-	Compare  Compare
-	Equal    Equal
-	Split    Split
+	Comparer             *base.Comparer
 
 	tableFilter *tableFilterReader
 
@@ -66,15 +62,6 @@ type Reader struct {
 
 	Properties  Properties
 	tableFormat TableFormat
-
-	// metaBufferPool is a buffer pool used exclusively when opening a table and
-	// loading its meta blocks. metaBufferPoolAlloc is used to batch-allocate
-	// the BufferPool.pool slice as a part of the Reader allocation. It's
-	// capacity 3 to accommodate the meta block (1), and both the compressed
-	// properties block (1) and decompressed properties block (1)
-	// simultaneously.
-	metaBufferPool      block.BufferPool
-	metaBufferPoolAlloc [3]block.AllocedBuffer
 }
 
 var _ CommonReader = (*Reader)(nil)
@@ -256,14 +243,14 @@ func (r *Reader) NewRawRangeDelIter(
 		return nil, err
 	}
 	if r.tableFormat.BlockColumnar() {
-		iter = colblk.NewKeyspanIter(r.Compare, h, transforms)
+		iter = colblk.NewKeyspanIter(r.Comparer.Compare, h, transforms)
 	} else {
 		iter, err = rowblk.NewFragmentIter(r.blockReader.FileNum(), r.Comparer, h, transforms)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return keyspan.MaybeAssert(iter, r.Compare), nil
+	return keyspan.MaybeAssert(iter, r.Comparer.Compare), nil
 }
 
 // NewRawRangeKeyIter returns an internal iterator for the contents of the
@@ -281,14 +268,14 @@ func (r *Reader) NewRawRangeKeyIter(
 		return nil, err
 	}
 	if r.tableFormat.BlockColumnar() {
-		iter = colblk.NewKeyspanIter(r.Compare, h, transforms)
+		iter = colblk.NewKeyspanIter(r.Comparer.Compare, h, transforms)
 	} else {
 		iter, err = rowblk.NewFragmentIter(r.blockReader.FileNum(), r.Comparer, h, transforms)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return keyspan.MaybeAssert(iter, r.Compare), nil
+	return keyspan.MaybeAssert(iter, r.Comparer.Compare), nil
 }
 
 // noReadHandle is used when we don't want to pass a ReadHandle to one of the
@@ -390,8 +377,24 @@ func (r *Reader) readValueBlock(
 	return r.blockReader.Read(ctx, env, readHandle, bh, noInitBlockMetadataFn)
 }
 
+// metaBufferPools is a sync pool of BufferPools used exclusively when opening a
+// table and loading its meta blocks.
+var metaBufferPools = sync.Pool{
+	New: func() any {
+		bp := new(block.BufferPool)
+		// New pools are initialized with a capacity of 3 to accommodate the
+		// meta block (1), and both the compressed properties block (1) and
+		// decompressed properties block (1) simultaneously.
+		bp.Init(3)
+		return bp
+	},
+}
+
 func (r *Reader) readMetaindex(
-	ctx context.Context, readHandle objstorage.ReadHandle, filters map[string]FilterPolicy,
+	ctx context.Context,
+	readHandle objstorage.ReadHandle,
+	filters map[string]FilterPolicy,
+	deniedUserProperties map[string]struct{},
 ) error {
 	// We use a BufferPool when reading metaindex blocks in order to avoid
 	// populating the block cache with these blocks. In heavy-write workloads,
@@ -401,13 +404,12 @@ func (r *Reader) readMetaindex(
 	// Additionally, these blocks are exceedingly unlikely to be read again
 	// while they're still in the block cache except in misconfigurations with
 	// excessive sstables counts or a file cache that's far too small.
-	r.metaBufferPool.InitPreallocated(r.metaBufferPoolAlloc[:0])
+	bufferPool := metaBufferPools.Get().(*block.BufferPool)
+	defer metaBufferPools.Put(bufferPool)
 	// When we're finished, release the buffers we've allocated back to memory
-	// allocator. We don't expect to use metaBufferPool again.
-	defer r.metaBufferPool.Release()
-	metaEnv := block.ReadEnv{
-		BufferPool: &r.metaBufferPool,
-	}
+	// allocator.
+	defer bufferPool.Release()
+	metaEnv := block.ReadEnv{BufferPool: bufferPool}
 
 	b, err := r.readMetaindexBlock(ctx, metaEnv, readHandle)
 	if err != nil {
@@ -433,7 +435,7 @@ func (r *Reader) readMetaindex(
 			return err
 		}
 		r.propertiesBH = bh
-		err := r.Properties.load(b.BlockData(), r.deniedUserProperties)
+		err := r.Properties.load(b.BlockData(), deniedUserProperties)
 		b.Release()
 		if err != nil {
 			return err
@@ -808,7 +810,6 @@ func NewReader(ctx context.Context, f objstorage.Readable, o ReaderOptions) (*Re
 	o = o.ensureDefaults()
 
 	r := &Reader{
-		deniedUserProperties: o.DeniedUserProperties,
 		filterMetricsTracker: o.FilterMetricsTracker,
 	}
 
@@ -828,21 +829,15 @@ func NewReader(ctx context.Context, f objstorage.Readable, o ReaderOptions) (*Re
 	r.footerBH = footer.footerBH
 
 	// Read the metaindex and properties blocks.
-	if err := r.readMetaindex(ctx, rh, o.Filters); err != nil {
+	if err := r.readMetaindex(ctx, rh, o.Filters, o.DeniedUserProperties); err != nil {
 		r.err = err
 		return nil, r.Close()
 	}
 
 	if r.Properties.ComparerName == "" || o.Comparer.Name == r.Properties.ComparerName {
 		r.Comparer = o.Comparer
-		r.Compare = o.Comparer.Compare
-		r.Equal = o.Comparer.Equal
-		r.Split = o.Comparer.Split
 	} else if comparer, ok := o.Comparers[r.Properties.ComparerName]; ok {
-		r.Comparer = o.Comparer
-		r.Compare = comparer.Compare
-		r.Equal = comparer.Equal
-		r.Split = comparer.Split
+		r.Comparer = comparer
 	} else {
 		r.err = errors.Errorf("pebble/table: %d: unknown comparer %s",
 			errors.Safe(r.blockReader.FileNum()), errors.Safe(r.Properties.ComparerName))

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -310,7 +310,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) init(
 	i.bpfs = filterer
 	i.useFilterBlock = useFilterBlock
 	i.reader = r
-	i.cmp = r.Compare
+	i.cmp = r.Comparer.Compare
 	i.transforms = transforms
 	if v != nil {
 		i.vState = v

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -52,8 +52,8 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 			return nil, err
 		}
 		var lookupKey []byte
-		if r.Split != nil {
-			lookupKey = key[:r.Split(key)]
+		if r.Comparer.Split != nil {
+			lookupKey = key[:r.Comparer.Split(key)]
 		} else {
 			lookupKey = key
 		}
@@ -70,7 +70,7 @@ func (r *Reader) get(key []byte) (value []byte, err error) {
 	}
 	ikv := i.SeekGE(key, base.SeekGEFlagsNone)
 
-	if ikv == nil || r.Compare(key, ikv.K.UserKey) != 0 {
+	if ikv == nil || r.Comparer.Compare(key, ikv.K.UserKey) != 0 {
 		err := i.Close()
 		if err == nil {
 			err = base.ErrNotFound

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -58,7 +58,7 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 		lower:            p.Lower,
 		upper:            p.Upper,
 		fileNum:          p.FileNum,
-		Compare:          reader.Compare,
+		Compare:          reader.Comparer.Compare,
 		isSharedIngested: p.IsSharedIngested,
 	}
 	v := VirtualReader{
@@ -150,7 +150,7 @@ func (v *VirtualReader) NewRawRangeDelIter(
 	// includes both point keys), but not [a#2,SET-b#3,SET] (as it would truncate
 	// the rangedel at b and lead to the point being uncovered).
 	return keyspan.Truncate(
-		v.reader.Compare, iter,
+		v.reader.Comparer.Compare, iter,
 		base.UserKeyBoundsFromInternal(v.vState.lower, v.vState.upper),
 	), nil
 }
@@ -181,7 +181,7 @@ func (v *VirtualReader) NewRawRangeKeyIter(
 		// TODO(bilal): Avoid these allocations by hoisting the transformer and
 		// transform iter into VirtualReader.
 		transform := &rangekey.ForeignSSTTransformer{
-			Equal:  v.reader.Equal,
+			Equal:  v.reader.Comparer.Equal,
 			SeqNum: base.SeqNum(syntheticSeqNum),
 		}
 		transformIter := &keyspan.TransformerIter{
@@ -201,7 +201,7 @@ func (v *VirtualReader) NewRawRangeKeyIter(
 	// includes both point keys), but not [a#2,SET-b#3,SET] (as it would truncate
 	// the range key at b and lead to the point being uncovered).
 	return keyspan.Truncate(
-		v.reader.Compare, iter,
+		v.reader.Comparer.Compare, iter,
 		base.UserKeyBoundsFromInternal(v.vState.lower, v.vState.upper),
 	), nil
 }

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -328,7 +328,7 @@ func RewriteKeySuffixesViaWriter(
 		if kv.Kind() != InternalKeyKindSet {
 			return nil, errors.New("invalid key type")
 		}
-		oldSuffix := kv.K.UserKey[r.Split(kv.K.UserKey):]
+		oldSuffix := kv.K.UserKey[r.Comparer.Split(kv.K.UserKey):]
 		if !bytes.Equal(oldSuffix, from) {
 			return nil, errors.Errorf("key has suffix %q, expected %q", oldSuffix, from)
 		}

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -54,7 +54,7 @@ Virtual tables: 0 (0B)
 Local tables size: 569B
 Compression types: snappy: 1
 Block cache: 3 entries (1.1KB)  hit rate: 18.2%
-Table cache: 1 entries (952B)  hit rate: 50.0%
+Table cache: 1 entries (800B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -75,7 +75,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 0.0%
-Table cache: 1 entries (952B)  hit rate: 0.0%
+Table cache: 1 entries (800B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -135,7 +135,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 33.3%
-Table cache: 2 entries (1.9KB)  hit rate: 66.7%
+Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
 Filter utility: 0.0%
@@ -181,7 +181,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 33.3%
-Table cache: 2 entries (1.9KB)  hit rate: 66.7%
+Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
 Filter utility: 0.0%
@@ -224,7 +224,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 33.3%
-Table cache: 1 entries (952B)  hit rate: 66.7%
+Table cache: 1 entries (800B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -503,7 +503,7 @@ Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 7
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (952B)  hit rate: 53.8%
+Table cache: 1 entries (800B)  hit rate: 53.8%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -567,7 +567,7 @@ Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Compression types: snappy: 10
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (952B)  hit rate: 53.8%
+Table cache: 1 entries (800B)  hit rate: 53.8%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -843,7 +843,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 1 entries (952B)  hit rate: 0.0%
+Table cache: 1 entries (800B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -892,7 +892,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 2
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (952B)  hit rate: 50.0%
+Table cache: 1 entries (800B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -941,7 +941,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 3
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (952B)  hit rate: 50.0%
+Table cache: 1 entries (800B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/tool/find.go
+++ b/tool/find.go
@@ -484,14 +484,14 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 					return nil, err
 				}
 				if iter == nil {
-					return keyspan.NewIter(r.Compare, nil), nil
+					return keyspan.NewIter(r.Comparer.Compare, nil), nil
 				}
 				defer iter.Close()
 
 				var tombstones []keyspan.Span
 				t, err := iter.First()
 				for ; t != nil; t, err = iter.Next() {
-					if !t.Contains(r.Compare, searchKey) {
+					if !t.Contains(r.Comparer.Compare, searchKey) {
 						continue
 					}
 					tombstones = append(tombstones, t.Clone())
@@ -501,9 +501,9 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 				}
 
 				slices.SortFunc(tombstones, func(a, b keyspan.Span) int {
-					return r.Compare(a.Start, b.Start)
+					return r.Comparer.Compare(a.Start, b.Start)
 				})
-				return keyspan.NewIter(r.Compare, tombstones), nil
+				return keyspan.NewIter(r.Comparer.Compare, tombstones), nil
 			}()
 			if err != nil {
 				return err
@@ -518,8 +518,8 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			foundRef := false
 			for kv != nil || rangeDel != nil {
 				if kv != nil &&
-					(rangeDel == nil || r.Compare(kv.K.UserKey, rangeDel.Start) < 0) {
-					if r.Compare(searchKey, kv.K.UserKey) != 0 {
+					(rangeDel == nil || r.Comparer.Compare(kv.K.UserKey, rangeDel.Start) < 0) {
+					if r.Comparer.Compare(searchKey, kv.K.UserKey) != 0 {
 						kv = nil
 						continue
 					}


### PR DESCRIPTION
Reduce the size of the Reader struct by 152 bytes by removing a few redundant Comparer fields and moving the meta buffer pool off the struct and into a heap pool. Pebble maintains a Reader struct per open sstable. In large LSMs, per-Reader memory is non-trivial.

Additionally, fix a bug during Reader initialization if the sstable's comparer did not match the default ReaderOptions.Comparer. Previously, we'd initialize the individual comparer funcs correctly, using the Comparer we retrieved from the o.Comparers map, but incorrectly initialized the top-level Comparer field to point to the default ReaderOptions.Comparer.