### PR TITLE
db: rework logAndApply

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -679,8 +679,8 @@ type compactionPickerByScore struct {
 	// This means that at some point in the future a compactionPickerByScore
 	// created in the past will have mutually inconsistent state in vers and
 	// l0Organizer. This is not a problem since (a) a new picker is created in
-	// logAndApply when a new version is installed, and (b) only the latest picker
-	// is used for picking compactions. This is ensured by holding
+	// UpdateVersionLocked when a new version is installed, and (b) only the
+	// latest picker is used for picking compactions. This is ensured by holding
 	// versionSet.logLock for both (a) and (b).
 	l0Organizer     *manifest.L0Organizer
 	virtualBackings *manifest.VirtualBackings

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2556,7 +2556,7 @@ func (i *createManifestErrorInjector) MaybeError(op errorfs.Op) error {
 		return nil
 	}
 	// This necessitates having a MaxManifestSize of 1, to reliably induce
-	// logAndApply errors.
+	// UpdateVersionLocked errors.
 	if strings.Contains(op.Path, "MANIFEST") && op.Kind == errorfs.OpCreate {
 		return errorfs.ErrInjected
 	}
@@ -2565,11 +2565,11 @@ func (i *createManifestErrorInjector) MaybeError(op errorfs.Op) error {
 
 var _ errorfs.Injector = &createManifestErrorInjector{}
 
-// TestCompaction_LogAndApplyFails exercises a flush or ingest encountering an
-// unrecoverable error during logAndApply.
+// TestCompaction_UpdateVersionFails exercises a flush or ingest encountering an
+// unrecoverable error during UpdateVersionLocked.
 //
 // Regression test for #1669.
-func TestCompaction_LogAndApplyFails(t *testing.T) {
+func TestCompaction_UpdateVersionFails(t *testing.T) {
 	// flushKeys writes the given keys to the DB, flushing the resulting memtable.
 	var key = []byte("foo")
 	flushErrC := make(chan error)
@@ -2652,8 +2652,9 @@ func TestCompaction_LogAndApplyFails(t *testing.T) {
 		err = addFn(db)
 		require.True(t, errors.Is(err, errorfs.ErrInjected))
 
-		// Under normal circumstances, such an error in logAndApply would panic and
-		// cause the DB to terminate here. Assert that we captured the fatal error.
+		// Under normal circumstances, such an error in UpdateVersionLocked would
+		// panic and cause the DB to terminate here. Assert that we captured the
+		// fatal error.
 		require.True(t, errors.Is(logger.err, errorfs.ErrInjected))
 	}
 	for _, tc := range testCases {

--- a/data_test.go
+++ b/data_test.go
@@ -1145,10 +1145,15 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 		ve.NewBlobFiles = slices.Collect(maps.Values(valueSeparator.metas))
 
 		jobID := d.newJobIDLocked()
-		d.mu.versions.logLock()
-		if err := d.mu.versions.logAndApply(jobID, ve, newFileMetrics(ve.NewTables), false, func() []compactionInfo {
-			return nil
-		}); err != nil {
+		err = d.mu.versions.UpdateVersionLocked(func() (versionUpdate, error) {
+			return versionUpdate{
+				VE:                      ve,
+				JobID:                   jobID,
+				Metrics:                 newFileMetrics(ve.NewTables),
+				InProgressCompactionsFn: func() []compactionInfo { return nil },
+			}, nil
+		})
+		if err != nil {
 			return nil, err
 		}
 		d.updateReadStateLocked(nil)

--- a/db.go
+++ b/db.go
@@ -321,7 +321,7 @@ type DB struct {
 	//
 	// Care is taken to avoid holding DB.mu during IO operations. Accomplishing
 	// this sometimes requires releasing DB.mu in a method that was called with
-	// it held. See versionSet.logAndApply() and DB.makeRoomForWrite() for
+	// it held. See versionSet.UpdateVersionLocked() and DB.makeRoomForWrite() for
 	// examples. This is a common pattern, so be careful about expectations that
 	// DB.mu will be held continuously across a set of calls.
 	mu struct {

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -96,9 +96,9 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 		}
 
 		// Fsync the directory we added the tables to. We need to do this at some
-		// point before we update the MANIFEST (via logAndApply), otherwise a crash
-		// can have the tables referenced in the MANIFEST, but not present in the
-		// directory.
+		// point before we update the MANIFEST (via UpdateVersionLocked), otherwise
+		// a crash can have the tables referenced in the MANIFEST, but not present
+		// in the directory.
 		if err := d.dataDir.Sync(); err != nil {
 			t.Fatal(err)
 		}

--- a/version_set.go
+++ b/version_set.go
@@ -382,8 +382,8 @@ func (vs *versionSet) close() error {
 	return nil
 }
 
-// logLock locks the manifest for writing. The lock must be released by either
-// a call to logUnlock or logAndApply.
+// logLock locks the manifest for writing. The lock must be released by
+// a call to logUnlock.
 //
 // DB.mu must be held when calling this method, but the mutex may be dropped and
 // re-acquired during the course of this method.
@@ -413,40 +413,56 @@ func (vs *versionSet) logUnlockAndInvalidatePickedCompactionCache() {
 	vs.logUnlock()
 }
 
-// logAndApply logs the version edit to the manifest, applies the version edit
-// to the current version, and installs the new version.
+// versionUpdate is returned by the function passed to UpdateVersionLocked.
 //
-// logAndApply fills in the following fields of the VersionEdit: NextFileNum,
-// LastSeqNum, RemovedBackingTables. The removed backing tables are those
-// backings that are no longer used (in the new version) after applying the edit
-// (as per vs.virtualBackings). Other than these fields, the VersionEdit must be
-// complete.
+// If VE is nil, there is no update to apply (but it is not an error).
+type versionUpdate struct {
+	VE      *manifest.VersionEdit
+	JobID   JobID
+	Metrics levelMetricsDelta
+	// InProgressCompactionFn is called while DB.mu is held after the I/O part of
+	// the update was performed. It should return any compactions that are
+	// in-progress (excluding than the one that is being applied).
+	InProgressCompactionsFn func() []compactionInfo
+	ForceManifestRotation   bool
+}
+
+// UpdateVersionLocked is used to update the current version.
+//
+// DB.mu must be held. UpdateVersionLocked first waits for any other version
+// update to complete, releasing and reacquiring DB.mu.
+//
+// UpdateVersionLocked then calls updateFn which builds a versionUpdate, while
+// holding DB.mu. The updateFn can release and reacquire DB.mu (it should
+// attempt to do as much work as possible outside of the lock).
+//
+// UpdateVersionLocked fills in the following fields of the VersionEdit:
+// NextFileNum, LastSeqNum, RemovedBackingTables. The removed backing tables are
+// those backings that are no longer used (in the new version) after applying
+// the edit (as per vs.virtualBackings). Other than these fields, the
+// VersionEdit must be complete.
 //
 // New table backing references (FileBacking.Ref) are taken as part of applying
 // the version edit. The state of the virtual backings (vs.virtualBackings) is
 // updated before logging to the manifest and installing the latest version;
 // this is ok because any failure in those steps is fatal.
-// TODO(radu): remove the error return.
 //
-// DB.mu must be held when calling this method and will be released temporarily
-// while performing file I/O. Requires that the manifest is locked for writing
-// (see logLock). Will unconditionally release the manifest lock (via
-// logUnlock) even if an error occurs.
-//
-// inProgressCompactions is called while DB.mu is held, to get the list of
-// in-progress compactions.
-func (vs *versionSet) logAndApply(
-	jobID JobID,
-	ve *versionEdit,
-	metrics *levelMetricsDelta,
-	forceRotation bool,
-	inProgressCompactions func() []compactionInfo,
-) error {
+// If updateFn returns an error, no update is applied and that same error is returned.
+// If versionUpdate.VE is nil, the no update is applied (and no error is returned).
+func (vs *versionSet) UpdateVersionLocked(updateFn func() (versionUpdate, error)) error {
+	vs.logLock()
+	defer vs.logUnlockAndInvalidatePickedCompactionCache()
+
+	vu, err := updateFn()
+	if err != nil || vu.VE == nil {
+		return err
+	}
+
 	if !vs.writing {
 		vs.opts.Logger.Fatalf("MANIFEST not locked for writing")
 	}
-	defer vs.logUnlockAndInvalidatePickedCompactionCache()
 
+	ve := vu.VE
 	if ve.MinUnflushedLogNum != 0 {
 		if ve.MinUnflushedLogNum < vs.minUnflushedLogNum ||
 			vs.nextFileNum.Load() <= uint64(ve.MinUnflushedLogNum) {
@@ -500,8 +516,8 @@ func (vs *versionSet) logAndApply(
 	// - The number of live files F in the DB is roughly stable: after writing
 	//   the snapshot (with F files), say we require that there be enough edits
 	//   such that the cumulative number of files in those edits, E, be greater
-	//   than F. This will ensure that the total amount of time in logAndApply
-	//   that is spent in snapshot writing is ~50%.
+	//   than F. This will ensure that the total amount of time in
+	//   UpdateVersionLocked that is spent in snapshot writing is ~50%.
 	//
 	// - The number of live files F in the DB is shrinking drastically, say from
 	//   F to F/10: This can happen for various reasons, like wide range
@@ -525,7 +541,7 @@ func (vs *versionSet) logAndApply(
 	// count in the current version.
 	vs.rotationHelper.AddRecord(int64(len(ve.DeletedTables) + len(ve.NewTables)))
 	sizeExceeded := vs.manifest.Size() >= vs.opts.MaxManifestFileSize
-	requireRotation := forceRotation || vs.manifest == nil
+	requireRotation := vu.ForceManifestRotation || vs.manifest == nil
 
 	var nextSnapshotFilecount int64
 	for i := range vs.metrics.Levels {
@@ -578,7 +594,7 @@ func (vs *versionSet) logAndApply(
 		if newManifestFileNum != 0 {
 			if err := vs.createManifest(vs.dirname, newManifestFileNum, minUnflushedLogNum, nextFileNum, newManifestVirtualBackings); err != nil {
 				vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
-					JobID:   int(jobID),
+					JobID:   int(vu.JobID),
 					Path:    base.MakeFilepath(vs.fs, vs.dirname, base.FileTypeManifest, newManifestFileNum),
 					FileNum: newManifestFileNum,
 					Err:     err,
@@ -612,7 +628,7 @@ func (vs *versionSet) logAndApply(
 				return errors.Wrap(err, "MANIFEST set current failed")
 			}
 			vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
-				JobID:   int(jobID),
+				JobID:   int(vu.JobID),
 				Path:    base.MakeFilepath(vs.fs, vs.dirname, base.FileTypeManifest, newManifestFileNum),
 				FileNum: newManifestFileNum,
 			})
@@ -635,7 +651,7 @@ func (vs *versionSet) logAndApply(
 	}
 	// Now that DB.mu is held again, initialize compacting file info in
 	// L0Sublevels.
-	inProgress := inProgressCompactions()
+	inProgress := vu.InProgressCompactionsFn()
 
 	vs.l0Organizer.PerformUpdate(l0Update, newVersion)
 	vs.l0Organizer.InitCompactingFileInfo(inProgressL0Compactions(inProgress))
@@ -685,9 +701,7 @@ func (vs *versionSet) logAndApply(
 		vs.manifestFileNum = newManifestFileNum
 	}
 
-	if metrics != nil {
-		vs.metrics.updateLevelMetrics(*metrics)
-	}
+	vs.metrics.updateLevelMetrics(vu.Metrics)
 	for i := range vs.metrics.Levels {
 		l := &vs.metrics.Levels[i]
 		l.NumFiles = int64(newVersion.Levels[i].Len())
@@ -935,7 +949,7 @@ func (vs *versionSet) createManifest(
 	snapshot.CreatedBackingTables = virtualBackings
 
 	// When creating a version snapshot for an existing DB, this snapshot VersionEdit will be
-	// immediately followed by another VersionEdit (being written in logAndApply()). That
+	// immediately followed by another VersionEdit (being written in UpdateVersionLocked()). That
 	// VersionEdit always contains a LastSeqNum, so we don't need to include that in the snapshot.
 	// But it does not necessarily include MinUnflushedLogNum, NextFileNum, so we initialize those
 	// using the corresponding fields in the versionSet (which came from the latest preceding
@@ -1105,7 +1119,7 @@ func findCurrentManifest(
 	return marker, manifestNum, true, nil
 }
 
-func newFileMetrics(newFiles []manifest.NewTableEntry) *levelMetricsDelta {
+func newFileMetrics(newFiles []manifest.NewTableEntry) levelMetricsDelta {
 	var m levelMetricsDelta
 	for _, nf := range newFiles {
 		lm := m[nf.Level]
@@ -1116,5 +1130,5 @@ func newFileMetrics(newFiles []manifest.NewTableEntry) *levelMetricsDelta {
 		lm.NumFiles++
 		lm.Size += int64(nf.Meta.Size)
 	}
-	return &m
+	return m
 }

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -122,13 +122,14 @@ func TestVersionSet(t *testing.T) {
 			}
 
 			mu.Lock()
-			vs.logLock()
-
-			forceRotation := rand.IntN(3) == 0
-			err = vs.logAndApply(
-				0 /* jobID */, ve, fileMetrics, forceRotation,
-				func() []compactionInfo { return nil },
-			)
+			err = vs.UpdateVersionLocked(func() (versionUpdate, error) {
+				return versionUpdate{
+					VE:                      ve,
+					Metrics:                 fileMetrics,
+					ForceManifestRotation:   rand.IntN(3) == 0,
+					InProgressCompactionsFn: func() []compactionInfo { return nil },
+				}, nil
+			})
 			mu.Unlock()
 			if err != nil {
 				td.Fatalf(t, "%v", err)


### PR DESCRIPTION
This commit replaces `logAndApply` with an `UpdateVersionLocked`
function that takes a closure and performs the log "locking" around
that closure. This makes it impossible for a caller to mess up the
locking.

I plan to look at the remaining uses of logLock/logUnlock separately.