### PR TITLE
db: fix TestCheckpointManyFiles

### DIFF
--- a/compaction_scheduler.go
+++ b/compaction_scheduler.go
@@ -237,7 +237,8 @@ func (c *pickedCompactionCache) add(pc *pickedCompaction) {
 // ConcurrencyLimitScheduler is the default scheduler used by Pebble. It
 // simply uses the concurrency limit retrieved from
 // DBForCompaction.GetAllowedWithoutPermission to decide the number of
-// compactions to schedule.
+// compactions to schedule. ConcurrencyLimitScheduler must have its Register
+// method called at most once -- i.e., it cannot be reused across DBs.
 //
 // Since the GetAllowedWithoutPermission value changes over time, the
 // scheduler needs to be quite current in its sampling, especially if the

--- a/open.go
+++ b/open.go
@@ -81,6 +81,9 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	// Make a copy of the options so that we don't mutate the passed in options.
 	opts = opts.Clone()
 	opts.EnsureDefaults()
+	if opts.Experimental.CompactionScheduler == nil {
+		opts.Experimental.CompactionScheduler = newConcurrencyLimitScheduler(defaultTimeSource{})
+	}
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}

--- a/open_test.go
+++ b/open_test.go
@@ -133,8 +133,6 @@ func TestErrorIfNotPristine(t *testing.T) {
 		ErrorIfNotPristine: true,
 	})
 	defer ensureFilesClosed(t, opts)()
-	// Ensures each DB will create its own CompactionScheduler in Open.
-	opts.Experimental.CompactionScheduler = nil
 
 	d0, err := Open("", opts)
 	require.NoError(t, err)

--- a/options.go
+++ b/options.go
@@ -1272,9 +1272,6 @@ func (o *Options) EnsureDefaults() {
 	if o.Experimental.MultiLevelCompactionHeuristic == nil {
 		o.Experimental.MultiLevelCompactionHeuristic = WriteAmpHeuristic{}
 	}
-	if o.Experimental.CompactionScheduler == nil {
-		o.Experimental.CompactionScheduler = newConcurrencyLimitScheduler(defaultTimeSource{})
-	}
 
 	o.initMaps()
 }


### PR DESCRIPTION
It was incorrectly using the same compaction scheduler across two DB open calls.

Fixes #4421