### PR TITLE
sstable: use correct footer size in EstimatedSize

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -189,7 +189,7 @@ func (w *RawColumnWriter) Error() error {
 // EstimatedSize returns the estimated size of the sstable being written if
 // a call to Close() was made without adding additional keys.
 func (w *RawColumnWriter) EstimatedSize() uint64 {
-	sz := rocksDBFooterLen + w.queuedDataSize
+	sz := uint64(w.opts.TableFormat.FooterSize()) + w.queuedDataSize
 	// TODO(jackson): Avoid iterating over partitions by incrementally
 	// maintaining the size contribution of all buffered partitions.
 	for _, bib := range w.indexBuffering.partitions {

--- a/sstable/format.go
+++ b/sstable/format.go
@@ -40,6 +40,17 @@ const (
 	TableFormatMinSupported = TableFormatPebblev1
 )
 
+var footerSizes [NumTableFormats]int = [NumTableFormats]int{
+	TableFormatLevelDB:   levelDBFooterLen,
+	TableFormatRocksDBv2: rocksDBFooterLen,
+	TableFormatPebblev1:  rocksDBFooterLen,
+	TableFormatPebblev2:  rocksDBFooterLen,
+	TableFormatPebblev3:  rocksDBFooterLen,
+	TableFormatPebblev4:  rocksDBFooterLen,
+	TableFormatPebblev5:  rocksDBFooterLen,
+	TableFormatPebblev6:  checkedPebbleDBFooterLen,
+}
+
 // TableFormatPebblev4, in addition to DELSIZED, introduces the use of
 // InternalKeyKindSSTableInternalObsoleteBit.
 //
@@ -253,6 +264,11 @@ func parseTableFormat(magic []byte, version uint32) (TableFormat, error) {
 // data, index and keyspan blocks.
 func (f TableFormat) BlockColumnar() bool {
 	return f >= TableFormatPebblev5
+}
+
+// FooterSize returns the maximum size of the footer for the table format.
+func (f TableFormat) FooterSize() int {
+	return footerSizes[f]
 }
 
 func (f TableFormat) newIndexIter() block.IndexBlockIterator {

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -624,6 +624,7 @@ func TestReadFooter(t *testing.T) {
 		{strings.Repeat("a", minFooterLen-1), "file size is too small"},
 		{strings.Repeat("a", levelDBFooterLen), "bad magic number"},
 		{strings.Repeat("a", rocksDBFooterLen), "bad magic number"},
+		{strings.Repeat("a", checkedPebbleDBFooterLen), "bad magic number"},
 		{encode(TableFormatLevelDB, 0)[1:], "file size is too small"},
 		{encode(TableFormatRocksDBv2, 0)[1:], "footer too short"},
 		{encode(TableFormatRocksDBv2, block.ChecksumTypeNone), "unsupported checksum type"},

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -336,7 +336,7 @@ a@2.SET.1:a2
 a@1.SET.1:a1
 b@2.SET.1:b2
 ----
-EstimatedSize()=53
+EstimatedSize()=57
 
 close
 ----


### PR DESCRIPTION
Use the correct footer size in (*RawColumnarWriter).EstimatedSize, and refactor some of the footer size accesses to use a new FooterSize method on the TableFormat type.