### PR TITLE
sstable: set minlz compression to default for v6+

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -191,7 +191,7 @@ func TestIngestLoadRand(t *testing.T) {
 			},
 			path: paths[i],
 		}
-		expected[i].tableMetadata.Stats.CompressionType = block.SnappyCompression
+		expected[i].tableMetadata.Stats.CompressionType = block.MinlzCompression
 		expected[i].StatsMarkValid()
 
 		func() {

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -786,14 +786,16 @@ func RandomOptions(
 		lopts.FilterPolicy = newTestingFilterPolicy(1 << rng.IntN(5))
 	}
 
-	// We use either no compression, snappy compression or zstd compression.
-	switch rng.IntN(3) {
+	// We use either no compression, snappy compression, zstd compression, or minlz compression.
+	switch rng.IntN(4) {
 	case 0:
 		lopts.Compression = func() block.Compression { return pebble.NoCompression }
 	case 1:
 		lopts.Compression = func() block.Compression { return pebble.ZstdCompression }
-	default:
+	case 2:
 		lopts.Compression = func() block.Compression { return pebble.SnappyCompression }
+	default:
+		lopts.Compression = func() block.Compression { return pebble.MinlzCompression }
 	}
 	opts.Levels = []pebble.LevelOptions{lopts}
 

--- a/options.go
+++ b/options.go
@@ -2160,7 +2160,7 @@ func (o *Options) MakeBlobWriterOptions(level int) blob.FileWriterOptions {
 
 func resolveDefaultCompression(c Compression) Compression {
 	if c <= DefaultCompression || c >= block.NCompression {
-		c = SnappyCompression
+		c = MinlzCompression
 	}
 	return c
 }

--- a/options_test.go
+++ b/options_test.go
@@ -127,7 +127,7 @@ func TestDefaultOptionsString(t *testing.T) {
   block_restart_interval=16
   block_size=4096
   block_size_threshold=90
-  compression=Snappy
+  compression=Minlz
   filter_policy=none
   filter_type=table
   index_block_size=4096

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -11,7 +11,7 @@ tree
      614      000007.sst
        0      LOCK
      133      MANIFEST-000001
-    1524      OPTIONS-000003
+    1523      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000001.MANIFEST-000001
             simple/
@@ -21,7 +21,7 @@ tree
       25        000004.log
      586        000005.sst
       85        MANIFEST-000001
-    1524        OPTIONS-000003
+    1523        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -79,7 +79,7 @@ cat build/OPTIONS-000003
   block_restart_interval=16
   block_size=4096
   block_size_threshold=90
-  compression=Snappy
+  compression=Minlz
   filter_policy=none
   filter_type=table
   index_block_size=4096

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -14,7 +14,7 @@ tree
        0      LOCK
      133      MANIFEST-000001
      205      MANIFEST-000010
-    1524      OPTIONS-000003
+    1523      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000002.MANIFEST-000010
             high_read_amp/
@@ -26,7 +26,7 @@ tree
       39        000008.log
      560        000009.sst
      157        MANIFEST-000010
-    1524        OPTIONS-000003
+    1523        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000010
 

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -331,6 +331,9 @@ func (o WriterOptions) ensureDefaults() WriterOptions {
 		o.Comparer = base.DefaultComparer
 	}
 	if o.Compression <= block.DefaultCompression || o.Compression >= block.NCompression {
+		o.Compression = block.MinlzCompression
+	}
+	if o.Compression == block.MinlzCompression && o.TableFormat <= TableFormatPebblev5 {
 		o.Compression = block.SnappyCompression
 	}
 	if o.IndexBlockSize <= 0 {

--- a/sstable/testdata/copy_span
+++ b/sstable/testdata/copy_span
@@ -173,7 +173,7 @@ d#0,SET: foobar
 
 copy-span test3 test4 b.SET.10 cc.SET.0
 ----
-copied 928 bytes
+copied 921 bytes
 
 iter test4
 ----
@@ -183,7 +183,7 @@ d#0,SET: foobar
 
 copy-span test3 test5 a.SET.10 bb.SET.0
 ----
-copied 936 bytes
+copied 918 bytes
 
 iter test5
 ----
@@ -213,7 +213,7 @@ d#0,SET: foobar
 
 copy-span test32 test33 b.SET.10 cc.SET.0
 ----
-copied 928 bytes
+copied 921 bytes
 
 iter test33
 ----
@@ -223,7 +223,7 @@ d#0,SET: foobar
 
 copy-span test32 test34 a.SET.10 bb.SET.0
 ----
-copied 936 bytes
+copied 918 bytes
 
 iter test34
 ----

--- a/sstable/testdata/rewriter_v6
+++ b/sstable/testdata/rewriter_v6
@@ -45,9 +45,9 @@ sstable
  ├── index  offset: 363  length: 37
  ├── top-index  offset: 405  length: 52
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
- ├── properties  offset: 536  length: 572
- ├── meta-index  offset: 1113  length: 88
- └── footer  offset: 1206  length: 57
+ ├── properties  offset: 536  length: 583
+ ├── meta-index  offset: 1124  length: 88
+ └── footer  offset: 1217  length: 57
 
 scan
 ----
@@ -80,9 +80,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 572
- ├── meta-index  offset: 1121  length: 88
- └── footer  offset: 1214  length: 57
+ ├── properties  offset: 544  length: 583
+ ├── meta-index  offset: 1132  length: 88
+ └── footer  offset: 1225  length: 57
 
 scan
 ----
@@ -115,9 +115,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 572
- ├── meta-index  offset: 1121  length: 88
- └── footer  offset: 1214  length: 57
+ ├── properties  offset: 544  length: 583
+ ├── meta-index  offset: 1132  length: 88
+ └── footer  offset: 1225  length: 57
 
 scan
 ----
@@ -150,9 +150,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 572
- ├── meta-index  offset: 1121  length: 88
- └── footer  offset: 1214  length: 57
+ ├── properties  offset: 544  length: 583
+ ├── meta-index  offset: 1132  length: 88
+ └── footer  offset: 1225  length: 57
 
 scan
 ----
@@ -186,9 +186,9 @@ sstable
  ├── index  offset: 363  length: 37
  ├── top-index  offset: 405  length: 52
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
- ├── properties  offset: 536  length: 572
- ├── meta-index  offset: 1113  length: 88
- └── footer  offset: 1206  length: 57
+ ├── properties  offset: 536  length: 583
+ ├── meta-index  offset: 1124  length: 88
+ └── footer  offset: 1217  length: 57
 
 scan
 ----

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -111,37 +111,37 @@ sstable
  │    ├── 00000    block:0/154
  │    │   
  │    └── trailer [compression=none checksum=0xda1c8436]
- ├── properties  offset: 200  length: 562
+ ├── properties  offset: 200  length: 559
  │    ├── 00000    obsolete-key (13)
  │    ├── 00013    pebble.colblk.schema (65)
  │    ├── 00078    pebble.num.values.in.blob-files (32)
  │    ├── 00110    pebble.raw.point-tombstone.key.size (36)
  │    ├── 00146    rocksdb.block.based.table.index.type (40)
  │    ├── 00186    rocksdb.comparator (42)
- │    ├── 00228    rocksdb.compression (25)
- │    ├── 00253    rocksdb.compression_options (122)
- │    ├── 00375    rocksdb.data.size (19)
- │    ├── 00394    rocksdb.deleted.keys (21)
- │    ├── 00415    rocksdb.filter.size (20)
- │    ├── 00435    rocksdb.index.size (19)
- │    ├── 00454    rocksdb.merge.operands (23)
- │    ├── 00477    rocksdb.merge.operator (40)
- │    ├── 00517    rocksdb.num.data.blocks (24)
- │    ├── 00541    rocksdb.num.entries (20)
- │    ├── 00561    rocksdb.num.range-deletions (28)
- │    ├── 00589    rocksdb.property.collectors (41)
- │    ├── 00630    rocksdb.raw.key.size (21)
- │    ├── 00651    rocksdb.raw.value.size (24)
- │    └── trailer [compression=snappy checksum=0xf0c5768d]
- ├── meta-index  offset: 767  length: 46
- │    ├── 0000    rocksdb.properties block:200/562
+ │    ├── 00228    rocksdb.compression (24)
+ │    ├── 00252    rocksdb.compression_options (122)
+ │    ├── 00374    rocksdb.data.size (19)
+ │    ├── 00393    rocksdb.deleted.keys (21)
+ │    ├── 00414    rocksdb.filter.size (20)
+ │    ├── 00434    rocksdb.index.size (19)
+ │    ├── 00453    rocksdb.merge.operands (23)
+ │    ├── 00476    rocksdb.merge.operator (40)
+ │    ├── 00516    rocksdb.num.data.blocks (24)
+ │    ├── 00540    rocksdb.num.entries (20)
+ │    ├── 00560    rocksdb.num.range-deletions (28)
+ │    ├── 00588    rocksdb.property.collectors (41)
+ │    ├── 00629    rocksdb.raw.key.size (21)
+ │    ├── 00650    rocksdb.raw.value.size (24)
+ │    └── trailer [compression=minlz checksum=0xefe5c665]
+ ├── meta-index  offset: 764  length: 46
+ │    ├── 0000    rocksdb.properties block:200/559
  │    │   
- │    └── trailer [compression=none checksum=0xaa86f2de]
- └── footer  offset: 818  length: 57
+ │    └── trailer [compression=none checksum=0x3da86560]
+ └── footer  offset: 815  length: 57
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=767, length=46
+      ├── 001  meta: offset=764, length=46
       ├── 004  index: offset=159, length=36
-      ├── 041  footer checksum: 0xe7d8ef2e
+      ├── 041  footer checksum: 0x35ccc1c0
       ├── 045  version: 6
       └── 049  magic number: 0xf09faab3f09faab3
 

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -96,7 +96,7 @@ rocksdb.raw.value.size: 0
 rocksdb.deleted.keys: 9
 rocksdb.num.range-deletions: 9
 rocksdb.num.data.blocks: 0
-rocksdb.compression: Snappy
+rocksdb.compression: Minlz
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
 rocksdb.comparator: pebble.internal.testkeys
 rocksdb.data.size: 0
@@ -228,32 +228,32 @@ seqnums:  [1-1]
 layout
 ----
 sstable
- ├── data  offset: 0  length: 74
- ├── data  offset: 79  length: 74
- ├── data  offset: 158  length: 74
- ├── index  offset: 237  length: 36
- ├── index  offset: 278  length: 37
- ├── index  offset: 320  length: 37
- ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 554
- ├── meta-index  offset: 974  length: 46
- └── footer  offset: 1025  length: 57
+ ├── data  offset: 0  length: 72
+ ├── data  offset: 77  length: 72
+ ├── data  offset: 154  length: 72
+ ├── index  offset: 231  length: 36
+ ├── index  offset: 272  length: 37
+ ├── index  offset: 314  length: 37
+ ├── top-index  offset: 356  length: 48
+ ├── properties  offset: 409  length: 530
+ ├── meta-index  offset: 944  length: 46
+ └── footer  offset: 995  length: 57
 
 # Exercise the non-Reader layout-decoding codepath.
 
 decode-layout
 ----
 sstable
- ├── data  offset: 0  length: 74
- ├── data  offset: 79  length: 74
- ├── data  offset: 158  length: 74
- ├── index  offset: 237  length: 36
- ├── index  offset: 278  length: 37
- ├── index  offset: 320  length: 37
- ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 554
- ├── meta-index  offset: 974  length: 46
- └── footer  offset: 1025  length: 57
+ ├── data  offset: 0  length: 72
+ ├── data  offset: 77  length: 72
+ ├── data  offset: 154  length: 72
+ ├── index  offset: 231  length: 36
+ ├── index  offset: 272  length: 37
+ ├── index  offset: 314  length: 37
+ ├── top-index  offset: 356  length: 48
+ ├── properties  offset: 409  length: 530
+ ├── meta-index  offset: 944  length: 46
+ └── footer  offset: 995  length: 57
 
 scan
 ----
@@ -298,9 +298,9 @@ layout
 sstable
  ├── index  offset: 0  length: 28
  ├── range-key  offset: 33  length: 84
- ├── properties  offset: 122  length: 577
- ├── meta-index  offset: 704  length: 65
- └── footer  offset: 774  length: 57
+ ├── properties  offset: 122  length: 574
+ ├── meta-index  offset: 701  length: 65
+ └── footer  offset: 771  length: 57
 
 props
 ----
@@ -312,7 +312,7 @@ rocksdb.num.range-deletions: 0
 pebble.num.range-key-dels: 0
 pebble.num.range-key-sets: 3
 rocksdb.num.data.blocks: 0
-rocksdb.compression: Snappy
+rocksdb.compression: Minlz
 rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
 rocksdb.comparator: pebble.internal.testkeys
 rocksdb.data.size: 0

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -993,7 +993,7 @@ c@5#6,DEL:
 layout
 ----
 sstable
- ├── data  offset: 0  length: 100
+ ├── data  offset: 0  length: 115
  │    ├── data block header
  │    │    ├── columnar block header
  │    │    │    ├── 000-004: x 03000000 # maximum key length: 3
@@ -1078,40 +1078,40 @@ sstable
  │    ├── b@3#2,SET:
  │    ├── c@6#7,DEL:
  │    ├── c@5#6,DEL:
- │    └── trailer [compression=snappy checksum=0x73ac4dc7]
- ├── index  offset: 105  length: 36
- │    ├── 00000    block:0/100
+ │    └── trailer [compression=none checksum=0x87ce3676]
+ ├── index  offset: 120  length: 36
+ │    ├── 00000    block:0/115
  │    │   
- │    └── trailer [compression=none checksum=0x760132f1]
- ├── properties  offset: 146  length: 525
+ │    └── trailer [compression=none checksum=0x631493a9]
+ ├── properties  offset: 161  length: 538
  │    ├── 00000    obsolete-key (13)
  │    ├── 00013    pebble.colblk.schema (65)
  │    ├── 00078    pebble.raw.point-tombstone.key.size (36)
  │    ├── 00114    rocksdb.block.based.table.index.type (40)
  │    ├── 00154    rocksdb.comparator (42)
- │    ├── 00196    rocksdb.compression (25)
- │    ├── 00221    rocksdb.compression_options (122)
- │    ├── 00343    rocksdb.data.size (18)
- │    ├── 00361    rocksdb.deleted.keys (21)
- │    ├── 00382    rocksdb.filter.size (20)
- │    ├── 00402    rocksdb.index.size (19)
- │    ├── 00421    rocksdb.merge.operands (23)
- │    ├── 00444    rocksdb.merge.operator (40)
- │    ├── 00484    rocksdb.num.data.blocks (24)
- │    ├── 00508    rocksdb.num.entries (20)
- │    ├── 00528    rocksdb.num.range-deletions (28)
- │    ├── 00556    rocksdb.property.collectors (41)
- │    ├── 00597    rocksdb.raw.key.size (21)
- │    ├── 00618    rocksdb.raw.value.size (23)
- │    └── trailer [compression=snappy checksum=0x6a5dbad6]
- ├── meta-index  offset: 676  length: 46
- │    ├── 0000    rocksdb.properties block:146/525
+ │    ├── 00196    rocksdb.compression (24)
+ │    ├── 00220    rocksdb.compression_options (122)
+ │    ├── 00342    rocksdb.data.size (18)
+ │    ├── 00360    rocksdb.deleted.keys (21)
+ │    ├── 00381    rocksdb.filter.size (20)
+ │    ├── 00401    rocksdb.index.size (19)
+ │    ├── 00420    rocksdb.merge.operands (23)
+ │    ├── 00443    rocksdb.merge.operator (40)
+ │    ├── 00483    rocksdb.num.data.blocks (24)
+ │    ├── 00507    rocksdb.num.entries (20)
+ │    ├── 00527    rocksdb.num.range-deletions (28)
+ │    ├── 00555    rocksdb.property.collectors (41)
+ │    ├── 00596    rocksdb.raw.key.size (21)
+ │    ├── 00617    rocksdb.raw.value.size (23)
+ │    └── trailer [compression=minlz checksum=0xa3191ff9]
+ ├── meta-index  offset: 704  length: 46
+ │    ├── 0000    rocksdb.properties block:161/538
  │    │   
- │    └── trailer [compression=none checksum=0xf5a62be1]
- └── footer  offset: 727  length: 57
+ │    └── trailer [compression=none checksum=0x3ca12e20]
+ └── footer  offset: 755  length: 57
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=676, length=46
-      ├── 004  index: offset=105, length=36
-      ├── 041  footer checksum: 0x29ebd1c0
+      ├── 001  meta: offset=704, length=46
+      ├── 004  index: offset=120, length=36
+      ├── 041  footer checksum: 0x583d3750
       ├── 045  version: 6
       └── 049  magic number: 0xf09faab3f09faab3

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -238,23 +238,23 @@ close: db/000009.sst
 sync: db
 sync: db/MANIFEST-000001
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): db/000005.sst
-read-at(649, 51): db/000005.sst
-read-at(132, 517): db/000005.sst
+read-at(711, 57): db/000005.sst
+read-at(660, 51): db/000005.sst
+read-at(145, 515): db/000005.sst
 open: db/000009.sst (options: *vfs.randomReadsOption)
-read-at(704, 57): db/000009.sst
-read-at(653, 51): db/000009.sst
-read-at(136, 517): db/000009.sst
+read-at(702, 57): db/000009.sst
+read-at(651, 51): db/000009.sst
+read-at(136, 515): db/000009.sst
 open: db/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): db/000007.sst
-read-at(649, 51): db/000007.sst
-read-at(132, 517): db/000007.sst
-read-at(91, 41): db/000005.sst
+read-at(711, 57): db/000007.sst
+read-at(660, 51): db/000007.sst
+read-at(145, 515): db/000007.sst
+read-at(104, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
-read-at(0, 91): db/000005.sst
-read-at(91, 41): db/000007.sst
+read-at(0, 104): db/000005.sst
+read-at(104, 41): db/000007.sst
 open: db/000007.sst (options: *vfs.sequentialReadsOption)
-read-at(0, 91): db/000007.sst
+read-at(0, 104): db/000007.sst
 create: db/000010.sst
 close: db/000005.sst
 read-at(95, 41): db/000009.sst
@@ -318,17 +318,17 @@ close: checkpoints/checkpoint1/000006.log
 scan checkpoints/checkpoint1
 ----
 open: checkpoints/checkpoint1/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint1/000007.sst
-read-at(649, 51): checkpoints/checkpoint1/000007.sst
-read-at(132, 517): checkpoints/checkpoint1/000007.sst
-read-at(91, 41): checkpoints/checkpoint1/000007.sst
-read-at(0, 91): checkpoints/checkpoint1/000007.sst
+read-at(711, 57): checkpoints/checkpoint1/000007.sst
+read-at(660, 51): checkpoints/checkpoint1/000007.sst
+read-at(145, 515): checkpoints/checkpoint1/000007.sst
+read-at(104, 41): checkpoints/checkpoint1/000007.sst
+read-at(0, 104): checkpoints/checkpoint1/000007.sst
 open: checkpoints/checkpoint1/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint1/000005.sst
-read-at(649, 51): checkpoints/checkpoint1/000005.sst
-read-at(132, 517): checkpoints/checkpoint1/000005.sst
-read-at(91, 41): checkpoints/checkpoint1/000005.sst
-read-at(0, 91): checkpoints/checkpoint1/000005.sst
+read-at(711, 57): checkpoints/checkpoint1/000005.sst
+read-at(660, 51): checkpoints/checkpoint1/000005.sst
+read-at(145, 515): checkpoints/checkpoint1/000005.sst
+read-at(104, 41): checkpoints/checkpoint1/000005.sst
+read-at(0, 104): checkpoints/checkpoint1/000005.sst
 a 1
 b 5
 c 3
@@ -341,11 +341,11 @@ g 10
 scan db
 ----
 open: db/000010.sst (options: *vfs.randomReadsOption)
-read-at(709, 57): db/000010.sst
-read-at(658, 51): db/000010.sst
-read-at(141, 517): db/000010.sst
-read-at(100, 41): db/000010.sst
-read-at(0, 100): db/000010.sst
+read-at(712, 57): db/000010.sst
+read-at(661, 51): db/000010.sst
+read-at(146, 515): db/000010.sst
+read-at(105, 41): db/000010.sst
+read-at(0, 105): db/000010.sst
 a 1
 b 5
 c 3
@@ -385,11 +385,11 @@ close: checkpoints/checkpoint2/000006.log
 scan checkpoints/checkpoint2
 ----
 open: checkpoints/checkpoint2/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint2/000007.sst
-read-at(649, 51): checkpoints/checkpoint2/000007.sst
-read-at(132, 517): checkpoints/checkpoint2/000007.sst
-read-at(91, 41): checkpoints/checkpoint2/000007.sst
-read-at(0, 91): checkpoints/checkpoint2/000007.sst
+read-at(711, 57): checkpoints/checkpoint2/000007.sst
+read-at(660, 51): checkpoints/checkpoint2/000007.sst
+read-at(145, 515): checkpoints/checkpoint2/000007.sst
+read-at(104, 41): checkpoints/checkpoint2/000007.sst
+read-at(0, 104): checkpoints/checkpoint2/000007.sst
 b 5
 d 7
 e 8
@@ -427,17 +427,17 @@ close: checkpoints/checkpoint3/000006.log
 scan checkpoints/checkpoint3
 ----
 open: checkpoints/checkpoint3/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint3/000007.sst
-read-at(649, 51): checkpoints/checkpoint3/000007.sst
-read-at(132, 517): checkpoints/checkpoint3/000007.sst
-read-at(91, 41): checkpoints/checkpoint3/000007.sst
-read-at(0, 91): checkpoints/checkpoint3/000007.sst
+read-at(711, 57): checkpoints/checkpoint3/000007.sst
+read-at(660, 51): checkpoints/checkpoint3/000007.sst
+read-at(145, 515): checkpoints/checkpoint3/000007.sst
+read-at(104, 41): checkpoints/checkpoint3/000007.sst
+read-at(0, 104): checkpoints/checkpoint3/000007.sst
 open: checkpoints/checkpoint3/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint3/000005.sst
-read-at(649, 51): checkpoints/checkpoint3/000005.sst
-read-at(132, 517): checkpoints/checkpoint3/000005.sst
-read-at(91, 41): checkpoints/checkpoint3/000005.sst
-read-at(0, 91): checkpoints/checkpoint3/000005.sst
+read-at(711, 57): checkpoints/checkpoint3/000005.sst
+read-at(660, 51): checkpoints/checkpoint3/000005.sst
+read-at(145, 515): checkpoints/checkpoint3/000005.sst
+read-at(104, 41): checkpoints/checkpoint3/000005.sst
+read-at(0, 104): checkpoints/checkpoint3/000005.sst
 a 1
 b 5
 c 3
@@ -570,11 +570,11 @@ close: checkpoints/checkpoint4/000008.log
 scan checkpoints/checkpoint4
 ----
 open: checkpoints/checkpoint4/000010.sst (options: *vfs.randomReadsOption)
-read-at(709, 57): checkpoints/checkpoint4/000010.sst
-read-at(658, 51): checkpoints/checkpoint4/000010.sst
-read-at(141, 517): checkpoints/checkpoint4/000010.sst
-read-at(100, 41): checkpoints/checkpoint4/000010.sst
-read-at(0, 100): checkpoints/checkpoint4/000010.sst
+read-at(712, 57): checkpoints/checkpoint4/000010.sst
+read-at(661, 51): checkpoints/checkpoint4/000010.sst
+read-at(146, 515): checkpoints/checkpoint4/000010.sst
+read-at(105, 41): checkpoints/checkpoint4/000010.sst
+read-at(0, 105): checkpoints/checkpoint4/000010.sst
 a 1
 b 5
 d 7

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -88,7 +88,7 @@ maybe-compact
 Deletion hints:
   L0.000004 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel L2 [000005] (760B) Score=0.00 + L3 [000006] (760B) Score=0.00 + L4 [000007] (760B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel L2 [000005] (758B) Score=0.00 + L3 [000006] (758B) Score=0.00 + L4 [000007] (758B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # Verify that compaction correctly handles the presence of multiple
 # overlapping hints which might delete a file multiple times. All of the
@@ -127,7 +127,7 @@ maybe-compact
 Deletion hints:
   L1.000005 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel L2 [000005] (760B) Score=0.00 + L3 [000006] (760B) Score=0.00 + L4 [000007] (760B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel L2 [000005] (758B) Score=0.00 + L3 [000006] (758B) Score=0.00 + L4 [000007] (758B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # Test a range tombstone that is already compacted into L6.
 
@@ -206,7 +206,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel L2 [000005] (760B) Score=0.00 + L3 [000006] (760B) Score=0.00 + L4 [000007] (760B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel L2 [000005] (758B) Score=0.00 + L3 [000006] (758B) Score=0.00 + L4 [000007] (758B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # A deletion hint present on an sstable in a higher level should NOT result in a
 # deletion-only compaction incorrectly removing an sstable in L6 following an
@@ -255,7 +255,7 @@ L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
 close-snapshot
 10
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (825B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (749B), in 1.0s (2.0s total), output rate 749B/s
+[JOB 100] compacted(elision-only) L6 [000004] (823B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (747B), in 1.0s (2.0s total), output rate 747B/s
 
 # In previous versions of the code, the deletion hint was removed by the
 # elision-only compaction because it zeroed sequence numbers of keys with
@@ -474,7 +474,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel L1 [000005] (752B) Score=0.00 + L2 [000006] (760B) Score=0.00 + L3 [000007] (760B) Score=0.00 + L4 [000008] (760B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
+  [JOB 100] compacted(delete-only) multilevel L1 [000005] (740B) Score=0.00 + L2 [000006] (758B) Score=0.00 + L3 [000007] (758B) Score=0.00 + L4 [000008] (758B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
 
 describe-lsm
 ----
@@ -542,7 +542,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000005] (747B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+  [JOB 100] compacted(delete-only) L6 [000005] (758B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 describe-lsm
 ----
@@ -608,7 +608,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000004] (897B) Score=0.00 -> L6 [000007 000008] (186B), in 1.0s (2.0s total), output rate 186B/s
+  [JOB 100] compacted(delete-only) L6 [000004] (919B) Score=0.00 -> L6 [000007 000008] (214B), in 1.0s (2.0s total), output rate 214B/s
 
 describe-lsm
 ----

--- a/testdata/compaction_picker_pick_file
+++ b/testdata/compaction_picker_pick_file
@@ -16,9 +16,9 @@ L2:
 file-sizes
 ----
 L1:
-  000004:[b#11,SET-c#11,SET]: 769 bytes (769B)
+  000004:[b#11,SET-c#11,SET]: 765 bytes (765B)
 L2:
-  000005:[c#0,SET-d#0,SET]: 756 bytes (756B)
+  000005:[c#0,SET-d#0,SET]: 765 bytes (765B)
 
 pick-file L1
 ----
@@ -131,12 +131,12 @@ L6:
 file-sizes
 ----
 L5:
-  000004:[c#11,SET-e#11,SET]: 99395 bytes (97KB)
-  000005:[f#11,SET-f#11,SET]: 58116 bytes (57KB)
+  000004:[c#11,SET-e#11,SET]: 99391 bytes (97KB)
+  000005:[f#11,SET-f#11,SET]: 58112 bytes (57KB)
 L6:
-  000006:[c#0,SET-c#0,SET]: 66310 bytes (65KB)
-  000007:[e#0,SET-e#0,SET]: 66310 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66310 bytes (65KB)
+  000006:[c#0,SET-c#0,SET]: 66306 bytes (65KB)
+  000007:[e#0,SET-e#0,SET]: 66306 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66306 bytes (65KB)
 
 # Sst 5 is picked since 65KB/57KB is less than 130KB/97KB.
 pick-file L5
@@ -168,12 +168,12 @@ file-sizes
 L5:
   000010:[c#11,SET-c#11,SET]: 32862 bytes (32KB)
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
-  000005:[f#11,SET-f#11,SET]: 58116 bytes (57KB)
+  000005:[f#11,SET-f#11,SET]: 58112 bytes (57KB)
 L6:
-  000006:[c#0,SET-c#0,SET]: 66310 bytes (65KB)
-  000009:[d#13,SET-d#13,SET]: 754 bytes (754B)
-  000007:[e#0,SET-e#0,SET]: 66310 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66310 bytes (65KB)
+  000006:[c#0,SET-c#0,SET]: 66306 bytes (65KB)
+  000009:[d#13,SET-d#13,SET]: 750 bytes (750B)
+  000007:[e#0,SET-e#0,SET]: 66306 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66306 bytes (65KB)
 
 # Superficially, sst 10 causes write amp of 65KB/32KB which is worse than sst
 # 5. But the garbage of ~64KB in the backing sst 4 is equally distributed
@@ -207,12 +207,12 @@ file-sizes
 ----
 L5:
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
-  000005:[f#11,SET-f#11,SET]: 58116 bytes (57KB)
+  000005:[f#11,SET-f#11,SET]: 58112 bytes (57KB)
 L6:
-  000012:[c#15,SET-c#15,SET]: 754 bytes (754B)
-  000009:[d#13,SET-d#13,SET]: 754 bytes (754B)
-  000007:[e#0,SET-e#0,SET]: 66310 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66310 bytes (65KB)
+  000012:[c#15,SET-c#15,SET]: 750 bytes (750B)
+  000009:[d#13,SET-d#13,SET]: 750 bytes (750B)
+  000007:[e#0,SET-e#0,SET]: 66306 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66306 bytes (65KB)
 
 # Even though picking sst 11 seems to cause poor write amp of 65KB/126B, it is
 # picked because it is blamed for all the garbage in backing sst 4 (~96KB),

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -24,7 +24,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	750B   0.0
+L5  	737B   0.0
 L6  	321KB  -
 
 enable-table-stats
@@ -37,7 +37,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 328891
+range-deletions-bytes-estimate: 328887
 
 scores
 ----
@@ -47,7 +47,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	750B   4.5
+L5  	737B   4.5
 L6  	321KB  -
 
 # Ensure that point deletions in a higher level result in a compensated level
@@ -80,7 +80,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	776B   0.0
+L5  	789B   0.0
 L6  	321KB  -
 
 enable-table-stats
@@ -92,7 +92,7 @@ wait-pending-table-stats
 num-entries: 5
 num-deletions: 5
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 164798
+point-deletions-bytes-estimate: 164802
 range-deletions-bytes-estimate: 0
 
 scores
@@ -103,7 +103,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	776B   2.3
+L5  	789B   2.3
 L6  	321KB  -
 
 # Run a similar test as above, but this time the table containing the DELs is
@@ -145,7 +145,7 @@ wait-pending-table-stats
 num-entries: 5
 num-deletions: 5
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 164806
+point-deletions-bytes-estimate: 164810
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -212,11 +212,11 @@ L6  	386KB  -
 lsm verbose
 ----
 L5:
-  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET] size:525399
-  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET] size:131854
+  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET] size:525395
+  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET] size:131850
 L6:
-  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET] size:263251
-  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET] size:131854
+  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET] size:263247
+  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET] size:131850
 
 # Attempting to schedule a compaction should begin a L5->L6 compaction.
 

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -41,7 +41,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (752B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (740B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that straddles a snapshot. It should not be compacted.
 define snapshots=(50) auto-compactions=off
@@ -80,12 +80,12 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 100
+point-deletions-bytes-estimate: 103
 range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (767B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (749B), in 1.0s (2.0s total), output rate 749B/s
+[JOB 100] compacted(elision-only) L6 [000004] (788B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (747B), in 1.0s (2.0s total), output rate 747B/s
 
 version
 ----
@@ -119,8 +119,8 @@ wait-pending-table-stats
 num-entries: 6
 num-deletions: 2
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 47
-range-deletions-bytes-estimate: 101
+point-deletions-bytes-estimate: 48
+range-deletions-bytes-estimate: 112
 
 maybe-compact
 ----
@@ -134,7 +134,7 @@ close-snapshot
 close-snapshot
 103
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (906B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (935B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that contains both deletions and non-deletions, but whose
 # non-deletions well outnumber its deletions. The table should not be
@@ -208,7 +208,7 @@ range-deletions-bytes-estimate: 16824
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=89.06 + L6 [000007] (17KB) Score=0.73 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
+[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=89.00 + L6 [000007] (17KB) Score=0.73 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
 
 define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
@@ -233,7 +233,7 @@ wait-pending-table-stats
 num-entries: 3
 num-deletions: 3
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 6988
+point-deletions-bytes-estimate: 6998
 range-deletions-bytes-estimate: 0
 
 # By plain file size, 000005 should be picked because it is larger and
@@ -243,7 +243,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (771B) Score=13.77 + L6 [000006] (13KB) Score=0.92 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(default) L5 [000004] (792B) Score=13.81 + L6 [000006] (13KB) Score=0.92 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -323,7 +323,7 @@ range-deletions-bytes-estimate: 94
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (968B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (747B), in 1.0s (2.0s total), output rate 747B/s
+[JOB 100] compacted(elision-only) L6 [000004] (975B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (758B), in 1.0s (2.0s total), output rate 758B/s
 
 # Close the DB, asserting that the reference counts balance.
 close
@@ -359,7 +359,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 2795
+point-deletions-bytes-estimate: 2799
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -376,7 +376,7 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (763B) Score=24.34 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(default) L5 [000004] (784B) Score=24.40 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -405,7 +405,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 2795
+point-deletions-bytes-estimate: 2799
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -422,4 +422,4 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (763B) Score=24.34 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(default) L5 [000004] (784B) Score=24.40 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -94,7 +94,7 @@ close: db/marker.manifest.000002.MANIFEST-000006
 remove: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 [JOB 3] MANIFEST created 000006
-[JOB 3] flushed 1 memtable (100B) to L0 [000005] (743B), in 1.0s (2.0s total), output rate 743B/s
+[JOB 3] flushed 1 memtable (100B) to L0 [000005] (741B), in 1.0s (2.0s total), output rate 741B/s
 
 compact
 ----
@@ -118,18 +118,18 @@ close: db/marker.manifest.000003.MANIFEST-000009
 remove: db/marker.manifest.000002.MANIFEST-000006
 sync: db
 [JOB 5] MANIFEST created 000009
-[JOB 5] flushed 1 memtable (100B) to L0 [000008] (743B), in 1.0s (2.0s total), output rate 743B/s
+[JOB 5] flushed 1 memtable (100B) to L0 [000008] (741B), in 1.0s (2.0s total), output rate 741B/s
 remove: db/MANIFEST-000001
 [JOB 5] MANIFEST deleted 000001
-[JOB 6] compacting(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00; OverlappingRatio: Single 0.00, Multi 0.00
+[JOB 6] compacting(default) L0 [000005 000008] (1.4KB) Score=0.00 + L6 [] (0B) Score=0.00; OverlappingRatio: Single 0.00, Multi 0.00
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(686, 57): db/000005.sst
-read-at(636, 50): db/000005.sst
-read-at(119, 517): db/000005.sst
+read-at(684, 57): db/000005.sst
+read-at(634, 50): db/000005.sst
+read-at(119, 515): db/000005.sst
 open: db/000008.sst (options: *vfs.randomReadsOption)
-read-at(686, 57): db/000008.sst
-read-at(636, 50): db/000008.sst
-read-at(119, 517): db/000008.sst
+read-at(684, 57): db/000008.sst
+read-at(634, 50): db/000008.sst
+read-at(119, 515): db/000008.sst
 read-at(78, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
 read-at(0, 78): db/000005.sst
@@ -151,7 +151,7 @@ close: db/marker.manifest.000004.MANIFEST-000011
 remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
 [JOB 6] MANIFEST created 000011
-[JOB 6] compacted(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (746B), in 1.0s (3.0s total), output rate 746B/s
+[JOB 6] compacted(default) L0 [000005 000008] (1.4KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (744B), in 1.0s (3.0s total), output rate 744B/s
 close: db/000005.sst
 close: db/000008.sst
 remove: db/MANIFEST-000006
@@ -186,7 +186,7 @@ close: db/marker.manifest.000005.MANIFEST-000014
 remove: db/marker.manifest.000004.MANIFEST-000011
 sync: db
 [JOB 8] MANIFEST created 000014
-[JOB 8] flushed 1 memtable (100B) to L0 [000013] (743B), in 1.0s (2.0s total), output rate 743B/s
+[JOB 8] flushed 1 memtable (100B) to L0 [000013] (741B), in 1.0s (2.0s total), output rate 741B/s
 
 enable-file-deletions
 ----
@@ -196,9 +196,9 @@ remove: db/MANIFEST-000009
 ingest
 ----
 open: ext/0
-read-at(689, 57): ext/0
-read-at(639, 50): ext/0
-read-at(122, 517): ext/0
+read-at(687, 57): ext/0
+read-at(637, 50): ext/0
+read-at(122, 515): ext/0
 read-at(81, 41): ext/0
 read-at(0, 81): ext/0
 close: ext/0
@@ -216,21 +216,21 @@ sync: db
 remove: db/MANIFEST-000011
 [JOB 10] MANIFEST deleted 000011
 remove: ext/0
-[JOB 10] ingested L0:000015 (746B)
+[JOB 10] ingested L0:000015 (744B)
 
 metrics
 ----
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |  0.40 |   97B |     1   746B |     0     0B |     3  2.2KB |    0B |   2 23.0
+    0 |     2  1.5KB     0B       0 |  0.40 |   97B |     1   744B |     0     0B |     3  2.2KB |    0B |   2 22.9
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   746B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   746B | 1.5KB |   1  0.5
-total |     3  2.2KB     0B       0 |     - |  843B |     1   746B |     0     0B |     4  3.7KB | 1.5KB |   3  4.5
+    6 |     1   744B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   744B | 1.4KB |   1  0.5
+total |     3  2.2KB     0B       0 |     - |  841B |     1   744B |     0     0B |     4  3.7KB | 1.4KB |   3  4.5
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 48B  written: 97B (102% overhead)
 Flushes: 3
@@ -241,7 +241,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 2.2KB
-Compression types: snappy: 3
+Compression types: minlz: 3
 Block cache: 2 entries (784B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
@@ -258,16 +258,16 @@ ingest-flushable
 ----
 sync-data: wal/000012.log
 open: ext/a
-read-at(689, 57): ext/a
-read-at(639, 50): ext/a
-read-at(122, 517): ext/a
+read-at(687, 57): ext/a
+read-at(637, 50): ext/a
+read-at(122, 515): ext/a
 read-at(81, 41): ext/a
 read-at(0, 81): ext/a
 close: ext/a
 open: ext/b
-read-at(689, 57): ext/b
-read-at(639, 50): ext/b
-read-at(122, 517): ext/b
+read-at(687, 57): ext/b
+read-at(637, 50): ext/b
+read-at(122, 515): ext/b
 read-at(81, 41): ext/b
 read-at(0, 81): ext/b
 close: ext/b
@@ -289,7 +289,7 @@ sync: wal
 [JOB 13] WAL created 000020
 remove: ext/a
 remove: ext/b
-[JOB 11] ingested as flushable 000017 (746B), 000018 (746B)
+[JOB 11] ingested as flushable 000017 (744B), 000018 (744B)
 sync-data: wal/000020.log
 close: wal/000020.log
 create: wal/000021.log
@@ -302,7 +302,7 @@ sync-data: db/000022.sst
 close: db/000022.sst
 sync: db
 sync: db/MANIFEST-000016
-[JOB 15] flushed 1 memtable (100B) to L0 [000022] (743B), in 1.0s (2.0s total), output rate 743B/s
+[JOB 15] flushed 1 memtable (100B) to L0 [000022] (741B), in 1.0s (2.0s total), output rate 741B/s
 [JOB 16] flushing 2 ingested tables
 create: db/MANIFEST-000023
 close: db/MANIFEST-000016
@@ -312,7 +312,7 @@ close: db/marker.manifest.000007.MANIFEST-000023
 remove: db/marker.manifest.000006.MANIFEST-000016
 sync: db
 [JOB 16] MANIFEST created 000023
-[JOB 16] flushed 2 ingested flushables L0:000017 (746B) + L6:000018 (746B) in 1.0s (2.0s total), output rate 1.5KB/s
+[JOB 16] flushed 2 ingested flushables L0:000017 (744B) + L6:000018 (744B) in 1.0s (2.0s total), output rate 1.5KB/s
 remove: db/MANIFEST-000014
 [JOB 16] MANIFEST deleted 000014
 [JOB 17] flushing 1 memtable (100B) to L0
@@ -330,8 +330,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     2  1.5KB     0B       0 |     - | 1.5KB |     1   746B |     0     0B |     1   746B | 1.5KB |   1  0.5
-total |     6  4.4KB     0B       0 |     - | 2.3KB |     3  2.2KB |     0     0B |     5  5.9KB | 1.5KB |   5  2.6
+    6 |     2  1.5KB     0B       0 |     - | 1.4KB |     1   744B |     0     0B |     1   744B | 1.4KB |   1  0.5
+total |     6  4.4KB     0B       0 |     - | 2.3KB |     3  2.2KB |     0     0B |     5  5.9KB | 1.4KB |   5  2.6
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 82B  written: 132B (61% overhead)
 Flushes: 6
@@ -342,7 +342,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 4.4KB
-Compression types: snappy: 6
+Compression types: minlz: 6
 Block cache: 6 entries (2.3KB)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -651,9 +651,9 @@ allowFlush
 get with-fs-logging
 small-00001
 ----
-read-at(158, 41): 000004.sst
-read-at(199, 74): 000004.sst
-read-at(0, 158): 000004.sst
+read-at(150, 41): 000004.sst
+read-at(191, 74): 000004.sst
+read-at(0, 150): 000004.sst
 small-00001:val-00001
 
 # When the key doesn't pass the bloom filter, we should see only two block
@@ -661,8 +661,8 @@ small-00001:val-00001
 get with-fs-logging
 small-00001-does-not-exist
 ----
-read-at(158, 41): 000004.sst
-read-at(199, 74): 000004.sst
+read-at(150, 41): 000004.sst
+read-at(191, 74): 000004.sst
 small-00001-does-not-exist: pebble: not found
 
 # When looking inside the large table, we will not read the bloom filter which
@@ -671,16 +671,16 @@ small-00001-does-not-exist: pebble: not found
 get with-fs-logging
 large-00001
 ----
-read-at(1165164, 65): 000005.sst
-read-at(1159763, 3000): 000005.sst
-read-at(0, 3069): 000005.sst
+read-at(973580, 65): 000005.sst
+read-at(968351, 2975): 000005.sst
+read-at(0, 2407): 000005.sst
 large-00001:val-00001
 
 # Same number of block reads for a key that doesn't exist.
 get with-fs-logging
 large-00001-does-not-exist
 ----
-read-at(1165164, 65): 000005.sst
-read-at(1159763, 3000): 000005.sst
-read-at(0, 3069): 000005.sst
+read-at(973580, 65): 000005.sst
+read-at(968351, 2975): 000005.sst
+read-at(0, 2407): 000005.sst
 large-00001-does-not-exist: pebble: not found

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -358,7 +358,7 @@ num-entries: 2
 num-deletions: 2
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1316
+range-deletions-bytes-estimate: 1327
 
 # A set operation takes precedence over a range deletion at the same
 # sequence number as can occur during ingestion.

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -330,8 +330,8 @@ gi: (foo, .)
 lsm verbose
 ----
 L6:
-  000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1352
-  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:933
+  000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1362
+  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:967
 
 download g h via-backing-file-download
 ----
@@ -341,8 +341,8 @@ ok
 lsm verbose
 ----
 L6:
-  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1015
-  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:930
+  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1023
+  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:950
 
 reopen
 ----

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -12,9 +12,9 @@ L6
   d@2.SET.2:v
 ----
 L5:
-  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:893 blobrefs:[(000921: 10); depth:1]
+  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:858 blobrefs:[(000921: 10); depth:1]
 L6:
-  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:849 blobrefs:[(000921: 6); depth:1]
+  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:858 blobrefs:[(000921: 6); depth:1]
 
 combined-iter
 first
@@ -33,7 +33,7 @@ c@2: (foobar, .)
 d@9: (v, .)
 d@2: (v, .)
 .
-stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 342B not cached (read time: 0s); points: 6 (18B keys, 8B values); separated: 2 (16B, 16B fetched)
+stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 363B not cached (read time: 0s); points: 6 (18B keys, 8B values); separated: 2 (16B, 16B fetched)
 
 # Try the same but avoid fetching one of the values (by using NextPrefix to step
 # over it).
@@ -53,7 +53,7 @@ c@9: (helloworld, .)
 d@9: (v, .)
 d@2: (v, .)
 .
-stats: seeked 1 times (1 internal); stepped 5 times (6 internal); blocks: 342B cached; points: 6 (18B keys, 8B values); separated: 2 (16B, 10B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (6 internal); blocks: 363B cached; points: 6 (18B keys, 8B values); separated: 2 (16B, 10B fetched)
 
 # Test a couple of blob files interleaved.
 
@@ -70,9 +70,9 @@ L6
   f@2.SETWITHDEL.3:blob{fileNum=000039 value=grapes}
 ----
 L5:
-  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:852 blobrefs:[(000039: 14), (000921: 20); depth:2]
+  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:858 blobrefs:[(000039: 14), (000921: 20); depth:2]
 L6:
-  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:861 blobrefs:[(000039: 11), (000921: 13); depth:2]
+  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:882 blobrefs:[(000039: 11), (000921: 13); depth:2]
 
 # The iterator stats should indicate that only the first value from each file
 # should trigger a read of the blob file. Once loaded, subsequent reads of the
@@ -99,19 +99,19 @@ next
 stats
 ----
 b@9: (orange, .)
-stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 345B not cached (read time: 0s); points: 1 (3B keys, 2B values); separated: 2 (11B, 6B fetched)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 396B not cached (read time: 0s); points: 1 (3B keys, 2B values); separated: 2 (11B, 6B fetched)
 b@2: (lemon, .)
-stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 345B not cached (read time: 0s); points: 2 (6B keys, 4B values); separated: 3 (21B, 11B fetched)
+stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 396B not cached (read time: 0s); points: 2 (6B keys, 4B values); separated: 3 (21B, 11B fetched)
 c@9: (canteloupe, .)
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 381B not cached (read time: 0s); points: 3 (9B keys, 6B values); separated: 4 (25B, 21B fetched)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 432B not cached (read time: 0s); points: 3 (9B keys, 6B values); separated: 4 (25B, 21B fetched)
 c@2: (kiwi, .)
 d@9: (honeydew, .)
 d@2: (tangerine, .)
-stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 381B not cached (read time: 0s); points: 6 (18B keys, 12B values); separated: 7 (52B, 42B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 432B not cached (read time: 0s); points: 6 (18B keys, 12B values); separated: 7 (52B, 42B fetched)
 e@1: (watermelon, .)
 f@2: (grapes, .)
 .
-stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 381B not cached (read time: 0s); points: 8 (24B keys, 16B values); separated: 8 (58B, 58B fetched)
+stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 432B not cached (read time: 0s); points: 8 (24B keys, 16B values); separated: 8 (58B, 58B fetched)
 
 # Test scanning a table, stepping into new blocks of the blob file. The stats
 # should reflect that a block is only loaded when stepping into a new block.
@@ -132,7 +132,7 @@ L6
   l.SETWITHDEL.2:blob{fileNum=000009 value=peach blockNum=6 offset=0}
 ----
 L6:
-  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:956 blobrefs:[(000009: 96); depth:1]
+  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:939 blobrefs:[(000009: 96); depth:1]
 
 combined-iter
 first
@@ -163,28 +163,28 @@ next
 stats
 ----
 a: (lemonmeringue, .)
-stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 264B not cached (read time: 0s); points: 1 (1B keys, 2B values); separated: 1 (13B, 13B fetched)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 266B not cached (read time: 0s); points: 1 (1B keys, 2B values); separated: 1 (13B, 13B fetched)
 b: (keylime, .)
-stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 264B not cached (read time: 0s); points: 2 (2B keys, 4B values); separated: 2 (20B, 20B fetched)
+stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 266B not cached (read time: 0s); points: 2 (2B keys, 4B values); separated: 2 (20B, 20B fetched)
 c: (pecan, .)
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 280B not cached (read time: 0s); points: 3 (3B keys, 6B values); separated: 3 (25B, 25B fetched)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 282B not cached (read time: 0s); points: 3 (3B keys, 6B values); separated: 3 (25B, 25B fetched)
 d: (cherry, .)
-stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 0B cached, 280B not cached (read time: 0s); points: 4 (4B keys, 8B values); separated: 4 (31B, 31B fetched)
+stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 0B cached, 282B not cached (read time: 0s); points: 4 (4B keys, 8B values); separated: 4 (31B, 31B fetched)
 e: (apple, .)
-stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 0B cached, 280B not cached (read time: 0s); points: 5 (5B keys, 10B values); separated: 5 (36B, 36B fetched)
+stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 0B cached, 282B not cached (read time: 0s); points: 5 (5B keys, 10B values); separated: 5 (36B, 36B fetched)
 f: (bananacream, .)
-stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 300B not cached (read time: 0s); points: 6 (6B keys, 12B values); separated: 6 (47B, 47B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 302B not cached (read time: 0s); points: 6 (6B keys, 12B values); separated: 6 (47B, 47B fetched)
 g: (chocolate, .)
-stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 300B not cached (read time: 0s); points: 7 (7B keys, 14B values); separated: 7 (56B, 56B fetched)
+stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 302B not cached (read time: 0s); points: 7 (7B keys, 14B values); separated: 7 (56B, 56B fetched)
 h: (strawberry, .)
-stats: seeked 1 times (1 internal); stepped 7 times (7 internal); blocks: 0B cached, 317B not cached (read time: 0s); points: 8 (8B keys, 16B values); separated: 8 (66B, 66B fetched)
+stats: seeked 1 times (1 internal); stepped 7 times (7 internal); blocks: 0B cached, 319B not cached (read time: 0s); points: 8 (8B keys, 16B values); separated: 8 (66B, 66B fetched)
 i: (custard, .)
-stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 317B not cached (read time: 0s); points: 9 (9B keys, 18B values); separated: 9 (73B, 73B fetched)
+stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 319B not cached (read time: 0s); points: 9 (9B keys, 18B values); separated: 9 (73B, 73B fetched)
 j: (blueberry, .)
-stats: seeked 1 times (1 internal); stepped 9 times (9 internal); blocks: 0B cached, 326B not cached (read time: 0s); points: 10 (10B keys, 20B values); separated: 10 (82B, 82B fetched)
+stats: seeked 1 times (1 internal); stepped 9 times (9 internal); blocks: 0B cached, 328B not cached (read time: 0s); points: 10 (10B keys, 20B values); separated: 10 (82B, 82B fetched)
 k: (raspberry, .)
-stats: seeked 1 times (1 internal); stepped 10 times (10 internal); blocks: 0B cached, 335B not cached (read time: 0s); points: 11 (11B keys, 22B values); separated: 11 (91B, 91B fetched)
+stats: seeked 1 times (1 internal); stepped 10 times (10 internal); blocks: 0B cached, 337B not cached (read time: 0s); points: 11 (11B keys, 22B values); separated: 11 (91B, 91B fetched)
 l: (peach, .)
-stats: seeked 1 times (1 internal); stepped 11 times (11 internal); blocks: 0B cached, 340B not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
+stats: seeked 1 times (1 internal); stepped 11 times (11 internal); blocks: 0B cached, 342B not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
 .
-stats: seeked 1 times (1 internal); stepped 12 times (12 internal); blocks: 0B cached, 340B not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
+stats: seeked 1 times (1 internal); stepped 12 times (12 internal); blocks: 0B cached, 342B not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)

--- a/testdata/iterator_stats
+++ b/testdata/iterator_stats
@@ -17,7 +17,7 @@ stats
 a: (1, .)
 c: (2, .)
 .
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 113B cached; points: 2 (2B keys, 2B values)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 125B cached; points: 2 (2B keys, 2B values)
 
 # Perform the same operation again with a new iterator. It should yield
 # identical statistics.
@@ -31,7 +31,7 @@ stats
 a: (1, .)
 c: (2, .)
 .
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 113B cached; points: 2 (2B keys, 2B values)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 125B cached; points: 2 (2B keys, 2B values)
 
 build ext2
 set d@10 d10
@@ -61,13 +61,13 @@ next
 stats
 ----
 c: (2, .)
-stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 113B cached; points: 1 (1B keys, 1B values)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 125B cached; points: 1 (1B keys, 1B values)
 d@10: (d10, .)
 d@9: (d9, .)
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 303B cached, 10B not cached (read time: 0s); points: 3 (8B keys, 6B values); separated: 1 (2B, 2B fetched)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 315B cached, 10B not cached (read time: 0s); points: 3 (8B keys, 6B values); separated: 1 (2B, 2B fetched)
 d@8: (d8, .)
-stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 303B cached, 10B not cached (read time: 0s); points: 4 (11B keys, 8B values); separated: 2 (4B, 4B fetched)
+stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 315B cached, 10B not cached (read time: 0s); points: 4 (11B keys, 8B values); separated: 2 (4B, 4B fetched)
 e@20: (e20, .)
-stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 303B cached, 10B not cached (read time: 0s); points: 5 (15B keys, 11B values); separated: 2 (4B, 4B fetched)
+stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 315B cached, 10B not cached (read time: 0s); points: 5 (15B keys, 11B values); separated: 2 (4B, 4B fetched)
 e@18: (e18, .)
-stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 303B cached, 10B not cached (read time: 0s); points: 6 (19B keys, 13B values); separated: 3 (7B, 7B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 315B cached, 10B not cached (read time: 0s); points: 6 (19B keys, 13B values); separated: 3 (7B, 7B fetched)

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev6
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev6
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1494
+range-deletions-bytes-estimate: 1516
 
 compact a-e L1
 ----
@@ -106,7 +106,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 747
+range-deletions-bytes-estimate: 758
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -6,9 +6,9 @@ L1
   d.SET.0:foo
 ----
 L0.0:
-  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:740
+  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:744
 L1:
-  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:751
+  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:762
 
 mark-for-compaction file=000005
 ----
@@ -20,9 +20,9 @@ marked L0.000004
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000005] (751B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (751B), in 1.0s (2.0s total), output rate 751B/s
-[JOB 100] compacted(rewrite) L0 [000004] (740B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (740B), in 1.0s (2.0s total), output rate 740B/s
+[JOB 100] compacted(rewrite) L1 [000005] (762B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (762B), in 1.0s (2.0s total), output rate 762B/s
+[JOB 100] compacted(rewrite) L0 [000004] (744B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (744B), in 1.0s (2.0s total), output rate 744B/s
 L0.0:
-  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:740
+  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:744
 L1:
-  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:751
+  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:762

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -55,14 +55,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   751B     0B       0 |  0.25 |   28B |     0     0B |     0     0B |     1   751B |    0B |   1 26.8
+    0 |     1   747B     0B       0 |  0.25 |   28B |     0     0B |     0     0B |     1   747B |    0B |   1 26.7
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-total |     1   751B     0B       0 |     - |   28B |     0     0B |     0     0B |     1   779B |    0B |   1 27.8
+total |     1   747B     0B       0 |     - |   28B |     0     0B |     0     0B |     1   775B |    0B |   1 27.7
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 17B  written: 28B (65% overhead)
 Flushes: 1
@@ -72,8 +72,8 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 751B
-Compression types: snappy: 1
+Local tables size: 747B
+Compression types: minlz: 1
 Block cache: 2 entries (795B)  hit rate: 0.0%
 Table cache: 1 entries (832B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -115,14 +115,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.5
+    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.3
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   752B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1  0.5
-total |     1   752B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
+    6 |     1   761B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   761B | 1.5KB |   1  0.5
+total |     1   761B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -132,8 +132,8 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.5KB, local: 1.5KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 752B
-Compression types: snappy: 1
+Local tables size: 761B
+Compression types: minlz: 1
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -161,14 +161,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.5
+    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.3
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   752B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1  0.5
-total |     1   752B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
+    6 |     1   761B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   761B | 1.5KB |   1  0.5
+total |     1   761B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -178,8 +178,8 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.5KB, local: 1.5KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 752B
-Compression types: snappy: 1
+Local tables size: 761B
+Compression types: minlz: 1
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -204,25 +204,25 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.5
+    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.3
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   752B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1  0.5
-total |     1   752B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
+    6 |     1   761B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   761B | 1.5KB |   1  0.5
+total |     1   761B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 2 (512KB)
-Zombie tables: 1 (751B, local: 751B)
+Zombie tables: 1 (747B, local: 747B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 752B
-Compression types: snappy: 1
+Local tables size: 761B
+Compression types: minlz: 1
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 1 entries (832B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -250,14 +250,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.5
+    0 |     0     0B     0B       0 |  0.00 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.3
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   752B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1  0.5
-total |     1   752B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
+    6 |     1   761B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   761B | 1.5KB |   1  0.5
+total |     1   761B     0B       0 |     - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -267,8 +267,8 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 752B
-Compression types: snappy: 1
+Local tables size: 761B
+Compression types: minlz: 1
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -284,7 +284,7 @@ Iter category stats:
 
 disk-usage
 ----
-2.4KB
+2.5KB
 
 additional-metrics
 ----
@@ -296,7 +296,7 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6          82B           0B
+      6          94B           0B
 
 batch
 set c@20 c20
@@ -326,25 +326,25 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  5.2KB     0B       0 |  0.25 |  165B |     0     0B |     0     0B |     9  6.7KB |    0B |   1 41.6
+    0 |     7  5.2KB     0B       0 |  0.25 |  165B |     0     0B |     0     0B |     9  6.7KB |    0B |   1 41.3
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   752B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1  0.5
-total |     8  6.0KB     0B       0 |     - |  165B |     0     0B |     0     0B |    10  7.6KB | 1.5KB |   2 47.1
+    6 |     1   761B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   761B | 1.5KB |   1  0.5
+total |     8  5.9KB     0B       0 |     - |  165B |     0     0B |     0     0B |    10  7.6KB | 1.5KB |   2 47.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
 Flushes: 3
-Compactions: 1  estimated debt: 6.0KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 5.9KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 6.0KB
-Compression types: snappy: 8
+Local tables size: 5.9KB
+Compression types: minlz: 8
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -368,7 +368,7 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6          82B           0B
+      6          94B           0B
 
 compact a-z
 ----
@@ -381,7 +381,7 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  165B |     0     0B |     0     0B |     9  6.7KB |    0B |   0 41.6
+    0 |     0     0B     0B       0 |  0.00 |  165B |     0     0B |     0     0B |     9  6.7KB |    0B |   0 41.3
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -399,7 +399,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 1.6KB
-Compression types: snappy: 2
+Compression types: minlz: 2
 Block cache: 0 entries (0B)  hit rate: 10.0%
 Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
@@ -423,7 +423,7 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6         220B          31B
+      6         250B          31B
 
 # Flushable ingestion metrics. This requires there be data in a memtable that
 # would overlap with the ingested table(s). Delayed flushes are disabled here to
@@ -487,14 +487,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     6  4.4KB     0B       0 |  0.50 |  211B |     3  2.2KB |     0     0B |    12  8.9KB |    0B |   2 43.2
+    0 |     6  4.4KB     0B       0 |  0.50 |  211B |     3  2.2KB |     0     0B |    12  8.8KB |    0B |   2 42.9
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     2  1.6KB    31B       0 |     - | 6.7KB |     0     0B |     0     0B |     2  1.6KB | 6.7KB |   1  0.2
-total |     8  6.0KB    31B       0 |     - | 2.4KB |     3  2.2KB |     0     0B |    14   13KB | 6.7KB |   3  5.3
+total |     8  6.0KB    31B       0 |     - | 2.4KB |     3  2.2KB |     0     0B |    14   13KB | 6.7KB |   3  5.4
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 176B  written: 211B (20% overhead)
 Flushes: 8
@@ -505,7 +505,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 6.0KB
-Compression types: snappy: 8
+Compression types: minlz: 8
 Block cache: 6 entries (2.3KB)  hit rate: 7.7%
 Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
@@ -555,7 +555,7 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |    13  9.5KB     0B       0 |  0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 51.9
+    0 |    13  9.5KB     0B       0 |  0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 51.6
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
@@ -573,7 +573,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 11KB
-Compression types: snappy: 15
+Compression types: minlz: 15
 Block cache: 6 entries (2.3KB)  hit rate: 7.7%
 Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
@@ -635,13 +635,13 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |    11  8.1KB     0B       0 |  0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 51.9
+    0 |    11  8.0KB     0B       0 |  0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 51.6
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     3  2.3KB    31B       0 |     - | 6.7KB |     1   754B |     0     0B |     2  1.6KB | 6.7KB |   1  0.2
+    6 |     3  2.4KB    31B       0 |     - | 6.7KB |     1   750B |     0     0B |     2  1.6KB | 6.7KB |   1  0.2
 total |    14   10KB    31B       0 |     - | 3.2KB |     4  2.9KB |     0     0B |    21   19KB | 6.7KB |   3  5.9
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
@@ -653,7 +653,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 10KB
-Compression types: snappy: 14
+Compression types: minlz: 14
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -738,13 +738,13 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   0 51.9
+    0 |     0     0B     0B       0 |  0.00 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   0 51.6
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     5  3.8KB    31B       0 |     - |  14KB |     2  1.5KB |     0     0B |     3  2.3KB |  14KB |   1  0.2
+    6 |     5  3.8KB    31B       0 |     - |  14KB |     2  1.5KB |     0     0B |     3  2.4KB |  14KB |   1  0.2
 total |     5  3.8KB    31B       0 |     - | 3.9KB |     5  3.7KB |     0     0B |    22   20KB |  14KB |   1  5.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
@@ -756,7 +756,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 3.8KB
-Compression types: snappy: 5
+Compression types: minlz: 5
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -794,14 +794,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     3  2.2KB     0B       0 |  0.25 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 59.3
+    0 |     3  2.2KB     0B       0 |  0.25 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 59.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     0     0B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-total |     3  2.2KB     0B       0 |     - |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 60.3
+total |     3  2.2KB     0B       0 |     - |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 60.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -812,7 +812,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 2.2KB
-Compression types: snappy: 3
+Compression types: minlz: 3
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -834,14 +834,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   0 59.3
+    0 |     0     0B     0B       0 |  0.00 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   0 59.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   767B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   767B | 2.2KB |   1  0.3
-total |     1   767B     0B       0 |     - |   38B |     0     0B |     0     0B |     4  3.0KB | 2.2KB |   1 80.5
+    6 |     1   763B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   763B | 2.2KB |   1  0.3
+total |     1   763B     0B       0 |     - |   38B |     0     0B |     0     0B |     4  3.0KB | 2.2KB |   1 80.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -852,7 +852,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
-Compression types: snappy: 1
+Compression types: minlz: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
@@ -890,14 +890,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   754B     0B       0 |  0.25 |   38B |     1   754B |     0     0B |     3  2.2KB |    0B |   1 59.3
+    0 |     1   750B     0B       0 |  0.25 |   38B |     1   750B |     0     0B |     3  2.2KB |    0B |   1 59.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   767B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   767B | 2.2KB |   1  0.3
-total |     2  1.5KB     0B       0 |     - |  792B |     1   754B |     0     0B |     4  3.7KB | 2.2KB |   2  4.8
+    6 |     1   763B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   763B | 2.2KB |   1  0.3
+total |     2  1.5KB     0B       0 |     - |  788B |     1   750B |     0     0B |     4  3.7KB | 2.2KB |   2  4.8
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -908,7 +908,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
-Compression types: snappy: 2
+Compression types: minlz: 2
 Block cache: 4 entries (1.5KB)  hit rate: 0.0%
 Table cache: 1 entries (832B)  hit rate: 42.9%
 Snapshots: 0  earliest seq num: 0
@@ -939,14 +939,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |  0.50 |   74B |     1   754B |     0     0B |     4  2.9KB |    0B |   2 40.6
+    0 |     2  1.5KB     0B       0 |  0.50 |   74B |     1   750B |     0     0B |     4  2.9KB |    0B |   2 40.4
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   767B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   767B | 2.2KB |   1  0.3
-total |     3  2.2KB     0B       0 |     - |  828B |     1   754B |     0     0B |     5  4.5KB | 2.2KB |   3  5.6
+    6 |     1   763B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   763B | 2.2KB |   1  0.3
+total |     3  2.2KB     0B       0 |     - |  824B |     1   750B |     0     0B |     5  4.5KB | 2.2KB |   3  5.6
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 44B  written: 74B (68% overhead)
 Flushes: 2
@@ -956,8 +956,8 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 751B
-Compression types: snappy: 3
+Local tables size: 747B
+Compression types: minlz: 3
 Block cache: 4 entries (1.5KB)  hit rate: 0.0%
 Table cache: 1 entries (832B)  hit rate: 42.9%
 Snapshots: 0  earliest seq num: 0
@@ -985,7 +985,7 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   767B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   1  0.0
+    6 |     1   763B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   1  0.0
 total |     3  2.2KB     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   3  0.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
@@ -996,8 +996,8 @@ MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 751B
-Compression types: snappy: 3
+Local tables size: 747B
+Compression types: minlz: 3
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -1025,8 +1025,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   767B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   767B | 2.2KB |   1  0.5
-total |     1   767B     0B       0 |     - |    0B |     0     0B |     0     0B |     1   767B | 2.2KB |   1  0.0
+    6 |     1   763B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   763B | 2.2KB |   1  0.5
+total |     1   763B     0B       0 |     - |    0B |     0     0B |     0     0B |     1   763B | 2.2KB |   1  0.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 1
@@ -1036,8 +1036,8 @@ MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 767B
-Compression types: snappy: 1
+Local tables size: 763B
+Compression types: minlz: 1
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0


### PR DESCRIPTION
set minlz to default compression for v6+, have a guard against using minlz for v5 and earlier.