### PR TITLE
manifest,record: disambiguate unexpected EOFs

### DIFF
--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -25,8 +25,6 @@ import (
 // TODO(peter): describe the MANIFEST file format, independently of the C++
 // project.
 
-var errCorruptManifest = base.CorruptionErrorf("pebble: corrupt manifest")
-
 type byteReader interface {
 	io.ByteReader
 	io.Reader
@@ -551,7 +549,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			return base.CorruptionErrorf("column families are not supported")
 
 		default:
-			return errCorruptManifest
+			return base.CorruptionErrorf("MANIFEST: unknown tag: %d", tag)
 		}
 	}
 	return nil
@@ -847,7 +845,7 @@ func (d versionEditDecoder) readBytes() ([]byte, error) {
 	_, err = io.ReadFull(d, s)
 	if err != nil {
 		if err == io.ErrUnexpectedEOF {
-			return nil, errCorruptManifest
+			return nil, base.CorruptionErrorf("pebble: corrupt manifest: failed to read %d bytes", n)
 		}
 		return nil, err
 	}
@@ -860,7 +858,7 @@ func (d versionEditDecoder) readLevel() (int, error) {
 		return 0, err
 	}
 	if u >= NumLevels {
-		return 0, errCorruptManifest
+		return 0, base.CorruptionErrorf("pebble: corrupt manifest: level %d >= %d", u, NumLevels)
 	}
 	return int(u), nil
 }
