### PR TITLE
manifest: don't crosscheck AddL0Files result every time

### DIFF
--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1295,7 +1295,10 @@ func (b *BulkVersionEdit) Apply(
 				v.L0Sublevels, err = curr.L0Sublevels.AddL0Files(addedTables, flushSplitBytes, &v.Levels[0])
 				if errors.Is(err, errInvalidL0SublevelsOpt) {
 					err = v.InitL0Sublevels(flushSplitBytes)
-				} else if invariants.Enabled && err == nil {
+				} else if invariants.Enabled && err == nil && invariants.Sometimes(10) {
+					// Rebuild from scratch to verify that AddL0Files did the right thing.
+					// Note that NewL0Sublevels updates fields in TableMetadata like
+					// L0Index, so we don't want to do this every time.
 					copyOfSublevels, err := NewL0Sublevels(&v.Levels[0], comparer.Compare, comparer.FormatKey, flushSplitBytes)
 					if err != nil {
 						panic(fmt.Sprintf("error when regenerating sublevels: %s", err))


### PR DESCRIPTION
In invariants.Enabled, we rebuild the L0 sublevels from scratch to
cross-check the result of the incremental updating. However, this
rebuilding reinitializes the fields inside TableMetadata (like
L0Index), correcting any mistake made by `AddL0Files` (but only in
invariant builds..)

This change adds an `invariant.Sometimes(10)` to only do this
sometimes.

In the future, we will want to move out the TableMetadata fields we're
modifying and cross-check those values too.