### PR TITLE
sstable: fix swallowed errors

### DIFF
--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -934,7 +934,9 @@ func (w *layoutWriter) Finish() (size uint64, err error) {
 	} else {
 		bw := rowblk.Writer{RestartInterval: 1}
 		for _, h := range w.handles {
-			bw.AddRaw(unsafe.Slice(unsafe.StringData(h.key), len(h.key)), h.encodedBlockHandle)
+			if err := bw.AddRaw(unsafe.Slice(unsafe.StringData(h.key), len(h.key)), h.encodedBlockHandle); err != nil {
+				return 0, err
+			}
 		}
 		b = bw.Finish()
 	}

--- a/sstable/rowblk/rowblk_iter_test.go
+++ b/sstable/rowblk/rowblk_iter_test.go
@@ -286,8 +286,8 @@ func TestBlockSyntheticPrefix(t *testing.T) {
 					"pear", "persimmon",
 				}
 				for _, k := range keys {
-					elidedPrefixWriter.Add(ikey(k), nil)
-					includedPrefixWriter.Add(ikey(prefix+k), nil)
+					require.NoError(t, elidedPrefixWriter.Add(ikey(k), nil))
+					require.NoError(t, includedPrefixWriter.Add(ikey(prefix+k), nil))
 				}
 
 				elidedPrefixBlock, includedPrefixBlock := elidedPrefixWriter.Finish(), includedPrefixWriter.Finish()

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -327,10 +327,13 @@ func (i *indexBlockBuf) shouldFlush(
 		int(nEntries), flushGovernor)
 }
 
-func (i *indexBlockBuf) add(key InternalKey, value []byte, inflightSize int) {
-	i.block.Add(key, value)
+func (i *indexBlockBuf) add(key InternalKey, value []byte, inflightSize int) error {
+	if err := i.block.Add(key, value); err != nil {
+		return err
+	}
 	size := i.block.EstimatedSize()
 	i.size.estimate.writtenWithTotal(uint64(size), inflightSize)
+	return nil
 }
 
 func (i *indexBlockBuf) finish() []byte {
@@ -1180,9 +1183,7 @@ func (w *RawRowWriter) addIndexEntry(
 			return err
 		}
 	}
-
-	writeTo.add(sep, encoded, inflightSize)
-	return nil
+	return writeTo.add(sep, encoded, inflightSize)
 }
 
 func (w *RawRowWriter) addPrevDataBlockToIndexBlockProps() {


### PR DESCRIPTION
In 0bd9d12668041bcc2b2be84afcf97a123cf13b3a I missed a couple of call sites that should propagate errors.