### PR TITLE
internal/manual: sometimes Go-allocate memory in race builds

### DIFF
--- a/internal/manual/manual_cgo.go
+++ b/internal/manual/manual_cgo.go
@@ -6,6 +6,12 @@ package manual
 
 // #include <stdlib.h>
 import "C"
+import (
+	"math/rand/v2"
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
 
 // The go:linkname directives provides backdoor access to private functions in
 // the runtime. Below we're accessing the throw function.
@@ -13,18 +19,36 @@ import "C"
 //go:linkname throw runtime.throw
 func throw(s string)
 
+// useGoAllocation is used in race-enabled builds to configure the package to
+// use ordinary Go allocations with make([]byte, n). This is done under the
+// assumption that the Go race detector will detect races within cgo-allocated
+// memory. Performing some allocations using Go allows the race detector to
+// observe concurrent memory access to memory allocated by this package.
+//
+// TODO(jackson): Confirm that the race detector does not detect races within
+// cgo-allocated memory.
+var useGoAllocation = invariants.RaceEnabled && rand.Uint32()%2 == 0
+
 // TODO(peter): Rather than relying an C malloc/free, we could fork the Go
 // runtime page allocator and allocate large chunks of memory using mmap or
 // similar.
 
-// New allocates a slice of size n. The returned slice is from manually managed
-// memory and MUST be released by calling Free. Failure to do so will result in
-// a memory leak.
+// New allocates a slice of size n. The returned slice is from manually
+// managed memory and MUST be released by calling Free. Failure to do so will
+// result in a memory leak.
 func New(purpose Purpose, n uintptr) Buf {
 	if n == 0 {
 		return Buf{}
 	}
 	recordAlloc(purpose, n)
+
+	// In race-enabled builds, we sometimes make allocations using Go to allow
+	// the race detector to observe concurrent memory access to memory allocated
+	// by this package. See the definition of useGoAllocation for more details.
+	if invariants.RaceEnabled && useGoAllocation {
+		b := make([]byte, n)
+		return Buf{data: unsafe.Pointer(&b[0]), n: n}
+	}
 	// We need to be conscious of the Cgo pointer passing rules:
 	//
 	//   https://golang.org/cmd/cgo/#hdr-Passing_pointers
@@ -52,6 +76,9 @@ func New(purpose Purpose, n uintptr) Buf {
 func Free(purpose Purpose, b Buf) {
 	if b.n != 0 {
 		recordFree(purpose, b.n)
-		C.free(b.data)
+
+		if !invariants.RaceEnabled || !useGoAllocation {
+			C.free(b.data)
+		}
 	}
 }


### PR DESCRIPTION
It's unclear if the Go race detector can detect race in memory that's allocated by cgo, but under the assumption it can't, this commit adapts the manual package to allocate some of its allocations using standard Go allocations in race builds. The hope is that if data races exist in the data structures allocated using the manual package, sometimes Go-allocating this memory will surface them in our race-build test runs.

Motivated by cockroachdb/cockroach#142868.