### PR TITLE
sstable: make code for creating ssts in tests reusable

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -110,8 +110,8 @@ func TestIngestLoad(t *testing.T) {
 			var br blobtest.References
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writerOpts)
 			for _, data := range strings.Split(td.Input, "\n") {
-				if strings.HasPrefix(data, "EncodeSpan: ") {
-					data = strings.TrimPrefix(data, "EncodeSpan: ")
+				if strings.HasPrefix(data, "Span: ") {
+					data = strings.TrimPrefix(data, "Span: ")
 					err := w.EncodeSpan(keyspan.ParseSpan(data))
 					if err != nil {
 						return err.Error()
@@ -3293,8 +3293,8 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 			TableFormat: sstable.TableFormatMax,
 		})
 		for _, data := range strings.Split(input, "\n") {
-			if strings.HasPrefix(data, "EncodeSpan: ") {
-				data = strings.TrimPrefix(data, "EncodeSpan: ")
+			if strings.HasPrefix(data, "Span: ") {
+				data = strings.TrimPrefix(data, "Span: ")
 				err := w.EncodeSpan(keyspan.ParseSpan(data))
 				if err != nil {
 					return nil, err

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -196,8 +196,8 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				}
 				keyValues := strings.Fields(line)
 				for _, kv := range keyValues {
-					if strings.HasPrefix(kv, "EncodeSpan:") {
-						kv = kv[len("EncodeSpan:"):]
+					if strings.HasPrefix(kv, "Span:") {
+						kv = kv[len("Span:"):]
 						s := keyspan.ParseSpan(kv)
 						if writeUnfragmented {
 							if err = w.EncodeSpan(s); err != nil {

--- a/sstable/blob/handle.go
+++ b/sstable/blob/handle.go
@@ -89,7 +89,7 @@ func (h InlineHandle) String() string {
 
 // SafeFormat implements redact.SafeFormatter.
 func (h InlineHandle) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("(f%d,blk%d[%d:%d])",
+	w.Printf("(%d, blk%d[%d:%d])",
 		h.ReferenceID, h.BlockNum, h.OffsetInBlock, h.OffsetInBlock+h.ValueLen)
 }
 

--- a/sstable/blob/handle.go
+++ b/sstable/blob/handle.go
@@ -89,7 +89,7 @@ func (h InlineHandle) String() string {
 
 // SafeFormat implements redact.SafeFormatter.
 func (h InlineHandle) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("(%d, blk%d[%d:%d])",
+	w.Printf("(f%d,blk%d[%d:%d])",
 		h.ReferenceID, h.BlockNum, h.OffsetInBlock, h.OffsetInBlock+h.ValueLen)
 }
 

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -128,8 +128,8 @@ func writeKVs(w RawWriter, input string) (err error) {
 	}()
 	for _, data := range strings.Split(input, "\n") {
 		switch {
-		case strings.HasPrefix(data, "EncodeSpan:"):
-			err = w.EncodeSpan(keyspan.ParseSpan(strings.TrimPrefix(data, "EncodeSpan:")))
+		case strings.HasPrefix(data, "Span:"):
+			err = w.EncodeSpan(keyspan.ParseSpan(strings.TrimPrefix(data, "Span:")))
 		default:
 			forceObsolete := strings.HasPrefix(data, "force-obsolete:")
 			if forceObsolete {
@@ -274,8 +274,8 @@ func runBuildRawCmd(
 		}
 	}()
 	for _, data := range strings.Split(td.Input, "\n") {
-		if strings.HasPrefix(data, "EncodeSpan:") {
-			data = strings.TrimPrefix(data, "EncodeSpan:")
+		if strings.HasPrefix(data, "Span:") {
+			data = strings.TrimPrefix(data, "Span:")
 			if err := w.EncodeSpan(keyspan.ParseSpan(data)); err != nil {
 				return nil, nil, err
 			}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -7,12 +7,10 @@ package sstable
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/datadriven"
@@ -25,7 +23,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
-	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -106,7 +103,7 @@ func runBuildMemObjCmd(
 			_ = w.Close()
 		}
 	}()
-	if err := writeKVs(w, td.Input); err != nil {
+	if err := ParseTestSST(w, td.Input); err != nil {
 		return nil, nil, err
 	}
 	if err := w.Close(); err != nil {
@@ -118,100 +115,6 @@ func runBuildMemObjCmd(
 		return nil, nil, err
 	}
 	return meta, obj, nil
-}
-
-func writeKVs(w RawWriter, input string) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.Errorf("%v", r)
-		}
-	}()
-	for _, data := range strings.Split(input, "\n") {
-		switch {
-		case strings.HasPrefix(data, "Span:"):
-			err = w.EncodeSpan(keyspan.ParseSpan(strings.TrimPrefix(data, "Span:")))
-		default:
-			forceObsolete := strings.HasPrefix(data, "force-obsolete:")
-			if forceObsolete {
-				data = strings.TrimSpace(strings.TrimPrefix(data, "force-obsolete:"))
-			}
-			j := strings.Index(data, ":")
-			key := base.ParseInternalKey(data[:j])
-			value := []byte(data[j+1:])
-
-			switch key.Kind() {
-			case InternalKeyKindRangeDelete:
-				if forceObsolete {
-					return errors.Errorf("force-obsolete is not allowed for RANGEDEL")
-				}
-				err = w.Add(key, value, false /* forceObsolete */)
-			default:
-				if bytes.HasPrefix(value, []byte("blobInlineHandle(")) {
-					var handle blob.InlineHandle
-					var attr base.ShortAttribute
-					handle, attr, err = decodeBlobInlineHandleAndAttribute(string(value))
-					if err != nil {
-						return err
-					}
-					err = w.AddWithBlobHandle(key, handle, attr, forceObsolete)
-				} else {
-					err = w.Add(key, value, forceObsolete)
-				}
-			}
-			if err != nil {
-				return err
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return err
-}
-
-// decodeBlobInlineHandleAndAttribute decodes a blob handle (in its inline form)
-// and its short attribute from a debug string. It expects a value of the form:
-// blobInlineHandle(<refIndex>, blk<blocknum>, <offset>, <valLen>, <attr>). For example:
-//
-//	blobInlineHandle(24, blk255, 10, 9235, 0x07)
-func decodeBlobInlineHandleAndAttribute(
-	ref string,
-) (blob.InlineHandle, base.ShortAttribute, error) {
-	fields := strings.FieldsFunc(strings.TrimSuffix(strings.TrimPrefix(ref, "blobInlineHandle("), ")"),
-		func(r rune) bool { return r == ',' || unicode.IsSpace(r) })
-	if len(fields) != 5 {
-		return blob.InlineHandle{}, base.ShortAttribute(0), errors.New("expected 5 fields")
-	}
-	refIdx, err := strconv.ParseUint(fields[0], 10, 32)
-	if err != nil {
-		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse file offset")
-	}
-	blockNum, err := strconv.ParseUint(strings.TrimPrefix(fields[1], "blk"), 10, 32)
-	if err != nil {
-		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse block number")
-	}
-	off, err := strconv.ParseUint(fields[2], 10, 32)
-	if err != nil {
-		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse offset")
-	}
-	valLen, err := strconv.ParseUint(fields[3], 10, 32)
-	if err != nil {
-		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse value length")
-	}
-	attr, err := hex.DecodeString(strings.TrimPrefix(fields[4], "0x"))
-	if err != nil {
-		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse attribute")
-	}
-	return blob.InlineHandle{
-		InlineHandlePreface: blob.InlineHandlePreface{
-			ReferenceID: blob.ReferenceID(refIdx),
-			ValueLen:    uint32(valLen),
-		},
-		HandleSuffix: blob.HandleSuffix{
-			BlockNum:      uint32(blockNum),
-			OffsetInBlock: uint32(off),
-		},
-	}, base.ShortAttribute(attr[0]), nil
 }
 
 func runBuildCmd(

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -168,16 +168,6 @@ func runVirtualReaderTest(t *testing.T, path string, blockSize, indexBlockSize i
 					NewTestKeysBlockPropertyCollector,
 				},
 			}
-			if arg, ok := td.Arg("table-format"); ok {
-				// The datadriven cmd parser will parse the TableFormat string
-				// because its string representation looks like the datadriven
-				// format for multiple arguments (<arg1>,<arg2>).
-				name, v := arg.TwoVals(t)
-				writerOpts.TableFormat, err = ParseTableFormatString(fmt.Sprintf("(%s,%s)", name, v))
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
 			wMeta, r, err = runBuildCmd(td, writerOpts, nil /* cacheHandle */)
 			if err != nil {
 				return err.Error()

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -278,16 +278,3 @@ func BenchmarkRewriteSST(b *testing.B) {
 		})
 	}
 }
-
-var test4bSuffixComparer = func() *base.Comparer {
-	c := new(base.Comparer)
-	*c = *base.DefaultComparer
-	c.Split = func(key []byte) int {
-		if len(key) > 4 {
-			return len(key) - 4
-		}
-		return len(key)
-	}
-	c.Name = "comparer-split-4b-suffix"
-	return c
-}()

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -6,10 +6,19 @@ package sstable
 
 import (
 	"context"
+	"encoding/hex"
+	"fmt"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"unicode"
 
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
 )
 
@@ -79,4 +88,173 @@ func ReadAll(
 		}
 	}
 	return points, rangeDels, rangeKeys, nil
+}
+
+// ParsedKVOrSpan represents a KV or a key span produced by ParseTestKVsAndSpans.
+//
+// There are three possibilities:
+//   - key span: only the Span field is set.
+//   - KV without blob value: only the Key and Value fields are set (and
+//     optionally ForceObsolete).
+//   - KV with blob value: only the Key, BlobHandle, and Attr fields are set
+//     (and optionally ForceObsolete).
+type ParsedKVOrSpan struct {
+	// If Span is not nil, the rest of the fields are unset.
+	Span          *keyspan.Span
+	Key           base.InternalKey
+	ForceObsolete bool
+	// Either Value is set, or BlobHandle and Attr are set.
+	Value      []byte
+	BlobHandle blob.InlineHandle
+	Attr       base.ShortAttribute
+}
+
+func (kv ParsedKVOrSpan) IsKeySpan() bool {
+	return kv.Span != nil
+}
+
+func (kv ParsedKVOrSpan) HasBlobValue() bool {
+	return kv.Span == nil && kv.Value == nil
+}
+
+func (kv ParsedKVOrSpan) String() string {
+	if kv.IsKeySpan() {
+		return fmt.Sprintf("Span: %s", kv.Span)
+	}
+	prefix := crstrings.If(kv.ForceObsolete, "force-obsolete: ")
+	if !kv.HasBlobValue() {
+		return fmt.Sprintf("%s%s = %s", prefix, kv.Key, kv.Value)
+	}
+	return fmt.Sprintf("%s%s = blobInlineHandle(%d, blk%d, %d, %d, 0x%02x)", prefix, kv.Key,
+		kv.BlobHandle.ReferenceID, kv.BlobHandle.BlockNum, kv.BlobHandle.OffsetInBlock, kv.BlobHandle.ValueLen, kv.Attr,
+	)
+}
+
+// ParseTestKVsAndSpans parses a multi-line string that defines SSTable contents.
+// The lines can be either key-value pairs or key spans.
+// Sample input showing the format:
+//
+//	a#1,SET = a
+//	force-obsolete: d#2,SET = d
+//	f#3,SET = blobInlineHandle(0, blk1, 10, 100, 0x07)
+//	Span: d-e:{(#4,RANGEDEL)}
+//	Span: a-d:{(#11,RANGEKEYSET,@10,foo)}
+//	Span: g-l:{(#5,RANGEDEL)}
+//	Span: y-z:{(#12,RANGEKEYSET,@11,foo)}
+//
+// Note that the older KV format "<user-key>.<kind>.<seq-num> : <value>" is also supported
+// (for now).
+func ParseTestKVsAndSpans(input string) (_ []ParsedKVOrSpan, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Newf("%v\n%s", r, debug.Stack())
+		}
+	}()
+	var result []ParsedKVOrSpan
+	for _, line := range crstrings.Lines(input) {
+		if strings.HasPrefix(line, "Span:") {
+			span := keyspan.ParseSpan(strings.TrimPrefix(line, "Span:"))
+			result = append(result, ParsedKVOrSpan{Span: &span})
+			continue
+		}
+
+		var kv ParsedKVOrSpan
+		line, kv.ForceObsolete = strings.CutPrefix(line, "force-obsolete:")
+		// There should be exactly one "=" or ":" in the remaining line.
+		keyStr, valStr, ok := strings.Cut(line, "=")
+		if !ok {
+			keyStr, valStr, ok = strings.Cut(line, ":")
+		}
+		if !ok {
+			return nil, errors.Newf("KV format is [force-obsolete:] <key>=<value> (or <key>:<value>): %q", line)
+		}
+		kv.Key = base.ParseInternalKey(strings.TrimSpace(keyStr))
+		valStr = strings.TrimSpace(valStr)
+
+		if kv.ForceObsolete && kv.Key.Kind() == InternalKeyKindRangeDelete {
+			return nil, errors.Errorf("force-obsolete is not allowed for RANGEDEL")
+		}
+
+		if strings.HasPrefix(valStr, "blobInlineHandle(") {
+			handle, attr, err := decodeBlobInlineHandleAndAttribute(valStr)
+			if err != nil {
+				return nil, err
+			}
+			kv.BlobHandle = handle
+			kv.Attr = attr
+		} else {
+			kv.Value = []byte(valStr)
+		}
+		result = append(result, kv)
+	}
+	return result, nil
+}
+
+// ParseTestSST parses the KVs and spans in the input (see ParseTestKVAndSpans)
+// and writes them to an sstable.
+func ParseTestSST(w RawWriter, input string) error {
+	kvs, err := ParseTestKVsAndSpans(input)
+	if err != nil {
+		return err
+	}
+	for _, kv := range kvs {
+		var err error
+		switch {
+		case kv.IsKeySpan():
+			err = w.EncodeSpan(*kv.Span)
+		case kv.HasBlobValue():
+			err = w.AddWithBlobHandle(kv.Key, kv.BlobHandle, kv.Attr, kv.ForceObsolete)
+		default:
+			err = w.Add(kv.Key, kv.Value, kv.ForceObsolete)
+		}
+		if err != nil {
+			return errors.Wrapf(err, "failed to write %s", kv)
+		}
+	}
+	return nil
+}
+
+// decodeBlobInlineHandleAndAttribute decodes a blob handle (in its inline form)
+// and its short attribute from a debug string. It expects a value of the form:
+// blobInlineHandle(<refIndex>, blk<blocknum>, <offset>, <valLen>, <attr>). For example:
+//
+//	blobInlineHandle(24, blk255, 10, 9235, 0x07)
+func decodeBlobInlineHandleAndAttribute(
+	ref string,
+) (blob.InlineHandle, base.ShortAttribute, error) {
+	fields := strings.FieldsFunc(strings.TrimSuffix(strings.TrimPrefix(ref, "blobInlineHandle("), ")"),
+		func(r rune) bool { return r == ',' || unicode.IsSpace(r) })
+	if len(fields) != 5 {
+		return blob.InlineHandle{}, base.ShortAttribute(0), errors.New("expected 5 fields")
+	}
+	refIdx, err := strconv.ParseUint(fields[0], 10, 32)
+	if err != nil {
+		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse file offset")
+	}
+	blockNum, err := strconv.ParseUint(strings.TrimPrefix(fields[1], "blk"), 10, 32)
+	if err != nil {
+		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse block number")
+	}
+	off, err := strconv.ParseUint(fields[2], 10, 32)
+	if err != nil {
+		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse offset")
+	}
+	valLen, err := strconv.ParseUint(fields[3], 10, 32)
+	if err != nil {
+		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse value length")
+	}
+	attr, err := hex.DecodeString(strings.TrimPrefix(fields[4], "0x"))
+	if err != nil {
+		return blob.InlineHandle{}, base.ShortAttribute(0), errors.Wrap(err, "failed to parse attribute")
+	}
+	return blob.InlineHandle{
+		InlineHandlePreface: blob.InlineHandlePreface{
+			ReferenceID: blob.ReferenceID(refIdx),
+			ValueLen:    uint32(valLen),
+		},
+		HandleSuffix: blob.HandleSuffix{
+			BlockNum:      uint32(blockNum),
+			OffsetInBlock: uint32(off),
+		},
+	}, base.ShortAttribute(attr[0]), nil
 }

--- a/sstable/testdata/block_properties
+++ b/sstable/testdata/block_properties
@@ -108,9 +108,9 @@ build collectors=(suffix)
 a@5.SET.1:foo
 b@10.SET.2:bar
 c@15.SET.3:baz
-EncodeSpan: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
-EncodeSpan: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
-EncodeSpan: f@20-z@25:{(#6,RANGEKEYDEL)}
+Span: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
+Span: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
+Span: f@20-z@25:{(#6,RANGEKEYDEL)}
 ----
 point:    [a@5#1,SET-c@15#3,SET]
 rangekey: [d@10#4,RANGEKEYSET-z@25#inf,RANGEKEYDEL]
@@ -135,9 +135,9 @@ build collectors=(suffix-point-keys-only)
 a@5.SET.1:foo
 b@10.SET.2:bar
 c@15.SET.3:baz
-EncodeSpan: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
-EncodeSpan: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
-EncodeSpan: f@20-z@25:{(#6,RANGEKEYDEL)}
+Span: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
+Span: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
+Span: f@20-z@25:{(#6,RANGEKEYDEL)}
 ----
 point:    [a@5#1,SET-c@15#3,SET]
 rangekey: [d@10#4,RANGEKEYSET-z@25#inf,RANGEKEYDEL]
@@ -162,9 +162,9 @@ build collectors=(suffix-range-keys-only)
 a@5.SET.1:foo
 b@10.SET.2:bar
 c@15.SET.3:baz
-EncodeSpan: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
-EncodeSpan: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
-EncodeSpan: f@20-z@25:{(#6,RANGEKEYDEL)}
+Span: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
+Span: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
+Span: f@20-z@25:{(#6,RANGEKEYDEL)}
 ----
 point:    [a@5#1,SET-c@15#3,SET]
 rangekey: [d@10#4,RANGEKEYSET-z@25#inf,RANGEKEYDEL]
@@ -190,9 +190,9 @@ build block-size=1 collectors=(suffix-point-keys-only,suffix-range-keys-only)
 a@5.SET.1:foo
 b@10.SET.2:bar
 c@15.SET.3:baz
-EncodeSpan: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
-EncodeSpan: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
-EncodeSpan: f@20-z@25:{(#6,RANGEKEYDEL)}
+Span: d@10-e@15:{(#4,RANGEKEYSET,@20,foo)}
+Span: e@15-f@20:{(#5,RANGEKEYUNSET,@25)}
+Span: f@20-z@25:{(#6,RANGEKEYDEL)}
 ----
 point:    [a@5#1,SET-c@15#3,SET]
 rangekey: [d@10#4,RANGEKEYSET-z@25#inf,RANGEKEYDEL]

--- a/sstable/testdata/columnar_writer/simple_binary
+++ b/sstable/testdata/columnar_writer/simple_binary
@@ -1052,7 +1052,7 @@ sstable
 # Test a sstable containing only a range deletion.
 
 build
-EncodeSpan: a-b:{(#10,RANGEDEL)}
+Span: a-b:{(#10,RANGEDEL)}
 ----
 rangedel: [a#10,RANGEDEL-b#inf,RANGEDEL]
 seqnums:  [10-10]
@@ -1151,8 +1151,8 @@ sstable
 # Test a sstable containing only range keys.
 
 build
-EncodeSpan: a-b:{(#10,RANGEKEYSET,@5,foo)}
-EncodeSpan: b-c:{(#9,RANGEKEYDEL)}
+Span: a-b:{(#10,RANGEKEYSET,@5,foo)}
+Span: b-c:{(#9,RANGEKEYDEL)}
 ----
 rangekey: [a#10,RANGEKEYSET-c#inf,RANGEKEYDEL]
 seqnums:  [9-10]

--- a/sstable/testdata/copy_span
+++ b/sstable/testdata/copy_span
@@ -1,7 +1,7 @@
 
 # Simple test case with row blocks.
 
-build test1 format=pebblev4
+build test1 table-format=Pebble,v4
 a.SET.5:foo
 b.SET.3:bar
 c.SET.4:baz
@@ -37,7 +37,7 @@ c#0,SET: baz
 
 
 # Try the above with small blocks.
-build test22 format=pebblev4 block_size=1 index_block_size=1
+build test22 table-format=Pebble,v4 block_size=1 index_block_size=1
 a.SET.5:foo
 b.SET.3:bar
 c.SET.4:baz
@@ -85,7 +85,7 @@ c#0,SET: baz
 
 # Try the above with columnar blocks.
 
-build test3 format=pebblev5
+build test3 table-format=Pebble,v5
 a.SET.5:foo
 b.SET.3:bar
 c.SET.4:baz
@@ -119,7 +119,7 @@ c#0,SET: baz
 
 
 # Try the above with small blocks.
-build test32 format=pebblev5 block_size=1 index_block_size=1
+build test32 table-format=Pebble,v5 block_size=1 index_block_size=1
 a.SET.5:foo
 b.SET.3:bar
 c.SET.4:baz
@@ -159,7 +159,7 @@ c#0,SET: baz
 
 # Try the above with checksummed columnar blocks.
 
-build test3 format=pebblev6
+build test3 table-format=Pebble,v6
 a.SET.5:foo
 b.SET.3:bar
 c.SET.4:baz
@@ -193,7 +193,7 @@ c#0,SET: baz
 
 
 # Try the above with small blocks.
-build test32 format=pebblev6 block_size=1 index_block_size=1
+build test32 table-format=Pebble,v6 block_size=1 index_block_size=1
 a.SET.5:foo
 b.SET.3:bar
 c.SET.4:baz

--- a/sstable/testdata/reader/iter
+++ b/sstable/testdata/reader/iter
@@ -360,7 +360,7 @@ bbx.SET.2:X
 bby.SET.2:Y
 bbz.SET.2:Z
 c.SET.3:C
-EncodeSpan: cc-ccc:{(#3,RANGEDEL)}
+Span: cc-ccc:{(#3,RANGEDEL)}
 cce.SET.3:E
 ccf.SET.3:F
 ccg.SET.3:G
@@ -384,7 +384,7 @@ ccx.SET.3:X
 ccy.SET.3:Y
 ccz.SET.3:Z
 d.SET.4:D
-EncodeSpan: dd-ddd:{(#4,RANGEDEL)}
+Span: dd-ddd:{(#4,RANGEDEL)}
 dde.SET.4:E
 ddf.SET.4:F
 ddg.SET.4:G

--- a/sstable/testdata/reader_hide_obsolete/iter
+++ b/sstable/testdata/reader_hide_obsolete/iter
@@ -315,7 +315,7 @@ build is-strict-obsolete
 d.SINGLEDEL.40:
 d.MERGE.30:D30
 ----
-MERGE not supported in a strict-obsolete sstable
+failed to write d#30,MERGE = D30: MERGE not supported in a strict-obsolete sstable
 
 # Regression test for #3761. If an entire block contains obsolete points,
 # skipBackward should still skip to blocks earlier in the sstable.

--- a/sstable/testdata/rewriter
+++ b/sstable/testdata/rewriter
@@ -208,9 +208,9 @@ c
 # Rewrite a table that contain only range keys.
 
 build block-size=1 index-block-size=1 filter comparer=split-4b-suffix
-EncodeSpan: a-b:{(#1,RANGEKEYSET,_xyz)}
-EncodeSpan: b-c:{(#1,RANGEKEYSET,_xyz)}
-EncodeSpan: c-d:{(#1,RANGEKEYSET,_xyz)}
+Span: a-b:{(#1,RANGEKEYSET,_xyz)}
+Span: b-c:{(#1,RANGEKEYSET,_xyz)}
+Span: c-d:{(#1,RANGEKEYSET,_xyz)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-1]

--- a/sstable/testdata/rewriter_v3
+++ b/sstable/testdata/rewriter_v3
@@ -208,9 +208,9 @@ c
 # Rewrite a table that contain only range keys.
 
 build block-size=1 index-block-size=1 filter comparer=split-4b-suffix
-EncodeSpan: a-b:{(#1,RANGEKEYSET,_xyz)}
-EncodeSpan: b-c:{(#1,RANGEKEYSET,_xyz)}
-EncodeSpan: c-d:{(#1,RANGEKEYSET,_xyz)}
+Span: a-b:{(#1,RANGEKEYSET,_xyz)}
+Span: b-c:{(#1,RANGEKEYSET,_xyz)}
+Span: c-d:{(#1,RANGEKEYSET,_xyz)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-1]

--- a/sstable/testdata/rewriter_v5
+++ b/sstable/testdata/rewriter_v5
@@ -208,9 +208,9 @@ c
 # Rewrite a table that contain only range keys.
 
 build block-size=1 index-block-size=1 filter
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@0)}
-EncodeSpan: b-c:{(#1,RANGEKEYSET,@0)}
-EncodeSpan: c-d:{(#1,RANGEKEYSET,@0)}
+Span: a-b:{(#1,RANGEKEYSET,@0)}
+Span: b-c:{(#1,RANGEKEYSET,@0)}
+Span: c-d:{(#1,RANGEKEYSET,@0)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-1]

--- a/sstable/testdata/rewriter_v6
+++ b/sstable/testdata/rewriter_v6
@@ -208,9 +208,9 @@ c
 # Rewrite a table that contain only range keys.
 
 build block-size=1 index-block-size=1 filter
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@0)}
-EncodeSpan: b-c:{(#1,RANGEKEYSET,@0)}
-EncodeSpan: c-d:{(#1,RANGEKEYSET,@0)}
+Span: a-b:{(#1,RANGEKEYSET,@0)}
+Span: b-c:{(#1,RANGEKEYSET,@0)}
+Span: c-d:{(#1,RANGEKEYSET,@0)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-1]

--- a/sstable/testdata/virtual_reader_iter
+++ b/sstable/testdata/virtual_reader_iter
@@ -31,10 +31,10 @@ build block-size=1 index-block-size=1
 a.SET.1:a
 d.SET.2:d
 f.SET.3:f
-EncodeSpan: d-e:{(#4,RANGEDEL)}
-EncodeSpan: a-d:{(#11,RANGEKEYSET,@10,foo)}
-EncodeSpan: g-l:{(#5,RANGEDEL)}
-EncodeSpan: y-z:{(#12,RANGEKEYSET,@11,foo)}
+Span: d-e:{(#4,RANGEDEL)}
+Span: a-d:{(#11,RANGEKEYSET,@10,foo)}
+Span: g-l:{(#5,RANGEDEL)}
+Span: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]
@@ -493,7 +493,7 @@ build
 a.SET.1:a
 d.SET.2:d
 e.SET.3:e
-EncodeSpan: d-e:{(#4,RANGEDEL)}
+Span: d-e:{(#4,RANGEDEL)}
 f.SET.5:f
 ----
 point:    [a#1,SET-f#5,SET]
@@ -530,7 +530,7 @@ build block-size=1 index-block-size=1
 a.SET.1:a
 d.SET.2:d
 e.SET.3:e
-EncodeSpan: d-e:{(#4,RANGEDEL)}
+Span: d-e:{(#4,RANGEDEL)}
 f.SET.5:f
 ----
 point:    [a#1,SET-f#5,SET]
@@ -568,10 +568,10 @@ a.SET.1:a
 b.SET.5:b
 d.SET.2:d
 f.SET.3:f
-EncodeSpan: d-e:{(#4,RANGEDEL)}
-EncodeSpan: a-d:{(#11,RANGEKEYSET,@10,foo)}
-EncodeSpan: g-l:{(#5,RANGEDEL)}
-EncodeSpan: y-z:{(#12,RANGEKEYSET,@11,foo)}
+Span: d-e:{(#4,RANGEDEL)}
+Span: a-d:{(#11,RANGEKEYSET,@10,foo)}
+Span: g-l:{(#5,RANGEDEL)}
+Span: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -1,5 +1,5 @@
 # Simple sanity test with single level index.
-build table-format=(Pebble,v4)
+build table-format=Pebble,v4
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c
@@ -26,7 +26,7 @@ props:
 
 # Repeat the above with (Pebble,v5).
 
-build table-format=(Pebble,v5)
+build table-format=Pebble,v5
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c
@@ -52,7 +52,7 @@ props:
 
 
 # Test 2: Similar to test 1 but force two level iterators.
-build block-size=1 index-block-size=1 table-format=(Pebble,v4)
+build block-size=1 index-block-size=1 table-format=Pebble,v4
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c
@@ -127,7 +127,7 @@ b,aa,false
 
 # Repeat the above with (Pebble,v5).
 
-build block-size=1 index-block-size=1 table-format=(Pebble,v5)
+build block-size=1 index-block-size=1 table-format=Pebble,v5
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c
@@ -200,7 +200,7 @@ constrain a,aa,false
 ----
 b,aa,false
 
-build block-size=1 index-block-size=1 table-format=(Pebble,v4)
+build block-size=1 index-block-size=1 table-format=Pebble,v4
 a.SET.1:a
 d.SET.2:d
 f.SET.3:f
@@ -232,7 +232,7 @@ props:
 
 # Repeat the above with (Pebble,v5).
 
-build block-size=1 index-block-size=1 table-format=(Pebble,v5)
+build block-size=1 index-block-size=1 table-format=Pebble,v5
 a.SET.1:a
 d.SET.2:d
 f.SET.3:f
@@ -262,7 +262,7 @@ props:
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
 
-build table-format=(Pebble,v4)
+build table-format=Pebble,v4
 a.SET.1:a
 b.SET.2:b
 c.SET.3:c
@@ -288,7 +288,7 @@ props:
 
 # Repeat the above with (Pebble,v5).
 
-build table-format=(Pebble,v5)
+build table-format=Pebble,v5
 a.SET.1:a
 b.SET.2:b
 c.SET.3:c

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -204,10 +204,10 @@ build block-size=1 index-block-size=1 table-format=(Pebble,v4)
 a.SET.1:a
 d.SET.2:d
 f.SET.3:f
-EncodeSpan: d-e:{(#4,RANGEDEL)}
-EncodeSpan: a-d:{(#11,RANGEKEYSET,@10,foo)}
-EncodeSpan: g-l:{(#5,RANGEDEL)}
-EncodeSpan: y-z:{(#12,RANGEKEYSET,@11,foo)}
+Span: d-e:{(#4,RANGEDEL)}
+Span: a-d:{(#11,RANGEKEYSET,@10,foo)}
+Span: g-l:{(#5,RANGEDEL)}
+Span: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]
@@ -236,10 +236,10 @@ build block-size=1 index-block-size=1 table-format=(Pebble,v5)
 a.SET.1:a
 d.SET.2:d
 f.SET.3:f
-EncodeSpan: d-e:{(#4,RANGEDEL)}
-EncodeSpan: a-d:{(#11,RANGEKEYSET,@10,foo)}
-EncodeSpan: g-l:{(#5,RANGEDEL)}
-EncodeSpan: y-z:{(#12,RANGEKEYSET,@11,foo)}
+Span: d-e:{(#4,RANGEDEL)}
+Span: a-d:{(#11,RANGEKEYSET,@10,foo)}
+Span: g-l:{(#5,RANGEDEL)}
+Span: y-z:{(#12,RANGEKEYSET,@11,foo)}
 ----
 point:    [a#1,SET-f#3,SET]
 rangedel: [d#4,RANGEDEL-l#inf,RANGEDEL]

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -253,7 +253,7 @@ c#1,SET:c
 # Enabling leveldb format disables the creation of a two-level index
 # (the input data here mirrors the test case above).
 
-build leveldb block-size=1 index-block-size=1
+build table-format=LevelDB block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -147,19 +147,19 @@ build
 a.SET.1:b
 a.SET.2:c
 ----
-pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
+failed to write a#2,SET = c: pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
 
 build
 b.SET.1:a
 a.SET.2:b
 ----
-pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
+failed to write a#2,SET = b: pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
 
 build
 b.RANGEDEL.1:c
 a.RANGEDEL.2:b
 ----
-pebble: keys must be added in order: b#1,RANGEDEL, a#2,RANGEDEL
+failed to write a#2,RANGEDEL = b: pebble: keys must be added in order: b#1,RANGEDEL, a#2,RANGEDEL
 
 build-raw
 .RANGEDEL.1:b

--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -23,9 +23,9 @@ f.SET.5:f
 g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
-EncodeSpan: j-k:{(#9,RANGEKEYDEL)}
-EncodeSpan: k-l:{(#10,RANGEKEYUNSET,@5)}
-EncodeSpan: l-m:{(#11,RANGEKEYSET,@10,foo)}
+Span: j-k:{(#9,RANGEKEYDEL)}
+Span: k-l:{(#10,RANGEKEYUNSET,@5)}
+Span: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -46,9 +46,9 @@ e.SINGLEDEL.5:
 f.SET.6:f
 g.DEL.7:
 h.SINGLEDEL.8:
-EncodeSpan: j-k:{(#9,RANGEKEYDEL)}
-EncodeSpan: k-l:{(#10,RANGEKEYUNSET,@5)}
-EncodeSpan: l-m:{(#11,RANGEKEYSET,@10,foo)}
+Span: j-k:{(#9,RANGEKEYDEL)}
+Span: k-l:{(#10,RANGEKEYUNSET,@5)}
+Span: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#8,SINGLEDEL]
 rangekey: [j#9,RANGEKEYDEL-m#inf,RANGEKEYSET]
@@ -91,11 +91,11 @@ i-j:{(#8,RANGEDEL)}
 # 1:          j---------------z
 
 build
-EncodeSpan: a-f:{(#3,RANGEDEL)}
-EncodeSpan: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
-EncodeSpan: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
-EncodeSpan: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
-EncodeSpan: s-z:{(#1,RANGEDEL)}
+Span: a-f:{(#3,RANGEDEL)}
+Span: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
+Span: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+Span: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
+Span: s-z:{(#1,RANGEDEL)}
 ----
 rangedel: [a#3,RANGEDEL-z#inf,RANGEDEL]
 seqnums:  [1-3]
@@ -193,20 +193,20 @@ rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
 seqnums:  [1-2]
 
 build
-EncodeSpan: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
 seqnums:  [1-2]
 
 build-raw
-EncodeSpan: b-c:{(#2,RANGEKEYSET,@10,foo)}
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo)}
 ----
 pebble: range keys starts must be added in increasing order: b#2,RANGEKEYSET, a#1,RANGEKEYSET
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEKEYSET,@10,foo)}
-EncodeSpan: c-d:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-c:{(#1,RANGEKEYSET,@10,foo)}
+Span: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-2]
@@ -215,7 +215,7 @@ seqnums:  [1-2]
 # though the key kinds must be ordered (descending).
 
 build-raw
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@t10) (#1,RANGEKEYDEL)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@t10) (#1,RANGEKEYDEL)}
 ----
 rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
 seqnums:  [1-1]
@@ -275,9 +275,9 @@ sstable
 # Range keys, if present, are shown in the layout.
 
 build
-EncodeSpan: a-b:{(#3,RANGEKEYSET,@3,foo)}
-EncodeSpan: b-c:{(#2,RANGEKEYSET,@2,bar)}
-EncodeSpan: c-d:{(#1,RANGEKEYSET,@1,baz)}
+Span: a-b:{(#3,RANGEKEYSET,@3,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@2,bar)}
+Span: c-d:{(#1,RANGEKEYSET,@1,baz)}
 ----
 rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-3]

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -1,4 +1,4 @@
-build table-format=(Pebble,v6)
+build table-format=Pebble,v6
 a@2.SET.1:blobInlineHandle(0, blk1, 10, 100, 0x07)
 b@5.SET.7:blobInlineHandle(0, blk2, 110, 200, 0x07)
 b@4.DEL.3:

--- a/sstable/testdata/writer_v3
+++ b/sstable/testdata/writer_v3
@@ -23,9 +23,9 @@ f.SET.5:f
 g.DEL.6:
 h.MERGE.7:h
 i.RANGEDEL.8:j
-EncodeSpan: j-k:{(#9,RANGEKEYDEL)}
-EncodeSpan: k-l:{(#10,RANGEKEYUNSET,@5)}
-EncodeSpan: l-m:{(#11,RANGEKEYSET,@10,foo)}
+Span: j-k:{(#9,RANGEKEYDEL)}
+Span: k-l:{(#10,RANGEKEYUNSET,@5)}
+Span: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -65,11 +65,11 @@ i-j:{(#8,RANGEDEL)}
 # 1:          j---------------z
 
 build
-EncodeSpan: a-f:{(#3,RANGEDEL)}
-EncodeSpan: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
-EncodeSpan: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
-EncodeSpan: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
-EncodeSpan: s-z:{(#1,RANGEDEL)}
+Span: a-f:{(#3,RANGEDEL)}
+Span: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
+Span: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+Span: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
+Span: s-z:{(#1,RANGEDEL)}
 ----
 rangedel: [a#3,RANGEDEL-z#inf,RANGEDEL]
 seqnums:  [1-3]
@@ -167,20 +167,20 @@ rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
 seqnums:  [1-2]
 
 build-raw
-EncodeSpan: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
 seqnums:  [1-2]
 
 build-raw
-EncodeSpan: b-c:{(#2,RANGEKEYSET,@10,foo)}
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo)}
 ----
 pebble: range keys starts must be added in increasing order: b#2,RANGEKEYSET, a#1,RANGEKEYSET
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEKEYSET,@10,foo)}
-EncodeSpan: c-d:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-c:{(#1,RANGEKEYSET,@10,foo)}
+Span: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-2]
@@ -189,7 +189,7 @@ seqnums:  [1-2]
 # though the key kinds must be ordered (descending).
 
 build-raw
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
 ----
 rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
 seqnums:  [1-1]
@@ -265,9 +265,9 @@ sstable
 # Range keys, if present, are shown in the layout.
 
 build
-EncodeSpan: a-b:{(#3,RANGEKEYSET,@3,foo)}
-EncodeSpan: b-c:{(#2,RANGEKEYSET,@2,bar)}
-EncodeSpan: c-d:{(#1,RANGEKEYSET,@1,baz)}
+Span: a-b:{(#3,RANGEKEYSET,@3,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@2,bar)}
+Span: c-d:{(#1,RANGEKEYSET,@1,baz)}
 ----
 rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-3]

--- a/sstable/testdata/writer_v3
+++ b/sstable/testdata/writer_v3
@@ -121,19 +121,19 @@ build
 a.SET.1:b
 a.SET.2:c
 ----
-pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
+failed to write a#2,SET = c: pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
 
 build
 b.SET.1:a
 a.SET.2:b
 ----
-pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
+failed to write a#2,SET = b: pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
 
 build
 b.RANGEDEL.1:c
 a.RANGEDEL.2:b
 ----
-pebble: keys must be added in order: b#1,RANGEDEL, a#2,RANGEDEL
+failed to write a#2,RANGEDEL = b: pebble: keys must be added in order: b#1,RANGEDEL, a#2,RANGEDEL
 
 build-raw
 .RANGEDEL.1:b

--- a/sstable/testdata/writer_v3
+++ b/sstable/testdata/writer_v3
@@ -243,7 +243,7 @@ c#1,SET:c
 # Enabling leveldb format disables the creation of a two-level index
 # (the input data here mirrors the test case above).
 
-build leveldb block-size=1 index-block-size=1
+build table-format=LevelDB block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -142,25 +142,25 @@ build
 a.SET.1:b
 a.SET.2:c
 ----
-pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
+failed to write a#2,SET = c: pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
 
 build
 b.SET.1:a
 a.SET.2:b
 ----
-pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
+failed to write a#2,SET = b: pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
 
 build
 b.RANGEDEL.1:c
 a.RANGEDEL.2:b
 ----
-RANGEDEL must be added through EncodeSpan
+failed to write b#1,RANGEDEL = c: RANGEDEL must be added through EncodeSpan
 
 build
 Span: b-c:{(#1,RANGEDEL)}
 Span: a-b:{(#2,RANGEDEL)}
 ----
-pebble: keys must be added in order: b-c:{(#1,RANGEDEL)}, a-b:{(#2,RANGEDEL)}
+failed to write Span: a-b:{(#2,RANGEDEL)}: pebble: keys must be added in order: b-c:{(#1,RANGEDEL)}, a-b:{(#2,RANGEDEL)}
 
 build-raw
 Span: a-c:{(#1,RANGEDEL)}

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -264,7 +264,7 @@ c#1,SET:c
 # Enabling leveldb format disables the creation of a two-level index
 # (the input data here mirrors the test case above).
 
-build leveldb block-size=1 index-block-size=1
+build table-format=LevelDB block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -18,14 +18,14 @@ build
 a.SET.1:a
 b.DEL.2:
 c.MERGE.3:c
-EncodeSpan: d-e:{(#4,RANGEDEL)}
+Span: d-e:{(#4,RANGEDEL)}
 f.SET.5:f
 g.DEL.6:
 h.MERGE.7:h
-EncodeSpan: i-j:{(#8,RANGEDEL)}
-EncodeSpan: j-k:{(#9,RANGEKEYDEL)}
-EncodeSpan: k-l:{(#10,RANGEKEYUNSET,@5)}
-EncodeSpan: l-m:{(#11,RANGEKEYSET,@10,foo)}
+Span: i-j:{(#8,RANGEDEL)}
+Span: j-k:{(#9,RANGEKEYDEL)}
+Span: k-l:{(#10,RANGEKEYUNSET,@5)}
+Span: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -36,11 +36,11 @@ build
 a.SET.1:a
 b.DEL.2:
 c.MERGE.3:c
-EncodeSpan: d-e:{(#4,RANGEDEL)}
+Span: d-e:{(#4,RANGEDEL)}
 f.SET.5:f
 g.DEL.6:
 h.MERGE.7:h
-EncodeSpan: i-j:{(#8,RANGEDEL)}
+Span: i-j:{(#8,RANGEDEL)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -65,11 +65,11 @@ i-j:{(#8,RANGEDEL)}
 # 1:          j---------------z
 
 build
-EncodeSpan: a-f:{(#3,RANGEDEL)}
-EncodeSpan: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
-EncodeSpan: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
-EncodeSpan: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
-EncodeSpan: s-z:{(#1,RANGEDEL)}
+Span: a-f:{(#3,RANGEDEL)}
+Span: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
+Span: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+Span: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
+Span: s-z:{(#1,RANGEDEL)}
 ----
 rangedel: [a#3,RANGEDEL-z#inf,RANGEDEL]
 seqnums:  [1-3]
@@ -113,7 +113,7 @@ obsolete-key: hex:0074
 # on that same key will be the actual boundary.
 
 build
-EncodeSpan: a-b:{(#3,RANGEDEL)}
+Span: a-b:{(#3,RANGEDEL)}
 b.SET.4:c
 ----
 point:    [b#4,SET-b#4,SET]
@@ -121,7 +121,7 @@ rangedel: [a#3,RANGEDEL-b#inf,RANGEDEL]
 seqnums:  [3-4]
 
 build
-EncodeSpan: a-b:{(#3,RANGEDEL)}
+Span: a-b:{(#3,RANGEDEL)}
 b.SET.2:c
 ----
 point:    [b#2,SET-b#2,SET]
@@ -129,7 +129,7 @@ rangedel: [a#3,RANGEDEL-b#inf,RANGEDEL]
 seqnums:  [2-3]
 
 build
-EncodeSpan: a-c:{(#3,RANGEDEL)}
+Span: a-c:{(#3,RANGEDEL)}
 b.SET.2:c
 ----
 point:    [b#2,SET-b#2,SET]
@@ -157,51 +157,51 @@ a.RANGEDEL.2:b
 RANGEDEL must be added through EncodeSpan
 
 build
-EncodeSpan: b-c:{(#1,RANGEDEL)}
-EncodeSpan: a-b:{(#2,RANGEDEL)}
+Span: b-c:{(#1,RANGEDEL)}
+Span: a-b:{(#2,RANGEDEL)}
 ----
 pebble: keys must be added in order: b-c:{(#1,RANGEDEL)}, a-b:{(#2,RANGEDEL)}
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEDEL)}
-EncodeSpan: a-c:{(#2,RANGEDEL)}
+Span: a-c:{(#1,RANGEDEL)}
+Span: a-c:{(#2,RANGEDEL)}
 ----
 pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEDEL)}
-EncodeSpan: b-d:{(#2,RANGEDEL)}
+Span: a-c:{(#1,RANGEDEL)}
+Span: b-d:{(#2,RANGEDEL)}
 ----
 pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, b-d:{(#2,RANGEDEL)}
 
 build-raw
-EncodeSpan: a-c:{(#2,RANGEDEL)}
-EncodeSpan: a-d:{(#1,RANGEDEL)}
+Span: a-c:{(#2,RANGEDEL)}
+Span: a-d:{(#1,RANGEDEL)}
 ----
 pebble: keys must be added in order: a-c:{(#2,RANGEDEL)}, a-d:{(#1,RANGEDEL)}
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEDEL)}
-EncodeSpan: c-d:{(#2,RANGEDEL)}
+Span: a-c:{(#1,RANGEDEL)}
+Span: c-d:{(#2,RANGEDEL)}
 ----
 rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
 seqnums:  [1-2]
 
 build-raw
-EncodeSpan: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
 seqnums:  [1-2]
 
 build-raw
-EncodeSpan: b-c:{(#2,RANGEKEYSET,@10,foo)}
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo)}
 ----
 pebble: keys must be added in order: b-c:{(#2,RANGEKEYSET)}, a-b:{(#1,RANGEKEYSET,@10,foo)}
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEKEYSET,@10,foo)}
-EncodeSpan: c-d:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-c:{(#1,RANGEKEYSET,@10,foo)}
+Span: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-2]
@@ -210,7 +210,7 @@ seqnums:  [1-2]
 # though the key kinds must be ordered (descending).
 
 build-raw
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
 ----
 rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
 seqnums:  [1-1]
@@ -286,9 +286,9 @@ sstable
 # Range keys, if present, are shown in the layout.
 
 build
-EncodeSpan: a-b:{(#3,RANGEKEYSET,@3,foo)}
-EncodeSpan: b-c:{(#2,RANGEKEYSET,@2,bar)}
-EncodeSpan: c-d:{(#1,RANGEKEYSET,@1,baz)}
+Span: a-b:{(#3,RANGEKEYSET,@3,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@2,bar)}
+Span: c-d:{(#1,RANGEKEYSET,@1,baz)}
 ----
 rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-3]

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -142,25 +142,25 @@ build
 a.SET.1:b
 a.SET.2:c
 ----
-pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
+failed to write a#2,SET = c: pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
 
 build
 b.SET.1:a
 a.SET.2:b
 ----
-pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
+failed to write a#2,SET = b: pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
 
 build
 b.RANGEDEL.1:c
 a.RANGEDEL.2:b
 ----
-RANGEDEL must be added through EncodeSpan
+failed to write b#1,RANGEDEL = c: RANGEDEL must be added through EncodeSpan
 
 build
 Span: b-c:{(#1,RANGEDEL)}
 Span: a-b:{(#2,RANGEDEL)}
 ----
-pebble: keys must be added in order: b-c:{(#1,RANGEDEL)}, a-b:{(#2,RANGEDEL)}
+failed to write Span: a-b:{(#2,RANGEDEL)}: pebble: keys must be added in order: b-c:{(#1,RANGEDEL)}, a-b:{(#2,RANGEDEL)}
 
 build-raw
 Span: a-c:{(#1,RANGEDEL)}

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -264,7 +264,7 @@ c#1,SET:c
 # Enabling leveldb format disables the creation of a two-level index
 # (the input data here mirrors the test case above).
 
-build leveldb block-size=1 index-block-size=1
+build table-format=LevelDB block-size=1 index-block-size=1
 a.SET.1:a
 b.SET.1:b
 c.SET.1:c

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -18,14 +18,14 @@ build
 a.SET.1:a
 b.DEL.2:
 c.MERGE.3:c
-EncodeSpan: d-e:{(#4,RANGEDEL)}
+Span: d-e:{(#4,RANGEDEL)}
 f.SET.5:f
 g.DEL.6:
 h.MERGE.7:h
-EncodeSpan: i-j:{(#8,RANGEDEL)}
-EncodeSpan: j-k:{(#9,RANGEKEYDEL)}
-EncodeSpan: k-l:{(#10,RANGEKEYUNSET,@5)}
-EncodeSpan: l-m:{(#11,RANGEKEYSET,@10,foo)}
+Span: i-j:{(#8,RANGEDEL)}
+Span: j-k:{(#9,RANGEKEYDEL)}
+Span: k-l:{(#10,RANGEKEYUNSET,@5)}
+Span: l-m:{(#11,RANGEKEYSET,@10,foo)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -36,11 +36,11 @@ build
 a.SET.1:a
 b.DEL.2:
 c.MERGE.3:c
-EncodeSpan: d-e:{(#4,RANGEDEL)}
+Span: d-e:{(#4,RANGEDEL)}
 f.SET.5:f
 g.DEL.6:
 h.MERGE.7:h
-EncodeSpan: i-j:{(#8,RANGEDEL)}
+Span: i-j:{(#8,RANGEDEL)}
 ----
 point:    [a#1,SET-h#7,MERGE]
 rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
@@ -65,11 +65,11 @@ i-j:{(#8,RANGEDEL)}
 # 1:          j---------------z
 
 build
-EncodeSpan: a-f:{(#3,RANGEDEL)}
-EncodeSpan: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
-EncodeSpan: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
-EncodeSpan: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
-EncodeSpan: s-z:{(#1,RANGEDEL)}
+Span: a-f:{(#3,RANGEDEL)}
+Span: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
+Span: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+Span: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
+Span: s-z:{(#1,RANGEDEL)}
 ----
 rangedel: [a#3,RANGEDEL-z#inf,RANGEDEL]
 seqnums:  [1-3]
@@ -113,7 +113,7 @@ obsolete-key: hex:0074
 # on that same key will be the actual boundary.
 
 build
-EncodeSpan: a-b:{(#3,RANGEDEL)}
+Span: a-b:{(#3,RANGEDEL)}
 b.SET.4:c
 ----
 point:    [b#4,SET-b#4,SET]
@@ -121,7 +121,7 @@ rangedel: [a#3,RANGEDEL-b#inf,RANGEDEL]
 seqnums:  [3-4]
 
 build
-EncodeSpan: a-b:{(#3,RANGEDEL)}
+Span: a-b:{(#3,RANGEDEL)}
 b.SET.2:c
 ----
 point:    [b#2,SET-b#2,SET]
@@ -129,7 +129,7 @@ rangedel: [a#3,RANGEDEL-b#inf,RANGEDEL]
 seqnums:  [2-3]
 
 build
-EncodeSpan: a-c:{(#3,RANGEDEL)}
+Span: a-c:{(#3,RANGEDEL)}
 b.SET.2:c
 ----
 point:    [b#2,SET-b#2,SET]
@@ -157,51 +157,51 @@ a.RANGEDEL.2:b
 RANGEDEL must be added through EncodeSpan
 
 build
-EncodeSpan: b-c:{(#1,RANGEDEL)}
-EncodeSpan: a-b:{(#2,RANGEDEL)}
+Span: b-c:{(#1,RANGEDEL)}
+Span: a-b:{(#2,RANGEDEL)}
 ----
 pebble: keys must be added in order: b-c:{(#1,RANGEDEL)}, a-b:{(#2,RANGEDEL)}
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEDEL)}
-EncodeSpan: a-c:{(#2,RANGEDEL)}
+Span: a-c:{(#1,RANGEDEL)}
+Span: a-c:{(#2,RANGEDEL)}
 ----
 pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEDEL)}
-EncodeSpan: b-d:{(#2,RANGEDEL)}
+Span: a-c:{(#1,RANGEDEL)}
+Span: b-d:{(#2,RANGEDEL)}
 ----
 pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, b-d:{(#2,RANGEDEL)}
 
 build-raw
-EncodeSpan: a-c:{(#2,RANGEDEL)}
-EncodeSpan: a-d:{(#1,RANGEDEL)}
+Span: a-c:{(#2,RANGEDEL)}
+Span: a-d:{(#1,RANGEDEL)}
 ----
 pebble: keys must be added in order: a-c:{(#2,RANGEDEL)}, a-d:{(#1,RANGEDEL)}
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEDEL)}
-EncodeSpan: c-d:{(#2,RANGEDEL)}
+Span: a-c:{(#1,RANGEDEL)}
+Span: c-d:{(#2,RANGEDEL)}
 ----
 rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
 seqnums:  [1-2]
 
 build-raw
-EncodeSpan: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
 seqnums:  [1-2]
 
 build-raw
-EncodeSpan: b-c:{(#2,RANGEKEYSET,@10,foo)}
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo)}
 ----
 pebble: keys must be added in order: b-c:{(#2,RANGEKEYSET)}, a-b:{(#1,RANGEKEYSET,@10,foo)}
 
 build-raw
-EncodeSpan: a-c:{(#1,RANGEKEYSET,@10,foo)}
-EncodeSpan: c-d:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-c:{(#1,RANGEKEYSET,@10,foo)}
+Span: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-2]
@@ -210,7 +210,7 @@ seqnums:  [1-2]
 # though the key kinds must be ordered (descending).
 
 build-raw
-EncodeSpan: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
 ----
 rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
 seqnums:  [1-1]
@@ -286,9 +286,9 @@ sstable
 # Range keys, if present, are shown in the layout.
 
 build
-EncodeSpan: a-b:{(#3,RANGEKEYSET,@3,foo)}
-EncodeSpan: b-c:{(#2,RANGEKEYSET,@2,bar)}
-EncodeSpan: c-d:{(#1,RANGEKEYSET,@1,baz)}
+Span: a-b:{(#3,RANGEKEYSET,@3,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@2,bar)}
+Span: c-d:{(#1,RANGEKEYSET,@1,baz)}
 ----
 rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-3]

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -1,7 +1,7 @@
 # Size of value index is 3 bytes plus 5 + 5 = 10 bytes of trailer of the value
 # block and value index block. So size 18 - 13 = 5 size of the value in the
 # value block.
-build table-format=(Pebble,v4)
+build table-format=Pebble,v4
 a@2.SET.1:a2
 b@5.SET.7:b5
 b@4.DEL.3:
@@ -36,7 +36,7 @@ scan-cloned-lazy-values
 
 # Repeat the above test with (Pebble,v5) [columnar blocks].
 
-build table-format=(Pebble,v5)
+build table-format=Pebble,v5
 a@2.SET.1:a2
 b@5.SET.7:b5
 b@4.DEL.3:
@@ -62,7 +62,7 @@ scan-cloned-lazy-values
 4(lazy: len 5, attr: 5): vbat2
 
 # Same data as previous, with disable-value-blocks set to true
-build disable-value-blocks=true table-format=(Pebble,v4)
+build disable-value-blocks=true table-format=Pebble,v4
 a@2.SET.1:a2
 b@5.SET.7:b5
 b@4.DEL.3:
@@ -89,7 +89,7 @@ b@2#1,SET:vbat2
 
 # Same as above but with (Pebble,v5) [columnar blocks].
 
-build disable-value-blocks=true table-format=(Pebble,v5)
+build disable-value-blocks=true table-format=Pebble,v5
 a@2.SET.1:a2
 b@5.SET.7:b5
 b@4.DEL.3:
@@ -109,7 +109,7 @@ b@2#1,SET:vbat2
 # Size of value index is 3 bytes plus 5 + 5 = 10 bytes of trailer of the value
 # block and value index block. So size 33 - 13 = 20 is the total size of the
 # values in the value block.
-build table-format=(Pebble,v4)
+build table-format=Pebble,v4
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 blue@8.SET.16:blue8s
@@ -156,7 +156,7 @@ scan-cloned-lazy-values
 
 # Same as above but with (Pebble,v5) [columnar blocks].
 
-build table-format=(Pebble,v5)
+build table-format=Pebble,v5
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 blue@8.SET.16:blue8s
@@ -195,7 +195,7 @@ scan-cloned-lazy-values
 # block has to encode two tuples, each of 4 bytes (blockNumByteLength=1,
 # blockOffsetByteLength=2, blockLengthByteLength=1), so 2*4=8. The total is
 # 15+26+8=49 bytes, which corresponds to "size: 49" below.
-build block-size=8 table-format=(Pebble,v4)
+build block-size=8 table-format=Pebble,v4
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 blue@8.SET.16:blue8s
@@ -330,7 +330,7 @@ sstable
 
 # Same as above but with (Pebble,v5) [columnar blocks].
 
-build block-size=8 table-format=(Pebble,v5)
+build block-size=8 table-format=Pebble,v5
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 blue@8.SET.16:blue8s
@@ -685,7 +685,7 @@ sstable
       └── 045  magic number: 0xf09faab3f09faab3
 
 # Require that [c,e) must be in-place.
-build in-place-bound=(c,e) table-format=(Pebble,v4)
+build in-place-bound=(c,e) table-format=Pebble,v4
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 c@10.SET.16:c10
@@ -724,7 +724,7 @@ scan-cloned-lazy-values
 
 # Same as above with (Pebble,v5) [columnar blocks].
 
-build in-place-bound=(c,e) table-format=(Pebble,v5)
+build in-place-bound=(c,e) table-format=Pebble,v5
 blue@10.SET.20:blue10
 blue@8.SET.18:blue8
 c@10.SET.16:c10
@@ -753,7 +753,7 @@ scan-cloned-lazy-values
 5(lazy: len 5, attr: 5): eat18
 
 # Try write empty values to value blocks.
-build table-format=(Pebble,v4)
+build table-format=Pebble,v4
 b@5.SET.7:b5
 b@3.SET.2:
 c@6.DEL.7:
@@ -831,7 +831,7 @@ sstable
 
 # Same as above but with (Pebble,v5) [columnar blocks].
 
-build table-format=(Pebble,v5)
+build table-format=Pebble,v5
 b@5.SET.7:b5
 b@3.SET.2:
 c@6.DEL.7:
@@ -975,7 +975,7 @@ sstable
       └── 045  magic number: 0xf09faab3f09faab3
 
 # Same as above but with (Pebble,v6) [footer checksum blocks].
-build table-format=(Pebble,v6)
+build table-format=Pebble,v6
 b@5.SET.7:b5
 b@3.SET.2:
 c@6.DEL.7:

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -176,7 +176,7 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat) {
 			return ""
 
 		case "write-kvs":
-			if err := writeKVs(w, td.Input); err != nil {
+			if err := ParseTestSST(w, td.Input); err != nil {
 				return err.Error()
 			}
 			return fmt.Sprintf("EstimatedSize()=%d", w.EstimatedSize())

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -353,16 +353,6 @@ func TestWriterWithValueBlocks(t *testing.T) {
 			if td.HasArg("block-size") {
 				td.ScanArgs(t, "block-size", &blockSize)
 			}
-			if arg, ok := td.Arg("table-format"); ok {
-				// The datadriven cmd parser will parse the TableFormat string
-				// because its string representation looks like the datadriven
-				// format for multiple arguments (<arg1>,<arg2>).
-				name, v := arg.TwoVals(t)
-				formatVersion, err = ParseTableFormatString(fmt.Sprintf("(%s,%s)", name, v))
-				if err != nil {
-					return err.Error()
-				}
-			}
 			var inPlaceValueBound UserKeyPrefixBound
 			if td.HasArg("in-place-bound") {
 				var l, u string
@@ -545,16 +535,6 @@ func TestWriterWithBlobValueHandles(t *testing.T) {
 			var blockSize int
 			if td.HasArg("block-size") {
 				td.ScanArgs(t, "block-size", &blockSize)
-			}
-			if arg, ok := td.Arg("table-format"); ok {
-				// The datadriven cmd parser will parse the TableFormat string
-				// because its string representation looks like the datadriven
-				// format for multiple arguments (<arg1>,<arg2>).
-				name, v := arg.TwoVals(t)
-				formatVersion, err = ParseTableFormatString(fmt.Sprintf("(%s,%s)", name, v))
-				if err != nil {
-					return err.Error()
-				}
 			}
 			meta, r, err = runBuildCmd(td, &WriterOptions{
 				BlockSize:               blockSize,

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -457,7 +457,7 @@ lsm db
 L6:
   000010:[a#0,SET-g#0,SET]
 
-build db ext1 format=pebblev2
+build db ext1 table-format=Pebble,v2
 set i i
 set j j
 set k k
@@ -474,7 +474,7 @@ L6:
   000013(000010):[d#0,SET-g#0,SET]
   000011:[i#20,SET-k#20,SET]
 
-build db ext2 format=pebblev2
+build db ext2 table-format=Pebble,v2
 set z z
 ----
 

--- a/testdata/excise
+++ b/testdata/excise
@@ -1,5 +1,5 @@
 
-build ext0 format=pebblev2
+build ext0 table-format=Pebble,v2
 set a 1
 set l 2
 ----
@@ -103,7 +103,7 @@ f: (bar, .)
 l: (2, .)
 .
 
-build ext1 format=pebblev2
+build ext1 table-format=Pebble,v2
 set d foo3
 set e bar2
 ----
@@ -137,14 +137,14 @@ l: (2, .)
 reset
 ----
 
-build ext3 format=pebblev2
+build ext3 table-format=Pebble,v2
 range-key-set c f @4 foobar
 ----
 
 ingest ext3
 ----
 
-build ext4 format=pebblev2
+build ext4 table-format=Pebble,v2
 set b bar
 del-range g i
 ----

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -16,7 +16,7 @@ ingest ext0
 lsm
 ----
 
-build ext0 format=pebblev2
+build ext0 table-format=Pebble,v2
 set a 1
 set b 2
 ----
@@ -116,7 +116,7 @@ b
 a:3
 b: pebble: not found
 
-build ext2 format=pebblev2
+build ext2 table-format=Pebble,v2
 set a 4
 set b 5
 set c 6
@@ -303,7 +303,7 @@ n
 m:12
 n:13
 
-build ext7 format=pebblev2
+build ext7 table-format=Pebble,v2
 del-range a c
 del-range x z
 ----

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -291,7 +291,7 @@ x: (bar, .)
 reset
 ----
 
-build-remote f7 block-size=5
+build-remote f7 block-size=5 index-block-size=5
 set b ignored
 set c foo
 set d haha
@@ -299,7 +299,7 @@ set e something
 set x ignored
 ----
 
-build-remote f8 block-size=100
+build-remote f8 block-size=100 index-block-size=100
 set a ignored
 set g foo
 set h foo

--- a/testdata/ingest_load
+++ b/testdata/ingest_load
@@ -58,7 +58,7 @@ b.MERGE.0:
   ranges: #0,DEL-#0,DEL
 
 load
-EncodeSpan: a-b:{(#0,RANGEDEL)}
+Span: a-b:{(#0,RANGEDEL)}
 ----
 1: a#0,RANGEDEL-b#inf,RANGEDEL
   points: a#0,RANGEDEL-b#inf,RANGEDEL
@@ -66,7 +66,7 @@ EncodeSpan: a-b:{(#0,RANGEDEL)}
 
 load
 a.SET.0:
-EncodeSpan: a-b:{(#0,RANGEDEL)}
+Span: a-b:{(#0,RANGEDEL)}
 ----
 1: a#0,RANGEDEL-b#inf,RANGEDEL
   points: a#0,RANGEDEL-b#inf,RANGEDEL
@@ -74,7 +74,7 @@ EncodeSpan: a-b:{(#0,RANGEDEL)}
 
 load
 a.SET.0:
-EncodeSpan: a-b:{(#0,RANGEDEL)}
+Span: a-b:{(#0,RANGEDEL)}
 ----
 1: a#0,RANGEDEL-b#inf,RANGEDEL
   points: a#0,RANGEDEL-b#inf,RANGEDEL
@@ -82,7 +82,7 @@ EncodeSpan: a-b:{(#0,RANGEDEL)}
 
 load
 b.SET.0:
-EncodeSpan: a-b:{(#0,RANGEDEL)}
+Span: a-b:{(#0,RANGEDEL)}
 ----
 1: a#0,RANGEDEL-b#0,SET
   points: a#0,RANGEDEL-b#0,SET
@@ -98,7 +98,7 @@ pebble: table format (Pebble,v4) is not within range supported at DB format majo
 # Tables with range keys only.
 
 load writer-version=16 db-version=16
-EncodeSpan: a-z:{(#0,RANGEKEYSET,@1,foo)}
+Span: a-z:{(#0,RANGEKEYSET,@1,foo)}
 ----
 1: a#0,RANGEKEYSET-z#inf,RANGEKEYSET
   points: #0,DEL-#0,DEL
@@ -110,9 +110,9 @@ load writer-version=16 db-version=16
 a.SET.0:
 b.SET.0:
 c.SET.0:
-EncodeSpan: w-x:{(#0,RANGEKEYSET,@1,foo)}
-EncodeSpan: x-y:{(#0,RANGEKEYSET,@2,bar)}
-EncodeSpan: y-z:{(#0,RANGEKEYSET,@3,baz)}
+Span: w-x:{(#0,RANGEKEYSET,@1,foo)}
+Span: x-y:{(#0,RANGEKEYSET,@2,bar)}
+Span: y-z:{(#0,RANGEKEYSET,@3,baz)}
 ----
 1: a#0,SET-z#inf,RANGEKEYSET
   points: a#0,SET-c#0,SET
@@ -120,7 +120,7 @@ EncodeSpan: y-z:{(#0,RANGEKEYSET,@3,baz)}
 
 load writer-version=16 db-version=16
 c.SET.0:d
-EncodeSpan: a-z:{(#0,RANGEKEYSET,@1,foo)}
+Span: a-z:{(#0,RANGEKEYSET,@1,foo)}
 ----
 1: a#0,RANGEKEYSET-z#inf,RANGEKEYSET
   points: c#0,SET-c#0,SET
@@ -128,7 +128,7 @@ EncodeSpan: a-z:{(#0,RANGEKEYSET,@1,foo)}
 
 load writer-version=16 db-version=16
 a.SET.0:z
-EncodeSpan: c-d:{(#0,RANGEKEYSET,@1,foo)}
+Span: c-d:{(#0,RANGEKEYSET,@1,foo)}
 ----
 1: a#0,SET-d#inf,RANGEKEYSET
   points: a#0,SET-a#0,SET
@@ -137,8 +137,8 @@ EncodeSpan: c-d:{(#0,RANGEKEYSET,@1,foo)}
 # NB: range dels sort before range keys
 
 load writer-version=16 db-version=16
-EncodeSpan: a-z:{(#0,RANGEDEL)}
-EncodeSpan: a-z:{(#0,RANGEKEYSET,@1,foo)}
+Span: a-z:{(#0,RANGEDEL)}
+Span: a-z:{(#0,RANGEKEYSET,@1,foo)}
 ----
 1: a#0,RANGEKEYSET-z#inf,RANGEDEL
   points: a#0,RANGEDEL-z#inf,RANGEDEL

--- a/testdata/ingest_update_seqnums
+++ b/testdata/ingest_update_seqnums
@@ -16,7 +16,7 @@ file 0
 # Point keys only (range del lower bound).
 
 load
-EncodeSpan: a-b:{(#0,RANGEDEL)}
+Span: a-b:{(#0,RANGEDEL)}
 c.SET.0:
 ----
 file 1
@@ -25,7 +25,7 @@ file 1
 
 load
 a.SET.0:
-EncodeSpan: b-c:{(#0,RANGEDEL)}
+Span: b-c:{(#0,RANGEDEL)}
 ----
 file 2
 
@@ -57,7 +57,7 @@ reset
 ----
 
 load
-EncodeSpan: a-c:{#0,RANGEKEYSET,@1,foo)}
+Span: a-c:{#0,RANGEKEYSET,@1,foo)}
 ----
 file 0
 
@@ -75,7 +75,7 @@ reset
 
 load
 a.SET.0:
-EncodeSpan: b-c:{#0,RANGEKEYSET,@1,foo)}
+Span: b-c:{#0,RANGEKEYSET,@1,foo)}
 d.SET.0:
 ----
 file 0
@@ -94,7 +94,7 @@ reset
 
 load
 a.SET.0:
-EncodeSpan: b-c:{(#0,RANGEKEYSET,@1,foo)}
+Span: b-c:{(#0,RANGEKEYSET,@1,foo)}
 ----
 file 0
 
@@ -111,7 +111,7 @@ reset
 ----
 
 load
-EncodeSpan: a-c:{#0,RANGEKEYSET,@1,foo)}
+Span: a-c:{#0,RANGEKEYSET,@1,foo)}
 d.SET.0:
 ----
 file 0
@@ -129,7 +129,7 @@ reset
 ----
 
 load
-EncodeSpan: a-d:{#0,RANGEKEYSET,@1,foo)}
+Span: a-d:{#0,RANGEKEYSET,@1,foo)}
 c.SET.0:
 ----
 file 0

--- a/testdata/level_checker
+++ b/testdata/level_checker
@@ -16,10 +16,10 @@
 define
 L
 a.SET.30 e.RANGEDEL.inf
-a.SET.30:30 c.SET.27:27 EncodeSpan:a-f:{(#8,RANGEDEL)}
+a.SET.30:30 c.SET.27:27 Span:a-f:{(#8,RANGEDEL)}
 L
 e.SET.10 g.SET.20
-e.SET.10:10 g.SET.20:20 EncodeSpan:e-f:{(#8,RANGEDEL)}
+e.SET.10:10 g.SET.20:20 Span:e-f:{(#8,RANGEDEL)}
 ----
 Level 1
   file 0: [a#30,SET-e#inf,RANGEDEL]
@@ -34,7 +34,7 @@ check
 define
 L
 a.SET.15 f.SET.16
-a.SET.15:15 c.SET.13:13 f.SET.16:16 EncodeSpan:a-h:{(#12,RANGEDEL)}
+a.SET.15:15 c.SET.13:13 f.SET.16:16 Span:a-h:{(#12,RANGEDEL)}
 L
 e.SET.10 g.SET.15
 e.SET.10:10 g.SET.15:15
@@ -52,10 +52,10 @@ check
 define
 L
 c.SET.30 f.RANGEDEL.0
-c.SET.30:30 d.SET.27:27 EncodeSpan:a-f:{(#8,RANGEDEL)}
+c.SET.30:30 d.SET.27:27 Span:a-f:{(#8,RANGEDEL)}
 L
 a.SET.10 c.RANGEDEL.inf
-a.SET.10:10 b.SET.12:12 EncodeSpan:a-f:{(#8,RANGEDEL)}
+a.SET.10:10 b.SET.12:12 Span:a-f:{(#8,RANGEDEL)}
 ----
 Level 1
   file 0: [c#30,SET-f#0,RANGEDEL]
@@ -70,7 +70,7 @@ check
 define
 L
 c.SET.15 g.SET.16
-c.SET.15:15 f.SET.13:13 g.SET.16:16 EncodeSpan:a-h:{(#12,RANGEDEL)}
+c.SET.15:15 f.SET.13:13 g.SET.16:16 Span:a-h:{(#12,RANGEDEL)}
 L
 b.SET.14 d.SET.10
 b.SET.14:14 d.SET.10:10
@@ -87,10 +87,10 @@ check
 define
 L
 a.SET.30 e.RANGEDEL.inf
-a.SET.30:30 c.SET.27:27 EncodeSpan:a-g:{(#8,RANGEDEL)}
+a.SET.30:30 c.SET.27:27 Span:a-g:{(#8,RANGEDEL)}
 L
 e.SET.10 g.SET.20
-e.SET.10:10 g.SET.20:20 EncodeSpan:e-g:{(#8,RANGEDEL)}
+e.SET.10:10 g.SET.20:20 Span:e-g:{(#8,RANGEDEL)}
 ----
 Level 1
   file 0: [a#30,SET-e#inf,RANGEDEL]
@@ -103,7 +103,7 @@ check
 define
 L
 a.SET.30 e.RANGEDEL.inf
-a.SET.30:30 c.SET.27:27 EncodeSpan:a-g:{(#8,RANGEDEL)}
+a.SET.30:30 c.SET.27:27 Span:a-g:{(#8,RANGEDEL)}
 L
 a.SET.10 g.SET.20
 a.SET.10:10 c.SET.28:28 g.SET.20:20
@@ -122,7 +122,7 @@ found InternalKey c#27,SET in L1: fileNum=000010 and InternalKey c#28,SET in L2:
 define
 L
 a.SET.30 g.RANGEDEL.inf
-a.SET.30:30 c.SET.27:27 EncodeSpan:a-g:{(#8,RANGEDEL)}
+a.SET.30:30 c.SET.27:27 Span:a-g:{(#8,RANGEDEL)}
 L
 g.SET.10 j.SET.20
 g.SET.10:10 j.SET.20:20
@@ -138,7 +138,7 @@ check
 define
 L
 a.SET.30 g.SET.8
-a.SET.30:30 c.SET.27:27 EncodeSpan:a-g:{(#8,RANGEDEL)} g.SET.8:8
+a.SET.30:30 c.SET.27:27 Span:a-g:{(#8,RANGEDEL)} g.SET.8:8
 L
 g.SET.10 j.SET.20
 g.SET.10:10 j.SET.20:20
@@ -158,7 +158,7 @@ a.SET.30 g.SET.30
 a.SET.30:30 c.SET.8:8 g.SET.30:30
 L
 a.SET.10 j.SET.20
-a.SET.10:10 j.SET.20:20 EncodeSpan:b-g:{(#10,RANGEDEL)}
+a.SET.10:10 j.SET.20:20 Span:b-g:{(#10,RANGEDEL)}
 ----
 Level 1
   file 0: [a#30,SET-g#30,SET]
@@ -172,10 +172,10 @@ tombstone b-g:{(#10,RANGEDEL)} in L2: fileNum=000017 deletes key c#8,SET in L1: 
 define
 L
 a.RANGEDEL.8 c.RANGEDEL.inf
-EncodeSpan:a-c:{(#8,RANGEDEL)}
+Span:a-c:{(#8,RANGEDEL)}
 L
 a.RANGEDEL.6 d.RANGEDEL.inf
-EncodeSpan:a-d:{(#6,RANGEDEL)} EncodeSpan:b-c:{(#10,RANGEDEL)}
+Span:a-d:{(#6,RANGEDEL)} Span:b-c:{(#10,RANGEDEL)}
 ----
 Level 1
   file 0: [a#8,RANGEDEL-c#inf,RANGEDEL]
@@ -227,7 +227,7 @@ out of order keys b#2,SET >= b#3,SET in L1: fileNum=000023
 define write-unfragmented disable-key-order-checks
 L
 a.RANGEDEL.1 g.RANGEDEL.inf
-EncodeSpan:d-e:{(#2,RANGEDEL)-(#1,RANGEDEL)} EncodeSpan:f-g:{(#3,RANGEDEL)} EncodeSpan:a-b:{(#4,RANGEDEL)}
+Span:d-e:{(#2,RANGEDEL)-(#1,RANGEDEL)} Span:f-g:{(#3,RANGEDEL)} Span:a-b:{(#4,RANGEDEL)}
 ----
 Level 1
   file 0: [a#1,RANGEDEL-g#inf,RANGEDEL]
@@ -240,7 +240,7 @@ unordered or unfragmented range delete tombstones f-g:{(#3,RANGEDEL)}, a-b:{(#4,
 define write-unfragmented disable-key-order-checks
 L
 a.RANGEDEL.1 d.RANGEDEL.inf
-EncodeSpan:a-d:{(#1,RANGEDEL)} EncodeSpan:b-c:{(#2,RANGEDEL)}
+Span:a-d:{(#1,RANGEDEL)} Span:b-c:{(#2,RANGEDEL)}
 ----
 Level 1
   file 0: [a#1,RANGEDEL-d#inf,RANGEDEL]
@@ -253,7 +253,7 @@ unordered or unfragmented range delete tombstones a-d:{(#1,RANGEDEL)}, b-c:{(#2,
 define write-unfragmented disable-key-order-checks
 L
 a.RANGEDEL.1 b.RANGEDEL.inf
-EncodeSpan:a-z:{(#1,RANGEDEL)} EncodeSpan:d-e:{(#2,RANGEDEL)}
+Span:a-z:{(#1,RANGEDEL)} Span:d-e:{(#2,RANGEDEL)}
 ----
 Level 1
   file 0: [a#1,RANGEDEL-b#inf,RANGEDEL]
@@ -364,7 +364,7 @@ merge processing error on key a#9,SINGLEDEL in L1: fileNum=000033: finish failed
 define
 L
 a@9.SET.9 f.RANGEDEL.inf
-a@9.SET.9:a9 a@6.SET.6:a6 EncodeSpan:a-f:{(#5,RANGEDEL)}
+a@9.SET.9:a9 a@6.SET.6:a6 Span:a-f:{(#5,RANGEDEL)}
 f@6.SET.6 f@6.SET.6
 f@6.SET.6:f6
 ----

--- a/testdata/level_iter_seek
+++ b/testdata/level_iter_seek
@@ -385,7 +385,7 @@ f.SET.5:f
 0: a#9,SET-b#8,SET
 1: c#7,SET-f#5,SET
 
-build format=pebblev2
+build table-format=Pebble,v2
 g.RANGEKEYDEL.6:h
 ----
 0: a#9,SET-b#8,SET


### PR DESCRIPTION
#### sstable: replace EncodeSpan with Span in tests


#### sstable: export functionality to parse SST contents

We export `ParseTestKVsAndSpans` which can parse multi-line SST
contents and `ParseTestSST` which also writes the contents to a
RawWriter.

#### sstable: export parsing of WriterOptions from testdata args


#### sstable: standardize format argument

There are multiple datadriven arguments with different values for
specifying the table format. This change standardizes all of them to
use `table-format`.