### PR TITLE
sstable: add AddWithBlobHandle

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -587,7 +587,7 @@ func runBuildRemoteCmd(td *datadriven.TestData, d *DB, storage remote.Storage) e
 	for kv := iter.First(); kv != nil; kv = iter.Next() {
 		tmp := kv.K
 		tmp.SetSeqNum(0)
-		if err := w.Raw().AddWithForceObsolete(tmp, kv.InPlaceValue(), false); err != nil {
+		if err := w.Raw().Add(tmp, kv.InPlaceValue(), false); err != nil {
 			return err
 		}
 	}
@@ -677,7 +677,7 @@ func runBuildCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
 	for kv := iter.First(); kv != nil; kv = iter.Next() {
 		tmp := kv.K
 		tmp.SetSeqNum(0)
-		if err := w.Raw().AddWithForceObsolete(tmp, kv.InPlaceValue(), false); err != nil {
+		if err := w.Raw().Add(tmp, kv.InPlaceValue(), false); err != nil {
 			return err
 		}
 	}

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -214,7 +214,7 @@ func (t *fileCacheTest) newTestHandle() (*fileCacheHandle, *fileCacheTestFS) {
 		}
 		tw := sstable.NewWriter(w, sstable.WriterOptions{TableFormat: sstable.TableFormatPebblev2})
 		ik := base.ParseInternalKey(fmt.Sprintf("k.SET.%d", i))
-		if err := tw.Raw().AddWithForceObsolete(ik, xxx[:i], false); err != nil {
+		if err := tw.Raw().Add(ik, xxx[:i], false); err != nil {
 			t.Fatal(err)
 		}
 		if err := tw.RangeKeySet([]byte("k"), []byte("l"), nil, xxx[:i]); err != nil {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -117,7 +117,7 @@ func TestIngestLoad(t *testing.T) {
 				}
 				key := base.ParseInternalKey(data[:j])
 				value := []byte(data[j+1:])
-				if err := w.AddWithForceObsolete(key, value, false /* forceObsolete */); err != nil {
+				if err := w.Add(key, value, false /* forceObsolete */); err != nil {
 					return err.Error()
 				}
 			}
@@ -203,7 +203,7 @@ func TestIngestLoadRand(t *testing.T) {
 					// Duplicate key, ignore.
 					continue
 				}
-				require.NoError(t, w.AddWithForceObsolete(keys[i], nil, false /* forceObsolete */))
+				require.NoError(t, w.Add(keys[i], nil, false /* forceObsolete */))
 				count++
 			}
 			expected[i].Stats.NumEntries = count
@@ -1136,7 +1136,7 @@ func testIngestSharedImpl(
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
-					require.NoError(t, w.AddWithForceObsolete(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
+					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
 					return nil
 				},
 				func(start, end []byte, seqNum base.SeqNum) error {
@@ -1638,7 +1638,7 @@ func TestConcurrentExcise(t *testing.T) {
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
-					require.NoError(t, w.AddWithForceObsolete(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
+					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
 					return nil
 				},
 				func(start, end []byte, seqNum base.SeqNum) error {
@@ -2075,7 +2075,7 @@ func TestIngestExternal(t *testing.T) {
 				func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
-					require.NoError(t, w.AddWithForceObsolete(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
+					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
 					return nil
 				},
 				func(start, end []byte, seqNum base.SeqNum) error {
@@ -2625,7 +2625,7 @@ func TestIngestCompact(t *testing.T) {
 
 	w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{})
 	key := []byte("a")
-	require.NoError(t, w.AddWithForceObsolete(base.MakeInternalKey(key, 0, InternalKeyKindSet), nil, false /* forceObsolete */))
+	require.NoError(t, w.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), nil, false /* forceObsolete */))
 	require.NoError(t, w.Close())
 
 	// Make N copies of the sstable.
@@ -3284,7 +3284,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 			}
 			key := base.ParseInternalKey(data[:j])
 			value := []byte(data[j+1:])
-			if err := w.AddWithForceObsolete(key, value, false /* forceObsolete */); err != nil {
+			if err := w.Add(key, value, false /* forceObsolete */); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -218,7 +218,7 @@ func (r *Runner) writeKeysToTable(tw sstable.RawWriter) (splitKey []byte, _ erro
 		if err != nil {
 			return nil, err
 		}
-		if err := tw.AddWithForceObsolete(kv.K, v, r.iter.ForceObsoleteDueToRangeDel()); err != nil {
+		if err := tw.Add(kv.K, v, r.iter.ForceObsoleteDueToRangeDel()); err != nil {
 			return nil, err
 		}
 		if r.iter.SnapshotPinned() {

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -213,7 +213,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 					j := strings.Index(kv, ":")
 					ikey := base.ParseInternalKey(kv[:j])
 					value := []byte(kv[j+1:])
-					err = w.AddWithForceObsolete(ikey, value, false /* forceObsolete */)
+					err = w.Add(ikey, value, false /* forceObsolete */)
 					if err != nil {
 						return err.Error()
 					}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -259,7 +259,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 				return err.Error()
 			}
 		default:
-			if err := w.AddWithForceObsolete(ikey, value, false /* forceObsolete */); err != nil {
+			if err := w.Add(ikey, value, false /* forceObsolete */); err != nil {
 				return err.Error()
 			}
 		}
@@ -534,7 +534,7 @@ func buildLevelIterTables(
 			key := []byte(fmt.Sprintf("%08d", i))
 			keys = append(keys, key)
 			ikey := base.MakeInternalKey(key, 0, InternalKeyKindSet)
-			require.NoError(b, w.AddWithForceObsolete(ikey, nil, false /* forceObsolete */))
+			require.NoError(b, w.Add(ikey, nil, false /* forceObsolete */))
 		}
 		if err := w.Close(); err != nil {
 			b.Fatal(err)

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -234,7 +234,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 							case InternalKeyKindRangeDelete:
 								frag.Add(keyspan.Span{Start: ikey.UserKey, End: value, Keys: []keyspan.Key{{Trailer: ikey.Trailer}}})
 							default:
-								if err := w.AddWithForceObsolete(ikey, value, false /* forceObsolete */); err != nil {
+								if err := w.Add(ikey, value, false /* forceObsolete */); err != nil {
 									return err.Error()
 								}
 							}
@@ -362,7 +362,7 @@ func buildMergingIterTables(
 		ikey.UserKey = key
 		j := rand.IntN(len(writers))
 		w := writers[j]
-		w.AddWithForceObsolete(ikey, nil, false /* forceObsolete */)
+		w.Add(ikey, nil, false /* forceObsolete */)
 	}
 
 	for _, w := range writers {
@@ -580,7 +580,7 @@ func buildLevelsForMergingIterSeqSeek(
 		key := []byte(fmt.Sprintf("%08d", i))
 		keys = append(keys, key)
 		ikey := base.MakeInternalKey(key, 0, InternalKeyKindSet)
-		require.NoError(b, w.AddWithForceObsolete(ikey, nil, false /* forceObsolete */))
+		require.NoError(b, w.Add(ikey, nil, false /* forceObsolete */))
 	}
 	if writeRangeTombstoneToLowestLevel {
 		require.NoError(b, w.EncodeSpan(keyspan.Span{
@@ -594,14 +594,14 @@ func buildLevelsForMergingIterSeqSeek(
 	for j := 1; j < len(files); j++ {
 		for _, k := range []int{0, len(keys) - 1} {
 			ikey := base.MakeInternalKey(keys[k], base.SeqNum(j), InternalKeyKindSet)
-			require.NoError(b, writers[j][0].AddWithForceObsolete(ikey, nil, false /* forceObsolete */))
+			require.NoError(b, writers[j][0].Add(ikey, nil, false /* forceObsolete */))
 		}
 	}
 	lastKey := []byte(fmt.Sprintf("%08d", i))
 	keys = append(keys, lastKey)
 	for j := 0; j < len(files); j++ {
 		lastIKey := base.MakeInternalKey(lastKey, base.SeqNum(j), InternalKeyKindSet)
-		require.NoError(b, writers[j][1].AddWithForceObsolete(lastIKey, nil, false /* forceObsolete */))
+		require.NoError(b, writers[j][1].Add(lastIKey, nil, false /* forceObsolete */))
 	}
 	for _, levelWriters := range writers {
 		for j, w := range levelWriters {

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -98,7 +98,7 @@ func writeSSTForIngestion(
 			return nil, err
 		}
 		t.opts.Comparer.ValidateKey.MustValidate(k.K.UserKey)
-		if err := w.Raw().AddWithForceObsolete(k.K, valBytes, false); err != nil {
+		if err := w.Raw().Add(k.K, valBytes, false); err != nil {
 			return nil, err
 		}
 	}

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -2003,7 +2003,7 @@ func (r *replicateOp) runSharedReplicate(
 			if err != nil {
 				panic(err)
 			}
-			return w.Raw().AddWithForceObsolete(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false)
+			return w.Raw().Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false)
 		},
 		func(start, end []byte, seqNum base.SeqNum) error {
 			return w.DeleteRange(start, end)
@@ -2067,7 +2067,7 @@ func (r *replicateOp) runExternalReplicate(
 				panic(err)
 			}
 			t.opts.Comparer.ValidateKey.MustValidate(key.UserKey)
-			return w.Raw().AddWithForceObsolete(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false)
+			return w.Raw().Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false)
 		},
 		func(start, end []byte, seqNum base.SeqNum) error {
 			t.opts.Comparer.ValidateKey.MustValidate(start)

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -603,7 +603,7 @@ func benchmarkRangeDelIterate(b *testing.B, entries, deleted int, snapshotCompac
 	})
 	for i := 0; i < entries; i++ {
 		key := base.MakeInternalKey(makeKey(i), 0, InternalKeyKindSet)
-		if err := w.AddWithForceObsolete(key, nil, false /* forceObsolete */); err != nil {
+		if err := w.Add(key, nil, false /* forceObsolete */); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -442,7 +442,7 @@ func TestScanInternal(t *testing.T) {
 					var err error
 					value, _, err = kv.Value(value)
 					require.NoError(t, err)
-					require.NoError(t, w.Raw().AddWithForceObsolete(kv.K, value, false))
+					require.NoError(t, w.Raw().Add(kv.K, value, false))
 				}
 				points.Close()
 				require.NoError(t, w.Close())

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/valblk"
-	"github.com/cockroachdb/redact"
 )
 
 var (
@@ -77,25 +76,6 @@ type FileWriterStats struct {
 	BlockLenLongest        uint64
 	UncompressedValueBytes uint64
 	FileLen                uint64
-}
-
-// Handle describes the location of a value stored within a blob file.
-type Handle struct {
-	FileNum       base.DiskFileNum
-	BlockNum      uint32
-	OffsetInBlock uint32
-	ValueLen      uint32
-}
-
-// String implements the fmt.Stringer interface.
-func (h Handle) String() string {
-	return redact.StringWithoutMarkers(h)
-}
-
-// SafeFormat implements redact.SafeFormatter.
-func (h Handle) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("(%s,blk%d[%d:%d])",
-		h.FileNum, h.BlockNum, h.OffsetInBlock, h.OffsetInBlock+h.ValueLen)
 }
 
 // A FileWriter writes a blob file.

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -78,12 +78,12 @@ func (r *ValueFetcher) Init(rp ReaderProvider, env block.ReadEnv) {
 func (r *ValueFetcher) Fetch(
 	ctx context.Context, handle []byte, fileNum base.DiskFileNum, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
-	vblkHandle := valblk.DecodeRemainingHandle(handle)
+	handleSuffix := DecodeHandleSuffix(handle)
 	vh := Handle{
 		FileNum:       fileNum,
-		BlockNum:      vblkHandle.BlockNum,
-		OffsetInBlock: vblkHandle.OffsetInBlock,
 		ValueLen:      valLen,
+		BlockNum:      handleSuffix.BlockNum,
+		OffsetInBlock: handleSuffix.OffsetInBlock,
 	}
 	v, err := r.retrieve(ctx, vh)
 	return v, false, err

--- a/sstable/blob/handle.go
+++ b/sstable/blob/handle.go
@@ -1,0 +1,152 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package blob
+
+import (
+	"encoding/binary"
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/valblk"
+	"github.com/cockroachdb/redact"
+)
+
+// MaxInlineHandleLength is the maximum length of an inline blob handle.
+//
+// Handle fields are varint encoded, so maximum 5 bytes each.
+const MaxInlineHandleLength = 4 * binary.MaxVarintLen32
+
+// Handle describes the location of a value stored within a blob file.
+type Handle struct {
+	FileNum       base.DiskFileNum
+	BlockNum      uint32
+	OffsetInBlock uint32
+	ValueLen      uint32
+}
+
+// String implements the fmt.Stringer interface.
+func (h Handle) String() string {
+	return redact.StringWithoutMarkers(h)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (h Handle) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("(%s,blk%d[%d:%d])",
+		h.FileNum, h.BlockNum, h.OffsetInBlock, h.OffsetInBlock+h.ValueLen)
+}
+
+// TODO(jackson): Consider encoding the handle's data using columnar block
+// primitives, rather than a variable-width encoding in the value column.
+
+// InlineHandle describes a handle as it is encoded within a sstable block. The
+// inline handle does not encode the blob file number outright. Instead it
+// encodes an index into the containing sstable's BlobReferences.
+//
+// The inline handle is composed of two parts: a preface (InlineHandlePreface)
+// and a suffix (HandleSuffix). The preface is eagerly decoded from the encoded
+// handle when returning an InternalValue to higher layers. The remaining bits
+// (the suffix) are decoded only when the value is being fetched from the blob
+// file.
+type InlineHandle struct {
+	InlineHandlePreface
+	HandleSuffix
+}
+
+// InlineHandlePreface is the prefix of an inline handle. It's eagerly decoded
+// when returning an InternalValue to higher layers.
+type InlineHandlePreface struct {
+	ReferenceIndex uint32
+	ValueLen       uint32
+}
+
+// HandleSuffix is the suffix of an inline handle. It's decoded only when the
+// value is being fetched from the blob file.
+type HandleSuffix struct {
+	BlockNum      uint32
+	OffsetInBlock uint32
+}
+
+// String implements the fmt.Stringer interface.
+func (h InlineHandle) String() string {
+	return redact.StringWithoutMarkers(h)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (h InlineHandle) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("(f%d,blk%d[%d:%d])",
+		h.ReferenceIndex, h.BlockNum, h.OffsetInBlock, h.OffsetInBlock+h.ValueLen)
+}
+
+// Encode encodes the inline handle into the provided buffer, returning the
+// number of bytes encoded.
+func (h InlineHandle) Encode(b []byte) int {
+	n := 0
+	n += binary.PutUvarint(b[n:], uint64(h.ReferenceIndex))
+	n += valblk.EncodeHandle(b[n:], valblk.Handle{
+		BlockNum:      h.BlockNum,
+		OffsetInBlock: h.OffsetInBlock,
+		ValueLen:      h.ValueLen,
+	})
+	return n
+}
+
+// DecodeInlineHandlePrefix decodes the blob reference index and value length
+// from the beginning of a variable-width encoded InlineHandle.
+func DecodeInlineHandlePrefix(src []byte) (InlineHandlePreface, []byte) {
+	ptr := unsafe.Pointer(&src[0])
+	var refIdx uint32
+	if a := *((*uint8)(ptr)); a < 128 {
+		refIdx = uint32(a)
+		src = src[1:]
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
+		refIdx = uint32(b)<<7 | uint32(a)
+		src = src[2:]
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
+		refIdx = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[3:]
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
+		refIdx = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[4:]
+	} else {
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
+		refIdx = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[5:]
+	}
+
+	ptr = unsafe.Pointer(&src[0])
+	var valueLen uint32
+	if a := *((*uint8)(ptr)); a < 128 {
+		valueLen = uint32(a)
+		src = src[1:]
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
+		valueLen = uint32(b)<<7 | uint32(a)
+		src = src[2:]
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
+		valueLen = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[3:]
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
+		valueLen = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[4:]
+	} else {
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
+		valueLen = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
+		src = src[5:]
+	}
+
+	return InlineHandlePreface{
+		ReferenceIndex: refIdx,
+		ValueLen:       valueLen,
+	}, src
+}
+
+// DecodeHandleSuffix decodes the block number and offset in block from the
+// encoded handle.
+func DecodeHandleSuffix(src []byte) HandleSuffix {
+	h := valblk.DecodeRemainingHandle(src)
+	return HandleSuffix{
+		BlockNum:      h.BlockNum,
+		OffsetInBlock: h.OffsetInBlock,
+	}
+}

--- a/sstable/block/kv.go
+++ b/sstable/block/kv.go
@@ -81,8 +81,8 @@ func InPlaceValuePrefix(setHasSameKeyPrefix bool) ValuePrefix {
 }
 
 // BlobValueHandlePrefix returns the ValuePrefix for a blob.
-func BlobValueHandlePrefix(setHasSameKeyPrefix bool) ValuePrefix {
-	prefix := valueKindIsBlobHandle
+func BlobValueHandlePrefix(setHasSameKeyPrefix bool, attr base.ShortAttribute) ValuePrefix {
+	prefix := valueKindIsBlobHandle | ValuePrefix(attr)
 	if setHasSameKeyPrefix {
 		prefix = prefix | setHasSameKeyPrefixMask
 	}

--- a/sstable/block/kv_test.go
+++ b/sstable/block/kv_test.go
@@ -50,6 +50,7 @@ func TestValuePrefix(t *testing.T) {
 			isValueBlockHandle: false,
 			isBlobHandle:       true,
 			setHasSamePrefix:   true,
+			attr:               2,
 		},
 	}
 	for _, tc := range testCases {
@@ -58,7 +59,7 @@ func TestValuePrefix(t *testing.T) {
 			if tc.isValueBlockHandle {
 				prefix = ValueBlockHandlePrefix(tc.setHasSamePrefix, tc.attr)
 			} else if tc.isBlobHandle {
-				prefix = BlobValueHandlePrefix(tc.setHasSamePrefix)
+				prefix = BlobValueHandlePrefix(tc.setHasSamePrefix, tc.attr)
 			} else {
 				prefix = InPlaceValuePrefix(tc.setHasSamePrefix)
 			}

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -317,7 +317,7 @@ func (w *RawColumnWriter) EncodeSpan(span keyspan.Span) error {
 	return nil
 }
 
-// AddWithForceObsolete adds a point key/value pair when writing a
+// Add adds a point key/value pair when writing a
 // strict-obsolete sstable. For a given Writer, the keys passed to Add must be
 // in increasing order. Span keys (range deletions, range keys) must be added
 // through EncodeSpan.
@@ -331,9 +331,7 @@ func (w *RawColumnWriter) EncodeSpan(span keyspan.Span) error {
 // that strict-obsolete ssts must satisfy. S2, due to RANGEDELs, is solely the
 // responsibility of the caller. S1 is solely the responsibility of the
 // callee.
-func (w *RawColumnWriter) AddWithForceObsolete(
-	key InternalKey, value []byte, forceObsolete bool,
-) error {
+func (w *RawColumnWriter) Add(key InternalKey, value []byte, forceObsolete bool) error {
 	switch key.Kind() {
 	case base.InternalKeyKindRangeDelete, base.InternalKeyKindRangeKeySet,
 		base.InternalKeyKindRangeKeyUnset, base.InternalKeyKindRangeKeyDelete:

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -140,9 +140,9 @@ func writeKVs(w RawWriter, input string) (err error) {
 				if forceObsolete {
 					return errors.Errorf("force-obsolete is not allowed for RANGEDEL")
 				}
-				err = w.AddWithForceObsolete(key, value, false /* forceObsolete */)
+				err = w.Add(key, value, false /* forceObsolete */)
 			default:
-				err = w.AddWithForceObsolete(key, value, forceObsolete)
+				err = w.Add(key, value, forceObsolete)
 			}
 		}
 		if err != nil {
@@ -223,7 +223,7 @@ func runBuildRawCmd(
 		j := strings.Index(data, ":")
 		key := base.ParseInternalKey(data[:j])
 		value := []byte(data[j+1:])
-		if err := w.AddWithForceObsolete(key, value, false); err != nil {
+		if err := w.Add(key, value, false); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/sstable/format.go
+++ b/sstable/format.go
@@ -29,7 +29,7 @@ const (
 	TableFormatPebblev3 // Value blocks.
 	TableFormatPebblev4 // DELSIZED tombstones.
 	TableFormatPebblev5 // Columnar blocks.
-	TableFormatPebblev6 // Checksum Footer.
+	TableFormatPebblev6 // Checksum footer + blob value handles.
 	NumTableFormats
 
 	TableFormatMax = NumTableFormats - 1

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -399,7 +399,7 @@ func buildRandomSSTable(f vfs.File, cfg randomTableConfig) (*WriterMetadata, err
 				value[j] = byte(cfg.rng.Uint32())
 			}
 		}
-		if err := w.AddWithForceObsolete(keys[i], value, false /* forceObsolete */); err != nil {
+		if err := w.Add(keys[i], value, false /* forceObsolete */); err != nil {
 			return nil, err
 		}
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1760,7 +1760,7 @@ func buildTestTableWithProvider(
 		value := make([]byte, i%100)
 		key = binary.BigEndian.AppendUint64(key, i)
 		ikey.UserKey = key
-		require.NoError(t, w.AddWithForceObsolete(ikey, value, false /* forceObsolete */))
+		require.NoError(t, w.Add(ikey, value, false /* forceObsolete */))
 	}
 
 	require.NoError(t, w.Close())
@@ -1798,7 +1798,7 @@ func buildBenchmarkTable(
 		binary.BigEndian.PutUint64(key, i+uint64(offset))
 		keys = append(keys, key)
 		ikey.UserKey = key
-		require.NoError(b, w.AddWithForceObsolete(ikey, nil, false /* forceObsolete */))
+		require.NoError(b, w.Add(ikey, nil, false /* forceObsolete */))
 	}
 
 	if err := w.Close(); err != nil {
@@ -2397,7 +2397,7 @@ func BenchmarkIteratorScanObsolete(b *testing.B) {
 			if i == 0 {
 				forceObsolete = false
 			}
-			require.NoError(b, w.AddWithForceObsolete(
+			require.NoError(b, w.Add(
 				base.MakeInternalKey(key, 0, InternalKeyKindSet), val, forceObsolete))
 		}
 		require.NoError(b, w.Close())

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangedel"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/cockroachdb/pebble/sstable/valblk"
@@ -592,6 +593,15 @@ func (w *RawRowWriter) Add(key InternalKey, value []byte, forceObsolete bool) er
 		return w.err
 	}
 	return w.addPoint(key, value, forceObsolete)
+}
+
+// AddWithBlobHandle implements the RawWriter interface. This implementation
+// does not support writing blob value handles.
+func (w *RawRowWriter) AddWithBlobHandle(
+	key InternalKey, h blob.InlineHandle, attr base.ShortAttribute, forceObsolete bool,
+) error {
+	w.err = errors.Newf("pebble: blob value handles are not supported in %s", w.tableFormat.String())
+	return w.err
 }
 
 func (w *RawRowWriter) makeAddPointDecisionV2(key InternalKey) error {

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -565,7 +565,7 @@ type bufferedIndexBlock struct {
 	block []byte
 }
 
-// AddWithForceObsolete must be used when writing a strict-obsolete sstable.
+// Add must be used when writing a strict-obsolete sstable.
 //
 // forceObsolete indicates whether the caller has determined that this key is
 // obsolete even though it may be the latest point key for this userkey. This
@@ -576,9 +576,7 @@ type bufferedIndexBlock struct {
 // that strict-obsolete ssts must satisfy. S2, due to RANGEDELs, is solely the
 // responsibility of the caller. S1 is solely the responsibility of the
 // callee.
-func (w *RawRowWriter) AddWithForceObsolete(
-	key InternalKey, value []byte, forceObsolete bool,
-) error {
+func (w *RawRowWriter) Add(key InternalKey, value []byte, forceObsolete bool) error {
 	if w.err != nil {
 		return w.err
 	}

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -343,7 +343,7 @@ func RewriteKeySuffixesViaWriter(
 		if invariants.Enabled && invariants.Sometimes(10) {
 			r.Comparer.ValidateKey.MustValidate(scratch.UserKey)
 		}
-		if err := w.AddWithForceObsolete(scratch, val, false); err != nil {
+		if err := w.Add(scratch, val, false); err != nil {
 			return nil, err
 		}
 		kv = i.Next()

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -193,7 +193,7 @@ func makeTestkeySSTable(
 	for i := 0; i < keys; i++ {
 		n := testkeys.WriteKey(keyBuf[len(sharedPrefix):], alphabet, int64(i))
 		key := append(keyBuf[:len(sharedPrefix)+n], suffix...)
-		err := w.Raw().AddWithForceObsolete(
+		err := w.Raw().Add(
 			base.MakeInternalKey(key, 0, InternalKeyKindSet), key, false)
 		if err != nil {
 			t.Fatal(err)

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -455,7 +455,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 						IndexBlockSize: indexBlockSize,
 					})
 					for _, k := range keys[:nk] {
-						if err := w.AddWithForceObsolete(InternalKey{UserKey: []byte(k)}, xxx[:vLen], false /* forceObsolete */); err != nil {
+						if err := w.Add(InternalKey{UserKey: []byte(k)}, xxx[:vLen], false /* forceObsolete */); err != nil {
 							t.Errorf("nk=%d, vLen=%d: set: %v", nk, vLen, err)
 							continue loop
 						}

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -1,0 +1,149 @@
+build table-format=(Pebble,v6)
+a@2.SET.1:blobInlineHandle(0, blk1, 10, 100, 0x07)
+b@5.SET.7:blobInlineHandle(0, blk2, 110, 200, 0x07)
+b@4.DEL.3:
+b@3.SET.2:blobInlineHandle(1, blk0, 0, 200, 0x07)
+b@2.SET.1:blobInlineHandle(1, blk1, 294, 103, 0x07)
+----
+blob-separated-values: num-values 4
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 133
+ │    ├── data block header
+ │    │    ├── columnar block header
+ │    │    │    ├── 000-004: x 03000000 # maximum key length: 3
+ │    │    │    ├── 004-005: x 01       # version 1
+ │    │    │    ├── 005-007: x 0700     # 7 columns
+ │    │    │    ├── 007-011: x 05000000 # 5 rows
+ │    │    │    ├── 011-012: b 00000100 # col 0: prefixbytes
+ │    │    │    ├── 012-016: x 2e000000 # col 0: page start 46
+ │    │    │    ├── 016-017: b 00000011 # col 1: bytes
+ │    │    │    ├── 017-021: x 39000000 # col 1: page start 57
+ │    │    │    ├── 021-022: b 00000010 # col 2: uint
+ │    │    │    ├── 022-026: x 4a000000 # col 2: page start 74
+ │    │    │    ├── 026-027: b 00000001 # col 3: bool
+ │    │    │    ├── 027-031: x 56000000 # col 3: page start 86
+ │    │    │    ├── 031-032: b 00000011 # col 4: bytes
+ │    │    │    ├── 032-036: x 68000000 # col 4: page start 104
+ │    │    │    ├── 036-037: b 00000001 # col 5: bool
+ │    │    │    ├── 037-041: x 82000000 # col 5: page start 130
+ │    │    │    ├── 041-042: b 00000001 # col 6: bool
+ │    │    │    └── 042-046: x 83000000 # col 6: page start 131
+ │    │    ├── data for column 0 (prefixbytes)
+ │    │    │    ├── 046-047: x 04 # bundle size: 16
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 047-048: x 01 # encoding: 1b
+ │    │    │    │    ├── 048-049: x 00 # data[0] = 0 [55 overall]
+ │    │    │    │    ├── 049-050: x 00 # data[1] = 0 [55 overall]
+ │    │    │    │    ├── 050-051: x 01 # data[2] = 1 [56 overall]
+ │    │    │    │    ├── 051-052: x 02 # data[3] = 2 [57 overall]
+ │    │    │    │    ├── 052-053: x 02 # data[4] = 2 [57 overall]
+ │    │    │    │    ├── 053-054: x 02 # data[5] = 2 [57 overall]
+ │    │    │    │    └── 054-055: x 02 # data[6] = 2 [57 overall]
+ │    │    │    └── data
+ │    │    │         ├── 055-055: x    # data[00]:  (block prefix)
+ │    │    │         ├── 055-055: x    # data[01]:  (bundle prefix)
+ │    │    │         ├── 055-056: x 61 # data[02]: a
+ │    │    │         ├── 056-057: x 62 # data[03]: b
+ │    │    │         ├── 057-057: x    # data[04]: .
+ │    │    │         ├── 057-057: x    # data[05]: .
+ │    │    │         └── 057-057: x    # data[06]: .
+ │    │    ├── data for column 1 (bytes)
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 057-058: x 01 # encoding: 1b
+ │    │    │    │    ├── 058-059: x 00 # data[0] = 0 [64 overall]
+ │    │    │    │    ├── 059-060: x 02 # data[1] = 2 [66 overall]
+ │    │    │    │    ├── 060-061: x 04 # data[2] = 4 [68 overall]
+ │    │    │    │    ├── 061-062: x 06 # data[3] = 6 [70 overall]
+ │    │    │    │    ├── 062-063: x 08 # data[4] = 8 [72 overall]
+ │    │    │    │    └── 063-064: x 0a # data[5] = 10 [74 overall]
+ │    │    │    └── data
+ │    │    │         ├── 064-066: x 4032 # data[0]: @2
+ │    │    │         ├── 066-068: x 4035 # data[1]: @5
+ │    │    │         ├── 068-070: x 4034 # data[2]: @4
+ │    │    │         ├── 070-072: x 4033 # data[3]: @3
+ │    │    │         └── 072-074: x 4032 # data[4]: @2
+ │    │    ├── data for column 2 (uint)
+ │    │    │    ├── 074-075: x 02   # encoding: 2b
+ │    │    │    ├── 075-076: x 00   # padding (aligning to 16-bit boundary)
+ │    │    │    ├── 076-078: x 0101 # data[0] = 257
+ │    │    │    ├── 078-080: x 0107 # data[1] = 1793
+ │    │    │    ├── 080-082: x 0003 # data[2] = 768
+ │    │    │    ├── 082-084: x 0102 # data[3] = 513
+ │    │    │    └── 084-086: x 0101 # data[4] = 257
+ │    │    ├── data for column 3 (bool)
+ │    │    │    ├── 086-087: x 00                                                               # default bitmap encoding
+ │    │    │    ├── 087-088: x 00                                                               # padding to align to 64-bit boundary
+ │    │    │    ├── 088-096: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+ │    │    │    └── 096-104: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+ │    │    ├── data for column 4 (bytes)
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 104-105: x 01 # encoding: 1b
+ │    │    │    │    ├── 105-106: x 00 # data[0] = 0 [111 overall]
+ │    │    │    │    ├── 106-107: x 04 # data[1] = 4 [115 overall]
+ │    │    │    │    ├── 107-108: x 09 # data[2] = 9 [120 overall]
+ │    │    │    │    ├── 108-109: x 09 # data[3] = 9 [120 overall]
+ │    │    │    │    ├── 109-110: x 0e # data[4] = 14 [125 overall]
+ │    │    │    │    └── 110-111: x 13 # data[5] = 19 [130 overall]
+ │    │    │    └── data
+ │    │    │         ├── 111-115: x 0064010a   # data[0]: "\x00d\x01\n"
+ │    │    │         ├── 115-120: x 00c801026e # data[1]: "\x00\xc8\x01\x02n"
+ │    │    │         ├── 120-120: x            # data[2]:
+ │    │    │         ├── 120-125: x 01c8010000 # data[3]: "\x01\xc8\x01\x00\x00"
+ │    │    │         └── 125-130: x 016701a602 # data[4]: "\x01g\x01\xa6\x02"
+ │    │    ├── data for column 5 (bool)
+ │    │    │    └── 130-131: x 01 # zero bitmap encoding
+ │    │    ├── data for column 6 (bool)
+ │    │    │    └── 131-132: x 01 # zero bitmap encoding
+ │    │    └── 132-133: x 00 # block padding byte
+ │    ├── a@2#1,SET:hex:0064010a
+ │    ├── b@5#7,SET:hex:00c801026e
+ │    ├── b@4#3,DEL:
+ │    ├── b@3#2,SET:hex:01c8010000
+ │    ├── b@2#1,SET:hex:016701a602
+ │    └── trailer [compression=none checksum=0x8f109d09]
+ ├── index  offset: 138  length: 36
+ │    ├── 00000    block:0/133
+ │    │   
+ │    └── trailer [compression=none checksum=0x863e7ff6]
+ ├── properties  offset: 179  length: 570
+ │    ├── 00000    obsolete-key (16) [restart]
+ │    ├── 00016    pebble.colblk.schema (68)
+ │    ├── 00084    pebble.num.values.in.blob-files (28)
+ │    ├── 00112    pebble.raw.point-tombstone.key.size (32)
+ │    ├── 00144    rocksdb.block.based.table.index.type (43)
+ │    ├── 00187    rocksdb.comparator (37)
+ │    ├── 00224    rocksdb.compression (16)
+ │    ├── 00240    rocksdb.compression_options (106)
+ │    ├── 00346    rocksdb.data.size (14)
+ │    ├── 00360    rocksdb.deleted.keys (15)
+ │    ├── 00375    rocksdb.filter.size (15)
+ │    ├── 00390    rocksdb.index.size (14)
+ │    ├── 00404    rocksdb.merge.operands (18)
+ │    ├── 00422    rocksdb.merge.operator (24)
+ │    ├── 00446    rocksdb.num.data.blocks (19)
+ │    ├── 00465    rocksdb.num.entries (11)
+ │    ├── 00476    rocksdb.num.range-deletions (19)
+ │    ├── 00495    rocksdb.property.collectors (36)
+ │    ├── 00531    rocksdb.raw.key.size (16)
+ │    ├── 00547    rocksdb.raw.value.size (15)
+ │    ├── restart points
+ │    │    └── 00562 [restart 0]
+ │    └── trailer [compression=none checksum=0x5aee2759]
+ ├── meta-index  offset: 754  length: 33
+ │    ├── 0000    rocksdb.properties block:179/570 [restart]
+ │    ├── restart points
+ │    │    └── 00025 [restart 0]
+ │    └── trailer [compression=none checksum=0x336f39a9]
+ └── footer  offset: 792  length: 57
+      ├── 000  checksum type: crc32c
+      ├── 001  meta: offset=754, length=33
+      ├── 004  index: offset=138, length=36
+      ├── 041  footer checksum: 0x7c352f7a
+      ├── 045  version: 6
+      └── 049  magic number: 0xf09faab3f09faab3
+
+# TODO(jackson): Test iteration over the blob-separated values when that's
+# supported.

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
 )
 
@@ -309,6 +310,10 @@ type RawWriter interface {
 	// responsibility of the caller. S1 is solely the responsibility of the
 	// callee.
 	Add(key InternalKey, value []byte, forceObsolete bool) error
+	// AddWithBlobHandle adds a key to the sstable, but encoding a blob value
+	// handle instead of an in-place value. See Add for more details. The caller
+	// must provide the already-extracted ShortAttribute for the value.
+	AddWithBlobHandle(key InternalKey, h blob.InlineHandle, attr base.ShortAttribute, forceObsolete bool) error
 	// EncodeSpan encodes the keys in the given span. The span can contain
 	// either only RANGEDEL keys or only range keys.
 	//

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -109,7 +109,7 @@ func (w *Writer) Set(key, value []byte) error {
 	}
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable delete the added points.
-	return w.rw.AddWithForceObsolete(base.MakeInternalKey(key, 0, InternalKeyKindSet), value, false)
+	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), value, false)
 }
 
 // Delete deletes the value for the given key. The sequence number is set to
@@ -126,7 +126,7 @@ func (w *Writer) Delete(key []byte) error {
 	}
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable delete the added points.
-	return w.rw.AddWithForceObsolete(base.MakeInternalKey(key, 0, InternalKeyKindDelete), nil, false)
+	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindDelete), nil, false)
 }
 
 // DeleteRange deletes all of the keys (and values) in the range [start,end)
@@ -167,7 +167,7 @@ func (w *Writer) Merge(key, value []byte) error {
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable that delete the added points. If the user configured this writer
 	// to be strict-obsolete, addPoint will reject the addition of this MERGE.
-	return w.rw.AddWithForceObsolete(base.MakeInternalKey(key, 0, InternalKeyKindMerge), value, false)
+	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindMerge), value, false)
 }
 
 // RangeKeySet sets a range between start (inclusive) and end (exclusive) with
@@ -297,7 +297,7 @@ func (w *Writer) Close() (err error) {
 type RawWriter interface {
 	// Error returns the current accumulated error if any.
 	Error() error
-	// AddWithForceObsolete must be used when writing a strict-obsolete sstable.
+	// Add adds a key-value pair to the sstable.
 	//
 	// forceObsolete indicates whether the caller has determined that this key is
 	// obsolete even though it may be the latest point key for this userkey. This
@@ -308,9 +308,7 @@ type RawWriter interface {
 	// that strict-obsolete ssts must satisfy. S2, due to RANGEDELs, is solely the
 	// responsibility of the caller. S1 is solely the responsibility of the
 	// callee.
-	AddWithForceObsolete(
-		key InternalKey, value []byte, forceObsolete bool,
-	) error
+	Add(key InternalKey, value []byte, forceObsolete bool) error
 	// EncodeSpan encodes the keys in the given span. The span can contain
 	// either only RANGEDEL keys or only range keys.
 	//

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -931,7 +931,7 @@ func TestWriterBlockPropertiesErrors(t *testing.T) {
 				}
 			}()
 
-			err = w.AddWithForceObsolete(k1, v1, false /* forceObsolete */)
+			err = w.Add(k1, v1, false /* forceObsolete */)
 			switch tc {
 			case errSiteAdd:
 				require.Error(t, err)
@@ -940,18 +940,18 @@ func TestWriterBlockPropertiesErrors(t *testing.T) {
 			case errSiteFinishBlock:
 				require.NoError(t, err)
 				// Addition of a second key completes the first block.
-				err = w.AddWithForceObsolete(k2, v2, false /* forceObsolete */)
+				err = w.Add(k2, v2, false /* forceObsolete */)
 				require.Error(t, err)
 				require.Equal(t, blockPropErr, err)
 				return
 			case errSiteFinishIndex:
 				require.NoError(t, err)
 				// Addition of a second key completes the first block.
-				err = w.AddWithForceObsolete(k2, v2, false /* forceObsolete */)
+				err = w.Add(k2, v2, false /* forceObsolete */)
 				require.NoError(t, err)
 				// The index entry for the first block is added after the completion of
 				// the second block, which is triggered by adding a third key.
-				err = w.AddWithForceObsolete(k3, v3, false /* forceObsolete */)
+				err = w.Add(k3, v3, false /* forceObsolete */)
 				require.Error(t, err)
 				require.Equal(t, blockPropErr, err)
 				return
@@ -1059,7 +1059,7 @@ func TestWriterRace(t *testing.T) {
 			f := &objstorage.MemObj{}
 			w := newRowWriter(f, opts)
 			for ki := 0; ki < len(keys); ki++ {
-				require.NoError(t, w.AddWithForceObsolete(
+				require.NoError(t, w.Add(
 					base.MakeInternalKey(keys[ki], base.SeqNum(ki), InternalKeyKindSet), val, false /* forceObsolete */))
 				require.Equal(
 					t, w.dataBlockBuf.dataBlock.CurKey().UserKey, keys[ki],

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -54,7 +54,7 @@ Virtual tables: 0 (0B)
 Local tables size: 569B
 Compression types: snappy: 1
 Block cache: 3 entries (1.1KB)  hit rate: 18.2%
-Table cache: 1 entries (824B)  hit rate: 50.0%
+Table cache: 1 entries (832B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -75,7 +75,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 0.0%
-Table cache: 1 entries (824B)  hit rate: 0.0%
+Table cache: 1 entries (832B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -224,7 +224,7 @@ Virtual tables: 0 (0B)
 Local tables size: 595B
 Compression types: snappy: 1
 Block cache: 2 entries (716B)  hit rate: 33.3%
-Table cache: 1 entries (824B)  hit rate: 66.7%
+Table cache: 1 entries (832B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
 Filter utility: 0.0%
@@ -503,7 +503,7 @@ Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 7
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (824B)  hit rate: 53.8%
+Table cache: 1 entries (832B)  hit rate: 53.8%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -567,7 +567,7 @@ Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Compression types: snappy: 10
 Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (824B)  hit rate: 53.8%
+Table cache: 1 entries (832B)  hit rate: 53.8%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -843,7 +843,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 1 entries (824B)  hit rate: 0.0%
+Table cache: 1 entries (832B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -892,7 +892,7 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 2
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (824B)  hit rate: 50.0%
+Table cache: 1 entries (832B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -941,7 +941,7 @@ Virtual tables: 0 (0B)
 Local tables size: 589B
 Compression types: snappy: 3
 Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (824B)  hit rate: 50.0%
+Table cache: 1 entries (832B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -32,7 +32,7 @@ func writeAndIngest(t *testing.T, mem vfs.FS, d *DB, k InternalKey, v []byte, fi
 	f, err := mem.Create(path, vfs.WriteCategoryUnspecified)
 	require.NoError(t, err)
 	w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{})
-	require.NoError(t, w.AddWithForceObsolete(k, v, false /* forceObsolete */))
+	require.NoError(t, w.Add(k, v, false /* forceObsolete */))
 	require.NoError(t, w.Close())
 	require.NoError(t, d.Ingest(context.Background(), []string{path}))
 }


### PR DESCRIPTION
Add a new AddWithBlobHandle method to the sstable.RawWriter interface allowing
the writing of key-value pairs with values that encode the location of the
value out-of-band in an external blob file.

Informs #112.