### PR TITLE
db: add support for blob files to versionSet

### DIFF
--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -163,7 +164,10 @@ type VersionEdit struct {
 	// DeletedBlobFiles holds all blob files that became unreferenced during the
 	// version edit. These blob files must not be referenced by any sstable in
 	// the resulting Version.
-	DeletedBlobFiles []base.DiskFileNum
+	//
+	// While replaying a MANIFEST, the values are nil. Otherwise the values must
+	// not be nil.
+	DeletedBlobFiles map[base.DiskFileNum]*BlobFileMetadata
 }
 
 // Decode decodes an edit from the specified reader.
@@ -539,7 +543,10 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			if err != nil {
 				return err
 			}
-			v.DeletedBlobFiles = append(v.DeletedBlobFiles, base.DiskFileNum(fileNum))
+			if v.DeletedBlobFiles == nil {
+				v.DeletedBlobFiles = make(map[base.DiskFileNum]*BlobFileMetadata)
+			}
+			v.DeletedBlobFiles[base.DiskFileNum(fileNum)] = nil
 
 		case tagPrevLogNumber:
 			n, err := d.readUvarint()
@@ -575,10 +582,7 @@ func (v *VersionEdit) string(verbose bool, fmtKey base.FormatKey) string {
 	if v.LastSeqNum != 0 {
 		fmt.Fprintf(&buf, "  last-seq-num:  %d\n", v.LastSeqNum)
 	}
-	entries := make([]DeletedTableEntry, 0, len(v.DeletedTables))
-	for df := range v.DeletedTables {
-		entries = append(entries, df)
-	}
+	entries := slices.Collect(maps.Keys(v.DeletedTables))
 	slices.SortFunc(entries, func(a, b DeletedTableEntry) int {
 		if v := stdcmp.Compare(a.Level, b.Level); v != 0 {
 			return v
@@ -607,7 +611,9 @@ func (v *VersionEdit) string(verbose bool, fmtKey base.FormatKey) string {
 	for _, f := range v.NewBlobFiles {
 		fmt.Fprintf(&buf, "  add-blob-file: %s\n", f.String())
 	}
-	for _, df := range v.DeletedBlobFiles {
+	deletedBlobFiles := slices.Collect(maps.Keys(v.DeletedBlobFiles))
+	slices.Sort(deletedBlobFiles)
+	for _, df := range deletedBlobFiles {
 		fmt.Fprintf(&buf, "  del-blob-file: %s\n", df)
 	}
 	return buf.String()
@@ -689,7 +695,10 @@ func ParseVersionEditDebug(s string) (_ *VersionEdit, err error) {
 			ve.NewBlobFiles = append(ve.NewBlobFiles, meta)
 
 		case "del-blob-file":
-			ve.DeletedBlobFiles = append(ve.DeletedBlobFiles, p.DiskFileNum())
+			if ve.DeletedBlobFiles == nil {
+				ve.DeletedBlobFiles = make(map[base.DiskFileNum]*BlobFileMetadata)
+			}
+			ve.DeletedBlobFiles[p.DiskFileNum()] = nil
 
 		default:
 			return nil, errors.Errorf("field %q not implemented", field)
@@ -824,7 +833,7 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 		e.writeUvarint(x.ValueSize)
 		e.writeUvarint(x.CreationTime)
 	}
-	for _, x := range v.DeletedBlobFiles {
+	for x := range v.DeletedBlobFiles {
 		e.writeUvarint(tagDeletedBlobFile)
 		e.writeUvarint(uint64(x))
 	}
@@ -940,7 +949,7 @@ type BulkVersionEdit struct {
 		// any sstables, making them obsolete within the resulting version (a
 		// zombie if still referenced by previous versions). Deleted file
 		// numbers must not exist in Added.
-		Deleted []base.DiskFileNum
+		Deleted map[base.DiskFileNum]*BlobFileMetadata
 		// DeletedReferences holds metadata of blob files referenced by tables
 		// deleted in the accumulated version edits. This is used during replay
 		// to populate the *BlobFileMetadata pointers of new blob references,
@@ -1018,8 +1027,8 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 		b.BlobFiles.Added[nbf.FileNum] = nbf
 	}
 
-	b.BlobFiles.Deleted = slices.Grow(b.BlobFiles.Deleted, len(ve.DeletedBlobFiles))
-	for _, dbf := range ve.DeletedBlobFiles {
+	b.BlobFiles.Deleted = make(map[base.DiskFileNum]*BlobFileMetadata, len(ve.DeletedBlobFiles))
+	for dbf, blobMeta := range ve.DeletedBlobFiles {
 		// If the blob file was added in a prior, accumulated version edit we
 		// can resolve the deletion by removing it from the added files map.
 		// Otherwise the blob file deleted was added prior to this bulk edit,
@@ -1028,7 +1037,7 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 		if b.BlobFiles.Added != nil && b.BlobFiles.Added[dbf] != nil {
 			delete(b.BlobFiles.Added, dbf)
 		} else {
-			b.BlobFiles.Deleted = append(b.BlobFiles.Deleted, dbf)
+			b.BlobFiles.Deleted[dbf] = blobMeta
 		}
 	}
 
@@ -1309,7 +1318,10 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 		for _, deletedLevel := range b.DeletedTables {
 			for _, dt := range deletedLevel {
 				for _, ref := range dt.BlobReferences {
-					if ref.Metadata.ActiveRefs.count == 0 && !slices.Contains(b.BlobFiles.Deleted, ref.FileNum) {
+					if ref.Metadata.ActiveRefs.count != 0 {
+						continue
+					}
+					if _, ok := b.BlobFiles.Deleted[ref.FileNum]; !ok {
 						panic(errors.AssertionFailedf("blob file %s has no active refs, but was not deleted in the version edit", ref.FileNum))
 					}
 				}

--- a/metrics.go
+++ b/metrics.go
@@ -312,6 +312,36 @@ type Metrics struct {
 		}
 	}
 
+	BlobFiles struct {
+		// The count of all live blob files.
+		LiveCount uint64
+		// The size of all live blob files.
+		LiveSize uint64
+		// The count of all obsolete blob files.
+		ObsoleteCount uint64
+		// The size of all obsolete blob files.
+		ObsoleteSize uint64
+		// The count of all zombie blob files.
+		ZombieCount uint64
+		// The size of all zombie blob files.
+		ZombieSize uint64
+		// Local file sizes.
+		Local struct {
+			// LiveSize is the number of bytes in live blob files.
+			LiveSize uint64
+			// LiveCount is the number of live blob files.
+			LiveCount uint64
+			// ObsoleteSize is the number of bytes in obsolete blob files.
+			ObsoleteSize uint64
+			// ObsoleteCount is the number of obsolete blob files.
+			ObsoleteCount uint64
+			// ZombieSize is the number of bytes in zombie blob files.
+			ZombieSize uint64
+			// ZombieCount is the number of zombie blob files.
+			ZombieCount uint64
+		}
+	}
+
 	FileCache CacheMetrics
 
 	// Count of the number of open sstable iterators.

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -395,6 +395,13 @@ func Copy(ctx context.Context, r ReadHandle, out Writable, offset, length uint64
 	return nil
 }
 
+// IsLocalBlobFile returns true if a blob file with the given fileNum exists and is
+// local.
+func IsLocalBlobFile(provider Provider, fileNum base.DiskFileNum) bool {
+	meta, err := provider.Lookup(base.FileTypeBlob, fileNum)
+	return err == nil && !meta.IsRemote()
+}
+
 // IsLocalTable returns true if a table with the given fileNum exists and is
 // local.
 func IsLocalTable(provider Provider, fileNum base.DiskFileNum) bool {

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -439,7 +439,7 @@ func (d *DB) scanObsoleteFiles(list []string, flushableIngests []*ingestedFlusha
 
 	d.mu.versions.obsoleteTables = mergeObjectInfos(d.mu.versions.obsoleteTables, obsoleteTables)
 	d.mu.versions.obsoleteBlobs = mergeObjectInfos(d.mu.versions.obsoleteBlobs, obsoleteBlobs)
-	d.mu.versions.updateObsoleteTableMetricsLocked()
+	d.mu.versions.updateObsoleteObjectMetricsLocked()
 	d.mu.versions.obsoleteManifests = mergeObsoleteFiles(d.mu.versions.obsoleteManifests, obsoleteManifests)
 	d.mu.versions.obsoleteOptions = mergeObsoleteFiles(d.mu.versions.obsoleteOptions, obsoleteOptions)
 }

--- a/testdata/version_set
+++ b/testdata/version_set
@@ -13,6 +13,8 @@ current version:
 no virtual backings
 no zombie tables
 no obsolete tables
+no zombie blob files
+no obsolete blob files
 
 reopen
 ----
@@ -23,6 +25,8 @@ current version:
 no virtual backings
 no zombie tables
 no obsolete tables
+no zombie blob files
+no obsolete blob files
 
 # Convert 000002 to a virtual table.
 apply
@@ -43,6 +47,8 @@ current version:
   000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=300
 no zombie tables
 no obsolete tables
+no zombie blob files
+no obsolete blob files
 
 # Add another virtual table.
 apply
@@ -60,6 +66,8 @@ current version:
   000002:  size=2000  useCount=2  protectionCount=0  virtualizedSize=700
 no zombie tables
 no obsolete tables
+no zombie blob files
+no obsolete blob files
 
 # Move a virtual table between levels.
 apply
@@ -80,6 +88,8 @@ current version:
   000002:  size=2000  useCount=2  protectionCount=0  virtualizedSize=700
 no zombie tables
 no obsolete tables
+no zombie blob files
+no obsolete blob files
 
 # Remove a virtual table.
 apply
@@ -96,6 +106,8 @@ current version:
   000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=400
 no zombie tables
 no obsolete tables
+no zombie blob files
+no obsolete blob files
 
 reopen
 ----
@@ -107,6 +119,8 @@ current version:
   000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=400
 no zombie tables
 no obsolete tables
+no zombie blob files
+no obsolete blob files
 
 # Remove the last virtual table. This should automatically remove the last backing.
 apply
@@ -122,6 +136,8 @@ current version:
 no virtual backings
 no zombie tables
 obsolete tables: 000002
+no zombie blob files
+no obsolete blob files
 
 # Add a virtual table with a new backing (like an ingestion would).
 apply
@@ -141,6 +157,8 @@ current version:
   000100:  size=100000  useCount=1  protectionCount=0  virtualizedSize=500
 no zombie tables
 obsolete tables: 000002
+no zombie blob files
+no obsolete blob files
 
 ref-version r1
 ----
@@ -153,6 +171,8 @@ current version:
   000100:  size=100000  useCount=1  protectionCount=0  virtualizedSize=500
 no zombie tables
 obsolete tables: 000002
+no zombie blob files
+no obsolete blob files
 
 # Delete a table and backing; but we have a ref on the previous version so the
 # backing should not become obsolete.
@@ -169,6 +189,8 @@ current version:
 no virtual backings
 zombie tables: 000100
 obsolete tables: 000002
+no zombie blob files
+no obsolete blob files
 
 # The backing is now obsolete.
 unref-version r1
@@ -179,6 +201,8 @@ current version:
 no virtual backings
 no zombie tables
 obsolete tables: 000002 000100
+no zombie blob files
+no obsolete blob files
 
 # Test backing protection mechanism.
 
@@ -202,6 +226,8 @@ current version:
   000101:  size=101000  useCount=2  protectionCount=0  virtualizedSize=1300
 no zombie tables
 obsolete tables: 000002 000100
+no zombie blob files
+no obsolete blob files
 
 protect-backing 101
 ----
@@ -215,6 +241,8 @@ current version:
   000101:  size=101000  useCount=2  protectionCount=1  virtualizedSize=1300
 no zombie tables
 obsolete tables: 000002 000100
+no zombie blob files
+no obsolete blob files
 
 # We should not see a "del-backing" field here.
 apply
@@ -232,6 +260,8 @@ current version:
   000101:  size=101000  useCount=0  protectionCount=1  virtualizedSize=0
 no zombie tables
 obsolete tables: 000002 000100
+no zombie blob files
+no obsolete blob files
 
 unprotect-backing 101
 ----
@@ -243,6 +273,8 @@ current version:
 unused virtual backings: 000101
 no zombie tables
 obsolete tables: 000002 000100
+no zombie blob files
+no obsolete blob files
 
 # Whatever this next apply is, it should remove the unused backing.
 apply
@@ -260,6 +292,8 @@ current version:
 no virtual backings
 no zombie tables
 obsolete tables: 000002 000100 000101
+no zombie blob files
+no obsolete blob files
 
 # Test handling of leaked protected backings.
 
@@ -282,6 +316,8 @@ current version:
   000102:  size=102000  useCount=1  protectionCount=0  virtualizedSize=900
 no zombie tables
 obsolete tables: 000002 000100 000101
+no zombie blob files
+no obsolete blob files
 
 protect-backing 102
 ----
@@ -296,6 +332,8 @@ current version:
   000102:  size=102000  useCount=1  protectionCount=1  virtualizedSize=900
 no zombie tables
 obsolete tables: 000002 000100 000101
+no zombie blob files
+no obsolete blob files
 
 apply
   del-table:   L1 000009
@@ -312,6 +350,8 @@ current version:
   000102:  size=102000  useCount=0  protectionCount=1  virtualizedSize=0
 no zombie tables
 obsolete tables: 000002 000100 000101
+no zombie blob files
+no obsolete blob files
 
 # Upon reopen, we still have a record of backing 102.
 reopen
@@ -326,6 +366,8 @@ current version:
 unused virtual backings: 000102
 no zombie tables
 no obsolete tables
+no zombie blob files
+no obsolete blob files
 
 # Whatever this next apply is, it should remove the leaked backing.
 apply
@@ -344,3 +386,179 @@ current version:
 no virtual backings
 no zombie tables
 obsolete tables: 000102
+no zombie blob files
+no obsolete blob files
+
+apply
+  add-blob-file: 000011 size:[20535 (20KB)] vals:[25935 (25KB)]
+  add-table: L3 000012:[f#1,SET-g#1,SET] blobrefs:[(000011: 25935); depth:1]
+----
+applied:
+  last-seq-num:  99
+  add-table:     L3 000012:[f#1,SET-g#1,SET]
+  add-blob-file: 000011 size:[20535 (20KB)] vals:[25935 (25KB)]
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+    000012:[f#1,SET-g#1,SET] seqnums:[0-0] points:[f#1,SET-g#1,SET] size:1200 blobrefs:[(000011: 25935); depth:1]
+no virtual backings
+no zombie tables
+obsolete tables: 000102
+no zombie blob files
+no obsolete blob files
+
+reopen
+----
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+    000012:[f#1,SET-g#1,SET] seqnums:[0-0] points:[f#1,SET-g#1,SET] size:1200 blobrefs:[(000011: 25935); depth:1]
+no virtual backings
+no zombie tables
+no obsolete tables
+no zombie blob files
+no obsolete blob files
+
+# Delete the referencing table and the blob file. There is no reference to the
+# previous Version, so the files should all be immediately obsolete.
+
+apply
+  del-table: L3 000012
+  del-blob-file: 000011
+----
+applied:
+  last-seq-num:  99
+  del-table:     L3 000012
+  del-blob-file: 000011
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+no virtual backings
+no zombie tables
+obsolete tables: 000012
+no zombie blob files
+obsolete blob files: 000011
+
+reopen
+----
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+no virtual backings
+no zombie tables
+no obsolete tables
+no zombie blob files
+no obsolete blob files
+
+apply
+  add-blob-file: 000013 size:[20535 (20KB)] vals:[25935 (25KB)]
+  add-table: L4 000014:[f#2,SET-g#2,SET] blobrefs:[(000013: 20000); depth:1]
+  add-table: L3 000015:[f#1,SET-g#1,SET] blobrefs:[(000013: 15935); depth:1]
+----
+applied:
+  last-seq-num:  99
+  add-table:     L4 000014:[f#2,SET-g#2,SET]
+  add-table:     L3 000015:[f#1,SET-g#1,SET]
+  add-blob-file: 000013 size:[20535 (20KB)] vals:[25935 (25KB)]
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+    000015:[f#1,SET-g#1,SET] seqnums:[0-0] points:[f#1,SET-g#1,SET] size:1500 blobrefs:[(000013: 15935); depth:1]
+  L4:
+    000014:[f#2,SET-g#2,SET] seqnums:[0-0] points:[f#2,SET-g#2,SET] size:1400 blobrefs:[(000013: 20000); depth:1]
+no virtual backings
+no zombie tables
+no obsolete tables
+no zombie blob files
+no obsolete blob files
+
+# Add a reference to the version.
+
+ref-version r2
+----
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+    000015:[f#1,SET-g#1,SET] seqnums:[0-0] points:[f#1,SET-g#1,SET] size:1500 blobrefs:[(000013: 15935); depth:1]
+  L4:
+    000014:[f#2,SET-g#2,SET] seqnums:[0-0] points:[f#2,SET-g#2,SET] size:1400 blobrefs:[(000013: 20000); depth:1]
+no virtual backings
+no zombie tables
+no obsolete tables
+no zombie blob files
+no obsolete blob files
+
+# Remove the blob file and the referencing tables. The sstables and blob files
+# should be considered zombies due to the outstanding reference on the previous
+# version.
+
+apply
+  del-table: L3 000015
+  del-table: L4 000014
+  del-blob-file: 000013
+----
+applied:
+  last-seq-num:  99
+  del-table:     L3 000015
+  del-table:     L4 000014
+  del-blob-file: 000013
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+no virtual backings
+zombie tables: 000014 000015
+no obsolete tables
+zombie blob files: 000013
+no obsolete blob files
+
+# Remove the reference to the version. The sstables and blob files should
+# transition to obsolete.
+
+unref-version r2
+----
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+no virtual backings
+no zombie tables
+obsolete tables: 000014 000015
+no zombie blob files
+obsolete blob files: 000013
+
+reopen
+----
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+no virtual backings
+no zombie tables
+no obsolete tables
+no zombie blob files
+no obsolete blob files

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -58,8 +58,9 @@ func TestVersionSet(t *testing.T) {
 	))
 	vs.logSeqNum.Store(100)
 
-	metas := make(map[base.FileNum]*manifest.TableMetadata)
+	tableMetas := make(map[base.FileNum]*manifest.TableMetadata)
 	backings := make(map[base.DiskFileNum]*manifest.FileBacking)
+	blobMetas := make(map[base.DiskFileNum]*manifest.BlobFileMetadata)
 	// When we parse VersionEdits, we get a new FileBacking each time. We need to
 	// deduplicate them, since they hold a ref count.
 	dedupBacking := func(b *manifest.FileBacking) *manifest.FileBacking {
@@ -93,17 +94,24 @@ func TestVersionSet(t *testing.T) {
 				// Set a size that depends on FileNum.
 				nf.Meta.Size = uint64(nf.Meta.FileNum) * 100
 				nf.Meta.FileBacking = dedupBacking(nf.Meta.FileBacking)
-				metas[nf.Meta.FileNum] = nf.Meta
+				tableMetas[nf.Meta.FileNum] = nf.Meta
 				if nf.Meta.Virtual == nil {
 					createFile(nf.Meta.FileBacking.DiskFileNum)
 				}
 			}
+			for _, bm := range ve.NewBlobFiles {
+				blobMetas[bm.FileNum] = bm
+			}
+
 			for de := range ve.DeletedTables {
-				m := metas[de.FileNum]
+				m := tableMetas[de.FileNum]
 				if m == nil {
 					td.Fatalf(t, "unknown FileNum %s", de.FileNum)
 				}
 				ve.DeletedTables[de] = m
+			}
+			for num := range ve.DeletedBlobFiles {
+				ve.DeletedBlobFiles[num] = blobMetas[num]
 			}
 			for i := range ve.CreatedBackingTables {
 				ve.CreatedBackingTables[i] = dedupBacking(ve.CreatedBackingTables[i])
@@ -178,12 +186,16 @@ func TestVersionSet(t *testing.T) {
 			}
 
 			// Repopulate the maps.
-			metas = make(map[base.FileNum]*manifest.TableMetadata)
+			tableMetas = make(map[base.FileNum]*manifest.TableMetadata)
 			backings = make(map[base.DiskFileNum]*manifest.FileBacking)
+			blobMetas = make(map[base.DiskFileNum]*manifest.BlobFileMetadata)
 			v := vs.currentVersion()
 			for _, l := range v.Levels {
 				for f := range l.All() {
-					metas[f.FileNum] = f
+					tableMetas[f.FileNum] = f
+					for _, b := range f.BlobReferences {
+						blobMetas[b.FileNum] = b.Metadata
+					}
 					dedupBacking(f.FileBacking)
 				}
 			}
@@ -199,28 +211,30 @@ func TestVersionSet(t *testing.T) {
 			}
 		}
 		buf.WriteString(vs.virtualBackings.String())
-		if vs.zombieTables.Count() == 0 {
-			buf.WriteString("no zombie tables\n")
-		} else {
-			nums := slices.Collect(maps.Keys(vs.zombieTables.objs))
-			slices.Sort(nums)
-			buf.WriteString("zombie tables:")
-			for _, n := range nums {
-				fmt.Fprintf(&buf, " %s", n)
+		printObjectBreakdown := func(kind string, zombies zombieObjects, obsolete []objectInfo) {
+			if zombies.Count() == 0 {
+				buf.WriteString(fmt.Sprintf("no zombie %s\n", kind))
+			} else {
+				nums := slices.Collect(maps.Keys(zombies.objs))
+				slices.Sort(nums)
+				buf.WriteString(fmt.Sprintf("zombie %s:", kind))
+				for _, n := range nums {
+					fmt.Fprintf(&buf, " %s", n)
+				}
+				buf.WriteString("\n")
 			}
-			buf.WriteString("\n")
-		}
-
-		if len(vs.obsoleteTables) == 0 {
-			buf.WriteString("no obsolete tables\n")
-		} else {
-			buf.WriteString("obsolete tables:")
-			for _, fi := range vs.obsoleteTables {
-				fmt.Fprintf(&buf, " %s", fi.FileNum)
+			if len(obsolete) == 0 {
+				buf.WriteString(fmt.Sprintf("no obsolete %s\n", kind))
+			} else {
+				buf.WriteString(fmt.Sprintf("obsolete %s:", kind))
+				for _, fi := range obsolete {
+					fmt.Fprintf(&buf, " %s", fi.FileNum)
+				}
+				buf.WriteString("\n")
 			}
-			buf.WriteString("\n")
 		}
-
+		printObjectBreakdown("tables", vs.zombieTables, vs.obsoleteTables)
+		printObjectBreakdown("blob files", vs.zombieBlobs, vs.obsoleteBlobs)
 		return buf.String()
 	})
 }


### PR DESCRIPTION
**manifest: include BlobFileMetadata for deleted blob files**

Adjust the VersionEdit to include a pointer to deleted blob files'
*BlobFileMetadata struct. During runtime when a blob file is deleted, this
pointer will be populated. During MANIFEST replay, it will not. This mirrors
the mechanics of VersionEdit.DeletedTables. It will be used to faciliate that
accounting of zombie blob files at runtime.

**db: add support for blob files to versionSet**

Adapt the versionSet to write extant blob files to new manifests during a
manifest rollover and support tracking zombie and obsolete blob files.

Informs #/112.