### PR TITLE
db: export FormatTableFormatV6

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1225,8 +1225,8 @@ func TestManualCompaction(t *testing.T) {
 		},
 		{
 			testData:   "testdata/manual_compaction_set_with_del_sstable_Pebblev6",
-			minVersion: formatTableFormatV6,
-			maxVersion: formatTableFormatV6,
+			minVersion: FormatTableFormatV6,
+			maxVersion: FormatTableFormatV6,
 		},
 	}
 

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -204,6 +204,16 @@ const (
 	// as a commitment that the WAL should have been synced up until the offset.
 	FormatWALSyncChunks
 
+	// FormatTableFormatV6 is a format major version enabling the sstable table
+	// format TableFormatPebblev6.
+	//
+	// The TableFormatPebblev6 sstable format introduces a checksum within the
+	// sstable footer, and allows inclusion of blob handle references within the
+	// value column of a sstable block.
+	//
+	// This format major version does not yet enable use of value separation.
+	FormatTableFormatV6
+
 	// -- Add new versions here --
 
 	// FormatNewest is the most recent format major version.
@@ -213,16 +223,6 @@ const (
 	// in tests) can be defined here.
 
 	// -- Add experimental versions here --
-
-	// formatTableFormatV6 is a format major version enabling the sstable table
-	// format TableFormatPebblev6.
-	//
-	// The TableFormatPebblev6 sstable format introduces a checksum within the
-	// sstable footer, and allows inclusion of blob handle references within the
-	// value column of a sstable block.
-	//
-	// This format major version does not yet enable use of value separation.
-	formatTableFormatV6
 
 	// internalFormatNewest is the most recent, possibly experimental format major
 	// version.
@@ -254,7 +254,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 		return sstable.TableFormatPebblev4
 	case FormatColumnarBlocks, FormatWALSyncChunks:
 		return sstable.TableFormatPebblev5
-	case formatTableFormatV6:
+	case FormatTableFormatV6:
 		return sstable.TableFormatPebblev6
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -268,7 +268,7 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
 		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix,
 		FormatFlushableIngestExcises, FormatColumnarBlocks, FormatWALSyncChunks,
-		formatTableFormatV6:
+		FormatTableFormatV6:
 		return sstable.TableFormatPebblev1
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -314,8 +314,8 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	FormatWALSyncChunks: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatWALSyncChunks)
 	},
-	formatTableFormatV6: func(d *DB) error {
-		return d.finalizeFormatVersUpgrade(formatTableFormatV6)
+	FormatTableFormatV6: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(FormatTableFormatV6)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -30,7 +30,7 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
-	require.Equal(t, FormatNewest, FormatMajorVersion(20))
+	require.Equal(t, FormatNewest, FormatMajorVersion(21))
 	require.Equal(t, internalFormatNewest, FormatMajorVersion(21))
 }
 
@@ -64,8 +64,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatColumnarBlocks, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatWALSyncChunks))
 	require.Equal(t, FormatWALSyncChunks, d.FormatMajorVersion())
-	require.NoError(t, d.RatchetFormatMajorVersion(formatTableFormatV6))
-	require.Equal(t, formatTableFormatV6, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatTableFormatV6))
+	require.Equal(t, FormatTableFormatV6, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -224,7 +224,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatFlushableIngestExcises:     {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
 		FormatColumnarBlocks:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
 		FormatWALSyncChunks:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
-		formatTableFormatV6:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
+		FormatTableFormatV6:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
 	}
 
 	// Valid versions.

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -259,7 +259,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 			FS: vfs.NewMem(),
 			Levels: []LevelOptions{
 				{TargetFileSize: 100},
-				{TargetFileSize: 100},
+				{TargetFileSize: 80},
 				{TargetFileSize: 1},
 			},
 			DebugCheck:         DebugCheckLevels,
@@ -381,9 +381,13 @@ L3:
 		}
 	}
 
