### PR TITLE
record: add logger to reader, update walSync test to use logger

### DIFF
--- a/record/testdata/walSync
+++ b/record/testdata/walSync
@@ -45,6 +45,9 @@ Blocks
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 1
 bytes read: 0
@@ -61,6 +64,9 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 1
 bytes read: 0
@@ -73,37 +79,118 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 19 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
+Read block 2 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 2
 bytes read: 0
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    └── Chunk #0 (offset 0, corrupt)
+ │         ├── Checksum: 3178158960
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 0
+ ├── Block #1
+ │    └── Chunk #0 (offset 32768)
+ │         └── EOF
+ └── 
 
 # Multiple corruption with no confirmation
 init
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
-
 EOF logNum=2
 ----
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=3178158960, length=32749, encoding=9
+	Checksum mismatch in block 1 at offset 32768; potential corruption
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    └── Chunk #0 (offset 0, corrupt)
+ │         ├── Checksum: 3178158960
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 0
+ ├── Block #1
+ │    └── Chunk #0 (offset 32768, corrupt)
+ │         ├── Checksum: 3178158960
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 0
+ ├── Block #2
+ │    └── Chunk #0 (offset 65536)
+ │         └── EOF
+ └── 
 
 # Multiple corruption but large offset is also corrupt, no confirmation
 init
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=true
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100000 corrupt=true
-
 EOF logNum=2
 ----
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2875854606, length=32749, encoding=9
+	Checksum mismatch in block 1 at offset 32768; potential corruption
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    └── Chunk #0 (offset 0, corrupt)
+ │         ├── Checksum: 3178158960
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 0
+ ├── Block #1
+ │    └── Chunk #0 (offset 32768, corrupt)
+ │         ├── Checksum: 2875854606
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 100000
+ ├── Block #2
+ │    └── Chunk #0 (offset 65536)
+ │         └── EOF
+ └── 
 
 # Simple corruption with confirmation
 init
@@ -114,9 +201,35 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 39 bytes
+	Block 1: Processing chunk at offset 0, checksum=2230101255, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=30000 (invalidOffset=19)
+	Corruption confirmed: syncedOffset 30000 exceeds invalidOffset 19
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    └── Chunk #0 (offset 0, corrupt)
+ │         ├── Checksum: 3178158960
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 0
+ ├── Block #1
+ │    ├── Chunk #0 (offset 32768)
+ │    │    ├── Checksum: 2230101255
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 30000
+ │    └── Chunk #1 (offset 32788)
+ │         └── EOF
+ └── 
 
 # Corrupt the first block with confirming chunks after. However, these next chunks
 # in the same block cannot be used to confirm because reading ahead jumps to the next
@@ -131,9 +244,48 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=19)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 19
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    ├── Chunk #0 (offset 0, corrupt)
+ │    │    ├── Checksum: 3716504721
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 0
+ │    ├── Chunk #1 (offset 20)
+ │    │    ├── Checksum: 3591204049
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 60
+ │    └── Chunk #2 (offset 40)
+ │         ├── Checksum: 649293827
+ │         ├── Encoded Length: 32709
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 60
+ ├── Block #1
+ │    └── Chunk #0 (offset 32768)
+ │         ├── Checksum: 400517472
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 32000
+ ├── Block #2
+ │    └── Chunk #0 (offset 65536)
+ │         └── EOF
+ └── 
 
 # Corrupt the first block with confirming chunks after. However, these next chunks
 # in the same block cannot be used to confirm because reading ahead jumps to the next
