### PR TITLE
db: add support for remote table metrics

### DIFF
--- a/db.go
+++ b/db.go
@@ -2049,7 +2049,7 @@ func (d *DB) Metrics() *Metrics {
 	}
 	metrics.Table.ZombieCount = int64(d.mu.versions.zombieTables.Count())
 	metrics.Table.ZombieSize = d.mu.versions.zombieTables.TotalSize()
-	metrics.Table.Local.ZombieSize = d.mu.versions.zombieTables.LocalSize()
+	metrics.Table.Local.ZombieCount, metrics.Table.Local.ZombieSize = d.mu.versions.zombieTables.LocalStats()
 	metrics.private.optionsFileSize = d.optionsFileSize
 
 	// TODO(jackson): Consider making these metrics optional.

--- a/metrics.go
+++ b/metrics.go
@@ -299,10 +299,16 @@ type Metrics struct {
 		Local struct {
 			// LiveSize is the number of bytes in live tables.
 			LiveSize uint64
+			// LiveCount is the number of live tables.
+			LiveCount uint64
 			// ObsoleteSize is the number of bytes in obsolete tables.
 			ObsoleteSize uint64
+			// ObsoleteCount is the number of obsolete tables.
+			ObsoleteCount uint64
 			// ZombieSize is the number of bytes in zombie tables.
 			ZombieSize uint64
+			// ZombieCount is the number of zombie tables.
+			ZombieCount uint64
 		}
 	}
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -395,6 +395,12 @@ func TestMetrics(t *testing.T) {
 						panic(fmt.Sprintf("invalid level %d", l))
 					}
 					buf.WriteString(fmt.Sprintf("%d\n", m.Levels[l].NumVirtualFiles))
+				} else if line == "remote-count" {
+					count, _ := m.RemoteTablesTotal()
+					buf.WriteString(fmt.Sprintf("%d\n", count))
+				} else if line == "remote-size" {
+					_, size := m.RemoteTablesTotal()
+					buf.WriteString(fmt.Sprintf("%s\n", humanize.Bytes.Uint64(size)))
 				} else {
 					panic(fmt.Sprintf("invalid field: %s", line))
 				}
@@ -427,6 +433,7 @@ func TestMetrics(t *testing.T) {
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}
 	})
+
 }
 
 func TestMetricsWAmpDisableWAL(t *testing.T) {

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -870,6 +870,13 @@ set b 2
 ingest ext1.sst
 ----
 
+metrics-value
+remote-count
+remote-size
+----
+2
+1.5KB
+
 lsm
 ----
 L0.0:


### PR DESCRIPTION
This patch adds a method to our `Metrics` struct, `RemoteTablesTotal`,
that will compute the total size and count of remote tables.

Informs: [#143850](https://github.com/cockroachdb/cockroach/issues/143850)