### PR TITLE
crl-release-24.1: sstable: copy filter block during suffix rewriting

### DIFF
--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"math"
+	"slices"
 	"sync"
 
 	"github.com/cespare/xxhash/v2"
@@ -144,7 +145,11 @@ func rewriteKeySuffixesInBlocks(
 			return nil, TableFormatUnspecified, errors.Wrap(err, "reading filter")
 		}
 		w.filter = copyFilterWriter{
-			origPolicyName: w.filter.policyName(), origMetaName: w.filter.metaName(), data: filterBlock,
+			origPolicyName: w.filter.policyName(),
+			origMetaName:   w.filter.metaName(),
+			// Clone the filter block, because readBlockBuf allows the
+			// returned byte slice to point directly into sst.
+			data: slices.Clone(filterBlock),
 		}
 	}
 
@@ -518,6 +523,10 @@ func NewMemReader(sst []byte, o ReaderOptions) (*Reader, error) {
 	return NewReader(newMemReader(sst), o)
 }
 
+// readBlockBuf may return a byte slice that points directly into sstBytes. If
+// the caller is going to expect that sstBytes remain stable, it should copy the
+// returned slice before writing it out to a objstorage.Writable which may
+// mangle it.
 func readBlockBuf(r *Reader, bh BlockHandle, buf []byte) ([]byte, []byte, error) {
 	raw := r.readable.(*memReader).b[bh.Offset : bh.Offset+bh.Length+blockTrailerLen]
 	if err := checkChecksum(r.checksumType, raw, bh, 0); err != nil {


### PR DESCRIPTION
Previously, during suffix rewriting, both row and columnar sstable writers could pass the input sstable's filter block into objstorage.Writable.Write by passing a subslice of the original input sstables byte slice. The Write method is permitted to mangle the input buffer, which in this case would corrupt the original input sstable.

Backport of pebble#4265.
Informs cockroachdb/cockroach#141493.