### PR TITLE
db: rename LevelMetrics table fields

### DIFF
--- a/cmd/pebble/write_bench.go
+++ b/cmd/pebble/write_bench.go
@@ -293,7 +293,7 @@ func runWriteBenchmark(_ *cobra.Command, args []string) error {
 			}
 
 			// Print the current stats.
-			l0Files := m.Levels[0].NumFiles
+			l0Files := m.Levels[0].TablesCount
 			l0Sublevels := m.Levels[0].Sublevels
 			nLevels := 0
 			for _, l := range m.Levels {

--- a/compaction.go
+++ b/compaction.go
@@ -1277,11 +1277,11 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 			levelMetrics = &LevelMetrics{}
 			c.metrics[level] = levelMetrics
 		}
-		levelMetrics.NumFiles--
-		levelMetrics.Size -= int64(m.Size)
+		levelMetrics.TablesCount--
+		levelMetrics.TablesSize -= int64(m.Size)
 		for i := range added {
-			levelMetrics.NumFiles++
-			levelMetrics.Size += int64(added[i].Meta.Size)
+			levelMetrics.TablesCount++
+			levelMetrics.TablesSize += int64(added[i].Meta.Size)
 		}
 	}
 
@@ -3250,8 +3250,8 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*versionEdit, error
 			outputMetrics.TablesFlushed++
 			outputMetrics.BytesFlushed += fileMeta.Size
 		}
-		outputMetrics.Size += int64(fileMeta.Size)
-		outputMetrics.NumFiles++
+		outputMetrics.TablesSize += int64(fileMeta.Size)
+		outputMetrics.TablesCount++
 		outputMetrics.Additional.BytesWrittenDataBlocks += t.WriterMeta.Properties.DataSize
 		outputMetrics.Additional.BytesWrittenValueBlocks += t.WriterMeta.Properties.ValueBlocksSize
 	}

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1661,9 +1661,9 @@ func TestCompactionPickerScores(t *testing.T) {
 			fmt.Fprintf(&buf, "L       Size   Score\n")
 			for l, lm := range d.Metrics().Levels {
 				if l < numLevels-1 {
-					fmt.Fprintf(&buf, "L%-3d\t%-7s%.1f\n", l, humanize.Bytes.Int64(lm.Size), lm.Score)
+					fmt.Fprintf(&buf, "L%-3d\t%-7s%.1f\n", l, humanize.Bytes.Int64(lm.TablesSize), lm.Score)
 				} else {
-					fmt.Fprintf(&buf, "L%-3d\t%-7s-\n", l, humanize.Bytes.Int64(lm.Size))
+					fmt.Fprintf(&buf, "L%-3d\t%-7s-\n", l, humanize.Bytes.Int64(lm.TablesSize))
 				}
 			}
 			return buf.String()

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -324,7 +324,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	require.NoError(t, d.Apply(b, nil))
 	require.NoError(t, d.Flush())
 	require.NoError(t, d.Compact([]byte{'a'}, []byte{'b'}, false))
-	require.Equal(t, 1, int(d.Metrics().Levels[6].NumFiles))
+	require.Equal(t, 1, int(d.Metrics().Levels[6].TablesCount))
 
 	d.mu.Lock()
 
@@ -401,8 +401,8 @@ func TestVirtualReadsWiring(t *testing.T) {
 				lm = &LevelMetrics{}
 				metrics[de.Level] = lm
 			}
-			metrics[de.Level].NumFiles--
-			metrics[de.Level].Size -= int64(f.Size)
+			metrics[de.Level].TablesCount--
+			metrics[de.Level].TablesSize -= int64(f.Size)
 		}
 		return metrics
 	}
@@ -441,7 +441,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	d.mu.Unlock()
 
 	// Confirm that there were only 2 virtual sstables in L6.
-	require.Equal(t, 2, int(d.Metrics().Levels[6].NumFiles))
+	require.Equal(t, 2, int(d.Metrics().Levels[6].TablesCount))
 
 	// These reads will go through the file cache.
 	iter, _ := d.NewIter(nil)

--- a/ingest.go
+++ b/ingest.go
@@ -2054,8 +2054,8 @@ func (d *DB) ingestApply(
 				levelMetrics = &LevelMetrics{}
 				metrics[f.Level] = levelMetrics
 			}
