### PR TITLE
rangedel: expose Fragmenter and Decode

### DIFF
--- a/rangedel/rangedel.go
+++ b/rangedel/rangedel.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package rangedel provides functionality for working with range deletions.
+package rangedel
+
+import (
+	"github.com/cockroachdb/pebble/internal/keyspan"
+	"github.com/cockroachdb/pebble/internal/rangedel"
+	"github.com/cockroachdb/pebble/sstable"
+)
+
+// Fragmenter exports the keyspan.Fragmenter type.
+type Fragmenter = keyspan.Fragmenter
+
+// Key exports the keyspan.Key type.
+type Key = keyspan.Key
+
+// Span exports the keyspan.Span type.
+type Span = keyspan.Span
+
+// Decode decodes an InternalKey representing a range deletion into a Span. If
+// keysDst is provided, keys will be appended to keysDst to reduce allocations.
+func Decode(ik sstable.InternalKey, val []byte, keysDst []Key) Span {
+	return rangedel.Decode(ik, val, keysDst)
+}

--- a/rangekey/rangekey.go
+++ b/rangekey/rangekey.go
@@ -26,8 +26,8 @@ func IsRangeKey(ik sstable.InternalKey) bool {
 	return rangekey.IsRangeKey(ik.Kind())
 }
 
-// Decode decodes an InternalKey into a keyspan.Span, if it is a range key. If
+// Decode decodes an InternalKey into a Span, if it is a range key. If
 // keysDst is provided, keys will be appended to keysDst to reduce allocations.
-func Decode(ik sstable.InternalKey, val []byte, keysDst []keyspan.Key) (Span, error) {
+func Decode(ik sstable.InternalKey, val []byte, keysDst []Key) (Span, error) {
 	return rangekey.Decode(ik, val, keysDst)
 }


### PR DESCRIPTION
Add a new `rangedel` package and define some aliases that can be used
from outside Pebble, similar to the `rangekey` package.