### PR TITLE
manifest: add L0Sublevels sanity checks, fix L0Index

### DIFF
--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -331,6 +331,7 @@ func NewL0Sublevels(
 	}
 
 	s.calculateFlushSplitKeys(flushSplitMaxBytes)
+	s.Check()
 	return s, nil
 }
 
@@ -441,8 +442,36 @@ func mergeIntervals(
 func (s *L0Sublevels) AddL0Files(
 	files []*TableMetadata, flushSplitMaxBytes int64, levelMetadata *LevelMetadata,
 ) (*L0Sublevels, error) {
-	if invariants.Enabled && s.addL0FilesCalled {
-		panic("AddL0Files called twice on the same receiver")
+	if s.addL0FilesCalled {
+		if invariants.Enabled {
+			panic("AddL0Files called twice on the same receiver")
+		}
+		return nil, errInvalidL0SublevelsOpt
+	}
+	if s.levelMetadata.Len()+len(files) != levelMetadata.Len() {
+		if invariants.Enabled {
+			panic("levelMetadata mismatch")
+		}
+		return nil, errInvalidL0SublevelsOpt
+	}
+	// AddL0Files only works when the files we are adding match exactly the last
+	// files in the new levelMetadata (and the previous s.levelMetadata matches a
+	// prefix of the new levelMetadata).
+	{
+		iterOld, iterNew := s.levelMetadata.Iter(), levelMetadata.Iter()
+		tOld, tNew := iterOld.First(), iterNew.First()
+		for i := 0; i < s.levelMetadata.Len(); i++ {
+			if tOld != tNew {
+				return nil, errInvalidL0SublevelsOpt
+			}
+			tOld, tNew = iterOld.Next(), iterNew.Next()
+		}
+		for i := range files {
+			if files[i] != tNew {
+				return nil, errInvalidL0SublevelsOpt
+			}
+			tNew = iterNew.Next()
+		}
 	}
 	s.addL0FilesCalled = true
 
@@ -630,6 +659,7 @@ func (s *L0Sublevels) AddL0Files(
 
 	newVal.flushSplitUserKeys = nil
 	newVal.calculateFlushSplitKeys(flushSplitMaxBytes)
+	newVal.Check()
 	return newVal, nil
 }
 
@@ -778,6 +808,33 @@ func (s *L0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 			for j := minIndex; j <= interval.filesMaxIntervalIndex; j++ {
 				min = j
 				s.orderedIntervals[j].intervalRangeIsBaseCompacting = true
+			}
+		}
+	}
+}
+
+// Check performs sanity checks on L0Sublevels in invariants mode.
+func (s *L0Sublevels) Check() {
+	if !invariants.Enabled {
+		return
+	}
+	iter := s.levelMetadata.Iter()
+	n := 0
+	for t := iter.First(); t != nil; n, t = n+1, iter.Next() {
+		if t.L0Index != n {
+			panic(fmt.Sprintf("t.L0Index out of sync (%d vs %d)", t.L0Index, n))
+		}
+	}
+	if len(s.Levels) != len(s.levelFiles) {
+		panic("Levels and levelFiles inconsistency")
+	}
+	for i := range s.Levels {
+		if s.Levels[i].Len() != len(s.levelFiles[i]) {
+			panic("Levels and levelFiles inconsistency")
+		}
+		for _, t := range s.levelFiles[i] {
+			if t.SubLevel != i {
+				panic("t.SubLevel out of sync")
 			}
 		}
 	}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -298,6 +298,8 @@ type TableMetadata struct {
 
 	// For L0 files only. Protected by DB.mu. Used to generate L0 sublevels and
 	// pick L0 compactions. Only accurate for the most recent Version.
+	// TODO(radu): this is very hacky and fragile. This information should live
+	// inside L0Sublevels.
 	SubLevel         int
 	L0Index          int
 	minIntervalIndex int


### PR DESCRIPTION
Add sanity checking to `L0Sublevels`.

The `L0Index` check was failing, suggesting that the code below made
an incorrect assumption about files exactly matching the last files in
the new levelMetadata:

```
	// Update interval indices for new files.
	for i, f := range files {
		f.L0Index = s.levelMetadata.Len() + i
```

I added extra checks to `AddL0Files` to bail out if this assumption is
not correct.