### PR TITLE
sstable: refactor prop block load

### DIFF
--- a/sstable/colblk/key_value_block.go
+++ b/sstable/colblk/key_value_block.go
@@ -5,6 +5,8 @@
 package colblk
 
 import (
+	"iter"
+
 	"github.com/cockroachdb/pebble/internal/binfmt"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 )
@@ -123,4 +125,15 @@ func (r *KeyValueBlockDecoder) KeyAt(i int) []byte {
 
 func (r *KeyValueBlockDecoder) ValueAt(i int) []byte {
 	return r.values.At(i)
+}
+
+// All returns an iterator that ranges over all key-value pairs in the block.
+func (r *KeyValueBlockDecoder) All() iter.Seq2[[]byte, []byte] {
+	return func(yield func([]byte, []byte) bool) {
+		for i := 0; i < r.BlockDecoder().Rows(); i++ {
+			if !yield(r.KeyAt(i), r.ValueAt(i)) {
+				return
+			}
+		}
+	}
 }

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
+	"iter"
 	"slices"
 	"sort"
 	"unsafe"
@@ -1940,6 +1941,17 @@ func (i *RawIter) Describe(tp treeprinter.Node, fmtKV DescribeKV) {
 	for j := 0; j < int(i.numRestarts); j++ {
 		offset := i.getRestart(j)
 		n.Childf("%05d [restart %d]", uint64(i.restarts+4*offsetInBlock(j)), offset)
+	}
+}
+
+// All returns an iterator that ranges over all key-value pairs in the block.
+func (i *RawIter) All() iter.Seq2[[]byte, []byte] {
+	return func(yield func([]byte, []byte) bool) {
+		for valid := i.First(); valid; valid = i.Next() {
+			if !yield(i.Key().UserKey, i.Value()) {
+				return
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
We now pass in an iterator to `load` in order to range all over the keys and values.