### PR TITLE
internal/manifest: use slices.SortFunc

### DIFF
--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -261,21 +261,10 @@ type L0Sublevels struct {
 	addL0FilesCalled bool
 }
 
-type sublevelSorter []*TableMetadata
-
-// Len implements sort.Interface.
-func (sl sublevelSorter) Len() int {
-	return len(sl)
-}
-
-// Less implements sort.Interface.
-func (sl sublevelSorter) Less(i, j int) bool {
-	return sl[i].minIntervalIndex < sl[j].minIntervalIndex
-}
-
-// Swap implements sort.Interface.
-func (sl sublevelSorter) Swap(i, j int) {
-	sl[i], sl[j] = sl[j], sl[i]
+func sortByMinIntervalIndex(files []*TableMetadata) {
+	slices.SortFunc(files, func(a, b *TableMetadata) int {
+		return stdcmp.Compare(a.minIntervalIndex, b.minIntervalIndex)
+	})
 }
 
 // NewL0Sublevels creates an L0Sublevels instance for a given set of L0 files.
@@ -331,7 +320,7 @@ func NewL0Sublevels(
 	}
 	// Sort each sublevel in increasing key order.
 	for i := range s.levelFiles {
-		sort.Sort(sublevelSorter(s.levelFiles[i]))
+		sortByMinIntervalIndex(s.levelFiles[i])
 	}
 
 	// Construct a parallel slice of sublevel B-Trees.
@@ -624,7 +613,7 @@ func (s *L0Sublevels) AddL0Files(
 
 	// Sort each updated sublevel in increasing key order.
 	for _, sublevel := range updatedSublevels {
-		sort.Sort(sublevelSorter(newVal.levelFiles[sublevel]))
+		sortByMinIntervalIndex(newVal.levelFiles[sublevel])
 	}
 
 	// Construct a parallel slice of sublevel B-Trees.


### PR DESCRIPTION
Use slices.SortFunc instead of implementing the sort.Interface in the implementation of L0 sublevels.