### PR TITLE
*: use unsafe.Add throughout

### DIFF
--- a/batchrepr/reader.go
+++ b/batchrepr/reader.go
@@ -123,17 +123,17 @@ func DecodeStr(data []byte) (odata []byte, s []byte, ok bool) {
 	if a := *((*uint8)(ptr)); a < 128 {
 		v = uint32(a)
 		n = 1
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		v = uint32(b)<<7 | uint32(a)
 		n = 2
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		n = 3
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		n = 4
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		n = 5
 	}

--- a/cockroachkvs/cockroachkvs.go
+++ b/cockroachkvs/cockroachkvs.go
@@ -984,27 +984,27 @@ func (ks *cockroachKeySeeker) MaterializeUserKey(
 		res := ki.Buf[:roachKeyLen+2+len(untypedVersion)]
 		*(*byte)(ptr) = 0
 		memmove(
-			unsafe.Pointer(uintptr(ptr)+1),
+			unsafe.Add(ptr, 1),
 			unsafe.Pointer(unsafe.SliceData(untypedVersion)),
 			uintptr(len(untypedVersion)),
 		)
-		*(*byte)(unsafe.Pointer(uintptr(ptr) + uintptr(len(untypedVersion)+1))) = byte(len(untypedVersion) + 1)
+		*(*byte)(unsafe.Add(ptr, len(untypedVersion)+1)) = byte(len(untypedVersion) + 1)
 		return res
 	}
 
 	// Inline binary.BigEndian.PutUint64. Note that this code is converted into
 	// word-size instructions by the compiler.
 	*(*byte)(ptr) = 0
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccWall >> 56)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccWall >> 48)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccWall >> 40)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 4)) = byte(mvccWall >> 32)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 5)) = byte(mvccWall >> 24)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 6)) = byte(mvccWall >> 16)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 7)) = byte(mvccWall >> 8)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 8)) = byte(mvccWall)
+	*(*byte)(unsafe.Add(ptr, 1)) = byte(mvccWall >> 56)
+	*(*byte)(unsafe.Add(ptr, 2)) = byte(mvccWall >> 48)
+	*(*byte)(unsafe.Add(ptr, 3)) = byte(mvccWall >> 40)
+	*(*byte)(unsafe.Add(ptr, 4)) = byte(mvccWall >> 32)
+	*(*byte)(unsafe.Add(ptr, 5)) = byte(mvccWall >> 24)
+	*(*byte)(unsafe.Add(ptr, 6)) = byte(mvccWall >> 16)
+	*(*byte)(unsafe.Add(ptr, 7)) = byte(mvccWall >> 8)
+	*(*byte)(unsafe.Add(ptr, 8)) = byte(mvccWall)
 
-	ptr = unsafe.Pointer(uintptr(ptr) + 9)
+	ptr = unsafe.Add(ptr, 9)
 	// This is an MVCC key.
 	if mvccLogical == 0 {
 		*(*byte)(ptr) = 9
@@ -1013,10 +1013,10 @@ func (ks *cockroachKeySeeker) MaterializeUserKey(
 
 	// Inline binary.BigEndian.PutUint32.
 	*(*byte)(ptr) = byte(mvccLogical >> 24)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccLogical >> 16)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccLogical >> 8)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccLogical)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 4)) = 13
+	*(*byte)(unsafe.Add(ptr, 1)) = byte(mvccLogical >> 16)
+	*(*byte)(unsafe.Add(ptr, 2)) = byte(mvccLogical >> 8)
+	*(*byte)(unsafe.Add(ptr, 3)) = byte(mvccLogical)
+	*(*byte)(unsafe.Add(ptr, 4)) = 13
 	return ki.Buf[:len(ki.Buf)+14]
 }
 

--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -298,18 +298,18 @@ func (b *PrefixBytes) SetAt(it *PrefixBytesIter, i int) {
 	it.Buf = it.Buf[:it.sharedAndBundlePrefixLen+rowSuffixLen]
 
 	ptr := unsafe.Pointer(unsafe.SliceData(it.Buf))
-	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(it.syntheticPrefixLen))
+	ptr = unsafe.Add(ptr, it.syntheticPrefixLen)
 	// Copy the shared key prefix.
 	memmove(ptr, b.rawBytes.data, uintptr(b.sharedPrefixLen))
 	// Copy the bundle prefix.
