### PR TITLE
sstable: use CommonProperties when Properties is unnecessary

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3224,7 +3224,7 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*versionEdit, error
 		// If the file didn't contain any range deletions, we can fill its
 		// table stats now, avoiding unnecessarily loading the table later.
 		maybeSetStatsFromProperties(
-			fileMeta.PhysicalMeta(), &t.WriterMeta.Properties,
+			fileMeta.PhysicalMeta(), &t.WriterMeta.Properties.CommonProperties,
 		)
 
 		if t.WriterMeta.HasPointKeys {

--- a/ingest.go
+++ b/ingest.go
@@ -357,7 +357,7 @@ func ingestLoad1(
 	// disallowing removal of an open file. Under MemFS, if we don't populate
 	// meta.Stats here, the file will be loaded into the file cache for
 	// calculating stats before we can remove the original link.
-	maybeSetStatsFromProperties(meta.PhysicalMeta(), &r.Properties)
+	maybeSetStatsFromProperties(meta.PhysicalMeta(), &r.Properties.CommonProperties)
 
 	{
 		iter, err := r.NewIter(sstable.NoTransforms, nil /* lower */, nil /* upper */, sstable.AssertNoBlobHandles)

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -252,12 +252,12 @@ func writeProperties(loaded map[uintptr]struct{}, v reflect.Value, buf *bytes.Bu
 	}
 }
 
-func (p *Properties) GetScaledProperties(backingSize, size uint64) Properties {
+func (p *Properties) GetScaledProperties(backingSize, size uint64) CommonProperties {
 	scale := func(a uint64) uint64 {
 		return (a*size + backingSize - 1) / backingSize
 	}
 
-	props := *p
+	props := p.CommonProperties
 	props.RawKeySize = scale(p.RawKeySize)
 	props.RawValueSize = scale(p.RawValueSize)
 	props.NumEntries = scale(p.NumEntries)

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -21,21 +21,9 @@ props:
   rocksdb.num.entries: 1
   rocksdb.raw.key.size: 3
   rocksdb.raw.value.size: 1
-  rocksdb.deleted.keys: 0
-  rocksdb.num.range-deletions: 0
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
-  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-  rocksdb.comparator: pebble.internal.testkeys
-  rocksdb.data.size: 50
-  rocksdb.filter.size: 0
-  rocksdb.index.size: 40
-  rocksdb.block.based.table.index.type: 0
-  rocksdb.merge.operator: pebble.concatenate
-  rocksdb.merge.operands: 0
-  rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-  obsolete-key: hex:01
-  pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
 
 # Repeat the above with (Pebble,v5).
 
@@ -60,22 +48,9 @@ props:
   rocksdb.num.entries: 1
   rocksdb.raw.key.size: 4
   rocksdb.raw.value.size: 1
-  rocksdb.deleted.keys: 0
-  rocksdb.num.range-deletions: 0
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
-  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-  rocksdb.comparator: pebble.internal.testkeys
-  rocksdb.data.size: 87
-  rocksdb.filter.size: 0
-  rocksdb.index.size: 56
-  rocksdb.block.based.table.index.type: 0
-  pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
-  rocksdb.merge.operator: pebble.concatenate
-  rocksdb.merge.operands: 0
-  rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-  obsolete-key: hex:01
-  pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
 
 
 # Test 2: Similar to test 1 but force two level iterators.
@@ -96,23 +71,9 @@ props:
   rocksdb.num.entries: 1
   rocksdb.raw.key.size: 2
   rocksdb.raw.value.size: 1
-  rocksdb.deleted.keys: 0
-  rocksdb.num.range-deletions: 0
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
-  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-  rocksdb.comparator: pebble.internal.testkeys
-  rocksdb.data.size: 108
-  rocksdb.filter.size: 0
-  rocksdb.index.partitions: 4
-  rocksdb.index.size: 276
-  rocksdb.block.based.table.index.type: 2
-  rocksdb.merge.operator: pebble.concatenate
-  rocksdb.merge.operands: 0
-  rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-  rocksdb.top-level.index.size: 131
-  obsolete-key: hex:01
-  pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
 
 # Test the constrain bounds function. It performs some subtle shrinking and
 # expanding of bounds. The current virtual sstable bounds are [b,c].
@@ -186,24 +147,9 @@ props:
   rocksdb.num.entries: 1
   rocksdb.raw.key.size: 5
   rocksdb.raw.value.size: 1
-  rocksdb.deleted.keys: 0
-  rocksdb.num.range-deletions: 0
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
-  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-  rocksdb.comparator: pebble.internal.testkeys
-  rocksdb.data.size: 316
-  rocksdb.filter.size: 0
-  rocksdb.index.partitions: 4
-  rocksdb.index.size: 302
-  rocksdb.block.based.table.index.type: 2
-  pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
-  rocksdb.merge.operator: pebble.concatenate
-  rocksdb.merge.operands: 0
-  rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-  rocksdb.top-level.index.size: 0
-  obsolete-key: hex:01
-  pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
 
 # Test the constrain bounds function. It performs some subtle shrinking and
 # expanding of bounds. The current virtual sstable bounds are [b,c].
@@ -284,26 +230,10 @@ props:
   rocksdb.raw.value.size: 1
   rocksdb.deleted.keys: 1
   rocksdb.num.range-deletions: 1
-  pebble.num.range-key-dels: 0
   pebble.num.range-key-sets: 1
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
-  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-  rocksdb.comparator: pebble.internal.testkeys
-  rocksdb.data.size: 81
-  rocksdb.filter.size: 0
-  rocksdb.index.partitions: 3
-  rocksdb.index.size: 208
-  rocksdb.block.based.table.index.type: 2
-  rocksdb.merge.operator: pebble.concatenate
-  rocksdb.merge.operands: 0
-  pebble.num.range-key-unsets: 0
-  rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-  pebble.raw.range-key.key.size: 18
-  pebble.raw.range-key.value.size: 20
-  rocksdb.top-level.index.size: 98
-  obsolete-key: hex:01
-  pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
 
 # Repeat the above with (Pebble,v5).
 
@@ -333,27 +263,10 @@ props:
   rocksdb.raw.value.size: 1
   rocksdb.deleted.keys: 1
   rocksdb.num.range-deletions: 1
-  pebble.num.range-key-dels: 0
   pebble.num.range-key-sets: 1
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
-  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-  rocksdb.comparator: pebble.internal.testkeys
-  rocksdb.data.size: 241
-  rocksdb.filter.size: 0
-  rocksdb.index.partitions: 3
-  rocksdb.index.size: 237
-  rocksdb.block.based.table.index.type: 2
-  pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
-  rocksdb.merge.operator: pebble.concatenate
-  rocksdb.merge.operands: 0
-  pebble.num.range-key-unsets: 0
-  rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-  pebble.raw.range-key.key.size: 4
-  pebble.raw.range-key.value.size: 6
-  rocksdb.top-level.index.size: 0
-  obsolete-key: hex:01
-  pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
 
 build table-format=Pebble,v4
 a.SET.1:a
@@ -376,21 +289,9 @@ props:
   rocksdb.num.entries: 2
   rocksdb.raw.key.size: 10
   rocksdb.raw.value.size: 2
-  rocksdb.deleted.keys: 0
-  rocksdb.num.range-deletions: 0
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
-  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-  rocksdb.comparator: pebble.internal.testkeys
-  rocksdb.data.size: 97
-  rocksdb.filter.size: 0
-  rocksdb.index.size: 40
-  rocksdb.block.based.table.index.type: 0
-  rocksdb.merge.operator: pebble.concatenate
-  rocksdb.merge.operands: 0
-  rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-  obsolete-key: hex:01
-  pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
 
 # Repeat the above with (Pebble,v5).
 
@@ -415,19 +316,6 @@ props:
   rocksdb.num.entries: 2
   rocksdb.raw.key.size: 10
   rocksdb.raw.value.size: 2
-  rocksdb.deleted.keys: 0
-  rocksdb.num.range-deletions: 0
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
-  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-  rocksdb.comparator: pebble.internal.testkeys
-  rocksdb.data.size: 107
-  rocksdb.filter.size: 0
-  rocksdb.index.size: 56
-  rocksdb.block.based.table.index.type: 0
-  pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
-  rocksdb.merge.operator: pebble.concatenate
-  rocksdb.merge.operands: 0
-  rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-  obsolete-key: hex:01
-  pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;

--- a/table_stats.go
+++ b/table_stats.go
@@ -306,7 +306,7 @@ func (d *DB) loadTableStats(
 
 	err := d.fileCache.withReader(
 		context.TODO(), block.NoReadEnv, meta, func(r *sstable.Reader, env sstable.ReadEnv) (err error) {
-			props := r.Properties
+			props := r.Properties.CommonProperties
 			if meta.Virtual != nil {
 				props = r.Properties.GetScaledProperties(env.Virtual.BackingSize, env.Virtual.Size)
 			}
@@ -342,7 +342,11 @@ func (d *DB) loadTableStats(
 // loadTablePointKeyStats calculates the point key statistics for the given
 // table. The provided manifest.TableStats are updated.
 func (d *DB) loadTablePointKeyStats(
-	props *sstable.Properties, v *version, level int, meta *tableMetadata, stats *manifest.TableStats,
+	props *sstable.CommonProperties,
+	v *version,
+	level int,
+	meta *tableMetadata,
+	stats *manifest.TableStats,
 ) error {
 	// TODO(jackson): If the file has a wide keyspace, the average
 	// value size beneath the entire file might not be representative
@@ -476,7 +480,7 @@ func (d *DB) loadTableRangeDelStats(
 }
 
 func (d *DB) estimateSizesBeneath(
-	v *version, level int, meta *tableMetadata, fileProps *sstable.Properties,
+	v *version, level int, meta *tableMetadata, fileProps *sstable.CommonProperties,
 ) (avgValueLogicalSize, compressionRatio float64, err error) {
 	// Find all files in lower levels that overlap with meta,
 	// summing their value sizes and entry counts.
@@ -649,7 +653,7 @@ func (d *DB) estimateReclaimedSizeBeneath(
 	return estimate, hintSeqNum, nil
 }
 
-func maybeSetStatsFromProperties(meta *tableMetadata, props *sstable.Properties) bool {
+func maybeSetStatsFromProperties(meta *tableMetadata, props *sstable.CommonProperties) bool {
 	// If a table contains range deletions or range key deletions, we defer the
 	// stats collection. There are two main reasons for this:
 	//
@@ -697,7 +701,7 @@ func maybeSetStatsFromProperties(meta *tableMetadata, props *sstable.Properties)
 }
 
 func pointDeletionsBytesEstimate(
-	fileSize uint64, props *sstable.Properties, avgValLogicalSize, compressionRatio float64,
+	fileSize uint64, props *sstable.CommonProperties, avgValLogicalSize, compressionRatio float64,
 ) (estimate uint64) {
 	if props.NumEntries == 0 {
 		return 0
@@ -784,7 +788,7 @@ func pointDeletionsBytesEstimate(
 }
 
 func estimatePhysicalSizes(
-	fileSize uint64, props *sstable.Properties,
+	fileSize uint64, props *sstable.CommonProperties,
 ) (avgValLogicalSize, compressionRatio float64) {
 	// RawKeySize and RawValueSize are uncompressed totals. Scale according to
 	// the data size to account for compression, index blocks and metadata

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -655,19 +655,9 @@ rocksdb.raw.key.size: 3
 rocksdb.raw.value.size: 1
 pebble.raw.point-tombstone.key.size: 1
 rocksdb.deleted.keys: 1
-rocksdb.num.range-deletions: 0
 rocksdb.num.data.blocks: 1
 rocksdb.compression: Snappy
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-rocksdb.comparator: pebble.internal.testkeys
-rocksdb.data.size: 53
-rocksdb.filter.size: 0
-rocksdb.index.size: 27
-rocksdb.block.based.table.index.type: 0
-rocksdb.merge.operator: pebble.concatenate
-rocksdb.merge.operands: 0
-rocksdb.property.collectors: [obsolete-key]
-obsolete-key: hex:00
 
 properties file=8
 ----
@@ -676,19 +666,9 @@ rocksdb.raw.key.size: 3
 rocksdb.raw.value.size: 1
 pebble.raw.point-tombstone.key.size: 1
 rocksdb.deleted.keys: 1
-rocksdb.num.range-deletions: 0
 rocksdb.num.data.blocks: 1
 rocksdb.compression: Snappy
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-rocksdb.comparator: pebble.internal.testkeys
-rocksdb.data.size: 53
-rocksdb.filter.size: 0
-rocksdb.index.size: 27
-rocksdb.block.based.table.index.type: 0
-rocksdb.merge.operator: pebble.concatenate
-rocksdb.merge.operands: 0
-rocksdb.property.collectors: [obsolete-key]
-obsolete-key: hex:00
 
 wait-pending-table-stats
 000007
@@ -793,50 +773,20 @@ properties file=12
 rocksdb.num.entries: 1
 rocksdb.raw.key.size: 2
 rocksdb.raw.value.size: 1
-rocksdb.deleted.keys: 0
-rocksdb.num.range-deletions: 0
-pebble.num.range-key-dels: 0
 pebble.num.range-key-sets: 1
 rocksdb.num.data.blocks: 1
 rocksdb.compression: Snappy
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-rocksdb.comparator: pebble.internal.testkeys
-rocksdb.data.size: 47
-rocksdb.filter.size: 0
-rocksdb.index.size: 27
-rocksdb.block.based.table.index.type: 0
-rocksdb.merge.operator: pebble.concatenate
-rocksdb.merge.operands: 0
-pebble.num.range-key-unsets: 0
-rocksdb.property.collectors: [obsolete-key]
-pebble.raw.range-key.key.size: 9
-pebble.raw.range-key.value.size: 10
-obsolete-key: hex:00
 
 properties file=13
 ----
 rocksdb.num.entries: 1
 rocksdb.raw.key.size: 2
 rocksdb.raw.value.size: 1
-rocksdb.deleted.keys: 0
-rocksdb.num.range-deletions: 0
-pebble.num.range-key-dels: 0
 pebble.num.range-key-sets: 1
 rocksdb.num.data.blocks: 1
 rocksdb.compression: Snappy
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-rocksdb.comparator: pebble.internal.testkeys
-rocksdb.data.size: 47
-rocksdb.filter.size: 0
-rocksdb.index.size: 27
-rocksdb.block.based.table.index.type: 0
-rocksdb.merge.operator: pebble.concatenate
-rocksdb.merge.operands: 0
-pebble.num.range-key-unsets: 0
-rocksdb.property.collectors: [obsolete-key]
-pebble.raw.range-key.key.size: 9
-pebble.raw.range-key.value.size: 10
-obsolete-key: hex:00
 
 wait-pending-table-stats
 000012
@@ -939,15 +889,6 @@ rocksdb.num.range-deletions: 1
 rocksdb.num.data.blocks: 1
 rocksdb.compression: Snappy
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-rocksdb.comparator: pebble.internal.testkeys
-rocksdb.data.size: 13
-rocksdb.filter.size: 0
-rocksdb.index.size: 29
-rocksdb.block.based.table.index.type: 0
-rocksdb.merge.operator: pebble.concatenate
-rocksdb.merge.operands: 0
-rocksdb.property.collectors: [obsolete-key]
-obsolete-key: hex:0074
 
 properties file=21
 ----
@@ -959,15 +900,6 @@ rocksdb.num.range-deletions: 1
 rocksdb.num.data.blocks: 1
 rocksdb.compression: Snappy
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
-rocksdb.comparator: pebble.internal.testkeys
-rocksdb.data.size: 13
-rocksdb.filter.size: 0
-rocksdb.index.size: 29
-rocksdb.block.based.table.index.type: 0
-rocksdb.merge.operator: pebble.concatenate
-rocksdb.merge.operands: 0
-rocksdb.property.collectors: [obsolete-key]
-obsolete-key: hex:0074
 
 wait-pending-table-stats
 000020


### PR DESCRIPTION
Use CommonProperties for functions where having all of the contents of Properites is unnecessary.