### PR TITLE
colblk: don't use UnsafeRawSlice to store PrefixBytesBuilder offsets

### DIFF
--- a/sstable/colblk/prefix_bytes_test.go
+++ b/sstable/colblk/prefix_bytes_test.go
@@ -348,9 +348,9 @@ func (b *PrefixBytesBuilder) debugString(offset uint32) string {
 	fmt.Fprint(&sb, "\nOffsets:")
 	for i := 0; i < b.offsets.count; i++ {
 		if i%10 == 0 {
-			fmt.Fprintf(&sb, "\n  %04d", b.offsets.elems.At(i))
+			fmt.Fprintf(&sb, "\n  %04d", b.offsets.elems[i])
 		} else {
-			fmt.Fprintf(&sb, "  %04d", b.offsets.elems.At(i))
+			fmt.Fprintf(&sb, "  %04d", b.offsets.elems[i])
 		}
 	}
 	fmt.Fprintf(&sb, "\nData (len=%d):\n", len(b.data))

--- a/sstable/colblk/raw_bytes.go
+++ b/sstable/colblk/raw_bytes.go
@@ -11,7 +11,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/pebble/internal/binfmt"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 )
 
@@ -221,12 +220,4 @@ func (b *RawBytesBuilder) Size(rows int, offset uint32) uint32 {
 // WriteDebug implements Encoder.
 func (b *RawBytesBuilder) WriteDebug(w io.Writer, rows int) {
 	fmt.Fprintf(w, "bytes: %d rows set; %d bytes in data", b.rows, len(b.data))
-}
-
-//gcassert:inline
-func unsafeGetUint64(slice []uint64, idx int) uint64 {
-	if invariants.Enabled {
-		_ = slice[idx]
-	}
-	return *(*uint64)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(slice)), uintptr(idx)<<3))
 }

