### PR TITLE
sstable: update testutil readall to return an error

### DIFF
--- a/internal/compact/spans_test.go
+++ b/internal/compact/spans_test.go
@@ -132,10 +132,11 @@ func TestSplitAndEncodeSpan(t *testing.T) {
 			tw := sstable.NewRawWriter(obj, wo)
 			require.NoError(t, SplitAndEncodeSpan(base.DefaultComparer.Compare, &span, upToKey, tw))
 			require.NoError(t, tw.Close())
-			_, rangeDels, rangeKeys := sstable.ReadAll(obj, sstable.ReaderOptions{
+			_, rangeDels, rangeKeys, err := sstable.ReadAll(obj, sstable.ReaderOptions{
 				Comparer:   wo.Comparer,
 				KeySchemas: sstable.MakeKeySchemas(wo.KeySchema),
 			})
+			require.NoError(t, err)
 			require.LessOrEqual(t, len(rangeDels)+len(rangeKeys), 1)
 			s := "."
 			if all := append(rangeDels, rangeKeys...); len(all) == 1 {

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
-	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable/block"
 )
@@ -18,14 +17,23 @@ import (
 // sstable. Closes the Readable. Panics on errors.
 func ReadAll(
 	r objstorage.Readable, ro ReaderOptions,
-) (points []base.InternalKV, rangeDels, rangeKeys []keyspan.Span) {
-	reader := testutils.CheckErr(NewReader(context.Background(), r, ro))
+) (points []base.InternalKV, rangeDels, rangeKeys []keyspan.Span, err error) {
+	reader, err := NewReader(context.Background(), r, ro)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	defer reader.Close()
-	pointIter := testutils.CheckErr(reader.NewIter(NoTransforms, nil /* lower */, nil /* upper */))
+	pointIter, err := reader.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	defer pointIter.Close()
 
 	for kv := pointIter.First(); kv != nil; kv = pointIter.Next() {
-		val, _ := testutils.CheckErr2(kv.Value(nil))
+		val, _, err := kv.Value(nil)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		points = append(points, base.InternalKV{
 			K: kv.K.Clone(),
 			V: base.MakeInPlaceValue(val),
@@ -33,18 +41,42 @@ func ReadAll(
 	}
 
 	ctx := context.Background()
-	if rangeDelIter := testutils.CheckErr(reader.NewRawRangeDelIter(ctx, NoFragmentTransforms, block.NoReadEnv)); rangeDelIter != nil {
+	rangeDelIter, err := reader.NewRawRangeDelIter(ctx, NoFragmentTransforms, block.NoReadEnv)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if rangeDelIter != nil {
 		defer rangeDelIter.Close()
-		for s := testutils.CheckErr(rangeDelIter.First()); s != nil; s = testutils.CheckErr(rangeDelIter.Next()) {
+		s, err := rangeDelIter.First()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		for s != nil {
 			rangeDels = append(rangeDels, s.Clone())
+			s, err = rangeDelIter.Next()
+			if err != nil {
+				return nil, nil, nil, err
+			}
 		}
 	}
 
-	if rangeKeyIter := testutils.CheckErr(reader.NewRawRangeKeyIter(ctx, NoFragmentTransforms, block.NoReadEnv)); rangeKeyIter != nil {
+	rangeKeyIter, err := reader.NewRawRangeKeyIter(ctx, NoFragmentTransforms, block.NoReadEnv)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if rangeKeyIter != nil {
 		defer rangeKeyIter.Close()
-		for s := testutils.CheckErr(rangeKeyIter.First()); s != nil; s = testutils.CheckErr(rangeKeyIter.Next()) {
+		s, err := rangeKeyIter.First()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		for s != nil {
 			rangeKeys = append(rangeKeys, s.Clone())
+			s, err = rangeKeyIter.Next()
+			if err != nil {
+				return nil, nil, nil, err
+			}
 		}
 	}
-	return points, rangeDels, rangeKeys
+	return points, rangeDels, rangeKeys, nil
 }


### PR DESCRIPTION
Port of #4388 to master.

ReadAll is importing testutils which is pulling testify and other
test dependencies in the final binary

update function to return an error without calling testutils