### PR TITLE
avoid timeouts and failures with asan builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,12 @@ testrace: testflags += -race -timeout 20m
 testrace: test
 
 testasan: testflags += -asan -timeout 20m
+testasan: TAGS += slowbuild
 testasan: test
 
 testmsan: export CC=clang
 testmsan: testflags += -msan -timeout 20m
+testmsan: TAGS += slowbuild
 testmsan: test
 
 .PHONY: testobjiotracing

--- a/commit_test.go
+++ b/commit_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/vfs"
@@ -88,7 +89,7 @@ func TestCommitPipeline(t *testing.T) {
 	p := newCommitPipeline(e.env())
 
 	n := 10000
-	if invariants.RaceEnabled {
+	if buildtags.SlowBuild {
 		// Under race builds we have to limit the concurrency or we hit the
 		// following error:
 		//

--- a/internal/buildtags/slow_build_off.go
+++ b/internal/buildtags/slow_build_off.go
@@ -1,0 +1,13 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build !race && !slowbuild
+
+package buildtags
+
+// SlowBuild is true if this is an instrumented testing build that is likely
+// to be significantly slower (like race or address sanitizer builds).
+//
+// Slow builds are either race builds or those built with a `slowbuild` tag.
+const SlowBuild = false

--- a/internal/buildtags/slow_build_on.go
+++ b/internal/buildtags/slow_build_on.go
@@ -1,0 +1,13 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build race || slowbuild
+
+package buildtags
+
+// SlowBuild is true if this is an instrumented testing build that is likely
+// to be significantly slower (like race or address sanitizer builds).
+//
+// Slow builds are either race builds or those built with a `slowbuild` tag.
+const SlowBuild = true

--- a/internal/intern/intern_test.go
+++ b/internal/intern/intern_test.go
@@ -8,11 +8,11 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 )
 
 func TestBytes(t *testing.T) {
-	if invariants.RaceEnabled {
+	if buildtags.Race {
 		// sync.Pool is a no-op under -race, making this test fail.
 		t.Skip("not supported under -race")
 	}

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/ghemawat/stream"
 	"github.com/stretchr/testify/require"
 )
@@ -62,9 +62,9 @@ func TestLint(t *testing.T) {
 		// GOARCH=386 messes with the installation of devtools.
 		t.Skip("lint checks skipped on GOARCH=386")
 	}
-	if invariants.RaceEnabled {
+	if buildtags.SlowBuild {
 		// We are not interested in race-testing the linters themselves.
-		t.Skip("lint checks skipped on race builds")
+		t.Skip("lint checks skipped on instrumented builds")
 	}
 
 	const root = "github.com/cockroachdb/pebble"

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/stretchr/testify/require"
 )
 
@@ -546,7 +546,7 @@ func TestRandomizedBTree(t *testing.T) {
 	rng := rand.New(rand.NewPCG(0, seed))
 
 	var numOps int
-	if invariants.RaceEnabled {
+	if buildtags.SlowBuild {
 		// Reduce the number of ops in race mode so the test doesn't take very long.
 		numOps = 1_000 + rng.IntN(4_000)
 	} else {

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -34,9 +34,9 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 	testOpts := metamorphic.RandomOptions(rng, metamorphic.TestkeysKeyFormat, nil /* custom opt parsers */)
 	{
 		nOps := 10000
-		if buildtags.Race {
-			// Reduce the number of operations in race mode (the test can time out if
-			// we are unlucky).
+		if buildtags.SlowBuild {
+			// Reduce the number of operations in instrumented builds (the test can
+			// time out if we are unlucky).
 			nOps = 2000
 		}
 		ops := metamorphic.GenerateOps(rng, uint64(nOps), metamorphic.TestkeysKeyFormat, metamorphic.WriteOpConfig())

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/metamorphic"
 )
@@ -95,7 +95,7 @@ func initCommonFlags() *CommonFlags {
 	flag.IntVar(&c.NumInstances, "num-instances", 1, "number of pebble instances to create (default: 1)")
 
 	defaultOpTimeout := 2 * time.Minute
-	if invariants.RaceEnabled {
+	if buildtags.SlowBuild {
 		defaultOpTimeout *= 5
 	}
 	flag.DurationVar(&c.OpTimeout, "op-timeout", defaultOpTimeout, "per-op timeout")
@@ -176,7 +176,7 @@ func initRunFlags(c *CommonFlags) *RunFlags {
 		"write an execution trace to `<run-dir>/file`")
 
 	ops := "uniform:5000-10000"
-	if invariants.RaceEnabled {
+	if buildtags.SlowBuild {
 		// Reduce the size of the test under race (to avoid timeouts).
 		ops = "uniform:1000-2000"
 	}

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
@@ -137,7 +137,7 @@ func TestSharedCacheRandomized(t *testing.T) {
 			for _, concurrentReads := range []bool{false, true} {
 				t.Run(fmt.Sprintf("concurrentReads=%v", concurrentReads), func(t *testing.T) {
 					maxShards := 32
-					if invariants.RaceEnabled {
+					if buildtags.SlowBuild {
 						maxShards = 8
 					}
 					numShards := rng.IntN(maxShards) + 1
@@ -200,7 +200,7 @@ func TestSharedCacheRandomized(t *testing.T) {
 	t.Run("32 KB block size", helper(32*1024, 1024*1024))
 	t.Run("1 MB block size", helper(1024*1024, 1024*1024))
 
-	if !invariants.RaceEnabled {
+	if !buildtags.SlowBuild {
 		for i := 0; i < 5; i++ {
 			exp := rng.IntN(11) + 10    // [10, 20]
 			randomBlockSize := 1 << exp // [1 KB, 1 MB]

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/batchrepr"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/datatest"
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -512,11 +513,10 @@ func TestCompactionsQuiesce(t *testing.T) {
 			}()
 
 			wait := 30 * time.Second
-			if invariants.Enabled {
+			if buildtags.SlowBuild {
+				wait = 5 * time.Minute
+			} else if invariants.Enabled {
 				wait = time.Minute
-				if invariants.RaceEnabled {
-					wait = 5 * time.Minute
-				}
 			}
 
 			// The above call to [Wait] should eventually return. [Wait] blocks


### PR DESCRIPTION
The asan build has been mostly failing due to timeouts. These slower
tests automatically adjust for race builds, but not for asan builds.

This commit adds a `buildtags.Instrumented` constant which indicates
if this is a race or asan or msan build. We switch various
`RaceEnabled` test checks to the new flag so we include these builds.