### PR TITLE
metamorphic: fix key format when running a single config

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -79,8 +79,7 @@ func runTestMeta(t *testing.T, addtlOptions ...option) {
 			tryToReduceCompare(t, runOnceFlags.Dir, testRootDir, runSubdirs, runOnceFlags.ReduceAttempts)
 			return
 		}
-		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs,
-			runOnceFlags.KeyFormat(), onceOpts...)
+		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs, onceOpts...)
 
 	case runOnceFlags.RunDir != "":
 		// The --run-dir flag is specified either in the child process (see
@@ -95,7 +94,7 @@ func runTestMeta(t *testing.T, addtlOptions ...option) {
 			return
 		}
 		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed,
-			filepath.Join(runOnceFlags.RunDir, "history"), runOnceFlags.KeyFormat(), onceOpts...)
+			filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
 
 	default:
 		opts := runFlags.MakeRunOptions()

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -228,6 +228,7 @@ func (ro *RunOnceFlags) MakeRunOnceOptions() []metamorphic.RunOnceOption {
 	onceOpts := []metamorphic.RunOnceOption{
 		metamorphic.MaxThreads(ro.MaxThreads),
 		metamorphic.OpTimeout(ro.OpTimeout),
+		ro.KeyFormat(),
 	}
 	if ro.Keep {
 		onceOpts = append(onceOpts, metamorphic.KeepData{})

--- a/internal/metamorphic/metarunner/main.go
+++ b/internal/metamorphic/metarunner/main.go
@@ -27,16 +27,14 @@ func main() {
 	switch {
 	case runOnceFlags.Compare != "":
 		testRootDir, runSubdirs := runOnceFlags.ParseCompare()
-		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs,
-			runOnceFlags.KeyFormat(), onceOpts...)
+		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs, onceOpts...)
 
 	case runOnceFlags.RunDir != "":
 		// The --run-dir flag is specified either in the child process (see
 		// runOptions() below) or the user specified it manually in order to re-run
 		// a test.
 		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed,
-			filepath.Join(runOnceFlags.RunDir, "history"),
-			runOnceFlags.KeyFormat(), onceOpts...)
+			filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
 
 	default:
 		t.Errorf("--compare or --run-dir must be used")

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -462,9 +462,7 @@ func (m MultiInstance) applyOnce(ro *runOnceOptions)   { ro.numInstances = int(m
 // to a file at the path `historyPath`.
 //
 // The `seed` parameter is not functional; it's used for context in logging.
-func RunOnce(
-	t TestingT, runDir string, seed uint64, historyPath string, kf KeyFormat, rOpts ...RunOnceOption,
-) {
+func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts ...RunOnceOption) {
 	runOpts := runOnceOptions{
 		customOptionParsers: map[string]func(string) (CustomOption, bool){},
 	}
@@ -483,7 +481,7 @@ func RunOnce(
 	// NB: It's important to use defaultTestOptions() here as the base into
 	// which we parse the serialized options. It contains the relevant defaults,
 	// like the appropriate block-property collectors.
-	testOpts := defaultTestOptions(kf)
+	testOpts := defaultTestOptions(runOpts.keyFormat)
 	opts := testOpts.Opts
 	require.NoError(t, parseOptions(testOpts, string(optionsData), runOpts.customOptionParsers))
 
@@ -662,9 +660,7 @@ func hashThread(objID objID, numThreads int) int {
 
 // Compare runs the metamorphic tests in the provided runDirs and compares their
 // histories.
-func Compare(
-	t TestingT, rootDir string, seed uint64, runDirs []string, kf KeyFormat, rOpts ...RunOnceOption,
-) {
+func Compare(t TestingT, rootDir string, seed uint64, runDirs []string, rOpts ...RunOnceOption) {
 	historyPaths := make([]string, len(runDirs))
 	for i := 0; i < len(runDirs); i++ {
 		historyPath := filepath.Join(rootDir, runDirs[i]+"-"+time.Now().Format("060102-150405.000"))
@@ -679,7 +675,7 @@ func Compare(
 	}()
 
 	for i, runDir := range runDirs {
-		RunOnce(t, runDir, seed, historyPaths[i], kf, rOpts...)
+		RunOnce(t, runDir, seed, historyPaths[i], rOpts...)
 	}
 
 	if t.Failed() {


### PR DESCRIPTION
`RunOnce` takes the `KeyFormat` separately, but the one we pass is
derived from the flags, not the one that is passed to us from e.g.
`TestMetaCockroachKVs`. This change fixes this.

Note that when running the test normally, the top-level process passes
`--key-format` to the child process, so in that case it works out.