### PR TITLE
colblk: remove use of UnsafeRawSlice in UintBuilder

### DIFF
--- a/cockroachkvs/rowblk_bench_test.go
+++ b/cockroachkvs/rowblk_bench_test.go
@@ -6,7 +6,6 @@ package cockroachkvs
 
 import (
 	"bytes"
-	"fmt"
 	"math/rand/v2"
 	"testing"
 	"time"
@@ -17,25 +16,10 @@ import (
 )
 
 func BenchmarkCockroachDataRowBlockWriter(b *testing.B) {
-	for _, alphaLen := range []int{4, 8, 26} {
-		for _, lenSharedPct := range []float64{0.25, 0.5} {
-			for _, roachKeyLen := range []int{8, 32, 128} {
-				lenShared := int(float64(roachKeyLen) * lenSharedPct)
-				for _, valueLen := range []int{8, 128, 1024} {
-					keyConfig := keyGenConfig{
-						PrefixAlphabetLen: alphaLen,
-						RoachKeyLen:       roachKeyLen,
-						PrefixLenShared:   lenShared,
-						AvgKeysPerPrefix:  2,
-						PercentLogical:    0,
-						BaseWallTime:      uint64(time.Now().UnixNano()),
-					}
-					b.Run(fmt.Sprintf("%s,valueLen=%d", keyConfig, valueLen), func(b *testing.B) {
-						benchmarkCockroachDataRowBlockWriter(b, keyConfig, valueLen)
-					})
-				}
-			}
-		}
+	for _, cfg := range benchConfigs {
+		b.Run(cfg.String(), func(b *testing.B) {
+			benchmarkCockroachDataRowBlockWriter(b, cfg.keyGenConfig, cfg.ValueLen)
+		})
 	}
 }
 
@@ -67,28 +51,11 @@ func benchmarkCockroachDataRowBlockWriter(b *testing.B, keyConfig keyGenConfig, 
 	}
 }
 
-func BenchmarkCockroachDataBlockIter(b *testing.B) {
-	for _, alphaLen := range []int{4, 8, 26} {
-		for _, lenSharedPct := range []float64{0.25, 0.5} {
-			for _, roachKeyLen := range []int{8, 32, 128} {
-				lenShared := int(float64(roachKeyLen) * lenSharedPct)
-				for _, logical := range []int{0, 100} {
-					for _, valueLen := range []int{8, 128, 1024} {
-						keyConfig := keyGenConfig{
-							PrefixAlphabetLen: alphaLen,
-							RoachKeyLen:       roachKeyLen,
-							PrefixLenShared:   lenShared,
-							PercentLogical:    logical,
-							BaseWallTime:      uint64(time.Now().UnixNano()),
-						}
-						b.Run(fmt.Sprintf("%s,value=%d", keyConfig, valueLen),
-							func(b *testing.B) {
-								benchmarkCockroachDataRowBlockIter(b, keyConfig, valueLen)
-							})
-					}
-				}
-			}
-		}
+func BenchmarkCockroachDataRowBlockIter(b *testing.B) {
+	for _, cfg := range benchConfigs {
+		b.Run(cfg.String(), func(b *testing.B) {
+			benchmarkCockroachDataRowBlockIter(b, cfg.keyGenConfig, cfg.ValueLen)
+		})
 	}
 }
 


### PR DESCRIPTION
#### cockroachkvs: reduce number of benchmarks

Using `benchdiff` for this package is impractical, there are many
hundreds of config variations across the benchmarks. This commit
switches to using a small number of configs instead.

#### colblk: remove use of UnsafeRawSlice in UintBuilder

There is not much benefit to using an unsafe slice rather than a
regular slice. We still use an unchecked get (except that we can check
the bounds in invariant builds).

```
name                                                                                                                                         old time/op    new time/op    delta
CockroachDataColBlockWriter/AlphaLen=8,Prefix=8,Shared=4,KeysPerPrefix=4,Logical=10,ValueLen=8-24                                               139µs ± 1%     140µs ± 1%    ~     (p=0.853 n=10+10)
CockroachDataColBlockWriter/AlphaLen=8,Prefix=128,Shared=64,KeysPerPrefix=4,Logical=50,ValueLen=128-24                                         32.3µs ± 2%    32.4µs ± 2%    ~     (p=0.971 n=10+10)
CockroachDataColBlockWriter/AlphaLen=26,Prefix=1024,Shared=512,KeysPerPrefix=1,ValueLen=1024-24                                                5.59µs ± 9%    5.60µs ±10%    ~     (p=0.754 n=10+10)
```