### PR TITLE
db: fix virtual table race

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -283,7 +283,7 @@ func (d *DB) Checkpoint(
 			}
 
 			fileBacking := f.FileBacking
-			if f.Virtual != nil {
+			if f.Virtual {
 				if _, ok := requiredVirtualBackingFiles[fileBacking.DiskFileNum]; ok {
 					continue
 				}

--- a/compaction.go
+++ b/compaction.go
@@ -424,7 +424,7 @@ func newCompaction(
 		if mustCopy {
 			// If the source is virtual, it's best to just rewrite the file as all
 			// conditions in the above comment are met.
-			if meta.Virtual == nil {
+			if !meta.Virtual {
 				c.kind = compactionKindCopy
 			}
 		} else {
@@ -2401,7 +2401,7 @@ func (d *DB) cleanupVersionEdit(ve *versionEdit) {
 		deletedFiles[key.FileNum] = struct{}{}
 	}
 	for i := range ve.NewTables {
-		if ve.NewTables[i].Meta.Virtual != nil {
+		if ve.NewTables[i].Meta.Virtual {
 			// We handle backing files separately.
 			continue
 		}
@@ -2562,7 +2562,7 @@ func (d *DB) runCopyCompaction(
 		}
 		// Note that based on logic in the compaction picker, we're guaranteed
 		// inputMeta.Virtual is nil.
-		if inputMeta.Virtual != nil {
+		if inputMeta.Virtual {
 			panic(errors.AssertionFailedf("cannot do a copy compaction of a virtual sstable across local/remote storage"))
 		}
 	}
@@ -2700,7 +2700,7 @@ func (d *DB) runCopyCompaction(
 		Level: c.outputLevel.level,
 		Meta:  newMeta,
 	}}
-	if newMeta.Virtual != nil {
+	if newMeta.Virtual {
 		ve.CreatedBackingTables = []*fileBacking{newMeta.FileBacking}
 	}
 	c.metrics[c.outputLevel.level] = &LevelMetrics{
@@ -2904,7 +2904,7 @@ func (d *DB) runDeleteOnlyCompaction(
 	// NewFiles.
 	usedBackingFiles := make(map[base.DiskFileNum]struct{})
 	for _, e := range ve.NewTables {
-		if e.Meta.Virtual != nil {
+		if e.Meta.Virtual {
 			usedBackingFiles[e.Meta.FileBacking.DiskFileNum] = struct{}{}
 		}
 	}

--- a/compaction.go
+++ b/compaction.go
@@ -2593,7 +2593,7 @@ func (d *DB) runCopyCompaction(
 	if objMeta.IsExternal() {
 		// external -> local/shared copy. File must be virtual.
 		// We will update this size later after we produce the new backing file.
-		newMeta.InitProviderBacking(base.DiskFileNum(newMeta.FileNum), inputMeta.FileBacking.Size)
+		newMeta.InitVirtualBacking(base.DiskFileNum(newMeta.FileNum), inputMeta.FileBacking.Size)
 	} else {
 		// local -> shared copy. New file is guaranteed to not be virtual.
 		newMeta.InitPhysicalBacking()

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1186,7 +1186,7 @@ func pickCompactionSeedFile(
 func responsibleForGarbageBytes(
 	virtualBackings *manifest.VirtualBackings, m *tableMetadata,
 ) uint64 {
-	if m.Virtual == nil {
+	if !m.Virtual {
 		return 0
 	}
 	useCount, virtualizedSize := virtualBackings.Usage(m.FileBacking.DiskFileNum)

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -600,7 +600,7 @@ func TestCompaction(t *testing.T) {
 		defer provider.Close()
 		for _, levelMetadata := range v.Levels {
 			for meta := range levelMetadata.All() {
-				if meta.Virtual != nil {
+				if meta.Virtual {
 					continue
 				}
 				f, err := provider.OpenForReading(context.Background(), base.FileTypeTable, meta.FileBacking.DiskFileNum, objstorage.OpenOptions{})
@@ -3001,7 +3001,7 @@ func hasExternalFiles(d *DB) bool {
 	for level := 0; level < manifest.NumLevels; level++ {
 		iter := v.Levels[level].Iter()
 		for m := iter.First(); m != nil; m = iter.Next() {
-			if m.Virtual != nil {
+			if m.Virtual {
 				meta, err := d.objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)
 				if err != nil {
 					panic(err)

--- a/data_test.go
+++ b/data_test.go
@@ -1289,7 +1289,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	props := r.Properties.String()
 	env := sstable.ReadEnv{}
 	if m != nil && m.Virtual != nil {
-		m.InitVirtual(false /* isShared */)
+		m.InitVirtual()
 		env.Virtual = m.Virtual
 		scaledProps := r.Properties.GetScaledProperties(m.FileBacking.Size, m.Size)
 		props = scaledProps.String()

--- a/data_test.go
+++ b/data_test.go
@@ -1288,9 +1288,8 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 
 	props := r.Properties.String()
 	env := sstable.ReadEnv{}
-	if m != nil && m.Virtual != nil {
-		m.InitVirtual()
-		env.Virtual = m.Virtual
+	if m != nil && m.Virtual {
+		env.Virtual = &m.VirtualParams
 		scaledProps := r.Properties.GetScaledProperties(m.FileBacking.Size, m.Size)
 		props = scaledProps.String()
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -1291,7 +1291,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	if m != nil && m.Virtual != nil {
 		m.InitVirtual(false /* isShared */)
 		env.Virtual = m.Virtual
-		scaledProps := r.Properties.GetScaledProperties(env.Virtual.BackingSize, env.Virtual.Size)
+		scaledProps := r.Properties.GetScaledProperties(m.FileBacking.Size, m.Size)
 		props = scaledProps.String()
 	}
 	if len(td.Input) == 0 {

--- a/db.go
+++ b/db.go
@@ -2248,7 +2248,7 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 				}
 				destTables[j].Properties = p
 			}
-			destTables[j].Virtual = m.Virtual != nil
+			destTables[j].Virtual = m.Virtual
 			destTables[j].BackingSSTNum = m.FileBacking.DiskFileNum
 			objMeta, err := d.objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)
 			if err != nil {

--- a/download.go
+++ b/download.go
@@ -403,7 +403,7 @@ func firstExternalFileInLevelIter(
 		f = it.Next()
 	}
 	for ; f != nil && endBound.IsUpperBoundFor(cmp, f.Smallest.UserKey); f = it.Next() {
-		if f.Virtual != nil && objstorage.IsExternalTable(objProvider, f.FileBacking.DiskFileNum) {
+		if f.Virtual && objstorage.IsExternalTable(objProvider, f.FileBacking.DiskFileNum) {
 			return f
 		}
 	}

--- a/download_test.go
+++ b/download_test.go
@@ -181,7 +181,7 @@ func TestDownloadTask(t *testing.T) {
 					ch <- ErrCancelledCompaction
 				} else {
 					fmt.Fprintf(&buf, "downloading %s\n", f.FileNum)
-					f.Virtual = nil
+					f.Virtual = false
 					f.FileBacking.DiskFileNum = base.DiskFileNum(f.FileNum)
 					ch <- nil
 				}

--- a/ingest.go
+++ b/ingest.go
@@ -129,7 +129,7 @@ func ingestSynthesizeShared(
 	// This ensures that we don't over-prioritize this sstable for compaction just
 	// yet, as we do not have a clear sense of what parts of this sstable are
 	// referenced by other nodes.
-	meta.InitProviderBacking(base.DiskFileNum(fileNum), sm.Size)
+	meta.InitVirtualBacking(base.DiskFileNum(fileNum), sm.Size)
 
 	if sm.LargestPointKey.Valid() && sm.LargestPointKey.UserKey != nil {
 		// Initialize meta.{HasPointKeys,Smallest,Largest}, etc.
@@ -768,7 +768,7 @@ func (d *DB) ingestAttachRemote(jobID JobID, lr ingestLoadResult) error {
 		// We have to attach the remote object (and assign it a DiskFileNum). For
 		// simplicity, we use the same number for both the FileNum and the
 		// DiskFileNum (even though this is a virtual sstable).
-		meta.InitProviderBacking(base.DiskFileNum(meta.FileNum), lr.external[i].external.Size)
+		meta.InitVirtualBacking(base.DiskFileNum(meta.FileNum), lr.external[i].external.Size)
 
 		// Set the underlying FileBacking's size to the same size as the virtualized
 		// view of the sstable. This ensures that we don't over-prioritize this

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -53,7 +53,7 @@ func MakeLevelMetadata(cmp Compare, level int, files []*TableMetadata) LevelMeta
 	lm.tree = makeBTree(cmp, bcmp, files)
 	for _, f := range files {
 		lm.totalSize += f.Size
-		if f.Virtual != nil {
+		if f.Virtual {
 			lm.NumVirtual++
 			lm.VirtualSize += f.Size
 		}
@@ -86,7 +86,7 @@ func (lm *LevelMetadata) insert(f *TableMetadata) error {
 		return err
 	}
 	lm.totalSize += f.Size
-	if f.Virtual != nil {
+	if f.Virtual {
 		lm.NumVirtual++
 		lm.VirtualSize += f.Size
 	}
@@ -95,7 +95,7 @@ func (lm *LevelMetadata) insert(f *TableMetadata) error {
 
 func (lm *LevelMetadata) remove(f *TableMetadata) {
 	lm.totalSize -= f.Size
-	if f.Virtual != nil {
+	if f.Virtual {
 		lm.NumVirtual--
 		lm.VirtualSize -= f.Size
 	}
@@ -328,7 +328,7 @@ func (ls *LevelSlice) SizeSum() uint64 {
 func (ls *LevelSlice) NumVirtual() uint64 {
 	var n uint64
 	for f := range ls.All() {
-		if f.Virtual != nil {
+		if f.Virtual {
 			n++
 		}
 	}
@@ -340,7 +340,7 @@ func (ls *LevelSlice) NumVirtual() uint64 {
 func (ls *LevelSlice) VirtualSizeSum() uint64 {
 	var sum uint64
 	for f := range ls.All() {
-		if f.Virtual != nil {
+		if f.Virtual {
 			sum += f.Size
 		}
 	}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -525,24 +525,27 @@ func (m *TableMetadata) InitPhysicalBacking() {
 	if m.Virtual != nil {
 		panic("pebble: virtual sstables should use a pre-existing FileBacking")
 	}
-	if m.FileBacking == nil {
-		m.FileBacking = &FileBacking{
-			DiskFileNum: base.PhysicalTableDiskFileNum(m.FileNum),
-			Size:        m.Size,
-		}
+	if m.FileBacking != nil {
+		panic("backing already initialized")
+	}
+	m.FileBacking = &FileBacking{
+		DiskFileNum: base.PhysicalTableDiskFileNum(m.FileNum),
+		Size:        m.Size,
 	}
 }
 
-// InitProviderBacking creates a new FileBacking for a file backed by
-// an objstorage.Provider.
-func (m *TableMetadata) InitProviderBacking(fileNum base.DiskFileNum, size uint64) {
+// InitVirtualBacking creates a new FileBacking for a virtual table.
+func (m *TableMetadata) InitVirtualBacking(fileNum base.DiskFileNum, size uint64) {
 	if m.Virtual == nil {
 		panic("pebble: provider-backed sstables must be virtual")
 	}
-	if m.FileBacking == nil {
-		m.FileBacking = &FileBacking{DiskFileNum: fileNum}
+	if m.FileBacking != nil {
+		panic("backing already initialized")
 	}
-	m.FileBacking.Size = size
+	m.FileBacking = &FileBacking{
+		DiskFileNum: fileNum,
+		Size:        size,
+	}
 }
 
 // ValidateVirtual should be called once the TableMetadata for a virtual sstable
@@ -927,7 +930,7 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 		m.InitPhysicalBacking()
 	} else {
 		m.Virtual = &virtual.VirtualReaderParams{}
-		m.InitProviderBacking(backingNum, 0 /* size */)
+		m.InitVirtualBacking(backingNum, 0 /* size */)
 	}
 	return m, nil
 }

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -354,9 +354,7 @@ func (m *TableMetadata) InitVirtual(isShared bool) {
 	m.Virtual.Lower = m.Smallest
 	m.Virtual.Upper = m.Largest
 	m.Virtual.FileNum = m.FileNum
-	m.Virtual.Size = m.Size
 	m.Virtual.IsSharedIngested = isShared && m.SyntheticSeqNum() != 0
-	m.Virtual.BackingSize = m.FileBacking.Size
 }
 
 // Ref increments the table's ref count. If this is the table's first reference,

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -350,11 +350,10 @@ type TableMetadata struct {
 	SyntheticPrefixAndSuffix sstable.SyntheticPrefixAndSuffix
 }
 
-func (m *TableMetadata) InitVirtual(isShared bool) {
+func (m *TableMetadata) InitVirtual() {
 	m.Virtual.Lower = m.Smallest
 	m.Virtual.Upper = m.Largest
 	m.Virtual.FileNum = m.FileNum
-	m.Virtual.IsSharedIngested = isShared && m.SyntheticSeqNum() != 0
 }
 
 // Ref increments the table's ref count. If this is the table's first reference,

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/sstable"
-	"github.com/cockroachdb/pebble/sstable/virtual"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
@@ -77,13 +76,13 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 		SmallestSeqNum:        9,
 		LargestSeqNum:         11,
 		LargestSeqNumAbsolute: 11,
-		FileBacking:           m1.FileBacking,
-		Virtual:               &virtual.VirtualReaderParams{},
+		Virtual:               true,
 	}).ExtendPointKeyBounds(
 		cmp,
 		base.MakeInternalKey([]byte("a"), 0, base.InternalKeyKindSet),
 		base.MakeInternalKey([]byte("c"), 0, base.InternalKeyKindSet),
 	)
+	m2.AttachVirtualBacking(m1.FileBacking)
 
 	ve1 := VersionEdit{
 		ComparerName:         "11",

--- a/internal/manifest/virtual_backings.go
+++ b/internal/manifest/virtual_backings.go
@@ -134,7 +134,7 @@ func (bv *VirtualBackings) Remove(n base.DiskFileNum) {
 // AddTable is used when a new table is using an exiting backing. The backing
 // must be in the set already.
 func (bv *VirtualBackings) AddTable(m *TableMetadata) {
-	if m.Virtual == nil {
+	if !m.Virtual {
 		panic(errors.AssertionFailedf("table %s not virtual", m.FileNum))
 	}
 	v := bv.mustGet(m.FileBacking.DiskFileNum)
@@ -149,7 +149,7 @@ func (bv *VirtualBackings) AddTable(m *TableMetadata) {
 // RemoveTable is used when a table using a backing is removed. The backing is
 // not removed from the set, even if it becomes unused.
 func (bv *VirtualBackings) RemoveTable(m *TableMetadata) {
-	if m.Virtual == nil {
+	if !m.Virtual {
 		panic(errors.AssertionFailedf("table %s not virtual", m.FileNum))
 	}
 	v := bv.mustGet(m.FileBacking.DiskFileNum)

--- a/internal/manifest/virtual_backings_test.go
+++ b/internal/manifest/virtual_backings_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/sstable/virtual"
 )
 
 func TestVirtualBackings(t *testing.T) {
@@ -41,7 +40,7 @@ func TestVirtualBackings(t *testing.T) {
 			m := &TableMetadata{
 				FileBacking: &FileBacking{DiskFileNum: n},
 				Size:        size,
-				Virtual:     &virtual.VirtualReaderParams{},
+				Virtual:     true,
 			}
 			bv.AddTable(m)
 
@@ -49,7 +48,7 @@ func TestVirtualBackings(t *testing.T) {
 			m := &TableMetadata{
 				FileBacking: &FileBacking{DiskFileNum: n},
 				Size:        size,
-				Virtual:     &virtual.VirtualReaderParams{},
+				Virtual:     true,
 			}
 			bv.RemoveTable(m)
 

--- a/lsm_view.go
+++ b/lsm_view.go
@@ -142,7 +142,7 @@ func (b *lsmViewBuilder) Build(
 		l.Tables = make([]lsmview.Table, len(files))
 		for j, f := range files {
 			t := &l.Tables[j]
-			if f.Virtual == nil {
+			if !f.Virtual {
 				t.Label = fmt.Sprintf("%d", f.FileNum)
 			} else {
 				t.Label = fmt.Sprintf("%d (%d)", f.FileNum, f.FileBacking.DiskFileNum)
@@ -167,7 +167,7 @@ func (b *lsmViewBuilder) tableDetails(
 
 	outf("%s: %s - %s", m.FileNum, m.Smallest.Pretty(b.fmtKey), m.Largest.Pretty(b.fmtKey))
 	outf("size: %s", humanize.Bytes.Uint64(m.Size))
-	if m.Virtual != nil {
+	if m.Virtual {
 		meta, err := objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)
 		var backingInfo string
 		switch {

--- a/sstable/virtual/virtual_reader_params.go
+++ b/sstable/virtual/virtual_reader_params.go
@@ -4,10 +4,9 @@ import "github.com/cockroachdb/pebble/internal/base"
 
 // VirtualReaderParams are the parameters necessary for a reader to read virtual sstables.
 type VirtualReaderParams struct {
-	Lower            base.InternalKey
-	Upper            base.InternalKey
-	FileNum          base.FileNum
-	IsSharedIngested bool
+	Lower   base.InternalKey
+	Upper   base.InternalKey
+	FileNum base.FileNum
 }
 
 // Constrain bounds will narrow the start, end bounds if they do not fit within

--- a/sstable/virtual/virtual_reader_params.go
+++ b/sstable/virtual/virtual_reader_params.go
@@ -8,11 +8,6 @@ type VirtualReaderParams struct {
 	Upper            base.InternalKey
 	FileNum          base.FileNum
 	IsSharedIngested bool
-	// Size is an estimate of the size of the [Lower, Upper) section of the table.
-	Size uint64
-	// BackingSize is the total size of the backing table. The ratio between Size
-	// and BackingSize is used to estimate statistics.
-	BackingSize uint64
 }
 
 // Constrain bounds will narrow the start, end bounds if they do not fit within

--- a/table_stats.go
+++ b/table_stats.go
@@ -307,7 +307,7 @@ func (d *DB) loadTableStats(
 	err := d.fileCache.withReader(
 		context.TODO(), block.NoReadEnv, meta, func(r *sstable.Reader, env sstable.ReadEnv) (err error) {
 			props := r.Properties.CommonProperties
-			if meta.Virtual != nil {
+			if meta.Virtual {
 				props = r.Properties.GetScaledProperties(meta.FileBacking.Size, meta.Size)
 			}
 			stats.NumEntries = props.NumEntries
@@ -517,7 +517,7 @@ func (d *DB) estimateSizesBeneath(
 		// variable.
 		for file = range v.Overlaps(l, meta.UserKeyBounds()).All() {
 			var err error
-			if file.Virtual != nil {
+			if file.Virtual {
 				err = d.fileCache.withReader(context.TODO(), block.NoReadEnv, file.VirtualMeta(), addVirtualTableStats)
 			} else {
 				err = d.fileCache.withReader(context.TODO(), block.NoReadEnv, file.PhysicalMeta(), addPhysicalTableStats)
@@ -622,7 +622,7 @@ func (d *DB) estimateReclaimedSizeBeneath(
 				}
 				var size uint64
 				var err error
-				if file.Virtual != nil {
+				if file.Virtual {
 					err = d.fileCache.withReader(
 						context.TODO(), block.NoReadEnv,
 						file.VirtualMeta(), func(r *sstable.Reader, env sstable.ReadEnv) (err error) {

--- a/table_stats.go
+++ b/table_stats.go
@@ -308,7 +308,7 @@ func (d *DB) loadTableStats(
 		context.TODO(), block.NoReadEnv, meta, func(r *sstable.Reader, env sstable.ReadEnv) (err error) {
 			props := r.Properties.CommonProperties
 			if meta.Virtual != nil {
-				props = r.Properties.GetScaledProperties(env.Virtual.BackingSize, env.Virtual.Size)
+				props = r.Properties.GetScaledProperties(meta.FileBacking.Size, meta.Size)
 			}
 			stats.NumEntries = props.NumEntries
 			stats.NumDeletions = props.NumDeletions

--- a/tool/db.go
+++ b/tool/db.go
@@ -742,7 +742,7 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 		for _, l := range v.Levels {
 			var level props
 			for t := range l.All() {
-				if t.Virtual != nil {
+				if t.Virtual {
 					// TODO(bananabrick): Handle virtual sstables here. We don't
 					// really have any stats or properties at this point. Maybe
 					// we could approximate some of these properties for virtual

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -295,8 +295,8 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 
 		for j := range ve.NewTables {
 			nf := &ve.NewTables[j]
-			if b, ok := backings[nf.BackingFileNum]; ok && nf.Meta.Virtual != nil {
-				nf.Meta.FileBacking = b
+			if b, ok := backings[nf.BackingFileNum]; ok && nf.Meta.Virtual {
+				nf.Meta.AttachVirtualBacking(b)
 			}
 			if _, ok := l.state.Files[nf.Meta.FileNum]; !ok {
 				l.state.Files[nf.Meta.FileNum] = lsmTableMetadata{
@@ -305,7 +305,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 					Largest:        l.findKey(nf.Meta.Largest),
 					SmallestSeqNum: nf.Meta.SmallestSeqNum,
 					LargestSeqNum:  nf.Meta.LargestSeqNum,
-					Virtual:        nf.Meta.Virtual != nil,
+					Virtual:        nf.Meta.Virtual,
 				}
 			}
 			edit.Added[nf.Level] = append(edit.Added[nf.Level], nf.Meta.FileNum)

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -112,7 +112,7 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 					fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 					formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 					formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
-					if f.Virtual != nil {
+					if f.Virtual {
 						fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
 					}
 					fmt.Fprintf(stdout, "\n")
@@ -128,7 +128,7 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 			fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 			formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
 			formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
-			if f.Virtual != nil {
+			if f.Virtual {
 				fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
 			}
 			fmt.Fprintf(stdout, "\n")

--- a/version_set.go
+++ b/version_set.go
@@ -314,7 +314,7 @@ func (vs *versionSet) load(
 
 	for _, addedLevel := range bve.AddedTables {
 		for _, m := range addedLevel {
-			if m.Virtual != nil {
+			if m.Virtual {
 				vs.virtualBackings.AddTable(m)
 			}
 		}
@@ -350,7 +350,7 @@ func (vs *versionSet) load(
 	}
 	for _, l := range newVersion.Levels {
 		for f := range l.All() {
-			if f.Virtual == nil {
+			if !f.Virtual {
 				isLocal, localSize := sizeIfLocal(f.FileBacking, vs.provider)
 				vs.metrics.Table.Local.LiveSize = uint64(int64(vs.metrics.Table.Local.LiveSize) + localSize)
 				if isLocal {
@@ -782,7 +782,7 @@ func getZombiesAndUpdateVirtualBackings(
 	// will stay on the stack.
 	stillUsed := make(map[base.DiskFileNum]struct{})
 	for _, nf := range ve.NewTables {
-		if nf.Meta.Virtual == nil {
+		if !nf.Meta.Virtual {
 			stillUsed[nf.Meta.FileBacking.DiskFileNum] = struct{}{}
 			isLocal, localFileDelta := sizeIfLocal(nf.Meta.FileBacking, provider)
 			localLiveSizeDelta += localFileDelta
@@ -795,7 +795,7 @@ func getZombiesAndUpdateVirtualBackings(
 		stillUsed[b.DiskFileNum] = struct{}{}
 	}
 	for _, m := range ve.DeletedTables {
-		if m.Virtual == nil {
+		if !m.Virtual {
 			// NB: this deleted file may also be in NewFiles or
 			// CreatedBackingTables, due to a file moving between levels, or
 			// becoming virtualized. In which case there is no change due to this
@@ -828,12 +828,12 @@ func getZombiesAndUpdateVirtualBackings(
 		}
 	}
 	for _, nf := range ve.NewTables {
-		if nf.Meta.Virtual != nil {
+		if nf.Meta.Virtual {
 			virtualBackings.AddTable(nf.Meta)
 		}
 	}
 	for _, m := range ve.DeletedTables {
-		if m.Virtual != nil {
+		if m.Virtual {
 			virtualBackings.RemoveTable(m)
 		}
 	}
@@ -1040,7 +1040,7 @@ func (vs *versionSet) append(v *version) {
 		// the version.
 		for _, l := range v.Levels {
 			for f := range l.All() {
-				if f.Virtual != nil {
+				if f.Virtual {
 					if _, ok := vs.virtualBackings.Get(f.FileBacking.DiskFileNum); !ok {
 						panic(fmt.Sprintf("%s is not in virtualBackings", f.FileBacking.DiskFileNum))
 					}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -94,7 +94,7 @@ func TestVersionSet(t *testing.T) {
 				nf.Meta.Size = uint64(nf.Meta.FileNum) * 100
 				nf.Meta.FileBacking = dedupBacking(nf.Meta.FileBacking)
 				metas[nf.Meta.FileNum] = nf.Meta
-				if nf.Meta.Virtual == nil {
+				if !nf.Meta.Virtual {
 					createFile(nf.Meta.FileBacking.DiskFileNum)
 				}
 			}


### PR DESCRIPTION
#### virtual: remove Size and BackingSize from VirtualReaderParams


#### virtual: move IsSharedIngested to ReadEnv

We don't know the value of this flag just from the TableMetadata,
which precludes pre-initializing `VirtualReaderParams`.

#### manifest: minor cleanup of init backing methods


#### db: fix virtual table race

We initialize the virtual params in the file cache, but this is racy.

To fix this:
 - we change Virtual to a bool, and change `VirtualReaderParams` to a
   non-pointer field.
 - we add `AttachVirtualBacking` and use that instead of setting
   `FileBacking` directly. This function also initializes the
   `VirtualParams`.

Fixes #4536