### PR TITLE
tool: add blob handle print mode to tools

### DIFF
--- a/sstable/values.go
+++ b/sstable/values.go
@@ -21,6 +21,24 @@ var AssertNoBlobHandles = TableBlobContext{
 	References: nil,
 }
 
+// DebugHandlesBlobContext is a TableBlobContext that configures a sstable
+// iterator to return the partially decoded inline blob handle upon encountering
+// a value that references an external blob file.
+var DebugHandlesBlobContext = TableBlobContext{
+	ValueFetcher: nil,
+	References:   nil,
+	// Passing a non-nil BlobHandleFn will return the partially decoded inline
+	// handle before panicking due to missing BlobReferences.
+	BlobHandleFn: func(preface blob.InlineHandlePreface, remainder []byte) base.InternalValue {
+		handleSuffix := blob.DecodeHandleSuffix(remainder)
+		ih := blob.InlineHandle{
+			InlineHandlePreface: preface,
+			HandleSuffix:        handleSuffix,
+		}
+		return base.MakeInPlaceValue([]byte(ih.String()))
+	},
+}
+
 // BlobReferences provides a mapping from an index to a file number for a
 // sstable's blob references. In practice, this is implemented by
 // manifest.BlobReferences.
@@ -41,6 +59,10 @@ type TableBlobContext struct {
 	// References provides a mapping from an index to a file number for a
 	// sstable's blob references.
 	References BlobReferences
+	// BlobHandleFn is an optional function that is invoked after an inline blob
+	// handle has had its preface decoded. Note that if this function is set,
+	// we will not do any work in making a lazy value.
+	BlobHandleFn func(preface blob.InlineHandlePreface, remainder []byte) base.InternalValue
 }
 
 // defaultInternalValueConstructor is the default implementation of the
@@ -76,13 +98,6 @@ func (i *defaultInternalValueConstructor) GetInternalValueForPrefixAndValueHandl
 		panic(errors.AssertionFailedf("block: %x is neither a valblk or blob handle prefix", vp))
 	}
 
-	// We can't convert a blob handle into an InternalValue without
-	// BlobReferences providing the mapping of a reference index to a blob file
-	// number.
-	if i.blobContext.References == nil {
-		panic(errors.AssertionFailedf("blob references not configured"))
-	}
-
 	// The first byte of [handle] is the valuePrefix byte.
 	//
 	// After that, is the inline-handle preface encoding a) the length of the
@@ -93,6 +108,20 @@ func (i *defaultInternalValueConstructor) GetInternalValueForPrefixAndValueHandl
 	// within the blob file. We defer parsing of it until the user retrieves the
 	// value. We propagate it as LazyValue.ValueOrHandle.
 	preface, remainder := blob.DecodeInlineHandlePreface(handle[1:])
+
+	// If BlobHandleFn is specified, we don't care about our value at all; we
+	// just need to return what we have already decoded for our inline blob
+	// handle.
+	if i.blobContext.BlobHandleFn != nil {
+		return i.blobContext.BlobHandleFn(preface, remainder)
+	}
+
+	// We can't convert a blob handle into an InternalValue without
+	// BlobReferences providing the mapping of a reference index to a blob file
+	// number.
+	if i.blobContext.References == nil {
+		panic(errors.AssertionFailedf("blob references not configured"))
+	}
 
 	if i.env.Stats != nil {
 		// TODO(jackson): Add stats to differentiate between blob values and

--- a/tool/find.go
+++ b/tool/find.go
@@ -55,6 +55,7 @@ type findT struct {
 	fmtKey       keyFormatter
 	fmtValue     valueFormatter
 	verbose      bool
+	blobMode     string
 
 	// Map from file num to version edit index which references the file num.
 	editRefs map[base.DiskFileNum][]int
@@ -117,6 +118,8 @@ provenance of the sstables (flushed, ingested, compacted).
 		&f.fmtKey, "key", "key formatter")
 	f.Root.Flags().Var(
 		&f.fmtValue, "value", "value formatter")
+	f.Root.Flags().StringVar(
+		&f.blobMode, "blob-mode", "none", "blob value formatter")
 	return f
 }
 
@@ -469,10 +472,17 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 				fragTransforms = m.FragmentIterTransforms()
 			}
 
-			// TODO(jackson): Adjust to support two modes: one that surfaces the
+			var blobContext sstable.TableBlobContext
+			switch ConvertToBlobRefMode(f.blobMode) {
+			case BlobRefModePrint:
+				blobContext = sstable.DebugHandlesBlobContext
+			default:
+				blobContext = sstable.AssertNoBlobHandles
+			}
+			// TODO(annie): Adjust to support two modes: one that surfaces the
 			// raw blob value handles, and one that fetches the blob values from
 			// blob files uncovered by scanning the directory entries. See #4448.
-			iter, err := r.NewIter(transforms, nil, nil, sstable.AssertNoBlobHandles)
+			iter, err := r.NewIter(transforms, nil, nil, blobContext)
 			if err != nil {
 				return err
 			}

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -195,3 +195,23 @@ func (t *T) ConfigureSharedStorage(
 	t.opts.Experimental.CreateOnShared = createOnShared
 	t.opts.Experimental.CreateOnSharedLocator = createOnSharedLocator
 }
+
+// BlobRefMode specifies how blob references should be handled.
+type BlobRefMode int
+
+const (
+	// BlobRefModeNone specifies the AssertNoBlobHandles TableBlobContext.
+	BlobRefModeNone BlobRefMode = iota
+	// BlobRefModePrint specifies a TableBlobContext that allows printing the
+	// raw blob handle without reading from any blob files.
+	BlobRefModePrint
+)
+
+func ConvertToBlobRefMode(s string) BlobRefMode {
+	switch s {
+	case "print":
+		return BlobRefModePrint
+	default:
+		return BlobRefModeNone
+	}
+}


### PR DESCRIPTION
This patch adds the ability for commands in the `tool` package (`find`, `sstable check`,`sstable scan`) that read sstables in isolation to support printing the inline blob handles of val-separated kvs.

Informs: #4448