### PR TITLE
crl-release-24.2: sstable: copy filter block during suffix rewriting

### DIFF
--- a/objstorage/test_utils.go
+++ b/objstorage/test_utils.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/pkg/errors"
 )
 
@@ -32,6 +33,13 @@ func (f *MemObj) Abort() { f.buf.Reset() }
 // Write is part of the Writable interface.
 func (f *MemObj) Write(p []byte) error {
 	_, err := f.buf.Write(p)
+	// Write is allowed to mangle the buffer. Do it sometimes in invariant
+	// builds to catch callers that don't handle this.
+	if invariants.Enabled && invariants.Sometimes(1) {
+		for i := range p {
+			p[i] = 0xFF
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
Previously, during suffix rewriting, both row and columnar sstable writers
could pass the input sstable's filter block into objstorage.Writable.Write by
passing a subslice of the original input sstables byte slice. The Write method
is permitted to mangle the input buffer, which in this case would corrupt the
original input sstable.

Informs cockroachdb/cockroach#141493.
Backport of #4265.