### PR TITLE
blob: add ValueFetcher

### DIFF
--- a/internal/base/lazy_value.go
+++ b/internal/base/lazy_value.go
@@ -165,7 +165,10 @@ type LazyFetcher struct {
 	err     error
 	value   []byte
 	// Attribute includes the short attribute and value length.
-	Attribute   AttributeAndLen
+	Attribute AttributeAndLen
+	// BlobFileNum identifies the blob file containing the value. It is only
+	// populated if the value is stored in a blob file.
+	BlobFileNum DiskFileNum
 	fetched     bool
 	callerOwned bool
 }
@@ -184,7 +187,7 @@ type ValueFetcher interface {
 	// will allocate a new slice for the value. In either case it will set
 	// callerOwned to true.
 	Fetch(
-		ctx context.Context, handle []byte, valLen uint32, buf []byte,
+		ctx context.Context, handle []byte, blobFileNum DiskFileNum, valLen uint32, buf []byte,
 	) (val []byte, callerOwned bool, err error)
 }
 
@@ -213,7 +216,7 @@ func (lv *LazyValue) fetchValue(
 	if !f.fetched {
 		f.fetched = true
 		f.value, f.callerOwned, f.err = f.Fetcher.Fetch(ctx,
-			lv.ValueOrHandle, lv.Fetcher.Attribute.ValueLen, buf)
+			lv.ValueOrHandle, lv.Fetcher.BlobFileNum, lv.Fetcher.Attribute.ValueLen, buf)
 	}
 	return f.value, f.callerOwned, f.err
 }