@@ -148,9 +300,52 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=383674465, length=32749, encoding=9
+	Checksum mismatch in block 1 at offset 32768; potential corruption
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    ├── Chunk #0 (offset 0, corrupt)
+ │    │    ├── Checksum: 3716504721
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 0
+ │    ├── Chunk #1 (offset 20)
+ │    │    ├── Checksum: 3591204049
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 60
+ │    └── Chunk #2 (offset 40)
+ │         ├── Checksum: 649293827
+ │         ├── Encoded Length: 32709
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 60
+ ├── Block #1
+ │    └── Chunk #0 (offset 32768, corrupt)
+ │         ├── Checksum: 383674465
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 32000
+ ├── Block #2
+ │    └── Chunk #0 (offset 65536)
+ │         └── EOF
+ └── 
 
 # Complex multiple corruption with no confirmation
 init
@@ -167,9 +362,84 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=383674465, length=32749, encoding=9
+	Checksum mismatch in block 1 at offset 32768; potential corruption
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=614591033, length=1, encoding=9
+	Checksum mismatch in block 2 at offset 20; potential corruption
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=1645328786, length=32749, encoding=9
+	Checksum mismatch in block 3 at offset 32768; potential corruption
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 0
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    ├── Chunk #0 (offset 0, corrupt)
+ │    │    ├── Checksum: 3716504721
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 0
+ │    ├── Chunk #1 (offset 20)
+ │    │    ├── Checksum: 3591204049
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 60
+ │    └── Chunk #2 (offset 40)
+ │         ├── Checksum: 649293827
+ │         ├── Encoded Length: 32709
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 60
+ ├── Block #1
+ │    └── Chunk #0 (offset 32768, corrupt)
+ │         ├── Checksum: 383674465
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 32000
+ ├── Block #2
+ │    ├── Chunk #0 (offset 65536, corrupt)
+ │    │    ├── Checksum: 614591033
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 32000
+ │    ├── Chunk #1 (offset 65556, corrupt)
+ │    │    ├── Checksum: 614591033
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 32000
+ │    └── Chunk #2 (offset 65576)
+ │         ├── Checksum: 1960442165
+ │         ├── Encoded Length: 32709
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 32000
+ ├── Block #3
+ │    └── Chunk #0 (offset 98304, corrupt)
+ │         ├── Checksum: 1645328786
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 64000
+ ├── Block #4
+ │    └── Chunk #0 (offset 131072)
+ │         └── EOF
+ └── 
 
 # Complex multiple corruption with confirmation in blockNum 3
 init
@@ -186,9 +456,80 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=383674465, length=32749, encoding=9
+	Checksum mismatch in block 1 at offset 32768; potential corruption
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=3716504721, length=1, encoding=9
+	Checksum mismatch in block 2 at offset 20; potential corruption
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=19)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 19
 error reading next: pebble/record: invalid chunk
 final blockNum: 3
 bytes read: 0
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    ├── Chunk #0 (offset 0, corrupt)
+ │    │    ├── Checksum: 3716504721
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 0
+ │    ├── Chunk #1 (offset 20)
+ │    │    ├── Checksum: 3591204049
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 60
+ │    └── Chunk #2 (offset 40)
+ │         ├── Checksum: 649293827
+ │         ├── Encoded Length: 32709
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 60
+ ├── Block #1
+ │    └── Chunk #0 (offset 32768, corrupt)
+ │         ├── Checksum: 383674465
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 32000
+ ├── Block #2
+ │    ├── Chunk #0 (offset 65536, corrupt)
+ │    │    ├── Checksum: 3716504721
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 0
+ │    ├── Chunk #1 (offset 65556, corrupt)
+ │    │    ├── Checksum: 3607915984
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 60
+ │    └── Chunk #2 (offset 65576)
+ │         ├── Checksum: 649293827
+ │         ├── Encoded Length: 32709
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 60
+ ├── Block #3
+ │    └── Chunk #0 (offset 98304)
+ │         ├── Checksum: 400517472
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 32000
+ ├── Block #4
+ │    └── Chunk #0 (offset 131072)
+ │         └── EOF
+ └── 
 
 # Complex multiple corruption with confirmation offset too small
 init