-	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(b.sharedPrefixLen))
+	ptr = unsafe.Add(ptr, b.sharedPrefixLen)
 	memmove(
 		ptr,
 		unsafe.Pointer(uintptr(b.rawBytes.data)+uintptr(bundleOffsetStart)),
 		uintptr(bundlePrefixLen))
 
 	// Copy the per-row suffix.
-	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(bundlePrefixLen))
+	ptr = unsafe.Add(ptr, bundlePrefixLen)
 	memmove(
 		ptr,
 		unsafe.Pointer(uintptr(b.rawBytes.data)+uintptr(rowSuffixStart)),
@@ -341,7 +341,7 @@ func (b *PrefixBytes) SetNext(it *PrefixBytesIter) {
 		// Copy in the per-row suffix.
 		ptr := unsafe.Pointer(unsafe.SliceData(it.Buf))
 		memmove(
-			unsafe.Pointer(uintptr(ptr)+uintptr(it.sharedAndBundlePrefixLen)),
+			unsafe.Add(ptr, it.sharedAndBundlePrefixLen),
 			unsafe.Pointer(uintptr(b.rawBytes.data)+uintptr(rowSuffixStart)),
 			uintptr(rowSuffixLen))
 		return
@@ -364,13 +364,14 @@ func (b *PrefixBytes) SetNext(it *PrefixBytesIter) {
 	it.Buf = it.Buf[:it.sharedAndBundlePrefixLen+rowSuffixLen]
 	// Copy in the new bundle suffix.
 	ptr := unsafe.Pointer(unsafe.SliceData(it.Buf))
-	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(it.syntheticPrefixLen) + uintptr(b.sharedPrefixLen))
+	ptr = unsafe.Add(ptr, it.syntheticPrefixLen)
+	ptr = unsafe.Add(ptr, b.sharedPrefixLen)
 	memmove(
 		ptr,
 		unsafe.Pointer(uintptr(b.rawBytes.data)+uintptr(bundlePrefixStart)),
 		uintptr(bundlePrefixLen))
 	// Copy in the per-row suffix.
-	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(bundlePrefixLen))
+	ptr = unsafe.Add(ptr, bundlePrefixLen)
 	memmove(
 		ptr,
 		unsafe.Pointer(uintptr(b.rawBytes.data)+uintptr(rowSuffixStart)),

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -343,58 +343,58 @@ func (i *Iter) readEntry() {
 	var shared uint32
 	if a := *((*uint8)(ptr)); a < 128 {
 		shared = uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		ptr = unsafe.Add(ptr, 1)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		shared = uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		ptr = unsafe.Add(ptr, 2)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		shared = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		ptr = unsafe.Add(ptr, 3)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		shared = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		shared = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		ptr = unsafe.Add(ptr, 5)
 	}
 
 	var unshared uint32
 	if a := *((*uint8)(ptr)); a < 128 {
 		unshared = uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		ptr = unsafe.Add(ptr, 1)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		unshared = uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		ptr = unsafe.Add(ptr, 2)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		unshared = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		ptr = unsafe.Add(ptr, 3)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		unshared = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		unshared = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		ptr = unsafe.Add(ptr, 5)
 	}
 
 	var value uint32
 	if a := *((*uint8)(ptr)); a < 128 {
 		value = uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		ptr = unsafe.Add(ptr, 1)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		value = uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		ptr = unsafe.Add(ptr, 2)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		value = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		ptr = unsafe.Add(ptr, 3)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		value = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		value = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		ptr = unsafe.Add(ptr, 5)
 	}
 	shared += i.transforms.SyntheticPrefixAndSuffix.PrefixLen()
 	unsharedKey := unsafe.Slice((*byte)(ptr), int(unshared))
@@ -409,7 +409,7 @@ func (i *Iter) readEntry() {
 	} else {
 		i.key = i.fullKey
 	}
-	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(unshared))
+	ptr = unsafe.Add(ptr, unshared)
 	i.val = unsafe.Slice((*byte)(ptr), int(value))
 	i.nextOffset = offsetInBlock(uintptr(ptr)-uintptr(i.ptr)) + offsetInBlock(value)
 }
@@ -426,7 +426,7 @@ func (i *Iter) readFirstKey() error {
 	// TODO(peter): remove this hack if go:inline is ever supported.
 
 	if shared := *((*uint8)(ptr)); shared == 0 {
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
+		ptr = unsafe.Add(ptr, 1)
 	} else {
 		// The shared length is != 0, which is invalid.
 		panic("first key in block must have zero shared length")
@@ -435,33 +435,33 @@ func (i *Iter) readFirstKey() error {
 	var unshared uint32
 	if a := *((*uint8)(ptr)); a < 128 {
 		unshared = uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		ptr = unsafe.Add(ptr, 1)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		unshared = uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		ptr = unsafe.Add(ptr, 2)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		unshared = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		ptr = unsafe.Add(ptr, 3)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		unshared = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		unshared = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		ptr = unsafe.Add(ptr, 5)
 	}
 
 	// Skip the value length.
 	if a := *((*uint8)(ptr)); a < 128 {
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a := *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); a < 128 {
-		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if a := *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); a < 128 {
-		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if a := *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); a < 128 {
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 1)
+	} else if a := *((*uint8)(unsafe.Add(ptr, 1))); a < 128 {
+		ptr = unsafe.Add(ptr, 2)
+	} else if a := *((*uint8)(unsafe.Add(ptr, 2))); a < 128 {
+		ptr = unsafe.Add(ptr, 3)
+	} else if a := *((*uint8)(unsafe.Add(ptr, 3))); a < 128 {
+		ptr = unsafe.Add(ptr, 4)
 	} else {
-		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		ptr = unsafe.Add(ptr, 5)
 	}
 
 	firstKey := unsafe.Slice((*byte)(ptr), int(unshared))
@@ -597,32 +597,32 @@ func (i *Iter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 			var v1 uint32
 			if a := *((*uint8)(ptr)); a < 128 {
 				v1 = uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 1)
-			} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+				ptr = unsafe.Add(ptr, 1)
+			} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 				v1 = uint32(b)<<7 | uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 2)
-			} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+				ptr = unsafe.Add(ptr, 2)
+			} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 				v1 = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 3)
-			} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+				ptr = unsafe.Add(ptr, 3)
+			} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 				v1 = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 4)
+				ptr = unsafe.Add(ptr, 4)
 			} else {
-				d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+				d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 				v1 = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 5)
+				ptr = unsafe.Add(ptr, 5)
 			}
 
 			if *((*uint8)(ptr)) < 128 {
-				ptr = unsafe.Pointer(uintptr(ptr) + 1)
-			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))) < 128 {
-				ptr = unsafe.Pointer(uintptr(ptr) + 2)
-			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))) < 128 {
-				ptr = unsafe.Pointer(uintptr(ptr) + 3)
-			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))) < 128 {
-				ptr = unsafe.Pointer(uintptr(ptr) + 4)
+				ptr = unsafe.Add(ptr, 1)
+			} else if *((*uint8)(unsafe.Add(ptr, 1))) < 128 {
+				ptr = unsafe.Add(ptr, 2)
+			} else if *((*uint8)(unsafe.Add(ptr, 2))) < 128 {
+				ptr = unsafe.Add(ptr, 3)
+			} else if *((*uint8)(unsafe.Add(ptr, 3))) < 128 {
+				ptr = unsafe.Add(ptr, 4)
 			} else {
-				ptr = unsafe.Pointer(uintptr(ptr) + 5)
+				ptr = unsafe.Add(ptr, 5)
 			}
 
 			// Manually inlining part of base.DecodeInternalKey provides a 5-10%
