### PR TITLE
record: change WriteWALSyncOffsets to respect runtime format ratcheting

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -253,8 +253,9 @@ func TestCommitPipelineWALClose(t *testing.T) {
 	}
 	p := newCommitPipeline(testEnv)
 	wal = record.NewLogWriter(sf, 0 /* logNum */, record.LogWriterConfig{
-		WALFsyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
-		QueueSemChan:    p.logSyncQSem,
+		WALFsyncLatency:     prometheus.NewHistogram(prometheus.HistogramOpts{}),
+		QueueSemChan:        p.logSyncQSem,
+		WriteWALSyncOffsets: func() bool { return false },
 	})
 
 	// Launch N (commitConcurrency) goroutines which each create a batch and
@@ -394,8 +395,9 @@ func BenchmarkCommitPipeline(b *testing.B) {
 					p := newCommitPipeline(nullCommitEnv)
 					wal = record.NewLogWriter(io.Discard, 0, /* logNum */
 						record.LogWriterConfig{
-							WALFsyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
-							QueueSemChan:    p.logSyncQSem,
+							WALFsyncLatency:     prometheus.NewHistogram(prometheus.HistogramOpts{}),
+							QueueSemChan:        p.logSyncQSem,
+							WriteWALSyncOffsets: func() bool { return false },
 						})
 					const keySize = 8
 					b.SetBytes(2 * keySize)

--- a/open.go
+++ b/open.go
@@ -372,7 +372,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		QueueSemChan:         d.commit.logSyncQSem,
 		Logger:               opts.Logger,
 		EventListener:        walEventListenerAdaptor{l: opts.EventListener},
-		WriteWALSyncOffsets:  FormatMajorVersion(d.mu.formatVers.vers.Load()) >= FormatWALSyncChunks,
+		WriteWALSyncOffsets:  func() bool { return d.FormatMajorVersion() >= FormatWALSyncChunks },
 	}
 	if opts.WALFailover != nil {
 		walOpts.Secondary = opts.WALFailover.Secondary

--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -509,8 +509,10 @@ type LogWriterConfig struct {
 	// callbacks are serialized since they are invoked from the flushLoop.
 	ExternalSyncQueueCallback ExternalSyncQueueCallback
 
-	// WriteWALSyncOffsets represents whether to write the WAL sync chunk format.
-	WriteWALSyncOffsets bool
+	// WriteWALSyncOffsets determines whether to write WAL sync chunk offsets.
+	// The format major version can change (ratchet) at runtime, so this must be
+	// a function rather than a static bool to ensure we use the latest format version.
+	WriteWALSyncOffsets func() bool
 }
 
 // ExternalSyncQueueCallback is to be run when a PendingSync has been
@@ -552,7 +554,7 @@ func NewLogWriter(
 		},
 	}
 