@@ -203,9 +544,69 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 1.
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=3716504721, length=1, encoding=9
+	Checksum mismatch in block 2 at offset 20; potential corruption
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3770313817, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=100 (invalidOffset=32787)
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 32749
+
+describe
+----
+Blocks
+ ├── Block #0
+ │    └── Chunk #0 (offset 0)
+ │         ├── Checksum: 3161447025
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 0
+ ├── Block #1
+ │    └── Chunk #0 (offset 32768, corrupt)
+ │         ├── Checksum: 3178158960
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 0
+ ├── Block #2
+ │    ├── Chunk #0 (offset 65536, corrupt)
+ │    │    ├── Checksum: 3716504721
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 0
+ │    ├── Chunk #1 (offset 65556, corrupt)
+ │    │    ├── Checksum: 3607915984
+ │    │    ├── Encoded Length: 1
+ │    │    ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │    │    ├── Log Num: 1
+ │    │    └── Synced Offset: 60
+ │    └── Chunk #2 (offset 65576)
+ │         ├── Checksum: 1521797213
+ │         ├── Encoded Length: 32709
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 100
+ ├── Block #3
+ │    └── Chunk #0 (offset 98304)
+ │         ├── Checksum: 3770313817
+ │         ├── Encoded Length: 32749
+ │         ├── Chunk encoding: 9 (chunkType: 1, wireFormat: 3)
+ │         ├── Log Num: 1
+ │         └── Synced Offset: 100
+ ├── Block #4
+ │    └── Chunk #0 (offset 131072)
+ │         └── EOF
+ └── 
 
 ###########################
 ###### log num cases ######
@@ -222,6 +623,9 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 1
 bytes read: 0
@@ -234,6 +638,12 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 19 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
+Read block 2 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 2
 bytes read: 0
@@ -247,6 +657,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2371060608, length=32749, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 0)
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -261,6 +680,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=3034178164, length=32749, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 100)
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -274,6 +702,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 39 bytes
+	Block 1: Processing chunk at offset 0, checksum=2230101255, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=30000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 30000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -291,6 +724,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -308,6 +746,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=685962385, length=32749, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 0)
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -317,13 +764,10 @@ init
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=32000 corrupt=false
-
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=32000 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=32000 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=32000 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=64000 corrupt=false
 
 EOF logNum=2
@@ -331,6 +775,21 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=685962385, length=32749, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 0)
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=2522303644, length=1, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 0)
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3593774434, length=32749, encoding=9
+	Mismatch log number in block 3 at offset 0 (expected 1, got 0)
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 0
@@ -341,13 +800,10 @@ init
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=0 offset=32000 corrupt=false
-
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=0 offset=0 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
 
 EOF logNum=2
@@ -355,6 +811,17 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=685962385, length=32749, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 0)
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=3981311476, length=1, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 0)
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 3
 bytes read: 0
@@ -377,6 +844,18 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 1.
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=3981311476, length=1, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 0)
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3770313817, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=100 (invalidOffset=32768)
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 32749
@@ -395,6 +874,9 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 1
 bytes read: 0
@@ -407,6 +889,12 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 19 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
+Read block 2 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 2
 bytes read: 0
@@ -414,14 +902,21 @@ bytes read: 0
 # Multiple wire issues with no confirmation
 init
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
-
 EOF logNum=2
 ----
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2710594051, length=32749, encoding=0
+	Invalid wire format detected in block 1 at offset 0
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -429,7 +924,6 @@ bytes read: 0
 # Multiple wire issues but large offset is also has issues, no confirmation
 init
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=100000 corrupt=false
 
 EOF logNum=2
@@ -437,6 +931,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2207032925, length=32749, encoding=0
+	Invalid wire format detected in block 1 at offset 0
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -444,13 +947,17 @@ bytes read: 0
 # Simple wire issues with confirmation
 init
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
-
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=30000 corrupt=false
 EOF logNum=2
 ----
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 39 bytes
+	Block 1: Processing chunk at offset 0, checksum=2230101255, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=30000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 30000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -462,13 +969,17 @@ init
 writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=32000 corrupt=false
 EOF logNum=2
 ----
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -480,14 +991,21 @@ init
 writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=32000 corrupt=false
