### PR TITLE
db: don't report compaction cancelled errors

### DIFF
--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -402,17 +402,6 @@ func newCountingMockLogger(t *testing.T) (*mockLogger, *int, *int) {
 	}, &infoCount, &errorCount
 }
 
-func TestMakeLoggingEventListenerBackgroundErrorCancelledCompaction(t *testing.T) {
-	mockLogger, infoCount, errorCount := newCountingMockLogger(t)
-	e := MakeLoggingEventListener(mockLogger)
-
-	e.BackgroundError(ErrCancelledCompaction)
-	require.Equal(t, 1, *infoCount)
-	require.Equal(t, 0, *errorCount)
-
-	testAllCallbacksSetInEventListener(t, e)
-}
-
 func TestMakeLoggingEventListenerBackgroundErrorOtherError(t *testing.T) {
 	mockLogger, infoCount, errorCount := newCountingMockLogger(t)
 	e := MakeLoggingEventListener(mockLogger)

--- a/testdata/concurrent_excise
+++ b/testdata/concurrent_excise
@@ -96,7 +96,7 @@ compact a-z
 ----
 ok
 
-wait-for-background-error
+wait-for-compaction-error
 ----
 pebble: compaction cancelled by a concurrent operation, will retry compaction
 


### PR DESCRIPTION
Small change to not report `ErrCancelledCompaction` as a background
error. We still log it as an `Infof`, but we do it in Pebble and not
in the event listener.