### PR TITLE
objstorage: check for missing file in remoteReadable

### DIFF
--- a/objstorage/objstorageprovider/remote.go
+++ b/objstorage/objstorageprovider/remote.go
@@ -348,7 +348,7 @@ func (p *provider) remoteOpenForReading(
 		}
 		return nil, err
 	}
-	return p.newRemoteReadable(reader, size, meta.DiskFileNum), nil
+	return p.newRemoteReadable(reader, size, meta.DiskFileNum, meta.Remote.Storage.IsNotExistError), nil
 }
 
 func (p *provider) remoteSize(meta objstorage.ObjectMetadata) (int64, error) {

--- a/objstorage/objstorageprovider/remote_backing.go
+++ b/objstorage/objstorageprovider/remote_backing.go
@@ -263,7 +263,7 @@ func (p *provider) AttachRemoteObjects(
 			_ = p.sharedUnref(d.meta)
 			// TODO(radu): clean up references previously created in this loop.
 			if d.meta.Remote.Storage.IsNotExistError(err) {
-				return nil, errors.Errorf("origin marker object %q does not exist;"+
+				return nil, base.CorruptionErrorf("origin marker object %q does not exist;"+
 					" object probably removed from the provider which created the backing", refName)
 			}
 			return nil, errors.Wrapf(err, "checking origin's marker object %s", refName)

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
@@ -83,7 +83,7 @@ p5b2 102
 ----
 <remote> create object "1ab5-5-000002.sst.ref.6.000102"
 <remote> close writer for "1ab5-5-000002.sst.ref.6.000102" after 0 bytes
-<remote> size of object "1ab5-5-000002.sst.ref.5.000002": error: file does not exist
+<remote> size of object "1ab5-5-000002.sst.ref.5.000002": error: in-mem remote storage object does not exist
 <remote> delete object "1ab5-5-000002.sst.ref.6.000102"
 <remote> list (prefix="1ab5-5-000002.sst.ref.", delimiter="")
 <remote> delete object "1ab5-5-000002.sst"

--- a/objstorage/remote/mem.go
+++ b/objstorage/remote/mem.go
@@ -8,9 +8,10 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"strings"
 	"sync"
+
+	"github.com/cockroachdb/errors"
 )
 
 // NewInMem returns an in-memory implementation of the remote.Storage
@@ -49,25 +50,32 @@ func (s *inMemStore) ReadObject(
 	if err != nil {
 		return nil, 0, err
 	}
-	return &inMemReader{data: obj.data}, int64(len(obj.data)), nil
+	return &inMemReader{objName: objName, store: s}, int64(len(obj.data)), nil
 }
 
 type inMemReader struct {
-	data []byte
+	objName string
+	store   *inMemStore
 }
 
 var _ ObjectReader = (*inMemReader)(nil)
 
 func (r *inMemReader) ReadAt(ctx context.Context, p []byte, offset int64) error {
-	if offset+int64(len(p)) > int64(len(r.data)) {
+	// We don't just store obj.data in the inMemReader because we want to emit an
+	// error if the object is deleted from under us.
+	obj, err := r.store.getObj(r.objName)
+	if err != nil {
+		return err
+	}
+	if offset+int64(len(p)) > int64(len(obj.data)) {
 		return io.EOF
 	}
-	copy(p, r.data[offset:])
+	copy(p, obj.data[offset:])
 	return nil
 }
 
 func (r *inMemReader) Close() error {
-	r.data = nil
+	r.store = nil
 	return nil
 }
 
@@ -135,15 +143,19 @@ func (s *inMemStore) Size(objName string) (int64, error) {
 }
 
 func (s *inMemStore) IsNotExistError(err error) bool {
-	return err == os.ErrNotExist
+	return errors.Is(err, inMemStoreNotExistErr)
 }
+
+// We use a custom "not exists" error to make sure that callers correctly use
+// IsNotExistError.
+var inMemStoreNotExistErr = errors.Newf("in-mem remote storage object does not exist")
 
 func (s *inMemStore) getObj(name string) (*inMemObj, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	obj, ok := s.mu.objects[name]
 	if !ok {
-		return nil, os.ErrNotExist
+		return nil, inMemStoreNotExistErr
 	}
 	return obj, nil
 }


### PR DESCRIPTION
An external file can go missing after we "open" it (i.e. after we
obtain a `remote.ObjectReader`). This should be marked as a corruption
error; this commit fixes this and adds a test.

Informs #4285