### PR TITLE
db: clean up level metric updates

### DIFF
--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -393,7 +393,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	d.checkVirtualBounds(v2)
 
 	// Write the version edit.
-	fileMetrics := func(ve *versionEdit) map[int]*LevelMetrics {
+	fileMetrics := func(ve *versionEdit) *levelMetricsDelta {
 		metrics := newFileMetrics(ve.NewTables)
 		for de, f := range ve.DeletedTables {
 			lm := metrics[de.Level]

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -606,7 +606,7 @@ func (d *DB) markFilesLocked(findFn findFilesFunc) error {
 	return d.mu.versions.logAndApply(
 		jobID,
 		&manifest.VersionEdit{},
-		map[int]*LevelMetrics{},
+		nil,  /* metrics */
 		true, /* forceRotation */
 		func() []compactionInfo { return d.getInProgressCompactionInfoLocked(nil) })
 }

--- a/ingest.go
+++ b/ingest.go
@@ -1914,7 +1914,7 @@ func (d *DB) ingestApply(
 	if exciseSpan.Valid() || (d.opts.Experimental.IngestSplit != nil && d.opts.Experimental.IngestSplit()) {
 		ve.DeletedTables = map[manifest.DeletedTableEntry]*manifest.TableMetadata{}
 	}
-	metrics := make(map[int]*LevelMetrics)
+	var metrics levelMetricsDelta
 
 	// Lock the manifest for writing before we use the current version to
 	// determine the target level. This prevents two concurrent ingestion jobs
@@ -2150,7 +2150,7 @@ func (d *DB) ingestApply(
 		}
 	}
 
-	if err := d.mu.versions.logAndApply(jobID, ve, metrics, false /* forceRotation */, func() []compactionInfo {
+	if err := d.mu.versions.logAndApply(jobID, ve, &metrics, false /* forceRotation */, func() []compactionInfo {
 		return d.getInProgressCompactionInfoLocked(nil)
 	}); err != nil {
 		// Note: any error during logAndApply is fatal; this won't be reachable in production.

--- a/metrics.go
+++ b/metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/record"
@@ -717,4 +718,16 @@ func (m *Metrics) StringForTests() string {
 	// invariants tag, etc.
 	mCopy.manualMemory = manual.Metrics{}
 	return redact.StringWithoutMarkers(&mCopy)
+}
+
+// levelMetricsDelta accumulates incremental ("delta") level metric updates
+// (e.g. from compactions or flushes).
+type levelMetricsDelta [manifest.NumLevels]*LevelMetrics
+
+func (m *Metrics) updateLevelMetrics(updates levelMetricsDelta) {
+	for i, u := range updates {
+		if u != nil {
+			m.Levels[i].Add(u)
+		}
+	}
 }

--- a/version_set.go
+++ b/version_set.go
@@ -443,7 +443,7 @@ func (vs *versionSet) logUnlockAndInvalidatePickedCompactionCache() {
 func (vs *versionSet) logAndApply(
 	jobID JobID,
 	ve *versionEdit,
-	metrics map[int]*LevelMetrics,
+	metrics *levelMetricsDelta,
 	forceRotation bool,
 	inProgressCompactions func() []compactionInfo,
 ) error {
@@ -685,8 +685,8 @@ func (vs *versionSet) logAndApply(
 		vs.manifestFileNum = newManifestFileNum
 	}
 
-	for level, update := range metrics {
-		vs.metrics.Levels[level].Add(update)
+	if metrics != nil {
+		vs.metrics.updateLevelMetrics(*metrics)
 	}
 	for i := range vs.metrics.Levels {
 		l := &vs.metrics.Levels[i]
@@ -1129,8 +1129,8 @@ func findCurrentManifest(
 	return marker, manifestNum, true, nil
 }
 
-func newFileMetrics(newFiles []manifest.NewTableEntry) map[int]*LevelMetrics {
-	m := map[int]*LevelMetrics{}
+func newFileMetrics(newFiles []manifest.NewTableEntry) *levelMetricsDelta {
+	var m levelMetricsDelta
 	for _, nf := range newFiles {
 		lm := m[nf.Level]
 		if lm == nil {
@@ -1140,5 +1140,5 @@ func newFileMetrics(newFiles []manifest.NewTableEntry) map[int]*LevelMetrics {
 		lm.NumFiles++
 		lm.Size += int64(nf.Meta.Size)
 	}
-	return m
+	return &m
 }


### PR DESCRIPTION
Replace the ad-hoc `map[int]*LevelMetrics` that is passed to
`logAndApply` with a `levelMetricsDelta` type which makes it more
clear what it is and how it is used.