-
 EOF logNum=2
 ----
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=910217490, length=32749, encoding=0
+	Invalid wire format detected in block 1 at offset 0
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -497,20 +1015,31 @@ init
 writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=9 logNum=1 offset=60 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=60 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=32000 corrupt=false
-
 writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=32000 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=32000 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=32000 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=64000 corrupt=false
-
 EOF logNum=2
 ----
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=910217490, length=32749, encoding=0
+	Invalid wire format detected in block 1 at offset 0
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=1220209282, length=1, encoding=0
+	Invalid wire format detected in block 2 at offset 0
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3371122657, length=32749, encoding=0
+	Invalid wire format detected in block 3 at offset 0
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 0
@@ -535,6 +1064,17 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=910217490, length=32749, encoding=0
+	Invalid wire format detected in block 1 at offset 0
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=3249240138, length=1, encoding=0
+	Invalid wire format detected in block 2 at offset 0
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 3
 bytes read: 0
@@ -543,20 +1083,28 @@ bytes read: 0
 # Complex multiple wire issue with confirmation offset too small
 init
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=0 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=0 logNum=1 offset=0 corrupt=false
-
 writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=0 corrupt=false
 writeChunk encodedLength=1 chunkLength=1 encoding=0 logNum=1 offset=60 corrupt=false
 writeChunk encodedLength=32709 chunkLength=32709 encoding=9 logNum=1 offset=100 corrupt=false
-
 writeChunk encodedLength=32749 chunkLength=32749 encoding=9 logNum=1 offset=100 corrupt=false
-
 EOF logNum=2
 ----
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 1.
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=3249240138, length=1, encoding=0
+	Invalid wire format detected in block 2 at offset 0
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3770313817, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=100 (invalidOffset=32768)
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 32749
@@ -575,6 +1123,12 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 19 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
+Read block 2 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 2
 bytes read: 32730
@@ -590,6 +1144,17 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=4108154917, length=32730, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=0 (invalidOffset=0)
+	Block 1: Processing chunk at offset 32749, checksum=0, length=0, encoding=0
+	Found invalid chunk marker at block 1 offset 32749; aborting this block scan
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -605,6 +1170,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=0
+	Found invalid chunk marker at block 1 offset 0; aborting this block scan
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 32730
@@ -620,6 +1194,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 39 bytes
+	Block 1: Processing chunk at offset 0, checksum=2654412641, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=100000 (invalidOffset=32749)
+	Corruption confirmed: syncedOffset 100000 exceeds invalidOffset 32749
 error reading next: pebble/record: zeroed chunk
 final blockNum: 1
 bytes read: 32730
@@ -633,6 +1212,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 39 bytes
+	Block 1: Processing chunk at offset 0, checksum=2654412641, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=100000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 100000 exceeds invalidOffset 0
 error reading next: pebble/record: zeroed chunk
 final blockNum: 1
 bytes read: 0
@@ -650,6 +1234,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2529962274, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=1000000 (invalidOffset=20)
+	Corruption confirmed: syncedOffset 1000000 exceeds invalidOffset 20
 error reading next: pebble/record: zeroed chunk
 final blockNum: 1
 bytes read: 1
@@ -668,6 +1257,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=0
+	Found invalid chunk marker at block 1 offset 0; aborting this block scan
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -686,6 +1284,16 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=957580701, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=1 (invalidOffset=20)
+	Block 1: Processing chunk at offset 20, checksum=0, length=0, encoding=0
+	Found invalid chunk marker at block 1 offset 20; aborting this block scan
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=1662040211, length=32749, encoding=9
+	Block 2: Found WAL sync chunk with syncedOffset=64000 (invalidOffset=20)
+	Corruption confirmed: syncedOffset 64000 exceeds invalidOffset 20
 error reading next: pebble/record: zeroed chunk
 final blockNum: 2
 bytes read: 1
