### PR TITLE
block: remove 'table' from error messages

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -569,7 +569,7 @@ func (r *Reader) doRead(
 	env.BlockRead(bh.Length, readDuration)
 	if err = ValidateChecksum(r.checksumType, compressed.BlockData(), bh); err != nil {
 		compressed.Release()
-		err = errors.Wrapf(err, "pebble/table: table %s", r.opts.CacheOpts.FileNum)
+		err = errors.Wrapf(err, "pebble: file %s", r.opts.CacheOpts.FileNum)
 		return Value{}, err
 	}
 	typ := CompressionIndicator(compressed.BlockData()[bh.Length])
@@ -646,7 +646,7 @@ func ReadRaw(
 ) ([]byte, error) {
 	size := f.Size()
 	if size < int64(len(buf)) {
-		return nil, base.CorruptionErrorf("pebble/table: invalid table %s (file size is too small)", errors.Safe(fileNum))
+		return nil, base.CorruptionErrorf("pebble: invalid file %s (file size is too small)", errors.Safe(fileNum))
 	}
 
 	readStopwatch := makeStopwatch()
@@ -664,7 +664,7 @@ func ReadRaw(
 			len(buf), readDuration.String())
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "pebble/table: invalid table (could not read footer)")
+		return nil, errors.Wrap(err, "pebble: invalid file (could not read footer)")
 	}
 	return buf, nil
 }

--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -78,7 +78,7 @@ func (snappyDecompressor) DecompressInto(buf, compressed []byte) error {
 		return err
 	}
 	if len(result) != len(buf) || (len(result) > 0 && &result[0] != &buf[0]) {
-		return base.CorruptionErrorf("pebble/table: decompressed into unexpected buffer: %p != %p",
+		return base.CorruptionErrorf("pebble: decompressed into unexpected buffer: %p != %p",
 			errors.Safe(result), errors.Safe(buf))
 	}
 	return nil
@@ -94,7 +94,7 @@ func (zstdDecompressor) DecompressedLen(b []byte) (decompressedLen int, err erro
 	// if we implement these algorithms in the future.
 	decodedLenU64, varIntLen := binary.Uvarint(b)
 	if varIntLen <= 0 {
-		return 0, base.CorruptionErrorf("pebble/table: compression block has invalid length")
+		return 0, base.CorruptionErrorf("pebble: compression block has invalid length")
 	}
 	return int(decodedLenU64), nil
 }

--- a/tool/testdata/sstable_check
+++ b/tool/testdata/sstable_check
@@ -44,7 +44,7 @@ WARNING: OUT OF ORDER KEYS!
 sstable check
 testdata/corrupted.sst
 ----
-corrupted.sst: pebble/table: table 000000: block 87/465: crc32c checksum mismatch c8539ba5 != b972e324
+corrupted.sst: pebble: file 000000: block 87/465: crc32c checksum mismatch c8539ba5 != b972e324
 
 sstable check
 testdata/bad-magic.sst


### PR DESCRIPTION
Remove mention of 'table' from codepaths used by both sstable and blob file readers.