### PR TITLE
db: add DB.Excise

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -108,7 +108,7 @@ func testCheckpointImpl(t *testing.T, ddFile string, createOnShared bool) {
 
 			// Hacky but the command doesn't expect a db string. Get rid of it.
 			td.CmdArgs = td.CmdArgs[1:]
-			if err := runIngestAndExciseCmd(td, d, mem); err != nil {
+			if err := runIngestAndExciseCmd(td, d); err != nil {
 				return err.Error()
 			}
 			return ""

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1386,7 +1386,7 @@ func TestCompactionPickerPickFile(t *testing.T) {
 			return ""
 
 		case "ingest-and-excise":
-			if err := runIngestAndExciseCmd(td, d, d.opts.FS); err != nil {
+			if err := runIngestAndExciseCmd(td, d); err != nil {
 				return err.Error()
 			}
 			return ""

--- a/data_test.go
+++ b/data_test.go
@@ -1252,7 +1252,18 @@ func (d *DB) waitTableStats() {
 	}
 }
 
-func runIngestAndExciseCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
+func runExciseCmd(td *datadriven.TestData, d *DB) error {
+	if len(td.CmdArgs) != 2 {
+		return errors.New("excise expects two arguments: <start-key> <end-key>")
+	}
+	exciseSpan := KeyRange{
+		Start: []byte(td.CmdArgs[0].String()),
+		End:   []byte(td.CmdArgs[1].String()),
+	}
+	return d.Excise(context.Background(), exciseSpan)
+}
+
+func runIngestAndExciseCmd(td *datadriven.TestData, d *DB) error {
 	var exciseSpan KeyRange
 	paths := make([]string, 0, len(td.CmdArgs))
 	for i, arg := range td.CmdArgs {

--- a/db_test.go
+++ b/db_test.go
@@ -2198,6 +2198,13 @@ func TestDeterminism(t *testing.T) {
 					require.NoError(t, runBuildCmd(td, d, fs))
 					return ""
 				})
+			case "excise":
+				return addStep(td, func(td *datadriven.TestData) string {
+					if err := runExciseCmd(td, d); err != nil {
+						return err.Error()
+					}
+					return ""
+				})
 			case "flush":
 				return addStep(td, func(td *datadriven.TestData) string {
 					_, err := d.AsyncFlush()
@@ -2208,7 +2215,7 @@ func TestDeterminism(t *testing.T) {
 				})
 			case "ingest-and-excise":
 				return addStep(td, func(td *datadriven.TestData) string {
-					if err := runIngestAndExciseCmd(td, d, fs); err != nil {
+					if err := runIngestAndExciseCmd(td, d); err != nil {
 						return err.Error()
 					}
 					return ""

--- a/excise.go
+++ b/excise.go
@@ -8,10 +8,41 @@ import (
 	"context"
 	"slices"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
 )
+
+// Excise atomically deletes all data overlapping with the provided span. All
+// data overlapping with the span is removed, including from open snapshots.
+// Only currently-open iterators will still observe the removed data (because an
+// open iterator pins all memtables and sstables in its view of the LSM until
+// it's closed). Excise may initiate a flush if there exists unflushed data
+// overlapping the excise span.
+func (d *DB) Excise(ctx context.Context, span KeyRange) error {
+	if err := d.closed.Load(); err != nil {
+		panic(err)
+	}
+	if d.opts.ReadOnly {
+		return ErrReadOnly
+	}
+	// Excise is only supported on prefix keys.
+	if d.opts.Comparer.Split(span.Start) != len(span.Start) {
+		return errors.New("Excise called with suffixed start key")
+	}
+	if d.opts.Comparer.Split(span.End) != len(span.End) {
+		return errors.New("Excise called with suffixed end key")
+	}
+	if v := d.FormatMajorVersion(); v < FormatVirtualSSTables {
+		return errors.Newf(
+			"store has format major version %d; Excise requires at least %d",
+			v, FormatVirtualSSTables,
+		)
+	}
+	_, err := d.ingest(ctx, nil, nil, span, nil)
+	return err
+}
 
 // excise updates ve to include a replacement of the file m with new virtual
 // sstables that exclude exciseSpan, returning a slice of newly-created files if

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -279,7 +279,7 @@ func TestMetrics(t *testing.T) {
 			return s
 
 		case "ingest-and-excise":
-			if err := runIngestAndExciseCmd(td, d, d.opts.FS); err != nil {
+			if err := runIngestAndExciseCmd(td, d); err != nil {
 				return err.Error()
 			}
 			return ""

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -142,7 +142,7 @@ func TestTableStats(t *testing.T) {
 			return ""
 
 		case "ingest-and-excise":
-			if err := runIngestAndExciseCmd(td, d, d.opts.FS); err != nil {
+			if err := runIngestAndExciseCmd(td, d); err != nil {
 				return err.Error()
 			}
 			// Wait for a possible flush.

--- a/testdata/determinism
+++ b/testdata/determinism
@@ -134,3 +134,12 @@ run count=100
 sequential( 0:define 1:memtable-info 2:batch 3:batch 4:memtable-info parallel( 5:batch 6:batch ) )
 ----
 ok
+
+excise a z
+----
+7:excise
+
+run count=100
+sequential( 0:define 1:memtable-info 2:batch 3:batch 4:memtable-info parallel( 5:batch 6:batch ) 7:excise )
+----
+ok

--- a/testdata/excise
+++ b/testdata/excise
@@ -28,7 +28,7 @@ L0.0:
 L6:
   000004:[a#10,SET-l#10,SET]
 
-excise c k
+excise-dryrun c k
 ----
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
@@ -38,7 +38,7 @@ would excise 2 files, use ingest-and-excise to excise.
   add-backing:   000004
 
 
-excise a e
+excise-dryrun a e
 ----
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
@@ -48,7 +48,7 @@ would excise 2 files, use ingest-and-excise to excise.
   add-backing:   000006
   add-backing:   000004
 
-excise e z
+excise-dryrun e z
 ----
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
@@ -58,7 +58,7 @@ would excise 2 files, use ingest-and-excise to excise.
   add-backing:   000006
   add-backing:   000004
 
-excise f l
+excise-dryrun f l
 ----
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
@@ -69,7 +69,7 @@ would excise 2 files, use ingest-and-excise to excise.
   add-backing:   000006
   add-backing:   000004
 
-excise f ll
+excise-dryrun f ll
 ----
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
@@ -79,7 +79,7 @@ would excise 2 files, use ingest-and-excise to excise.
   add-backing:   000006
   add-backing:   000004
 
-excise p q
+excise-dryrun p q
 ----
 would excise 0 files, use ingest-and-excise to excise.
 
@@ -159,7 +159,7 @@ L0.0:
 L6:
   000004:[c#10,RANGEKEYSET-f#inf,RANGEKEYSET]
 
-excise f g
+excise-dryrun f g
 ----
 would excise 1 files, use ingest-and-excise to excise.
   del-table:     L0 000005
@@ -167,21 +167,21 @@ would excise 1 files, use ingest-and-excise to excise.
   add-table:     L0 000007(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL] size:1
   add-backing:   000005
 
-excise b c
+excise-dryrun b c
 ----
 would excise 1 files, use ingest-and-excise to excise.
   del-table:     L0 000005
   add-table:     L0 000008(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL] size:1
   add-backing:   000005
 
-excise i j
+excise-dryrun i j
 ----
 would excise 0 files, use ingest-and-excise to excise.
 
 # Excise mid range key. This will not happen in practice, but excise()
 # supports it.
 
-excise c d
+excise-dryrun c d
 ----
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000005
@@ -708,6 +708,37 @@ b: (somethingElse, .)
 c: (somethingElse, .)
 .
 .
+
+excise aa ab
+----
+
+lsm
+----
+L0.0:
+  000019:[a#22,SET-a#22,SET]
+  000020:[b#23,SET-f#23,SET]
+L6:
+  000023(000018):[a#0,SET-a#0,SET]
+  000022(000018):[f#0,SET-x#0,SET]
+
+excise g h
+----
+
+lsm
+----
+L0.0:
+  000019:[a#22,SET-a#22,SET]
+  000020:[b#23,SET-f#23,SET]
+L6:
+  000023(000018):[a#0,SET-a#0,SET]
+  000024(000018):[f#0,SET-f#0,SET]
+  000025(000018):[x#0,SET-x#0,SET]
+
+excise a z
+----
+
+lsm
+----
 
 # Two overlapping ingestions wait on one another even if
 # the overlap is only on the excise span.


### PR DESCRIPTION
Add an Excise method to the DB allowing an excise without an accompanying ingestion. This will be used in CockroachDB to recover from corruption by excising out corrupted sstables.

For now, this implementation uses DB.ingest. I think a future refactor should be able to clean these code paths up and potentially refactor excise to be independent of the ingest codepath. Today, it's necessary to reuse the logic to perform excises as 'flushable ingests.'

Closes #4286.