### PR TITLE
db: allow loose excised table bounds when using DB.Excise()

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1345,10 +1345,11 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 		levelMetrics.TablesIngested++
 	}
 	if ingestFlushable.exciseSpan.Valid() {
+		exciseBounds := ingestFlushable.exciseSpan.UserKeyBounds()
 		// Iterate through all levels and find files that intersect with exciseSpan.
 		for layer, ls := range c.version.AllLevelsAndSublevels() {
 			for m := range ls.Overlaps(d.cmp, ingestFlushable.exciseSpan.UserKeyBounds()).All() {
-				leftTable, rightTable, err := d.exciseTable(context.TODO(), ingestFlushable.exciseSpan.UserKeyBounds(), m, layer.Level())
+				leftTable, rightTable, err := d.exciseTable(context.TODO(), exciseBounds, m, layer.Level(), tightExciseBounds)
 				if err != nil {
 					return nil, err
 				}
@@ -2750,7 +2751,8 @@ func (d *DB) applyHintOnFile(
 	}
 
 	levelMetrics.TablesExcised++
-	leftTable, rightTable, err := d.exciseTable(context.TODO(), base.UserKeyBoundsEndExclusive(h.start, h.end), f, level)
+	exciseBounds := base.UserKeyBoundsEndExclusive(h.start, h.end)
+	leftTable, rightTable, err := d.exciseTable(context.TODO(), exciseBounds, f, level, tightExciseBounds)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when running excise for delete-only compaction")
 	}

--- a/excise.go
+++ b/excise.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/objstorage"
 )
 
 // Excise atomically deletes all data overlapping with the provided span. All
@@ -40,14 +41,33 @@ func (d *DB) Excise(ctx context.Context, span KeyRange) error {
 			v, FormatVirtualSSTables,
 		)
 	}
-	_, err := d.ingest(ctx, nil, nil, span, nil)
+	_, err := d.ingest(ctx, ingestArgs{ExciseSpan: span, ExciseBoundsPolicy: tightExciseBoundsIfLocal})
 	return err
 }
+
+// exciseBoundsPolicy controls whether we open excised files to obtain tight
+// bounds for the remaining file(s).
+type exciseBoundsPolicy uint8
+
+const (
+	// tightExciseBounds means that we will always open the file to find the exact
+	// bounds of the remaining file(s).
+	tightExciseBounds exciseBoundsPolicy = iota
+	// looseExciseBounds means that we will not open the file and will assign bounds
+	// pessimistically.
+	looseExciseBounds
+	// tightExciseBoundsLocalOnly means that we will only open the file if it is
+	// local; otherwise we will assign loose bounds to the remaining file(s).
+	tightExciseBoundsIfLocal
+)
 
 // exciseTable initializes up to two virtual tables for what is left over after
 // excising the given span from the table.
 //
-// Returns the left and/or right tables, if they exist.
+// Returns the left and/or right tables, if they exist. The boundsPolicy controls
+// whether we create iterators for m to determine tight bounds. Note that if the
+// exciseBounds are end-inclusive, tight bounds will be used regardless of the
+// policy.
 //
 // The file bounds must overlap with the excise span.
 //
