### PR TITLE
manifest: track current blob file state in CurrentBlobFileSet

### DIFF
--- a/db.go
+++ b/db.go
@@ -2061,7 +2061,12 @@ func (d *DB) Metrics() *Metrics {
 	backingCount, backingTotalSize := d.mu.versions.virtualBackings.Stats()
 	metrics.Table.BackingTableCount = uint64(backingCount)
 	metrics.Table.BackingTableSize = backingTotalSize
+	blobStats := d.mu.versions.blobFiles.Stats()
 	d.mu.versions.logUnlock()
+	metrics.BlobFiles.LiveCount = blobStats.Count
+	metrics.BlobFiles.LiveSize = blobStats.PhysicalSize
+	metrics.BlobFiles.ValueSize = blobStats.ValueSize
+	metrics.BlobFiles.ReferencedValueSize = blobStats.ReferencedValueSize
 
 	metrics.LogWriter.FsyncLatency = d.mu.log.metrics.fsyncLatency
 	if err := metrics.LogWriter.Merge(&d.mu.log.metrics.LogWriterMetrics); err != nil {

--- a/internal/manifest/blob_metadata_test.go
+++ b/internal/manifest/blob_metadata_test.go
@@ -5,8 +5,12 @@
 package manifest
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,4 +47,62 @@ func TestBlobFileMetadata_ParseRoundTrip(t *testing.T) {
 			require.Equal(t, want, got)
 		})
 	}
+}
+
+func TestCurrentBlobFileSet(t *testing.T) {
+	var (
+		buf        bytes.Buffer
+		set        CurrentBlobFileSet
+		tableMetas = make(map[base.FileNum]*TableMetadata)
+	)
+	parseAndFillVersionEdit := func(s string) *VersionEdit {
+		ve, err := ParseVersionEditDebug(s)
+		require.NoError(t, err)
+		for i, m := range ve.NewTables {
+			if existingMeta, ok := tableMetas[m.Meta.FileNum]; ok {
+				// Ensure pointer equality of the *TableMetadata.
+				// ParseVersionEditDebug will return a new *TableMetadata every
+				// time it decodes it.
+				ve.NewTables[i].Meta = existingMeta
+			} else {
+				tableMetas[m.Meta.FileNum] = m.Meta
+			}
+		}
+		for dte := range ve.DeletedTables {
+			ve.DeletedTables[dte] = tableMetas[dte.FileNum]
+		}
+		return ve
+	}
+
+	datadriven.RunTest(t, "testdata/current_blob_file_set", func(t *testing.T, d *datadriven.TestData) string {
+		buf.Reset()
+		switch d.Cmd {
+		case "init":
+			ve := parseAndFillVersionEdit(d.Input)
+			bve := &BulkVersionEdit{}
+			if err := bve.Accumulate(ve); err != nil {
+				return fmt.Sprintf("error accumulating version edit: %s", err)
+			}
+			set.Init(bve)
+			return set.Stats().String()
+		case "applyAndUpdateVersionEdit":
+			ve := parseAndFillVersionEdit(d.Input)
+			if err := set.ApplyAndUpdateVersionEdit(ve); err != nil {
+				return fmt.Sprintf("error applying and updating version edit: %s", err)
+			}
+			fmt.Fprintf(&buf, "modified version edit:\n%s", ve.DebugString(base.DefaultFormatter))
+			fmt.Fprintf(&buf, "current blob file set:\n%s", set.Stats().String())
+			return buf.String()
+		case "metadatas":
+			for _, m := range set.Metadatas() {
+				fmt.Fprintf(&buf, "%s\n", m)
+			}
+			return buf.String()
+		case "stats":
+			return set.Stats().String()
+		default:
+			t.Fatalf("unknown command: %s", d.Cmd)
+		}
+		return ""
+	})
 }

