### PR TITLE
internal/compact: preserve blob references

### DIFF
--- a/internal/base/lazy_value.go
+++ b/internal/base/lazy_value.go
@@ -216,7 +216,7 @@ func (lv *LazyValue) fetchValue(
 	if !f.fetched {
 		f.fetched = true
 		f.value, f.callerOwned, f.err = f.Fetcher.Fetch(ctx,
-			lv.ValueOrHandle, lv.Fetcher.BlobFileNum, lv.Fetcher.Attribute.ValueLen, buf)
+			lv.ValueOrHandle, f.BlobFileNum, f.Attribute.ValueLen, buf)
 	}
 	return f.value, f.callerOwned, f.err
 }
@@ -262,8 +262,9 @@ func (lv *LazyValue) Clone(buf []byte, fetcher *LazyFetcher) (LazyValue, []byte)
 	var lvCopy LazyValue
 	if lv.Fetcher != nil {
 		*fetcher = LazyFetcher{
-			Fetcher:   lv.Fetcher.Fetcher,
-			Attribute: lv.Fetcher.Attribute,
+			Fetcher:     lv.Fetcher.Fetcher,
+			Attribute:   lv.Fetcher.Attribute,
+			BlobFileNum: lv.Fetcher.BlobFileNum,
 			// Not copying anything that has been extracted.
 		}
 		lvCopy.Fetcher = fetcher

--- a/internal/base/lazy_value_test.go
+++ b/internal/base/lazy_value_test.go
@@ -58,9 +58,11 @@ func TestLazyValue(t *testing.T) {
 						numCalls++
 						require.Equal(t, []byte("foo-handle"), handle)
 						require.Equal(t, uint32(3), valLen)
+						require.Equal(t, DiskFileNum(90), blobFileNum)
 						return fooBytes1, callerOwned, nil
 					}),
-				Attribute: AttributeAndLen{ValueLen: 3, ShortAttribute: 7},
+				Attribute:   AttributeAndLen{ValueLen: 3, ShortAttribute: 7},
+				BlobFileNum: 90,
 			},
 		}
 		require.Equal(t, []byte("foo"), getValue(fooLV3, callerOwned))

--- a/internal/base/value.go
+++ b/internal/base/value.go
@@ -27,6 +27,13 @@ func MakeInPlaceValue(val []byte) InternalValue {
 	return InternalValue{lazyValue: LazyValue{ValueOrHandle: val}}
 }
 
+// IsBlobValueHandle returns true iff the value is a blob value handle, pointing
+// to a value stored externally in a blob file.
+func (v *InternalValue) IsBlobValueHandle() bool {
+	f := v.lazyValue.Fetcher
+	return f != nil && f.BlobFileNum > 0
+}
+
 // IsInPlaceValue returns true iff the value was stored in-place and does not
 // need to be fetched externally.
 func (v *InternalValue) IsInPlaceValue() bool {

--- a/internal/compact/testdata/iter
+++ b/internal/compact/testdata/iter
@@ -1124,3 +1124,44 @@ next
 ----
 a#3,SET:val
 .
+
+# Define an input sequence of simple blob references, all pointing into the same
+# blob file block.
+
+define
+a.SET.9:blobref(000294, blk2, 10, 20)
+b.SET.3:blobref(000294, blk2, 30, 5)
+c.SETWITHDEL.8:blobref(000294, blk2, 35, 100)
+d.SET.2:blobref(000294, blk2, 135, 4)
+----
+
+# An iterator should preserve blob references.
+
+iter
+first
+next
+next
+next
+----
+a#9,SET:<blobref(000294, encodedHandle=020a, valLen=20)>
+b#3,SET:<blobref(000294, encodedHandle=021e, valLen=5)>
+c#8,SETWITHDEL:<blobref(000294, encodedHandle=0223, valLen=100)>
+d#2,SET:<blobref(000294, encodedHandle=028701, valLen=4)>
+
+# The iterator may need to fetch a blob value if it's an operand to the merge
+# operator.
+
+define
+a.SET.3:blobref(000294, blk2, 10, 20)
+b.MERGE.9:mergekeyvalue
+b.SETWITHDEL.8:blobref(000294, blk2, 35, 100)
+----
+
+iter
+first
+next
+next
+----
+a#3,SET:<blobref(000294, encodedHandle=020a, valLen=20)>
+b#9,SET:<fetched value from blobref(000294, encodedHandle=0223, valLen=100)>mergekeyvalue[base]
+.


### PR DESCRIPTION
Adapt the compaction iterator to preserve blob file references by cloning the
LazyValues. Compactions that do not rewrite blob files will avoid ever
retrieving the corresponding values.

Additionally, fix LazyValue.Clone to copy the BlobFileNum of the LazyFetcher.

Informs https://github.com/cockroachdb/pebble/issues/112.