### PR TITLE
db: refactor race-build file cache reference tracking

### DIFF
--- a/file_cache.go
+++ b/file_cache.go
@@ -107,9 +107,12 @@ type fileCacheHandle struct {
 	// This struct is only populated in race builds.
 	raceMu struct {
 		sync.Mutex
-		// iters maps sstable.Iterator objects to the stack trace recorded at
-		// creation time.
-		iters map[any][]byte
+		// nextRefID is the next ID to allocate for a new reference.
+		nextRefID uint64
+		// openRefs maps reference IDs to the stack trace recorded at creation
+		// time.  It's used to track which call paths leaked open references to
+		// files.
+		openRefs map[uint64][]byte
 	}
 }
 
@@ -134,7 +137,7 @@ func (c *FileCache) newHandle(
 	t.readerOpts = readerOpts
 	t.readerOpts.FilterMetricsTracker = &sstable.FilterMetricsTracker{}
 	if invariants.RaceEnabled {
-		t.raceMu.iters = make(map[any][]byte)
+		t.raceMu.openRefs = make(map[uint64][]byte)
 	}
 	return t
 }
@@ -151,7 +154,7 @@ func (h *fileCacheHandle) Close() error {
 			err = errors.Errorf("leaked iterators: %d", errors.Safe(v))
 		} else {
 			var buf bytes.Buffer
-			for _, stack := range h.raceMu.iters {
+			for _, stack := range h.raceMu.openRefs {
 				fmt.Fprintf(&buf, "%s\n", stack)
 			}
 			err = errors.Errorf("leaked iterators: %d\n%s", errors.Safe(v), buf.String())
@@ -348,10 +351,10 @@ func NewFileCache(numShards int, size int) *FileCache {
 		v := vRef.Value()
 		handle := key.handle
 		v.readerProvider.init(c, key)
-		v.closeHook = func(iterator any) {
+		v.closeHook = func(refID uint64) {
 			if invariants.RaceEnabled {
 				handle.raceMu.Lock()
-				delete(handle.raceMu.iters, iterator)
+				delete(handle.raceMu.openRefs, refID)
 				handle.raceMu.Unlock()
 			}
 			// closeHook is called when an iterator is closed; the initialization of
@@ -572,17 +575,27 @@ func (h *fileCacheHandle) newPointIter(
 	if err != nil {
 		return nil, err
 	}
-	// NB: v.closeHook takes responsibility for calling unrefValue(v) here. Take
-	// care to avoid introducing an allocation here by adding a closure.
-	iter.SetCloseHook(v.closeHook)
-	handle.iterCount.Add(1)
+	// NB: closeHook (v.closeHook) takes responsibility for calling
+	// unrefValue(v) here. Take care to avoid introducing an allocation here by
+	// adding a closure.
+	refID, closeHook := h.addReference(v)
+	iter.SetCloseHook(refID, closeHook)
+	return iter, nil
+}
+
+func (h *fileCacheHandle) addReference(
+	v *fileCacheValue,
+) (refID uint64, closeHook func(refID uint64)) {
+	h.iterCount.Add(1)
 	if invariants.RaceEnabled {
 		stack := debug.Stack()
 		h.raceMu.Lock()
-		h.raceMu.iters[iter] = stack
+		refID = h.raceMu.nextRefID
+		h.raceMu.openRefs[refID] = stack
+		h.raceMu.nextRefID++
 		h.raceMu.Unlock()
 	}
-	return iter, nil
+	return refID, v.closeHook
 }
 
 // newRangeDelIter is an internal helper that constructs an iterator over a
@@ -736,7 +749,7 @@ func (h *fileCacheHandle) getTableProperties(file *tableMetadata) (*sstable.Prop
 }
 
 type fileCacheValue struct {
-	closeHook func(i any)
+	closeHook func(refID uint64)
 	reader    io.Closer // *sstable.Reader
 	isShared  bool
 

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -50,11 +50,11 @@ type Iterator interface {
 	NextPrefix(succKey []byte) *base.InternalKV
 
 	// SetCloseHook sets a function that will be called when the iterator is
-	// closed.  This is used by the file cache to release the reference count on
+	// closed. This is used by the file cache to release the reference count on
 	// the open sstable.Reader when the iterator is closed. The closures takes
-	// the iterator as a parameter to enable invariant-build tracking of leaked
-	// iterators.
-	SetCloseHook(fn func(any))
+	// the a reference ID as a parameter to enable invariant-build tracking of
+	// leaked references.
+	SetCloseHook(refID uint64, fn func(refID uint64))
 }
 
 // Iterator positioning optimizations and singleLevelIterator and

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -71,7 +71,8 @@ type singleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIte
 	vbRH         objstorage.ReadHandle
 	vbRHPrealloc objstorageprovider.PreallocatedReadHandle
 	err          error
-	closeHook    func(i any)
+	fileRefID    invariants.Value[uint64]
+	closeHook    func(refID uint64)
 
 	readBlockEnv block.ReadEnv
 
@@ -1515,9 +1516,11 @@ func (i *singleLevelIterator[I, PI, D, PD]) Error() error {
 
 // SetCloseHook sets a function that will be called when the iterator is closed.
 // This is used by the file cache to release the reference count on the open
-// sstable.Reader when the iterator is closed. The closures takes the iterator
-// as a parameter to enable invariant-build tracking of leaked iterators.
-func (i *singleLevelIterator[I, PI, D, PD]) SetCloseHook(fn func(i any)) {
+// sstable.Reader when the iterator is closed. SetCloseHook also takes a
+// reference ID which it passes back into fn to enable invariant-build tracking
+// of leaked iterators.
+func (i *singleLevelIterator[I, PI, D, PD]) SetCloseHook(refID uint64, fn func(refID uint64)) {
+	i.fileRefID.Set(refID)
 	i.closeHook = fn
 }
 
@@ -1546,7 +1549,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) closeInternal() error {
 	}
 
 	if i.closeHook != nil {
-		i.closeHook(i)
+		i.closeHook(i.fileRefID.Get())
 	}
 	var err error
 	err = firstError(err, PD(&i.data).Close())

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -1015,8 +1015,8 @@ func (i *twoLevelIterator[I, PI, D, PD]) SetContext(ctx context.Context) {
 	i.secondLevel.SetContext(ctx)
 }
 
-func (i *twoLevelIterator[I, PI, D, PD]) SetCloseHook(fn func(i any)) {
-	i.secondLevel.SetCloseHook(fn)
+func (i *twoLevelIterator[I, PI, D, PD]) SetCloseHook(refID uint64, fn func(refID uint64)) {
+	i.secondLevel.SetCloseHook(refID, fn)
 }
 
 func (i *twoLevelIterator[I, PI, D, PD]) SetupForCompaction() {


### PR DESCRIPTION
Previously the file cache used a pointer to the sstable iterator to maintain the stack traces of the origination of open references during race builds. This was a bit ambiguous. With the introduction of blob files, references will also be maintained by non-sstable iterators (eg, a cached blob file reader within an iterator's blob value fetcher).

This commit refactors this reference tracking to propagate a uint64 reference ID along with the closeHook, requiring the user to pass the reference ID back in their invocation of the closeHook. In production builds, this reference ID is always zero and is not stored. This hopefully will make usages unambiguous.