### PR TITLE
crl-release-25.1: rowblk: raise max block size to (1<<31)-1; error rather than panic

### DIFF
--- a/cockroachkvs/rowblk_bench_test.go
+++ b/cockroachkvs/rowblk_bench_test.go
@@ -58,8 +58,11 @@ func benchmarkCockroachDataRowBlockWriter(b *testing.B, keyConfig keyGenConfig, 
 			if j > 0 {
 				samePrefix = bytes.Equal(keys[j], keys[j-1])
 			}
-			w.AddWithOptionalValuePrefix(
+			err := w.AddWithOptionalValuePrefix(
 				ik, false, values[j], prevKeyLen, true, block.InPlaceValuePrefix(samePrefix), samePrefix)
+			if err != nil {
+				b.Fatalf("error adding key: %v", err)
+			}
 			j++
 			prevKeyLen = len(ik.UserKey)
 		}
@@ -108,8 +111,11 @@ func benchmarkCockroachDataRowBlockIter(b *testing.B, keyConfig keyGenConfig, va
 		if count > 0 {
 			samePrefix = bytes.Equal(keys[count], keys[count-1])
 		}
-		w.AddWithOptionalValuePrefix(
+		err := w.AddWithOptionalValuePrefix(
 			ik, false, values[count], prevKeyLen, true, block.InPlaceValuePrefix(samePrefix), samePrefix)
+		if err != nil {
+			b.Fatalf("error adding key: %v", err)
+		}
 		count++
 		prevKeyLen = len(ik.UserKey)
 	}

--- a/options.go
+++ b/options.go
@@ -458,8 +458,8 @@ func (o *LevelOptions) EnsureDefaults() *LevelOptions {
 	}
 	if o.BlockSize <= 0 {
 		o.BlockSize = base.DefaultBlockSize
-	} else if o.BlockSize > sstable.MaximumBlockSize {
-		panic(errors.Errorf("BlockSize %d exceeds MaximumBlockSize", o.BlockSize))
+	} else if o.BlockSize > sstable.MaximumRestartOffset {
+		panic(errors.Errorf("BlockSize %d exceeds MaximumRestartOffset", o.BlockSize))
 	}
 	if o.BlockSizeThreshold <= 0 {
 		o.BlockSizeThreshold = base.DefaultBlockSizeThreshold

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -968,7 +968,9 @@ func (w *RawColumnWriter) Close() (err error) {
 		// reduces table size without a significant impact on performance.
 		raw.RestartInterval = propertiesBlockRestartInterval
 		w.props.CompressionOptions = rocksDBCompressionOptions
-		w.props.save(w.opts.TableFormat, &raw)
+		if err := w.props.save(w.opts.TableFormat, &raw); err != nil {
+			return err
+		}
 		if _, err := w.layout.WritePropertiesBlock(raw.Finish()); err != nil {
 			return err
 		}

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -851,7 +851,9 @@ func (w *layoutWriter) Finish() (size uint64, err error) {
 	})
 	bw := rowblk.Writer{RestartInterval: 1}
 	for _, h := range w.handles {
-		bw.AddRaw(unsafe.Slice(unsafe.StringData(h.key), len(h.key)), h.encodedBlockHandle)
+		if err := bw.AddRaw(unsafe.Slice(unsafe.StringData(h.key), len(h.key)), h.encodedBlockHandle); err != nil {
+			return 0, err
+		}
 	}
 	metaIndexHandle, err := w.writeBlock(bw.Finish(), block.NoCompression, &w.buf)
 	if err != nil {

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	// MaximumBlockSize is the maximum permissible size of a block.
-	MaximumBlockSize = rowblk.MaximumSize
+	// MaximumRestartOffset is the maximum permissible value for a restart
+	// offset within a block. That is, the maximum block size that allows adding
+	// an additional restart point.
+	MaximumRestartOffset = rowblk.MaximumRestartOffset
 	// DefaultNumDeletionsThreshold defines the minimum number of point
 	// tombstones that must be present in a data block for it to be
 	// considered tombstone-dense.

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -340,7 +340,7 @@ func (p *Properties) saveString(m map[string][]byte, offset uintptr, value strin
 	m[propOffsetTagMap[offset]] = []byte(value)
 }
 
-func (p *Properties) save(tblFormat TableFormat, w *rowblk.Writer) {
+func (p *Properties) save(tblFormat TableFormat, w *rowblk.Writer) error {
 	m := make(map[string][]byte)
 	for k, v := range p.UserProperties {
 		m[k] = []byte(v)
@@ -439,6 +439,9 @@ func (p *Properties) save(tblFormat TableFormat, w *rowblk.Writer) {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		w.AddRawString(key, m[key])
+		if err := w.AddRawString(key, m[key]); err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -103,7 +103,7 @@ func TestPropertiesSave(t *testing.T) {
 		// Check that we can save properties and read them back.
 		var w rowblk.Writer
 		w.RestartInterval = propertiesBlockRestartInterval
-		e.save(TableFormatPebblev2, &w)
+		require.NoError(t, e.save(TableFormatPebblev2, &w))
 		var props Properties
 
 		require.NoError(t, props.load(w.Finish(), make(map[string]struct{})))
@@ -130,7 +130,7 @@ func TestPropertiesSave(t *testing.T) {
 func BenchmarkPropertiesLoad(b *testing.B) {
 	var w rowblk.Writer
 	w.RestartInterval = propertiesBlockRestartInterval
-	testProps.save(TableFormatPebblev2, &w)
+	require.NoError(b, testProps.save(TableFormatPebblev2, &w))
 	block := w.Finish()
 
 	b.ResetTimer()

--- a/sstable/rowblk/rowblk_bench_test.go
+++ b/sstable/rowblk/rowblk_bench_test.go
@@ -56,7 +56,9 @@ func createBenchBlock(
 	for i := 0; w.EstimatedSize() < blockSize; i++ {
 		key := []byte(fmt.Sprintf("%s%05d%s", string(writtenPrefix), i, origSuffix))
 		ikey.UserKey = key
-		w.Add(ikey, nil)
+		if err := w.Add(ikey, nil); err != nil {
+			panic(err)
+		}
 		var readKey []byte
 		if withSyntheticPrefix {
 			readKey = append(readKey, benchPrefix...)

--- a/sstable/rowblk/rowblk_fragment_iter_test.go
+++ b/sstable/rowblk/rowblk_fragment_iter_test.go
@@ -55,8 +55,7 @@ func TestBlockFragmentIterator(t *testing.T) {
 			// Range del or range key blocks always use restart interval 1.
 			w := Writer{RestartInterval: 1}
 			emitFn := func(k base.InternalKey, v []byte) error {
-				w.Add(k, v)
-				return nil
+				return w.Add(k, v)
 			}
 			for _, s := range spans {
 				if s.Keys[0].Kind() == base.InternalKeyKindRangeDelete {

--- a/sstable/rowblk/rowblk_iter_test.go
+++ b/sstable/rowblk/rowblk_iter_test.go
@@ -16,6 +16,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/itertest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
@@ -123,7 +124,7 @@ func TestBlockIter2(t *testing.T) {
 				case "build":
 					w := &Writer{RestartInterval: r}
 					for _, e := range strings.Split(strings.TrimSpace(d.Input), ",") {
-						w.Add(makeIkey(e), nil)
+						require.NoError(t, w.Add(makeIkey(e), nil))
 					}
 					blk = w.Finish()
 					return ""
@@ -155,7 +156,7 @@ func TestBlockIterKeyStability(t *testing.T) {
 		[]byte("banana"),
 	}
 	for i := range expected {
-		w.Add(base.InternalKey{UserKey: expected[i]}, nil)
+		require.NoError(t, w.Add(base.InternalKey{UserKey: expected[i]}, nil))
 	}
 	blk := w.Finish()
 
@@ -213,7 +214,7 @@ func TestBlockIterReverseDirections(t *testing.T) {
 		[]byte("carrot"),
 	}
 	for i := range keys {
-		w.Add(base.InternalKey{UserKey: keys[i]}, nil)
+		require.NoError(t, w.Add(base.InternalKey{UserKey: keys[i]}, nil))
 	}
 	blk := w.Finish()
 
@@ -284,8 +285,8 @@ func TestBlockSyntheticPrefix(t *testing.T) {
 					"pear", "persimmon",
 				}
 				for _, k := range keys {
-					elidedPrefixWriter.Add(ikey(k), nil)
-					includedPrefixWriter.Add(ikey(prefix+k), nil)
+					require.NoError(t, elidedPrefixWriter.Add(ikey(k), nil))
+					require.NoError(t, includedPrefixWriter.Add(ikey(prefix+k), nil))
 				}
 
 				elidedPrefixBlock, includedPrefixBlock := elidedPrefixWriter.Finish(), includedPrefixWriter.Finish()
@@ -466,8 +467,12 @@ func TestBlockSyntheticSuffix(t *testing.T) {
 	}
 }
 
+// TestSingularKVBlockRestartsOverflow tests a scenario where a large key-value
+// pair is written to a block, such that the total block size exceeds 4GiB. This
+// works becasue the restart table never needs to encode a restart offset beyond
+// the 1st key-value pair. The offset of the restarts table itself may exceed
+// 2^32-1 but the iterator takes care to support this.
 func TestSingularKVBlockRestartsOverflow(t *testing.T) {
-
 	_, isCI := os.LookupEnv("CI")
 	if isCI {
 		t.Skip("Skipping test: requires too much memory for CI now.")
@@ -484,12 +489,11 @@ func TestSingularKVBlockRestartsOverflow(t *testing.T) {
 
 	var largeKeySize int64 = 2 << 30   // 2GB key size
 	var largeValueSize int64 = 2 << 30 // 2GB value size
-
 	largeKey := bytes.Repeat([]byte("k"), int(largeKeySize))
 	largeValue := bytes.Repeat([]byte("v"), int(largeValueSize))
 
 	writer := &Writer{RestartInterval: 1}
-	writer.Add(base.InternalKey{UserKey: largeKey}, largeValue)
+	require.NoError(t, writer.Add(base.InternalKey{UserKey: largeKey}, largeValue))
 	blockData := writer.Finish()
 	iter, err := NewIter(bytes.Compare, nil, nil, blockData, block.NoTransforms)
 	require.NoError(t, err, "failed to create iterator for block")
@@ -501,7 +505,7 @@ func TestSingularKVBlockRestartsOverflow(t *testing.T) {
 	// Ensure that SeekGE() finds the correct KV
 	require.NotNil(t, kv, "failed to find the key")
 	require.Equal(t, largeKey, kv.K.UserKey, "unexpected key")
-	require.Equal(t, largeValue, kv.V.ValueOrHandle, "unexpected value")
+	require.Equal(t, largeValue, kv.InPlaceValue(), "unexpected value")
 
 	// Ensure that SeekGE() does not raise panic due to integer overflow
 	// indexing problems.
@@ -510,29 +514,30 @@ func TestSingularKVBlockRestartsOverflow(t *testing.T) {
 	// Ensure that SeekLT() finds the correct KV
 	require.NotNil(t, kv, "failed to find the key")
 	require.Equal(t, largeKey, kv.K.UserKey, "unexpected key")
-	require.Equal(t, largeValue, kv.V.ValueOrHandle, "unexpected value")
+	require.Equal(t, largeValue, kv.InPlaceValue(), "unexpected value")
 }
 
-func TestBufferExceeding256MBShouldPanic(t *testing.T) {
-
+// TestExceedingMaximumRestartOffset tests that writing a block that exceeds the
+// maximum restart offset errors.
+func TestExceedingMaximumRestartOffset(t *testing.T) {
 	_, isCI := os.LookupEnv("CI")
 	if isCI {
 		t.Skip("Skipping test: requires too much memory for CI now.")
 	}
 
-	// Test that writing to a block that is already >= 256MiB
-	// causes a panic to occur.
-
+	// Test that writing to a block that is already >= 2GiB
+	// returns an error.
+	//
 	// Skip this test on 32-bit architectures because they may not
 	// have sufficient memory to reliably execute this test.
 	if runtime.GOARCH == "386" || runtime.GOARCH == "arm" || strconv.IntSize == 32 {
 		t.Skip("Skipping test: not supported on 32-bit architecture")
 	}
 
-	// Adding 64 KVs each with size 4MiB will create a block
-	// size of >= ~256MiB
-	const numKVs = 64
-	const valueSize = (1 << 20) * 4
+	// Adding 512 KVs each with size 4MiB will create a block
+	// size of >= 2GiB.
+	const numKVs = 512
+	const valueSize = (4 << 20)
 
 	type KVTestPair struct {
 		key   []byte
@@ -545,40 +550,34 @@ func TestBufferExceeding256MBShouldPanic(t *testing.T) {
 		key := fmt.Sprintf("key-%04d", i)
 		KVTestPairs[i] = KVTestPair{key: []byte(key), value: value4MB}
 	}
-
 	writer := &Writer{RestartInterval: 1}
 	for _, KVPair := range KVTestPairs {
-		writer.Add(base.InternalKey{UserKey: KVPair.key}, KVPair.value)
+		require.NoError(t, writer.Add(base.InternalKey{UserKey: KVPair.key}, KVPair.value))
 	}
 
-	// Check that buffer is larger than 256MiB
-	require.Greater(t, len(writer.buf), MaximumSize)
+	// Check that buffer is larger than 2GiB.
+	require.Greater(t, len(writer.buf), MaximumRestartOffset)
 
-	// Check that a panic has occurred after the final write after the 256MiB
+	// Check that an error is returned after the final write after the 2GiB
 	// threshold has been crossed
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected panic on the last write, but none occurred")
-		}
-	}()
-	writer.Add(base.InternalKey{UserKey: []byte("arbitrary-last-key")}, []byte("arbitrary-last-value"))
+	err := writer.Add(base.InternalKey{UserKey: []byte("arbitrary-last-key")}, []byte("arbitrary-last-value"))
+	require.NotNil(t, err)
+	require.True(t, errors.Is(err, ErrBlockTooBig))
 }
 
+// TestMultipleKVBlockRestartsOverflow tests that SeekGE() works when
+// iter.restarts is greater than math.MaxUint32 for multiple KVs. Test writes
+// <2GiB to the block and then 4GiB causing iter.restarts to be an int >
+// math.MaxUint32. Reaching just shy of 2GiB before adding 4GiB allows the
+// final write to succeed without surpassing 2GiB limit. Then verify that
+// SeekGE() returns valid output without integer overflow.
+//
+// Although the block exceeds math.MaxUint32 bytes, no individual KV pair has an
+// offset that exceeds MaximumRestartOffset.
 func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
-
-	_, isCI := os.LookupEnv("CI")
-	if isCI {
-		t.Skip("Skipping test: requires too much memory for CI now.")
+	if _, isCI := os.LookupEnv("CI"); isCI {
+		t.Skip("Skipping test: requires too much memory for CI.")
 	}
-
-	// Tests that SeekGE() works when iter.restarts is
-	// greater than math.MaxUint32 for multiple KVs.
-	// Test writes < 256MiB to the block and then 4GiB
-	// causing iter.restarts will be an int > math.MaxUint32.
-	// Reaching just shy of 256MiB before adding 4GiB allows
-	// the final write to succeed without surpassing 256MiB
-	// limit.  Then test whether SeekGE() will return valid
-	// output without integer overflow.
 
 	// Skip this test on 32-bit architectures because they may not
 	// have sufficient memory to reliably execute this test.
@@ -586,10 +585,10 @@ func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
 		t.Skip("Skipping test: not supported on 32-bit architecture")
 	}
 
-	// Write just shy of 256MiB to the block 63 * 4MiB < 256MiB
-	const numKVs = 63
+	// Write just shy of 2GiB to the block 511 * 4MiB < 2GiB.
+	const numKVs = 511
 	const valueSize = 4 * (1 << 20)
-	var FourGB int64 = 4 * (1 << 30)
+	var fourGB int64 = 4 * (1 << 30)
 
 	type KVTestPair struct {
 		key   []byte
@@ -611,21 +610,21 @@ func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
 	// Add the 4GiB KV, causing iter.restarts >= math.MaxUint32.
 	// Ensure that SeekGE() works thereafter without integer
 	// overflows.
-	writer.Add(base.InternalKey{UserKey: []byte("large-kv")}, []byte(strings.Repeat("v", int(FourGB))))
+	writer.Add(base.InternalKey{UserKey: []byte("large-kv")}, bytes.Repeat([]byte("v"), int(fourGB)))
 
 	blockData := writer.Finish()
 	iter, err := NewIter(bytes.Compare, nil, nil, blockData, block.NoTransforms)
 	require.NoError(t, err, "failed to create iterator for block")
-	require.Greater(t, int64(iter.restarts), int64(MaximumSize), "check iter.restarts > 256MiB")
+	require.Greater(t, int64(iter.restarts), int64(MaximumRestartOffset), "check iter.restarts > 2GiB")
 	require.Greater(t, int64(iter.restarts), int64(math.MaxUint32), "check iter.restarts > 2^32-1")
 
 	for i := 0; i < numKVs; i++ {
 		key := []byte(fmt.Sprintf("key-%04d", i))
-		value := []byte(strings.Repeat("a", valueSize))
+		value := bytes.Repeat([]byte("a"), valueSize)
 		kv := iter.SeekGE(key, base.SeekGEFlagsNone)
 		require.NotNil(t, kv, "failed to find the large key")
 		require.Equal(t, key, kv.K.UserKey, "unexpected key")
-		require.Equal(t, value, kv.V.ValueOrHandle, "unexpected value")
+		require.Equal(t, value, kv.InPlaceValue(), "unexpected value")
 	}
 }
 

--- a/sstable/rowblk/rowblk_rewrite.go
+++ b/sstable/rowblk/rowblk_rewrite.go
@@ -82,7 +82,9 @@ func (r *Rewriter) RewriteSuffixes(
 		if invariants.Enabled && invariants.Sometimes(10) {
 			r.comparer.ValidateKey.MustValidate(r.scratchKey.UserKey)
 		}
-		r.writer.Add(r.scratchKey, v)
+		if err := r.writer.Add(r.scratchKey, v); err != nil {
+			return base.InternalKey{}, base.InternalKey{}, nil, err
+		}
 		if start.UserKey == nil {
 			// Copy the first key.
 			start.Trailer = r.scratchKey.Trailer

--- a/sstable/rowblk/rowblk_writer_test.go
+++ b/sstable/rowblk/rowblk_writer_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestBlockWriterClear(t *testing.T) {
 	w := Writer{RestartInterval: 16}
-	w.Add(ikey("apple"), nil)
-	w.Add(ikey("apricot"), nil)
-	w.Add(ikey("banana"), nil)
+	require.NoError(t, w.Add(ikey("apple"), nil))
+	require.NoError(t, w.Add(ikey("apricot"), nil))
+	require.NoError(t, w.Add(ikey("banana"), nil))
 
 	w.Reset()
 
@@ -43,9 +43,9 @@ func TestBlockWriterClear(t *testing.T) {
 
 func TestBlockWriter(t *testing.T) {
 	w := &Writer{RestartInterval: 16}
-	w.AddRawString("apple", nil)
-	w.AddRawString("apricot", nil)
-	w.AddRawString("banana", nil)
+	require.NoError(t, w.AddRawString("apple", nil))
+	require.NoError(t, w.AddRawString("apricot", nil))
+	require.NoError(t, w.AddRawString("banana", nil))
 	block := w.Finish()
 
 	expected := []byte(
@@ -69,8 +69,9 @@ func TestBlockWriterWithPrefix(t *testing.T) {
 		addValuePrefix bool,
 		valuePrefix block.ValuePrefix,
 		setHasSameKeyPrefix bool) {
-		w.AddWithOptionalValuePrefix(
+		err := w.AddWithOptionalValuePrefix(
 			key, false, value, len(key.UserKey), addValuePrefix, valuePrefix, setHasSameKeyPrefix)
+		require.NoError(t, err)
 	}
 	addAdapter(
 		ikey("apple"), []byte("red"), false, 0, true)

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -351,14 +351,17 @@ func (i *indexBlockBuf) shouldFlush(
 		int(nEntries), flushGovernor)
 }
 
-func (i *indexBlockBuf) add(key InternalKey, value []byte, inflightSize int) {
-	i.block.Add(key, value)
+func (i *indexBlockBuf) add(key InternalKey, value []byte, inflightSize int) error {
+	if err := i.block.Add(key, value); err != nil {
+		return err
+	}
 	size := i.block.EstimatedSize()
 	if i.size.useMutex {
 		i.size.mu.Lock()
 		defer i.size.mu.Unlock()
 	}
 	i.size.estimate.writtenWithTotal(uint64(size), inflightSize)
+	return nil
 }
 
 func (i *indexBlockBuf) finish() []byte {
@@ -818,9 +821,11 @@ func (w *RawRowWriter) addPoint(key InternalKey, value []byte, forceObsolete boo
 	}
 
 	w.maybeAddToFilter(key.UserKey)
-	w.dataBlockBuf.dataBlock.AddWithOptionalValuePrefix(
+	if err := w.dataBlockBuf.dataBlock.AddWithOptionalValuePrefix(
 		key, isObsolete, valueStoredWithKey, maxSharedKeyLen, addPrefixToValueStoredWithKey, prefix,
-		setHasSameKeyPrefix)
+		setHasSameKeyPrefix); err != nil {
+		return err
+	}
 
 	w.meta.updateSeqNum(key.SeqNum())
 
@@ -931,8 +936,7 @@ func (w *RawRowWriter) addTombstone(key InternalKey, value []byte) error {
 	w.props.NumRangeDeletions++
 	w.props.RawKeySize += uint64(key.Size())
 	w.props.RawValueSize += uint64(len(value))
-	w.rangeDelBlock.Add(key, value)
-	return nil
+	return w.rangeDelBlock.Add(key, value)
 }
 
 // addRangeKey adds a range key set, unset, or delete key/value pair to the
@@ -1022,8 +1026,7 @@ func (w *RawRowWriter) addRangeKey(key InternalKey, value []byte) error {
 	}
 
 	// Add the key to the block.
-	w.rangeKeyBlock.Add(key, value)
-	return nil
+	return w.rangeKeyBlock.Add(key, value)
 }
 
 func (w *RawRowWriter) maybeAddToFilter(key []byte) {
@@ -1238,9 +1241,7 @@ func (w *RawRowWriter) addIndexEntry(
 			return err
 		}
 	}
-
-	writeTo.add(sep, encoded, inflightSize)
-	return nil
+	return writeTo.add(sep, encoded, inflightSize)
 }
 
 func (w *RawRowWriter) addPrevDataBlockToIndexBlockProps() {
@@ -1398,10 +1399,13 @@ func (w *RawRowWriter) writeTwoLevelIndex() (block.Handle, error) {
 		if err != nil {
 			return block.Handle{}, err
 		}
-		w.topLevelIndexBlock.Add(b.sep, block.HandleWithProperties{
+		err = w.topLevelIndexBlock.Add(b.sep, block.HandleWithProperties{
 			Handle: bh,
 			Props:  b.properties,
 		}.EncodeVarints(w.blockBuf.tmp[:]))
+		if err != nil {
+			return block.Handle{}, err
+		}
 	}
 
 	// NB: RocksDB includes the block trailer length in the index size
@@ -1659,7 +1663,9 @@ func (w *RawRowWriter) Close() (err error) {
 		// reduces table size without a significant impact on performance.
 		raw.RestartInterval = propertiesBlockRestartInterval
 		w.props.CompressionOptions = rocksDBCompressionOptions
-		w.props.save(w.tableFormat, &raw)
+		if err := w.props.save(w.tableFormat, &raw); err != nil {
+			return err
+		}
 		if _, err := w.layout.WritePropertiesBlock(raw.Finish()); err != nil {
 			return err
 		}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -542,8 +542,8 @@ func TestClearDataBlockBuf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	d := newDataBlockBuf(1, block.ChecksumTypeCRC32c)
 	d.blockBuf.dataBuf = make([]byte, 1)
-	d.dataBlock.Add(ikey("apple"), nil)
-	d.dataBlock.Add(ikey("banana"), nil)
+	require.NoError(t, d.dataBlock.Add(ikey("apple"), nil))
+	require.NoError(t, d.dataBlock.Add(ikey("banana"), nil))
 
 	d.clear()
 	testBlockBufClear(t, &d.blockBuf, &blockBuf{})
@@ -554,8 +554,8 @@ func TestClearDataBlockBuf(t *testing.T) {
 func TestClearIndexBlockBuf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	i := newIndexBlockBuf(false)
-	i.block.Add(ikey("apple"), nil)
-	i.block.Add(ikey("banana"), nil)
+	require.NoError(t, i.block.Add(ikey("apple"), nil))
+	require.NoError(t, i.block.Add(ikey("banana"), nil))
 	i.clear()
 
 	require.Equal(


### PR DESCRIPTION
25.1 backport of #4503 and #4507.

----

Relax the maximum block size to reclaim 7-unused bits within the restart offsets. This provides additional leeway for massive blocks we're sometimes forced to construct due to very large key-value pairs. Additionally, this commit turns this check into an error that we propagate up and out of the sstable Writer rather than panicking with an assertion failure. In practice this means a DB that hits this limit may fail a compaction without bringing down the node. The DB may repeat the compaction in a busy loop, but it's possible for the DB to make some forward progress in the meantime.