@@ -705,6 +1313,20 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 1.
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=957580701, length=1, encoding=9
+	Block 2: Found WAL sync chunk with syncedOffset=1 (invalidOffset=32788)
+	Block 2: Processing chunk at offset 20, checksum=0, length=0, encoding=0
+	Found invalid chunk marker at block 2 offset 20; aborting this block scan
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3770313817, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=100 (invalidOffset=32788)
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 32750
@@ -722,6 +1344,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=19)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 19
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -734,6 +1361,9 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 1
 bytes read: 0
@@ -747,6 +1377,12 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 19 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
+Read block 2 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 2
 bytes read: 0
@@ -761,6 +1397,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=3161447025, length=64000, encoding=9
+	Chunk in block 1 spans beyond block boundaries (begin=19, end=64019, n=32768)
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -775,6 +1420,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2172933859, length=64000, encoding=9
+	Chunk in block 1 spans beyond block boundaries (begin=19, end=64019, n=32768)
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -788,6 +1442,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 39 bytes
+	Block 1: Processing chunk at offset 0, checksum=2230101255, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=30000 (invalidOffset=19)
+	Corruption confirmed: syncedOffset 30000 exceeds invalidOffset 19
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -805,6 +1464,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2172933859, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=1000 (invalidOffset=19)
+	Corruption confirmed: syncedOffset 1000 exceeds invalidOffset 19
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -822,6 +1486,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=400517472, length=64000, encoding=9
+	Chunk in block 1 spans beyond block boundaries (begin=19, end=64019, n=32768)
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -841,6 +1514,21 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=685962385, length=32749, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 0)
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=2522303644, length=1, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 0)
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3593774434, length=32749, encoding=9
+	Mismatch log number in block 3 at offset 0 (expected 1, got 0)
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 0
@@ -860,6 +1548,17 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=400517472, length=64000, encoding=9
+	Chunk in block 1 spans beyond block boundaries (begin=19, end=64019, n=32768)
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=3699662224, length=200, encoding=9
+	Checksum mismatch in block 2 at offset 219; potential corruption
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=39)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 39
 error reading next: pebble/record: invalid chunk
 final blockNum: 3
 bytes read: 1
@@ -880,6 +1579,21 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 1.
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=400517472, length=64000, encoding=9
+	Chunk in block 2 spans beyond block boundaries (begin=19, end=64019, n=32768)
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3699662224, length=200, encoding=9
+	Checksum mismatch in block 3 at offset 219; potential corruption
+Read block 4 with 32768 bytes
+	Block 4: Processing chunk at offset 0, checksum=3770313817, length=32749, encoding=9
+	Block 4: Found WAL sync chunk with syncedOffset=100 (invalidOffset=32807)
+Read block 5 with 19 bytes
+	Block 5: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 5 at offset 0 (expected 1, got 2)
+Read block 6 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 6
 bytes read: 32750
@@ -897,6 +1611,9 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 1
 bytes read: 0
@@ -909,6 +1626,12 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 19 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
+Read block 2 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 2
 bytes read: 0
@@ -922,6 +1645,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=4212587649, length=32749, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 1
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -935,6 +1667,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=3910387679, length=32749, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 1
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -948,6 +1689,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 39 bytes
+	Block 1: Processing chunk at offset 0, checksum=2230101255, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=30000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 30000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -965,6 +1711,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 0
@@ -982,6 +1733,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=3601296272, length=32749, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 1
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 0
@@ -1001,6 +1761,21 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=3601296272, length=32749, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 1
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=3330109772, length=1, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 2
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=611851875, length=32749, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 3
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 0
@@ -1020,6 +1795,17 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=3601296272, length=32749, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 1
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=1030283140, length=1, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 2
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=400517472, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=32000 (invalidOffset=0)
+	Corruption confirmed: syncedOffset 32000 exceeds invalidOffset 0
 error reading next: pebble/record: invalid chunk
 final blockNum: 3
 bytes read: 0
