### PR TITLE
internal/manifest: add test for zero allocs when ranging

### DIFF
--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -783,3 +783,52 @@ func TestCalculateInuseKeyRangesRandomized(t *testing.T) {
 		}
 	}
 }
+
+func TestIterAllocs(t *testing.T) {
+	t.Run("LevelSlice", func(t *testing.T) {
+		var testLevelSlice = func() LevelSlice {
+			const n = 10
+			var tables []*TableMetadata
+			for i := 0; i < n; i++ {
+				tables = append(tables, &TableMetadata{
+					FileNum:     base.FileNum(i),
+					FileBacking: &FileBacking{},
+				})
+			}
+			return NewLevelSliceSeqSorted(tables)
+		}()
+		allocs := testing.AllocsPerRun(100, func() {
+			for v := range testLevelSlice.All() {
+				if v == nil {
+					panic("nil")
+				}
+			}
+		})
+		if allocs > 0 {
+			t.Fatalf("allocs=%f", allocs)
+		}
+	})
+	t.Run("LevelMetadata", func(t *testing.T) {
+		var testLevelMetadata = func() LevelMetadata {
+			const n = 1000
+			var tables []*TableMetadata
+			for i := 0; i < n; i++ {
+				tables = append(tables, &TableMetadata{
+					FileNum:     base.FileNum(i),
+					FileBacking: &FileBacking{},
+				})
+			}
+			return MakeLevelMetadata(base.DefaultComparer.Compare, 0, tables)
+		}()
+		allocs := testing.AllocsPerRun(100, func() {
+			for v := range testLevelMetadata.All() {
+				if v == nil {
+					panic("nil")
+				}
+			}
+		})
+		if allocs > 0 {
+			t.Fatalf("allocs=%f", allocs)
+		}
+	})
+}


### PR DESCRIPTION
Add a unit test that asserts ranging over a LevelMetadata or LevelSlice through their All methods result in zero allocations.