@@ -780,32 +780,32 @@ func (i *Iter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 			var v1 uint32
 			if a := *((*uint8)(ptr)); a < 128 {
 				v1 = uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 1)
-			} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+				ptr = unsafe.Add(ptr, 1)
+			} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 				v1 = uint32(b)<<7 | uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 2)
-			} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+				ptr = unsafe.Add(ptr, 2)
+			} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 				v1 = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 3)
-			} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+				ptr = unsafe.Add(ptr, 3)
+			} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 				v1 = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 4)
+				ptr = unsafe.Add(ptr, 4)
 			} else {
-				d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+				d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 				v1 = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-				ptr = unsafe.Pointer(uintptr(ptr) + 5)
+				ptr = unsafe.Add(ptr, 5)
 			}
 
 			if *((*uint8)(ptr)) < 128 {
-				ptr = unsafe.Pointer(uintptr(ptr) + 1)
-			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))) < 128 {
-				ptr = unsafe.Pointer(uintptr(ptr) + 2)
-			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))) < 128 {
-				ptr = unsafe.Pointer(uintptr(ptr) + 3)
-			} else if *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))) < 128 {
-				ptr = unsafe.Pointer(uintptr(ptr) + 4)
+				ptr = unsafe.Add(ptr, 1)
+			} else if *((*uint8)(unsafe.Add(ptr, 1))) < 128 {
+				ptr = unsafe.Add(ptr, 2)
+			} else if *((*uint8)(unsafe.Add(ptr, 2))) < 128 {
+				ptr = unsafe.Add(ptr, 3)
+			} else if *((*uint8)(unsafe.Add(ptr, 3))) < 128 {
+				ptr = unsafe.Add(ptr, 4)
 			} else {
-				ptr = unsafe.Pointer(uintptr(ptr) + 5)
+				ptr = unsafe.Add(ptr, 5)
 			}
 
 			// Manually inlining part of base.DecodeInternalKey provides a 5-10%
