### PR TITLE
sstable: avoid double compression with noop compressor

### DIFF
--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -230,7 +230,7 @@ func CompressAndChecksumWithCompressor(
 	// Compress the buffer, discarding the result if the improvement isn't at
 	// least 12.5%.
 	algo, buf := compressor.Compress(buf, blockData)
-	if len(buf) >= len(blockData)-len(blockData)/8 {
+	if len(buf) >= len(blockData)-len(blockData)/8 && algo != NoCompressionIndicator {
 		algo, buf = (noopCompressor{}).Compress(buf, blockData)
 	}
 


### PR DESCRIPTION
Add a check for NoCompressionIndicator to avoid compressing twice with the noop compressor.