### PR TITLE
sstable: add IterOptions

### DIFF
--- a/cockroachkvs/cockroachkvs_bench_test.go
+++ b/cockroachkvs/cockroachkvs_bench_test.go
@@ -130,9 +130,11 @@ func benchmarkRandSeekInSST(
 	// Iterate through the entire table to warm up the cache.
 	var stats base.InternalIteratorStats
 	rp := sstable.MakeTrivialReaderProvider(reader)
-	iter, err := reader.NewPointIter(
-		ctx, sstable.NoTransforms, nil, nil, nil, sstable.NeverUseFilterBlock,
-		block.ReadEnv{Stats: &stats, IterStats: nil}, rp)
+	iter, err := reader.NewPointIter(ctx, sstable.IterOptions{
+		FilterBlockSizeLimit: sstable.NeverUseFilterBlock,
+		Env:                  block.ReadEnv{Stats: &stats, IterStats: nil},
+		ReaderProvider:       rp,
+	})
 	require.NoError(b, err)
 	n := 0
 	for kv := iter.First(); kv != nil; kv = iter.Next() {
@@ -146,9 +148,11 @@ func benchmarkRandSeekInSST(
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		key := queryKeys[i%numQueryKeys]
-		iter, err := reader.NewPointIter(
-			ctx, sstable.NoTransforms, nil, nil, nil, sstable.NeverUseFilterBlock,
-			block.ReadEnv{Stats: &stats, IterStats: nil}, rp)
+		iter, err := reader.NewPointIter(ctx, sstable.IterOptions{
+			FilterBlockSizeLimit: sstable.NeverUseFilterBlock,
+			Env:                  block.ReadEnv{Stats: &stats, IterStats: nil},
+			ReaderProvider:       rp,
+		})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -176,9 +176,14 @@ func createExternalPointIter(
 			// BlockPropertiesFilterer that includes obsoleteKeyBlockPropertyFilter.
 			transforms := sstable.IterTransforms{SyntheticSeqNum: sstable.SyntheticSeqNum(seqNum)}
 			seqNum--
-			pointIter, err = r.NewPointIter(
-				ctx, transforms, it.opts.LowerBound, it.opts.UpperBound, nil, /* BlockPropertiesFilterer */
-				sstable.NeverUseFilterBlock, readEnv, sstable.MakeTrivialReaderProvider(r))
+			pointIter, err = r.NewPointIter(ctx, sstable.IterOptions{
+				Lower:                it.opts.LowerBound,
+				Upper:                it.opts.UpperBound,
+				Transforms:           transforms,
+				FilterBlockSizeLimit: sstable.NeverUseFilterBlock,
+				Env:                  readEnv,
+				ReaderProvider:       sstable.MakeTrivialReaderProvider(r),
+			})
 			if err == nil {
 				rangeDelIter, err = r.NewRawRangeDelIter(ctx, sstable.FragmentIterTransforms{
 					SyntheticSeqNum: sstable.SyntheticSeqNum(seqNum),

--- a/file_cache.go
+++ b/file_cache.go
@@ -679,9 +679,15 @@ func (h *fileCacheHandle) newPointIter(
 	if internalOpts.compaction {
 		iter, err = cr.NewCompactionIter(transforms, internalOpts.readEnv, &v.readerProvider)
 	} else {
-		iter, err = cr.NewPointIter(
-			ctx, transforms, opts.GetLowerBound(), opts.GetUpperBound(), filterer,
-			filterBlockSizeLimit, internalOpts.readEnv, &v.readerProvider)
+		iter, err = cr.NewPointIter(ctx, sstable.IterOptions{
+			Lower:                opts.GetLowerBound(),
+			Upper:                opts.GetUpperBound(),
+			Transforms:           transforms,
+			FilterBlockSizeLimit: filterBlockSizeLimit,
+			Filterer:             filterer,
+			Env:                  internalOpts.readEnv,
+			ReaderProvider:       &v.readerProvider,
+		})
 	}
 	if err != nil {
 		return nil, err

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -183,16 +183,21 @@ func (lt *levelIterTest) newIters(
 	transforms := file.IterTransforms()
 	var set iterSet
 	if kinds.Point() {
-		iter, err := lt.readers[file.FileNum].NewPointIter(
-			ctx, transforms,
-			opts.LowerBound, opts.UpperBound, nil, sstable.AlwaysUseFilterBlock, iio.readEnv, sstable.MakeTrivialReaderProvider(lt.readers[file.FileNum]))
+		iter, err := lt.readers[file.FileNum].NewPointIter(ctx, sstable.IterOptions{
+			Lower:                opts.GetLowerBound(),
+			Upper:                opts.GetUpperBound(),
+			Transforms:           transforms,
+			FilterBlockSizeLimit: sstable.AlwaysUseFilterBlock,
+			Env:                  iio.readEnv,
+			ReaderProvider:       sstable.MakeTrivialReaderProvider(lt.readers[file.FileNum]),
+		})
 		if err != nil {
 			return iterSet{}, errors.CombineErrors(err, set.CloseAll())
 		}
 		set.point = iter
 	}
 	if kinds.RangeDeletion() {
-		rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(context.Background(), file.FragmentIterTransforms(), block.NoReadEnv)
+		rangeDelIter, err := lt.readers[file.FileNum].NewRawRangeDelIter(ctx, file.FragmentIterTransforms(), block.NoReadEnv)
 		if err != nil {
 			return iterSet{}, errors.CombineErrors(err, set.CloseAll())
 		}

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -986,9 +986,15 @@ func TestBlockProperties(t *testing.T) {
 			} else if !ok {
 				return "filter excludes entire table"
 			}
-			iter, err := r.NewPointIter(
-				context.Background(),
-				NoTransforms, lower, upper, filterer, NeverUseFilterBlock, block.ReadEnv{Stats: &stats, IterStats: nil}, MakeTrivialReaderProvider(r))
+			iter, err := r.NewPointIter(context.Background(), IterOptions{
+				Lower:                lower,
+				Upper:                upper,
+				Transforms:           NoTransforms,
+				Filterer:             filterer,
+				FilterBlockSizeLimit: NeverUseFilterBlock,
+				Env:                  block.ReadEnv{Stats: &stats, IterStats: nil},
+				ReaderProvider:       MakeTrivialReaderProvider(r),
+			})
 			if err != nil {
 				return err.Error()
 			}
@@ -1069,9 +1075,15 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 			} else if !ok {
 				return "filter excludes entire table"
 			}
-			iter, err := r.NewPointIter(
-				context.Background(),
-				NoTransforms, lower, upper, filterer, NeverUseFilterBlock, block.ReadEnv{Stats: &stats, IterStats: nil}, MakeTrivialReaderProvider(r))
+			iter, err := r.NewPointIter(context.Background(), IterOptions{
+				Lower:                lower,
+				Upper:                upper,
+				Transforms:           NoTransforms,
+				Filterer:             filterer,
+				FilterBlockSizeLimit: NeverUseFilterBlock,
+				Env:                  block.ReadEnv{Stats: &stats, IterStats: nil},
+				ReaderProvider:       MakeTrivialReaderProvider(r),
+			})
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -105,15 +105,13 @@ func runErrorInjectionTest(t *testing.T, seed int64) {
 	if rng.IntN(2) == 1 {
 		filterBlockSizeLimit = NeverUseFilterBlock
 	}
-	it, err := r.NewPointIter(
-		context.Background(),
-		NoTransforms,
-		nil /* lower TODO */, nil, /* upper TODO */
-		filterer,
-		filterBlockSizeLimit,
-		block.ReadEnv{Stats: &stats, IterStats: nil},
-		MakeTrivialReaderProvider(r),
-	)
+	it, err := r.NewPointIter(context.Background(), IterOptions{
+		Transforms:           NoTransforms,
+		Filterer:             filterer,
+		FilterBlockSizeLimit: filterBlockSizeLimit,
+		Env:                  block.ReadEnv{Stats: &stats, IterStats: nil},
+		ReaderProvider:       MakeTrivialReaderProvider(r),
+	})
 	require.NoError(t, err)
 	defer it.Close()
 

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -25,15 +25,7 @@ type CommonReader interface {
 		ctx context.Context, transforms FragmentIterTransforms, env block.ReadEnv,
 	) (keyspan.FragmentIterator, error)
 
-	NewPointIter(
-		ctx context.Context,
-		transforms IterTransforms,
-		lower, upper []byte,
-		filterer *BlockPropertiesFilterer,
-		filterBlockSizeLimit FilterBlockSizeLimit,
-		env block.ReadEnv,
-		rp valblk.ReaderProvider,
-	) (Iterator, error)
+	NewPointIter(ctx context.Context, opts IterOptions) (Iterator, error)
 
 	NewCompactionIter(
 		transforms IterTransforms,

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -55,28 +55,20 @@ func TestIteratorErrorOnInit(t *testing.T) {
 	var stats base.InternalIteratorStats
 	for k := 0; k < 20; k++ {
 		if rand.IntN(2) == 0 {
-			_, err := newRowBlockSingleLevelIterator(
-				context.Background(),
-				r,
-				nil, /* v */
-				NoTransforms,
-				nil /* lower */, nil, /* upper */
-				nil /* filterer */, NeverUseFilterBlock,
-				block.ReadEnv{Stats: &stats, BufferPool: &pool},
-				MakeTrivialReaderProvider(r),
-			)
+			_, err := newRowBlockSingleLevelIterator(context.Background(), r, nil /*virtualState*/, IterOptions{
+				Transforms:           NoTransforms,
+				FilterBlockSizeLimit: NeverUseFilterBlock,
+				Env:                  block.ReadEnv{Stats: &stats, BufferPool: &pool},
+				ReaderProvider:       MakeTrivialReaderProvider(r),
+			})
 			require.Error(t, err)
 		} else {
-			_, err := newRowBlockTwoLevelIterator(
-				context.Background(),
-				r,
-				nil, /* v */
-				NoTransforms,
-				nil /* lower */, nil, /* upper */
-				nil /* filterer */, NeverUseFilterBlock,
-				block.ReadEnv{Stats: &stats, BufferPool: &pool},
-				MakeTrivialReaderProvider(r),
-			)
+			_, err := newRowBlockTwoLevelIterator(context.Background(), r, nil /*virtualState*/, IterOptions{
+				Transforms:           NoTransforms,
+				FilterBlockSizeLimit: NeverUseFilterBlock,
+				Env:                  block.ReadEnv{Stats: &stats, BufferPool: &pool},
+				ReaderProvider:       MakeTrivialReaderProvider(r),
+			})
 			require.Error(t, err)
 		}
 	}

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -111,18 +111,8 @@ func (v *VirtualReader) NewCompactionIter(
 // We assume that the [lower, upper) bounds (if specified) will have at least
 // some overlap with the virtual sstable bounds. No overlap is not currently
 // supported in the iterator.
-func (v *VirtualReader) NewPointIter(
-	ctx context.Context,
-	transforms IterTransforms,
-	lower, upper []byte,
-	filterer *BlockPropertiesFilterer,
-	filterBlockSizeLimit FilterBlockSizeLimit,
-	env block.ReadEnv,
-	rp valblk.ReaderProvider,
-) (Iterator, error) {
-	return v.reader.newPointIter(
-		ctx, transforms, lower, upper, filterer, filterBlockSizeLimit,
-		env, rp, &v.vState)
+func (v *VirtualReader) NewPointIter(ctx context.Context, opts IterOptions) (Iterator, error) {
+	return v.reader.newPointIter(ctx, opts, &v.vState)
 }
 
 // ValidateBlockChecksumsOnBacking will call ValidateBlockChecksumsOnBacking on the underlying reader.


### PR DESCRIPTION
Add a IterOptions struct for propagating point iterator configuration options. The set of possible configuration options has ballooned and the struct makes call sites a little more legible.