--- a/internal/manifest/testdata/current_blob_file_set
+++ b/internal/manifest/testdata/current_blob_file_set
@@ -1,0 +1,75 @@
+init
+----
+Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, Count: 0}
+
+# A version edit that does not contain blob files leaves the set unchanged.
+
+applyAndUpdateVersionEdit
+  add-table: L3 000010:[d#1,SET-e#1,SET]
+----
+modified version edit:
+  add-table:     L3 000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET]
+current blob file set:
+Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, Count: 0}
+
+# A version edit that adds a new blob file records the new file and reference.
+
+applyAndUpdateVersionEdit
+  add-table: L3 000011:[d#1,SET-e#1,SET] blobrefs:[(000012: 25935); depth:1]
+  add-blob-file: 000012 size:[20535 (20KB)] vals:[25935 (25KB)]
+----
+modified version edit:
+  add-table:     L3 000011:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] blobrefs:[(000012: 25935); depth:1]
+  add-blob-file: 000012 size:[20535 (20KB)] vals:[25935 (25KB)]
+current blob file set:
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 25935, Count: 1}
+
+# A version edit that moves a referencing table from one level to another should
+# leave the blob set unchanged.
+
+applyAndUpdateVersionEdit
+  del-table: L3 000011
+  add-table: L4 000011:[d#1,SET-e#1,SET] blobrefs:[(000012: 25935); depth:1]
+----
+modified version edit:
+  del-table:     L3 000011
+  add-table:     L4 000011:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] blobrefs:[(000012: 25935); depth:1]
+current blob file set:
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 25935, Count: 1}
+
+# A version edit that moves references from deleted tables to created tables
+# preseves the referenced blob file in the set, but updates the reference data.
+
+applyAndUpdateVersionEdit
+  del-table: L4 000011
+  add-table: L5 000013:[d#1,SET-e#1,SET] blobrefs:[(000012: 10); depth:2]
+  add-table: L5 000014:[f#1,SET-g#1,SET] blobrefs:[(000012: 15935); depth:2]
+----
+modified version edit:
+  del-table:     L4 000011
+  add-table:     L5 000013:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] blobrefs:[(000012: 10); depth:2]
+  add-table:     L5 000014:[f#1,SET-g#1,SET] seqnums:[0-0] points:[f#1,SET-g#1,SET] blobrefs:[(000012: 15935); depth:2]
+current blob file set:
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 15945, Count: 2}
+
+# Remove one of the two references.
+
+applyAndUpdateVersionEdit
+  del-table: L5 000014
+----
+modified version edit:
+  del-table:     L5 000014
+current blob file set:
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 10, Count: 1}
+
+# Remove the last reference. The version edit should be modified to include the
+# removal of the blob file.
+
+applyAndUpdateVersionEdit
+  del-table: L5 000013
+----
+modified version edit:
+  del-table:     L5 000013
+  del-blob-file: 000012
+current blob file set:
+Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, Count: 0}

--- a/metrics.go
+++ b/metrics.go
@@ -315,29 +315,50 @@ type Metrics struct {
 	BlobFiles struct {
 		// The count of all live blob files.
 		LiveCount uint64
-		// The size of all live blob files.
+		// The physical file size of all live blob files.
 		LiveSize uint64
+		// ValueSize is the sum of the length of the uncompressed values in all
+		// live (referenced by some sstable(s) within the current version) blob
+		// files. ValueSize may be greater than LiveSize when compression is
+		// effective. ValueSize includes bytes in live blob files that are not
+		// actually reachable by any sstable key. If any value within the blob
+		// file is reachable by a key in a live sstable, then the entirety of
+		// the blob file's values are included within ValueSize.
+		ValueSize uint64
+		// ReferencedValueSize is the sum of the length of the uncompressed
+		// values (in all live blob files) that are still referenced by keys
+		// within live tables. Over the lifetime of a blob file, a blob file's
+		// references are removed as some compactions choose to write new blob
+		// files containing the same values or keys referencing the file's
+		// values are deleted. ReferencedValueSize accounts the volume of bytes
+		// that are actually reachable by some key in a live table.
+		//
+		// The difference between ValueSize and ReferencedValueSize is
+		// (uncompressed) space amplification that could be reclaimed if all
+		// blob files were rewritten, discarding values that are no longer
+		// referenced by any keys in any sstables within the current version.
+		ReferencedValueSize uint64
 		// The count of all obsolete blob files.
 		ObsoleteCount uint64
-		// The size of all obsolete blob files.
+		// The physical size of all obsolete blob files.
 		ObsoleteSize uint64
 		// The count of all zombie blob files.
 		ZombieCount uint64
-		// The size of all zombie blob files.
+		// The physical size of all zombie blob files.
 		ZombieSize uint64
 		// Local file sizes.
 		Local struct {
-			// LiveSize is the number of bytes in live blob files.
+			// LiveSize is the physical size of local live blob files.
 			LiveSize uint64
-			// LiveCount is the number of live blob files.
+			// LiveCount is the number of local live blob files.
 			LiveCount uint64
-			// ObsoleteSize is the number of bytes in obsolete blob files.
+			// ObsoleteSize is the physical size of local obsolete blob files.
 			ObsoleteSize uint64
-			// ObsoleteCount is the number of obsolete blob files.
+			// ObsoleteCount is the number of local obsolete blob files.
 			ObsoleteCount uint64
-			// ZombieSize is the number of bytes in zombie blob files.
+			// ZombieSize is the physical size of local zombie blob files.
 			ZombieSize uint64
-			// ZombieCount is the number of zombie blob files.
+			// ZombieCount is the number of local zombie blob files.
 			ZombieCount uint64
 		}
 	}


### PR DESCRIPTION
Previously although machinery existed to support removal of blob files in a
VersionEdit's DeletedBlobFiles, the field was never populated because there was
no logic to notice that the final reference to a blob file was removed. This
commit introduces a new type CurrentBlobFileSet that tracks the set of blob
files that are referenced within the latest Version of the LSM. The versionSet
is updated to maintain a CurrentBlobFileSet.

Before applying a new version edit, we pass the version edit through
CurrentBlobFileSet's ApplyAndUpdateVersionEdit. This method updates the
CurrentBlobFileSet's accounting of all extant references to blob files and adds
new entries to VersionEdit.DeletedBlobFiles if any blob file is now
unreferenced.

In the future CurrentBlobFileSet's index of blob files can be used to pick blob
files to be re-written in place to reduce space amplification.

Informs #112.