@@ -876,8 +874,8 @@ func (d versionEditDecoder) readFileNum() (base.FileNum, error) {
 func (d versionEditDecoder) readUvarint() (uint64, error) {
 	u, err := binary.ReadUvarint(d)
 	if err != nil {
-		if err == io.EOF {
-			return 0, errCorruptManifest
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return 0, base.CorruptionErrorf("pebble: corrupt manifest: failed to read uvarint")
 		}
 		return 0, err
 	}

--- a/open.go
+++ b/open.go
@@ -950,20 +950,29 @@ func (d *DB) replayWAL(
 			// surfaces record.ErrInvalidChunk or record.ErrZeroedChunk. These
 			// errors are always indicative of corruption and data loss.
 			//
-			// Otherwise, the reader surfaces io.ErrUnexpectedEOF indicating that
-			// the WAL terminated uncleanly and ambiguously. If the WAL is the
-			// most recent logical WAL, the caller passes in (strictWALTail=false),
-			// indicating we should tolerate the unclean ending. If the WAL is an
-			// older WAL, the caller passes in (strictWALTail=true), indicating that
-			// the WAL should have been closed cleanly, and we should interpret
-			// the `io.ErrUnexpectedEOF` as corruption and stop recovery.
+			// Otherwise, the reader surfaces record.ErrUnexpectedEOF indicating
+			// that the WAL terminated uncleanly and ambiguously. If the WAL is
+			// the most recent logical WAL, the caller passes in
+			// (strictWALTail=false), indicating we should tolerate the unclean
+			// ending. If the WAL is an older WAL, the caller passes in
+			// (strictWALTail=true), indicating that the WAL should have been
+			// closed cleanly, and we should interpret the
+			// `record.ErrUnexpectedEOF` as corruption and stop recovery.
 			if errors.Is(err, io.EOF) {
 				break
-			} else if errors.Is(err, io.ErrUnexpectedEOF) && !strictWALTail {
+			} else if errors.Is(err, record.ErrUnexpectedEOF) && !strictWALTail {
 				break
-			} else if errors.Is(err, record.ErrInvalidChunk) || errors.Is(err, record.ErrZeroedChunk) {
-				// If a read-ahead returns one of these errors, they should be marked with corruption.
-				// Other I/O related errors should not be marked with corruption and simply returned.
+			} else if (errors.Is(err, record.ErrUnexpectedEOF) && strictWALTail) ||
+				errors.Is(err, record.ErrInvalidChunk) || errors.Is(err, record.ErrZeroedChunk) {
+				// If a read-ahead returns record.ErrInvalidChunk or
+				// record.ErrZeroedChunk, then there's definitively corruption.
+				//
+				// If strictWALTail=true, then record.ErrUnexpectedEOF should
+				// also be considered corruption because the strictWALTail
+				// indicates we expect a clean end to the WAL.
+				//
+				// Other I/O related errors should not be marked with corruption
+				// and simply returned.
 				err = errors.Mark(err, ErrCorruption)
 			}
 

--- a/record/testdata/walSync
+++ b/record/testdata/walSync
@@ -47,8 +47,8 @@ read
 ----
 Starting read ahead for corruption. Block corrupted 0.
 Read block 1 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 1
 bytes read: 0
 
@@ -66,8 +66,8 @@ read
 ----
 Starting read ahead for corruption. Block corrupted 0.
 Read block 1 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 1
 bytes read: 0
 
@@ -84,8 +84,8 @@ Read block 1 with 19 bytes
 	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
 Read block 2 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 2
 bytes read: 0
 
@@ -121,8 +121,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -165,8 +165,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -308,8 +308,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -376,8 +376,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 0
 
@@ -555,8 +555,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 32749
 
@@ -625,8 +625,8 @@ read
 ----
 Starting read ahead for corruption. Block corrupted 0.
 Read block 1 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 1
 bytes read: 0
 
@@ -643,8 +643,8 @@ Read block 1 with 19 bytes
 	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
 Read block 2 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 2
 bytes read: 0
 
@@ -665,8 +665,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -688,8 +688,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -754,8 +754,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -789,8 +789,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 0
 
@@ -855,8 +855,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 32749
 
@@ -876,8 +876,8 @@ read
 ----
 Starting read ahead for corruption. Block corrupted 0.
 Read block 1 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 1
 bytes read: 0
 
@@ -894,8 +894,8 @@ Read block 1 with 19 bytes
 	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
 Read block 2 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 2
 bytes read: 0
 
@@ -916,8 +916,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -939,8 +939,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1005,8 +1005,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1039,8 +1039,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 0
 
@@ -1104,8 +1104,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 32749
 
@@ -1128,8 +1128,8 @@ Read block 1 with 19 bytes
 	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
 Read block 2 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 2
 bytes read: 32730
 
@@ -1154,8 +1154,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1178,8 +1178,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 32730
 
@@ -1265,8 +1265,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1326,8 +1326,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 32750
 
@@ -1363,8 +1363,8 @@ read
 ----
 Starting read ahead for corruption. Block corrupted 0.
 Read block 1 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 1
 bytes read: 0
 
@@ -1382,8 +1382,8 @@ Read block 1 with 19 bytes
 	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
 Read block 2 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 2
 bytes read: 0
 
@@ -1405,8 +1405,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1428,8 +1428,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1494,8 +1494,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1528,8 +1528,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 0
 
@@ -1593,8 +1593,8 @@ Read block 5 with 19 bytes
 	Block 5: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 5 at offset 0 (expected 1, got 2)
 Read block 6 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 6
 bytes read: 32750
 
@@ -1613,8 +1613,8 @@ read
 ----
 Starting read ahead for corruption. Block corrupted 0.
 Read block 1 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 1
 bytes read: 0
 
@@ -1631,8 +1631,8 @@ Read block 1 with 19 bytes
 	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
 Read block 2 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 2
 bytes read: 0
 
@@ -1653,8 +1653,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1675,8 +1675,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1741,8 +1741,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 0
 
@@ -1775,8 +1775,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 0
 
@@ -1834,8 +1834,8 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 32749
 
@@ -1877,8 +1877,8 @@ Read block 1 with 19 bytes
 	Block 1: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 1 at offset 0 (expected 1, got 2)
 Read block 2 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 2
 bytes read: 32738
 
@@ -1903,8 +1903,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 32738
 
@@ -1991,8 +1991,8 @@ Read block 2 with 19 bytes
 	Block 2: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 2 at offset 0 (expected 1, got 2)
 Read block 3 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 3
 bytes read: 1
 
@@ -2053,7 +2053,7 @@ Read block 4 with 19 bytes
 	Block 4: Processing chunk at offset 0, checksum=0, length=0, encoding=9
 	Mismatch log number in block 4 at offset 0 (expected 1, got 2)
 Read block 5 with 0 bytes
-	Encountered io.EOF; returning io.ErrUnexpectedEOF since no sync offset found.
-error reading next: unexpected EOF
+	Encountered io.EOF; returning ErrUnexpectedEOF since no sync offset found.
+error reading next: pebble/record: unexpected EOF
 final blockNum: 5
 bytes read: 32750

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"unsafe"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
+	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -466,4 +468,79 @@ func splitAt(s string, chars string) (string, string) {
 		return s, ""
 	}
 	return s[:i], s[i+1:]
+}
+
+// TestCrashDuringManifestWrite_LargeKeys tests a crash mid-manifest write. It
+// uses randomly-sized keys with a very high max in order to test version edits
+// of variable sizes. Large version edits may be broken into multiple 'chunks'
+// across multiple 32KiB blocks within the record package's encoding. There have
+// previously been issues specifically decoding these multi-block version edits.
+func TestCrashDuringManifestWrite_LargeKeys(t *testing.T) {
+	seed := rand.Uint64()
+	t.Logf("seed: %d", seed)
+	rng := rand.New(rand.NewPCG(seed, 0))
+
+	// crashClone is nil until a clone of the memFS is constructed, where the
+	// clone will lose 50% of the unsynced data. Each iteration constructs one
+	// clone at a random time, and the DB keeps setting values until the clone
+	// is created. Then a new DB is opened with the cloned memFS.
+	var crashClone atomic.Pointer[vfs.MemFS]
+	makeFS := func(iter uint64) vfs.FS {
+		memFS := vfs.NewCrashableMem()
+		return errorfs.Wrap(memFS, errorfs.InjectorFunc(func(op errorfs.Op) error {
+			if crashClone.Load() != nil || op.Kind != errorfs.OpFileWrite {
+				return nil
+			}
+			typ, _, ok := base.ParseFilename(memFS, memFS.PathBase(op.Path))
+			if !ok || typ != base.FileTypeManifest {
+				return nil
+			}
+			if rng.IntN(5) == 0 {
+				crashClone.Store(memFS.CrashClone(vfs.CrashCloneCfg{
+					UnsyncedDataPercent: 50,
+					RNG:                 rand.New(rand.NewPCG(seed, iter)),
+				}))
+			}
+			return nil
+		}))
+	}
+
+	opts := &Options{Logger: testLogger{t: t}}
+	lel := MakeLoggingEventListener(opts.Logger)
+	opts.EventListener = &lel
+
+	k := slices.Concat([]byte("averyl"), bytes.Repeat([]byte{'o'}, rng.IntN(100000)), []byte("ngkey"))
+	baseLen := len(k)
+	newKey := func(i int) []byte {
+		return append(k[:baseLen], fmt.Sprintf("%10d", i)...)
+	}
+
+	const numIterations = 10
+	var keyIndex int
+	for i := 0; i < numIterations; i++ {
+		func() {
+			crashClone.Store(nil)
+
+			opts.FS = makeFS(uint64(i))
+			d, err := Open("foo", opts)
+			require.NoError(t, err)
+			func() {
+				defer func() { require.NoError(t, d.Close()) }()
+				for j := 0; crashClone.Load() == nil; j++ {
+					keyIndex++
+					require.NoError(t, d.Set(newKey(keyIndex), []byte("value"), Sync))
+					if j%10 == 0 {
+						_, err := d.AsyncFlush()
+						require.NoError(t, err)
+					}
+				}
+				require.NotNil(t, crashClone.Load())
+			}()
+
+			opts.FS = crashClone.Load()
+			d, err = Open("foo", opts)
+			require.NoError(t, err)
+			require.NoError(t, d.Close())
+		}()
+	}
 }

--- a/wal/testdata/reader
+++ b/wal/testdata/reader
@@ -90,7 +90,7 @@ r.NextRecord() = (rr, (000002.log: 111), <nil>)
 r.NextRecord() = (rr, (000002.log: 272), <nil>)
   io.ReadAll(rr) = ("2a0000000000000001000000ec8367c42ebf0ffad5c57ece37b18559ba95ad78... <64000-byte record>", <nil>)
   BatchHeader: [seqNum=42,count=1]
-r.NextRecord() = (rr, (000002.log: 64294), unexpected EOF)
+r.NextRecord() = (rr, (000002.log: 64294), pebble/record: unexpected EOF)
 
 # Test a typical failure scenario. Start off with a recycled log file (000003)
 # that would be on the primary device. It closes "unclean" because we're unable
@@ -253,7 +253,7 @@ r.NextRecord() = (rr, (000005-001.log: 55), 6022 from previous files, <nil>)
 r.NextRecord() = (rr, (000005-001.log: 482), 6022 from previous files, <nil>)
   io.ReadAll(rr) = ("12750100000000001d0000007575c6296b096226e5e78b9760aa7c2ecfa913b6... <199-byte record>", <nil>)
   BatchHeader: [seqNum=95506,count=29]
-r.NextRecord() = (rr, (000005-001.log: 692), 6022 from previous files, unexpected EOF)
+r.NextRecord() = (rr, (000005-001.log: 692), 6022 from previous files, pebble/record: unexpected EOF)
 
 # Read again, this time pretending we found a third segment with the
 # logNameIndex=002. This helps exercise error conditions switching to a new


### PR DESCRIPTION
Disambiguate an unexpected EOF in the record envelope (eg, missing chunks) from an unexpected EOF within the body of the record. An unexpected EOF of the envelope may occur if the process crashes while appending a version edit to the manifest file. An unexpected EOF within the record indicates corruption.

Previously, some version edit code paths re-mapped an unexpected EOF while parsing the record envelope into a corruption error. In this case, recovery failed improperly when it should've ignored the incomplete version edit.

In the other direction, some code paths would return io.ErrUnexpectedEOF while decoding the version edit structure within a valid envelope record. In this case, the caller interpreted the ErrUnexpectedEOF as a sudden end to the record envelope, and recovery succeeded improperly when it should've aborted with a corruption error.

Close #4561.