### PR TITLE
db: prohibit ingestion or external iteration of sstables with blob refs

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1225,8 +1225,8 @@ func TestManualCompaction(t *testing.T) {
 		},
 		{
 			testData:   "testdata/manual_compaction_set_with_del_sstable_Pebblev6",
-			minVersion: formatChecksumFooter,
-			maxVersion: formatChecksumFooter,
+			minVersion: formatTableFormatV6,
+			maxVersion: formatTableFormatV6,
 		},
 	}
 

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -26,7 +26,8 @@ import (
 // sorted in internal key order, where lower index files contain keys that sort
 // left of files with higher indexes.
 //
-// Input sstables must only contain keys with the zero sequence number.
+// Input sstables must only contain keys with the zero sequence number and must
+// not contain references to values in external blob files.
 //
 // Iterators constructed through NewExternalIter do not support all iterator
 // options, including block-property and table filters. NewExternalIter errors
@@ -301,6 +302,9 @@ func openExternalTables(
 		r, err := sstable.NewReader(ctx, readable, readerOpts)
 		if err != nil {
 			return readers, err
+		}
+		if r.Properties.NumValuesInBlobFiles > 0 {
+			return readers, errors.Newf("pebble: NewExternalIter does not support blob references")
 		}
 		readers = append(readers, r)
 	}

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -214,10 +214,15 @@ const (
 
 	// -- Add experimental versions here --
 
-	// formatChecksumFooter is a format major version enabling use of the
-	// TableFormatPebblev6 table format. It is a format allowing for the checksum
-	// of sstable footers.
-	formatChecksumFooter
+	// formatTableFormatV6 is a format major version enabling the sstable table
+	// format TableFormatPebblev6.
+	//
+	// The TableFormatPebblev6 sstable format introduces a checksum within the
+	// sstable footer, and allows inclusion of blob handle references within the
+	// value column of a sstable block.
+	//
+	// This format major version does not yet enable use of value separation.
+	formatTableFormatV6
 
 	// internalFormatNewest is the most recent, possibly experimental format major
 	// version.
@@ -249,7 +254,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 		return sstable.TableFormatPebblev4
 	case FormatColumnarBlocks, FormatWALSyncChunks:
 		return sstable.TableFormatPebblev5
-	case formatChecksumFooter:
+	case formatTableFormatV6:
 		return sstable.TableFormatPebblev6
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -263,7 +268,7 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
 		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix,
 		FormatFlushableIngestExcises, FormatColumnarBlocks, FormatWALSyncChunks,
-		formatChecksumFooter:
+		formatTableFormatV6:
 		return sstable.TableFormatPebblev1
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -309,8 +314,8 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	FormatWALSyncChunks: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatWALSyncChunks)
 	},
-	formatChecksumFooter: func(d *DB) error {
-		return d.finalizeFormatVersUpgrade(formatChecksumFooter)
+	formatTableFormatV6: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(formatTableFormatV6)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -64,8 +64,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatColumnarBlocks, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatWALSyncChunks))
 	require.Equal(t, FormatWALSyncChunks, d.FormatMajorVersion())
-	require.NoError(t, d.RatchetFormatMajorVersion(formatChecksumFooter))
-	require.Equal(t, formatChecksumFooter, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(formatTableFormatV6))
+	require.Equal(t, formatTableFormatV6, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -224,7 +224,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatFlushableIngestExcises:     {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
 		FormatColumnarBlocks:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
 		FormatWALSyncChunks:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
-		formatChecksumFooter:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
+		formatTableFormatV6:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
 	}
 
 	// Valid versions.

--- a/ingest.go
+++ b/ingest.go
@@ -337,6 +337,10 @@ func ingestLoad1(
 				r.Properties.KeySchemaName)
 		}
 	}
+	if r.Properties.NumValuesInBlobFiles > 0 {
+		return nil, keyspan.Span{}, errors.Newf(
+			"pebble: ingesting tables with blob references is not supported")
+	}
 
 	meta = &tableMetadata{}
 	meta.FileNum = fileNum
