### PR TITLE
manifest: cleanup related to making level slices

### DIFF
--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -337,9 +337,8 @@ func NewL0Sublevels(
 	// Construct a parallel slice of sublevel B-Trees.
 	// TODO(jackson): Consolidate and only use the B-Trees.
 	for _, sublevelFiles := range s.levelFiles {
-		tr, ls := makeBTree(cmp, btreeCmpSmallestKey(cmp), sublevelFiles)
+		ls := makeLevelSlice(cmp, btreeCmpSmallestKey(cmp), sublevelFiles)
 		s.Levels = append(s.Levels, ls)
-		tr.Release(ignoreObsoleteFiles{})
 	}
 
 	s.calculateFlushSplitKeys(flushSplitMaxBytes)
@@ -630,7 +629,7 @@ func (s *L0Sublevels) AddL0Files(
 	// Construct a parallel slice of sublevel B-Trees.
 	// TODO(jackson): Consolidate and only use the B-Trees.
 	for _, sublevel := range updatedSublevels {
-		tr, ls := makeBTree(newVal.cmp, btreeCmpSmallestKey(newVal.cmp), newVal.levelFiles[sublevel])
+		ls := makeLevelSlice(newVal.cmp, btreeCmpSmallestKey(newVal.cmp), newVal.levelFiles[sublevel])
 		if sublevel == len(newVal.Levels) {
 			newVal.Levels = append(newVal.Levels, ls)
 		} else {
@@ -638,7 +637,6 @@ func (s *L0Sublevels) AddL0Files(
 			// populated correctly.
 			newVal.Levels[sublevel] = ls
 		}
-		tr.Release(ignoreObsoleteFiles{})
 	}
 
 	newVal.flushSplitUserKeys = nil

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -65,7 +65,9 @@ func makeBTree(cmp base.Compare, bcmp btreeCmp, files []*TableMetadata) (btree, 
 	t.cmp = cmp
 	t.bcmp = bcmp
 	for _, f := range files {
-		t.Insert(f)
+		if err := t.Insert(f); err != nil {
+			panic(err)
+		}
 	}
 	return t, newLevelSlice(t.Iter())
 }

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1208,7 +1208,7 @@ func NewVersion(
 		// order to test consistency checking, etc. Once we've constructed the
 		// initial B-Tree, we swap out the btreeCmp for the correct one.
 		// TODO(jackson): Adjust or remove the tests and remove this.
-		v.Levels[l].tree, _ = makeBTree(comparer.Compare, btreeCmpSpecificOrder(files[l]), files[l])
+		v.Levels[l].tree = makeBTree(comparer.Compare, btreeCmpSpecificOrder(files[l]), files[l])
 		v.Levels[l].level = l
 		if l == 0 {
 			v.Levels[l].tree.bcmp = btreeCmpSeqNum

--- a/testdata/compaction_check_ordering
+++ b/testdata/compaction_check_ordering
@@ -41,8 +41,9 @@ L0
 L0 files 000001 and 000002 are not properly ordered: <#2-#4> vs <#3-#3>
 
 check-ordering
-L0
+L0.0
   a.SET.3-d.SET.3
+L0.1
   a.SET.3-b.SET.3
 ----
 OK


### PR DESCRIPTION
#### manifest: check Insert error in makeBTree


#### manifest: add separate makeLevelSlice

All callers of `makeBTree` either need just the tree or just the
slice, so make a separate function for the slice.