@@ -1192,62 +1192,62 @@ func (i *Iter) nextPrefixV3(succKey []byte) *base.InternalKV {
 		var shared uint32
 		if a := *((*uint8)(ptr)); a < 128 {
 			shared = uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 1)
-		} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			ptr = unsafe.Add(ptr, 1)
+		} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 			shared = uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 2)
-		} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			ptr = unsafe.Add(ptr, 2)
+		} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 			shared = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 3)
-		} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			ptr = unsafe.Add(ptr, 3)
+		} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 			shared = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 4)
+			ptr = unsafe.Add(ptr, 4)
 		} else {
-			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+			d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 			shared = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+			ptr = unsafe.Add(ptr, 5)
 		}
 		// Decode the unshared key length integer.
 		var unshared uint32
 		if a := *((*uint8)(ptr)); a < 128 {
 			unshared = uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 1)
-		} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			ptr = unsafe.Add(ptr, 1)
+		} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 			unshared = uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 2)
-		} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			ptr = unsafe.Add(ptr, 2)
+		} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 			unshared = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 3)
-		} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			ptr = unsafe.Add(ptr, 3)
+		} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 			unshared = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 4)
+			ptr = unsafe.Add(ptr, 4)
 		} else {
-			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+			d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 			unshared = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+			ptr = unsafe.Add(ptr, 5)
 		}
 		// Decode the value length integer.
 		var value uint32
 		if a := *((*uint8)(ptr)); a < 128 {
 			value = uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 1)
-		} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			ptr = unsafe.Add(ptr, 1)
+		} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 			value = uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 2)
-		} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			ptr = unsafe.Add(ptr, 2)
+		} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 			value = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 3)
-		} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			ptr = unsafe.Add(ptr, 3)
+		} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 			value = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 4)
+			ptr = unsafe.Add(ptr, 4)
 		} else {
-			d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+			d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 			value = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-			ptr = unsafe.Pointer(uintptr(ptr) + 5)
+			ptr = unsafe.Add(ptr, 5)
 		}
 		shared += i.transforms.SyntheticPrefixAndSuffix.PrefixLen()
 		// The starting position of the value.