+	// TODO(jackson): Create a datadriven test and exercise it on
+	// TableFormatPebblev6 and later format major versions. This test is tightly
+	// coupled to the current estimated sizes and won't produce the necessary
+	// input LSM structure on later format major versions.
 	versions := []FormatMajorVersion{
 		FormatMinSupported,
-		FormatNewest,
+		FormatWALSyncChunks,
 	}
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("version-%s", version), func(t *testing.T) {

--- a/testdata/compaction_picker_pick_file
+++ b/testdata/compaction_picker_pick_file
@@ -16,9 +16,9 @@ L2:
 file-sizes
 ----
 L1:
-  000004:[b#11,SET-c#11,SET]: 743 bytes (743B)
+  000004:[b#11,SET-c#11,SET]: 747 bytes (747B)
 L2:
-  000005:[c#0,SET-d#0,SET]: 730 bytes (730B)
+  000005:[c#0,SET-d#0,SET]: 734 bytes (734B)
 
 pick-file L1
 ----
@@ -131,12 +131,12 @@ L6:
 file-sizes
 ----
 L5:
-  000004:[c#11,SET-e#11,SET]: 99369 bytes (97KB)
-  000005:[f#11,SET-f#11,SET]: 58090 bytes (57KB)
+  000004:[c#11,SET-e#11,SET]: 99373 bytes (97KB)
+  000005:[f#11,SET-f#11,SET]: 58094 bytes (57KB)
 L6:
-  000006:[c#0,SET-c#0,SET]: 66284 bytes (65KB)
-  000007:[e#0,SET-e#0,SET]: 66284 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66284 bytes (65KB)
+  000006:[c#0,SET-c#0,SET]: 66288 bytes (65KB)
+  000007:[e#0,SET-e#0,SET]: 66288 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66288 bytes (65KB)
 
 # Sst 5 is picked since 65KB/57KB is less than 130KB/97KB.
 pick-file L5
@@ -168,12 +168,12 @@ file-sizes
 L5:
   000010:[c#11,SET-c#11,SET]: 32862 bytes (32KB)
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
-  000005:[f#11,SET-f#11,SET]: 58090 bytes (57KB)
+  000005:[f#11,SET-f#11,SET]: 58094 bytes (57KB)
 L6:
-  000006:[c#0,SET-c#0,SET]: 66284 bytes (65KB)
-  000009:[d#13,SET-d#13,SET]: 728 bytes (728B)
-  000007:[e#0,SET-e#0,SET]: 66284 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66284 bytes (65KB)
+  000006:[c#0,SET-c#0,SET]: 66288 bytes (65KB)
+  000009:[d#13,SET-d#13,SET]: 732 bytes (732B)
+  000007:[e#0,SET-e#0,SET]: 66288 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66288 bytes (65KB)
 
 # Superficially, sst 10 causes write amp of 65KB/32KB which is worse than sst
 # 5. But the garbage of ~64KB in the backing sst 4 is equally distributed
@@ -207,12 +207,12 @@ file-sizes
 ----
 L5:
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
-  000005:[f#11,SET-f#11,SET]: 58090 bytes (57KB)
+  000005:[f#11,SET-f#11,SET]: 58094 bytes (57KB)
 L6:
-  000012:[c#15,SET-c#15,SET]: 728 bytes (728B)
-  000009:[d#13,SET-d#13,SET]: 728 bytes (728B)
-  000007:[e#0,SET-e#0,SET]: 66284 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66284 bytes (65KB)
+  000012:[c#15,SET-c#15,SET]: 732 bytes (732B)
+  000009:[d#13,SET-d#13,SET]: 732 bytes (732B)
+  000007:[e#0,SET-e#0,SET]: 66288 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66288 bytes (65KB)
 
 # Even though picking sst 11 seems to cause poor write amp of 65KB/126B, it is
 # picked because it is blamed for all the garbage in backing sst 4 (~96KB),

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -24,7 +24,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	720B   0.0
+L5  	724B   0.0
 L6  	321KB  -
 
 enable-table-stats
@@ -37,7 +37,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 328865
+range-deletions-bytes-estimate: 328869
 
 scores
 ----
@@ -47,7 +47,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	720B   4.5
+L5  	724B   4.5
 L6  	321KB  -
 
 # Ensure that point deletions in a higher level result in a compensated level
@@ -80,7 +80,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	774B   0.0
+L5  	778B   0.0
 L6  	321KB  -
 
 enable-table-stats
@@ -92,7 +92,7 @@ wait-pending-table-stats
 num-entries: 5
 num-deletions: 5
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 164784
+point-deletions-bytes-estimate: 164788
 range-deletions-bytes-estimate: 0
 
 scores
@@ -103,7 +103,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	774B   2.3
+L5  	778B   2.3
 L6  	321KB  -
 
 # Run a similar test as above, but this time the table containing the DELs is
@@ -145,7 +145,7 @@ wait-pending-table-stats
 num-entries: 5
 num-deletions: 5
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 164792
+point-deletions-bytes-estimate: 164796
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -212,11 +212,11 @@ L6  	386KB  -
 lsm verbose
 ----
 L5:
-  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET] size:525373
-  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET] size:131828
+  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET] size:525377
+  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET] size:131832
 L6:
-  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET] size:263225
-  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET] size:131828
+  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET] size:263229
+  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET] size:131832
 
 # Attempting to schedule a compaction should begin a L5->L6 compaction.
 

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -330,8 +330,8 @@ gi: (foo, .)
 lsm verbose
 ----
 L6:
-  000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1329
-  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:907
+  000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1333
+  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:911
 
 download g h via-backing-file-download
 ----
@@ -341,8 +341,8 @@ ok
 lsm verbose
 ----
 L6:
-  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:976
-  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:891
+  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:980
+  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:895
 
 reopen
 ----

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -55,14 +55,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   589B     0B       0 |  0.25 |   28B |     0     0B |     0     0B |     1   589B |    0B |   1 21.0
+    0 |     1   729B     0B       0 |  0.25 |   28B |     0     0B |     0     0B |     1   729B |    0B |   1 26.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-total |     1   589B     0B       0 |     - |   28B |     0     0B |     0     0B |     1   617B |    0B |   1 22.0
+total |     1   729B     0B       0 |     - |   28B |     0     0B |     0     0B |     1   757B |    0B |   1 27.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 17B  written: 28B (65% overhead)
 Flushes: 1
@@ -72,9 +72,9 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 589B
+Local tables size: 729B
 Compression types: snappy: 1
-Block cache: 2 entries (716B)  hit rate: 0.0%
+Block cache: 2 entries (795B)  hit rate: 0.0%
 Table cache: 1 entries (832B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -84,11 +84,11 @@ Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtabl
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 disk-usage
 ----
-2.0KB
+2.1KB
 
 batch
 set b 2
@@ -115,26 +115,26 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.2KB |    0B |   0 21.0
+    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 26.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     1   595B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 32.7
+    6 |     1   730B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   730B | 1.4KB |   1  0.5
+total |     1   730B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 2 (512KB)
-Zombie tables: 2 (1.2KB, local: 1.2KB)
+Zombie tables: 2 (1.4KB, local: 1.4KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 595B
+Local tables size: 730B
 Compression types: snappy: 1
-Block cache: 2 entries (716B)  hit rate: 33.3%
+Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
@@ -142,14 +142,14 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 disk-usage
 ----
-3.3KB
+3.7KB
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -161,26 +161,26 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.2KB |    0B |   0 21.0
+    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 26.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     1   595B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 32.7
+    6 |     1   730B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   730B | 1.4KB |   1  0.5
+total |     1   730B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 2 (512KB)
-Zombie tables: 2 (1.2KB, local: 1.2KB)
+Zombie tables: 2 (1.4KB, local: 1.4KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 595B
+Local tables size: 730B
 Compression types: snappy: 1
-Block cache: 2 entries (716B)  hit rate: 33.3%
+Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
@@ -188,10 +188,10 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 # Closing iter c will release one of the zombie sstables. The other
 # zombie sstable is still referenced by iter b.
@@ -204,26 +204,26 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.2KB |    0B |   0 21.0
+    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 26.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     1   595B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 32.7
+    6 |     1   730B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   730B | 1.4KB |   1  0.5
+total |     1   730B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 2 (512KB)
-Zombie tables: 1 (589B, local: 589B)
+Zombie tables: 1 (729B, local: 729B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 595B
+Local tables size: 730B
 Compression types: snappy: 1
-Block cache: 2 entries (716B)  hit rate: 33.3%
+Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 1 entries (832B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -231,14 +231,14 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 disk-usage
 ----
-2.7KB
+3.0KB
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -250,14 +250,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.2KB |    0B |   0 21.0
+    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 26.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     1   595B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  1.8KB | 1.2KB |   1 32.7
+    6 |     1   730B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   730B | 1.4KB |   1  0.5
+total |     1   730B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
@@ -267,7 +267,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 595B
+Local tables size: 730B
 Compression types: snappy: 1
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
@@ -277,26 +277,26 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 disk-usage
 ----
-2.1KB
+2.3KB
 
 additional-metrics
 ----
 block bytes written:
  __level___data-block__value-block
-      0          54B           0B
+      0         162B           0B
       1           0B           0B
       2           0B           0B
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6          33B           0B
+      6          82B           0B
 
 batch
 set c@20 c20
@@ -311,9 +311,13 @@ set c@14 c14
 flush
 ----
 L0.0:
-  000010:[c@20#12,SET-c@18#14,SET]
-  000011:[c@17#15,SET-c@15#17,SET]
-  000012:[c@14#18,SET-c@14#18,SET]
+  000010:[c@20#12,SET-c@20#12,SET]
+  000011:[c@19#13,SET-c@19#13,SET]
+  000012:[c@18#14,SET-c@18#14,SET]
+  000013:[c@17#15,SET-c@17#15,SET]
+  000014:[c@16#16,SET-c@16#16,SET]
+  000015:[c@15#17,SET-c@15#17,SET]
+  000016:[c@14#18,SET-c@14#18,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
 
@@ -322,25 +326,25 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     3  2.0KB    38B       0 |  0.25 |  149B |     0     0B |     0     0B |     5  3.2KB |    0B |   1 21.8
+    0 |     7  5.1KB     0B       0 |  0.25 |  149B |     0     0B |     0     0B |     9  6.5KB |    0B |   1 44.7
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     4  2.6KB    38B       0 |     - |  149B |     0     0B |     0     0B |     6  3.9KB | 1.2KB |   2 26.8
+    6 |     1   730B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   730B | 1.4KB |   1  0.5
+total |     8  5.8KB     0B       0 |     - |  149B |     0     0B |     0     0B |    10  7.4KB | 1.4KB |   2 50.6
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
-Compactions: 1  estimated debt: 2.6KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 5.8KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 2.6KB
-Compression types: snappy: 4
+Local tables size: 5.8KB
+Compression types: snappy: 8
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -349,43 +353,42 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:88 BlockBytesInCache:44 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 additional-metrics
 ----
 block bytes written:
  __level___data-block__value-block
-      0         198B          38B
+      0         820B           0B
       1           0B           0B
       2           0B           0B
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6          33B           0B
+      6          82B           0B
 
 compact a-z
 ----
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
+  000017:[c@20#0,SET-c@14#0,SET]
 
 metrics
 ----
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  149B |     0     0B |     0     0B |     5  3.2KB |    0B |   0 21.8
+    0 |     0     0B     0B       0 |  0.00 |  149B |     0     0B |     0     0B |     9  6.5KB |    0B |   0 44.7
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |     3  2.0KB    41B       0 |     - |  149B |     0     0B |     0     0B |     8  5.3KB | 3.2KB |   1 36.7
+    6 |     2  1.6KB    31B       0 |     - | 6.5KB |     0     0B |     0     0B |     2  1.6KB | 6.5KB |   1  0.2
+total |     2  1.6KB    31B       0 |     - |  149B |     0     0B |     0     0B |    11  8.3KB | 6.5KB |   1 56.7
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
@@ -395,32 +398,32 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 2.0KB
-Compression types: snappy: 3
-Block cache: 0 entries (0B)  hit rate: 14.3%
-Table cache: 0 entries (0B)  hit rate: 58.3%
+Local tables size: 1.6KB
+Compression types: snappy: 2
+Block cache: 0 entries (0B)  hit rate: 10.0%
+Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:1099 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 additional-metrics
 ----
 block bytes written:
  __level___data-block__value-block
-      0         198B          38B
+      0         820B           0B
       1           0B           0B
       2           0B           0B
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6         143B          41B
+      6         220B          31B
 
 # Flushable ingestion metrics. This requires there be data in a memtable that
 # would overlap with the ingested table(s). Delayed flushes are disabled here to
@@ -463,15 +466,16 @@ disable
 flush
 ----
 L0.1:
-  000015:[d#22,SET-d#22,SET]
-  000016:[e#23,SET-e#23,SET]
-  000019:[f#24,SET-f#24,SET]
+  000018:[d#22,SET-d#22,SET]
+  000019:[e#23,SET-e#23,SET]
+  000022:[f#24,SET-f#24,SET]
 L0.0:
-  000023:[d#19,SET-f#21,SET]
+  000026:[d#19,SET-d#19,SET]
+  000027:[e#20,SET-e#20,SET]
+  000028:[f#21,SET-f#21,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
+  000017:[c@20#0,SET-c@14#0,SET]
 
 # We expect the ingested-as-flushable count to be three (one for each ingested
 # table). The unknown category in the iter category stats is because of a gap
@@ -483,38 +487,37 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.3KB     0B       0 |  0.50 |  187B |     3  1.7KB |     0     0B |     6  3.8KB |    0B |   2 20.6
+    0 |     6  4.3KB     0B       0 |  0.50 |  187B |     3  2.1KB |     0     0B |    12  8.6KB |    0B |   2 47.3
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |     7  4.3KB    41B       0 |     - | 1.9KB |     3  1.7KB |     0     0B |     9  7.7KB | 3.2KB |   3  4.0
+    6 |     2  1.6KB    31B       0 |     - | 6.5KB |     0     0B |     0     0B |     2  1.6KB | 6.5KB |   1  0.2
+total |     8  5.9KB    31B       0 |     - | 2.3KB |     3  2.1KB |     0     0B |    14   13KB | 6.5KB |   3  5.4
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 176B  written: 187B (6% overhead)
 Flushes: 8
-Compactions: 2  estimated debt: 4.3KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 5.9KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 4.3KB
-Compression types: snappy: 7
-Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (832B)  hit rate: 53.8%
+Local tables size: 5.9KB
+Compression types: snappy: 8
+Block cache: 6 entries (2.3KB)  hit rate: 7.7%
+Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
+Ingestions: 2  as flushable: 2 (2.1KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
-       pebble-ingest,     latency: {BlockBytes:64 BlockBytesInCache:0 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:1099 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 batch
 set g g
@@ -529,56 +532,60 @@ set m m
 flush
 ----
 L0.1:
-  000015:[d#22,SET-d#22,SET]
-  000016:[e#23,SET-e#23,SET]
-  000019:[f#24,SET-f#24,SET]
+  000018:[d#22,SET-d#22,SET]
+  000019:[e#23,SET-e#23,SET]
+  000022:[f#24,SET-f#24,SET]
 L0.0:
-  000023:[d#19,SET-f#21,SET]
-  000025:[g#25,SET-i#27,SET]
-  000026:[j#28,SET-l#30,SET]
-  000027:[m#31,SET-m#31,SET]
+  000026:[d#19,SET-d#19,SET]
+  000027:[e#20,SET-e#20,SET]
+  000028:[f#21,SET-f#21,SET]
+  000030:[g#25,SET-g#25,SET]
+  000031:[h#26,SET-h#26,SET]
+  000032:[i#27,SET-i#27,SET]
+  000033:[j#28,SET-j#28,SET]
+  000034:[k#29,SET-k#29,SET]
+  000035:[l#30,SET-l#30,SET]
+  000036:[m#31,SET-m#31,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
+  000017:[c@20#0,SET-c@14#0,SET]
 
 metrics
 ----
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  4.1KB     0B       0 |  0.50 |  245B |     3  1.7KB |     0     0B |     9  5.5KB |    0B |   2 23.1
+    0 |    13  9.3KB     0B       0 |  0.50 |  245B |     3  2.1KB |     0     0B |    19   14KB |    0B |   2 56.9
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |    10  6.1KB    41B       0 |     - | 2.0KB |     3  1.7KB |     0     0B |    12  9.5KB | 3.2KB |   3  4.8
+    6 |     2  1.6KB    31B       0 |     - | 6.5KB |     0     0B |     0     0B |     2  1.6KB | 6.5KB |   1  0.2
+total |    15   11KB    31B       0 |     - | 2.4KB |     3  2.1KB |     0     0B |    21   18KB | 6.5KB |   3  7.4
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
-Compactions: 2  estimated debt: 6.1KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 11KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 6.1KB
-Compression types: snappy: 10
-Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (832B)  hit rate: 53.8%
+Local tables size: 11KB
+Compression types: snappy: 15
+Block cache: 6 entries (2.3KB)  hit rate: 7.7%
+Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
+Ingestions: 2  as flushable: 2 (2.1KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
-       pebble-ingest,     latency: {BlockBytes:64 BlockBytesInCache:0 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:1099 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 build ext1
 set z z
@@ -591,19 +598,22 @@ ingest-and-excise ext1 excise=i-k
 lsm
 ----
 L0.1:
-  000015:[d#22,SET-d#22,SET]
-  000016:[e#23,SET-e#23,SET]
-  000019:[f#24,SET-f#24,SET]
+  000018:[d#22,SET-d#22,SET]
+  000019:[e#23,SET-e#23,SET]
+  000022:[f#24,SET-f#24,SET]
 L0.0:
-  000023:[d#19,SET-f#21,SET]
-  000029(000025):[g#25,SET-h#26,SET]
-  000030(000026):[k#29,SET-l#30,SET]
-  000027:[m#31,SET-m#31,SET]
+  000026:[d#19,SET-d#19,SET]
+  000027:[e#20,SET-e#20,SET]
+  000028:[f#21,SET-f#21,SET]
+  000030:[g#25,SET-g#25,SET]
+  000031:[h#26,SET-h#26,SET]
+  000034:[k#29,SET-k#29,SET]
+  000035:[l#30,SET-l#30,SET]
+  000036:[m#31,SET-m#31,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
-  000028:[z#33,SET-z#33,SET]
+  000017:[c@20#0,SET-c@14#0,SET]
+  000037:[z#33,SET-z#33,SET]
 
 # There should be 2 backing tables. Note that tiny sstables have inaccurate
 # virtual sstable sizes.
@@ -614,49 +624,48 @@ num-virtual
 num-virtual 0
 virtual-size
 ----
-2
-1.2KB
-2
-2
-102B
+0
+0B
+0
+0
+0B
 
 metrics zero-cache-hits-misses
 ----
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  3.0KB     0B       2 |  0.50 |  245B |     3  1.7KB |     0     0B |     9  5.5KB |    0B |   2 23.1
+    0 |    11  7.8KB     0B       0 |  0.50 |  245B |     3  2.1KB |     0     0B |    19   14KB |    0B |   2 56.9
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     4  2.6KB    41B       0 |     - | 3.2KB |     1   589B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |    11  5.6KB    41B       2 |     - | 2.5KB |     4  2.3KB |     0     0B |    12   10KB | 3.2KB |   3  4.0
+    6 |     3  2.3KB    31B       0 |     - | 6.5KB |     1   732B |     0     0B |     2  1.6KB | 6.5KB |   1  0.2
+total |    14   10KB    31B       0 |     - | 3.1KB |     4  2.9KB |     0     0B |    21   18KB | 6.5KB |   3  5.9
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
-Compactions: 2  estimated debt: 5.6KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 10KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
-Backing tables: 2 (1.2KB)
-Virtual tables: 2 (102B)
-Local tables size: 6.7KB
-Compression types: snappy: 11
+Backing tables: 0 (0B)
+Virtual tables: 0 (0B)
+Local tables size: 10KB
+Compression types: snappy: 14
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 3  as flushable: 2 (1.7KB in 3 tables)
+Ingestions: 3  as flushable: 2 (2.1KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
-       pebble-ingest,     latency: {BlockBytes:200 BlockBytesInCache:0 BlockReadDuration:30ms}
+   pebble-compaction, non-latency: {BlockBytes:1099 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 # Virtualize a virtual sstable.
 build ext1
@@ -671,20 +680,22 @@ ingest-and-excise ext1 excise=k-l
 lsm
 ----
 L0.1:
-  000015:[d#22,SET-d#22,SET]
-  000016:[e#23,SET-e#23,SET]
-  000019:[f#24,SET-f#24,SET]
+  000018:[d#22,SET-d#22,SET]
+  000019:[e#23,SET-e#23,SET]
+  000022:[f#24,SET-f#24,SET]
 L0.0:
-  000023:[d#19,SET-f#21,SET]
-  000029(000025):[g#25,SET-h#26,SET]
-  000032(000026):[l#30,SET-l#30,SET]
-  000027:[m#31,SET-m#31,SET]
+  000026:[d#19,SET-d#19,SET]
+  000027:[e#20,SET-e#20,SET]
+  000028:[f#21,SET-f#21,SET]
+  000030:[g#25,SET-g#25,SET]
+  000031:[h#26,SET-h#26,SET]
+  000035:[l#30,SET-l#30,SET]
+  000036:[m#31,SET-m#31,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
-  000028:[z#33,SET-z#33,SET]
-  000031:[zz#35,SET-zz#35,SET]
+  000017:[c@20#0,SET-c@14#0,SET]
+  000037:[z#33,SET-z#33,SET]
+  000038:[zz#35,SET-zz#35,SET]
 
 metrics-value
 num-backing
@@ -693,21 +704,20 @@ num-virtual
 num-virtual 0
 virtual-size
 ----
-2
-1.2KB
-2
-2
-102B
+0
+0B
+0
+0
+0B
 
 compact a-z
 ----
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
-  000033:[d#0,SET-m#0,SET]
-  000028:[z#33,SET-z#33,SET]
-  000031:[zz#35,SET-zz#35,SET]
+  000017:[c@20#0,SET-c@14#0,SET]
+  000039:[d#0,SET-m#0,SET]
+  000037:[z#33,SET-z#33,SET]
+  000038:[zz#35,SET-zz#35,SET]
 
 # Virtual sstables metrics should be gone after the compaction.
 metrics-value
@@ -728,14 +738,14 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  245B |     3  1.7KB |     0     0B |     9  5.5KB |    0B |   0 23.1
+    0 |     0     0B     0B       0 |  0.00 |  245B |     3  2.1KB |     0     0B |    19   14KB |    0B |   0 56.9
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     6  3.8KB    41B       0 |     - | 6.2KB |     2  1.2KB |     0     0B |     4  2.6KB | 6.2KB |   1  0.4
-total |     6  3.8KB    41B       0 |     - | 3.1KB |     5  2.9KB |     0     0B |    13   11KB | 6.2KB |   1  3.6
+    6 |     5  3.7KB    31B       0 |     - |  14KB |     2  1.4KB |     0     0B |     3  2.3KB |  14KB |   1  0.2
+total |     5  3.7KB    31B       0 |     - | 3.8KB |     5  3.6KB |     0     0B |    22   20KB |  14KB |   1  5.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
@@ -745,21 +755,20 @@ MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 3.8KB
-Compression types: snappy: 6
+Local tables size: 3.7KB
+Compression types: snappy: 5
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
-Ingestions: 4  as flushable: 2 (1.7KB in 3 tables)
+Ingestions: 4  as flushable: 2 (2.1KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:677 BlockBytesInCache:376 BlockReadDuration:70ms}
-       pebble-ingest,     latency: {BlockBytes:272 BlockBytesInCache:72 BlockReadDuration:30ms}
+   pebble-compaction, non-latency: {BlockBytes:2228 BlockBytesInCache:457 BlockReadDuration:150ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
-                   c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 
 # Create a DB where lower levels are written as shared tables. All ingests also
 # become shared tables.
@@ -775,7 +784,9 @@ set c 1
 flush
 ----
 L0.0:
-  000005:[a#10,SET-c#12,SET]
+  000005:[a#10,SET-a#10,SET]
+  000006:[b#11,SET-b#11,SET]
+  000007:[c#12,SET-c#12,SET]
 
 # One local table.
 metrics
@@ -783,14 +794,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   604B     0B       0 |  0.25 |   38B |     0     0B |     0     0B |     1   604B |    0B |   1 15.9
+    0 |     3  2.1KB     0B       0 |  0.25 |   38B |     0     0B |     0     0B |     3  2.1KB |    0B |   1 57.6
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-total |     1   604B     0B       0 |     - |   38B |     0     0B |     0     0B |     1   642B |    0B |   1 16.9
+total |     3  2.1KB     0B       0 |     - |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 58.6
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -800,8 +811,8 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 604B
-Compression types: snappy: 1
+Local tables size: 2.1KB
+Compression types: snappy: 3
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -815,7 +826,7 @@ Iter category stats:
 compact a-z
 ----
 L6:
-  000006:[a#10,SET-c#12,SET]
+  000008:[a#0,SET-c#0,SET]
 
 # Table becomes shared, so local table size becomes 0.
 metrics
@@ -823,19 +834,19 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   38B |     0     0B |     0     0B |     1   604B |    0B |   0 15.9
+    0 |     0     0B     0B       0 |  0.00 |   38B |     0     0B |     0     0B |     3  2.1KB |    0B |   0 57.6
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   604B     0B       0 |     - |  604B |     0     0B |     0     0B |     1   604B |    0B |   1  1.0
-total |     1   604B     0B       0 |     - |   38B |     0     0B |     0     0B |     2  1.2KB |    0B |   1 32.8
+    6 |     1   745B     0B       0 |     - | 2.1KB |     0     0B |     0     0B |     1   745B | 2.1KB |   1  0.3
+total |     1   745B     0B       0 |     - |   38B |     0     0B |     0     0B |     4  2.9KB | 2.1KB |   1 78.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 1  multi-level: 0
+             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
@@ -843,14 +854,14 @@ Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 1 entries (832B)  hit rate: 0.0%
+Table cache: 0 entries (0B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
+   pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
 
 build ext1.sst
 set b 2
@@ -862,9 +873,9 @@ ingest ext1.sst
 lsm
 ----
 L0.0:
-  000007:[b#13,SET-b#13,SET]
+  000009:[b#13,SET-b#13,SET]
 L6:
-  000006:[a#10,SET-c#12,SET]
+  000008:[a#0,SET-c#0,SET]
 
 # Ingest is also shared table, so local table size stays 0.
 metrics
@@ -872,35 +883,35 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   589B     0B       0 |  0.25 |   38B |     1   589B |     0     0B |     1   604B |    0B |   1 15.9
+    0 |     1   732B     0B       0 |  0.25 |   38B |     1   732B |     0     0B |     3  2.1KB |    0B |   1 57.6
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   604B     0B       0 |     - |  604B |     0     0B |     0     0B |     1   604B |    0B |   1  1.0
-total |     2  1.2KB     0B       0 |     - |  627B |     1   589B |     0     0B |     2  1.8KB |    0B |   2  2.9
+    6 |     1   745B     0B       0 |     - | 2.1KB |     0     0B |     0     0B |     1   745B | 2.1KB |   1  0.3
+total |     2  1.4KB     0B       0 |     - |  770B |     1   732B |     0     0B |     4  3.6KB | 2.1KB |   2  4.8
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
-Compactions: 1  estimated debt: 1.2KB  in progress: 0 (0B)
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 1  multi-level: 0
+Compactions: 1  estimated debt: 1.4KB  in progress: 0 (0B)
+             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
 Compression types: snappy: 2
-Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (832B)  hit rate: 50.0%
+Block cache: 4 entries (1.5KB)  hit rate: 0.0%
+Table cache: 1 entries (832B)  hit rate: 42.9%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 1  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-       pebble-ingest,     latency: {BlockBytes:59 BlockBytesInCache:0 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
+       pebble-ingest,     latency: {BlockBytes:127 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 batch
 set b 3
@@ -909,11 +920,11 @@ set b 3
 flush
 ----
 L0.1:
-  000009:[b#14,SET-b#14,SET]
+  000011:[b#14,SET-b#14,SET]
 L0.0:
-  000007:[b#13,SET-b#13,SET]
+  000009:[b#13,SET-b#13,SET]
 L6:
-  000006:[a#10,SET-c#12,SET]
+  000008:[a#0,SET-c#0,SET]
 
 # Local table size increases due to flush.
 metrics
@@ -921,35 +932,35 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.2KB     0B       0 |  0.50 |   66B |     1   589B |     0     0B |     2  1.2KB |    0B |   2 18.1
+    0 |     2  1.4KB     0B       0 |  0.50 |   66B |     1   732B |     0     0B |     4  2.8KB |    0B |   2 44.2
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   604B     0B       0 |     - |  604B |     0     0B |     0     0B |     1   604B |    0B |   1  1.0
-total |     3  1.7KB     0B       0 |     - |  655B |     1   589B |     0     0B |     3  2.4KB |    0B |   3  3.7
+    6 |     1   745B     0B       0 |     - | 2.1KB |     0     0B |     0     0B |     1   745B | 2.1KB |   1  0.3
+total |     3  2.2KB     0B       0 |     - |  798B |     1   732B |     0     0B |     5  4.4KB | 2.1KB |   3  5.6
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 44B  written: 66B (50% overhead)
 Flushes: 2
-Compactions: 1  estimated debt: 1.7KB  in progress: 0 (0B)
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 1  multi-level: 0
+Compactions: 1  estimated debt: 2.2KB  in progress: 0 (0B)
+             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 589B
+Local tables size: 729B
 Compression types: snappy: 3
-Block cache: 4 entries (1.4KB)  hit rate: 0.0%
-Table cache: 1 entries (832B)  hit rate: 50.0%
+Block cache: 4 entries (1.5KB)  hit rate: 0.0%
+Table cache: 1 entries (832B)  hit rate: 42.9%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 1  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-       pebble-ingest,     latency: {BlockBytes:59 BlockBytesInCache:0 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
+       pebble-ingest,     latency: {BlockBytes:127 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 # Reopen DB, to ensure stats are consistent. Also, reopened DB is not
 # configured to write shared tables.
@@ -961,24 +972,24 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.2KB     0B       0 |  0.50 |    0B |     0     0B |     0     0B |     0     0B |    0B |   2  0.0
+    0 |     2  1.4KB     0B       0 |  0.50 |    0B |     0     0B |     0     0B |     0     0B |    0B |   2  0.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   604B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   1  0.0
-total |     3  1.7KB     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   3  0.0
+    6 |     1   745B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   1  0.0
+total |     3  2.2KB     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   3  0.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 1
-Compactions: 0  estimated debt: 1.7KB  in progress: 0 (0B)
+Compactions: 0  estimated debt: 2.2KB  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 589B
+Local tables size: 729B
 Compression types: snappy: 3
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
@@ -993,7 +1004,7 @@ Iter category stats:
 compact a-z
 ----
 L6:
-  000014:[a#0,SET-c#0,SET]
+  000016:[a#0,SET-c#0,SET]
 
 # All tables are local after compaction.
 metrics zero-cache-hits-misses
@@ -1007,8 +1018,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   603B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   603B | 1.7KB |   1  0.5
-total |     1   603B     0B       0 |     - |    0B |     0     0B |     0     0B |     1   603B | 1.7KB |   1  0.0
+    6 |     1   745B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   745B | 2.2KB |   1  0.5
+total |     1   745B     0B       0 |     - |    0B |     0     0B |     0     0B |     1   745B | 2.2KB |   1  0.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 1
@@ -1018,7 +1029,7 @@ MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 603B
+Local tables size: 745B
 Compression types: snappy: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
@@ -1028,4 +1039,4 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:147 BlockBytesInCache:0 BlockReadDuration:30ms}
+   pebble-compaction, non-latency: {BlockBytes:354 BlockBytesInCache:0 BlockReadDuration:30ms}

--- a/tool/testdata/db_upgrade
+++ b/tool/testdata/db_upgrade
@@ -27,7 +27,7 @@ db get foo yellow
 db upgrade foo
 ----
 ----
-Upgrading DB from internal version 16 to 20.
+Upgrading DB from internal version 16 to 21.
 WARNING!!!
 This DB will not be usable with older versions of Pebble!
 
@@ -43,7 +43,7 @@ Continue? [Y/N] Error: EOF
 
 db upgrade foo --yes
 ----
-Upgrading DB from internal version 16 to 20.
+Upgrading DB from internal version 16 to 21.
 Upgrade complete.
 
 db get foo blue
@@ -56,4 +56,4 @@ db get foo yellow
 
 db upgrade foo
 ----
-DB is already at internal version 20.
+DB is already at internal version 21.


### PR DESCRIPTION
Export the new format major version that enables use of TableFormatPebblev6, and update FormatNewest to point to this format major version. This new table format adds the checksum over the sstable footer, and allows the encoding of blob handles within the value column.