### PR TITLE
sstable: add Compressor to column writer

### DIFF
--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -218,23 +218,20 @@ func (b *PhysicalBlock) WriteTo(w objstorage.Writable) (n int, err error) {
 func CompressAndChecksum(
 	dst *[]byte, blockData []byte, compression Compression, checksummer *Checksummer,
 ) PhysicalBlock {
+	compressor := GetCompressor(compression)
+	defer compressor.Close()
+	return CompressAndChecksumWithCompressor(dst, blockData, compressor, checksummer)
+}
+
+func CompressAndChecksumWithCompressor(
+	dst *[]byte, blockData []byte, compressor Compressor, checksummer *Checksummer,
+) PhysicalBlock {
 	buf := (*dst)[:0]
 	// Compress the buffer, discarding the result if the improvement isn't at
 	// least 12.5%.
-	algo := NoCompressionIndicator
-	if compression != NoCompression {
-		compressor := GetCompressor(compression)
-		defer compressor.Close()
-		algo, buf = compressor.Compress(buf, blockData)
-		if len(buf) >= len(blockData)-len(blockData)/8 {
-			algo = NoCompressionIndicator
-		}
-	}
-	if algo == NoCompressionIndicator {
-		// We don't want to use the given blockData buffer directly: typically the
-		// result will be written to disk and that can mangle the buffer, leading to
-		// fragile code.
-		buf = append(buf[:0], blockData...)
+	algo, buf := compressor.Compress(buf, blockData)
+	if len(buf) >= len(blockData)-len(blockData)/8 {
+		algo, buf = (noopCompressor{}).Compress(buf, blockData)
 	}
 
 	*dst = buf

--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -26,7 +26,8 @@ var _ Compressor = snappyCompressor{}
 var _ Compressor = minlzCompressor{}
 
 func (noopCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte) {
-	panic("NoCompressionCompressor.Compress() should not be called.")
+	dst = append(dst[:0], src...)
+	return NoCompressionIndicator, dst
 }
 func (noopCompressor) Close() {}
 


### PR DESCRIPTION
For future adaptive compressor changes, the columnar writer should have its own compressor so that adaptive compressor state can be persisted 1:1 with a columnar writer.