### PR TITLE
db: file excise code cleanup

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1345,13 +1345,6 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 				if err != nil {
 					return nil, err
 				}
-
-				if _, ok := ve.DeletedTables[deletedFileEntry{
-					Level:   layer.Level(),
-					FileNum: m.FileNum,
-				}]; !ok {
-					panic("did not excise file that overlaps with the excise span")
-				}
 				replacedFiles[m.FileNum] = newFiles
 				updateLevelMetricsOnExcise(m, layer.Level(), newFiles)
 			}
@@ -2739,12 +2732,6 @@ func (d *DB) applyHintOnFile(
 	newFiles, err = d.exciseTable(context.TODO(), base.UserKeyBoundsEndExclusive(h.start, h.end), f, ve, level)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when running excise for delete-only compaction")
-	}
-	if _, ok := ve.DeletedTables[deletedFileEntry{
-		Level:   level,
-		FileNum: f.FileNum,
-	}]; !ok {
-		panic("pebble: delete-only compaction hint overlapping a file did not excise that file")
 	}
 	return newFiles, nil
 }

--- a/compaction.go
+++ b/compaction.go
@@ -1341,7 +1341,7 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 		// Iterate through all levels and find files that intersect with exciseSpan.
 		for layer, ls := range c.version.AllLevelsAndSublevels() {
 			for m := range ls.Overlaps(d.cmp, ingestFlushable.exciseSpan.UserKeyBounds()).All() {
-				newFiles, err := d.excise(context.TODO(), ingestFlushable.exciseSpan.UserKeyBounds(), m, ve, layer.Level())
+				newFiles, err := d.exciseTable(context.TODO(), ingestFlushable.exciseSpan.UserKeyBounds(), m, ve, layer.Level())
 				if err != nil {
 					return nil, err
 				}
@@ -2704,7 +2704,7 @@ func (d *DB) runCopyCompaction(
 
 // applyHintOnFile applies a deleteCompactionHint to a file, and updates the
 // versionEdit accordingly. It returns a list of new files that were created
-// if the hint was applied partially to a file (eg. through an excise as opposed
+// if the hint was applied partially to a file (eg. through an exciseTable as opposed
 // to an outright deletion). levelMetrics is kept up-to-date with the number
 // of tables deleted or excised.
 func (d *DB) applyHintOnFile(
@@ -2736,7 +2736,7 @@ func (d *DB) applyHintOnFile(
 	}
 
 	levelMetrics.TablesExcised++
-	newFiles, err = d.excise(context.TODO(), base.UserKeyBoundsEndExclusive(h.start, h.end), f, ve, level)
+	newFiles, err = d.exciseTable(context.TODO(), base.UserKeyBoundsEndExclusive(h.start, h.end), f, ve, level)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when running excise for delete-only compaction")
 	}

--- a/compaction.go
+++ b/compaction.go
@@ -1341,10 +1341,11 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 		// Iterate through all levels and find files that intersect with exciseSpan.
 		for layer, ls := range c.version.AllLevelsAndSublevels() {
 			for m := range ls.Overlaps(d.cmp, ingestFlushable.exciseSpan.UserKeyBounds()).All() {
-				newFiles, err := d.exciseTable(context.TODO(), ingestFlushable.exciseSpan.UserKeyBounds(), m, ve, layer.Level())
+				leftTable, rightTable, err := d.exciseTable(context.TODO(), ingestFlushable.exciseSpan.UserKeyBounds(), m, layer.Level())
 				if err != nil {
 					return nil, err
 				}
+				newFiles := applyExciseToVersionEdit(ve, m, leftTable, rightTable, layer.Level())
 				replacedFiles[m.FileNum] = newFiles
 				updateLevelMetricsOnExcise(m, layer.Level(), newFiles)
 			}
@@ -2723,16 +2724,17 @@ func (d *DB) applyHintOnFile(
 		return nil, nil
 	}
 	// The hint overlaps with only a part of the file, not the entirety of it. We need
-	// to use d.excise. (hintOverlap == hintExcisesFile)
+	// to use d.exciseTable. (hintOverlap == hintExcisesFile)
 	if d.FormatMajorVersion() < FormatVirtualSSTables {
 		panic("pebble: delete-only compaction hint excising a file is not supported in this version")
 	}
 
 	levelMetrics.TablesExcised++
-	newFiles, err = d.exciseTable(context.TODO(), base.UserKeyBoundsEndExclusive(h.start, h.end), f, ve, level)
+	leftTable, rightTable, err := d.exciseTable(context.TODO(), base.UserKeyBoundsEndExclusive(h.start, h.end), f, level)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when running excise for delete-only compaction")
 	}
+	newFiles = applyExciseToVersionEdit(ve, f, leftTable, rightTable, level)
 	return newFiles, nil
 }
 

--- a/download.go
+++ b/download.go
@@ -248,13 +248,14 @@ func (d *DB) newDownloadSpanTask(vers *version, sp DownloadSpan) (_ *downloadSpa
 	// [sp.StartKey, sp.EndKey). Expand the bounds to the left so that we
 	// include the start keys of any external sstables that overlap with
 	// sp.StartKey.
-	vers.IterAllLevelsAndSublevels(func(iter manifest.LevelIterator, level manifest.Layer) {
+	for _, ls := range vers.AllLevelsAndSublevels() {
+		iter := ls.Iter()
 		if f := iter.SeekGE(d.cmp, sp.StartKey); f != nil &&
 			objstorage.IsExternalTable(d.objProvider, f.FileBacking.DiskFileNum) &&
 			d.cmp(f.Smallest.UserKey, bounds.Start) < 0 {
 			bounds.Start = f.Smallest.UserKey
 		}
-	})
+	}
 	startCursor := downloadCursor{
 		level:  0,
 		key:    bounds.Start,

--- a/excise.go
+++ b/excise.go
@@ -44,15 +44,15 @@ func (d *DB) Excise(ctx context.Context, span KeyRange) error {
 	return err
 }
 
-// excise updates ve to include a replacement of the file m with new virtual
-// sstables that exclude exciseSpan, returning a slice of newly-created files if
-// any. If the entirety of m is deleted by exciseSpan, no new sstables are added
-// and m is deleted. Note that ve is updated in-place.
+// exciseTable updates ve to include a replacement of the table m with new
+// virtual sstables that exclude exciseSpan, returning a slice of newly-created
+// files if any. If the entirety of m is deleted by exciseSpan, no new sstables
+// are added and m is deleted. Note that ve is updated in-place.
 //
 // This method is agnostic to whether d.mu is held or not. Some cases call it with
 // the db mutex held (eg. ingest-time excises), while in the case of compactions
 // the mutex is not held.
-func (d *DB) excise(
+func (d *DB) exciseTable(
 	ctx context.Context, exciseSpan base.UserKeyBounds, m *tableMetadata, ve *versionEdit, level int,
 ) ([]manifest.NewTableEntry, error) {
 	numCreatedFiles := 0

--- a/excise.go
+++ b/excise.go
@@ -248,9 +248,8 @@ func determineLeftTableBounds(
 				// The key is owned by the range key iter, so we need to copy it.
 				lastRangeKey = slices.Clone(rkey.End)
 			}
-			lastRangeKeyKind := rkey.Keys[0].Kind()
 			leftTable.ExtendRangeKeyBounds(cmp, originalTable.SmallestRangeKey,
-				base.MakeExclusiveSentinelKey(lastRangeKeyKind, lastRangeKey))
+				base.MakeExclusiveSentinelKey(rkey.LargestKey().Kind(), lastRangeKey))
 		}
 	}
 	return nil

--- a/ingest.go
+++ b/ingest.go
@@ -1871,12 +1871,6 @@ func (d *DB) ingestSplit(
 		if err != nil {
 			return err
 		}
-		if _, ok := ve.DeletedTables[deletedFileEntry{
-			Level:   s.level,
-			FileNum: splitFile.FileNum,
-		}]; !ok {
-			panic("did not split file that was expected to be split")
-		}
 		replacedFiles[splitFile.FileNum] = added
 		for i := range added {
 			addedBounds := added[i].Meta.UserKeyBounds()
@@ -2107,13 +2101,6 @@ func (d *DB) ingestApply(
 				newFiles, err := d.exciseTable(ctx, exciseSpan.UserKeyBounds(), m, ve, layer.Level())
 				if err != nil {
 					return nil, err
-				}
-
-				if _, ok := ve.DeletedTables[deletedFileEntry{
-					Level:   layer.Level(),
-					FileNum: m.FileNum,
-				}]; !ok {
-					panic("did not excise file that overlaps with the excise span")
 				}
 				replacedFiles[m.FileNum] = newFiles
 				updateLevelMetricsOnExcise(m, layer.Level(), newFiles)

--- a/ingest.go
+++ b/ingest.go
@@ -1867,7 +1867,7 @@ func (d *DB) ingestSplit(
 		// as we're guaranteed to not have any data overlap between splitFile and
 		// s.ingestFile. d.excise will return an error if we pass an inclusive user
 		// key bound _and_ we end up seeing data overlap at the end key.
-		added, err := d.excise(ctx, base.UserKeyBoundsFromInternal(s.ingestFile.Smallest, s.ingestFile.Largest), splitFile, ve, s.level)
+		added, err := d.exciseTable(ctx, base.UserKeyBoundsFromInternal(s.ingestFile.Smallest, s.ingestFile.Largest), splitFile, ve, s.level)
 		if err != nil {
 			return err
 		}
@@ -2104,7 +2104,7 @@ func (d *DB) ingestApply(
 		// out.
 		for layer, ls := range current.AllLevelsAndSublevels() {
 			for m := range ls.Overlaps(d.cmp, exciseSpan.UserKeyBounds()).All() {
-				newFiles, err := d.excise(ctx, exciseSpan.UserKeyBounds(), m, ve, layer.Level())
+				newFiles, err := d.exciseTable(ctx, exciseSpan.UserKeyBounds(), m, ve, layer.Level())
 				if err != nil {
 					return nil, err
 				}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -895,7 +895,7 @@ func TestExcise(t *testing.T) {
 			for l, ls := range current.AllLevelsAndSublevels() {
 				iter := ls.Iter()
 				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
-					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, l.Level())
+					_, err := d.exciseTable(context.Background(), exciseSpan.UserKeyBounds(), m, ve, l.Level())
 					if err != nil {
 						td.Fatalf(t, "error when excising %s: %s", m.FileNum, err.Error())
 					}
@@ -1245,7 +1245,7 @@ func testIngestSharedImpl(
 			for level := range current.Levels {
 				iter := current.Levels[level].Iter()
 				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
-					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, level)
+					_, err := d.exciseTable(context.Background(), exciseSpan.UserKeyBounds(), m, ve, level)
 					if err != nil {
 						d.mu.Lock()
 						d.mu.versions.logUnlock()
@@ -1749,7 +1749,7 @@ func TestConcurrentExcise(t *testing.T) {
 			for level := range current.Levels {
 				iter := current.Levels[level].Iter()
 				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
-					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, level)
+					_, err := d.exciseTable(context.Background(), exciseSpan.UserKeyBounds(), m, ve, level)
 					if err != nil {
 						d.mu.Lock()
 						d.mu.versions.logUnlock()

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -892,14 +892,15 @@ func TestExcise(t *testing.T) {
 			d.mu.Unlock()
 			current := d.mu.versions.currentVersion()
 
-			current.IterAllLevelsAndSublevels(func(iter manifest.LevelIterator, l manifest.Layer) {
+			for l, ls := range current.AllLevelsAndSublevels() {
+				iter := ls.Iter()
 				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
 					_, err := d.excise(context.Background(), exciseSpan.UserKeyBounds(), m, ve, l.Level())
 					if err != nil {
 						td.Fatalf(t, "error when excising %s: %s", m.FileNum, err.Error())
 					}
 				}
-			})
+			}
 
 			d.mu.Lock()
 			d.mu.versions.logUnlock()


### PR DESCRIPTION
This set of changes attempts to tame the function that excises a file which is several screens long.

This is in preparation for work on #4417.

#### db: find strict overlap with excise span

`Version.Overlaps()` returns all "indirect" overlaps in L0. This is
not what we want when we look for files to excise.

This change replaces `Overlaps()` with using `LevelSlice.Overlaps()`
on each sublevel/level.

#### db: rename excise to exciseTable


#### db: require overlap in exciseTable

Now that we only call it when there is overlap, `exciseTable` asserts
that the table is overlapping.

#### db: extract determineLeftTableBounds from exciseTable


#### db: extract determineRightTableBounds from exciseTable


#### db: extract VersionEdit logic from exciseTable

Add a separate function for applying an excise to a `VersionEdit`;
`exciseTable` is simplified to return the left and right tables.

#### db: extract determineExcisedTableSize from exciseTable