### PR TITLE
db: fix L0Organizer race during logAndApply

### DIFF
--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -314,8 +314,9 @@ func TestLevelIterEquivalence(t *testing.T) {
 			b.AddedTables[6] = amap
 			l0Organizer := manifest.NewL0Organizer(base.DefaultComparer, 0 /* flushSplitBytes */)
 			emptyVersion := manifest.NewInitialVersion(base.DefaultComparer)
-			v, err := b.Apply(emptyVersion, l0Organizer, 0)
+			v, err := b.Apply(emptyVersion, 0)
 			require.NoError(t, err)
+			l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(b, v), v)
 			levelIter.Init(
 				context.Background(),
 				keyspan.SpanIterOptions{}, base.DefaultComparer.Compare, tableNewIters,

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -54,9 +54,10 @@ func readManifest(filename string) (*Version, error) {
 		if err := bve.Accumulate(&ve); err != nil {
 			return nil, err
 		}
-		if v, err = bve.Apply(v, l0Organizer, 32000); err != nil {
+		if v, err = bve.Apply(v, 32000); err != nil {
 			return nil, err
 		}
+		l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(&bve, v), v)
 	}
 	return v, nil
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -128,7 +128,8 @@ func replayManifest(
 	}
 	l0Organizer := manifest.NewL0Organizer(cmp, opts.FlushSplitBytes)
 	emptyVersion := manifest.NewInitialVersion(cmp)
-	v, err := bve.Apply(emptyVersion, l0Organizer, opts.Experimental.ReadCompactionRate)
+	v, err := bve.Apply(emptyVersion, opts.Experimental.ReadCompactionRate)
 	require.NoError(t, err)
+	l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(&bve, v), v)
 	return v, l0Organizer
 }

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1214,8 +1214,7 @@ func NewVersionForTesting(
 			v.Levels[l].totalSize += f.Size
 		}
 	}
-	l0Organizer.ResetForTesting(&v.Levels[0])
-	v.L0SublevelFiles = l0Organizer.SublevelFiles()
+	l0Organizer.ResetForTesting(v)
 	return v
 }
 

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1149,9 +1149,10 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 // the levels.
 //
 // curr may be nil, which is equivalent to a pointer to a zero version.
-func (b *BulkVersionEdit) Apply(
-	curr *Version, l0Organizer *L0Organizer, readCompactionRate int64,
-) (*Version, error) {
+//
+// Not that L0SublevelFiles is not initialized in the returned version; it is
+// the caller's responsibility to set it using L0Organizer.PerformUpdate().
+func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Version, error) {
 	comparer := curr.cmp
 	v := &Version{
 		cmp: comparer,
@@ -1292,9 +1293,6 @@ func (b *BulkVersionEdit) Apply(
 			}
 		}
 	}
-
-	l0Organizer.Update(b.AddedTables[0], b.DeletedTables[0], &v.Levels[0])
-	v.L0SublevelFiles = l0Organizer.SublevelFiles()
 
 	// We maintain stats about active references in blob files and can infer
 	// when a blob file has become a 'zombie,' and is no longer referenced in

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -449,10 +449,11 @@ func TestVersionEditApply(t *testing.T) {
 				if l0Organizer == nil {
 					d.Fatalf(t, "no L0 organizer")
 				}
-				newv, err := bve.Apply(v, l0Organizer, readCompactionRate)
+				newv, err := bve.Apply(v, readCompactionRate)
 				if err != nil {
 					return err.Error()
 				}
+				l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(&bve, newv), newv)
 				if saveName != "" {
 					versions[saveName] = newv
 					l0Organizers[saveName] = l0Organizer
@@ -461,7 +462,7 @@ func TestVersionEditApply(t *testing.T) {
 				// Reinitialize the L0 organizer in case we want to use the same version
 				// again (l0Organizer now reflects newv).
 				l0Organizer = NewL0Organizer(base.DefaultComparer, flushSplitBytes)
-				l0Organizer.ResetForTesting(&v.Levels[0])
+				l0Organizer.ResetForTesting(v)
 				l0Organizers[name] = l0Organizer
 
 				return newv.DebugString()

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -802,10 +802,11 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 				}
 
 				// Apply the edit.
-				v, err = bve.Apply(v, l0Organizer, r.Opts.Experimental.ReadCompactionRate)
+				v, err = bve.Apply(v, r.Opts.Experimental.ReadCompactionRate)
 				if err != nil {
 					return err
 				}
+				l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(&bve, v), v)
 				// AddedTablesByFileNum maps file number to table metadata for all added
 				// sstables from accumulated version edits so we must retain it.
 				bve = manifest.BulkVersionEdit{AddedTablesByFileNum: bve.AddedTablesByFileNum}

--- a/tool/db.go
+++ b/tool/db.go
@@ -723,10 +723,11 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 		}
 		l0Organizer := manifest.NewL0Organizer(cmp, d.opts.FlushSplitBytes)
 		emptyVersion := manifest.NewInitialVersion(cmp)
-		v, err := bve.Apply(emptyVersion, l0Organizer, d.opts.Experimental.ReadCompactionRate)
+		v, err := bve.Apply(emptyVersion, d.opts.Experimental.ReadCompactionRate)
 		if err != nil {
 			return err
 		}
+		l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(&bve, v), v)
 
 		objProvider, err := objstorageprovider.Open(objstorageprovider.DefaultSettings(d.opts.FS, dirname))
 		if err != nil {

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -243,11 +243,12 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			if comparer != nil {
 				l0Organizer := manifest.NewL0Organizer(comparer, 0 /* flushSplitBytes */)
 				emptyVersion := manifest.NewInitialVersion(comparer)
-				v, err := bve.Apply(emptyVersion, l0Organizer, m.opts.Experimental.ReadCompactionRate)
+				v, err := bve.Apply(emptyVersion, m.opts.Experimental.ReadCompactionRate)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
 					return
 				}
+				l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(&bve, v), v)
 				m.printLevels(comparer.Compare, stdout, v)
 			}
 		}()
@@ -628,7 +629,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 					l0Organizer = manifest.NewL0Organizer(cmp, 0 /* flushSplitBytes */)
 					v = manifest.NewInitialVersion(cmp)
 				}
-				newv, err := bve.Apply(v, l0Organizer, m.opts.Experimental.ReadCompactionRate)
+				newv, err := bve.Apply(v, m.opts.Experimental.ReadCompactionRate)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)
@@ -648,6 +649,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 					ok = false
 					break
 				}
+				l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(&bve, newv), newv)
 				v = newv
 			}
 		}()


### PR DESCRIPTION
In `logAndApply`, we `Apply` the bulk version edit without holding
`DB.mu`. `Apply` internally updates `L0Organizer` which is supposed to
be protected by `DB.mu`.

Note that the same thing was happening before the `L0Organizer`, but
because the incremental updating of sublevels doesn't work with
compactions, we were always generating new `L0Sublevels`, so the
previous version's sublevels were still usable.

We separate the updating of L0 sublevels from `Apply` so we can do the
former under the lock.

Fixes #4471