### PR TITLE
internal/blobtest: move blob testutils

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/blobtest"
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
@@ -672,10 +672,10 @@ func runBuildRemoteCmd(td *datadriven.TestData, d *DB, storage remote.Storage) e
 }
 
 type dataDrivenCmdOptions struct {
-	blobValues *testutils.BlobValues
+	blobValues *blobtest.Values
 }
 
-func withBlobValues(bv *testutils.BlobValues) func(*dataDrivenCmdOptions) {
+func withBlobValues(bv *blobtest.Values) func(*dataDrivenCmdOptions) {
 	return func(o *dataDrivenCmdOptions) { o.blobValues = bv }
 }
 
@@ -725,7 +725,7 @@ func runBuildCmd(
 	}
 
 	writeOpts := d.opts.MakeWriterOptions(0 /* level */, tableFormat)
-	var blobReferences testutils.BlobReferences
+	var blobReferences blobtest.References
 	f, err := fs.Create(path, vfs.WriteCategoryUnspecified)
 	if err != nil {
 		return err

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/blobtest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -34,7 +34,7 @@ func TestExternalIterator(t *testing.T) {
 	d, err := Open("", o)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, d.Close()) }()
-	var bv testutils.BlobValues
+	var bv blobtest.Values
 
 	getOptsAndFiles := func(td *datadriven.TestData) (opts IterOptions, files [][]sstable.ReadableFile) {
 		opts = IterOptions{KeyTypes: IterKeyTypePointsAndRanges}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/blobtest"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
@@ -106,8 +106,8 @@ func TestIngestLoad(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			var bv testutils.BlobValues
-			var br testutils.BlobReferences
+			var bv blobtest.Values
+			var br blobtest.References
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writerOpts)
 			for _, data := range strings.Split(td.Input, "\n") {
 				if strings.HasPrefix(data, "EncodeSpan: ") {

--- a/value_separation_test.go
+++ b/value_separation_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/blobtest"
 	"github.com/cockroachdb/pebble/internal/compact"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
-	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
@@ -29,7 +29,7 @@ import (
 
 func TestValueSeparationPolicy(t *testing.T) {
 	var (
-		bv  testutils.BlobValues
+		bv  blobtest.Values
 		vs  compact.ValueSeparation
 		tw  sstable.RawWriter
 		fn  base.DiskFileNum
@@ -71,7 +71,7 @@ func TestValueSeparationPolicy(t *testing.T) {
 				if tw != nil {
 					require.NoError(t, tw.Close())
 				}
-				bv = testutils.BlobValues{}
+				bv = blobtest.Values{}
 				switch x := d.CmdArgs[0].String(); x {
 				case "never-separate-values":
 					vs = compact.NeverSeparateValues{}


### PR DESCRIPTION
Move blob-related testutils into a separate blobtest package. Future work will require a transitive dependency on the sstable package (via internal/manifest).