@@ -1037,6 +1823,18 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 1.
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=1030283140, length=1, encoding=100
+	Invalid chunk encoding encountered (value: 100); stopping chunk scan in block 2
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3770313817, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=100 (invalidOffset=32768)
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 32749
@@ -1056,6 +1854,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2928164217, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=60000 (invalidOffset=32757)
+	Corruption confirmed: syncedOffset 60000 exceeds invalidOffset 32757
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 32738
@@ -1069,6 +1872,12 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 19 bytes
+	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
+Read block 2 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 2
 bytes read: 32738
@@ -1084,6 +1893,17 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=1047728140, length=32738, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=0 (invalidOffset=32757)
+	Block 1: Processing chunk at offset 32757, checksum=16843009, length=257, encoding=9
+	Incomplete header in block 1 at offset 32757; breaking out
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 32738
@@ -1099,6 +1919,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=1660446616, length=32738, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=1000000 (invalidOffset=32757)
+	Corruption confirmed: syncedOffset 1000000 exceeds invalidOffset 32757
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 32738
@@ -1113,6 +1938,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 39 bytes
+	Block 1: Processing chunk at offset 0, checksum=2654412641, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=100000 (invalidOffset=32757)
+	Corruption confirmed: syncedOffset 100000 exceeds invalidOffset 32757
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 32738
@@ -1130,6 +1960,11 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=2529962274, length=32749, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=1000000 (invalidOffset=20)
+	Corruption confirmed: syncedOffset 1000000 exceeds invalidOffset 20
 error reading next: pebble/record: invalid chunk
 final blockNum: 1
 bytes read: 1
@@ -1148,6 +1983,15 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=1306192168, length=32738, encoding=0
+	Invalid wire format detected in block 1 at offset 0
+Read block 2 with 19 bytes
+	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
+Read block 3 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 3
 bytes read: 1
@@ -1166,6 +2010,16 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 0.
+Read block 1 with 32768 bytes
+	Block 1: Processing chunk at offset 0, checksum=957580701, length=1, encoding=9
+	Block 1: Found WAL sync chunk with syncedOffset=1 (invalidOffset=20)
+	Block 1: Processing chunk at offset 20, checksum=16843009, length=257, encoding=9
+	Mismatch log number in block 1 at offset 20 (expected 1, got 0)
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=1662040211, length=32749, encoding=9
+	Block 2: Found WAL sync chunk with syncedOffset=64000 (invalidOffset=20)
+	Corruption confirmed: syncedOffset 64000 exceeds invalidOffset 20
 error reading next: pebble/record: invalid chunk
 final blockNum: 2
 bytes read: 1
@@ -1186,6 +2040,20 @@ EOF logNum=2
 
 read
 ----
+Starting read ahead for corruption. Block corrupted 1.
+Read block 2 with 32768 bytes
+	Block 2: Processing chunk at offset 0, checksum=957580701, length=1, encoding=9
+	Block 2: Found WAL sync chunk with syncedOffset=1 (invalidOffset=32788)
+	Block 2: Processing chunk at offset 20, checksum=16843009, length=257, encoding=9
+	Mismatch log number in block 2 at offset 20 (expected 1, got 0)
+Read block 3 with 32768 bytes
+	Block 3: Processing chunk at offset 0, checksum=3770313817, length=32749, encoding=9
+	Block 3: Found WAL sync chunk with syncedOffset=100 (invalidOffset=32788)
+Read block 4 with 19 bytes
+	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
+	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
+Read block 5 with 0 bytes
+	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
 error reading next: unexpected EOF
 final blockNum: 5
 bytes read: 32750


### PR DESCRIPTION
add test logger to walSync test.
