### PR TITLE
db: add support for reading blob values

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -216,6 +217,9 @@ type compaction struct {
 	// blob files. This consumes more write bandwidth because all values are
 	// rewritten. However it restores locality.
 	getValueSeparation func(JobID, *compaction, sstable.TableFormat) compact.ValueSeparation
+	// valueFetcher is used to fetch values from blob files. It's propagated
+	// down the iterator tree through the internal iterator options.
+	valueFetcher blob.ValueFetcher
 
 	// startLevel is the level that is being compacted. Inputs from startLevel
 	// and outputLevel will be merged to produce a set of outputLevel files.
@@ -3085,16 +3089,19 @@ func (d *DB) compactAndWrite(
 	// translate to 3 MiB per compaction.
 	c.bufferPool.Init(12)
 	defer c.bufferPool.Release()
+	env := block.ReadEnv{
+		BufferPool: &c.bufferPool,
+		Stats:      &c.stats,
+		IterStats: d.fileCache.SSTStatsCollector().Accumulator(
+			uint64(uintptr(unsafe.Pointer(c))),
+			categoryCompaction,
+		),
+	}
+	c.valueFetcher.Init(d.fileCache, env)
 	iiopts := internalIterOpts{
-		compaction: true,
-		readEnv: block.ReadEnv{
-			BufferPool: &c.bufferPool,
-			Stats:      &c.stats,
-			IterStats: d.fileCache.SSTStatsCollector().Accumulator(
-				uint64(uintptr(unsafe.Pointer(c))),
-				categoryCompaction,
-			),
-		},
+		compaction:       true,
+		readEnv:          env,
+		blobValueFetcher: &c.valueFetcher,
 	}
 
 	pointIter, rangeDelIter, rangeKeyIter, err := c.newInputIters(d.newIters, d.tableNewRangeKeyIter, iiopts)

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -610,7 +610,7 @@ func TestCompaction(t *testing.T) {
 					return "", "", errors.WithStack(err)
 				}
 				defer r.Close()
-				iter, err := r.NewIter(sstable.NoTransforms, nil /* lower */, nil /* upper */)
+				iter, err := r.NewIter(sstable.NoTransforms, nil /* lower */, nil /* upper */, sstable.AssertNoBlobHandles)
 				if err != nil {
 					return "", "", errors.WithStack(err)
 				}

--- a/file_cache.go
+++ b/file_cache.go
@@ -677,7 +677,11 @@ func (h *fileCacheHandle) newPointIter(
 		internalOpts.readEnv.IterStats = handle.SSTStatsCollector().Accumulator(uint64(uintptr(unsafe.Pointer(r))), opts.Category)
 	}
 	if internalOpts.compaction {
-		iter, err = cr.NewCompactionIter(transforms, internalOpts.readEnv, &v.readerProvider)
+		iter, err = cr.NewCompactionIter(transforms, internalOpts.readEnv,
+			&v.readerProvider, sstable.TableBlobContext{
+				ValueFetcher: internalOpts.blobValueFetcher,
+				References:   file.BlobReferences,
+			})
 	} else {
 		iter, err = cr.NewPointIter(ctx, sstable.IterOptions{
 			Lower:                opts.GetLowerBound(),
@@ -687,6 +691,10 @@ func (h *fileCacheHandle) newPointIter(
 			Filterer:             filterer,
 			Env:                  internalOpts.readEnv,
 			ReaderProvider:       &v.readerProvider,
+			BlobContext: sstable.TableBlobContext{
+				ValueFetcher: internalOpts.blobValueFetcher,
+				References:   file.BlobReferences,
+			},
 		})
 	}
 	if err != nil {

--- a/ingest.go
+++ b/ingest.go
@@ -360,7 +360,7 @@ func ingestLoad1(
 	maybeSetStatsFromProperties(meta.PhysicalMeta(), &r.Properties)
 
 	{
-		iter, err := r.NewIter(sstable.NoTransforms, nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(sstable.NoTransforms, nil /* lower */, nil /* upper */, sstable.AssertNoBlobHandles)
 		if err != nil {
 			return nil, keyspan.Span{}, err
 		}

--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -416,6 +416,9 @@ type InternalIteratorStats struct {
 		// ValueBytesFetched is the total byte length of the values (in value
 		// blocks) that were retrieved.
 		ValueBytesFetched uint64
+
+		// TODO(jackson): Add stats for distinguishing between value-block
+		// values and blob values.
 	}
 }
 

--- a/internal/compact/spans_test.go
+++ b/internal/compact/spans_test.go
@@ -135,7 +135,7 @@ func TestSplitAndEncodeSpan(t *testing.T) {
 			_, rangeDels, rangeKeys, err := sstable.ReadAll(obj, sstable.ReaderOptions{
 				Comparer:   wo.Comparer,
 				KeySchemas: sstable.MakeKeySchemas(wo.KeySchema),
-			})
+			}, base.NoBlobFetches)
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(rangeDels)+len(rangeKeys), 1)
 			s := "."

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/strparse"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/redact"
 )
@@ -223,6 +224,9 @@ type BlobReferenceDepth int
 // are ordered by earliest appearance within the sstable. The ordering is
 // persisted to the manifest.
 type BlobReferences []BlobReference
+
+// Assert that BlobReferences implements sstable.BlobReferences.
+var _ sstable.BlobReferences = BlobReferences{}
 
 // FileNumByID returns the FileNum for the identified BlobReference.
 func (br BlobReferences) FileNumByID(i blob.ReferenceID) base.DiskFileNum {

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -109,7 +109,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 			if err != nil {
 				return iterSet{}, err
 			}
-			iter, err := r.NewIter(sstable.NoTransforms, nil /* lower */, nil /* upper */)
+			iter, err := r.NewIter(sstable.NoTransforms, nil /* lower */, nil /* upper */, sstable.AssertNoBlobHandles)
 			if err != nil {
 				return iterSet{}, err
 			}

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -274,7 +274,7 @@ func openExternalObj(
 		start = syntheticPrefix.Invert(start)
 		end = syntheticPrefix.Invert(end)
 	}
-	pointIter, err = reader.NewIter(sstable.NoTransforms, start, end)
+	pointIter, err = reader.NewIter(sstable.NoTransforms, start, end, sstable.AssertNoBlobHandles)
 	panicIfErr(err)
 
 	rangeDelIter, err = reader.NewRawRangeDelIter(context.Background(), sstable.NoFragmentTransforms, block.NoReadEnv)

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -962,7 +962,7 @@ func findManifestStart(
 }
 
 // loadFlushedSSTableKeys copies keys from the sstables specified by `fileNums`
-// in the directory specified by `path` into the provided the batch. Keys are
+// in the directory specified by `path` into the provided batch. Keys are
 // applied to the batch in the order dictated by their sequence numbers within
 // the sstables, ensuring the relative relationship between sequence numbers is
 // maintained.
@@ -999,7 +999,13 @@ func loadFlushedSSTableKeys(
 			defer r.Close()
 
 			// Load all the point keys.
-			iter, err := r.NewIter(sstable.NoTransforms, nil, nil)
+			iter, err := r.NewIter(sstable.NoTransforms, nil, nil,
+				// TODO(jackson): We should update this to use a
+				// blob.ValueFetcher configured with a custom reader provider
+				// that opens the appropriate blob files. We'll also need to
+				// update the workload capture-side to collect blob files.
+				// See #4459.
+				sstable.AssertNoBlobHandles)
 			if err != nil {
 				return err
 			}

--- a/replay/workload_capture.go
+++ b/replay/workload_capture.go
@@ -179,6 +179,7 @@ func (w *WorkloadCollector) onFlushEnd(info pebble.FlushInfo) {
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	// TODO(jackson): Copy blob files.
 	for _, table := range info.Output {
 		w.enqueueCopyLocked(base.PhysicalTableDiskFileNum(table.FileNum))
 	}

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -165,6 +165,19 @@ func (w *FileWriter) EstimatedSize() uint64 {
 	return sz
 }
 
+// FlushForTesting flushes the current block to the write queue. Writers should
+// generally not call FlushForTesting, and instead let the heuristics configured
+// through FileWriterOptions handle flushing.
+//
+// It's exposed so that tests can force flushes to construct blob files with
+// arbitrary structures.
+func (w *FileWriter) FlushForTesting() {
+	if w.b.Size() == 0 {
+		return
+	}
+	w.flush()
+}
+
 func (w *FileWriter) flush() {
 	pb, bh := w.b.CompressAndChecksum()
 	compressedLen := uint64(pb.LengthWithoutTrailer())

--- a/sstable/blob/blob_test.go
+++ b/sstable/blob/blob_test.go
@@ -110,7 +110,7 @@ func TestHandleRoundtrip(t *testing.T) {
 	for _, h := range handles {
 		var buf [MaxInlineHandleLength]byte
 		n := h.Encode(buf[:])
-		preface, rem := DecodeInlineHandlePrefix(buf[:n])
+		preface, rem := DecodeInlineHandlePreface(buf[:n])
 		suffix := DecodeHandleSuffix(rem)
 		require.Equal(t, h.InlineHandlePreface, preface)
 		require.Equal(t, h.HandleSuffix, suffix)

--- a/sstable/blob/handle.go
+++ b/sstable/blob/handle.go
@@ -106,9 +106,9 @@ func (h InlineHandle) Encode(b []byte) int {
 	return n
 }
 
-// DecodeInlineHandlePrefix decodes the blob reference index and value length
+// DecodeInlineHandlePreface decodes the blob reference index and value length
 // from the beginning of a variable-width encoded InlineHandle.
-func DecodeInlineHandlePrefix(src []byte) (InlineHandlePreface, []byte) {
+func DecodeInlineHandlePreface(src []byte) (InlineHandlePreface, []byte) {
 	ptr := unsafe.Pointer(&src[0])
 	var refIdx uint32
 	if a := *((*uint8)(ptr)); a < 128 {

--- a/sstable/block_property_test.go
+++ b/sstable/block_property_test.go
@@ -994,6 +994,7 @@ func TestBlockProperties(t *testing.T) {
 				FilterBlockSizeLimit: NeverUseFilterBlock,
 				Env:                  block.ReadEnv{Stats: &stats, IterStats: nil},
 				ReaderProvider:       MakeTrivialReaderProvider(r),
+				BlobContext:          AssertNoBlobHandles,
 			})
 			if err != nil {
 				return err.Error()
@@ -1083,6 +1084,7 @@ func TestBlockProperties_BoundLimited(t *testing.T) {
 				FilterBlockSizeLimit: NeverUseFilterBlock,
 				Env:                  block.ReadEnv{Stats: &stats, IterStats: nil},
 				ReaderProvider:       MakeTrivialReaderProvider(r),
+				BlobContext:          AssertNoBlobHandles,
 			})
 			if err != nil {
 				return err.Error()

--- a/sstable/copier_test.go
+++ b/sstable/copier_test.go
@@ -126,7 +126,7 @@ func TestCopySpan(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			iter, err := r.NewIter(block.NoTransforms, start, end)
+			iter, err := r.NewIter(block.NoTransforms, start, end, AssertNoBlobHandles)
 			if err != nil {
 				return err.Error()
 			}

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -111,6 +111,7 @@ func runErrorInjectionTest(t *testing.T, seed int64) {
 		FilterBlockSizeLimit: filterBlockSizeLimit,
 		Env:                  block.ReadEnv{Stats: &stats, IterStats: nil},
 		ReaderProvider:       MakeTrivialReaderProvider(r),
+		BlobContext:          AssertNoBlobHandles,
 	})
 	require.NoError(t, err)
 	defer it.Close()

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -31,6 +31,7 @@ type CommonReader interface {
 		transforms IterTransforms,
 		env block.ReadEnv,
 		rp valblk.ReaderProvider,
+		blobContext TableBlobContext,
 	) (Iterator, error)
 
 	EstimateDiskUsage(start, end []byte) (uint64, error)

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -96,10 +96,13 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 
 // NewCompactionIter is the compaction iterator function for virtual readers.
 func (v *VirtualReader) NewCompactionIter(
-	transforms IterTransforms, env block.ReadEnv, rp valblk.ReaderProvider,
+	transforms IterTransforms,
+	env block.ReadEnv,
+	rp valblk.ReaderProvider,
+	blobContext TableBlobContext,
 ) (Iterator, error) {
 	return v.reader.newCompactionIter(
-		transforms, env, rp, &v.vState)
+		transforms, env, rp, &v.vState, blobContext)
 }
 
 // NewPointIter returns an iterator for the point keys in the table.

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -62,7 +62,7 @@ func check(fs vfs.FS, filename string, comparer *Comparer, fp FilterPolicy) erro
 		}
 
 		// Check using SeekGE.
-		iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 		if err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func check(fs vfs.FS, filename string, comparer *Comparer, fp FilterPolicy) erro
 		}
 
 		// Check using Find.
-		iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ func check(fs vfs.FS, filename string, comparer *Comparer, fp FilterPolicy) erro
 		{0, "~"},
 	}
 	for _, ct := range countTests {
-		iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+		iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 		if err != nil {
 			return err
 		}
@@ -186,7 +186,7 @@ func check(fs vfs.FS, filename string, comparer *Comparer, fp FilterPolicy) erro
 			upper = []byte(words[upperIdx])
 		}
 
-		iter, err := r.NewIter(NoTransforms, lower, upper)
+		iter, err := r.NewIter(NoTransforms, lower, upper, AssertNoBlobHandles)
 		if err != nil {
 			return err
 		}
@@ -474,7 +474,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 					if err != nil {
 						t.Errorf("nk=%d, vLen=%d: reader open: %v", nk, vLen, err)
 					}
-					iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+					iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 					require.NoError(t, err)
 					for kv := iter.First(); kv != nil; kv = iter.Next() {
 						got++
@@ -509,7 +509,7 @@ func TestReaderSymtheticSeqNum(t *testing.T) {
 	const syntheticSeqNum = 42
 	transforms := IterTransforms{SyntheticSeqNum: syntheticSeqNum}
 
-	iter, err := r.NewIter(transforms, nil /* lower */, nil /* upper */)
+	iter, err := r.NewIter(transforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 	require.NoError(t, err)
 	for kv := iter.First(); kv != nil; kv = iter.Next() {
 		if syntheticSeqNum != kv.K.SeqNum() {

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -16,14 +16,14 @@ import (
 // ReadAll returns all point keys, range del spans, and range key spans from an
 // sstable. Closes the Readable. Panics on errors.
 func ReadAll(
-	r objstorage.Readable, ro ReaderOptions,
+	r objstorage.Readable, ro ReaderOptions, blobValueFetcher base.ValueFetcher,
 ) (points []base.InternalKV, rangeDels, rangeKeys []keyspan.Span, err error) {
 	reader, err := NewReader(context.Background(), r, ro)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	defer reader.Close()
-	pointIter, err := reader.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+	pointIter, err := reader.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/sstable/values.go
+++ b/sstable/values.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/blob"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/valblk"
+)
+
+// AssertNoBlobHandles is a TableBlobContext that configures a sstable iterator
+// to panic if it ever encounters a value that references an external blob file.
+var AssertNoBlobHandles = TableBlobContext{
+	ValueFetcher: base.NoBlobFetches,
+	// Passing a nil BlobReferences will cause any attempt to construct an
+	// InternalValue from a blob handle to panic.
+	References: nil,
+}
+
+// BlobReferences provides a mapping from an index to a file number for a
+// sstable's blob references. In practice, this is implemented by
+// manifest.BlobReferences.
+type BlobReferences interface {
+	// FileNumByID returns the FileNum for the identified BlobReference.
+	FileNumByID(i blob.ReferenceID) base.DiskFileNum
+	// IDByFileNum returns the reference ID for the given FileNum. If the file
+	// number is not found, the second return value is false.
+	IDByFileNum(fileNum base.DiskFileNum) (blob.ReferenceID, bool)
+}
+
+// TableBlobContext configures how values that reference external blob files
+// should be retrieved and handled.
+type TableBlobContext struct {
+	// ValueFetcher is used as the base.ValueFetcher for values returned that
+	// reference external blob files.
+	ValueFetcher base.ValueFetcher
+	// References provides a mapping from an index to a file number for a
+	// sstable's blob references.
+	References BlobReferences
+}
+
+// defaultInternalValueConstructor is the default implementation of the
+// block.GetInternalValueForPrefixAndValueHandler interface.
+type defaultInternalValueConstructor struct {
+	blobContext TableBlobContext
+	env         *block.ReadEnv
+	vbReader    valblk.Reader
+
+	// lazyFetcher is the LazyFetcher value embedded in any LazyValue that we
+	// return. It is used to avoid having a separate allocation for that.
+	lazyFetcher base.LazyFetcher
+}
+
+// Assert that defaultInternalValueConstructor implements the
+// block.GetInternalValueForPrefixAndValueHandler interface.
+var _ block.GetInternalValueForPrefixAndValueHandler = (*defaultInternalValueConstructor)(nil)
+
+// GetInternalValueForPrefixAndValueHandle returns a InternalValue for the
+// given value prefix and value.
+//
+// The result is only valid until the next call to
+// GetInternalValueForPrefixAndValueHandle. Use InternalValue.Clone if the
+// lifetime of the InternalValue needs to be extended. For more details, see
+// the "memory management" comment where LazyValue is declared.
+func (i *defaultInternalValueConstructor) GetInternalValueForPrefixAndValueHandle(
+	handle []byte,
+) base.InternalValue {
+	vp := block.ValuePrefix(handle[0])
+	if vp.IsValueBlockHandle() {
+		return i.vbReader.GetInternalValueForPrefixAndValueHandle(handle)
+	} else if !vp.IsBlobValueHandle() {
+		panic(errors.AssertionFailedf("block: %x is neither a valblk or blob handle prefix", vp))
+	}
+
+	// We can't convert a blob handle into an InternalValue without
+	// BlobReferences providing the mapping of a reference index to a blob file
+	// number.
+	if i.blobContext.References == nil {
+		panic(errors.AssertionFailedf("blob references not configured"))
+	}
+
+	// The first byte of [handle] is the valuePrefix byte.
+	//
+	// After that, is the inline-handle preface encoding a) the length of the
+	// value and b) the blob reference index. We need to map the blob reference
+	// index into a file number,
+	//
+	// The remainder of the handle (the suffix) encodes the value's location
+	// within the blob file. We defer parsing of it until the user retrieves the
+	// value. We propagate it as LazyValue.ValueOrHandle.
+	preface, remainder := blob.DecodeInlineHandlePreface(handle[1:])
+
+	if i.env.Stats != nil {
+		// TODO(jackson): Add stats to differentiate between blob values and
+		// value-block values.
+		i.env.Stats.SeparatedPointValue.Count++
+		i.env.Stats.SeparatedPointValue.ValueBytes += uint64(preface.ValueLen)
+	}
+
+	i.lazyFetcher = base.LazyFetcher{
+		Fetcher: i.blobContext.ValueFetcher,
+		Attribute: base.AttributeAndLen{
+			ValueLen:       preface.ValueLen,
+			ShortAttribute: vp.ShortAttribute(),
+		},
+		BlobFileNum: i.blobContext.References.FileNumByID(preface.ReferenceID),
+	}
+	return base.MakeLazyValue(base.LazyValue{
+		ValueOrHandle: remainder,
+		Fetcher:       &i.lazyFetcher,
+	})
+}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -193,7 +193,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat) {
 			return formatWriterMetadata(td, meta)
 
 		case "scan":
-			iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+			iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 			if err != nil {
 				return err.Error()
 			}
@@ -398,12 +398,12 @@ func TestWriterWithValueBlocks(t *testing.T) {
 
 		case "scan-raw":
 			// Raw scan does not fetch from value blocks.
-			iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+			iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 			if err != nil {
 				return err.Error()
 			}
 			forceRowIterIgnoreValueBlocks := func(i *singleLevelIteratorRowBlocks) {
-				i.vbReader = valblk.Reader{}
+				i.internalValueConstructor.vbReader = valblk.Reader{}
 				i.data.SetGetLazyValuer(nil)
 				i.data.SetHasValuePrefix(false)
 			}
@@ -442,7 +442,7 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			return buf.String()
 
 		case "scan":
-			iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+			iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 			if err != nil {
 				return err.Error()
 			}
@@ -458,7 +458,7 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			return buf.String()
 
 		case "scan-cloned-lazy-values":
-			iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */)
+			iter, err := r.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)
 			if err != nil {
 				return err.Error()
 			}
@@ -1128,7 +1128,7 @@ func TestWriterRace(t *testing.T) {
 			r, err := NewMemReader(f.Data(), readerOpts)
 			require.NoError(t, err)
 			defer r.Close()
-			it, err := r.NewIter(NoTransforms, nil, nil)
+			it, err := r.NewIter(NoTransforms, nil, nil, AssertNoBlobHandles)
 			require.NoError(t, err)
 			defer it.Close()
 			ki := 0

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -1,3 +1,6 @@
+# Test a simple scenario where two distinct sstables contain blob handles
+# referencing the same file.
+
 define verbose format-major-version=21
 L5
   b@9.SET.9:v
@@ -12,3 +15,176 @@ L5:
   000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:885 blobrefs:[(000921: 10); depth:1]
 L6:
   000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:863 blobrefs:[(000921: 6); depth:1]
+
+combined-iter
+first
+next
+next
+next
+next
+next
+next
+stats
+----
+b@9: (v, .)
+b@2: (v, .)
+c@9: (helloworld, .)
+c@2: (foobar, .)
+d@9: (v, .)
+d@2: (v, .)
+.
+stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 342B not cached (read time: 0s); points: 6 (18B keys, 8B values); separated: 2 (16B, 16B fetched)
+
+# Try the same but avoid fetching one of the values (by using NextPrefix to step
+# over it).
+
+combined-iter
+first
+next
+next
+next-prefix
+next
+next
+stats
+----
+b@9: (v, .)
+b@2: (v, .)
+c@9: (helloworld, .)
+d@9: (v, .)
+d@2: (v, .)
+.
+stats: seeked 1 times (1 internal); stepped 5 times (6 internal); blocks: 342B cached; points: 6 (18B keys, 8B values); separated: 2 (16B, 10B fetched)
+
+# Test a couple of blob files interleaved.
+
+define verbose format-major-version=21
+L5
+  b@9.SETWITHDEL.9:blob{fileNum=000039 value=orange}
+  c@9.SETWITHDEL.9:blob{fileNum=000921 value=canteloupe}
+  d@9.SETWITHDEL.9:blob{fileNum=000039 value=honeydew}
+  e@1.SETWITHDEL.9:blob{fileNum=000921 value=watermelon}
+L6
+  b@2.SETWITHDEL.9:blob{fileNum=000039 value=lemon}
+  c@2.SETWITHDEL.2:blob{fileNum=000921 value=kiwi}
+  d@2.SETWITHDEL.2:blob{fileNum=000921 value=tangerine}
+  f@2.SETWITHDEL.3:blob{fileNum=000039 value=grapes}
+----
+L5:
+  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:866 blobrefs:[(000039: 14), (000921: 20); depth:2]
+L6:
+  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:875 blobrefs:[(000039: 11), (000921: 13); depth:2]
+
+# The iterator stats should indicate that only the first value from each file
+# should trigger a read of the blob file. Once loaded, subsequent reads of the
+# values within the same blocks should not be recorded as block loads cached or
+# uncached, because the blob value fetcher retains its handle on the block.
+#
+# TODO(jackson): Add stats on the count of blob value retrievals that hit on the
+# existing cached readers.
+
+combined-iter
+first
+stats
+next
+stats
+next
+stats
+next
+next
+next
+stats
+next
+next
+next
+stats
+----
+b@9: (orange, .)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 345B not cached (read time: 0s); points: 1 (3B keys, 2B values); separated: 2 (11B, 6B fetched)
+b@2: (lemon, .)
+stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 345B not cached (read time: 0s); points: 2 (6B keys, 4B values); separated: 3 (21B, 11B fetched)
+c@9: (canteloupe, .)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 381B not cached (read time: 0s); points: 3 (9B keys, 6B values); separated: 4 (25B, 21B fetched)
+c@2: (kiwi, .)
+d@9: (honeydew, .)
+d@2: (tangerine, .)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 381B not cached (read time: 0s); points: 6 (18B keys, 12B values); separated: 7 (52B, 42B fetched)
+e@1: (watermelon, .)
+f@2: (grapes, .)
+.
+stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 381B not cached (read time: 0s); points: 8 (24B keys, 16B values); separated: 8 (58B, 58B fetched)
+
+# Test scanning a table, stepping into new blocks of the blob file. The stats
+# should reflect that a block is only loaded when stepping into a new block.
+
+define verbose format-major-version=21
+L6
+  a.SETWITHDEL.2:blob{fileNum=000009 value=lemonmeringue}
+  b.SETWITHDEL.2:blob{fileNum=000009 value=keylime}
+  c.SETWITHDEL.2:blob{fileNum=000009 value=pecan blockNum=1 offset=0}
+  d.SETWITHDEL.2:blob{fileNum=000009 value=cherry}
+  e.SETWITHDEL.2:blob{fileNum=000009 value=apple}
+  f.SETWITHDEL.2:blob{fileNum=000009 value=bananacream blockNum=2 offset=0}
+  g.SETWITHDEL.2:blob{fileNum=000009 value=chocolate}
+  h.SETWITHDEL.2:blob{fileNum=000009 value=strawberry blockNum=3 offset=0}
+  i.SETWITHDEL.2:blob{fileNum=000009 value=custard}
+  j.SETWITHDEL.2:blob{fileNum=000009 value=blueberry blockNum=4 offset=0}
+  k.SETWITHDEL.2:blob{fileNum=000009 value=raspberry blockNum=5 offset=0}
+  l.SETWITHDEL.2:blob{fileNum=000009 value=peach blockNum=6 offset=0}
+----
+L6:
+  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:945 blobrefs:[(000009: 96); depth:1]
+
+combined-iter
+first
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+next
+stats
+----
+a: (lemonmeringue, .)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 264B not cached (read time: 0s); points: 1 (1B keys, 2B values); separated: 1 (13B, 13B fetched)
+b: (keylime, .)
+stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 264B not cached (read time: 0s); points: 2 (2B keys, 4B values); separated: 2 (20B, 20B fetched)
+c: (pecan, .)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 280B not cached (read time: 0s); points: 3 (3B keys, 6B values); separated: 3 (25B, 25B fetched)
+d: (cherry, .)
+stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 0B cached, 280B not cached (read time: 0s); points: 4 (4B keys, 8B values); separated: 4 (31B, 31B fetched)
+e: (apple, .)
+stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 0B cached, 280B not cached (read time: 0s); points: 5 (5B keys, 10B values); separated: 5 (36B, 36B fetched)
+f: (bananacream, .)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 300B not cached (read time: 0s); points: 6 (6B keys, 12B values); separated: 6 (47B, 47B fetched)
+g: (chocolate, .)
+stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 300B not cached (read time: 0s); points: 7 (7B keys, 14B values); separated: 7 (56B, 56B fetched)
+h: (strawberry, .)
+stats: seeked 1 times (1 internal); stepped 7 times (7 internal); blocks: 0B cached, 317B not cached (read time: 0s); points: 8 (8B keys, 16B values); separated: 8 (66B, 66B fetched)
+i: (custard, .)
+stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 317B not cached (read time: 0s); points: 9 (9B keys, 18B values); separated: 9 (73B, 73B fetched)
+j: (blueberry, .)
+stats: seeked 1 times (1 internal); stepped 9 times (9 internal); blocks: 0B cached, 326B not cached (read time: 0s); points: 10 (10B keys, 20B values); separated: 10 (82B, 82B fetched)
+k: (raspberry, .)
+stats: seeked 1 times (1 internal); stepped 10 times (10 internal); blocks: 0B cached, 335B not cached (read time: 0s); points: 11 (11B keys, 22B values); separated: 11 (91B, 91B fetched)
+l: (peach, .)
+stats: seeked 1 times (1 internal); stepped 11 times (11 internal); blocks: 0B cached, 340B not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
+.
+stats: seeked 1 times (1 internal); stepped 12 times (12 internal); blocks: 0B cached, 340B not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)

--- a/testdata/value_separation_policy
+++ b/testdata/value_separation_policy
@@ -106,7 +106,7 @@ c#9,SET:paddy
 ----
 # create: 000005.sst
 RawWriter.AddWithBlobHandle("a#9,SET", "(f0,blk0[0:5])", 5, false)
-RawWriter.AddWithBlobHandle("a#5,SET", "(f1,blk0[5:9])", 4, false)
+RawWriter.AddWithBlobHandle("a#5,SET", "(f1,blk0[0:4])", 4, false)
 RawWriter.Add("b#2,DEL", "", false)
 RawWriter.Add("c#9,SET", "paddy", false)
 
@@ -130,7 +130,7 @@ e#9,SET:blob{value=yayoi}
 ----
 # create: 000006.sst
 RawWriter.Add("d#2,DEL", "", false)
-RawWriter.AddWithBlobHandle("e#9,SET", "(f0,blk0[9:14])", 5, false)
+RawWriter.AddWithBlobHandle("e#9,SET", "(f0,blk0[4:9])", 5, false)
 
 estimated-sizes
 ----

--- a/tool/find.go
+++ b/tool/find.go
@@ -468,7 +468,10 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 				fragTransforms = m.FragmentIterTransforms()
 			}
 
-			iter, err := r.NewIter(transforms, nil, nil)
+			// TODO(jackson): Adjust to support two modes: one that surfaces the
+			// raw blob value handles, and one that fetches the blob values from
+			// blob files uncovered by scanning the directory entries. See #4448.
+			iter, err := r.NewIter(transforms, nil, nil, sstable.AssertNoBlobHandles)
 			if err != nil {
 				return err
 			}

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -164,14 +164,17 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
 		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
 
-		iter, err := r.NewIter(sstable.NoTransforms, nil, nil)
+		// TODO(jackson): Adjust to support two modes: one that surfaces the raw
+		// blob value handles, and one that fetches the blob values from blob
+		// files uncovered by scanning the directory entries. See #4448.
+		iter, err := r.NewIter(sstable.NoTransforms, nil, nil, sstable.AssertNoBlobHandles)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
 			return
 		}
 
 		// Verify that SeekPrefixGE can find every key in the table.
-		prefixIter, err := r.NewIter(sstable.NoTransforms, nil, nil)
+		prefixIter, err := r.NewIter(sstable.NoTransforms, nil, nil, sstable.AssertNoBlobHandles)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
 			return
@@ -332,7 +335,10 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 			prefix = fmt.Sprintf("%s: ", path)
 		}
 
-		iter, err := r.NewIter(sstable.NoTransforms, nil, s.end)
+		// TODO(jackson): Adjust to support two modes: one that surfaces the raw
+		// blob value handles, and one that fetches the blob values from blob
+		// files uncovered by scanning the directory entries. See #4448.
+		iter, err := r.NewIter(sstable.NoTransforms, nil, s.end, sstable.AssertNoBlobHandles)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s%s\n", prefix, err)
 			return

--- a/value_separation.go
+++ b/value_separation.go
@@ -251,7 +251,7 @@ func (vs *preserveBlobReferences) Add(
 	lv := kv.V.LazyValue()
 	fn := lv.Fetcher.BlobFileNum
 
-	refIdx, found := vs.currReferences.IDByFileNum(fn)
+	refID, found := vs.currReferences.IDByFileNum(fn)
 	if !found {
 		// This is the first time we're seeing this blob file for this sstable.
 		// Find the blob file metadata for this file among the input metadatas.
@@ -259,21 +259,21 @@ func (vs *preserveBlobReferences) Add(
 		if !found {
 			return errors.AssertionFailedf("pebble: blob file %s not found among input sstables", fn)
 		}
-		refIdx = blob.ReferenceID(len(vs.currReferences))
+		refID = blob.ReferenceID(len(vs.currReferences))
 		vs.currReferences = append(vs.currReferences, manifest.BlobReference{
 			FileNum:  fn,
 			Metadata: vs.inputBlobMetadatas[idx],
 		})
 	}
 
-	if invariants.Enabled && vs.currReferences[refIdx].Metadata.FileNum != fn {
+	if invariants.Enabled && vs.currReferences[refID].Metadata.FileNum != fn {
 		panic("wrong reference index")
 	}
 
 	handleSuffix := blob.DecodeHandleSuffix(lv.ValueOrHandle)
 	inlineHandle := blob.InlineHandle{
 		InlineHandlePreface: blob.InlineHandlePreface{
-			ReferenceID: refIdx,
+			ReferenceID: refID,
 			ValueLen:    lv.Fetcher.Attribute.ValueLen,
 		},
 		HandleSuffix: handleSuffix,
@@ -282,7 +282,7 @@ func (vs *preserveBlobReferences) Add(
 	if err != nil {
 		return err
 	}
-	vs.currReferences[refIdx].ValueSize += uint64(lv.Fetcher.Attribute.ValueLen)
+	vs.currReferences[refID].ValueSize += uint64(lv.Fetcher.Attribute.ValueLen)
 	vs.totalValueSize += uint64(lv.Fetcher.Attribute.ValueLen)
 	return nil
 }


### PR DESCRIPTION
Initialize iterators and compactions with a blob.ValueFetcher that's propagated
through to sstable iterators. When an sstable iterator encounters a blob value
handle, it constructs an internal value with the blob.ValueFetcher configured
as the ValueFetcher.

Close https://github.com/cockroachdb/pebble/issues/4394.
Informs https://github.com/cockroachdb/pebble/issues/112.