--- a/sstable/colblk/uints.go
+++ b/sstable/colblk/uints.go
@@ -388,22 +388,22 @@ func uintColumnFinish(
 
 	switch e.Width() {
 	case 1:
-		dest := makeUnsafeRawSlice[uint8](unsafe.Pointer(&buf[offset])).Slice(rows)
+		dest := buf[offset : offset+uint32(rows)]
 		reduceUints(deltaBase, values, dest)
 
 	case 2:
-		dest := makeUnsafeRawSlice[uint16](unsafe.Pointer(&buf[offset])).Slice(rows)
+		dest := unsafe.Slice((*uint16)(unsafe.Pointer(&buf[offset])), rows)
 		reduceUints(deltaBase, values, dest)
 
 	case 4:
-		dest := makeUnsafeRawSlice[uint32](unsafe.Pointer(&buf[offset])).Slice(rows)
+		dest := unsafe.Slice((*uint32)(unsafe.Pointer(&buf[offset])), rows)
 		reduceUints(deltaBase, values, dest)
 
 	case 8:
 		if deltaBase != 0 {
 			panic("unreachable")
 		}
-		dest := makeUnsafeRawSlice[uint64](unsafe.Pointer(&buf[offset])).Slice(rows)
+		dest := unsafe.Slice((*uint64)(unsafe.Pointer(&buf[offset])), rows)
 		copy(dest, values)
 
 	default:

--- a/sstable/colblk/uints_encode.go
+++ b/sstable/colblk/uints_encode.go
@@ -1,0 +1,66 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package colblk
+
+import (
+	"unsafe"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
+
+// serializedInt is the list of types we can serialize. Note that more types of
+// integers are encoded on top of the serialized ints.
+type serializedUint interface {
+	~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// uintsEncoder is a helper struct to encode integers into a buffer using
+// little-endian encoding.
+type uintsEncoder[T serializedUint] struct {
+	// The underlying slice contains the integers to be encoded. Integers are
+	// stored in the native byte order and are converted to little-endian at the
+	// end (if necessary).
+	slice []T
+}
+
+// makeUintsEncoder initializes a uintsEncoder that will write out integers to
+// the given buffer, in little-endian order.
+// UnsafeSet() is used to set values, then Finish() must be called at the end.
+func makeUintsEncoder[T serializedUint](targetBuf []byte, n int) uintsEncoder[T] {
+	ptr := unsafe.Pointer(unsafe.SliceData(targetBuf))
+	if align(uintptr(ptr), unsafe.Sizeof(T(0))) != uintptr(ptr) {
+		panic(errors.AssertionFailedf("slice pointer %p not %d-byte aligned", ptr, unsafe.Sizeof(T(0))))
+	}
+	if len(targetBuf) < n*int(unsafe.Sizeof(T(0))) {
+		panic(errors.AssertionFailedf("target buffer is too small"))
+	}
+	return uintsEncoder[T]{
+		slice: unsafe.Slice((*T)(ptr), n),
+	}
+}
+
+// Len returns the number of elements that the encoder holds.
+func (s uintsEncoder[T]) Len() int {
+	return len(s.slice)
+}
+
+// UnsafeSet sets the value at an index. It's unsafe in that we don't do bounds
+// checking (except in invariant builds).
+func (s uintsEncoder[T]) UnsafeSet(i int, v T) {
+	if invariants.Enabled {
+		_ = s.slice[i]
+	}
+	*(*T)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(s.slice)), unsafe.Sizeof(T(0))*uintptr(i))) = v
+}
+
+// CopyFrom sets the values from the given slice, starting at the given index.
+func (s uintsEncoder[T]) CopyFrom(i int, in []T) {
+	copy(s.slice[i:i+len(in)], in)
+}
+
+func (s uintsEncoder[T]) Finish() {
+	// TODO(radu): swap order on big-endian arch.
+}


### PR DESCRIPTION
#### colblk: add uintsEncoder helper

This replaces the use of `UnsafeRawSlice` for writing out integers.
This separation will help with cleanly and efficiently adding big
endian support.

#### colblk: don't use UnsafeRawSlice to store PrefixBytesBuilder offsets

We can use a simple slice, along with some helpers that avoid bounds
checking. UnsafeRawSlice can now only be used to read values.

---

No differences in ColBlockWriter benchmarks:
```
name                                                                                                    old time/op    new time/op    delta
CockroachDataColBlockWriter/AlphaLen=8,Prefix=8,Shared=4,KeysPerPrefix=4,Logical=10,ValueLen=8-10         63.5µs ± 1%    63.1µs ± 3%   ~     (p=0.113 n=9+10)
CockroachDataColBlockWriter/AlphaLen=8,Prefix=128,Shared=64,KeysPerPrefix=4,Logical=50,ValueLen=128-10    15.3µs ± 2%    15.1µs ± 4%   ~     (p=0.393 n=10+10)
CockroachDataColBlockWriter/AlphaLen=26,Prefix=1024,Shared=512,KeysPerPrefix=1,ValueLen=1024-10           3.12µs ± 6%    3.13µs ± 5%   ~     (p=0.869 n=10+10)

name                                                                                                    old alloc/op   new alloc/op   delta
CockroachDataColBlockWriter/AlphaLen=8,Prefix=8,Shared=4,KeysPerPrefix=4,Logical=10,ValueLen=8-10          9.00B ± 0%     9.00B ± 0%   ~     (all equal)
CockroachDataColBlockWriter/AlphaLen=8,Prefix=128,Shared=64,KeysPerPrefix=4,Logical=50,ValueLen=128-10     2.00B ± 0%     2.00B ± 0%   ~     (all equal)
CockroachDataColBlockWriter/AlphaLen=26,Prefix=1024,Shared=512,KeysPerPrefix=1,ValueLen=1024-10            0.00B          0.00B        ~     (all equal)

name                                                                                                    old allocs/op  new allocs/op  delta
CockroachDataColBlockWriter/AlphaLen=8,Prefix=8,Shared=4,KeysPerPrefix=4,Logical=10,ValueLen=8-10           0.00           0.00        ~     (all equal)
CockroachDataColBlockWriter/AlphaLen=8,Prefix=128,Shared=64,KeysPerPrefix=4,Logical=50,ValueLen=128-10      0.00           0.00        ~     (all equal)
CockroachDataColBlockWriter/AlphaLen=26,Prefix=1024,Shared=512,KeysPerPrefix=1,ValueLen=1024-10             0.00           0.00        ~     (all equal)
```