### PR TITLE
db: add problem spans data structure, check when picking auto compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1788,7 +1788,7 @@ func (d *DB) makeCompactionEnvLocked() *compactionEnv {
 	if d.closed.Load() != nil || d.opts.ReadOnly {
 		return nil
 	}
-	return &compactionEnv{
+	env := &compactionEnv{
 		diskAvailBytes:          d.diskAvailBytes.Load(),
 		earliestSnapshotSeqNum:  d.mu.snapshots.earliest(),
 		earliestUnflushedSeqNum: d.getEarliestUnflushedSeqNumLocked(),
@@ -1799,6 +1799,10 @@ func (d *DB) makeCompactionEnvLocked() *compactionEnv {
 			rescheduleReadCompaction: &d.mu.compact.rescheduleReadCompaction,
 		},
 	}
+	if !d.problemSpans.IsEmpty() {
+		env.problemSpans = &d.problemSpans
+	}
+	return env
 }
 
 // pickAnyCompaction tries to pick a manual or automatic compaction.
@@ -2324,7 +2328,7 @@ func (d *DB) compact(c *compaction, errChannel chan error) {
 		d.mu.Lock()
 		c.grantHandle.Started()
 		if err := d.compact1(c, errChannel); err != nil {
-			d.handleCompactFailure(err)
+			d.handleCompactFailure(c, err)
 		}
 		if c.isDownload {
 			d.mu.compact.downloadingCount--
@@ -2362,13 +2366,34 @@ func (d *DB) compact(c *compaction, errChannel chan error) {
 	})
 }
 
-func (d *DB) handleCompactFailure(err error) {
+func (d *DB) handleCompactFailure(c *compaction, err error) {
 	if errors.Is(err, ErrCancelledCompaction) {
 		// ErrCancelledCompaction is expected during normal operation, so we don't
 		// want to report it as a background error.
 		d.opts.Logger.Infof("%v", err)
 		return
 	}
+
+	// Record problem spans for a short duration, unless the error is a corruption.
+	expiration := 30 * time.Second
+	if IsCorruptionError(err) {
+		// TODO(radu): ideally, we should be using the corruption reporting
+		// mechanism which has a tighter span for the corruption. We would need to
+		// somehow plumb the level of the file.
+		expiration = 5 * time.Minute
+	}
+	for i := range c.inputs {
+		level := c.inputs[i].level
+		if level == 0 {
+			// We do not set problem spans on L0, as they could block flushes.
+			continue
+		}
+		it := c.inputs[i].files.Iter()
+		for f := it.First(); f != nil; f = it.Next() {
+			d.problemSpans.Add(level, f.UserKeyBounds(), expiration)
+		}
+	}
+
 	// TODO(peter): count consecutive compaction errors and backoff.
 	d.opts.EventListener.BackgroundError(err)
 }

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/problemspans"
 )
 
 // The minimum count for an intra-L0 compaction. This matches the RocksDB
@@ -39,6 +40,10 @@ type compactionEnv struct {
 	earliestSnapshotSeqNum  base.SeqNum
 	inProgressCompactions   []compactionInfo
 	readCompactionEnv       readCompactionEnv
+	// problemSpans is checked by the compaction picker to avoid compactions that
+	// overlap an active "problem span". It can be nil when there are no problem
+	// spans.
+	problemSpans *problemspans.ByLevel
 }
 
 type compactionPicker interface {
@@ -414,7 +419,10 @@ func (pc *pickedCompaction) maybeExpandBounds(smallest InternalKey, largest Inte
 // setupInputs returns true if a compaction has been set up. It returns false if
 // a concurrent compaction is occurring on the start or output level files.
 func (pc *pickedCompaction) setupInputs(
-	opts *Options, diskAvailBytes uint64, startLevel *compactionLevel,
+	opts *Options,
+	diskAvailBytes uint64,
+	startLevel *compactionLevel,
+	problemSpans *problemspans.ByLevel,
 ) bool {
 	// maxExpandedBytes is the maximum size of an expanded compaction. If
 	// growing a compaction results in a larger size, the original compaction
@@ -423,7 +431,7 @@ func (pc *pickedCompaction) setupInputs(
 		opts, adjustedOutputLevel(pc.outputLevel.level, pc.baseLevel), diskAvailBytes,
 	)
 
-	if anyTablesCompacting(startLevel.files) {
+	if !canCompactTables(startLevel.files, startLevel.level, problemSpans) {
 		return false
 	}
 
@@ -434,7 +442,7 @@ func (pc *pickedCompaction) setupInputs(
 	// left empty for those.
 	if startLevel.level != pc.outputLevel.level {
 		pc.outputLevel.files = pc.version.Overlaps(pc.outputLevel.level, pc.userKeyBounds())
-		if anyTablesCompacting(pc.outputLevel.files) {
+		if !canCompactTables(pc.outputLevel.files, pc.outputLevel.level, problemSpans) {
 			return false
 		}
 
@@ -504,7 +512,7 @@ func (pc *pickedCompaction) setupInputs(
 				*pc.lcf = *oldLcf
 			}
 		}
-	} else if pc.grow(pc.smallest, pc.largest, maxExpandedBytes, startLevel) {
+	} else if pc.grow(pc.smallest, pc.largest, maxExpandedBytes, startLevel, problemSpans) {
 		pc.maybeExpandBounds(manifest.KeyRange(pc.cmp,
 			startLevel.files.All(), pc.outputLevel.files.All()))
 	}
@@ -521,13 +529,16 @@ func (pc *pickedCompaction) setupInputs(
 // c.level+1 files in the compaction, and returns whether the inputs grew. sm
 // and la are the smallest and largest InternalKeys in all of the inputs.
 func (pc *pickedCompaction) grow(
-	sm, la InternalKey, maxExpandedBytes uint64, startLevel *compactionLevel,
+	sm, la InternalKey,
+	maxExpandedBytes uint64,
+	startLevel *compactionLevel,
+	problemSpans *problemspans.ByLevel,
 ) bool {
 	if pc.outputLevel.files.Empty() {
 		return false
 	}
 	grow0 := pc.version.Overlaps(startLevel.level, base.UserKeyBoundsFromInternal(sm, la))
-	if anyTablesCompacting(grow0) {
+	if !canCompactTables(grow0, startLevel.level, problemSpans) {
 		return false
 	}
 	if grow0.Len() <= startLevel.files.Len() {
@@ -540,10 +551,10 @@ func (pc *pickedCompaction) grow(
 	// sm1 and la1 could shift the output level keyspace when pc.outputLevel.files is set to grow1.
 	sm1, la1 := manifest.KeyRange(pc.cmp, grow0.All(), pc.outputLevel.files.All())
 	grow1 := pc.version.Overlaps(pc.outputLevel.level, base.UserKeyBoundsFromInternal(sm1, la1))
-	if anyTablesCompacting(grow1) {
+	if grow1.Len() != pc.outputLevel.files.Len() {
 		return false
 	}
-	if grow1.Len() != pc.outputLevel.files.Len() {
+	if !canCompactTables(grow1, pc.outputLevel.level, problemSpans) {
 		return false
 	}
 	startLevel.files = grow0
@@ -570,18 +581,23 @@ func (pc *pickedCompaction) setupMultiLevelCandidate(opts *Options, diskAvailByt
 	pc.startLevel = &pc.inputs[0]
 	pc.extraLevels = []*compactionLevel{&pc.inputs[1]}
 	pc.outputLevel = &pc.inputs[2]
-	return pc.setupInputs(opts, diskAvailBytes, pc.extraLevels[len(pc.extraLevels)-1])
+	return pc.setupInputs(opts, diskAvailBytes, pc.extraLevels[len(pc.extraLevels)-1], nil /* TODO(radu) */)
 }
 
-// anyTablesCompacting returns true if any tables in the level slice are
-// compacting.
-func anyTablesCompacting(inputs manifest.LevelSlice) bool {
+// canCompactTables returns true if the tables in the level slice are not
+// compacting already and don't intersect any problem spans.
+func canCompactTables(
+	inputs manifest.LevelSlice, level int, problemSpans *problemspans.ByLevel,
+) bool {
 	for f := range inputs.All() {
 		if f.IsCompacting() {
-			return true
+			return false
+		}
+		if problemSpans != nil && problemSpans.Overlaps(level, f.UserKeyBounds()) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // newCompactionPickerByScore creates a compactionPickerByScore associated with
@@ -1033,6 +1049,7 @@ func pickCompactionSeedFile(
 	opts *Options,
 	level, outputLevel int,
 	earliestSnapshotSeqNum base.SeqNum,
+	problemSpans *problemspans.ByLevel,
 ) (manifest.LevelFile, bool) {
 	// Select the file within the level to compact. We want to minimize write
 	// amplification, but also ensure that (a) deletes are propagated to the
@@ -1067,11 +1084,14 @@ func pickCompactionSeedFile(
 
 	for f := startIter.First(); f != nil; f = startIter.Next() {
 		var overlappingBytes uint64
-		compacting := f.IsCompacting()
-		if compacting {
+		if f.IsCompacting() {
 			// Move on if this file is already being compacted. We'll likely
 			// still need to move past the overlapping output files regardless,
 			// but in cases where all start-level files are compacting we won't.
+			continue
+		}
+		if problemSpans != nil && problemSpans.Overlaps(level, f.UserKeyBounds()) {
+			// File touches problem span which temporarily disallows auto compactions.
 			continue
 		}
 
@@ -1080,9 +1100,20 @@ func pickCompactionSeedFile(
 			outputFile = outputIter.Next()
 		}
 
-		for outputFile != nil && sstableKeyCompare(cmp, outputFile.Smallest, f.Largest) <= 0 && !compacting {
+		skip := false
+		for outputFile != nil && sstableKeyCompare(cmp, outputFile.Smallest, f.Largest) <= 0 {
 			overlappingBytes += outputFile.Size
-			compacting = compacting || outputFile.IsCompacting()
+			if outputFile.IsCompacting() {
+				// If one of the overlapping files is compacting, we're not going to be
+				// able to compact f anyway, so skip it.
+				skip = true
+				break
+			}
+			if problemSpans != nil && problemSpans.Overlaps(outputLevel, outputFile.UserKeyBounds()) {
+				// Overlapping file touches problem span which temporarily disallows auto compactions.
+				skip = true
+				break
+			}
 
 			// For files in the bottommost level of the LSM, the
 			// Stats.RangeDeletionsBytesEstimate field is set to the estimate
@@ -1129,11 +1160,7 @@ func pickCompactionSeedFile(
 			}
 			outputFile = outputIter.Next()
 		}
-
-		// If the input level file or one of the overlapping files is
-		// compacting, we're not going to be able to compact this file
-		// anyways, so skip it.
-		if compacting {
+		if skip {
 			continue
 		}
 
@@ -1312,7 +1339,7 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 
 		// info.level > 0
 		var ok bool
-		info.file, ok = pickCompactionSeedFile(p.vers, p.virtualBackings, p.opts, info.level, info.outputLevel, env.earliestSnapshotSeqNum)
+		info.file, ok = pickCompactionSeedFile(p.vers, p.virtualBackings, p.opts, info.level, info.outputLevel, env.earliestSnapshotSeqNum, env.problemSpans)
 		if !ok {
 			continue
 		}
@@ -1504,9 +1531,7 @@ func (p *compactionPickerByScore) pickedCompactionFromCandidateFile(
 		return nil
 	}
 
-	if !pc.setupInputs(p.opts, env.diskAvailBytes, pc.startLevel) {
-		// TODO(radu): do we expect this to happen? (it does seem to happen if I add
-		// a log here).
+	if !pc.setupInputs(p.opts, env.diskAvailBytes, pc.startLevel, env.problemSpans) {
 		return nil
 	}
 
@@ -1639,8 +1664,7 @@ func pickAutoLPositive(
 		}
 	}
 
-	if !pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel) {
-		opts.Logger.Errorf("%v", base.AssertionFailedf("setupInputs failed"))
+	if !pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel, env.problemSpans) {
 		return nil
 	}
 	return pc.maybeAddLevel(opts, env.diskAvailBytes)
@@ -1781,10 +1805,10 @@ func pickL0(
 	//
 	// TODO(bilal) Remove the minCompactionDepth parameter once fixing it at 1
 	// has been shown to not cause a performance regression.
-	lcf := l0Organizer.PickBaseCompaction(opts.Logger, 1, vers.Levels[baseLevel].Slice())
+	lcf := l0Organizer.PickBaseCompaction(opts.Logger, 1, vers.Levels[baseLevel].Slice(), baseLevel, env.problemSpans)
 	if lcf != nil {
 		pc := newPickedCompactionFromL0(lcf, opts, vers, l0Organizer, baseLevel, true)
-		if pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel) {
+		if pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel, env.problemSpans) {
 			if pc.startLevel.files.Empty() {
 				opts.Logger.Errorf("%v", base.AssertionFailedf("empty compaction chosen"))
 			}
@@ -1798,10 +1822,10 @@ func pickL0(
 	// compaction. Note that we pass in L0CompactionThreshold here as opposed to
 	// 1, since choosing a single sublevel intra-L0 compaction is
 	// counterproductive.
-	lcf = l0Organizer.PickIntraL0Compaction(env.earliestUnflushedSeqNum, minIntraL0Count)
+	lcf = l0Organizer.PickIntraL0Compaction(env.earliestUnflushedSeqNum, minIntraL0Count, env.problemSpans)
 	if lcf != nil {
 		pc := newPickedCompactionFromL0(lcf, opts, vers, l0Organizer, 0, false)
-		if pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel) {
+		if pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel, env.problemSpans) {
 			if pc.startLevel.files.Empty() {
 				opts.Logger.Fatalf("empty compaction chosen")
 			}
@@ -1854,7 +1878,9 @@ func newPickedManualCompaction(
 		// Nothing to do
 		return nil, false
 	}
-	if !pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel) {
+	// We use nil problemSpans because we don't want problem spans to prevent
+	// manual compactions.
+	if !pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel, nil /* problemSpans */) {
 		// setupInputs returned false indicating there's a conflicting
 		// concurrent compaction.
 		return nil, true
@@ -1899,7 +1925,7 @@ func pickDownloadCompaction(
 	pc = newPickedCompaction(opts, vers, l0Organizer, level, level, baseLevel)
 	pc.kind = kind
 	pc.startLevel.files = manifest.NewLevelSliceKeySorted(opts.Comparer.Compare, []*tableMetadata{file})
-	if !pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel) {
+	if !pc.setupInputs(opts, env.diskAvailBytes, pc.startLevel, nil /* problemSpans */) {
 		// setupInputs returned false indicating there's a conflicting
 		// concurrent compaction.
 		return nil
@@ -1950,7 +1976,7 @@ func pickReadTriggeredCompactionHelper(
 	pc = newPickedCompaction(p.opts, p.vers, p.l0Organizer, rc.level, defaultOutputLevel(rc.level, p.baseLevel), p.baseLevel)
 
 	pc.startLevel.files = overlapSlice
-	if !pc.setupInputs(p.opts, env.diskAvailBytes, pc.startLevel) {
+	if !pc.setupInputs(p.opts, env.diskAvailBytes, pc.startLevel, env.problemSpans) {
 		return nil
 	}
 	if inputRangeAlreadyCompacting(env, pc) {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -18,11 +18,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
@@ -2840,4 +2842,174 @@ func TestCompactionErrorStats(t *testing.T) {
 	require.Equal(t, 9, int(d.mu.snapshots.cumulativePinnedSize))
 	d.mu.Unlock()
 	require.NoError(t, d.Close())
+}
+
+func TestCompactionCorruption(t *testing.T) {
+	mem := vfs.NewMem()
+	var numFinishedCompactions atomic.Int32
+	opts := &Options{
+		FS:                 mem,
+		FormatMajorVersion: FormatNewest,
+		EventListener: &EventListener{
+			DataCorruption: func(info DataCorruptionInfo) {
+				if testing.Verbose() {
+					fmt.Printf("got expected data corruption: %s\n", info.Path)
+				}
+			},
+			CompactionEnd: func(info CompactionInfo) {
+				if info.Err == nil {
+					numFinishedCompactions.Add(1)
+				}
+			},
+		},
+	}
+	opts.WithFSDefaults()
+	remoteStorage := remote.NewInMem()
+	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		"external-locator": remoteStorage,
+	})
+	d, err := Open("", opts)
+	require.NoError(t, err)
+
+	var now crtime.AtomicMono
+	now.Store(1)
+	d.problemSpans.InitForTesting(manifest.NumLevels, d.cmp, func() crtime.Mono { return now.Load() })
+
+	randKey := func() []byte {
+		return []byte{'a' + byte(rand.IntN(26))}
+	}
+
+	var workloadWG sync.WaitGroup
+	var stopWorkload atomic.Bool
+	defer stopWorkload.Store(true)
+	startWorkload := func() {
+		stopWorkload.Store(false)
+		workloadWG.Add(1)
+		go func() {
+			defer workloadWG.Done()
+			for !stopWorkload.Load() {
+				b := d.NewBatch()
+				v := make([]byte, 100+rand.IntN(1000))
+				for i := range v {
+					v[i] = byte(rand.Uint32())
+				}
+				for i := 0; i < 100; i++ {
+					if err := b.Set(randKey(), v, nil); err != nil {
+						panic(err)
+					}
+				}
+				if err := b.Commit(nil); err != nil {
+					panic(err)
+				}
+				if err := d.Flush(); err != nil {
+					panic(err)
+				}
+				time.Sleep(10 * time.Microsecond)
+			}
+		}()
+	}
+
+	datadriven.RunTest(t, "testdata/compaction_corruption", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "build-remote":
+			require.NoError(t, runBuildRemoteCmd(td, d, remoteStorage))
+
+		case "ingest-external":
+			require.NoError(t, runIngestExternalCmd(t, td, d, remoteStorage, "external-locator"))
+
+		case "move-remote-object":
+			if len(td.CmdArgs) < 2 {
+				td.Fatalf(t, "build <path> <new-path> argument missing")
+			}
+			before := td.CmdArgs[0].String()
+			after := td.CmdArgs[1].String()
+			ctx := context.Background()
+			reader, objSize, err := remoteStorage.ReadObject(ctx, before)
+			require.NoError(t, err)
+			buf := make([]byte, objSize)
+			require.NoError(t, reader.ReadAt(ctx, buf, 0))
+			require.NoError(t, reader.Close())
+			require.NoError(t, remoteStorage.Delete(before))
+			writer, err := remoteStorage.CreateObject(after)
+			require.NoError(t, err)
+			n, err := writer.Write(buf)
+			require.NoError(t, err)
+			require.Equal(t, len(buf), n)
+			require.NoError(t, writer.Close())
+			return fmt.Sprintf("%s -> %s", before, after)
+
+		case "start-workload":
+			startWorkload()
+
+		case "stop-workload":
+			stopWorkload.Store(true)
+			workloadWG.Wait()
+
+		case "wait-for-problem-span":
+			timeout := time.Now().Add(100 * time.Second)
+			for d.problemSpans.IsEmpty() {
+				if timeout.Before(time.Now()) {
+					td.Fatalf(t, "timeout waiting for problem span")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			if testing.Verbose() {
+				fmt.Printf("%s: wait-for-problem-span:\n%s", td.Pos, d.problemSpans.String())
+			}
+
+		case "wait-for-compactions":
+			target := numFinishedCompactions.Load() + 5
+			timeout := time.Now().Add(10 * time.Second)
+			for numFinishedCompactions.Load() < target {
+				if timeout.Before(time.Now()) {
+					td.Fatalf(t, "timeout waiting for compactions")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+
+		case "expire-spans":
+			now.Store(now.Load() + crtime.Mono(30*time.Minute))
+
+		case "wait-for-no-external-files":
+			timeout := time.Now().Add(10 * time.Second)
+			for hasExternalFiles(d) {
+				if timeout.Before(time.Now()) {
+					td.Fatalf(t, "timeout waiting for compactions")
+				}
+			}
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+
+		return ""
+	})
+}
+
+func hasExternalFiles(d *DB) bool {
+	v := func() *version {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+
+		v := d.mu.versions.currentVersion()
+		v.Ref()
+		return v
+	}()
+	defer v.Unref()
+
+	for level := 0; level < manifest.NumLevels; level++ {
+		iter := v.Levels[level].Iter()
+		for m := iter.First(); m != nil; m = iter.Next() {
+			if m.Virtual {
+				meta, err := d.objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)
+				if err != nil {
+					panic(err)
+				}
+				if meta.IsExternal() {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/data_test.go
+++ b/data_test.go
@@ -1378,7 +1378,8 @@ func runIngestExternalCmd(
 		}
 		sz, err := st.Size(objName)
 		if err != nil {
-			return errors.Wrapf(err, "sizeof %s", objName)
+			// Tests can attach files that don't exist. Mock a size.
+			sz = 1024
 		}
 		ef := ExternalFile{
 			Locator:     remote.Locator(locator),

--- a/db.go
+++ b/db.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan/keyspanimpl"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
+	"github.com/cockroachdb/pebble/internal/problemspans"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/rangekey"
@@ -504,6 +505,11 @@ type DB struct {
 			externalSize *manifest.Annotator[uint64]
 		}
 	}
+
+	// problemSpans keeps track of spans of keys within LSM levels where
+	// compactions have failed; used to avoid retrying these compactions too
+	// quickly.
+	problemSpans problemspans.ByLevel
 
 	// Normally equal to time.Now() but may be overridden in tests.
 	timeNow func() time.Time

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cockroachdb/pebble
 require (
 	github.com/DataDog/zstd v1.5.7
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
+	github.com/RaduBerinde/axisds v0.0.0-20250405232732-ecb85bedf677
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cockroachdb/crlib v0.0.0-20241112164430-1264a2edc35b
 	github.com/cockroachdb/datadriven v1.0.3-0.20250407164829-2945557346d5
@@ -38,6 +39,7 @@ require (
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/btree v1.1.3 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190129172621-c8b1d7a94ddf
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/RaduBerinde/axisds v0.0.0-20250405232732-ecb85bedf677 h1:NofOMIO/Z3301wDc9gIM/M0/+YjvOYSvUe7+30bkxkA=
+github.com/RaduBerinde/axisds v0.0.0-20250405232732-ecb85bedf677/go.mod h1:YO26VdZg1RVVjEhjmeEJE/4bLnD2mowj5eDiZQSLtlE=
 github.com/aclements/go-gg v0.0.0-20170118225347-6dbb4e4fefb0/go.mod h1:55qNq4vcpkIuHowELi5C8e+1yUHtoLoOUR9QU5j7Tes=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
@@ -104,6 +106,8 @@ github.com/gonum/internal v0.0.0-20181124074243-f884aa714029/go.mod h1:Pu4dmpkhS
 github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9/go.mod h1:XA3DeT6rxh2EAE789SSiSJNqxPaC0aE9J8NTOI0Jo/A=
 github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP0HCqCz+K4ts155PXIlUywf0wqN+GfPZw=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -360,7 +360,7 @@ func TestL0Sublevels(t *testing.T) {
 			var lcf *L0CompactionFiles
 			if pickBaseCompaction {
 				baseFiles := NewLevelSliceKeySorted(base.DefaultComparer.Compare, fileMetas[baseLevel])
-				lcf = sublevels.PickBaseCompaction(base.DefaultLogger, minCompactionDepth, baseFiles)
+				lcf = sublevels.PickBaseCompaction(base.DefaultLogger, minCompactionDepth, baseFiles, 0, nil)
 				if lcf != nil {
 					// Try to extend the base compaction into a more rectangular
 					// shape, using the smallest/largest keys of the files before
@@ -387,7 +387,7 @@ func TestL0Sublevels(t *testing.T) {
 						lcf)
 				}
 			} else {
-				lcf = sublevels.PickIntraL0Compaction(earliestUnflushedSeqNum, minCompactionDepth)
+				lcf = sublevels.PickIntraL0Compaction(earliestUnflushedSeqNum, minCompactionDepth, nil /* problemSpans */)
 			}
 			if lcf == nil {
 				return "no compaction picked"
@@ -613,7 +613,7 @@ func BenchmarkL0SublevelsInitAndPick(b *testing.B) {
 		if sl == nil {
 			b.Fatal("expected non-nil L0Sublevels to be generated")
 		}
-		c := sl.PickBaseCompaction(base.DefaultLogger, 2, LevelSlice{})
+		c := sl.PickBaseCompaction(base.DefaultLogger, 2, LevelSlice{}, 0, nil)
 		if c == nil {
 			b.Fatal("expected non-nil compaction to be generated")
 		}

--- a/internal/problemspans/by_level.go
+++ b/internal/problemspans/by_level.go
@@ -1,0 +1,117 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package problemspans
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// ByLevel maintains a set of spans (separated by LSM level) with expiration
+// times and allows checking for overlap against active (non-expired) spans.
+//
+// When the spans added to the set are not overlapping, all operations are
+// logarithmic.
+//
+// ByLevel is safe for concurrent use.
+type ByLevel struct {
+	empty  atomic.Bool
+	mu     sync.Mutex
+	levels []Set
+}
+
+// Init must be called before using the ByLevel.
+func (bl *ByLevel) Init(numLevels int, cmp base.Compare) {
+	bl.empty.Store(false)
+	bl.levels = make([]Set, numLevels)
+	for i := range bl.levels {
+		bl.levels[i].Init(cmp)
+	}
+}
+
+// InitForTesting is used by tests which mock the time source.
+func (bl *ByLevel) InitForTesting(numLevels int, cmp base.Compare, nowFn func() crtime.Mono) {
+	bl.empty.Store(false)
+	bl.levels = make([]Set, numLevels)
+	for i := range bl.levels {
+		bl.levels[i].init(cmp, nowFn)
+	}
+}
+
+// IsEmpty returns true if there are no problem spans (the "normal" case). It
+// can be used in fast paths to avoid checking for specific overlaps.
+func (bl *ByLevel) IsEmpty() bool {
+	if bl.empty.Load() {
+		// Fast path.
+		return true
+	}
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	for i := range bl.levels {
+		if !bl.levels[i].IsEmpty() {
+			return false
+		}
+	}
+	bl.empty.Store(true)
+	return true
+}
+
+// Add a span on a specific level. The span automatically expires after the
+// given duration.
+func (bl *ByLevel) Add(level int, bounds base.UserKeyBounds, expiration time.Duration) {
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	bl.empty.Store(false)
+	bl.levels[level].Add(bounds, expiration)
+}
+
+// Overlaps returns true if any active (non-expired) span on the given level
+// overlaps the given bounds.
+func (bl *ByLevel) Overlaps(level int, bounds base.UserKeyBounds) bool {
+	if bl.empty.Load() {
+		// Fast path.
+		return false
+	}
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	return bl.levels[level].Overlaps(bounds)
+}
+
+// Excise a span from all levels. Any overlapping active (non-expired) spans are
+// split or trimmed accordingly.
+func (bl *ByLevel) Excise(bounds base.UserKeyBounds) {
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	for i := range bl.levels {
+		bl.levels[i].Excise(bounds)
+	}
+}
+
+// String prints all active (non-expired) span fragments.
+func (bl *ByLevel) String() string {
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	var buf strings.Builder
+
+	for i := range bl.levels {
+		if !bl.levels[i].IsEmpty() {
+			fmt.Fprintf(&buf, "L%d:\n", i)
+			for _, line := range crstrings.Lines(bl.levels[i].String()) {
+				fmt.Fprintf(&buf, "  %s\n", line)
+			}
+		}
+	}
+	if buf.Len() == 0 {
+		return "<empty>"
+	}
+	return buf.String()
+}

--- a/internal/problemspans/by_level_test.go
+++ b/internal/problemspans/by_level_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package problemspans
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestByLevel(t *testing.T) {
+	const numLevels = 7
+	now := crtime.Mono(0)
+	nowFn := func() crtime.Mono { return now }
+	var byLevel ByLevel
+	byLevel.InitForTesting(numLevels, base.DefaultComparer.Compare, nowFn)
+
+	datadriven.RunTest(t, "testdata/by_level", func(t *testing.T, td *datadriven.TestData) string {
+		var nowStr string
+		if td.MaybeScanArgs(t, "now", &nowStr) {
+			var nowVal int
+			if n, err := fmt.Sscanf(nowStr, "%ds", &nowVal); err != nil || n != 1 {
+				td.Fatalf(t, "error parsing now %q: %v", nowStr, err)
+			}
+			v := crtime.Mono(time.Duration(nowVal) * time.Second)
+			if v < now {
+				td.Fatalf(t, "now cannot go backwards")
+			}
+			now = v
+		}
+
+		var out bytes.Buffer
+		switch td.Cmd {
+
+		case "add":
+			for _, line := range crstrings.Lines(td.Input) {
+				parts := strings.SplitN(line, " ", 2)
+				require.Equalf(t, 2, len(parts), "%s", line)
+				var level int
+				_, err := fmt.Sscanf(parts[0], "L%d", &level)
+				require.NoError(t, err)
+				bounds, expiration := parseSetLine(parts[1], true /* withTime */)
+				// The test uses absolute expiration times.
+				byLevel.Add(level, bounds, expiration.Sub(now))
+			}
+
+		case "excise":
+			for _, line := range crstrings.Lines(td.Input) {
+				bounds, _ := parseSetLine(line, false /* withTime */)
+				byLevel.Excise(bounds)
+			}
+
+		case "overlap":
+			for _, line := range crstrings.Lines(td.Input) {
+				parts := strings.SplitN(line, " ", 2)
+				require.Equal(t, 2, len(parts))
+				var level int
+				_, err := fmt.Sscanf(parts[0], "L%d", &level)
+				require.NoError(t, err)
+				bounds, _ := parseSetLine(parts[1], false /* withTime */)
+				res := "overlap"
+				if !byLevel.Overlaps(level, bounds) {
+					res = "no overlap"
+				}
+				fmt.Fprintf(&out, "%s: %s\n", bounds, res)
+			}
+
+		case "is-empty":
+			if byLevel.IsEmpty() {
+				out.WriteString("empty\n")
+			} else {
+				out.WriteString("not empty\n")
+			}
+		default:
+			td.Fatalf(t, "unknown command %q", td.Cmd)
+		}
+		out.WriteString("ByLevel:\n")
+		for _, l := range crstrings.Lines(byLevel.String()) {
+			fmt.Fprintf(&out, "  %s\n", l)
+		}
+		return out.String()
+	})
+}

--- a/internal/problemspans/doc.go
+++ b/internal/problemspans/doc.go
@@ -1,0 +1,28 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package problemspans provides functionality for tracking and managing key
+// spans that have been identified as problematic. It allows users to add spans
+// with associated expiration times, check if a given key range overlaps any
+// active (non-expired) spans, and remove spans when issues are resolved.
+//
+// This package is designed for efficiently tracking key ranges that may need
+// special handling.
+//
+// Key Features:
+//
+//   - **Span Registration:**
+//     Add spans with specified expiration times so that they automatically
+//     become inactive after a set duration.
+//
+//   - **Overlap Detection:**
+//     Quickly check if a key range overlaps with any active problematic spans.
+//
+//   - **Span Excise:**
+//     Remove or adjust spans to reflect changes as issues are resolved.
+//
+//   - **Level-Based Organization:**
+//     The package offers a structure to organize and manage problematic spans
+//     per level, with built-in support for concurrent operations.
+package problemspans

--- a/internal/problemspans/set.go
+++ b/internal/problemspans/set.go
@@ -1,0 +1,122 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package problemspans
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/RaduBerinde/axisds"
+	"github.com/RaduBerinde/axisds/regiontree"
+	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// Set maintains a set of spans with expiration times and allows checking for
+// overlap against non-expired spans.
+//
+// When the spans added to the set are not overlapping, all operations are
+// logarithmic.
+//
+// Set is not safe for concurrent use.
+type Set struct {
+	cmp   base.Compare
+	nowFn func() crtime.Mono
+
+	now crtime.Mono
+
+	// We use a region tree with key boundaries and the expirationTime as a
+	// property.
+	rt regiontree.T[axisds.Endpoint[[]byte], expirationTime]
+}
+
+// expirationTime of a problem span. 0 means that there is no problem span in a
+// region. Expiration times <= Set.now are equivalent to 0.
+type expirationTime crtime.Mono
+
+// Init must be called before a Set can be used.
+func (s *Set) Init(cmp base.Compare) {
+	s.init(cmp, crtime.NowMono)
+}
+
+func (s *Set) init(cmp base.Compare, nowFn func() crtime.Mono) {
+	*s = Set{}
+	s.cmp = cmp
+	s.nowFn = nowFn
+	// The region tree supports a property equality function that "evolves" over
+	// time, in that some properties that used to not be equal become equal. In
+	// our case expired properties become equal to 0.
+	//
+	// Note that the region tree automatically removes boundaries between two
+	// regions that have expired, even during enumeration.
+	propEqFn := func(a, b expirationTime) bool {
+		return a == b ||
+			crtime.Mono(a) <= s.now && crtime.Mono(b) <= s.now // Both are expired or 0.
+	}
+	endpointCmp := axisds.EndpointCompareFn(axisds.CompareFn[[]byte](cmp))
+	s.rt = regiontree.Make(endpointCmp, propEqFn)
+}
+
+func boundsToEndpoints(bounds base.UserKeyBounds) (start, end axisds.Endpoint[[]byte]) {
+	start = axisds.MakeStartEndpoint(bounds.Start, axisds.Inclusive)
+	end = axisds.MakeEndEndpoint(bounds.End.Key, axisds.InclusiveIf(bounds.End.Kind == base.Inclusive))
+	return start, end
+}
+
+// Add a span to the set. The span automatically expires after the given duration.
+func (s *Set) Add(bounds base.UserKeyBounds, expiration time.Duration) {
+	s.now = s.nowFn()
+	expTime := expirationTime(s.now + crtime.Mono(expiration))
+	start, end := boundsToEndpoints(bounds)
+	s.rt.Update(start, end, func(p expirationTime) expirationTime {
+		return max(p, expTime)
+	})
+}
+
+// Overlaps returns true if the bounds overlap with a non-expired span.
+func (s *Set) Overlaps(bounds base.UserKeyBounds) bool {
+	s.now = s.nowFn()
+	start, end := boundsToEndpoints(bounds)
+	return s.rt.AnyWithGC(start, end, func(exp expirationTime) bool {
+		return crtime.Mono(exp) > s.now
+	})
+}
+
+// Excise removes a span fragment from all spans in the set. Any overlapping
+// non-expired spans are cut accordingly.
+func (s *Set) Excise(bounds base.UserKeyBounds) {
+	s.now = s.nowFn()
+	start, end := boundsToEndpoints(bounds)
+	s.rt.Update(start, end, func(p expirationTime) expirationTime {
+		return 0
+	})
+}
+
+// IsEmpty returns true if the set contains no non-expired spans.
+func (s *Set) IsEmpty() bool {
+	s.now = s.nowFn()
+	return s.rt.IsEmpty()
+}
+
+// String prints all active (non-expired) span fragments.
+func (s *Set) String() string {
+	var buf strings.Builder
+	s.now = s.nowFn()
+	s.rt.EnumerateAll(func(start, end axisds.Endpoint[[]byte], prop expirationTime) bool {
+		fmt.Fprintf(&buf, "%s  expires in: %s\n", keyEndpointIntervalFormatter(start, end), time.Duration(prop)-time.Duration(s.now))
+		return true
+	})
+	if buf.Len() == 0 {
+		return "<empty>"
+	}
+	return buf.String()
+}
+
+var keyBoundaryFormatter axisds.BoundaryFormatter[[]byte] = func(b []byte) string {
+	return string(b)
+}
+
+var keyEndpointIntervalFormatter = axisds.MakeEndpointIntervalFormatter(keyBoundaryFormatter)

--- a/internal/problemspans/set_test.go
+++ b/internal/problemspans/set_test.go
@@ -1,0 +1,205 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package problemspans
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+func TestSet(t *testing.T) {
+	now := crtime.Mono(0)
+	nowFn := func() crtime.Mono { return now }
+	var set Set
+	set.init(base.DefaultComparer.Compare, nowFn)
+
+	datadriven.RunTest(t, "testdata/set", func(t *testing.T, td *datadriven.TestData) string {
+		var nowStr string
+		if td.MaybeScanArgs(t, "now", &nowStr) {
+			var nowVal int
+			if n, err := fmt.Sscanf(nowStr, "%ds", &nowVal); err != nil || n != 1 {
+				td.Fatalf(t, "error parsing now %q: %v", nowStr, err)
+			}
+			v := crtime.Mono(time.Duration(nowVal) * time.Second)
+			if v < now {
+				td.Fatalf(t, "now cannot go backwards")
+			}
+			now = v
+		}
+
+		var out bytes.Buffer
+		switch td.Cmd {
+		case "reset":
+			set.init(base.DefaultComparer.Compare, nowFn)
+			now = 0
+
+		case "add":
+			for _, line := range crstrings.Lines(td.Input) {
+				bounds, expiration := parseSetLine(line, true /* withTime */)
+				// The test uses absolute expiration times.
+				set.Add(bounds, expiration.Sub(now))
+			}
+
+		case "excise":
+			for _, line := range crstrings.Lines(td.Input) {
+				bounds, _ := parseSetLine(line, false /* withTime */)
+				set.Excise(bounds)
+			}
+
+		case "overlap":
+			for _, line := range crstrings.Lines(td.Input) {
+				bounds, _ := parseSetLine(line, false /* withTime */)
+				res := "overlap"
+				if !set.Overlaps(bounds) {
+					res = "no overlap"
+				}
+				fmt.Fprintf(&out, "%s: %s\n", bounds, res)
+			}
+
+		case "is-empty":
+			if set.IsEmpty() {
+				out.WriteString("empty\n")
+			} else {
+				out.WriteString("not empty\n")
+			}
+		default:
+			td.Fatalf(t, "unknown command %q", td.Cmd)
+		}
+		out.WriteString("Set:\n")
+		for _, l := range crstrings.Lines(set.String()) {
+			fmt.Fprintf(&out, "  %s\n", l)
+		}
+		return out.String()
+	})
+}
+
+func parseSetLine(line string, withTime bool) (base.UserKeyBounds, crtime.Mono) {
+	var span1, span2 string
+	var timeVal int
+	if withTime {
+		n, err := fmt.Sscanf(line, "%s %s %ds", &span1, &span2, &timeVal)
+		if err != nil || n != 3 {
+			panic(fmt.Sprintf("error parsing line %q: n=%d err=%v", line, n, err))
+		}
+	} else {
+		n, err := fmt.Sscanf(line, "%s %s", &span1, &span2)
+		if err != nil || n != 2 {
+			panic(fmt.Sprintf("error parsing line %q: n=%d err=%v", line, n, err))
+		}
+	}
+	bounds := base.ParseUserKeyBounds(span1 + " " + span2)
+	return bounds, crtime.Mono(time.Duration(timeVal) * time.Second)
+}
+
+// TestSetRandomized cross-checks the Set implementation against a trivial
+// implementation.
+func TestSetRandomized(t *testing.T) {
+	now := crtime.Mono(0)
+	nowFn := func() crtime.Mono { return now }
+
+	for test := 0; test < 1000; test++ {
+		var set Set
+		set.init(base.DefaultComparer.Compare, nowFn)
+		var naive naiveSet
+
+		keys := 4 + rand.Intn(100)
+		key := func(k int) []byte {
+			return []byte(fmt.Sprintf("%04d", k))
+		}
+		for op := 0; op < 300; op++ {
+			k1, k2 := rand.Intn(keys), rand.Intn(keys)
+			if k1 > k2 {
+				k1, k2 = k2, k1
+			}
+			bounds := base.UserKeyBoundsInclusive(key(k1), key(k2))
+			if k1 < k2 && rand.Intn(2) == 0 {
+				bounds.End.Kind = base.Exclusive
+			}
+
+			if n := rand.Intn(10); n < 2 {
+				expiration := time.Duration(rand.Intn(100))
+				set.Add(bounds, expiration)
+				naive.Add(bounds, now+crtime.Mono(expiration))
+			} else if bounds.End.Kind == base.Exclusive && n == 9 {
+				set.Excise(bounds)
+				naive.Excise(bounds)
+			} else {
+				overlap := set.Overlaps(bounds)
+				expected := naive.Overlaps(bounds, now)
+				if expected != overlap {
+					t.Fatalf("expected overlap=%t, got %t for bounds %s", expected, overlap, bounds)
+				}
+			}
+
+			if rand.Intn(4) == 0 {
+				now += crtime.Mono(rand.Intn(40))
+			}
+		}
+	}
+}
+
+type naiveSpan struct {
+	bounds     base.UserKeyBounds
+	expiration crtime.Mono
+}
+
+type naiveSet struct {
+	spans []naiveSpan
+}
+
+func (ns *naiveSet) Add(bounds base.UserKeyBounds, expiration crtime.Mono) {
+	ns.spans = append(ns.spans, naiveSpan{bounds, expiration})
+}
+
+func (ns *naiveSet) Overlaps(bounds base.UserKeyBounds, now crtime.Mono) bool {
+	for _, sp := range ns.spans {
+		if sp.expiration > now && sp.bounds.Overlaps(base.DefaultComparer.Compare, &bounds) {
+			return true
+		}
+	}
+	return false
+}
+
+func (ns *naiveSet) Excise(bounds base.UserKeyBounds) {
+	if bounds.End.Kind != base.Exclusive {
+		panic("inclusive end not supported")
+	}
+	var overlapping []naiveSpan
+
+	cmp := base.DefaultComparer.Compare
+	ns.spans = slices.DeleteFunc(ns.spans, func(sp naiveSpan) bool {
+		if sp.bounds.Overlaps(cmp, &bounds) {
+			overlapping = append(overlapping, sp)
+			return true
+		}
+		return false
+	})
+	for _, sp := range overlapping {
+		if cmp(sp.bounds.Start, bounds.Start) < 0 {
+			ns.spans = append(ns.spans, naiveSpan{
+				bounds:     base.UserKeyBoundsEndExclusive(sp.bounds.Start, bounds.Start),
+				expiration: sp.expiration,
+			})
+		}
+		if bounds.End.CompareUpperBounds(cmp, sp.bounds.End) < 0 {
+			ns.spans = append(ns.spans, naiveSpan{
+				bounds: base.UserKeyBounds{
+					Start: bounds.End.Key,
+					End:   sp.bounds.End,
+				},
+				expiration: sp.expiration,
+			})
+		}
+	}
+}

--- a/internal/problemspans/testdata/by_level
+++ b/internal/problemspans/testdata/by_level
@@ -1,0 +1,80 @@
+is-empty
+----
+empty
+ByLevel:
+  <empty>
+
+add
+L2 [c, f) 10s
+L4 [d, h) 10s
+----
+ByLevel:
+  L2:
+    [c, f)  expires in: 10s
+  L4:
+    [d, h)  expires in: 10s
+
+is-empty
+----
+not empty
+ByLevel:
+  L2:
+    [c, f)  expires in: 10s
+  L4:
+    [d, h)  expires in: 10s
+
+overlap
+L1 [a, z)
+L3 [a, z]
+L2 [a, c)
+L2 [d, d]
+L2 [f, z]
+L4 [a, c]
+L4 [g, g]
+----
+[a, z): no overlap
+[a, z]: no overlap
+[a, c): no overlap
+[d, d]: overlap
+[f, z]: no overlap
+[a, c]: no overlap
+[g, g]: overlap
+ByLevel:
+  L2:
+    [c, f)  expires in: 10s
+  L4:
+    [d, h)  expires in: 10s
+
+excise
+[d, e)
+----
+ByLevel:
+  L2:
+    [c, d)  expires in: 10s
+    [e, f)  expires in: 10s
+  L4:
+    [e, h)  expires in: 10s
+
+overlap
+L2 [da, db]
+L2 [e, e]
+L4 [da, db]
+L4 [e, e]
+----
+[da, db]: no overlap
+[e, e]: overlap
+[da, db]: no overlap
+[e, e]: overlap
+ByLevel:
+  L2:
+    [c, d)  expires in: 10s
+    [e, f)  expires in: 10s
+  L4:
+    [e, h)  expires in: 10s
+
+overlap now=20s
+L2 [a, z]
+----
+[a, z]: no overlap
+ByLevel:
+  <empty>

--- a/internal/problemspans/testdata/set
+++ b/internal/problemspans/testdata/set
@@ -1,0 +1,202 @@
+add
+[b, c) 10s
+----
+Set:
+  [b, c)  expires in: 10s
+
+# Positive overlap tests.
+overlap now=5s
+[a, b]
+[a, bb)
+[a, bb]
+[b, b]
+[a, z)
+[b1, b2)
+[b5, d)
+----
+[a, b]: overlap
+[a, bb): overlap
+[a, bb]: overlap
+[b, b]: overlap
+[a, z): overlap
+[b1, b2): overlap
+[b5, d): overlap
+Set:
+  [b, c)  expires in: 5s
+
+# Negative overlap tests.
+overlap now=5s
+[a, b)
+[c, d]
+[u, v)
+----
+[a, b): no overlap
+[c, d]: no overlap
+[u, v): no overlap
+Set:
+  [b, c)  expires in: 5s
+
+add
+[b2, b5] 5s
+----
+Set:
+  [b, c)  expires in: 5s
+
+add
+[b2, b5] 15s
+----
+Set:
+  [b, b2)  expires in: 5s
+  [b2, b5]  expires in: 10s
+  (b5, c)  expires in: 5s
+
+add
+[a, d] 5s
+----
+Set:
+  [b, b2)  expires in: 5s
+  [b2, b5]  expires in: 10s
+  (b5, c)  expires in: 5s
+
+add
+[a, d] 15s
+----
+Set:
+  [a, d]  expires in: 10s
+
+add
+[c, c] 20s
+----
+Set:
+  [a, c)  expires in: 10s
+  [c, c]  expires in: 15s
+  (c, d]  expires in: 10s
+
+overlap now=10s
+[a, a]
+[a, b)
+[b, c)
+[c, c]
+[d, e]
+[e, f)
+----
+[a, a]: overlap
+[a, b): overlap
+[b, c): overlap
+[c, c]: overlap
+[d, e]: overlap
+[e, f): no overlap
+Set:
+  [a, c)  expires in: 5s
+  [c, c]  expires in: 10s
+  (c, d]  expires in: 5s
+
+is-empty
+----
+not empty
+Set:
+  [a, c)  expires in: 5s
+  [c, c]  expires in: 10s
+  (c, d]  expires in: 5s
+
+overlap now=18s
+[a, a]
+[a, b)
+[b, c)
+[c, c]
+[d, e]
+[e, f)
+----
+[a, a]: no overlap
+[a, b): no overlap
+[b, c): no overlap
+[c, c]: overlap
+[d, e]: no overlap
+[e, f): no overlap
+Set:
+  [c, c]  expires in: 2s
+
+overlap now=21s
+[a, z]
+----
+[a, z]: no overlap
+Set:
+  <empty>
+
+is-empty
+----
+empty
+Set:
+  <empty>
+
+add
+[b, c) 30s
+----
+Set:
+  [b, c)  expires in: 9s
+
+add
+[d, e) 30s
+----
+Set:
+  [b, c)  expires in: 9s
+  [d, e)  expires in: 9s
+
+excise
+[b5, d2]
+----
+Set:
+  [b, b5)  expires in: 9s
+  (d2, e)  expires in: 9s
+
+overlap
+[d, d]
+[a, b5)
+[d20, z]
+----
+[d, d]: no overlap
+[a, b5): overlap
+[d20, z]: overlap
+Set:
+  [b, b5)  expires in: 9s
+  (d2, e)  expires in: 9s
+
+overlap now=30s
+[a, b5)
+----
+[a, b5): no overlap
+Set:
+  <empty>
+
+is-empty
+----
+empty
+Set:
+  <empty>
+
+add
+[a, b] 40s
+[d, e] 50s
+----
+Set:
+  [a, b]  expires in: 10s
+  [d, e]  expires in: 20s
+
+is-empty
+----
+not empty
+Set:
+  [a, b]  expires in: 10s
+  [d, e]  expires in: 20s
+
+is-empty now=45s
+----
+not empty
+Set:
+  [d, e]  expires in: 5s
+
+is-empty now=55s
+----
+empty
+Set:
+  <empty>

--- a/open.go
+++ b/open.go
@@ -232,6 +232,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	}
 	d.mu.versions = &versionSet{}
 	d.diskAvailBytes.Store(math.MaxUint64)
+	d.problemSpans.Init(manifest.NumLevels, opts.Comparer.Compare)
 
 	defer func() {
 		// If an error or panic occurs during open, attempt to release the manually

--- a/testdata/compaction_corruption
+++ b/testdata/compaction_corruption
@@ -1,0 +1,48 @@
+build-remote file1
+a#0,SET = avalue
+e#0,SET = bvalue
+f#0,SET = cvalue
+----
+
+build-remote file2-not-there
+g#0,SET = dvalue
+p#0,SET = evalue
+u#0,SET = fvalue
+----
+
+build-remote file3
+v#0,SET = gvalue
+x#0,SET = hvalue
+z#0,SET = ivalue
+----
+
+ingest-external file1
+file1 bounds=(a,f)
+file2 bounds=(g,u)
+file3 bounds=(v,z)
+----
+
+start-workload
+----
+
+# Verify that a problem span is set.
+wait-for-problem-span
+----
+
+# Verify that compactions still go through.
+wait-for-compactions
+----
+
+# Make file2 appear.
+move-remote-object file2-not-there file2
+----
+file2-not-there -> file2
+
+# Expire spans.
+expire-spans
+----
+
+# Compactions should now go through and eventually there should be no external
+# files.
+wait-for-no-external-files
+----

--- a/testdata/compaction_picker_pick_file
+++ b/testdata/compaction_picker_pick_file
@@ -220,3 +220,81 @@ L6:
 pick-file L5
 ----
 000011:[e#11,SET-e#11,SET]
+
+define
+L1
+  b.SET.11:foo
+  c.SET.11:foo
+L2
+  c.SET.0:foo
+  d.SET.0:foo
+----
+L1:
+  000004:[b#11,SET-c#11,SET]
+L2:
+  000005:[c#0,SET-d#0,SET]
+
+pick-file L1
+----
+000004:[b#11,SET-c#11,SET]
+
+problem-spans
+L1 [a, bb]
+----
+
+pick-file L1
+----
+(none)
+
+pick-file L2
+----
+000005:[c#0,SET-d#0,SET]
+
+problem-spans
+L2 [c, e]
+----
+
+pick-file L2
+----
+(none)
+
+define
+L1
+  b.SET.11:foo
+  c.SET.11:foo
+L1
+  d.SET.11:foo
+  e.SET.11:foo
+L1
+  f.SET.11:foo
+  g.SET.11:foo
+L2
+  a.SET.0:foo
+  z.SET.0:foo
+----
+L1:
+  000004:[b#11,SET-c#11,SET]
+  000005:[d#11,SET-e#11,SET]
+  000006:[f#11,SET-g#11,SET]
+L2:
+  000007:[a#0,SET-z#0,SET]
+
+pick-file L1
+----
+000004:[b#11,SET-c#11,SET]
+
+problem-spans
+L1 [bb, dd)
+----
+
+pick-file L1
+----
+000006:[f#11,SET-g#11,SET]
+
+problem-spans
+L1 [b1, b2]
+----
+
+pick-file L1
+----
+000005:[d#11,SET-e#11,SET]


### PR DESCRIPTION
Note: first commit is #4403.

The structure uses a library I wrote over the weekend: https://github.com/RaduBerinde/axisds
I hope to add (over time) more data structures around intervals, order maintenance, etc.

#### problemspans: add data structure

Package problemspans provides functionality for tracking and managing
key spans that have been identified as problematic. It allows users to
add spans with associated expiration times, check if a given key range
overlaps any active (non-expired) spans, and remove spans when issues
are resolved.

#### db: check problem spans when picking auto compactions

We check the problem spans to avoid any overlap when picking
compactions. Note that normally the problem spans are empty and these
checks are avoided.

We add a test that verifies that compactions still go through after
trying to compact a non-existent external file.

Fixes #4285
Informs #1192