-	if logWriterConfig.WriteWALSyncOffsets {
+	if logWriterConfig.WriteWALSyncOffsets() {
 		r.emitFragment = r.emitFragmentSyncOffsets
 	} else {
 		r.emitFragment = r.emitFragmentRecyclable

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -223,16 +223,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |  0.40 |   81B |     1   746B |     0     0B |     3  2.2KB |    0B |   2 27.5
+    0 |     2  1.5KB     0B       0 |  0.40 |   97B |     1   746B |     0     0B |     3  2.2KB |    0B |   2 23.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   746B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   746B | 1.5KB |   1  0.5
-total |     3  2.2KB     0B       0 |     - |  827B |     1   746B |     0     0B |     4  3.7KB | 1.5KB |   3  4.6
+total |     3  2.2KB     0B       0 |     - |  843B |     1   746B |     0     0B |     4  3.7KB | 1.5KB |   3  4.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 48B  written: 81B (69% overhead)
+WAL: 1 files (0B)  in: 48B  written: 97B (102% overhead)
 Flushes: 3
 Compactions: 1  estimated debt: 2.2KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -324,7 +324,7 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.9KB     0B       0 |  0.80 |  108B |     2  1.5KB |     0     0B |     4  2.9KB |    0B |   4 27.5
+    0 |     4  2.9KB     0B       0 |  0.80 |  132B |     2  1.5KB |     0     0B |     4  2.9KB |    0B |   4 22.5
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -333,7 +333,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     2  1.5KB     0B       0 |     - | 1.5KB |     1   746B |     0     0B |     1   746B | 1.5KB |   1  0.5
 total |     6  4.4KB     0B       0 |     - | 2.3KB |     3  2.2KB |     0     0B |     5  5.9KB | 1.5KB |   5  2.6
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 82B  written: 108B (32% overhead)
+WAL: 1 files (0B)  in: 82B  written: 132B (61% overhead)
 Flushes: 6
 Compactions: 1  estimated debt: 4.4KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -115,16 +115,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 26.5
+    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 23.2
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     1   743B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.8
+total |     1   743B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 35.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
+WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -161,16 +161,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 26.5
+    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 23.2
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     1   743B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.8
+total |     1   743B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 35.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
+WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -204,16 +204,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 26.5
+    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 23.2
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     1   743B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.8
+total |     1   743B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 35.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
+WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -250,16 +250,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   56B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 26.5
+    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.4KB |    0B |   0 23.2
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     1   743B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.8
+total |     1   743B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 35.8
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
+WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -326,16 +326,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  5.2KB     0B       0 |  0.25 |  149B |     0     0B |     0     0B |     9  6.6KB |    0B |   1 45.5
+    0 |     7  5.2KB     0B       0 |  0.25 |  165B |     0     0B |     0     0B |     9  6.6KB |    0B |   1 41.1
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     8  5.9KB     0B       0 |     - |  149B |     0     0B |     0     0B |    10  7.5KB | 1.4KB |   2 51.5
+total |     8  5.9KB     0B       0 |     - |  165B |     0     0B |     0     0B |    10  7.5KB | 1.4KB |   2 46.6
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
+WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
 Flushes: 3
 Compactions: 1  estimated debt: 5.9KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -381,16 +381,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  149B |     0     0B |     0     0B |     9  6.6KB |    0B |   0 45.5
+    0 |     0     0B     0B       0 |  0.00 |  165B |     0     0B |     0     0B |     9  6.6KB |    0B |   0 41.1
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     2  1.6KB    31B       0 |     - | 6.6KB |     0     0B |     0     0B |     2  1.6KB | 6.6KB |   1  0.2
-total |     2  1.6KB    31B       0 |     - |  149B |     0     0B |     0     0B |    11  8.4KB | 6.6KB |   1 57.6
+total |     2  1.6KB    31B       0 |     - |  165B |     0     0B |     0     0B |    11  8.4KB | 6.6KB |   1 52.1
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
+WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
 Flushes: 3
 Compactions: 2  estimated debt: 0B  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -487,7 +487,7 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     6  4.4KB     0B       0 |  0.50 |  187B |     3  2.2KB |     0     0B |    12  8.8KB |    0B |   2 48.1
+    0 |     6  4.4KB     0B       0 |  0.50 |  211B |     3  2.2KB |     0     0B |    12  8.8KB |    0B |   2 42.7
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -496,7 +496,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     2  1.6KB    31B       0 |     - | 6.6KB |     0     0B |     0     0B |     2  1.6KB | 6.6KB |   1  0.2
 total |     8  6.0KB    31B       0 |     - | 2.4KB |     3  2.2KB |     0     0B |    14   13KB | 6.6KB |   3  5.4
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 176B  written: 187B (6% overhead)
+WAL: 1 files (0B)  in: 176B  written: 211B (20% overhead)
 Flushes: 8
 Compactions: 2  estimated debt: 6.0KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -555,16 +555,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |    13  9.4KB     0B       0 |  0.50 |  245B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 57.9
+    0 |    13  9.4KB     0B       0 |  0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 51.2
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     2  1.6KB    31B       0 |     - | 6.6KB |     0     0B |     0     0B |     2  1.6KB | 6.6KB |   1  0.2
-total |    15   11KB    31B       0 |     - | 2.4KB |     3  2.2KB |     0     0B |    21   18KB | 6.6KB |   3  7.4
+total |    15   11KB    31B       0 |     - | 2.5KB |     3  2.2KB |     0     0B |    21   18KB | 6.6KB |   3  7.3
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
+WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
 Compactions: 2  estimated debt: 11KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -635,16 +635,16 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |    11  8.0KB     0B       0 |  0.50 |  245B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 57.9
+    0 |    11  8.0KB     0B       0 |  0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 51.2
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     3  2.4KB    31B       0 |     - | 6.6KB |     1   745B |     0     0B |     2  1.6KB | 6.6KB |   1  0.2
-total |    14   10KB    31B       0 |     - | 3.1KB |     4  2.9KB |     0     0B |    21   19KB | 6.6KB |   3  5.9
+total |    14   10KB    31B       0 |     - | 3.2KB |     4  2.9KB |     0     0B |    21   19KB | 6.6KB |   3  5.9
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
+WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
 Compactions: 2  estimated debt: 10KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -738,7 +738,7 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  245B |     3  2.2KB |     0     0B |    19   14KB |    0B |   0 57.9
+    0 |     0     0B     0B       0 |  0.00 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   0 51.2
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -747,7 +747,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     6 |     5  3.8KB    31B       0 |     - |  14KB |     2  1.4KB |     0     0B |     3  2.4KB |  14KB |   1  0.2
 total |     5  3.8KB    31B       0 |     - | 3.9KB |     5  3.6KB |     0     0B |    22   20KB |  14KB |   1  5.2
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
+WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
 Compactions: 3  estimated debt: 0B  in progress: 0 (0B)
              default: 3  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
@@ -932,16 +932,16 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |  0.50 |   66B |     1   745B |     0     0B |     4  2.9KB |    0B |   2 45.0
+    0 |     2  1.5KB     0B       0 |  0.50 |   74B |     1   745B |     0     0B |     4  2.9KB |    0B |   2 40.1
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   758B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   758B | 2.2KB |   1  0.3
-total |     3  2.2KB     0B       0 |     - |  811B |     1   745B |     0     0B |     5  4.4KB | 2.2KB |   3  5.6
+total |     3  2.2KB     0B       0 |     - |  819B |     1   745B |     0     0B |     5  4.4KB | 2.2KB |   3  5.5
 -------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 44B  written: 66B (50% overhead)
+WAL: 1 files (0B)  in: 44B  written: 74B (68% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 2.2KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -352,6 +352,7 @@ func TestManagerFailover(t *testing.T) {
 					Logger:                      nil,
 					EventListener:               nil,
 					FailoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
+					WriteWALSyncOffsets:         func() bool { return false },
 				}
 				require.NoError(t, memFS.MkdirAll(dirs[primaryDirIndex], 0755))
 				require.NoError(t, memFS.MkdirAll(dirs[secondaryDirIndex], 0755))
@@ -587,6 +588,7 @@ func TestFailoverManager_Quiesce(t *testing.T) {
 			UnhealthyOperationLatencyThreshold: func() (time.Duration, bool) { return time.Millisecond, true },
 		},
 		FailoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
+		WriteWALSyncOffsets:         func() bool { return false },
 	}, nil /* initial  logs */))
 	for i := 0; i < 3; i++ {
 		w, err := m.Create(NumWAL(i), i)

--- a/wal/failover_writer.go
+++ b/wal/failover_writer.go
@@ -464,8 +464,10 @@ type failoverWriterOpts struct {
 
 	writerCreatedForTest chan<- struct{}
 
-	// writeWALSyncOffsets represents whether to write the WAL sync chunk format.
-	writeWALSyncOffsets bool
+	// writeWALSyncOffsets determines whether to write WAL sync chunk offsets.
+	// The format major version can change (ratchet) at runtime, so this must be
+	// a function rather than a static bool to ensure we use the latest format version.
+	writeWALSyncOffsets func() bool
 }
 
 func simpleLogCreator(

--- a/wal/failover_writer_test.go
+++ b/wal/failover_writer_test.go
@@ -286,6 +286,7 @@ func TestFailoverWriter(t *testing.T) {
 						failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 						writerClosed:                func(_ logicalLogWithSizesEtc) {},
 						writerCreatedForTest:        logWriterCreated,
+						writeWALSyncOffsets:         func() bool { return false },
 					}, testDirs[dirIndex])
 					require.NoError(t, err)
 					if !noWaitForLogWriterCreation {
@@ -650,6 +651,7 @@ func TestConcurrentWritersWithManyRecords(t *testing.T) {
 		failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		writerClosed:                func(_ logicalLogWithSizesEtc) {},
 		writerCreatedForTest:        logWriterCreated,
+		writeWALSyncOffsets:         func() bool { return false },
 	}, dirs[dirIndex])
 	require.NoError(t, err)
 	wg := &sync.WaitGroup{}
@@ -751,6 +753,7 @@ func TestFailoverWriterManyRecords(t *testing.T) {
 		stopper:                     stopper,
 		failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		writerClosed:                func(_ logicalLogWithSizesEtc) {},
+		writeWALSyncOffsets:         func() bool { return false },
 	}, dir)
 	require.NoError(t, err)
 	var buf [1]byte

