### PR TITLE
manifest: simplify BulkVersionEdit.Apply

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -549,9 +549,7 @@ func newFlush(
 		}
 	}
 
-	if cur.L0Sublevels != nil {
-		c.l0Limits = cur.L0Sublevels.FlushSplitKeys()
-	}
+	c.l0Limits = cur.L0Sublevels.FlushSplitKeys()
 
 	smallestSet, largestSet := false, false
 	updatePointBounds := func(iter internalIterator) {
@@ -1016,7 +1014,7 @@ func (d *DB) addInProgressCompaction(c *compaction) {
 		}
 	}
 
-	if (isIntraL0 || isBase) && c.version.L0Sublevels != nil {
+	if isIntraL0 || isBase {
 		l0Inputs := []manifest.LevelSlice{c.startLevel.files}
 		if isIntraL0 {
 			l0Inputs = append(l0Inputs, c.outputLevel.files)

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 func newVersion(opts *Options, files [numLevels][]*tableMetadata) *version {
-	v := manifest.NewVersion(
+	v := manifest.NewVersionForTesting(
 		opts.Comparer,
 		opts.FlushSplitBytes,
 		files)

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -429,7 +429,7 @@ func TestGetIter(t *testing.T) {
 
 			files[tt.level] = append(files[tt.level], meta)
 		}
-		v := manifest.NewVersion(cmp, 10<<20, files)
+		v := manifest.NewVersionForTesting(cmp, 10<<20, files)
 		err := v.CheckOrdering()
 		if tc.badOrdering && err == nil {
 			t.Errorf("desc=%q: want bad ordering, got nil error", desc)

--- a/internal/compact/splitting_test.go
+++ b/internal/compact/splitting_test.go
@@ -34,7 +34,7 @@ func TestOutputSplitter(t *testing.T) {
 					files[1] = append(files[1], f)
 				}
 			}
-			v := manifest.NewVersion(base.DefaultComparer, 64*1024, files)
+			v := manifest.NewVersionForTesting(base.DefaultComparer, 64*1024, files)
 			if err := v.CheckOrdering(); err != nil {
 				d.Fatalf(t, "%v", err)
 			}

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -312,7 +312,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 				amap[metas[i].FileNum] = metas[i]
 			}
 			b.AddedTables[6] = amap
-			v, err := b.Apply(nil, base.DefaultComparer, 0, 0)
+			v, err := b.Apply(manifest.NewVersion(base.DefaultComparer), 0, 0)
 			require.NoError(t, err)
 			levelIter.Init(
 				context.Background(),

--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -26,7 +26,7 @@ func makeTestVersion(numFiles int) (*Version, []*TableMetadata) {
 	var levelFiles [7][]*TableMetadata
 	levelFiles[6] = files
 
-	v := NewVersion(base.DefaultComparer, 0, levelFiles)
+	v := NewVersionForTesting(base.DefaultComparer, 0, levelFiles)
 	return v, files
 }
 

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -32,7 +32,7 @@ func readManifest(filename string) (*Version, error) {
 	}
 	defer f.Close()
 	rr := record.NewReader(f, 0 /* logNum */)
-	var v *Version
+	v := NewVersion(base.DefaultComparer)
 	addedByFileNum := make(map[base.FileNum]*TableMetadata)
 	for {
 		r, err := rr.Next()
@@ -51,7 +51,7 @@ func readManifest(filename string) (*Version, error) {
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}
-		if v, err = bve.Apply(v, base.DefaultComparer, 10<<20, 32000); err != nil {
+		if v, err = bve.Apply(v, 10<<20, 32000); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -127,7 +127,7 @@ func replayManifest(t *testing.T, opts *pebble.Options, dirname string) *manifes
 		require.NoError(t, bve.Accumulate(&ve))
 	}
 	v, err := bve.Apply(
-		nil /* version */, cmp, opts.FlushSplitBytes,
+		manifest.NewVersion(cmp), opts.FlushSplitBytes,
 		opts.Experimental.ReadCompactionRate)
 	require.NoError(t, err)
 	return v

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -443,7 +443,7 @@ func TestVersionEditApply(t *testing.T) {
 					}
 				}
 
-				newv, err := bve.Apply(v, base.DefaultComparer, flushSplitBytes, readCompactionRate)
+				newv, err := bve.Apply(v, flushSplitBytes, readCompactionRate)
 				if err != nil {
 					return err.Error()
 				}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -438,7 +438,7 @@ func TestTableMetadata_ParseRoundTrip(t *testing.T) {
 func TestCalculateInuseKeyRanges(t *testing.T) {
 	newVersion := func(files [NumLevels][]*TableMetadata) *Version {
 		t.Helper()
-		v := NewVersion(base.DefaultComparer, 64*1024, files)
+		v := NewVersionForTesting(base.DefaultComparer, 64*1024, files)
 		if err := v.CheckOrdering(); err != nil {
 			t.Fatal(err)
 		}
@@ -740,7 +740,7 @@ func TestCalculateInuseKeyRangesRandomized(t *testing.T) {
 				return cmp(a.Smallest.UserKey, b.Smallest.UserKey)
 			})
 		}
-		v := NewVersion(base.DefaultComparer, 64*1024, files)
+		v := NewVersionForTesting(base.DefaultComparer, 64*1024, files)
 		if err := v.CheckOrdering(); err != nil {
 			t.Fatal(err)
 		}

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -279,7 +279,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				// Start from level 1 in this test.
 				files[i+1] = levels[i]
 			}
-			version := manifest.NewVersion(
+			version := manifest.NewVersionForTesting(
 				testkeys.Comparer,
 				0,
 				files)

--- a/open_test.go
+++ b/open_test.go
@@ -1457,7 +1457,7 @@ func TestCheckConsistency(t *testing.T) {
 					}
 				}
 
-				v := manifest.NewVersion(base.DefaultComparer, 0, filesByLevel)
+				v := manifest.NewVersionForTesting(base.DefaultComparer, 0, filesByLevel)
 				err := checkConsistency(v, provider)
 				if err != nil {
 					if redactErr {

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -714,7 +714,7 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 
 	var cumulativeWriteBytes uint64
 	var flushBufs flushBuffers
-	var v *manifest.Version
+	v := manifest.NewVersion(r.Opts.Comparer)
 	var previousVersion *manifest.Version
 	var bve manifest.BulkVersionEdit
 	bve.AddedTablesByFileNum = make(map[base.FileNum]*manifest.TableMetadata)
@@ -724,7 +724,6 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 	currentVersion := func() (*manifest.Version, error) {
 		var err error
 		v, err = bve.Apply(v,
-			r.Opts.Comparer,
 			r.Opts.FlushSplitBytes,
 			r.Opts.Experimental.ReadCompactionRate)
 		bve = manifest.BulkVersionEdit{AddedTablesByFileNum: bve.AddedTablesByFileNum}

--- a/tool/db.go
+++ b/tool/db.go
@@ -716,7 +716,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 			}
 		}
 		v, err := bve.Apply(
-			nil /* version */, cmp, d.opts.FlushSplitBytes,
+			manifest.NewVersion(cmp), d.opts.FlushSplitBytes,
 			d.opts.Experimental.ReadCompactionRate,
 		)
 		if err != nil {

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -322,7 +322,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 			}
 		}
 
-		v := manifest.NewVersion(l.cmp, 0, currentFiles)
+		v := manifest.NewVersionForTesting(l.cmp, 0, currentFiles)
 		edit.Sublevels = make(map[base.FileNum]int)
 		for sublevel, files := range v.L0SublevelFiles {
 			iter := files.Iter()

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -243,7 +243,8 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 
 			if comparer != nil {
 				v, err := bve.Apply(
-					nil /* version */, comparer, 0,
+					manifest.NewVersion(comparer),
+					0,
 					m.opts.Experimental.ReadCompactionRate,
 				)
 				if err != nil {
@@ -625,7 +626,10 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 				}
 				// TODO(sbhola): add option to Apply that reports all errors instead of
 				// one error.
-				newv, err := bve.Apply(v, cmp, 0, m.opts.Experimental.ReadCompactionRate)
+				if v == nil {
+					v = manifest.NewVersion(cmp)
+				}
+				newv, err := bve.Apply(v, 0, m.opts.Experimental.ReadCompactionRate)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)


### PR DESCRIPTION
Require a non-nil version to simplify the interface and the code a
bit.

We also remove unnecessary nil checks for `Version.L0Sublevels`, which
is never the case.