### PR TITLE
db: embed DataCorruptionInfo into corruption errors

### DIFF
--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -590,11 +590,15 @@ func TestSSTCorruptionEvent(t *testing.T) {
 			}
 			_, _, err = d.Get(key(5))
 			require.Error(t, err)
+			require.True(t, IsCorruptionError(err))
+			infoInError := ExtractDataCorruptionInfo(err)
+			require.NotNil(t, infoInError)
 			require.Greater(t, len(events), 0)
 			info := events[0]
 			require.Equal(t, info.Path, sstFileName)
 			require.False(t, info.IsRemote)
 			require.Equal(t, base.UserKeyBoundsInclusive(key(0), key(99)), info.Bounds)
+			require.Equal(t, info, *infoInError)
 
 			d.Close()
 		})

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -192,7 +192,7 @@ func (t *fileCacheTest) cleanup() {
 	t.blockCache.Unref()
 }
 
-func noopCorruptionFn(any, error) {}
+func noopCorruptionFn(_ any, err error) error { return err }
 
 // newTestHandle creates a filesystem with a set of test tables and an
 // associated file cache handle. The caller must close the handle.

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -378,8 +378,9 @@ type ReadEnv struct {
 
 	// ReportCorruptionFn is called with ReportCorruptionArg and the error
 	// whenever an SSTable corruption is detected. The argument is used to avoid
-	// allocating a separate function for each object.
-	ReportCorruptionFn  func(opaque any, err error)
+	// allocating a separate function for each object. It returns an error with
+	// more details.
+	ReportCorruptionFn  func(opaque any, err error) error
 	ReportCorruptionArg any
 }
 
@@ -407,10 +408,11 @@ func (env *ReadEnv) BlockRead(blockLength uint64, readDuration time.Duration) {
 
 // maybeReportCorruption calls the ReportCorruptionFn if the given error
 // indicates corruption.
-func (env *ReadEnv) maybeReportCorruption(err error) {
+func (env *ReadEnv) maybeReportCorruption(err error) error {
 	if env.ReportCorruptionFn != nil && base.IsCorruptionError(err) {
-		env.ReportCorruptionFn(env.ReportCorruptionArg, err)
+		return env.ReportCorruptionFn(env.ReportCorruptionArg, err)
 	}
+	return err
 }
 
 // A Reader reads blocks from a single file, handling caching, checksum
@@ -472,8 +474,7 @@ func (r *Reader) Read(
 		}
 		value, err := r.doRead(ctx, env, readHandle, bh, initBlockMetadataFn)
 		if err != nil {
-			env.maybeReportCorruption(err)
-			return BufferHandle{}, err
+			return BufferHandle{}, env.maybeReportCorruption(err)
 		}
 		return value.MakeHandle(), nil
 	}
@@ -491,8 +492,7 @@ func (r *Reader) Read(
 		// to report corruption errors separately, since the ReportCorruptionArg
 		// could be different. In particular, we might read the same physical block
 		// (e.g. an index block) for two different virtual tables.
-		env.maybeReportCorruption(err)
-		return BufferHandle{}, err
+		return BufferHandle{}, env.maybeReportCorruption(err)
 	}
 
 	if cv != nil {
@@ -508,8 +508,7 @@ func (r *Reader) Read(
 	value, err := r.doRead(ctx, env, readHandle, bh, initBlockMetadataFn)
 	if err != nil {
 		crh.SetReadError(err)
-		env.maybeReportCorruption(err)
-		return BufferHandle{}, err
+		return BufferHandle{}, env.maybeReportCorruption(err)
 	}
 	crh.SetReadValue(value.v)
 	return value.MakeHandle(), nil


### PR DESCRIPTION
We now add the `DataCorruptionInfo` to corruption errors and allow
users to extract it using `ExtractDataCorruptionInfo()`.