--- a/internal/base/lazy_value_test.go
+++ b/internal/base/lazy_value_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 type valueFetcherFunc func(
-	handle []byte, valLen uint32, buf []byte) (val []byte, callerOwned bool, err error)
+	handle []byte, blobFileNum DiskFileNum, valLen uint32, buf []byte) (val []byte, callerOwned bool, err error)
 
 func (v valueFetcherFunc) Fetch(
-	ctx context.Context, handle []byte, valLen uint32, buf []byte,
+	ctx context.Context, handle []byte, blobFileNum DiskFileNum, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
-	return v(handle, valLen, buf)
+	return v(handle, blobFileNum, valLen, buf)
 }
 
 func TestLazyValue(t *testing.T) {
@@ -54,7 +54,7 @@ func TestLazyValue(t *testing.T) {
 			ValueOrHandle: []byte("foo-handle"),
 			Fetcher: &LazyFetcher{
 				Fetcher: valueFetcherFunc(
-					func(handle []byte, valLen uint32, buf []byte) ([]byte, bool, error) {
+					func(handle []byte, blobFileNum DiskFileNum, valLen uint32, buf []byte) ([]byte, bool, error) {
 						numCalls++
 						require.Equal(t, []byte("foo-handle"), handle)
 						require.Equal(t, uint32(3), valLen)

--- a/sstable/blob/blob_test.go
+++ b/sstable/blob/blob_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/cockroachdb/crlib/crstrings"
@@ -25,23 +26,9 @@ func TestBlobWriter(t *testing.T) {
 		buf.Reset()
 		switch td.Cmd {
 		case "build":
-			var (
-				targetBlockSize    int = 128
-				blockSizeThreshold int = 90
-				compression            = block.NoCompression
-			)
-			td.MaybeScanArgs(t, "target-block-size", &targetBlockSize)
-			td.MaybeScanArgs(t, "block-size-threshold", &blockSizeThreshold)
-			if cmdArg, ok := td.Arg("compression"); ok {
-				compression = block.CompressionFromString(cmdArg.SingleVal(t))
-			}
-
+			opts := scanFileWriterOptions(t, td)
 			obj = &objstorage.MemObj{}
-			w := NewFileWriter(000001, obj, FileWriterOptions{
-				Compression:   compression,
-				ChecksumType:  block.ChecksumTypeCRC32c,
-				FlushGovernor: block.MakeFlushGovernor(targetBlockSize, blockSizeThreshold, 0, nil),
-			})
+			w := NewFileWriter(000001, obj, opts)
 			for _, l := range crstrings.Lines(td.Input) {
 				h := w.AddValue([]byte(l))
 				fmt.Fprintln(&buf, h)
@@ -50,12 +37,7 @@ func TestBlobWriter(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			fmt.Fprintf(&buf, "Stats:\n")
-			fmt.Fprintf(&buf, "  BlockCount: %d\n", stats.BlockCount)
-			fmt.Fprintf(&buf, "  ValueCount: %d\n", stats.ValueCount)
-			fmt.Fprintf(&buf, "  BlockLenLongest: %d\n", stats.BlockLenLongest)
-			fmt.Fprintf(&buf, "  UncompressedValueBytes: %d\n", stats.UncompressedValueBytes)
-			fmt.Fprintf(&buf, "  FileLen: %d\n", stats.FileLen)
+			printFileWriterStats(&buf, stats)
 			return buf.String()
 		case "open":
 			r, err := NewFileReader(context.Background(), obj, FileReaderOptions{})
@@ -71,4 +53,31 @@ func TestBlobWriter(t *testing.T) {
 			panic(fmt.Sprintf("unknown command: %s", td.Cmd))
 		}
 	})
+}
+
+func scanFileWriterOptions(t *testing.T, td *datadriven.TestData) FileWriterOptions {
+	var (
+		targetBlockSize    int = 128
+		blockSizeThreshold int = 90
+		compression            = block.NoCompression
+	)
+	td.MaybeScanArgs(t, "target-block-size", &targetBlockSize)
+	td.MaybeScanArgs(t, "block-size-threshold", &blockSizeThreshold)
+	if cmdArg, ok := td.Arg("compression"); ok {
+		compression = block.CompressionFromString(cmdArg.SingleVal(t))
+	}
+	return FileWriterOptions{
+		Compression:   compression,
+		ChecksumType:  block.ChecksumTypeCRC32c,
+		FlushGovernor: block.MakeFlushGovernor(targetBlockSize, blockSizeThreshold, 0, nil),
+	}
+}
+
+func printFileWriterStats(w io.Writer, stats FileWriterStats) {
+	fmt.Fprintf(w, "Stats:\n")
+	fmt.Fprintf(w, "  BlockCount: %d\n", stats.BlockCount)
+	fmt.Fprintf(w, "  ValueCount: %d\n", stats.ValueCount)
+	fmt.Fprintf(w, "  BlockLenLongest: %d\n", stats.BlockLenLongest)
+	fmt.Fprintf(w, "  UncompressedValueBytes: %d\n", stats.UncompressedValueBytes)
+	fmt.Fprintf(w, "  FileLen: %d\n", stats.FileLen)
 }

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -1,0 +1,211 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package blob
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/valblk"
+)
+
+const maxCachedReaders = 5
+
+// A ValueReader is an interface defined over a file that can be used to read
+// value blocks.
+type ValueReader interface {
+	// ValueIndexHandle returns the handle for the file's value index block.
+	ValueIndexHandle() valblk.IndexHandle
+
+	// InitReadHandle initializes a ReadHandle for the file, using the provided
+	// preallocated read handle to avoid an allocation.
+	InitReadHandle(rh *objstorageprovider.PreallocatedReadHandle) objstorage.ReadHandle
+
+	// ReadValueBlock retrieves a value block described by the provided block
+	// handle from the block cache, or reads it from the blob file if it's not
+	// already cached.
+	ReadValueBlock(context.Context, block.ReadEnv, objstorage.ReadHandle,
+		block.Handle) (block.BufferHandle, error)
+
+	// ReadValueIndexBlock retrieves the index block from the block cache, or
+	// reads it from the blob file if it's not already cached.
+	ReadValueIndexBlock(context.Context, block.ReadEnv, objstorage.ReadHandle) (block.BufferHandle, error)
+}
+
+// A ReaderProvider is an interface that can be used to retrieve a ValueReader
+// for a given file number.
+type ReaderProvider interface {
+	// GetValueReader returns a ValueReader for the given file number.
+	GetValueReader(ctx context.Context, fileNum base.DiskFileNum) (r ValueReader, closeFunc func(), err error)
+}
+
+// A ValueFetcher retrieves values stored out-of-band in separate blob files.
+// The ValueFetcher caches accessed file readers to avoid redundant file cache
+// and block cache lookups when performing consecutive value retrievals.
+//
+// A single ValueFetcher can be used to fetch values from multiple files, and it
+// will internally cache readers for each file.
+type ValueFetcher struct {
+	readerProvider ReaderProvider
+	env            block.ReadEnv
+	fetchCount     int
+	readers        [maxCachedReaders]cachedReader
+}
+
+// TODO(jackson): Support setting up a read handle for compaction when relevant.
+
+// Assert that ValueFetcher implements the ValueFetcher interface.
+var _ base.ValueFetcher = (*ValueFetcher)(nil)
+
+// Init initializes the ValueFetcher.
+func (r *ValueFetcher) Init(rp ReaderProvider, env block.ReadEnv) {
+	r.readerProvider = rp
+	r.env = env
+	if r.readerProvider == nil {
+		panic("readerProvider is nil")
+	}
+}
+
+// Fetch returns the value, given the handle. Fetch must not be called after
+// Close.
+func (r *ValueFetcher) Fetch(
+	ctx context.Context, handle []byte, fileNum base.DiskFileNum, valLen uint32, buf []byte,
+) (val []byte, callerOwned bool, err error) {
+	vblkHandle := valblk.DecodeRemainingHandle(handle)
+	vh := Handle{
+		FileNum:       fileNum,
+		BlockNum:      vblkHandle.BlockNum,
+		OffsetInBlock: vblkHandle.OffsetInBlock,
+		ValueLen:      valLen,
+	}
+	v, err := r.retrieve(ctx, vh)
+	return v, false, err
+}
+
+func (r *ValueFetcher) retrieve(ctx context.Context, vh Handle) (val []byte, err error) {
+	// Look for a cached reader for the file. Also, find the least-recently used
+	// reader. If we don't find a cached reader, we'll replace the
+	// least-recently used reader with the new one for the file indicated by
+	// vh.FileNum.
+	var cr *cachedReader
+	var oldestFetchIndex int
+	for i := range r.readers {
+		if r.readers[i].fileNum == vh.FileNum && r.readers[i].r != nil {
+			cr = &r.readers[i]
+			break
+		} else if r.readers[i].lastFetchCount < r.readers[oldestFetchIndex].lastFetchCount {
+			oldestFetchIndex = i
+		}
+	}
+
+	if cr == nil {
+		// No cached reader found for the file. Get one from the file cache.
+		cr = &r.readers[oldestFetchIndex]
+		// Release the previous reader, if any.
+		if cr.r != nil {
+			if err = cr.Close(); err != nil {
+				return nil, err
+			}
+		}
+		if cr.r, cr.closeFunc, err = r.readerProvider.GetValueReader(ctx, vh.FileNum); err != nil {
+			return nil, err
+		}
+		cr.fileNum = vh.FileNum
+		cr.rh = cr.r.InitReadHandle(&cr.preallocRH)
+	}
+
+	r.fetchCount++
+	cr.lastFetchCount = r.fetchCount
+	val, err = cr.GetUnsafeValue(ctx, vh, r.env)
+	return val, err
+}
+
+// Close closes the ValueFetcher and releases all cached readers. Once Close is
+// called, the ValueFetcher is no longer usable.
+func (r *ValueFetcher) Close() error {
+	var err error
+	for i := range r.readers {
+		if r.readers[i].r != nil {
+			err = errors.CombineErrors(err, r.readers[i].Close())
+		}
+	}
+	return err
+}
+
+// cachedReader holds a Reader into an open file, and possibly blocks retrieved
+// from the block cache.
+type cachedReader struct {
+	fileNum            base.DiskFileNum
+	r                  ValueReader
+	closeFunc          func()
+	rh                 objstorage.ReadHandle
+	lastFetchCount     int
+	currentBlockNum    uint32
+	currentBlockLoaded bool
+	currentBlockBuf    block.BufferHandle
+	indexBlockBuf      block.BufferHandle
+	preallocRH         objstorageprovider.PreallocatedReadHandle
+}
+
+// GetUnsafeValue retrieves the value for the given handle. The value is
+// returned as a byte slice pointing directly into the block cache's data. The
+// value is only guaranteed to be stable until the next call to GetUnsafeValue
+// or until the cachedReader is closed.
+func (cr *cachedReader) GetUnsafeValue(
+	ctx context.Context, vh Handle, env block.ReadEnv,
+) ([]byte, error) {
+	ctx = objiotracing.WithBlockType(ctx, objiotracing.ValueBlock)
+
+	if !cr.indexBlockBuf.Valid() {
+		// Read the index block.
+		var err error
+		cr.indexBlockBuf, err = cr.r.ReadValueIndexBlock(ctx, env, cr.rh)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !cr.currentBlockLoaded || vh.BlockNum != cr.currentBlockNum {
+		// Translate the handle's block number into a block handle via the blob
+		// file's index block.
+		h, err := valblk.DecodeBlockHandleFromIndex(cr.indexBlockBuf.BlockData(), vh.BlockNum, cr.r.ValueIndexHandle())
+		if err != nil {
+			return nil, err
+		}
+		cr.currentBlockBuf.Release()
+		cr.currentBlockLoaded = false
+		cr.currentBlockBuf, err = cr.r.ReadValueBlock(ctx, env, cr.rh, h)
+		if err != nil {
+			return nil, err
+		}
+		cr.currentBlockNum = vh.BlockNum
+		cr.currentBlockLoaded = true
+	}
+	data := cr.currentBlockBuf.BlockData()
+	if len(data) < int(vh.OffsetInBlock+vh.ValueLen) {
+		return nil, base.CorruptionErrorf("blob file %s: block %d: expected block length %d, got %d",
+			vh.FileNum, vh.BlockNum, vh.OffsetInBlock+vh.ValueLen, len(data))
+	}
+	return data[vh.OffsetInBlock : vh.OffsetInBlock+vh.ValueLen], nil
+}
+
+// Close releases resources associated with the reader.
+func (cfr *cachedReader) Close() (err error) {
+	if cfr.rh != nil {
+		err = cfr.rh.Close()
+	}
+	cfr.indexBlockBuf.Release()
+	cfr.currentBlockBuf.Release()
+	// Release the cfg.Reader. closeFunc is provided by the file cache and
+	// decrements the refcount on the open file reader.
+	cfr.closeFunc()
+	*cfr = cachedReader{}
+	return err
+}

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package blob
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/sstableinternal"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/valblk"
+	"github.com/stretchr/testify/require"
+)
+
+type mockReaderProvider struct {
+	w       *bytes.Buffer
+	readers map[base.DiskFileNum]*FileReader
+}
+
+func (rp *mockReaderProvider) GetValueReader(
+	ctx context.Context, fileNum base.DiskFileNum,
+) (r ValueReader, closeFunc func(), err error) {
+	fmt.Fprintf(rp.w, "# GetValueReader(%s)\n", fileNum)
+
+	vr, ok := rp.readers[fileNum]
+	if !ok {
+		return nil, nil, errors.Newf("no reader for file %s", fileNum)
+	}
+	return vr, func() {}, nil
+}
+
+func TestValueFetcher(t *testing.T) {
+	ctx := context.Background()
+	var buf bytes.Buffer
+	rp := &mockReaderProvider{
+		w:       &buf,
+		readers: map[base.DiskFileNum]*FileReader{},
+	}
+	fetchers := map[string]*ValueFetcher{}
+	defer func() {
+		for _, f := range fetchers {
+			require.NoError(t, f.Close())
+		}
+		for _, r := range rp.readers {
+			require.NoError(t, r.Close())
+		}
+	}()
+
+	var handleBuf [valblk.HandleMaxLen]byte
+	datadriven.RunTest(t, "testdata/value_fetcher", func(t *testing.T, td *datadriven.TestData) string {
+		buf.Reset()
+		switch td.Cmd {
+		case "define":
+			var fileNum uint64
+			td.ScanArgs(t, "filenum", &fileNum)
+			opts := scanFileWriterOptions(t, td)
+			obj := &objstorage.MemObj{}
+			w := NewFileWriter(base.DiskFileNum(fileNum), obj, opts)
+			for _, l := range crstrings.Lines(td.Input) {
+				h := w.AddValue([]byte(l))
+				fmt.Fprintln(&buf, h)
+			}
+			stats, err := w.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			printFileWriterStats(&buf, stats)
+
+			r, err := NewFileReader(ctx, obj, FileReaderOptions{
+				ReaderOptions: block.ReaderOptions{
+					CacheOpts: sstableinternal.CacheOptions{
+						FileNum: base.DiskFileNum(fileNum),
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			rp.readers[base.DiskFileNum(fileNum)] = r
+			return buf.String()
+		case "new-fetcher":
+			var name string
+			td.ScanArgs(t, "name", &name)
+			fetchers[name] = &ValueFetcher{}
+			fetchers[name].Init(rp, block.ReadEnv{})
+			return ""
+		case "fetch":
+			var (
+				name                            string
+				blobFileNum                     uint64
+				valLen, blockNum, offsetInBlock uint32
+			)
+			td.ScanArgs(t, "name", &name)
+			td.ScanArgs(t, "filenum", &blobFileNum)
+			td.ScanArgs(t, "valLen", &valLen)
+			td.ScanArgs(t, "blknum", &blockNum)
+			td.ScanArgs(t, "off", &offsetInBlock)
+			fetcher := fetchers[name]
+			if fetcher == nil {
+				t.Fatalf("fetcher %s not found", name)
+			}
+			handle := encodeRemainingHandle(handleBuf[:], blockNum, offsetInBlock)
+
+			val, _, err := fetcher.Fetch(ctx, handle, base.DiskFileNum(blobFileNum), valLen, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeValueFetcherState(&buf, fetcher)
+			fmt.Fprintf(&buf, "%s\n", val)
+			return buf.String()
+		default:
+			panic(fmt.Sprintf("unknown command: %s", td.Cmd))
+		}
+	})
+}
+
+func encodeRemainingHandle(dst []byte, blockNum uint32, offsetInBlock uint32) []byte {
+	n := valblk.EncodeHandle(dst, valblk.Handle{
+		ValueLen:      0,
+		BlockNum:      blockNum,
+		OffsetInBlock: offsetInBlock,
+	})
+	return dst[1:n]
+}
+
+func writeValueFetcherState(w *bytes.Buffer, f *ValueFetcher) {
+	fmt.Fprintf(w, "ValueFetcher{\n")
+	for _, cr := range f.readers {
+		if cr.r == nil {
+			fmt.Fprintln(w, "  empty")
+			continue
+		}
+		fmt.Fprintf(w, "  %s (blk%d)\n", cr.fileNum, cr.currentBlockNum)
+	}
+	fmt.Fprintf(w, "}\n")
+}

--- a/sstable/blob/testdata/value_fetcher
+++ b/sstable/blob/testdata/value_fetcher
@@ -1,0 +1,325 @@
+define filenum=000001 target-block-size=64 block-size-threshold=90
+canteloupe
+apple
+orange
+blueberry
+kiwi
+tangerine
+pear
+pomegranate
+guava
+watermelon
+fig
+plum
+raspberry
+strawberry
+durian
+honeydew
+starfruit
+mango
+grape
+papaya
+lychee
+persimmon
+mandarin
+peach
+apricot
+nectarine
+----
+(000001,blk0[0:10])
+(000001,blk0[10:15])
+(000001,blk0[15:21])
+(000001,blk0[21:30])
+(000001,blk0[30:34])
+(000001,blk0[34:43])
+(000001,blk0[43:47])
+(000001,blk0[47:58])
+(000001,blk0[58:63])
+(000001,blk1[0:10])
+(000001,blk1[10:13])
+(000001,blk1[13:17])
+(000001,blk1[17:26])
+(000001,blk1[26:36])
+(000001,blk1[36:42])
+(000001,blk1[42:50])
+(000001,blk1[50:59])
+(000001,blk1[59:64])
+(000001,blk2[0:5])
+(000001,blk2[5:11])
+(000001,blk2[11:17])
+(000001,blk2[17:26])
+(000001,blk2[26:34])
+(000001,blk2[34:39])
+(000001,blk2[39:46])
+(000001,blk2[46:55])
+Stats:
+  BlockCount: 3
+  ValueCount: 26
+  BlockLenLongest: 64
+  UncompressedValueBytes: 182
+  FileLen: 240
+
+define filenum=000002 target-block-size=64 block-size-threshold=90
+kale
+spinach
+watercress
+argula
+lettuce
+cabbage
+chard
+endive
+bok choy
+sorrel
+mustard greens
+collard greens
+microgreens
+----
+(000002,blk0[0:4])
+(000002,blk0[4:11])
+(000002,blk0[11:21])
+(000002,blk0[21:27])
+(000002,blk0[27:34])
+(000002,blk0[34:41])
+(000002,blk0[41:46])
+(000002,blk0[46:52])
+(000002,blk0[52:60])
+(000002,blk1[0:6])
+(000002,blk1[6:20])
+(000002,blk1[20:34])
+(000002,blk1[34:45])
+Stats:
+  BlockCount: 2
+  ValueCount: 13
+  BlockLenLongest: 60
+  UncompressedValueBytes: 105
+  FileLen: 155
+
+define filenum=000003 target-block-size=64 block-size-threshold=90
+beet
+carrot
+turnip
+rutabaga
+parsnip
+celery
+sweet potato
+potato
+----
+(000003,blk0[0:4])
+(000003,blk0[4:10])
+(000003,blk0[10:16])
+(000003,blk0[16:24])
+(000003,blk0[24:31])
+(000003,blk0[31:37])
+(000003,blk0[37:49])
+(000003,blk0[49:55])
+Stats:
+  BlockCount: 1
+  ValueCount: 8
+  BlockLenLongest: 55
+  UncompressedValueBytes: 55
+  FileLen: 97
+
+define filenum=000004 target-block-size=64 block-size-threshold=90
+onion
+garlic
+leek
+scallion
+shallots
+ramps
+chives
+----
+(000004,blk0[0:5])
+(000004,blk0[5:11])
+(000004,blk0[11:15])
+(000004,blk0[15:23])
+(000004,blk0[23:31])
+(000004,blk0[31:36])
+(000004,blk0[36:42])
+Stats:
+  BlockCount: 1
+  ValueCount: 7
+  BlockLenLongest: 42
+  UncompressedValueBytes: 42
+  FileLen: 84
+
+define filenum=000005 target-block-size=64 block-size-threshold=90
+shitake
+oyster
+enoki
+portobello
+porcini
+morel
+chanterelle
+cremini
+maitake
+----
+(000005,blk0[0:7])
+(000005,blk0[7:13])
+(000005,blk0[13:18])
+(000005,blk0[18:28])
+(000005,blk0[28:35])
+(000005,blk0[35:40])
+(000005,blk0[40:51])
+(000005,blk0[51:58])
+(000005,blk1[0:7])
+Stats:
+  BlockCount: 2
+  ValueCount: 9
+  BlockLenLongest: 58
+  UncompressedValueBytes: 65
+  FileLen: 115
+
+define filenum=000006 target-block-size=64 block-size-threshold=90
+squash
+pumpkin
+cucumber
+----
+(000006,blk0[0:6])
+(000006,blk0[6:13])
+(000006,blk0[13:21])
+Stats:
+  BlockCount: 1
+  ValueCount: 3
+  BlockLenLongest: 21
+  UncompressedValueBytes: 21
+  FileLen: 63
+
+new-fetcher name=iter1
+----
+
+fetch name=iter1 filenum=000001 valLen=10 blknum=0 off=0
+----
+# GetValueReader(000001)
+ValueFetcher{
+  000001 (blk0)
+  empty
+  empty
+  empty
+  empty
+}
+canteloupe
+
+fetch name=iter1 filenum=000001 valLen=5 blknum=0 off=10
+----
+ValueFetcher{
+  000001 (blk0)
+  empty
+  empty
+  empty
+  empty
+}
+apple
+
+new-fetcher name=iter2
+----
+
+fetch name=iter2 filenum=000001 blknum=2 valLen=5 off=34
+----
+# GetValueReader(000001)
+ValueFetcher{
+  000001 (blk2)
+  empty
+  empty
+  empty
+  empty
+}
+peach
+
+fetch name=iter1 filenum=000001 valLen=4 blknum=1 off=13
+----
+ValueFetcher{
+  000001 (blk1)
+  empty
+  empty
+  empty
+  empty
+}
+plum
+
+fetch name=iter2 filenum=000006 blknum=0 valLen=7 off=6
+----
+# GetValueReader(000006)
+ValueFetcher{
+  000001 (blk2)
+  000006 (blk0)
+  empty
+  empty
+  empty
+}
+pumpkin
+
+fetch name=iter2 filenum=000005 blknum=1 valLen=7 off=0
+----
+# GetValueReader(000005)
+ValueFetcher{
+  000001 (blk2)
+  000006 (blk0)
+  000005 (blk1)
+  empty
+  empty
+}
+maitake
+
+fetch name=iter2 filenum=000003 blknum=0 valLen=12 off=37
+----
+# GetValueReader(000003)
+ValueFetcher{
+  000001 (blk2)
+  000006 (blk0)
+  000005 (blk1)
+  000003 (blk0)
+  empty
+}
+sweet potato
+
+fetch name=iter2 filenum=000002 blknum=1 valLen=14 off=6
+----
+# GetValueReader(000002)
+ValueFetcher{
+  000001 (blk2)
+  000006 (blk0)
+  000005 (blk1)
+  000003 (blk0)
+  000002 (blk1)
+}
+mustard greens
+
+fetch name=iter2 filenum=000004 blknum=0 valLen=5 off=31
+----
+# GetValueReader(000004)
+ValueFetcher{
+  000004 (blk0)
+  000006 (blk0)
+  000005 (blk1)
+  000003 (blk0)
+  000002 (blk1)
+}
+ramps
+
+fetch name=iter2 filenum=000004 blknum=0 valLen=6 off=36
+----
+ValueFetcher{
+  000004 (blk0)
+  000006 (blk0)
+  000005 (blk1)
+  000003 (blk0)
+  000002 (blk1)
+}
+chives
+
+# Although iter2 has previously fetched from file 000001, we've fetched from 5
+# distinct other files since then, so 0000001 will have been evicted. The
+# following fetch from filenum 000001 should log a GetValueReader(000001) as we
+# need to reobtain a blob file reader.
+
+fetch name=iter2 filenum=000001 blknum=2 valLen=9 off=17
+----
+# GetValueReader(000001)
+ValueFetcher{
+  000004 (blk0)
+  000001 (blk2)
+  000005 (blk1)
+  000003 (blk0)
+  000002 (blk1)
+}
+persimmon

--- a/sstable/blob/testdata/writer
+++ b/sstable/blob/testdata/writer
@@ -55,7 +55,7 @@ nectarine
 Stats:
   BlockCount: 3
   ValueCount: 26
-  BlockLenLongest: 69
+  BlockLenLongest: 64
   UncompressedValueBytes: 182
   FileLen: 240
 
@@ -63,4 +63,4 @@ open
 ----
 TableFormat: blobV1
 ChecksumType: crc32c
-IndexHandle: {Handle: {197,14}, DataLens:(1,1,1)}
+IndexHandle: {Handle: {197,9}, DataLens:(1,1,1)}

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -26,7 +26,10 @@ import (
 
 // Handle is the file offset and length of a block.
 type Handle struct {
-	Offset, Length uint64
+	// Offset identifies the offset of the block within the file.
+	Offset uint64
+	// Length is the length of the block data (excludes the trailer).
+	Length uint64
 }
 
 // EncodeVarints encodes the block handle into dst using a variable-width

--- a/sstable/block/kv.go
+++ b/sstable/block/kv.go
@@ -15,6 +15,7 @@ const (
 	// 2 most-significant bits of valuePrefix encodes the value-kind.
 	valueKindMask               ValuePrefix = 0xC0
 	valueKindIsValueBlockHandle ValuePrefix = 0x80
+	valueKindIsBlobHandle       ValuePrefix = 0x40
 	valueKindIsInPlaceValue     ValuePrefix = 0x00
 
 	// 1 bit indicates SET has same key prefix as immediately preceding key that
@@ -40,6 +41,11 @@ func (vp ValuePrefix) IsInPlaceValue() bool {
 // IsValueBlockHandle returns true if the ValuePrefix is for a valblk.Handle.
 func (vp ValuePrefix) IsValueBlockHandle() bool {
 	return vp&valueKindMask == valueKindIsValueBlockHandle
+}
+
+// IsBlobValueHandle returns true if the ValuePrefix is for a blob.
+func (vp ValuePrefix) IsBlobValueHandle() bool {
+	return vp&valueKindMask == valueKindIsBlobHandle
 }
 
 // SetHasSamePrefix returns true if the ValuePrefix encodes that the key is a
@@ -68,6 +74,15 @@ func ValueBlockHandlePrefix(setHasSameKeyPrefix bool, attribute base.ShortAttrib
 // InPlaceValuePrefix returns the ValuePrefix for an in-place value.
 func InPlaceValuePrefix(setHasSameKeyPrefix bool) ValuePrefix {
 	prefix := valueKindIsInPlaceValue
+	if setHasSameKeyPrefix {
+		prefix = prefix | setHasSameKeyPrefixMask
+	}
+	return prefix
+}
+
+// BlobValueHandlePrefix returns the ValuePrefix for a blob.
+func BlobValueHandlePrefix(setHasSameKeyPrefix bool) ValuePrefix {
+	prefix := valueKindIsBlobHandle
 	if setHasSameKeyPrefix {
 		prefix = prefix | setHasSameKeyPrefixMask
 	}

--- a/sstable/block/kv_test.go
+++ b/sstable/block/kv_test.go
@@ -14,40 +14,58 @@ import (
 
 func TestValuePrefix(t *testing.T) {
 	testCases := []struct {
-		isHandle         bool
-		setHasSamePrefix bool
-		attr             base.ShortAttribute
+		isValueBlockHandle bool
+		isBlobHandle       bool
+		setHasSamePrefix   bool
+		attr               base.ShortAttribute
 	}{
 		{
-			isHandle:         false,
-			setHasSamePrefix: false,
+			isValueBlockHandle: false,
+			isBlobHandle:       false,
+			setHasSamePrefix:   false,
 		},
 		{
-			isHandle:         false,
-			setHasSamePrefix: true,
+			isValueBlockHandle: false,
+			isBlobHandle:       false,
+			setHasSamePrefix:   true,
 		},
 		{
-			isHandle:         true,
-			setHasSamePrefix: false,
-			attr:             5,
+			isValueBlockHandle: true,
+			isBlobHandle:       false,
+			setHasSamePrefix:   false,
+			attr:               5,
 		},
 		{
-			isHandle:         true,
-			setHasSamePrefix: true,
-			attr:             2,
+			isValueBlockHandle: true,
+			isBlobHandle:       false,
+			setHasSamePrefix:   true,
+			attr:               2,
+		},
+		{
+			isValueBlockHandle: false,
+			isBlobHandle:       true,
+			setHasSamePrefix:   false,
+		},
+		{
+			isValueBlockHandle: false,
+			isBlobHandle:       true,
+			setHasSamePrefix:   true,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
 			var prefix ValuePrefix
-			if tc.isHandle {
+			if tc.isValueBlockHandle {
 				prefix = ValueBlockHandlePrefix(tc.setHasSamePrefix, tc.attr)
+			} else if tc.isBlobHandle {
+				prefix = BlobValueHandlePrefix(tc.setHasSamePrefix)
 			} else {
 				prefix = InPlaceValuePrefix(tc.setHasSamePrefix)
 			}
-			require.Equal(t, tc.isHandle, prefix.IsValueBlockHandle())
+			require.Equal(t, tc.isValueBlockHandle, prefix.IsValueBlockHandle())
+			require.Equal(t, tc.isBlobHandle, prefix.IsBlobValueHandle())
 			require.Equal(t, tc.setHasSamePrefix, prefix.SetHasSamePrefix())
-			if tc.isHandle {
+			if tc.isValueBlockHandle {
 				require.Equal(t, tc.attr, prefix.ShortAttribute())
 			}
 		})

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -224,13 +224,13 @@ func newColumnBlockSingleLevelIterator(
 		ctx, r, v, transforms, lower, upper, filterer, useFilterBlock,
 		env,
 	)
-	var getLazyValuer block.GetInternalValueForPrefixAndValueHandler
+	var getInternalValuer block.GetInternalValueForPrefixAndValueHandler
 	if r.Properties.NumValueBlocks > 0 {
 		i.vbReader = valblk.MakeReader(i, rp, r.valueBIH, env.Stats)
-		getLazyValuer = &i.vbReader
+		getInternalValuer = &i.vbReader
 		i.vbRH = r.blockReader.UsePreallocatedReadHandle(objstorage.NoReadBefore, &i.vbRHPrealloc)
 	}
-	i.data.InitOnce(r.keySchema, r.Comparer, getLazyValuer)
+	i.data.InitOnce(r.keySchema, r.Comparer, getInternalValuer)
 	indexH, err := r.readTopLevelIndexBlock(ctx, i.readBlockEnv, i.indexFilterRH)
 	if err == nil {
 		err = i.index.InitHandle(r.Comparer, indexH, transforms)

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -173,7 +173,7 @@ func newColumnBlockTwoLevelIterator(
 	i.secondLevel.init(ctx, r, v, transforms, lower, upper, filterer,
 		false, // Disable the use of the filter block in the second level.
 		env)
-	var getLazyValuer block.GetInternalValueForPrefixAndValueHandler
+	var getInternalValuer block.GetInternalValueForPrefixAndValueHandler
 	if r.Properties.NumValueBlocks > 0 {
 		// NB: we cannot avoid this ~248 byte allocation, since valueBlockReader
 		// can outlive the singleLevelIterator due to be being embedded in a
@@ -185,11 +185,11 @@ func newColumnBlockTwoLevelIterator(
 		// separated to their callers, they can put this valueBlockReader into a
 		// sync.Pool.
 		i.secondLevel.vbReader = valblk.MakeReader(&i.secondLevel, rp, r.valueBIH, env.Stats)
-		getLazyValuer = &i.secondLevel.vbReader
+		getInternalValuer = &i.secondLevel.vbReader
 		i.secondLevel.vbRH = r.blockReader.UsePreallocatedReadHandle(
 			objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
-	i.secondLevel.data.InitOnce(r.keySchema, r.Comparer, getLazyValuer)
+	i.secondLevel.data.InitOnce(r.keySchema, r.Comparer, getInternalValuer)
 	i.useFilterBlock = shouldUseFilterBlock(r, filterBlockSizeLimit)
 	topLevelIndexH, err := r.readTopLevelIndexBlock(ctx, i.secondLevel.readBlockEnv, i.secondLevel.indexFilterRH)
 	if err == nil {

--- a/sstable/valblk/reader.go
+++ b/sstable/valblk/reader.go
@@ -190,7 +190,7 @@ func newValueBlockFetcher(
 
 // Fetch implements base.ValueFetcher.
 func (f *valueBlockFetcher) Fetch(
-	ctx context.Context, handle []byte, valLen uint32, buf []byte,
+	ctx context.Context, handle []byte, blobFileNum base.DiskFileNum, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
 	if !f.closed {
 		val, err := f.getValueInternal(handle, valLen)


### PR DESCRIPTION
Add a ValueFetcher type that implements base.ValueFetcher for fetching values
from blob files. Additionally, fix a couple bugs around block lengths in the
serialization of blob files that were hidden by the lack of read-path testing.

Closes #4321.
Informs #112.