### PR TITLE
db: support arbitrary blob references in datadriven DB define cmds

### DIFF
--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -49,6 +49,8 @@ type OutputTable struct {
 	WriterMeta sstable.WriterMetadata
 	// BlobReferences is the list of blob references for the table.
 	BlobReferences []manifest.BlobReference
+	// BlobReferenceDepth is the depth of the blob references for the table.
+	BlobReferenceDepth int
 }
 
 // OutputBlob contains metadata about a blob file that was created during a
@@ -136,8 +138,9 @@ type ValueSeparation interface {
 // ValueSeparationMetadata describes metadata about a table's blob references,
 // and optionally a newly constructed blob file.
 type ValueSeparationMetadata struct {
-	BlobReferences    []manifest.BlobReference
-	BlobReferenceSize uint64
+	BlobReferences     []manifest.BlobReference
+	BlobReferenceSize  uint64
+	BlobReferenceDepth int
 
 	// The below fields are only populated if a new blob file was created.
 	BlobFileStats    blob.FileWriterStats
@@ -216,6 +219,7 @@ func (r *Runner) WriteTable(objMeta objstorage.ObjectMetadata, tw sstable.RawWri
 		r.err = errors.CombineErrors(r.err, valSepErr)
 	} else {
 		r.tables[len(r.tables)-1].BlobReferences = valSepMeta.BlobReferences
+		r.tables[len(r.tables)-1].BlobReferenceDepth = valSepMeta.BlobReferenceDepth
 		if valSepMeta.BlobFileObject.DiskFileNum != 0 {
 			r.blobs = append(r.blobs, OutputBlob{
 				Stats:    valSepMeta.BlobFileStats,

--- a/options.go
+++ b/options.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/cockroachdb/pebble/vfs"
@@ -2076,6 +2077,22 @@ func (o *Options) MakeWriterOptions(level int, format sstable.TableFormat) sstab
 	writerOpts.NumDeletionsThreshold = o.Experimental.NumDeletionsThreshold
 	writerOpts.DeletionSizeRatioThreshold = o.Experimental.DeletionSizeRatioThreshold
 	return writerOpts
+}
+
+// MakeBlobWriterOptions constructs blob.FileWriterOptions from the corresponding
+// options in the receiver.
+func (o *Options) MakeBlobWriterOptions(level int) blob.FileWriterOptions {
+	lo := o.Level(level)
+	return blob.FileWriterOptions{
+		Compression:  resolveDefaultCompression(lo.Compression()),
+		ChecksumType: block.ChecksumTypeCRC32c,
+		FlushGovernor: block.MakeFlushGovernor(
+			lo.BlockSize,
+			lo.BlockSizeThreshold,
+			base.SizeClassAwareBlockSizeThreshold,
+			o.AllocatorSizeClasses,
+		),
+	}
 }
 
 func resolveDefaultCompression(c Compression) Compression {

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -1,0 +1,14 @@
+define verbose format-major-version=21
+L5
+  b@9.SET.9:v
+  c@9.SET.9:blob{fileNum=000921 value=helloworld}
+  d@9.SET.9:v
+L6
+  b@2.SET.2:v
+  c@2.SET.2:blob{fileNum=000921 value=foobar}
+  d@2.SET.2:v
+----
+L5:
+  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:885 blobrefs:[(000921: 10); depth:1]
+L6:
+  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:863 blobrefs:[(000921: 6); depth:1]


### PR DESCRIPTION
Adapt the `define` datadriven command used to define arbitrary database states
to support arbitrary blob references within KVs. This command will encode the
describe blob handle, set the appropriate metadata on the TableMetadata, write
the referenced blob files to objstorage, and include the BlobMetadata in the
resulting version edit.

This commit just introduces the logic to support blob references and a simple
define test. As subsequent value separation work is committed, it'll use this
this testing mechanism for tailored unit tests.