@@ -55,28 +75,45 @@ func (d *DB) Excise(ctx context.Context, span KeyRange) error {
 // the db mutex held (eg. ingest-time excises), while in the case of compactions
 // the mutex is not held.
 func (d *DB) exciseTable(
-	ctx context.Context, exciseSpan base.UserKeyBounds, m *tableMetadata, level int,
+	ctx context.Context,
+	exciseBounds base.UserKeyBounds,
+	m *tableMetadata,
+	level int,
+	boundsPolicy exciseBoundsPolicy,
 ) (leftTable, rightTable *tableMetadata, _ error) {
 	// Check if there's actually an overlap between m and exciseSpan.
 	mBounds := m.UserKeyBounds()
-	if !exciseSpan.Overlaps(d.cmp, &mBounds) {
+	if !exciseBounds.Overlaps(d.cmp, &mBounds) {
 		return nil, nil, base.AssertionFailedf("excise span does not overlap table")
 	}
 	// Fast path: m sits entirely within the exciseSpan, so just delete it.
-	if exciseSpan.ContainsInternalKey(d.cmp, m.Smallest) && exciseSpan.ContainsInternalKey(d.cmp, m.Largest) {
+	if exciseBounds.ContainsInternalKey(d.cmp, m.Smallest) && exciseBounds.ContainsInternalKey(d.cmp, m.Largest) {
 		return nil, nil, nil
 	}
 
-	// The file partially overlaps the excise span; we will need to open it to
-	// determine tight bounds for the left-over table(s).
-	iters, err := d.newIters(ctx, m, &IterOptions{
-		Category: categoryIngest,
-		layer:    manifest.Level(level),
-	}, internalIterOpts{}, iterPointKeys|iterRangeDeletions|iterRangeKeys)
-	if err != nil {
-		return nil, nil, err
+	looseBounds := boundsPolicy == looseExciseBounds ||
+		(boundsPolicy == tightExciseBoundsIfLocal && !objstorage.IsLocalTable(d.objProvider, m.FileBacking.DiskFileNum))
+
+	if exciseBounds.End.Kind == base.Inclusive {
+		// Loose bounds are not allowed with end-inclusive bounds. This can only
+		// happen for ingest splits.
+		looseBounds = false
 	}
-	defer func() { _ = iters.CloseAll() }()
+
+	// The file partially overlaps the excise span; unless looseBounds is true, we
+	// will need to open it to determine tight bounds for the left-over table(s).
+	var iters iterSet
+	if !looseBounds {
+		var err error
+		iters, err = d.newIters(ctx, m, &IterOptions{
+			Category: categoryIngest,
+			layer:    manifest.Level(level),
+		}, internalIterOpts{}, iterPointKeys|iterRangeDeletions|iterRangeKeys)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer func() { _ = iters.CloseAll() }()
+	}
 
 	// Create a file to the left of the excise span, if necessary.
 	// The bounds of this file will be [m.Smallest, lastKeyBefore(exciseSpan.Start)].
@@ -100,7 +137,7 @@ func (d *DB) exciseTable(
 	// files, then grab the lock again and recalculate for just the files that
 	// have changed since our previous calculation. Do this optimiaztino as part of
 	// https://github.com/cockroachdb/pebble/issues/2112 .
-	if d.cmp(m.Smallest.UserKey, exciseSpan.Start) < 0 {
+	if d.cmp(m.Smallest.UserKey, exciseBounds.Start) < 0 {
 		leftTable = &tableMetadata{
 			Virtual:     true,
 			FileBacking: m.FileBacking,
@@ -112,7 +149,9 @@ func (d *DB) exciseTable(
 			LargestSeqNumAbsolute:    m.LargestSeqNumAbsolute,
 			SyntheticPrefixAndSuffix: m.SyntheticPrefixAndSuffix,
 		}
-		if err := determineLeftTableBounds(d.cmp, m, leftTable, exciseSpan.Start, iters); err != nil {
+		if looseBounds {
+			looseLeftTableBounds(d.cmp, m, leftTable, exciseBounds.Start)
+		} else if err := determineLeftTableBounds(d.cmp, m, leftTable, exciseBounds.Start, iters); err != nil {
 			return nil, nil, err
 		}
 
@@ -129,7 +168,7 @@ func (d *DB) exciseTable(
 		}
 	}
 	// Create a file to the right, if necessary.
-	if !exciseSpan.End.IsUpperBoundForInternalKey(d.cmp, m.Largest) {
+	if !exciseBounds.End.IsUpperBoundForInternalKey(d.cmp, m.Largest) {
 		// Create a new file, rightFile, between [firstKeyAfter(exciseSpan.End), m.Largest].
 		//
 		// See comment before the definition of leftFile for the motivation behind
@@ -145,7 +184,10 @@ func (d *DB) exciseTable(
 			LargestSeqNumAbsolute:    m.LargestSeqNumAbsolute,
 			SyntheticPrefixAndSuffix: m.SyntheticPrefixAndSuffix,
 		}
-		if err := determineRightTableBounds(d.cmp, m, rightTable, exciseSpan.End, iters); err != nil {
+		if looseBounds {
+			// We already checked that the end bound is exclusive.
+			looseRightTableBounds(d.cmp, m, rightTable, exciseBounds.End.Key)
+		} else if err := determineRightTableBounds(d.cmp, m, rightTable, exciseBounds.End, iters); err != nil {
 			return nil, nil, err
 		}
 		if rightTable.HasRangeKeys || rightTable.HasPointKeys {
@@ -207,8 +249,62 @@ func exciseOverlapBounds(
 	return extended
 }
 
+// looseLeftTableBounds initializes the bounds for the table that remains to the
+// left of the excise span after excising originalTable, without consulting the
+// contents of originalTable. The resulting bounds are loose.
+//
+// Sets the smallest and largest keys, as well as HasPointKeys/HasRangeKeys in
+// the leftFile.
+func looseLeftTableBounds(
+	cmp Compare, originalTable, leftTable *tableMetadata, exciseSpanStart []byte,
+) {
+	if originalTable.HasPointKeys {
+		largestPointKey := originalTable.LargestPointKey
+		if largestPointKey.IsUpperBoundFor(cmp, exciseSpanStart) {
+			largestPointKey = base.MakeRangeDeleteSentinelKey(exciseSpanStart)
+		}
+		leftTable.ExtendPointKeyBounds(cmp, originalTable.SmallestPointKey, largestPointKey)
+	}
+	if originalTable.HasRangeKeys {
+		largestRangeKey := originalTable.LargestRangeKey
+		if largestRangeKey.IsUpperBoundFor(cmp, exciseSpanStart) {
+			largestRangeKey = base.MakeExclusiveSentinelKey(InternalKeyKindRangeKeyMin, exciseSpanStart)
+		}
+		leftTable.ExtendRangeKeyBounds(cmp, originalTable.SmallestRangeKey, largestRangeKey)
+	}
+}
+
+// looseRightTableBounds initializes the bounds for the table that remains to the
+// right of the excise span after excising originalTable, without consulting the
+// contents of originalTable. The resulting bounds are loose.
+//
+// Sets the smallest and largest keys, as well as HasPointKeys/HasRangeKeys in
+// the rightFile.
+//
+// The excise span end bound is assumed to be exclusive; this function cannot be
+// used with an inclusive end bound.
+func looseRightTableBounds(
+	cmp Compare, originalTable, rightTable *tableMetadata, exciseSpanEnd []byte,
+) {
+	if originalTable.HasPointKeys {
+		smallestPointKey := originalTable.SmallestPointKey
+		if !smallestPointKey.IsUpperBoundFor(cmp, exciseSpanEnd) {
+			smallestPointKey = base.MakeInternalKey(exciseSpanEnd, 0, base.InternalKeyKindMaxForSSTable)
+		}
+		rightTable.ExtendPointKeyBounds(cmp, smallestPointKey, originalTable.LargestPointKey)
+	}
+	if originalTable.HasRangeKeys {
+		smallestRangeKey := originalTable.SmallestRangeKey
+		if !smallestRangeKey.IsUpperBoundFor(cmp, exciseSpanEnd) {
+			smallestRangeKey = base.MakeInternalKey(exciseSpanEnd, 0, base.InternalKeyKindRangeKeyMax)
+		}
+		rightTable.ExtendRangeKeyBounds(cmp, smallestRangeKey, originalTable.LargestRangeKey)
+	}
+}
+
 // determineLeftTableBounds calculates the bounds for the table that remains to
-// the left of the excise span after excising originalFile.
+// the left of the excise span after excising originalTable. The bounds around
+// the excise span are determined precisely by looking inside the file.
 //
 // Sets the smallest and largest keys, as well as HasPointKeys/HasRangeKeys in
 // the leftFile.
@@ -256,7 +352,8 @@ func determineLeftTableBounds(
 }
 
 // determineRightTableBounds calculates the bounds for the table that remains to
-// the right of the excise span after excising originalFile.
+// the right of the excise span after excising originalTable. The bounds around
+// the excise span are determined precisely by looking inside the file.
 //
 // Sets the smallest and largest keys, as well as HasPointKeys/HasRangeKeys in
 // the right.

--- a/ingest.go
+++ b/ingest.go
@@ -1148,7 +1148,7 @@ func (d *DB) Ingest(ctx context.Context, paths []string) error {
 	if d.opts.ReadOnly {
 		return ErrReadOnly
 	}
-	_, err := d.ingest(ctx, paths, nil /* shared */, KeyRange{}, nil /* external */)
+	_, err := d.ingest(ctx, ingestArgs{Local: paths})
 	return err
 }
 
@@ -1236,7 +1236,7 @@ func (d *DB) IngestWithStats(ctx context.Context, paths []string) (IngestOperati
 	if d.opts.ReadOnly {
 		return IngestOperationStats{}, ErrReadOnly
 	}
-	return d.ingest(ctx, paths, nil, KeyRange{}, nil)
+	return d.ingest(ctx, ingestArgs{Local: paths})
 }
 
 // IngestExternalFiles does the same as IngestWithStats, and additionally
@@ -1256,7 +1256,7 @@ func (d *DB) IngestExternalFiles(
 	if d.opts.Experimental.RemoteStorage == nil {
 		return IngestOperationStats{}, errors.New("pebble: cannot ingest external files without shared storage configured")
 	}
-	return d.ingest(ctx, nil, nil, KeyRange{}, external)
+	return d.ingest(ctx, ingestArgs{External: external})
 }
 
 // IngestAndExcise does the same as IngestWithStats, and additionally accepts a
@@ -1295,7 +1295,14 @@ func (d *DB) IngestAndExcise(
 			v, FormatMinForSharedObjects,
 		)
 	}
-	return d.ingest(ctx, paths, shared, exciseSpan, external)
+	args := ingestArgs{
+		Local:              paths,
+		Shared:             shared,
+		External:           external,
+		ExciseSpan:         exciseSpan,
+		ExciseBoundsPolicy: tightExciseBounds,
+	}
+	return d.ingest(ctx, args)
 }
 
 // Both DB.mu and commitPipeline.mu must be held while this is called.
@@ -1433,18 +1440,27 @@ func (d *DB) handleIngestAsFlushable(
 	return nil
 }
 
+type ingestArgs struct {
+	// Local sstables to ingest.
+	Local []string
+	// Shared sstables to ingest.
+	Shared []SharedSSTMeta
+	// External sstables to ingest.
+	External []ExternalFile
+	// ExciseSpan (unset if not excising).
+	ExciseSpan         KeyRange
+	ExciseBoundsPolicy exciseBoundsPolicy
+}
+
 // See comment at Ingest() for details on how this works.
-func (d *DB) ingest(
-	ctx context.Context,
-	paths []string,
-	shared []SharedSSTMeta,
-	exciseSpan KeyRange,
-	external []ExternalFile,
-) (IngestOperationStats, error) {
+func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats, error) {
+	paths := args.Local
+	shared := args.Shared
+	external := args.External
 	if len(shared) > 0 && d.opts.Experimental.RemoteStorage == nil {
 		panic("cannot ingest shared sstables with nil SharedStorage")
 	}
-	if (exciseSpan.Valid() || len(shared) > 0 || len(external) > 0) && d.FormatMajorVersion() < FormatVirtualSSTables {
+	if (args.ExciseSpan.Valid() || len(shared) > 0 || len(external) > 0) && d.FormatMajorVersion() < FormatVirtualSSTables {
 		return IngestOperationStats{}, errors.New("pebble: format major version too old for excise, shared or external sstable ingestion")
 	}
 	if len(external) > 0 && d.FormatMajorVersion() < FormatSyntheticPrefixSuffix {
@@ -1476,13 +1492,13 @@ func (d *DB) ingest(
 		return IngestOperationStats{}, err
 	}
 
-	if loadResult.fileCount() == 0 && !exciseSpan.Valid() {
+	if loadResult.fileCount() == 0 && !args.ExciseSpan.Valid() {
 		// All of the sstables to be ingested were empty. Nothing to do.
 		return IngestOperationStats{}, nil
 	}
 
 	// Verify the sstables do not overlap.
-	if err := ingestSortAndVerify(d.cmp, loadResult, exciseSpan); err != nil {
+	if err := ingestSortAndVerify(d.cmp, loadResult, args.ExciseSpan); err != nil {
 		return IngestOperationStats{}, err
 	}
 
@@ -1532,21 +1548,21 @@ func (d *DB) ingest(
 		for _, m := range loadResult.external {
 			overlapBounds = append(overlapBounds, m.tableMetadata)
 		}
-		if exciseSpan.Valid() {
-			overlapBounds = append(overlapBounds, &exciseSpan)
+		if args.ExciseSpan.Valid() {
+			overlapBounds = append(overlapBounds, &args.ExciseSpan)
 		}
 
 		d.mu.Lock()
 		defer d.mu.Unlock()
 
-		if exciseSpan.Valid() {
+		if args.ExciseSpan.Valid() {
 			// Check if any of the currently-open EventuallyFileOnlySnapshots
 			// overlap in key ranges with the excise span. If so, we need to
 			// check for memtable overlaps with all bounds of that
 			// EventuallyFileOnlySnapshot in addition to the ingestion's own
 			// bounds too.
 			overlapBounds = append(overlapBounds, exciseOverlapBounds(
-				d.cmp, &d.mu.snapshots.snapshotList, exciseSpan, seqNum)...)
+				d.cmp, &d.mu.snapshots.snapshotList, args.ExciseSpan, seqNum)...)
 		}
 
 		// Check to see if any files overlap with any of the memtables. The queue
@@ -1611,7 +1627,7 @@ func (d *DB) ingest(
 		canIngestFlushable := d.FormatMajorVersion() >= FormatFlushableIngest &&
 			(len(d.mu.mem.queue) < d.opts.MemTableStopWritesThreshold) &&
 			!d.opts.Experimental.DisableIngestAsFlushable() && !hasRemoteFiles &&
-			(!exciseSpan.Valid() || d.FormatMajorVersion() >= FormatFlushableIngestExcises)
+			(!args.ExciseSpan.Valid() || d.FormatMajorVersion() >= FormatFlushableIngestExcises)
 
 		if !canIngestFlushable {
 			// We're not able to ingest as a flushable,
@@ -1643,7 +1659,7 @@ func (d *DB) ingest(
 		for i := range fileMetas {
 			fileMetas[i] = loadResult.local[i].tableMetadata
 		}
-		err = d.handleIngestAsFlushable(fileMetas, seqNum, exciseSpan)
+		err = d.handleIngestAsFlushable(fileMetas, seqNum, args.ExciseSpan)
 	}
 
 	var ve *versionEdit
@@ -1664,7 +1680,7 @@ func (d *DB) ingest(
 		// assign the lowest sequence number in the set of sequence numbers for this
 		// ingestion to the excise. Note that we've already allocated fileCount+1
 		// sequence numbers in this case.
-		if exciseSpan.Valid() {
+		if args.ExciseSpan.Valid() {
 			seqNum++ // the first seqNum is reserved for the excise.
 		}
 		// Update the sequence numbers for all ingested sstables'
@@ -1692,7 +1708,7 @@ func (d *DB) ingest(
 
 		// Assign the sstables to the correct level in the LSM and apply the
 		// version edit.
-		ve, err = d.ingestApply(ctx, jobID, loadResult, mut, exciseSpan, seqNum)
+		ve, err = d.ingestApply(ctx, jobID, loadResult, mut, args.ExciseSpan, args.ExciseBoundsPolicy, seqNum)
 	}
 
 	// Only one ingest can occur at a time because if not, one would block waiting
@@ -1701,7 +1717,7 @@ func (d *DB) ingest(
 	// changes to the WAL and memtable. This will cause a bigger commit hiccup
 	// during ingestion.
 	seqNumCount := loadResult.fileCount()
-	if exciseSpan.Valid() {
+	if args.ExciseSpan.Valid() {
 		seqNumCount++
 	}
 	d.commit.ingestSem <- struct{}{}
@@ -1871,7 +1887,8 @@ func (d *DB) ingestSplit(
 		// as we're guaranteed to not have any data overlap between splitFile and
 		// s.ingestFile. d.excise will return an error if we pass an inclusive user
 		// key bound _and_ we end up seeing data overlap at the end key.
-		leftTable, rightTable, err := d.exciseTable(ctx, base.UserKeyBoundsFromInternal(s.ingestFile.Smallest, s.ingestFile.Largest), splitFile, s.level)
+		exciseBounds := base.UserKeyBoundsFromInternal(s.ingestFile.Smallest, s.ingestFile.Largest)
+		leftTable, rightTable, err := d.exciseTable(ctx, exciseBounds, splitFile, s.level, tightExciseBounds)
 		if err != nil {
 			return err
 		}
@@ -1907,6 +1924,7 @@ func (d *DB) ingestApply(
 	lr ingestLoadResult,
 	mut *memTable,
 	exciseSpan KeyRange,
+	exciseBoundsPolicy exciseBoundsPolicy,
 	exciseSeqNum base.SeqNum,
 ) (*versionEdit, error) {
 	d.mu.Lock()
@@ -2080,6 +2098,7 @@ func (d *DB) ingestApply(
 			}
 		}
 		if exciseSpan.Valid() {
+			exciseBounds := exciseSpan.UserKeyBounds()
 			// Iterate through all levels and find files that intersect with exciseSpan.
 			//
 			// TODO(bilal): We could drop the DB mutex here as we don't need it for
@@ -2097,7 +2116,7 @@ func (d *DB) ingestApply(
 			// compactions to error out.
 			for layer, ls := range current.AllLevelsAndSublevels() {
 				for m := range ls.Overlaps(d.cmp, exciseSpan.UserKeyBounds()).All() {
-					leftTable, rightTable, err := d.exciseTable(ctx, exciseSpan.UserKeyBounds(), m, layer.Level())
+					leftTable, rightTable, err := d.exciseTable(ctx, exciseBounds, m, layer.Level(), exciseBoundsPolicy)
 					if err != nil {
 						return versionUpdate{}, err
 					}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -926,10 +926,11 @@ func testIngestSharedImpl(
 			d.mu.versions.logLock()
 			d.mu.Unlock()
 			current := d.mu.versions.currentVersion()
+			exciseBounds := exciseSpan.UserKeyBounds()
 			for level := range current.Levels {
 				iter := current.Levels[level].Iter()
 				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
-					leftTable, rightTable, err := d.exciseTable(context.Background(), exciseSpan.UserKeyBounds(), m, level)
+					leftTable, rightTable, err := d.exciseTable(context.Background(), exciseBounds, m, level, tightExciseBounds)
 					if err != nil {
 						d.mu.Lock()
 						d.mu.versions.logUnlock()

--- a/testdata/excise
+++ b/testdata/excise
@@ -734,6 +734,43 @@ L6:
   000024(000018):[f#0,SET-f#0,SET]
   000025(000018):[x#0,SET-x#0,SET]
 
+build-remote remote1
+g#0,SET = foo
+h#0,SET = bar
+i#0,SET = foobar
+----
+
+ingest-external
+remote1 bounds=(g,j)
+----
+
+lsm
+----
+L0.0:
+  000019:[a#22,SET-a#22,SET]
+  000020:[b#23,SET-f#23,SET]
+L6:
+  000023(000018):[a#0,SET-a#0,SET]
+  000024(000018):[f#0,SET-f#0,SET]
+  000026(000026):[g#26,DELSIZED-j#inf,RANGEDEL]
+  000025(000018):[x#0,SET-x#0,SET]
+
+# Non-local tables are excised with loose bounds.
+excise ga ha
+----
+
+lsm
+----
+L0.0:
+  000019:[a#22,SET-a#22,SET]
+  000020:[b#23,SET-f#23,SET]
+L6:
+  000023(000018):[a#0,SET-a#0,SET]
+  000024(000018):[f#0,SET-f#0,SET]
+  000027(000026):[g#26,DELSIZED-ga#inf,RANGEDEL]
+  000028(000026):[ha#0,DELSIZED-j#inf,RANGEDEL]
+  000025(000018):[x#0,SET-x#0,SET]
+
 excise a z
 ----
 

--- a/testdata/excise_bounds
+++ b/testdata/excise_bounds
@@ -14,6 +14,9 @@ excise
 Right table bounds:
   overall: c#1,SET - e#1,SET
   point:   c#1,SET - e#1,SET
+Right table bounds (loose):
+  overall: bb#0,DELSIZED - e#1,SET
+  point:   bb#0,DELSIZED - e#1,SET
 
 excise
 [a, b]
@@ -33,6 +36,9 @@ excise
 Right table bounds:
   overall: c#1,SET - e#1,SET
   point:   c#1,SET - e#1,SET
+Right table bounds (loose):
+  overall: c#0,DELSIZED - e#1,SET
+  point:   c#0,DELSIZED - e#1,SET
 
 excise
 [a, cc]
@@ -58,6 +64,9 @@ excise
 Left table bounds:
   overall: b#1,SET - b#1,SET
   point:   b#1,SET - b#1,SET
+Left table bounds (loose):
+  overall: b#1,SET - bb#inf,RANGEDEL
+  point:   b#1,SET - bb#inf,RANGEDEL
 
 excise
 [c, z)
@@ -65,6 +74,9 @@ excise
 Left table bounds:
   overall: b#1,SET - b#1,SET
   point:   b#1,SET - b#1,SET
+Left table bounds (loose):
+  overall: b#1,SET - c#inf,RANGEDEL
+  point:   b#1,SET - c#inf,RANGEDEL
 
 excise
 [cc, z)
@@ -72,6 +84,9 @@ excise
 Left table bounds:
   overall: b#1,SET - c#1,SET
   point:   b#1,SET - c#1,SET
+Left table bounds (loose):
+  overall: b#1,SET - cc#inf,RANGEDEL
+  point:   b#1,SET - cc#inf,RANGEDEL
 
 excise
 [bb, cc)
@@ -79,9 +94,15 @@ excise
 Left table bounds:
   overall: b#1,SET - b#1,SET
   point:   b#1,SET - b#1,SET
+Left table bounds (loose):
+  overall: b#1,SET - bb#inf,RANGEDEL
+  point:   b#1,SET - bb#inf,RANGEDEL
 Right table bounds:
   overall: d#1,SET - e#1,SET
   point:   d#1,SET - e#1,SET
+Right table bounds (loose):
+  overall: cc#0,DELSIZED - e#1,SET
+  point:   cc#0,DELSIZED - e#1,SET
 
 excise
 [bb, cc]
@@ -89,6 +110,9 @@ excise
 Left table bounds:
   overall: b#1,SET - b#1,SET
   point:   b#1,SET - b#1,SET
+Left table bounds (loose):
+  overall: b#1,SET - bb#inf,RANGEDEL
+  point:   b#1,SET - bb#inf,RANGEDEL
 Right table bounds:
   overall: d#1,SET - e#1,SET
   point:   d#1,SET - e#1,SET
@@ -99,9 +123,15 @@ excise
 Left table bounds:
   overall: b#1,SET - b#1,SET
   point:   b#1,SET - b#1,SET
+Left table bounds (loose):
+  overall: b#1,SET - bb#inf,RANGEDEL
+  point:   b#1,SET - bb#inf,RANGEDEL
 Right table bounds:
   overall: d#1,SET - e#1,SET
   point:   d#1,SET - e#1,SET
+Right table bounds (loose):
+  overall: d#0,DELSIZED - e#1,SET
+  point:   d#0,DELSIZED - e#1,SET
 
 # Test with a RANGEDEL.
 build-sst
@@ -120,6 +150,9 @@ excise
 Right table bounds:
   overall: cc#2,RANGEDEL - e#1,SET
   point:   cc#2,RANGEDEL - e#1,SET
+Right table bounds (loose):
+  overall: cc#0,DELSIZED - e#1,SET
+  point:   cc#0,DELSIZED - e#1,SET
 
 excise
 [b, b]
@@ -142,14 +175,23 @@ excise
 Left table bounds:
   overall: b#1,SET - cc#inf,RANGEDEL
   point:   b#1,SET - cc#inf,RANGEDEL
+Left table bounds (loose):
+  overall: b#1,SET - cc#inf,RANGEDEL
+  point:   b#1,SET - cc#inf,RANGEDEL
 Right table bounds:
   overall: e#1,SET - e#1,SET
   point:   e#1,SET - e#1,SET
+Right table bounds (loose):
+  overall: e#0,DELSIZED - e#1,SET
+  point:   e#0,DELSIZED - e#1,SET
 
 excise
 [cc, e]
 ----
 Left table bounds:
+  overall: b#1,SET - cc#inf,RANGEDEL
+  point:   b#1,SET - cc#inf,RANGEDEL
+Left table bounds (loose):
   overall: b#1,SET - cc#inf,RANGEDEL
   point:   b#1,SET - cc#inf,RANGEDEL
 
@@ -173,6 +215,10 @@ Right table bounds:
   overall: cc#2,RANGEKEYSET - e#1,SET
   point:   cc#1,SET - e#1,SET
   range:   cc#2,RANGEKEYSET - d#inf,RANGEKEYSET
+Right table bounds (loose):
+  overall: cc#0,DELSIZED - e#1,SET
+  point:   cc#0,DELSIZED - e#1,SET
+  range:   cc#0,RANGEKEYSET - d#inf,RANGEKEYSET
 
 excise
 [b, cc]
@@ -186,9 +232,17 @@ Left table bounds:
   overall: b#1,SET - cc#inf,RANGEKEYSET
   point:   b#1,SET - b#1,SET
   range:   c#2,RANGEKEYSET - cc#inf,RANGEKEYSET
+Left table bounds (loose):
+  overall: b#1,SET - cc#inf,RANGEDEL
+  point:   b#1,SET - cc#inf,RANGEDEL
+  range:   c#2,RANGEKEYSET - cc#inf,RANGEKEYDEL
 Right table bounds:
   overall: e#1,SET - e#1,SET
   point:   e#1,SET - e#1,SET
+Right table bounds (loose):
+  overall: e#0,DELSIZED - e#1,SET
+  point:   e#0,DELSIZED - e#1,SET
+  range:   e#0,RANGEKEYSET - d#inf,RANGEKEYSET
 
 excise
 [cc, e]
@@ -197,3 +251,7 @@ Left table bounds:
   overall: b#1,SET - cc#inf,RANGEKEYSET
   point:   b#1,SET - b#1,SET
   range:   c#2,RANGEKEYSET - cc#inf,RANGEKEYSET
+Left table bounds (loose):
+  overall: b#1,SET - cc#inf,RANGEDEL
+  point:   b#1,SET - cc#inf,RANGEDEL
+  range:   c#2,RANGEKEYSET - cc#inf,RANGEKEYDEL


### PR DESCRIPTION
This PR is for the top commit only:

#### db: allow loose excised table bounds when using DB.Excise()

In the future we can easily change the policy for IngestAndExcise as
well if we decide to.

Fixes #4417