### PR TITLE
record: add a bitflip check to WAL corruption

### DIFF
--- a/internal/bitflip/bitflip.go
+++ b/internal/bitflip/bitflip.go
@@ -1,0 +1,31 @@
+package bitflip
+
+// CheckSliceForBitFlip flips bits in data to see if it matches the expected checksum.
+// Returns the index and bit if successful.
+func CheckSliceForBitFlip(
+	data []byte, computeChecksum func([]byte) uint32, expectedChecksum uint32,
+) (found bool, indexFound int, bitFound int) {
+	// TODO(edward) This checking process likely can be made faster.
+	iterationLimit := 40 * (1 << 10) // 40KB
+	for i := 0; i < min(len(data), iterationLimit); i++ {
+		foundFlip, bit := checkByteForFlip(data, i, computeChecksum, expectedChecksum)
+		if foundFlip {
+			return true, i, bit
+		}
+	}
+	return false, 0, 0
+}
+
+func checkByteForFlip(
+	data []byte, i int, computeChecksum func([]byte) uint32, expectedChecksum uint32,
+) (found bool, bit int) {
+	for bit := 0; bit < 8; bit++ {
+		data[i] ^= (1 << bit)
+		var computedChecksum = computeChecksum(data)
+		data[i] ^= (1 << bit)
+		if computedChecksum == expectedChecksum {
+			return true, bit
+		}
+	}
+	return false, 0
+}

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/crlib/fifo"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/bitflip"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/crc"
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -174,51 +175,28 @@ func ValidateChecksum(checksumType ChecksumType, b []byte, bh Handle) error {
 	if expectedChecksum != computedChecksum {
 		// Check if the checksum was due to a singular bit flip and report it.
 		data := slices.Clone(b[:bh.Length+1])
-		found, indexFound, bitFound := checkSliceForBitFlip(data, checksumType, expectedChecksum)
+		var checksumFunction func([]byte) uint32
+		switch checksumType {
+		case ChecksumTypeCRC32c:
+			checksumFunction = func(data []byte) uint32 {
+				return crc.New(data).Value()
+			}
+		case ChecksumTypeXXHash64:
+			checksumFunction = func(data []byte) uint32 {
+				return uint32(xxhash.Sum64(data))
+			}
+		}
+		found, indexFound, bitFound := bitflip.CheckSliceForBitFlip(data, checksumFunction, expectedChecksum)
 		err := base.CorruptionErrorf("block %d/%d: %s checksum mismatch %x != %x",
 			errors.Safe(bh.Offset), errors.Safe(bh.Length), checksumType,
 			expectedChecksum, computedChecksum)
 		if found {
-			err = errors.WithSafeDetails(err, ". bit flip found: byte index %d. got: %x. want: %x.",
-				indexFound, data[indexFound], data[indexFound]^(1<<bitFound))
+			err = errors.WithSafeDetails(err, ". bit flip found: byte index %d. got: 0x%x. want: 0x%x.",
+				errors.Safe(indexFound), errors.Safe(data[indexFound]), errors.Safe(data[indexFound]^(1<<bitFound)))
 		}
 		return err
 	}
 	return nil
-}
-
-func checkSliceForBitFlip(
-	data []byte, checksumType ChecksumType, expectedChecksum uint32,
-) (found bool, indexFound int, bitFound int) {
-	// TODO(edward) This checking process likely can be made faster.
-	iterationLimit := 40 * (1 << 10) // 40KB
-	for i := 0; i < min(len(data), iterationLimit); i++ {
-		foundFlip, bit := checkByteForFlip(data, i, checksumType, expectedChecksum)
-		if foundFlip {
-			return true, i, bit
-		}
-	}
-	return false, 0, 0
-}
-
-func checkByteForFlip(
-	data []byte, i int, checksumType ChecksumType, expectedChecksum uint32,
-) (found bool, bit int) {
-	for bit := 0; bit < 8; bit++ {
-		data[i] ^= (1 << bit)
-		var computedChecksum uint32
-		switch checksumType {
-		case ChecksumTypeCRC32c:
-			computedChecksum = crc.New(data).Value()
-		case ChecksumTypeXXHash64:
-			computedChecksum = uint32(xxhash.Sum64(data))
-		}
-		data[i] ^= (1 << bit)
-		if computedChecksum == expectedChecksum {
-			return true, bit
-		}
-	}
-	return false, 0
 }
 
 // Metadata is an in-memory buffer that stores metadata for a block. It is

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1512,7 +1512,7 @@ func TestReaderChecksumErrors(t *testing.T) {
 									checkBitFlipErr := func(err error) bool {
 										if err != nil {
 											details := errors.GetAllSafeDetails(err)
-											re := regexp.MustCompile(`bit flip found`)
+											re := regexp.MustCompile(`bit flip found.+byte index \d+\. got: 0x[0-9A-Fa-f]{1,2}\. want: 0x[0-9A-Fa-f]{1,2}\.`)
 											for _, d := range details {
 												for _, s := range d.SafeDetails {
 													if re.MatchString(s) {
@@ -1520,7 +1520,7 @@ func TestReaderChecksumErrors(t *testing.T) {
 													}
 												}
 											}
-											require.Fail(t, "expected at least one detail to match bit flip found", err)
+											require.Fail(t, "expected at least one detail to match bit flip pattern", err)
 										}
 										return false
 									}


### PR DESCRIPTION
Checks if there was a bitflip that occurred when a chunk corruption is found. Similar to https://github.com/cockroachdb/pebble/pull/4406.