### PR TITLE
internal/manifest: define BlobReferenceDepth type

### DIFF
--- a/internal/blobtest/handles.go
+++ b/internal/blobtest/handles.go
@@ -190,8 +190,8 @@ func (bv *Values) ParseInlineHandle(
 	}
 	return blob.InlineHandle{
 		InlineHandlePreface: blob.InlineHandlePreface{
-			ReferenceIndex: references.MapToReferenceIndex(fullHandle.FileNum),
-			ValueLen:       fullHandle.ValueLen,
+			ReferenceID: references.MapToReferenceID(fullHandle.FileNum),
+			ValueLen:    fullHandle.ValueLen,
 		},
 		HandleSuffix: blob.HandleSuffix{
 			BlockNum:      fullHandle.BlockNum,
@@ -261,14 +261,14 @@ type References struct {
 	fileNums []base.DiskFileNum
 }
 
-// MapToReferenceIndex maps the given file number to a reference index.
-func (b *References) MapToReferenceIndex(fileNum base.DiskFileNum) uint32 {
+// MapToReferenceID maps the given file number to a reference ID.
+func (b *References) MapToReferenceID(fileNum base.DiskFileNum) blob.ReferenceID {
 	for i, fn := range b.fileNums {
 		if fn == fileNum {
-			return uint32(i)
+			return blob.ReferenceID(i)
 		}
 	}
 	i := uint32(len(b.fileNums))
 	b.fileNums = append(b.fileNums, fileNum)
-	return i
+	return blob.ReferenceID(i)
 }

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -48,7 +48,7 @@ type OutputTable struct {
 	// failure (see Result), WriterMeta might not be set.
 	WriterMeta sstable.WriterMetadata
 	// BlobReferences is the list of blob references for the table.
-	BlobReferences []manifest.BlobReference
+	BlobReferences manifest.BlobReferences
 	// BlobReferenceDepth is the depth of the blob references for the table.
 	BlobReferenceDepth manifest.BlobReferenceDepth
 }
@@ -138,7 +138,7 @@ type ValueSeparation interface {
 // ValueSeparationMetadata describes metadata about a table's blob references,
 // and optionally a newly constructed blob file.
 type ValueSeparationMetadata struct {
-	BlobReferences     []manifest.BlobReference
+	BlobReferences     manifest.BlobReferences
 	BlobReferenceSize  uint64
 	BlobReferenceDepth manifest.BlobReferenceDepth
 

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -50,7 +50,7 @@ type OutputTable struct {
 	// BlobReferences is the list of blob references for the table.
 	BlobReferences []manifest.BlobReference
 	// BlobReferenceDepth is the depth of the blob references for the table.
-	BlobReferenceDepth int
+	BlobReferenceDepth manifest.BlobReferenceDepth
 }
 
 // OutputBlob contains metadata about a blob file that was created during a
@@ -140,7 +140,7 @@ type ValueSeparation interface {
 type ValueSeparationMetadata struct {
 	BlobReferences     []manifest.BlobReference
 	BlobReferenceSize  uint64
-	BlobReferenceDepth int
+	BlobReferenceDepth manifest.BlobReferenceDepth
 
 	// The below fields are only populated if a new blob file was created.
 	BlobFileStats    blob.FileWriterStats

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -238,7 +238,7 @@ type TableMetadata struct {
 	Largest  InternalKey
 	// BlobReferences is a list of blob files containing values that are
 	// referenced by this sstable.
-	BlobReferences []BlobReference
+	BlobReferences BlobReferences
 	// BlobReferenceDepth is the stack depth of blob files referenced by this
 	// sstable. See the comment on the BlobReferenceDepth type for more details.
 	//

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -357,7 +357,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			}{}
 			var syntheticPrefix sstable.SyntheticPrefix
 			var syntheticSuffix sstable.SyntheticSuffix
-			var blobReferences []BlobReference
+			var blobReferences BlobReferences
 			var blobReferenceDepth BlobReferenceDepth
 			if tag == tagNewFile4 || tag == tagNewFile5 {
 				for {

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -358,7 +358,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			var syntheticPrefix sstable.SyntheticPrefix
 			var syntheticSuffix sstable.SyntheticSuffix
 			var blobReferences []BlobReference
-			var blobReferenceDepth uint64
+			var blobReferenceDepth BlobReferenceDepth
 			if tag == tagNewFile4 || tag == tagNewFile5 {
 				for {
 					customTag, err := d.readUvarint()
@@ -414,10 +414,11 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 					case customTagBlobReferences:
 						// The first varint encodes the 'blob reference depth'
 						// of the table.
-						blobReferenceDepth, err = d.readUvarint()
+						v, err := d.readUvarint()
 						if err != nil {
 							return err
 						}
+						blobReferenceDepth = BlobReferenceDepth(v)
 						n, err := d.readUvarint()
 						if err != nil {
 							return err
@@ -457,7 +458,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				LargestSeqNum:            largestSeqNum,
 				LargestSeqNumAbsolute:    largestSeqNum,
 				BlobReferences:           blobReferences,
-				BlobReferenceDepth:       int(blobReferenceDepth),
+				BlobReferenceDepth:       blobReferenceDepth,
 				MarkedForCompaction:      markedForCompaction,
 				Virtual:                  virtualState.virtual,
 				SyntheticPrefixAndSuffix: sstable.MakeSyntheticPrefixAndSuffix(syntheticPrefix, syntheticSuffix),

--- a/sstable/blob/blob_test.go
+++ b/sstable/blob/blob_test.go
@@ -87,8 +87,8 @@ func TestHandleRoundtrip(t *testing.T) {
 	handles := []InlineHandle{
 		{
 			InlineHandlePreface: InlineHandlePreface{
-				ReferenceIndex: 0,
-				ValueLen:       29357353,
+				ReferenceID: 0,
+				ValueLen:    29357353,
 			},
 			HandleSuffix: HandleSuffix{
 				BlockNum:      194,
@@ -97,8 +97,8 @@ func TestHandleRoundtrip(t *testing.T) {
 		},
 		{
 			InlineHandlePreface: InlineHandlePreface{
-				ReferenceIndex: 129,
-				ValueLen:       205,
+				ReferenceID: 129,
+				ValueLen:    205,
 			},
 			HandleSuffix: HandleSuffix{
 				BlockNum:      2,

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -204,8 +204,8 @@ func decodeBlobInlineHandleAndAttribute(
 	}
 	return blob.InlineHandle{
 		InlineHandlePreface: blob.InlineHandlePreface{
-			ReferenceIndex: uint32(refIdx),
-			ValueLen:       uint32(valLen),
+			ReferenceID: blob.ReferenceID(refIdx),
+			ValueLen:    uint32(valLen),
 		},
 		HandleSuffix: blob.HandleSuffix{
 			BlockNum:      uint32(blockNum),

--- a/value_separation.go
+++ b/value_separation.go
@@ -193,7 +193,7 @@ type preserveBlobReferences struct {
 	// for every unique blob file referenced by input sstables.
 	// inputBlobMetadatas must be sorted by FileNum.
 	inputBlobMetadatas       []*manifest.BlobFileMetadata
-	outputBlobReferenceDepth int
+	outputBlobReferenceDepth manifest.BlobReferenceDepth
 
 	// state
 	buf            []byte
@@ -321,6 +321,6 @@ func (vs *preserveBlobReferences) FinishOutput() (compact.ValueSeparationMetadat
 		// reflecting the worst-case overlap of referenced blob files. If this
 		// sstable references fewer unique blob files, reduce its depth to the
 		// count of unique files.
-		BlobReferenceDepth: min(vs.outputBlobReferenceDepth, len(references)),
+		BlobReferenceDepth: min(vs.outputBlobReferenceDepth, manifest.BlobReferenceDepth(len(references))),
 	}, nil
 }

--- a/value_separation_test.go
+++ b/value_separation_test.go
@@ -251,6 +251,6 @@ func (d *defineDBValueSeparator) FinishOutput() (compact.ValueSeparationMetadata
 		return compact.ValueSeparationMetadata{}, err
 	}
 	// TODO(jackson): Support setting a specific depth from the datadriven test.
-	m.BlobReferenceDepth = len(m.BlobReferences)
+	m.BlobReferenceDepth = manifest.BlobReferenceDepth(len(m.BlobReferences))
 	return m, nil
 }


### PR DESCRIPTION
Define a BlobReferenceDepth and move the documentation of the blob reference
depth from the TableMetadata field onto the type, making the documentation more
discoverable.

Define a BlobReferences type for a slice of blob references, and use it on the
TableMetadata for its BlobReferences field. When yielding an InternalValue
backed by a blob value handle to higher levels, an iterator will need to map
the blob handle's file reference index to the file number. This type will
implement the interface to perform this mapping.