### PR TITLE
*: use iter.Seq for ranging over TableMetadata

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"iter"
 	"math"
 	"runtime/pprof"
 	"slices"
@@ -294,9 +295,9 @@ type compaction struct {
 func (c *compaction) inputLargestSeqNumAbsolute() base.SeqNum {
 	var seqNum base.SeqNum
 	for _, cl := range c.inputs {
-		cl.files.Each(func(m *manifest.TableMetadata) {
+		for m := range cl.files.All() {
 			seqNum = max(seqNum, m.LargestSeqNumAbsolute)
-		})
+		}
 	}
 	return seqNum
 }
@@ -313,8 +314,7 @@ func (c *compaction) makeInfo(jobID JobID) CompactionInfo {
 	}
 	for _, cl := range c.inputs {
 		inputInfo := LevelInfo{Level: cl.level, Tables: nil}
-		iter := cl.files.Iter()
-		for m := iter.First(); m != nil; m = iter.Next() {
+		for m := range cl.files.All() {
 			inputInfo.Tables = append(inputInfo.Tables, m.TableInfo())
 		}
 		info.Input = append(info.Input, inputInfo)
@@ -454,9 +454,9 @@ func newDeleteOnlyCompaction(
 	}
 
 	// Set c.smallest, c.largest.
-	files := make([]manifest.LevelIterator, 0, len(inputs))
+	files := make([]iter.Seq[*manifest.TableMetadata], 0, len(inputs))
 	for _, in := range inputs {
-		files = append(files, in.files.Iter())
+		files = append(files, in.files.All())
 	}
 	c.smallest, c.largest = manifest.KeyRange(opts.Comparer.Compare, files...)
 	return c
@@ -983,8 +983,7 @@ func (c *compaction) String() string {
 	for level := c.startLevel.level; level <= c.outputLevel.level; level++ {
 		i := level - c.startLevel.level
 		fmt.Fprintf(&buf, "%d:", level)
-		iter := c.inputs[i].files.Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range c.inputs[i].files.All() {
 			fmt.Fprintf(&buf, " %s:%s-%s", f.FileNum, f.Smallest, f.Largest)
 		}
 		fmt.Fprintf(&buf, "\n")
@@ -1021,8 +1020,7 @@ func (d *DB) addInProgressCompaction(c *compaction) {
 	d.mu.compact.inProgress[c] = struct{}{}
 	var isBase, isIntraL0 bool
 	for _, cl := range c.inputs {
-		iter := cl.files.Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range cl.files.All() {
 			if f.IsCompacting() {
 				d.opts.Logger.Fatalf("L%d->L%d: %s already being compacted", c.startLevel.level, c.outputLevel.level, f.FileNum)
 			}
@@ -1059,8 +1057,7 @@ func (d *DB) addInProgressCompaction(c *compaction) {
 func (d *DB) clearCompactingState(c *compaction, rollback bool) {
 	c.versionEditApplied = true
 	for _, cl := range c.inputs {
-		iter := cl.files.Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range cl.files.All() {
 			if !f.IsCompacting() {
 				d.opts.Logger.Fatalf("L%d->L%d: %s not being compacted", c.startLevel.level, c.outputLevel.level, f.FileNum)
 			}
@@ -1346,9 +1343,7 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 		// Iterate through all levels and find files that intersect with exciseSpan.
 		for l := range c.version.Levels {
 			overlaps := c.version.Overlaps(l, base.UserKeyBoundsEndExclusive(ingestFlushable.exciseSpan.Start, ingestFlushable.exciseSpan.End))
-			iter := overlaps.Iter()
-
-			for m := iter.First(); m != nil; m = iter.Next() {
+			for m := range overlaps.All() {
 				newFiles, err := d.excise(context.TODO(), ingestFlushable.exciseSpan.UserKeyBounds(), m, ve, l)
 				if err != nil {
 					return nil, err
@@ -1568,8 +1563,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 				// cancel the compaction.
 				for c2 := range d.mu.compact.inProgress {
 					for i := range c2.inputs {
-						iter := c2.inputs[i].files.Iter()
-						for f := iter.First(); f != nil; f = iter.Next() {
+						for f := range c2.inputs[i].files.All() {
 							if _, ok := ve.DeletedTables[deletedFileEntry{FileNum: f.FileNum, Level: c2.inputs[i].level}]; ok {
 								c2.cancel.Store(true)
 								break
@@ -2248,10 +2242,7 @@ func checkDeleteCompactionHints(
 		filesDeletedByCurrentHint := 0
 		var filesDeletedByLevel [7][]*tableMetadata
 		for l := h.tombstoneLevel + 1; l < numLevels; l++ {
-			overlaps := v.Overlaps(l, base.UserKeyBoundsEndExclusive(h.start, h.end))
-			iter := overlaps.Iter()
-
-			for m := iter.First(); m != nil; m = iter.Next() {
+			for m := range v.Overlaps(l, base.UserKeyBoundsEndExclusive(h.start, h.end)).All() {
 				doesHintApply := h.canDeleteOrExcise(cmp, m, snapshots, exciseEnabled)
 				if m.IsCompacting() || doesHintApply == hintDoesNotApply || files[m] {
 					continue
@@ -2770,17 +2761,16 @@ func (d *DB) runDeleteOnlyCompactionForLevel(
 	fragments []deleteCompactionHintFragment,
 	exciseEnabled bool,
 ) error {
-	curFragment := 0
-	iter := cl.files.Iter()
 	if cl.level == 0 {
 		panic("cannot run delete-only compaction for L0")
 	}
+	curFragment := 0
 
 	// Outer loop loops on files. Middle loop loops on fragments. Inner loop
 	// loops on raw fragments of hints. Number of fragments are bounded by
 	// the number of hints this compaction was created with, which is capped
 	// in the compaction picker to avoid very CPU-hot loops here.
-	for f := iter.First(); f != nil; f = iter.Next() {
+	for f := range cl.files.All() {
 		// curFile usually matches f, except if f got excised in which case
 		// it maps to a virtual file that replaces f, or nil if f got removed
 		// in its entirety.
@@ -3172,8 +3162,7 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*versionEdit, error
 		DeletedTables: map[deletedFileEntry]*tableMetadata{},
 	}
 	for _, cl := range c.inputs {
-		iter := cl.files.Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range cl.files.All() {
 			ve.DeletedTables[deletedFileEntry{
 				Level:   cl.level,
 				FileNum: f.FileNum,

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -182,9 +182,9 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 
 	resetCompacting := func() {
 		for _, files := range vers.Levels {
-			files.Slice().Each(func(f *tableMetadata) {
+			for f := range files.All() {
 				f.CompactionState = manifest.CompactionStateNotCompacting
-			})
+			}
 		}
 	}
 
@@ -265,10 +265,10 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 						break
 					}
 					for _, cl := range pc.inputs {
-						cl.files.Each(func(f *tableMetadata) {
+						for f := range cl.files.All() {
 							f.CompactionState = manifest.CompactionStateCompacting
 							fmt.Fprintf(&b, "  %s marked as compacting\n", f)
-						})
+						}
 					}
 				}
 
@@ -320,9 +320,9 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 						// L0->Lbase: mark all of Lbase as compacting.
 						c.inputs[1].files = vers.Levels[c.outputLevel].Slice()
 						for _, in := range c.inputs {
-							in.files.Each(func(f *tableMetadata) {
+							for f := range in.files.All() {
 								f.CompactionState = manifest.CompactionStateCompacting
-							})
+							}
 						}
 					}
 				}
@@ -1118,9 +1118,9 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 				}
 
 				fmt.Fprintf(&buf, "L%d\n", cl.level)
-				cl.files.Each(func(f *tableMetadata) {
+				for f := range cl.files.All() {
 					fmt.Fprintf(&buf, "  %s\n", f)
-				})
+				}
 			}
 			if isCompacting {
 				fmt.Fprintf(&buf, "is-compacting\n")
@@ -1224,9 +1224,9 @@ func TestPickedCompactionExpandInputs(t *testing.T) {
 				}
 
 				var buf bytes.Buffer
-				iter.Take().Slice().Each(func(f *tableMetadata) {
+				for f := range iter.Take().Slice().All() {
 					fmt.Fprintf(&buf, "%d: %s-%s\n", f.FileNum, f.Smallest, f.Largest)
-				})
+				}
 				return buf.String()
 
 			default:
@@ -1654,9 +1654,9 @@ func TestCompactionPickerScores(t *testing.T) {
 
 func fileNums(files manifest.LevelSlice) string {
 	var ss []string
-	files.Each(func(f *tableMetadata) {
+	for f := range files.All() {
 		ss = append(ss, f.FileNum.String())
-	})
+	}
 	sort.Strings(ss)
 	return strings.Join(ss, ",")
 }

--- a/data_test.go
+++ b/data_test.go
@@ -1207,8 +1207,7 @@ func runTableStatsCmd(td *datadriven.TestData, d *DB) string {
 	defer d.mu.Unlock()
 	v := d.mu.versions.currentVersion()
 	for _, levelMetadata := range v.Levels {
-		iter := levelMetadata.Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range levelMetadata.All() {
 			if f.FileNum != fileNum {
 				continue
 			}
@@ -1242,8 +1241,7 @@ func runVersionFileSizes(v *version) string {
 			continue
 		}
 		fmt.Fprintf(&buf, "L%d:\n", l)
-		iter := levelMetadata.Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range levelMetadata.All() {
 			fmt.Fprintf(&buf, "  %s: %d bytes (%s)", f, f.Size, humanize.Bytes.Uint64(f.Size))
 			if f.IsCompacting() {
 				fmt.Fprintf(&buf, " (IsCompacting)")
@@ -1263,8 +1261,7 @@ func runMetadataCommand(t *testing.T, td *datadriven.TestData, d *DB) string {
 	d.mu.Lock()
 	currVersion := d.mu.versions.currentVersion()
 	for _, level := range currVersion.Levels {
-		lIter := level.Iter()
-		for f := lIter.First(); f != nil; f = lIter.Next() {
+		for f := range level.All() {
 			if f.FileNum == base.FileNum(uint64(file)) {
 				m = f
 				break
@@ -1288,8 +1285,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	d.mu.Lock()
 	currVersion := d.mu.versions.currentVersion()
 	for _, level := range currVersion.Levels {
-		lIter := level.Iter()
-		for f := lIter.First(); f != nil; f = lIter.Next() {
+		for f := range level.All() {
 			if f.FileNum == base.FileNum(uint64(file)) {
 				m = f
 				break

--- a/db.go
+++ b/db.go
@@ -2221,9 +2221,8 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 	destTables := make([]SSTableInfo, totalTables)
 	destLevels := make([][]SSTableInfo, len(srcLevels))
 	for i := range destLevels {
-		iter := srcLevels[i].Iter()
 		j := 0
-		for m := iter.First(); m != nil; m = iter.Next() {
+		for m := range srcLevels[i].All() {
 			if opt.start != nil && opt.end != nil {
 				b := base.UserKeyBoundsEndExclusive(opt.start, opt.end)
 				if !m.Overlaps(d.opts.Comparer.Compare, &b) {

--- a/download_test.go
+++ b/download_test.go
@@ -134,8 +134,7 @@ func TestDownloadTask(t *testing.T) {
 				compacting[base.FileNum(n)] = struct{}{}
 			}
 			for _, lm := range vers.Levels {
-				iter := lm.Iter()
-				for f := iter.First(); f != nil; f = iter.Next() {
+				for f := range lm.All() {
 					if _, ok := compacting[f.FileNum]; ok {
 						f.CompactionState = manifest.CompactionStateCompacting
 						delete(compacting, f.FileNum)

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -433,8 +433,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 
 	currVersion = d.mu.versions.currentVersion()
 	l6 = currVersion.Levels[6]
-	l6FileIter = l6.Iter()
-	for f := l6FileIter.First(); f != nil; f = l6FileIter.Next() {
+	for f := range l6.All() {
 		require.Equal(t, true, f.Virtual)
 	}
 	d.mu.Unlock()

--- a/ingest.go
+++ b/ingest.go
@@ -2103,10 +2103,7 @@ func (d *DB) ingestApply(
 		// for files, and if they are, we should signal those compactions to error
 		// out.
 		for level := range current.Levels {
-			overlaps := current.Overlaps(level, exciseSpan.UserKeyBounds())
-			iter := overlaps.Iter()
-
-			for m := iter.First(); m != nil; m = iter.Next() {
+			for m := range current.Overlaps(level, exciseSpan.UserKeyBounds()).All() {
 				newFiles, err := d.excise(ctx, exciseSpan.UserKeyBounds(), m, ve, level)
 				if err != nil {
 					return nil, err
@@ -2154,8 +2151,7 @@ func (d *DB) ingestApply(
 			// ingestion.
 			if checkCompactions {
 				for i := range c.inputs {
-					iter := c.inputs[i].files.Iter()
-					for f := iter.First(); f != nil; f = iter.Next() {
+					for f := range c.inputs[i].files.All() {
 						if _, ok := replacedFiles[f.FileNum]; ok {
 							c.cancel.Store(true)
 							break

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -919,8 +919,7 @@ func TestExcise(t *testing.T) {
 			currVersion := d.mu.versions.currentVersion()
 			var ptr *manifest.FileBacking
 			for _, level := range currVersion.Levels {
-				lIter := level.Iter()
-				for f := lIter.First(); f != nil; f = lIter.Next() {
+				for f := range level.All() {
 					if _, ok := fileNums[f.FileNum]; ok {
 						if ptr == nil {
 							ptr = f.FileBacking

--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -163,10 +163,8 @@ func BenchmarkNumFilesRangeAnnotation(b *testing.B) {
 			toDelete := rng.IntN(count)
 			v.Levels[6].tree.Delete(files[toDelete], ignoreObsoleteFiles{})
 
-			overlaps := v.Overlaps(6, b)
-			iter := overlaps.Iter()
 			numFiles := 0
-			for f := iter.First(); f != nil; f = iter.Next() {
+			for range v.Overlaps(6, b).All() {
 				numFiles++
 			}
 

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -585,7 +585,7 @@ func (s *L0Sublevels) AddL0Files(
 	// with a binary search, or by only looping through files to the right of
 	// the first interval touched by this method.
 	for sublevel := range s.Levels {
-		s.Levels[sublevel].Each(func(f *TableMetadata) {
+		for f := range s.Levels[sublevel].All() {
 			oldIntervalDelta := f.maxIntervalIndex - f.minIntervalIndex + 1
 			oldMinIntervalIndex := f.minIntervalIndex
 			f.minIntervalIndex = oldToNewMap[f.minIntervalIndex]
@@ -614,7 +614,7 @@ func (s *L0Sublevels) AddL0Files(
 					newVal.orderedIntervals[i].estimatedBytes += f.Size / uint64(newIntervalDelta)
 				}
 			}
-		})
+		}
 	}
 	updatedSublevels := make([]int, 0)
 	// Update interval indices for new files.
@@ -743,8 +743,7 @@ func (s *L0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 		s.orderedIntervals[i].intervalRangeIsBaseCompacting = false
 	}
 
-	iter := s.levelMetadata.Iter()
-	for f := iter.First(); f != nil; f = iter.Next() {
+	for f := range s.levelMetadata.All() {
 		if invariants.Enabled {
 			if !bytes.Equal(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest.UserKey) {
 				panic(fmt.Sprintf("f.minIntervalIndex in TableMetadata out of sync with intervals in L0Sublevels: %s != %s",
@@ -1139,8 +1138,7 @@ func (s *L0Sublevels) UpdateStateForStartedCompaction(inputs []LevelSlice, isBas
 	minIntervalIndex := -1
 	maxIntervalIndex := 0
 	for i := range inputs {
-		iter := inputs[i].Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range inputs[i].All() {
 			for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {
 				interval := &s.orderedIntervals[i]
 				interval.compactingFileCount++

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -473,7 +473,7 @@ func TestL0Sublevels(t *testing.T) {
 				}
 			}
 			slice := NewLevelSliceSeqSorted(files)
-			sm, la := KeyRange(base.DefaultComparer.Compare, slice.Iter())
+			sm, la := KeyRange(base.DefaultComparer.Compare, slice.All())
 			activeCompactions = append(activeCompactions, L0Compaction{Smallest: sm, Largest: la})
 			if err := sublevels.UpdateStateForStartedCompaction([]LevelSlice{slice}, true); err != nil {
 				return err.Error()

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -71,9 +71,7 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 		}
 
 		for l := level; l < manifest.NumLevels; l++ {
-			o := v.Overlaps(l, base.UserKeyBoundsInclusive(smallest, largest))
-			iter := o.Iter()
-			for f := iter.First(); f != nil; f = iter.Next() {
+			for f := range v.Overlaps(l, base.UserKeyBoundsInclusive(smallest, largest)).All() {
 				// CalculateInuseKeyRanges only guarantees that it returns key
 				// ranges covering in-use ranges within [smallest, largest]. If
 				// this file extends before or after smallest/largest, truncate

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -417,8 +417,7 @@ func TestVersionEditApply(t *testing.T) {
 				bve := BulkVersionEdit{}
 				bve.AddedTablesByFileNum = make(map[base.FileNum]*TableMetadata)
 				for _, l := range v.Levels {
-					it := l.Iter()
-					for f := it.First(); f != nil; f = it.Next() {
+					for f := range l.All() {
 						bve.AddedTablesByFileNum[f.FileNum] = f
 					}
 				}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -84,7 +84,7 @@ func TestIkeyRange(t *testing.T) {
 		}
 		levelMetadata := MakeLevelMetadata(base.DefaultComparer.Compare, 0, f)
 
-		sm, la := KeyRange(base.DefaultComparer.Compare, levelMetadata.Iter())
+		sm, la := KeyRange(base.DefaultComparer.Compare, levelMetadata.All())
 		got := string(sm.UserKey) + "-" + string(la.UserKey)
 		if got != tc.want {
 			t.Errorf("KeyRange(%q) = %q, %q", tc.input, got, tc.want)
@@ -114,9 +114,9 @@ func TestOverlaps(t *testing.T) {
 			overlaps := v.Overlaps(level, base.UserKeyBoundsEndExclusiveIf([]byte(start), []byte(end), exclusiveEnd))
 			var buf bytes.Buffer
 			fmt.Fprintf(&buf, "%d files:\n", overlaps.Len())
-			overlaps.Each(func(f *TableMetadata) {
+			for f := range overlaps.All() {
 				fmt.Fprintf(&buf, "%s\n", f.DebugString(base.DefaultFormatter, false))
-			})
+			}
 			return buf.String()
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
@@ -298,11 +298,11 @@ func TestCheckOrdering(t *testing.T) {
 				}
 				// L0 files compare on sequence numbers. Use the seqnums from the
 				// smallest / largest bounds for the table.
-				v.Levels[0].Slice().Each(func(m *TableMetadata) {
+				for m := range v.Levels[0].All() {
 					m.SmallestSeqNum = m.Smallest.SeqNum()
 					m.LargestSeqNum = m.Largest.SeqNum()
 					m.LargestSeqNumAbsolute = m.LargestSeqNum
-				})
+				}
 				if err = v.CheckOrdering(); err != nil {
 					return err.Error()
 				}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -368,9 +368,9 @@ func TestReadSampling(t *testing.T) {
 
 			d.mu.Lock()
 			for _, l := range d.mu.versions.currentVersion().Levels {
-				l.Slice().Each(func(f *tableMetadata) {
+				for f := range l.All() {
 					f.AllowedSeeks.Store(allowedSeeks)
-				})
+				}
 			}
 			d.mu.Unlock()
 			return ""
@@ -398,12 +398,12 @@ func TestReadSampling(t *testing.T) {
 			var foundAllowedSeeks int64 = -1
 			d.mu.Lock()
 			for _, l := range d.mu.versions.currentVersion().Levels {
-				l.Slice().Each(func(f *tableMetadata) {
+				for f := range l.All() {
 					if f.FileNum == base.FileNum(fileNum) {
 						actualAllowedSeeks := f.AllowedSeeks.Load()
 						foundAllowedSeeks = actualAllowedSeeks
 					}
-				})
+				}
 			}
 			d.mu.Unlock()
 

--- a/lsm_view.go
+++ b/lsm_view.go
@@ -69,9 +69,9 @@ func (b *lsmViewBuilder) InitLevels(v *version) {
 	var levels [][]*tableMetadata
 	for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
 		var files []*tableMetadata
-		v.L0SublevelFiles[sublevel].Each(func(f *tableMetadata) {
+		for f := range v.L0SublevelFiles[sublevel].All() {
 			files = append(files, f)
-		})
+		}
 
 		levelNames = append(levelNames, fmt.Sprintf("L0.%d", sublevel))
 		levels = append(levels, files)
@@ -82,9 +82,9 @@ func (b *lsmViewBuilder) InitLevels(v *version) {
 	}
 	for level := 1; level < len(v.Levels); level++ {
 		var files []*tableMetadata
-		v.Levels[level].Slice().Each(func(f *tableMetadata) {
+		for f := range v.Levels[level].All() {
 			files = append(files, f)
-		})
+		}
 		levelNames = append(levelNames, fmt.Sprintf("L%d", level))
 		levels = append(levels, files)
 	}

--- a/open.go
+++ b/open.go
@@ -1258,8 +1258,7 @@ func checkConsistency(v *manifest.Version, objProvider objstorage.Provider) erro
 	var errs []error
 	dedup := make(map[base.DiskFileNum]struct{})
 	for level, files := range v.Levels {
-		iter := files.Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range files.All() {
 			backingState := f.FileBacking
 			if _, ok := dedup[backingState.DiskFileNum]; ok {
 				continue

--- a/tool/db.go
+++ b/tool/db.go
@@ -734,9 +734,8 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 		var total props
 		var all []props
 		for _, l := range v.Levels {
-			iter := l.Iter()
 			var level props
-			for t := iter.First(); t != nil; t = iter.Next() {
+			for t := range l.All() {
 				if t.Virtual {
 					// TODO(bananabrick): Handle virtual sstables here. We don't
 					// really have any stats or properties at this point. Maybe

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -325,8 +325,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 		v := manifest.NewVersion(l.cmp, 0, currentFiles)
 		edit.Sublevels = make(map[base.FileNum]int)
 		for sublevel, files := range v.L0SublevelFiles {
-			iter := files.Iter()
-			for f := iter.First(); f != nil; f = iter.Next() {
+			for f := range files.All() {
 				if len(l.state.Edits) > 0 {
 					lastEdit := l.state.Edits[len(l.state.Edits)-1]
 					if sublevel2, ok := lastEdit.Sublevels[f.FileNum]; ok && sublevel == sublevel2 {

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -105,9 +105,9 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 		if level == 0 && len(v.L0SublevelFiles) > 0 && !v.Levels[level].Empty() {
 			for sublevel := len(v.L0SublevelFiles) - 1; sublevel >= 0; sublevel-- {
 				fmt.Fprintf(stdout, "--- L0.%d ---\n", sublevel)
-				v.L0SublevelFiles[sublevel].Each(func(f *manifest.TableMetadata) {
+				for f := range v.L0SublevelFiles[sublevel].All() {
 					if !anyOverlapFile(cmp, f, m.filterStart, m.filterEnd) {
-						return
+						continue
 					}
 					fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 					formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
@@ -116,13 +116,12 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 						fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
 					}
 					fmt.Fprintf(stdout, "\n")
-				})
+				}
 			}
 			continue
 		}
 		fmt.Fprintf(stdout, "--- L%d ---\n", level)
-		iter := v.Levels[level].Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range v.Levels[level].All() {
 			if !anyOverlapFile(cmp, f, m.filterStart, m.filterEnd) {
 				continue
 			}

--- a/version_set.go
+++ b/version_set.go
@@ -357,8 +357,7 @@ func (vs *versionSet) load(
 		l.Size = int64(files.SizeSum())
 	}
 	for _, l := range newVersion.Levels {
-		iter := l.Iter()
-		for f := iter.First(); f != nil; f = iter.Next() {
+		for f := range l.All() {
 			if !f.Virtual {
 				_, localSize := sizeIfLocal(f.FileBacking, vs.provider)
 				vs.metrics.Table.Local.LiveSize = uint64(int64(vs.metrics.Table.Local.LiveSize) + localSize)
@@ -926,8 +925,7 @@ func (vs *versionSet) createManifest(
 	}
 
 	for level, levelMetadata := range vs.currentVersion().Levels {
-		iter := levelMetadata.Iter()
-		for meta := iter.First(); meta != nil; meta = iter.Next() {
+		for meta := range levelMetadata.All() {
 			snapshot.NewTables = append(snapshot.NewTables, newTableEntry{
 				Level: level,
 				Meta:  meta,
@@ -1006,8 +1004,7 @@ func (vs *versionSet) append(v *version) {
 		// Verify that the virtualBackings contains all the backings referenced by
 		// the version.
 		for _, l := range v.Levels {
-			iter := l.Iter()
-			for f := iter.First(); f != nil; f = iter.Next() {
+			for f := range l.All() {
 				if f.Virtual {
 					if _, ok := vs.virtualBackings.Get(f.FileBacking.DiskFileNum); !ok {
 						panic(fmt.Sprintf("%s is not in virtualBackings", f.FileBacking.DiskFileNum))
@@ -1026,8 +1023,7 @@ func (vs *versionSet) addLiveFileNums(m map[base.DiskFileNum]struct{}) {
 	current := vs.currentVersion()
 	for v := vs.versions.Front(); true; v = v.Next() {
 		for _, lm := range v.Levels {
-			iter := lm.Iter()
-			for f := iter.First(); f != nil; f = iter.Next() {
+			for f := range lm.All() {
 				m[f.FileBacking.DiskFileNum] = struct{}{}
 			}
 		}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -180,8 +180,7 @@ func TestVersionSet(t *testing.T) {
 			backings = make(map[base.DiskFileNum]*manifest.FileBacking)
 			v := vs.currentVersion()
 			for _, l := range v.Levels {
-				it := l.Iter()
-				for f := it.First(); f != nil; f = it.Next() {
+				for f := range l.All() {
 					metas[f.FileNum] = f
 					dedupBacking(f.FileBacking)
 				}


### PR DESCRIPTION
Use the new Go 1.23 iter.Seq type to range over collections of TableMetadata. The LevelMetadata and LevelSlice types are updated with All methods, returning an iter.Seq[*TableMetadata].