--- a/wal/reader_test.go
+++ b/wal/reader_test.go
@@ -127,7 +127,9 @@ func TestReader(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, dir.Sync())
 			require.NoError(t, dir.Close())
-			w := record.NewLogWriter(f, base.DiskFileNum(logNum), record.LogWriterConfig{})
+			w := record.NewLogWriter(f, base.DiskFileNum(logNum), record.LogWriterConfig{
+				WriteWALSyncOffsets: func() bool { return false },
+			})
 
 			lines := datadrivenutil.Lines(td.Input)
 			var offset int64

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -147,9 +147,11 @@ type Options struct {
 	// configured.
 	FailoverWriteAndSyncLatency prometheus.Histogram
 
-	// WriteWALSyncOffsets represents whether to write the WAL sync chunk format.
+	// WriteWALSyncOffsets determines whether to write WAL sync chunk offsets.
+	// The format major version can change (ratchet) at runtime, so this must be
+	// a function rather than a static bool to ensure we use the latest format version.
 	// It is plumbed down from wal.Options to record.newLogWriter.
-	WriteWALSyncOffsets bool
+	WriteWALSyncOffsets func() bool
 }
 
 // Init constructs and initializes a WAL manager from the provided options and


### PR DESCRIPTION
Changes WriteWALSyncOffsets a function so it always checks the current format version when creating a new WAL. The format major version can change (ratchet) at runtime, so WriteWALSyncOffsets should be a function so we can use the latest format version.