### PR TITLE
rowblk: raise max block size to 1<<31; error rather than panic

### DIFF
--- a/cockroachkvs/rowblk_bench_test.go
+++ b/cockroachkvs/rowblk_bench_test.go
@@ -42,8 +42,11 @@ func benchmarkCockroachDataRowBlockWriter(b *testing.B, keyConfig KeyGenConfig, 
 			if j > 0 {
 				samePrefix = bytes.Equal(keys[j], keys[j-1])
 			}
-			w.AddWithOptionalValuePrefix(
+			err := w.AddWithOptionalValuePrefix(
 				ik, false, values[j], prevKeyLen, true, block.InPlaceValuePrefix(samePrefix), samePrefix)
+			if err != nil {
+				b.Fatalf("error adding key: %v", err)
+			}
 			j++
 			prevKeyLen = len(ik.UserKey)
 		}
@@ -75,8 +78,11 @@ func benchmarkCockroachDataRowBlockIter(b *testing.B, keyConfig KeyGenConfig, va
 		if count > 0 {
 			samePrefix = bytes.Equal(keys[count], keys[count-1])
 		}
-		w.AddWithOptionalValuePrefix(
+		err := w.AddWithOptionalValuePrefix(
 			ik, false, values[count], prevKeyLen, true, block.InPlaceValuePrefix(samePrefix), samePrefix)
+		if err != nil {
+			b.Fatalf("error adding key: %v", err)
+		}
 		count++
 		prevKeyLen = len(ik.UserKey)
 	}

--- a/options.go
+++ b/options.go
@@ -450,8 +450,8 @@ func (o *LevelOptions) EnsureDefaults() {
 	}
 	if o.BlockSize <= 0 {
 		o.BlockSize = base.DefaultBlockSize
-	} else if o.BlockSize > sstable.MaximumBlockSize {
-		panic(errors.Errorf("BlockSize %d exceeds MaximumBlockSize", o.BlockSize))
+	} else if o.BlockSize > sstable.MaximumRestartOffset {
+		panic(errors.Errorf("BlockSize %d exceeds MaximumRestartOffset", o.BlockSize))
 	}
 	if o.BlockSizeThreshold <= 0 {
 		o.BlockSizeThreshold = base.DefaultBlockSizeThreshold

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1015,7 +1015,9 @@ func (w *RawColumnWriter) Close() (err error) {
 		// reduces table size without a significant impact on performance.
 		raw.RestartInterval = propertiesBlockRestartInterval
 		w.props.CompressionOptions = rocksDBCompressionOptions
-		w.props.save(w.opts.TableFormat, &raw)
+		if err := w.props.save(w.opts.TableFormat, &raw); err != nil {
+			return err
+		}
 		if _, err := w.layout.WritePropertiesBlock(raw.Finish()); err != nil {
 			return err
 		}

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	// MaximumBlockSize is the maximum permissible size of a block.
-	MaximumBlockSize = rowblk.MaximumSize
+	// MaximumRestartOffset is the maximum permissible size of a block.
+	MaximumRestartOffset = rowblk.MaximumRestartOffset
 	// DefaultNumDeletionsThreshold defines the minimum number of point
 	// tombstones that must be present in a data block for it to be
 	// considered tombstone-dense.

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -342,7 +342,7 @@ func (p *Properties) saveString(m map[string][]byte, offset uintptr, value strin
 	m[propOffsetTagMap[offset]] = []byte(value)
 }
 
-func (p *Properties) save(tblFormat TableFormat, w *rowblk.Writer) {
+func (p *Properties) save(tblFormat TableFormat, w *rowblk.Writer) error {
 	m := make(map[string][]byte)
 	for k, v := range p.UserProperties {
 		m[k] = []byte(v)
@@ -444,8 +444,11 @@ func (p *Properties) save(tblFormat TableFormat, w *rowblk.Writer) {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		w.AddRawString(key, m[key])
+		if err := w.AddRawString(key, m[key]); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 var (

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -103,7 +103,7 @@ func TestPropertiesSave(t *testing.T) {
 		// Check that we can save properties and read them back.
 		var w rowblk.Writer
 		w.RestartInterval = propertiesBlockRestartInterval
-		e.save(TableFormatPebblev2, &w)
+		require.NoError(t, e.save(TableFormatPebblev2, &w))
 		var props Properties
 
 		require.NoError(t, props.load(w.Finish(), make(map[string]struct{})))
@@ -130,7 +130,7 @@ func TestPropertiesSave(t *testing.T) {
 func BenchmarkPropertiesLoad(b *testing.B) {
 	var w rowblk.Writer
 	w.RestartInterval = propertiesBlockRestartInterval
-	testProps.save(TableFormatPebblev2, &w)
+	require.NoError(b, testProps.save(TableFormatPebblev2, &w))
 	block := w.Finish()
 
 	b.ResetTimer()

--- a/sstable/rowblk/rowblk_bench_test.go
+++ b/sstable/rowblk/rowblk_bench_test.go
@@ -56,7 +56,9 @@ func createBenchBlock(
 	for i := 0; w.EstimatedSize() < blockSize; i++ {
 		key := []byte(fmt.Sprintf("%s%05d%s", string(writtenPrefix), i, origSuffix))
 		ikey.UserKey = key
-		w.Add(ikey, nil)
+		if err := w.Add(ikey, nil); err != nil {
+			panic(err)
+		}
 		var readKey []byte
 		if withSyntheticPrefix {
 			readKey = append(readKey, benchPrefix...)

--- a/sstable/rowblk/rowblk_fragment_iter_test.go
+++ b/sstable/rowblk/rowblk_fragment_iter_test.go
@@ -57,8 +57,7 @@ func TestBlockFragmentIterator(t *testing.T) {
 			// Range del or range key blocks always use restart interval 1.
 			w := Writer{RestartInterval: 1}
 			emitFn := func(k base.InternalKey, v []byte) error {
-				w.Add(k, v)
-				return nil
+				return w.Add(k, v)
 			}
 			for _, s := range spans {
 				if s.Keys[0].Kind() == base.InternalKeyKindRangeDelete {

--- a/sstable/rowblk/rowblk_iter_test.go
+++ b/sstable/rowblk/rowblk_iter_test.go
@@ -16,6 +16,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/itertest"
@@ -124,7 +125,7 @@ func TestBlockIter2(t *testing.T) {
 				case "build":
 					w := &Writer{RestartInterval: r}
 					for _, e := range strings.Split(strings.TrimSpace(d.Input), ",") {
-						w.Add(makeIkey(e), nil)
+						require.NoError(t, w.Add(makeIkey(e), nil))
 					}
 					blk = w.Finish()
 					return ""
@@ -156,7 +157,7 @@ func TestBlockIterKeyStability(t *testing.T) {
 		[]byte("banana"),
 	}
 	for i := range expected {
-		w.Add(base.InternalKey{UserKey: expected[i]}, nil)
+		require.NoError(t, w.Add(base.InternalKey{UserKey: expected[i]}, nil))
 	}
 	blk := w.Finish()
 
@@ -214,7 +215,7 @@ func TestBlockIterReverseDirections(t *testing.T) {
 		[]byte("carrot"),
 	}
 	for i := range keys {
-		w.Add(base.InternalKey{UserKey: keys[i]}, nil)
+		require.NoError(t, w.Add(base.InternalKey{UserKey: keys[i]}, nil))
 	}
 	blk := w.Finish()
 
@@ -468,10 +469,12 @@ func TestBlockSyntheticSuffix(t *testing.T) {
 }
 
 func TestSingularKVBlockRestartsOverflow(t *testing.T) {
-
 	_, isCI := os.LookupEnv("CI")
 	if isCI {
 		t.Skip("Skipping test: requires too much memory for CI now.")
+	}
+	if buildtags.SlowBuild {
+		t.Skip("Skipping test: requires too much memory for instrumented builds")
 	}
 
 	// Test that SeekGE() and SeekLT() function correctly
@@ -483,14 +486,14 @@ func TestSingularKVBlockRestartsOverflow(t *testing.T) {
 		t.Skip("Skipping test: not supported on 32-bit architecture")
 	}
 
-	var largeKeySize int64 = 2 << 30   // 2GB key size
-	var largeValueSize int64 = 2 << 30 // 2GB value size
+	const largeKeySize = 2 << 30   // 2GB key size
+	const largeValueSize = 2 << 30 // 2GB value size
 
-	largeKey := bytes.Repeat([]byte("k"), int(largeKeySize))
-	largeValue := bytes.Repeat([]byte("v"), int(largeValueSize))
+	largeKey := bytes.Repeat([]byte("k"), largeKeySize)
+	largeValue := bytes.Repeat([]byte("v"), largeValueSize)
 
 	writer := &Writer{RestartInterval: 1}
-	writer.Add(base.InternalKey{UserKey: largeKey}, largeValue)
+	require.NoError(t, writer.Add(base.InternalKey{UserKey: largeKey}, largeValue))
 	blockData := writer.Finish()
 	iter, err := NewIter(bytes.Compare, nil, nil, blockData, block.NoTransforms)
 	require.NoError(t, err, "failed to create iterator for block")
@@ -514,26 +517,30 @@ func TestSingularKVBlockRestartsOverflow(t *testing.T) {
 	require.Equal(t, largeValue, kv.InPlaceValue(), "unexpected value")
 }
 
-func TestBufferExceeding256MBShouldPanic(t *testing.T) {
-
+// TestExceedingMaximumRestartOffset tests that writing a block that exceeds the
+// maximum restart offset errors.
+func TestExceedingMaximumRestartOffset(t *testing.T) {
 	_, isCI := os.LookupEnv("CI")
 	if isCI {
 		t.Skip("Skipping test: requires too much memory for CI now.")
 	}
+	if buildtags.SlowBuild {
+		t.Skip("Skipping test: requires too much memory for instrumented builds")
+	}
 
-	// Test that writing to a block that is already >= 256MiB
+	// Test that writing to a block that is already >= 2GiB
 	// causes a panic to occur.
-
+	//
 	// Skip this test on 32-bit architectures because they may not
 	// have sufficient memory to reliably execute this test.
 	if runtime.GOARCH == "386" || runtime.GOARCH == "arm" || strconv.IntSize == 32 {
 		t.Skip("Skipping test: not supported on 32-bit architecture")
 	}
 
-	// Adding 64 KVs each with size 4MiB will create a block
-	// size of >= ~256MiB
-	const numKVs = 64
-	const valueSize = (1 << 20) * 4
+	// Adding 512 KVs each with size 4MiB will create a block
+	// size of >= 2GiB.
+	const numKVs = 512
+	const valueSize = (4 << 20)
 
 	type KVTestPair struct {
 		key   []byte
@@ -546,36 +553,34 @@ func TestBufferExceeding256MBShouldPanic(t *testing.T) {
 		key := fmt.Sprintf("key-%04d", i)
 		KVTestPairs[i] = KVTestPair{key: []byte(key), value: value4MB}
 	}
-
 	writer := &Writer{RestartInterval: 1}
 	for _, KVPair := range KVTestPairs {
-		writer.Add(base.InternalKey{UserKey: KVPair.key}, KVPair.value)
+		require.NoError(t, writer.Add(base.InternalKey{UserKey: KVPair.key}, KVPair.value))
 	}
 
-	// Check that buffer is larger than 256MiB
-	require.Greater(t, len(writer.buf), MaximumSize)
+	// Check that buffer is larger than 2GiB.
+	require.Greater(t, len(writer.buf), MaximumRestartOffset)
 
-	// Check that a panic has occurred after the final write after the 256MiB
+	// Check that an error is returned after the final write after the 2GiB
 	// threshold has been crossed
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected panic on the last write, but none occurred")
-		}
-	}()
-	writer.Add(base.InternalKey{UserKey: []byte("arbitrary-last-key")}, []byte("arbitrary-last-value"))
+	err := writer.Add(base.InternalKey{UserKey: []byte("arbitrary-last-key")}, []byte("arbitrary-last-value"))
+	require.NotNil(t, err)
+	require.True(t, errors.Is(err, ErrBlockTooBig))
 }
 
 // TestMultipleKVBlockRestartsOverflow tests that SeekGE() works when
 // iter.restarts is greater than math.MaxUint32 for multiple KVs. Test writes
-// <256MiB to the block and then 4GiB causing iter.restarts to be an int >
-// math.MaxUint32. Reaching just shy of 256MiB before adding 4GiB allows the
-// final write to succeed without surpassing 256MiB limit. Then verify that
+// <2GiB to the block and then 4GiB causing iter.restarts to be an int >
+// math.MaxUint32. Reaching just shy of 2GiB before adding 4GiB allows the
+// final write to succeed without surpassing 2GiB limit. Then verify that
 // SeekGE() returns valid output without integer overflow.
+//
+// Although the block exceeds math.MaxUint32 bytes, no individual KV pair has an
+// offset that exceeds MaximumRestartOffset.
 func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
 	if _, isCI := os.LookupEnv("CI"); isCI {
 		t.Skip("Skipping test: requires too much memory for CI.")
 	}
-
 	if buildtags.SlowBuild {
 		t.Skip("Skipping test: requires too much memory for instrumented builds")
 	}
@@ -586,10 +591,10 @@ func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
 		t.Skip("Skipping test: not supported on 32-bit architecture")
 	}
 
-	// Write just shy of 256MiB to the block 63 * 4MiB < 256MiB
-	const numKVs = 63
+	// Write just shy of 2GiB to the block 511 * 4MiB < 2GiB.
+	const numKVs = 511
 	const valueSize = 4 * (1 << 20)
-	var FourGB int64 = 4 * (1 << 30)
+	const fourGB = 4 * (1 << 30)
 
 	type KVTestPair struct {
 		key   []byte
@@ -611,17 +616,17 @@ func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
 	// Add the 4GiB KV, causing iter.restarts >= math.MaxUint32.
 	// Ensure that SeekGE() works thereafter without integer
 	// overflows.
-	writer.Add(base.InternalKey{UserKey: []byte("large-kv")}, []byte(strings.Repeat("v", int(FourGB))))
+	writer.Add(base.InternalKey{UserKey: []byte("large-kv")}, bytes.Repeat([]byte("v"), fourGB))
 
 	blockData := writer.Finish()
 	iter, err := NewIter(bytes.Compare, nil, nil, blockData, block.NoTransforms)
 	require.NoError(t, err, "failed to create iterator for block")
-	require.Greater(t, int64(iter.restarts), int64(MaximumSize), "check iter.restarts > 256MiB")
+	require.Greater(t, int64(iter.restarts), int64(MaximumRestartOffset), "check iter.restarts > 2GiB")
 	require.Greater(t, int64(iter.restarts), int64(math.MaxUint32), "check iter.restarts > 2^32-1")
 
 	for i := 0; i < numKVs; i++ {
 		key := []byte(fmt.Sprintf("key-%04d", i))
-		value := []byte(strings.Repeat("a", valueSize))
+		value := bytes.Repeat([]byte("a"), valueSize)
 		kv := iter.SeekGE(key, base.SeekGEFlagsNone)
 		require.NotNil(t, kv, "failed to find the large key")
 		require.Equal(t, key, kv.K.UserKey, "unexpected key")

--- a/sstable/rowblk/rowblk_rewrite.go
+++ b/sstable/rowblk/rowblk_rewrite.go
@@ -82,7 +82,9 @@ func (r *Rewriter) RewriteSuffixes(
 		if invariants.Enabled && invariants.Sometimes(10) {
 			r.comparer.ValidateKey.MustValidate(r.scratchKey.UserKey)
 		}
-		r.writer.Add(r.scratchKey, v)
+		if err := r.writer.Add(r.scratchKey, v); err != nil {
+			return base.InternalKey{}, base.InternalKey{}, nil, err
+		}
 		if start.UserKey == nil {
 			// Copy the first key.
 			start.Trailer = r.scratchKey.Trailer

--- a/sstable/rowblk/rowblk_writer.go
+++ b/sstable/rowblk/rowblk_writer.go
@@ -15,10 +15,13 @@ import (
 )
 
 const (
-	// MaximumSize is an extremely generous maximum block size of 256MiB. We
-	// explicitly place this limit to reserve a few bits in the restart for internal
-	// use.
-	MaximumSize = 1 << 28
+	// MaximumRestartOffset indicates the maximum offset that we can encode
+	// within a restart point of a row-oriented block. The last bit is reserved
+	// for the setHasSameKeyPrefixSinceLastRestart flag within a restart point.
+	// If a block exceeds this size and we attempt to add another KV pair, the
+	// restart points table will be unable to express the position of the pair,
+	// resulting in undefined behavior and arbitrary corruption.
+	MaximumRestartOffset = 1 << 31
 	// EmptySize holds the size of an empty block. Every block ends in a uint32
 	// trailer encoding the number of restart points within the block.
 	EmptySize = 4
@@ -37,6 +40,9 @@ const (
 	// key trailer.
 	TrailerObsoleteMask = (base.InternalKeyTrailer(base.SeqNumMax) << 8) | base.InternalKeyTrailer(base.InternalKeyKindSSTableInternalObsoleteMask)
 )
+
+// ErrBlockTooBig is surfaced when a block exceeds the maximum size.
+var ErrBlockTooBig = errors.New("rowblk: block size exceeds maximum size")
 
 // Writer buffers and serializes key/value pairs into a row-oriented block.
 type Writer struct {
@@ -126,11 +132,12 @@ func (w *Writer) storeWithOptionalValuePrefix(
 	addValuePrefix bool,
 	valuePrefix block.ValuePrefix,
 	setHasSameKeyPrefix bool,
-) {
-	// Ensure that the block size does not exceed rowblk.MaximumSize before writing more data
-	if len(w.buf) >= MaximumSize {
-		panic(errors.AssertionFailedf("rowblk: adding KV to %d-block; already exceeds %d-byte maximum",
-			len(w.buf), MaximumSize))
+) error {
+	// Check that the block does not already exceed MaximumRestartOffset. If it
+	// does and we append the additional key-value pair, the new key-value pair's
+	// offset in the block will be inexpressible as a restart point.
+	if len(w.buf) >= MaximumRestartOffset {
+		return errors.WithDetailf(ErrBlockTooBig, "block is %d bytes long", len(w.buf))
 	}
 
 	shared := 0
@@ -232,11 +239,12 @@ func (w *Writer) storeWithOptionalValuePrefix(
 	w.curValue = w.buf[n-len(value):]
 
 	w.nEntries++
+	return nil
 }
 
 // Add adds a key value pair to the block without a value prefix.
-func (w *Writer) Add(key base.InternalKey, value []byte) {
-	w.AddWithOptionalValuePrefix(
+func (w *Writer) Add(key base.InternalKey, value []byte) error {
+	return w.AddWithOptionalValuePrefix(
 		key, false, value, len(key.UserKey), false, 0, false)
 }
 
@@ -260,7 +268,7 @@ func (w *Writer) AddWithOptionalValuePrefix(
 	addValuePrefix bool,
 	valuePrefix block.ValuePrefix,
 	setHasSameKeyPrefix bool,
-) {
+) error {
 	w.curKey, w.prevKey = w.prevKey, w.curKey
 
 	size := key.Size()
@@ -273,7 +281,7 @@ func (w *Writer) AddWithOptionalValuePrefix(
 	}
 	key.Encode(w.curKey)
 
-	w.storeWithOptionalValuePrefix(
+	return w.storeWithOptionalValuePrefix(
 		size, value, maxSharedKeyLen, addValuePrefix, valuePrefix, setHasSameKeyPrefix)
 }
 
@@ -312,7 +320,7 @@ func (w *Writer) EstimatedSize() int {
 }
 
 // AddRaw adds a key value pair to the block.
-func (w *Writer) AddRaw(key, value []byte) {
+func (w *Writer) AddRaw(key, value []byte) error {
 	w.curKey, w.prevKey = w.prevKey, w.curKey
 
 	size := len(key)
@@ -321,11 +329,11 @@ func (w *Writer) AddRaw(key, value []byte) {
 	}
 	w.curKey = w.curKey[:size]
 	copy(w.curKey, key)
-	w.storeWithOptionalValuePrefix(
+	return w.storeWithOptionalValuePrefix(
 		size, value, len(key), false, 0, false)
 }
 
 // AddRawString is AddRaw but with a string key.
-func (w *Writer) AddRawString(key string, value []byte) {
-	w.AddRaw(unsafe.Slice(unsafe.StringData(key), len(key)), value)
+func (w *Writer) AddRawString(key string, value []byte) error {
+	return w.AddRaw(unsafe.Slice(unsafe.StringData(key), len(key)), value)
 }

--- a/sstable/rowblk/rowblk_writer_test.go
+++ b/sstable/rowblk/rowblk_writer_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestBlockWriterClear(t *testing.T) {
 	w := Writer{RestartInterval: 16}
-	w.Add(ikey("apple"), nil)
-	w.Add(ikey("apricot"), nil)
-	w.Add(ikey("banana"), nil)
+	require.NoError(t, w.Add(ikey("apple"), nil))
+	require.NoError(t, w.Add(ikey("apricot"), nil))
+	require.NoError(t, w.Add(ikey("banana"), nil))
 
 	w.Reset()
 
@@ -43,9 +43,9 @@ func TestBlockWriterClear(t *testing.T) {
 
 func TestBlockWriter(t *testing.T) {
 	w := &Writer{RestartInterval: 16}
-	w.AddRawString("apple", nil)
-	w.AddRawString("apricot", nil)
-	w.AddRawString("banana", nil)
+	require.NoError(t, w.AddRawString("apple", nil))
+	require.NoError(t, w.AddRawString("apricot", nil))
+	require.NoError(t, w.AddRawString("banana", nil))
 	block := w.Finish()
 
 	expected := []byte(
@@ -69,8 +69,9 @@ func TestBlockWriterWithPrefix(t *testing.T) {
 		addValuePrefix bool,
 		valuePrefix block.ValuePrefix,
 		setHasSameKeyPrefix bool) {
-		w.AddWithOptionalValuePrefix(
+		err := w.AddWithOptionalValuePrefix(
 			key, false, value, len(key.UserKey), addValuePrefix, valuePrefix, setHasSameKeyPrefix)
+		require.NoError(t, err)
 	}
 	addAdapter(
 		ikey("apple"), []byte("red"), false, 0, true)

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -586,8 +586,8 @@ func TestClearDataBlockBuf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	d := newDataBlockBuf(1, block.ChecksumTypeCRC32c)
 	d.blockBuf.dataBuf = make([]byte, 1)
-	d.dataBlock.Add(ikey("apple"), nil)
-	d.dataBlock.Add(ikey("banana"), nil)
+	require.NoError(t, d.dataBlock.Add(ikey("apple"), nil))
+	require.NoError(t, d.dataBlock.Add(ikey("banana"), nil))
 
 	d.clear()
 	testBlockBufClear(t, &d.blockBuf, &blockBuf{})
@@ -598,8 +598,8 @@ func TestClearDataBlockBuf(t *testing.T) {
 func TestClearIndexBlockBuf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	i := newIndexBlockBuf()
-	i.block.Add(ikey("apple"), nil)
-	i.block.Add(ikey("banana"), nil)
+	require.NoError(t, i.block.Add(ikey("apple"), nil))
+	require.NoError(t, i.block.Add(ikey("banana"), nil))
 	i.clear()
 
 	require.Equal(


### PR DESCRIPTION
Relax the maximum block size to reclaim 7-unused bits within the restart offsets. This provides additional leeway for massive blocks we're sometimes forced to construct due to very large key-value pairs. Additionally, this commit turns this check into an error that we propagate up and out of the sstable Writer rather than panicking with an assertion failure. In practice this means a DB that hits this limit may fail a compaction without bringing down the node. The DB may repeat the compaction in a busy loop, but it's possible for the DB to make some forward progress in the meantime.

Future work will look at adapting sstable splitting to split preemptively to avoid the maximum.