-			levelMetrics.NumFiles++
-			levelMetrics.Size += int64(m.Size)
+			levelMetrics.TablesCount++
+			levelMetrics.TablesSize += int64(m.Size)
 			levelMetrics.BytesIngested += m.Size
 			levelMetrics.TablesIngested++
 		}
@@ -2072,11 +2072,11 @@ func (d *DB) ingestApply(
 				levelMetrics = &LevelMetrics{}
 				metrics[level] = levelMetrics
 			}
-			levelMetrics.NumFiles--
-			levelMetrics.Size -= int64(m.Size)
+			levelMetrics.TablesCount--
+			levelMetrics.TablesSize -= int64(m.Size)
 			for i := range added {
-				levelMetrics.NumFiles++
-				levelMetrics.Size += int64(added[i].Meta.Size)
+				levelMetrics.TablesCount++
+				levelMetrics.TablesSize += int64(added[i].Meta.Size)
 			}
 		}
 		if exciseSpan.Valid() {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2764,7 +2764,7 @@ func BenchmarkSeekPrefixTombstones(b *testing.B) {
 	}
 
 	d.mu.Lock()
-	require.Equal(b, int64(ks.Count()-1), d.mu.versions.metrics.Levels[numLevels-1].NumFiles)
+	require.Equal(b, int64(ks.Count()-1), d.mu.versions.metrics.Levels[numLevels-1].TablesCount)
 	d.mu.Unlock()
 
 	seekKey := testkeys.Key(ks, 1)
@@ -3053,7 +3053,7 @@ func runBenchmarkQueueWorkload(b *testing.B, deleteRatio float32, initOps int, v
 	for i := 0; i < numLevels; i++ {
 		numTombstones := stats.Levels[i].KindsCount[base.InternalKeyKindDelete]
 		numSets := stats.Levels[i].KindsCount[base.InternalKeyKindSet]
-		numTables := metrics.Levels[i].NumFiles
+		numTables := metrics.Levels[i].TablesCount
 		if numSets > 0 {
 			b.Logf("L%d: %d tombstones, %d sets, %d sstables\n", i, numTombstones, numSets, numTables)
 		}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -82,10 +82,10 @@ func exampleMetrics() Metrics {
 		l := &m.Levels[i]
 		base := uint64((i + 1) * 100)
 		l.Sublevels = int32(i + 1)
-		l.NumFiles = int64(base) + 1
-		l.NumVirtualFiles = uint64(base) + 1
-		l.VirtualSize = base + 3
-		l.Size = int64(base) + 2
+		l.TablesCount = int64(base) + 1
+		l.VirtualTablesCount = uint64(base) + 1
+		l.VirtualTablesSize = base + 3
+		l.TablesSize = int64(base) + 2
 		l.Score = float64(base) + 3
 		l.BytesIn = base + 4
 		l.BytesIngested = base + 4
@@ -394,7 +394,7 @@ func TestMetrics(t *testing.T) {
 					if l >= numLevels {
 						panic(fmt.Sprintf("invalid level %d", l))
 					}
-					buf.WriteString(fmt.Sprintf("%d\n", m.Levels[l].NumVirtualFiles))
+					buf.WriteString(fmt.Sprintf("%d\n", m.Levels[l].VirtualTablesCount))
 				} else if line == "remote-count" {
 					count, _ := m.RemoteTablesTotal()
 					buf.WriteString(fmt.Sprintf("%d\n", count))

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -320,7 +320,7 @@ func (d *DB) getDeletionPacerInfo() deletionPacerInfo {
 	pacerInfo.freeBytes = d.calculateDiskAvailableBytes()
 	d.mu.Lock()
 	pacerInfo.obsoleteBytes = d.mu.versions.metrics.Table.ObsoleteSize
-	pacerInfo.liveBytes = uint64(d.mu.versions.metrics.Total().Size)
+	pacerInfo.liveBytes = uint64(d.mu.versions.metrics.Total().TablesSize)
 	d.mu.Unlock()
 	return pacerInfo
 }

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -117,8 +117,8 @@ func TestVersionSet(t *testing.T) {
 					lm = &LevelMetrics{}
 					fileMetrics[de.Level] = lm
 				}
-				lm.NumFiles--
-				lm.Size -= int64(f.Size)
+				lm.TablesCount--
+				lm.TablesSize -= int64(f.Size)
 			}
 
 			mu.Lock()


### PR DESCRIPTION
Rename LevelMetrics fields that refer to 'files' to refer to 'tables' instead. With the introduction of value separation, significant volumes of data will live in blob files not accounted within these particular existing metrics.