### PR TITLE
db: refactor obsolete, zombie file tracking

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2406,7 +2406,7 @@ func (d *DB) cleanupVersionEdit(ve *versionEdit) {
 		// Add this file to zombie tables as well, as the versionSet
 		// asserts on whether every obsolete file was at one point
 		// marked zombie.
-		d.mu.versions.zombieTables[of.DiskFileNum] = objectInfo{
+		d.mu.versions.zombieTables.Add(objectInfo{
 			fileInfo: fileInfo{
 				FileNum:  of.DiskFileNum,
 				FileSize: of.Size,
@@ -2417,7 +2417,7 @@ func (d *DB) cleanupVersionEdit(ve *versionEdit) {
 			// disaggregated storage; if this becomes the norm, we should do
 			// an objprovider lookup here.
 			isLocal: true,
-		}
+		})
 	}
 	d.mu.versions.addObsoleteLocked(obsoleteFiles)
 }
@@ -3025,13 +3025,7 @@ func (d *DB) runCompaction(
 			// Add this file to zombie tables as well, as the versionSet
 			// asserts on whether every obsolete file was at one point
 			// marked zombie.
-			d.mu.versions.zombieTables[backing.DiskFileNum] = objectInfo{
-				fileInfo: fileInfo{
-					FileNum:  backing.DiskFileNum,
-					FileSize: backing.Size,
-				},
-				isLocal: true,
-			}
+			d.mu.versions.zombieTables.AddMetadata(&result.Tables[i].ObjMeta, backing.Size)
 		}
 		d.mu.versions.addObsoleteLocked(obsoleteFiles)
 		d.mu.Unlock()

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -260,11 +260,11 @@ sync: db1/temporary.000460.dbtmp
 close: db1/temporary.000460.dbtmp
 rename: db1/temporary.000460.dbtmp -> db1/OPTIONS-000460
 sync: db1
+remove: db1/OPTIONS-000003
 remove: db1/000123.sst
 remove: db1/000456.sst
 remove: db1/000234.blob
 remove: db1/000345.blob
-remove: db1/OPTIONS-000003
 
 list db1
 ----

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -154,12 +154,12 @@ sync: db
 [JOB 6] compacted(default) L0 [000005 000008] (1.4KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (733B), in 1.0s (3.0s total), output rate 733B/s
 close: db/000005.sst
 close: db/000008.sst
+remove: db/MANIFEST-000006
+[JOB 6] MANIFEST deleted 000006
 remove: db/000005.sst
 [JOB 6] sstable deleted 000005
 remove: db/000008.sst
 [JOB 6] sstable deleted 000008
-remove: db/MANIFEST-000006
-[JOB 6] MANIFEST deleted 000006
 
 disable-file-deletions
 ----

--- a/testdata/version_set
+++ b/testdata/version_set
@@ -120,7 +120,7 @@ current version:
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 no virtual backings
-zombie tables: 000002
+no zombie tables
 obsolete tables: 000002
 
 # Add a virtual table with a new backing (like an ingestion would).
@@ -139,7 +139,7 @@ current version:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 100000:
   000100:  size=100000  useCount=1  protectionCount=0  virtualizedSize=500
-zombie tables: 000002
+no zombie tables
 obsolete tables: 000002
 
 ref-version r1
@@ -151,7 +151,7 @@ current version:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 100000:
   000100:  size=100000  useCount=1  protectionCount=0  virtualizedSize=500
-zombie tables: 000002
+no zombie tables
 obsolete tables: 000002
 
 # Delete a table and backing; but we have a ref on the previous version so the
@@ -167,7 +167,7 @@ current version:
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 no virtual backings
-zombie tables: 000002 000100
+zombie tables: 000100
 obsolete tables: 000002
 
 # The backing is now obsolete.
@@ -177,7 +177,7 @@ current version:
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 no virtual backings
-zombie tables: 000002 000100
+no zombie tables
 obsolete tables: 000002 000100
 
 # Test backing protection mechanism.
@@ -200,7 +200,7 @@ current version:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 101000:
   000101:  size=101000  useCount=2  protectionCount=0  virtualizedSize=1300
-zombie tables: 000002 000100
+no zombie tables
 obsolete tables: 000002 000100
 
 protect-backing 101
@@ -213,7 +213,7 @@ current version:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 101000:
   000101:  size=101000  useCount=2  protectionCount=1  virtualizedSize=1300
-zombie tables: 000002 000100
+no zombie tables
 obsolete tables: 000002 000100
 
 # We should not see a "del-backing" field here.
@@ -230,7 +230,7 @@ current version:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 101000:
   000101:  size=101000  useCount=0  protectionCount=1  virtualizedSize=0
-zombie tables: 000002 000100
+no zombie tables
 obsolete tables: 000002 000100
 
 unprotect-backing 101
@@ -241,7 +241,7 @@ current version:
 1 virtual backings, total size 101000:
   000101:  size=101000  useCount=0  protectionCount=0  virtualizedSize=0
 unused virtual backings: 000101
-zombie tables: 000002 000100
+no zombie tables
 obsolete tables: 000002 000100
 
 # Whatever this next apply is, it should remove the unused backing.
@@ -258,7 +258,7 @@ current version:
   L3:
     000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
 no virtual backings
-zombie tables: 000002 000100 000101
+no zombie tables
 obsolete tables: 000002 000100 000101
 
 # Test handling of leaked protected backings.
@@ -280,7 +280,7 @@ current version:
     000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
 1 virtual backings, total size 102000:
   000102:  size=102000  useCount=1  protectionCount=0  virtualizedSize=900
-zombie tables: 000002 000100 000101
+no zombie tables
 obsolete tables: 000002 000100 000101
 
 protect-backing 102
@@ -294,7 +294,7 @@ current version:
     000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
 1 virtual backings, total size 102000:
   000102:  size=102000  useCount=1  protectionCount=1  virtualizedSize=900
-zombie tables: 000002 000100 000101
+no zombie tables
 obsolete tables: 000002 000100 000101
 
 apply
@@ -310,7 +310,7 @@ current version:
     000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
 1 virtual backings, total size 102000:
   000102:  size=102000  useCount=0  protectionCount=1  virtualizedSize=0
-zombie tables: 000002 000100 000101
+no zombie tables
 obsolete tables: 000002 000100 000101
 
 # Upon reopen, we still have a record of backing 102.
@@ -342,5 +342,5 @@ current version:
     000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
     000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
 no virtual backings
-zombie tables: 000102
+no zombie tables
 obsolete tables: 000102

--- a/version_set.go
+++ b/version_set.go
@@ -81,15 +81,16 @@ type versionSet struct {
 
 	// A pointer to versionSet.addObsoleteLocked. Avoids allocating a new closure
 	// on the creation of every version.
-	obsoleteFn        func(manifest.ObsoleteFiles)
+	obsoleteFn func(manifest.ObsoleteFiles)
+	// obsolete{Tables,Blobs,Manifests,Options} are sorted by file number ascending.
 	obsoleteTables    []objectInfo
 	obsoleteBlobs     []objectInfo
-	obsoleteManifests []fileInfo
-	obsoleteOptions   []fileInfo
+	obsoleteManifests []obsoleteFile
+	obsoleteOptions   []obsoleteFile
 
 	// Zombie tables which have been removed from the current version but are
 	// still referenced by an inuse iterator.
-	zombieTables map[base.DiskFileNum]objectInfo
+	zombieTables zombieObjects
 
 	// virtualBackings contains information about the FileBackings which support
 	// virtual sstables in the latest version. It is mainly used to determine when
@@ -136,13 +137,6 @@ type versionSet struct {
 	pickedCompactionCache pickedCompactionCache
 }
 
-// objectInfo describes an object in object storage (either a sstable or a blob
-// file).
-type objectInfo struct {
-	fileInfo
-	isLocal bool
-}
-
 func (vs *versionSet) init(
 	dirname string,
 	provider objstorage.Provider,
@@ -162,7 +156,7 @@ func (vs *versionSet) init(
 	vs.versions.Init(mu)
 	vs.l0Organizer = manifest.NewL0Organizer(opts.Comparer, opts.FlushSplitBytes)
 	vs.obsoleteFn = vs.addObsoleteLocked
-	vs.zombieTables = make(map[base.DiskFileNum]objectInfo)
+	vs.zombieTables = makeZombieObjects()
 	vs.virtualBackings = manifest.MakeVirtualBackings()
 	vs.nextFileNum.Store(1)
 	vs.manifestMarker = marker
@@ -648,13 +642,13 @@ func (vs *versionSet) logAndApply(
 	// will unref the previous version which could result in addObsoleteLocked
 	// being called.
 	for _, b := range zombieBackings {
-		vs.zombieTables[b.backing.DiskFileNum] = objectInfo{
+		vs.zombieTables.Add(objectInfo{
 			fileInfo: fileInfo{
 				FileNum:  b.backing.DiskFileNum,
 				FileSize: b.backing.Size,
 			},
 			isLocal: b.isLocal,
-		}
+		})
 	}
 
 	// Unref the removed backings and report those that already became obsolete.
@@ -677,9 +671,13 @@ func (vs *versionSet) logAndApply(
 	}
 	if newManifestFileNum != 0 {
 		if vs.manifestFileNum != 0 {
-			vs.obsoleteManifests = append(vs.obsoleteManifests, fileInfo{
-				FileNum:  vs.manifestFileNum,
-				FileSize: prevManifestFileSize,
+			vs.obsoleteManifests = append(vs.obsoleteManifests, obsoleteFile{
+				fileType: base.FileTypeManifest,
+				fs:       vs.fs,
+				path:     base.MakeFilepath(vs.fs, vs.dirname, base.FileTypeManifest, vs.manifestFileNum),
+				fileNum:  vs.manifestFileNum,
+				fileSize: prevManifestFileSize,
+				isLocal:  true,
 			})
 		}
 		vs.manifestFileNum = newManifestFileNum
@@ -1051,38 +1049,14 @@ func (vs *versionSet) addObsoleteLocked(obsolete manifest.ObsoleteFiles) {
 		return
 	}
 
+	// Note that the tables transition from zombie *to* obsolete, and will no
+	// longer be considered zombie.
 	obsoleteFileInfo := make([]objectInfo, len(obsolete.FileBackings))
 	for i, bs := range obsolete.FileBackings {
-		obsoleteFileInfo[i].FileNum = bs.DiskFileNum
-		obsoleteFileInfo[i].FileSize = bs.Size
+		obsoleteFileInfo[i] = vs.zombieTables.Extract(bs.DiskFileNum)
 	}
 
-	if invariants.Enabled {
-		dedup := make(map[base.DiskFileNum]struct{})
-		for _, fi := range obsoleteFileInfo {
-			dedup[fi.FileNum] = struct{}{}
-		}
-		if len(dedup) != len(obsoleteFileInfo) {
-			panic("pebble: duplicate FileBacking present in obsolete list")
-		}
-	}
-
-	for i, fi := range obsoleteFileInfo {
-		// Note that the obsolete tables are no longer zombie by the definition of
-		// zombie, but we leave them in the zombie tables map until they are
-		// deleted from disk.
-		//
-		// TODO(sumeer): this means that the zombie metrics, like ZombieSize,
-		// computed in DB.Metrics are also being counted in the obsolete metrics.
-		// Was this intentional?
-		info, ok := vs.zombieTables[fi.FileNum]
-		if !ok {
-			vs.opts.Logger.Fatalf("MANIFEST obsolete table %s not marked as zombie", fi.FileNum)
-		}
-		obsoleteFileInfo[i].isLocal = info.isLocal
-	}
-
-	vs.obsoleteTables = append(vs.obsoleteTables, obsoleteFileInfo...)
+	vs.obsoleteTables = mergeObjectInfos(vs.obsoleteTables, obsoleteFileInfo)
 	vs.updateObsoleteTableMetricsLocked()
 }
 

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand/v2"
 	"slices"
 	"strconv"
@@ -197,15 +198,12 @@ func TestVersionSet(t *testing.T) {
 			}
 		}
 		buf.WriteString(vs.virtualBackings.String())
-		if len(vs.zombieTables) == 0 {
+		if vs.zombieTables.Count() == 0 {
 			buf.WriteString("no zombie tables\n")
 		} else {
-			var nums []base.DiskFileNum
-			for k := range vs.zombieTables {
-				nums = append(nums, k)
-			}
-			buf.WriteString("zombie tables:")
+			nums := slices.Collect(maps.Keys(vs.zombieTables.objs))
 			slices.Sort(nums)
+			buf.WriteString("zombie tables:")
 			for _, n := range nums {
 				fmt.Fprintf(&buf, " %s", n)
 			}


### PR DESCRIPTION
Add a zombieObjects type for tracking the lifecycle of zombie objects. Today this is used for zombie sstable objects. With the introduction of blob files (#112) we'll also need to track the lifecycle of zombie blob file objects.

Additionally, refactor the lifecycle so that a file is considered either zombie or obsolete but not both. And avoid scanning the list of zombie objects on every call to Metrics, instead incrementally maintaining stats on the zombieObjects type.