### PR TITLE
sstable: use blobtest

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -692,7 +692,6 @@ func runBuildCmd(
 	if err := sstable.ParseWriterOptions(&writeOpts, td.CmdArgs[1:]...); err != nil {
 		return err
 	}
-	var blobReferences blobtest.References
 	f, err := fs.Create(path, vfs.WriteCategoryUnspecified)
 	if err != nil {
 		return err
@@ -706,8 +705,11 @@ func runBuildCmd(
 		v := kv.InPlaceValue()
 		// If the value looks like it's a debug blob handle, parse it and add it
 		// to the sstable as a blob handle.
-		if ddOpts.blobValues != nil && ddOpts.blobValues.IsBlobHandle(string(v)) {
-			handle, err := ddOpts.blobValues.ParseInlineHandle(string(v), &blobReferences)
+		if blobtest.IsBlobHandle(string(v)) {
+			if ddOpts.blobValues == nil {
+				return errors.Newf("test not set up to support blob handles")
+			}
+			handle, _, err := ddOpts.blobValues.ParseInlineHandle(string(v))
 			if err != nil {
 				return err
 			}

--- a/data_test.go
+++ b/data_test.go
@@ -1135,13 +1135,18 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 
 	if len(ve.NewTables) > 0 {
 		// Collect any blob files created.
-		err := blobtest.WriteFiles(&valueSeparator.bv, func(fileNum base.DiskFileNum) (objstorage.Writable, error) {
+		fileStats, err := valueSeparator.bv.WriteFiles(func(fileNum base.DiskFileNum) (objstorage.Writable, error) {
 			writable, _, err := d.objProvider.Create(context.Background(), base.FileTypeBlob, fileNum, objstorage.CreateOptions{})
 			return writable, err
-		}, d.opts.MakeBlobWriterOptions(0), valueSeparator.metas)
+		}, d.opts.MakeBlobWriterOptions(0))
 		if err != nil {
 			return nil, err
 		}
+		for f, stats := range fileStats {
+			valueSeparator.metas[f].Size = stats.FileLen
+			valueSeparator.metas[f].ValueSize = stats.UncompressedValueBytes
+		}
+
 		ve.NewBlobFiles = slices.Collect(maps.Values(valueSeparator.metas))
 
 		jobID := d.newJobIDLocked()

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -107,7 +107,6 @@ func TestIngestLoad(t *testing.T) {
 				return err.Error()
 			}
 			var bv blobtest.Values
-			var br blobtest.References
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writerOpts)
 			for _, data := range strings.Split(td.Input, "\n") {
 				if strings.HasPrefix(data, "Span: ") {
@@ -124,8 +123,8 @@ func TestIngestLoad(t *testing.T) {
 					return fmt.Sprintf("malformed input: %s\n", data)
 				}
 				key := base.ParseInternalKey(data[:j])
-				if bv.IsBlobHandle(data[j+1:]) {
-					ih, err := bv.ParseInlineHandle(data[j+1:], &br)
+				if blobtest.IsBlobHandle(data[j+1:]) {
+					ih, _, err := bv.ParseInlineHandle(data[j+1:])
 					require.NoError(t, err)
 					if err := w.AddWithBlobHandle(key, ih, base.ShortAttribute(0), false /* forceObsolete */); err != nil {
 						return err.Error()

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/blobtest"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
@@ -54,7 +55,8 @@ func runBuildMemObjCmd(
 			_ = w.Close()
 		}
 	}()
-	if err := ParseTestSST(w, td.Input); err != nil {
+	var bv blobtest.Values
+	if err := ParseTestSST(w, td.Input, &bv); err != nil {
 		return nil, nil, err
 	}
 	if err := w.Close(); err != nil {

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -101,11 +101,11 @@ sstable
  │    │    ├── data for column 6 (bool)
  │    │    │    └── 152-153: x 01 # zero bitmap encoding
  │    │    └── 153-154: x 00 # block padding byte
- │    ├── a@2#1,SET:value handle {ValueLen:0 BlockNum:10 OffsetInBlock:1}
- │    ├── b@5#7,SET:value handle {ValueLen:0 BlockNum:200 OffsetInBlock:2}
+ │    ├── a@2#1,SET:blob handle (f0,blk1[10:20])
+ │    ├── b@5#7,SET:blob handle (f0,blk2[110:310])
  │    ├── b@4#3,DEL:
- │    ├── b@3#2,SET:value handle {ValueLen:1 BlockNum:200 OffsetInBlock:0}
- │    ├── b@2#1,SET:value handle {ValueLen:1 BlockNum:103 OffsetInBlock:1}
+ │    ├── b@3#2,SET:blob handle (f1,blk0[0:200])
+ │    ├── b@2#1,SET:blob handle (f1,blk1[294:397])
  │    └── trailer [compression=none checksum=0x834a75d7]
  ├── index  offset: 159  length: 36
  │    ├── 00000    block:0/154

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -1,9 +1,9 @@
 build table-format=Pebble,v6
-a@2.SET.1:blobInlineHandle(0, blk1, 10, 100, 0x07)
-b@5.SET.7:blobInlineHandle(0, blk2, 110, 200, 0x07)
+a@2.SET.1:blob{fileNum=1 blockNum=1 offset=10 valueLen=10}attr=7
+b@5.SET.7:blob{fileNum=1 blockNum=2 offset=110 valueLen=200}attr=7
 b@4.DEL.3:
-b@3.SET.2:blobInlineHandle(1, blk0, 0, 200, 0x07)
-b@2.SET.1:blobInlineHandle(1, blk1, 294, 103, 0x07)
+b@3.SET.2:blob{fileNum=2 blockNum=0 offset=0 valueLen=200}attr=7
+b@2.SET.1:blob{fileNum=2 blockNum=1 offset=294 valueLen=103}attr=7
 ----
 blob-separated-values: num-values 4
 
@@ -88,7 +88,7 @@ sstable
  │    │    │    │    ├── 109-110: x 11 # data[4] = 17 [128 overall]
  │    │    │    │    └── 110-111: x 17 # data[5] = 23 [134 overall]
  │    │    │    └── data
- │    │    │         ├── 111-116: x 470064010a   # data[0]: "G\x00d\x01\n"
+ │    │    │         ├── 111-116: x 47000a010a   # data[0]: "G\x00\n\x01\n"
  │    │    │         ├── 116-122: x 4700c801026e # data[1]: "G\x00\xc8\x01\x02n"
  │    │    │         ├── 122-122: x              # data[2]:
  │    │    │         ├── 122-128: x 6701c8010000 # data[3]: "g\x01\xc8\x01\x00\x00"
@@ -101,12 +101,12 @@ sstable
  │    │    ├── data for column 6 (bool)
  │    │    │    └── 152-153: x 01 # zero bitmap encoding
  │    │    └── 153-154: x 00 # block padding byte
- │    ├── a@2#1,SET:value handle {ValueLen:0 BlockNum:100 OffsetInBlock:1}
+ │    ├── a@2#1,SET:value handle {ValueLen:0 BlockNum:10 OffsetInBlock:1}
  │    ├── b@5#7,SET:value handle {ValueLen:0 BlockNum:200 OffsetInBlock:2}
  │    ├── b@4#3,DEL:
  │    ├── b@3#2,SET:value handle {ValueLen:1 BlockNum:200 OffsetInBlock:0}
  │    ├── b@2#1,SET:value handle {ValueLen:1 BlockNum:103 OffsetInBlock:1}
- │    └── trailer [compression=none checksum=0x196b9b28]
+ │    └── trailer [compression=none checksum=0x834a75d7]
  ├── index  offset: 159  length: 36
  │    ├── 00000    block:0/154
  │    │   
@@ -134,7 +134,7 @@ sstable
  │    ├── 00547    rocksdb.raw.value.size (15)
  │    ├── restart points
  │    │    └── 00562 [restart 0]
- │    └── trailer [compression=none checksum=0xaaf4ac72]
+ │    └── trailer [compression=none checksum=0x2ff97e5d]
  ├── meta-index  offset: 775  length: 46
  │    ├── 0000    rocksdb.properties block:200/570
  │    │   

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/blobtest"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
@@ -176,7 +177,8 @@ func runDataDriven(t *testing.T, file string, tableFormat TableFormat) {
 			return ""
 
 		case "write-kvs":
-			if err := ParseTestSST(w, td.Input); err != nil {
+			var bv blobtest.Values
+			if err := ParseTestSST(w, td.Input, &bv); err != nil {
 				return err.Error()
 			}
 			return fmt.Sprintf("EstimatedSize()=%d", w.EstimatedSize())


### PR DESCRIPTION
#### blobtest: don't depend on manifest

Minor refactor so `blobtest` doesn't depend on `manifest` and can be
used from `sstable`.

#### sstable: use blobtest

Use blobtest and replace the one-off `blobInlineHandle` parsing.