### PR TITLE
github: add pebble-release branches to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,13 @@ on:
     branches:
       - master
       - crl-release-*
+      - pebble-release-*
+
   pull_request:
     branches:
       - master
       - crl-release-*
+      - pebble-release-*
 
 jobs:
 


### PR DESCRIPTION
This will make a difference when we fork the next pebble-release
branch.