-		valuePtr := unsafe.Pointer(uintptr(ptr) + uintptr(unshared))
+		valuePtr := unsafe.Add(ptr, unshared)
 		i.nextOffset = offsetInBlock(uintptr(valuePtr)-uintptr(i.ptr)) + offsetInBlock(value)
 		if invariants.Enabled && unshared < 8 {
 			// This should not happen since only the key prefix is shared, so even
@@ -1257,7 +1257,7 @@ func (i *Iter) nextPrefixV3(succKey []byte) *base.InternalKV {
 		}
 		// The trailer is written in little endian, so the key kind is the first
 		// byte in the trailer that is encoded in the slice [unshared-8:unshared].
-		keyKind := base.InternalKeyKind(*(*byte)(unsafe.Pointer(uintptr(ptr) + uintptr(unshared) - 8)))
+		keyKind := base.InternalKeyKind(*(*byte)(unsafe.Add(ptr, unshared-8)))
 		keyKind = keyKind & base.InternalKeyKindSSTableInternalObsoleteMask
 		prefixChanged := false
 		if keyKind == base.InternalKeyKindSet {
@@ -1437,7 +1437,7 @@ start:
 		i.nextOffset = i.offset
 		e := &i.cached[n]
 		i.offset = e.offset
-		i.val = unsafe.Slice((*byte)(unsafe.Pointer(uintptr(i.ptr)+uintptr(e.valStart))), int(e.valSize))
+		i.val = unsafe.Slice((*byte)(unsafe.Add(i.ptr, e.valStart)), int(e.valSize))
 		// Manually inlined version of i.decodeInternalKey(i.key).
 		i.key = i.cachedBuf[e.keyStart:e.keyEnd]
 		if n := len(i.key) - 8; n >= 0 {
@@ -1653,7 +1653,7 @@ func (i *Iter) Describe(tp treeprinter.Node, fmtKV DescribeKV) {
 			Offset:    i.offset,
 			Length:    int32(i.nextOffset - i.offset),
 		}
-		ptr := unsafe.Pointer(uintptr(i.ptr) + uintptr(i.offset))
+		ptr := unsafe.Add(i.ptr, i.offset)
 		enc.KeyShared, ptr = decodeVarint(ptr)
 		enc.KeyUnshared, ptr = decodeVarint(ptr)
 		enc.ValueLen, _ = decodeVarint(ptr)
@@ -1725,7 +1725,7 @@ func (i *RawIter) readEntry() {
 	value, ptr := decodeVarint(ptr)
 	i.key = append(i.key[:shared], unsafe.Slice((*byte)(ptr), int(unshared))...)
 	i.key = i.key[:len(i.key):len(i.key)]
-	ptr = unsafe.Pointer(uintptr(ptr) + uintptr(unshared))
+	ptr = unsafe.Add(ptr, unshared)
 	i.val = unsafe.Slice((*byte)(ptr), int(value))
 	i.nextOffset = offsetInBlock(uintptr(ptr)-uintptr(i.ptr)) + offsetInBlock(value)
 }
@@ -1767,7 +1767,7 @@ func (i *RawIter) SeekGE(key []byte) bool {
 		offset := int32(binary.LittleEndian.Uint32(i.data[int(i.restarts)+4*j:]))
 		// For a restart point, there are 0 bytes shared with the previous key.
 		// The varint encoding of 0 occupies 1 byte.
-		ptr := unsafe.Pointer(uintptr(i.ptr) + uintptr(offset+1))
+		ptr := unsafe.Add(i.ptr, offset+1)
 		// Decode the key at that restart point, and compare it to the key sought.
 		v1, ptr := decodeVarint(ptr)
 		_, ptr = decodeVarint(ptr)
@@ -1839,7 +1839,7 @@ func (i *RawIter) Prev() bool {
 		i.nextOffset = i.offset
 		e := &i.cached[n-1]
 		i.offset = e.offset
-		i.val = unsafe.Slice((*byte)(unsafe.Pointer(uintptr(i.ptr)+uintptr(e.valStart))), int(e.valSize))
+		i.val = unsafe.Slice((*byte)(unsafe.Add(i.ptr, e.valStart)), int(e.valSize))
 		i.ikey.UserKey = i.cachedBuf[e.keyStart:e.keyEnd]
 		i.cached = i.cached[:n]
 		return true
@@ -1924,7 +1924,7 @@ func (i *RawIter) Describe(tp treeprinter.Node, fmtKV DescribeKV) {
 			Offset:    i.offset,
 			Length:    int32(i.nextOffset - i.offset),
 		}
-		ptr := unsafe.Pointer(uintptr(i.ptr) + uintptr(i.offset))
+		ptr := unsafe.Add(i.ptr, i.offset)
 		enc.KeyShared, ptr = decodeVarint(ptr)
 		enc.KeyUnshared, ptr = decodeVarint(ptr)
 		enc.ValueLen, _ = decodeVarint(ptr)
@@ -1946,19 +1946,19 @@ func (i *RawIter) Describe(tp treeprinter.Node, fmtKV DescribeKV) {
 func decodeVarint(ptr unsafe.Pointer) (uint32, unsafe.Pointer) {
 	if a := *((*uint8)(ptr)); a < 128 {
 		return uint32(a),
-			unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+			unsafe.Add(ptr, 1)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		return uint32(b)<<7 | uint32(a),
-			unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+			unsafe.Add(ptr, 2)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		return uint32(c)<<14 | uint32(b)<<7 | uint32(a),
-			unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+			unsafe.Add(ptr, 3)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		return uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a),
-			unsafe.Pointer(uintptr(ptr) + 4)
+			unsafe.Add(ptr, 4)
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		return uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a),
-			unsafe.Pointer(uintptr(ptr) + 5)
+			unsafe.Add(ptr, 5)
 	}
 }

--- a/sstable/valblk/valblk.go
+++ b/sstable/valblk/valblk.go
@@ -210,17 +210,17 @@ func DecodeLenFromHandle(src []byte) (uint32, []byte) {
 	if a := *((*uint8)(ptr)); a < 128 {
 		v = uint32(a)
 		src = src[1:]
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		v = uint32(b)<<7 | uint32(a)
 		src = src[2:]
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		src = src[3:]
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		src = src[4:]
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 		src = src[5:]
 	}
@@ -238,33 +238,33 @@ func DecodeRemainingHandle(src []byte) Handle {
 	var v uint32
 	if a := *((*uint8)(ptr)); a < 128 {
 		v = uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+		ptr = unsafe.Add(ptr, 1)
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		v = uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 2)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+		ptr = unsafe.Add(ptr, 2)
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 3)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+		ptr = unsafe.Add(ptr, 3)
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-		ptr = unsafe.Pointer(uintptr(ptr) + 5)
+		ptr = unsafe.Add(ptr, 5)
 	}
 	vh.BlockNum = v
 
 	if a := *((*uint8)(ptr)); a < 128 {
 		v = uint32(a)
-	} else if a, b := a&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 1))); b < 128 {
+	} else if a, b := a&0x7f, *((*uint8)(unsafe.Add(ptr, 1))); b < 128 {
 		v = uint32(b)<<7 | uint32(a)
-	} else if b, c := b&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 2))); c < 128 {
+	} else if b, c := b&0x7f, *((*uint8)(unsafe.Add(ptr, 2))); c < 128 {
 		v = uint32(c)<<14 | uint32(b)<<7 | uint32(a)
-	} else if c, d := c&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 3))); d < 128 {
+	} else if c, d := c&0x7f, *((*uint8)(unsafe.Add(ptr, 3))); d < 128 {
 		v = uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 	} else {
-		d, e := d&0x7f, *((*uint8)(unsafe.Pointer(uintptr(ptr) + 4)))
+		d, e := d&0x7f, *((*uint8)(unsafe.Add(ptr, 4)))
 		v = uint32(e)<<28 | uint32(d)<<21 | uint32(c)<<14 | uint32(b)<<7 | uint32(a)
 	}
 	vh.OffsetInBlock = v


### PR DESCRIPTION
Use unsafe.Add to simplify pointer math throughout the codebase, primarily in manually-inlined varint decoding routines.