@@ -1079,6 +1083,10 @@ func ingestTargetLevel(
 // flushed. The ingested sstable files are moved into the DB and must reside on
 // the same filesystem as the DB. Sstables can be created for ingestion using
 // sstable.Writer. On success, Ingest removes the input paths.
+//
+// Ingested sstables must have been created with a known KeySchema (when written
+// with columnar blocks) and Comparer. They must not contain any references to
+// external blob files.
 //
 // Two types of sstables are accepted for ingestion(s): one is sstables present
 // in the instance's vfs.FS and can be referenced locally. The other is sstables

--- a/testdata/external_iterator
+++ b/testdata/external_iterator
@@ -10,6 +10,9 @@ del-range c z
 # Test that a delete range in a more recent file shadows keys in an
 # earlier file.
 
+iter-init-error files=(1)
+----
+
 iter files=(1)
 first
 next
@@ -33,6 +36,9 @@ next
 b: (b, .)
 .
 
+iter-init-error files=(2, 1)
+----
+
 build 3
 set a a
 set f f
@@ -52,6 +58,9 @@ a: (a, .)
 b: (b, .)
 f: (f, .)
 .
+
+iter-init-error files=(3, 2, 1)
+----
 
 # Test including range keys, and merging the range key state across
 # files. Range keys should be interleaved.
@@ -113,6 +122,9 @@ b: (b, . UPDATED)
 bb: (ac, .)
 d: (., [d-e) @3=bar UPDATED)
 
+iter-init-error files=(5, 6, 4, 3, 2, 1)
+----
+
 # Test range keys that overlap each other with identical state. These
 # should be defragmented and exposed as a single range key.
 
@@ -147,6 +159,9 @@ set k@3 v
 set p@4 v
 ----
 
+iter-init-error files=(points, ag, ek)  mask-suffix=@7
+----
+
 iter files=(points, ag, ek) mask-suffix=@7
 first
 next
@@ -176,6 +191,9 @@ next
 ----
 a: (., [a-k) @5=foo, @4=bar, @1=bax UPDATED)
 a@4: (v, [a-k) @5=foo, @4=bar, @1=bax)
+
+iter-init-error files=(points, ag, ek, stacked)
+----
 
 # Test mutating the external iterator's options through SetOptions.
 
@@ -222,6 +240,9 @@ set aaaaa@3 aaaaa@3
 set aaaaa@1 aaaaa@1
 ----
 
+iter-init-error files=(a, aa, aaa, aaaa, aaaaa)
+----
+
 iter files=(a, aa, aaa, aaaa, aaaaa)
 seek-ge a
 next
@@ -246,3 +267,15 @@ aaaa@1: (aaaa@1, .)
 aaaaa@3: (aaaaa@3, .)
 aaaaa@1: (aaaaa@1, .)
 stats: seeked 5 times (5 internal); stepped 5 times (5 internal); blocks: 0B cached, 1.3KB not cached (read time: 0s); points: 10 (50B keys, 35B values); separated: 5 (25B, 25B fetched)
+
+build table-with-blob-refs
+set a@9 a9
+set a@8 a8
+set b@3 blob{fileNum=1005 value=a-value-stored-in-a-blob-file}
+set c@9 c9
+----
+
+iter files=(table-with-blob-refs)
+seek-ge a
+----
+error: pebble: NewExternalIter does not support blob references

--- a/testdata/ingest_load
+++ b/testdata/ingest_load
@@ -150,3 +150,8 @@ load writer-version=15 db-version=14
 a.SET.0:
 ----
 pebble: table format (Pebble,v4) is not within range supported at DB format major version 14, ((Pebble,v1),(Pebble,v3))
+
+load writer-version=21 db-version=21
+d.SET.0:blob{fileNum=2952 value=foo}
+----
+pebble: ingesting tables with blob references is not supported


### PR DESCRIPTION
This commit adds validation to NewExternalIter and the ingestion pathways prohibiting the external iteration or ingestion of sstables containing blob references.

This could conceivably be relaxed in the future if we provide a mechanism to provide the referenced blob files too, but for now this is an error condition.

Additionally the most recent experimental format major version that introduces the TableFormatPebblev6 is renamed to capture the fact that it most significantly will enable use of blob value separation (in addition to the introduction of a checksum covering sstable footer data).