### PR TITLE
db: add compaction value separation mechanics

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -580,7 +580,7 @@ func TestCompactionPickerL0(t *testing.T) {
 			var result strings.Builder
 			if pc != nil {
 				checkClone(t, pc)
-				c := newCompaction(pc, opts, time.Now(), nil /* provider */, noopGrantHandle{})
+				c := newCompaction(pc, opts, time.Now(), nil /* provider */, noopGrantHandle{}, neverSeparateValues)
 				fmt.Fprintf(&result, "L%d -> L%d\n", pc.startLevel.level, pc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", pc.startLevel.level, fileNums(pc.startLevel.files))
 				if !pc.outputLevel.files.Empty() {
@@ -809,7 +809,7 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 			var result strings.Builder
 			fmt.Fprintf(&result, "picker.getCompactionConcurrency: %d\n", allowedCompactions)
 			if pc != nil {
-				c := newCompaction(pc, opts, time.Now(), nil /* provider */, noopGrantHandle{})
+				c := newCompaction(pc, opts, time.Now(), nil /* provider */, noopGrantHandle{}, neverSeparateValues)
 				fmt.Fprintf(&result, "L%d -> L%d\n", pc.startLevel.level, pc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", pc.startLevel.level, fileNums(pc.startLevel.files))
 				if !pc.outputLevel.files.Empty() {

--- a/download.go
+++ b/download.go
@@ -439,7 +439,7 @@ func (d *DB) tryLaunchDownloadForFile(
 
 	download.numLaunchedDownloads++
 	doneCh = make(chan error, 1)
-	c := newCompaction(pc, d.opts, d.timeNow(), d.objProvider, noopGrantHandle{})
+	c := newCompaction(pc, d.opts, d.timeNow(), d.objProvider, noopGrantHandle{}, d.determineCompactionValueSeparation)
 	c.isDownload = true
 	d.mu.compact.downloadingCount++
 	d.addInProgressCompaction(c)

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -215,10 +215,17 @@ const (
 	// This format major version does not yet enable use of value separation.
 	FormatTableFormatV6
 
+	// formatValueSeparation enables the use of value separation, separating
+	// values into external blob files that do not participate in every
+	// compaction.
+	//
+	// TODO(jackson): Export this format major version once stable.
+	formatValueSeparation
+
 	// -- Add new versions here --
 
 	// FormatNewest is the most recent format major version.
-	FormatNewest FormatMajorVersion = iota - 1
+	FormatNewest FormatMajorVersion = FormatTableFormatV6
 
 	// Experimental versions, which are excluded by FormatNewest (but can be used
 	// in tests) can be defined here.
@@ -255,7 +262,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 		return sstable.TableFormatPebblev4
 	case FormatColumnarBlocks, FormatWALSyncChunks:
 		return sstable.TableFormatPebblev5
-	case FormatTableFormatV6:
+	case FormatTableFormatV6, formatValueSeparation:
 		return sstable.TableFormatPebblev6
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -269,7 +276,7 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
 		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix,
 		FormatFlushableIngestExcises, FormatColumnarBlocks, FormatWALSyncChunks,
-		FormatTableFormatV6:
+		FormatTableFormatV6, formatValueSeparation:
 		return sstable.TableFormatPebblev1
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -317,6 +324,9 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	},
 	FormatTableFormatV6: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatTableFormatV6)
+	},
+	formatValueSeparation: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(formatValueSeparation)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -27,11 +27,13 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatFlushableIngestExcises, FormatMajorVersion(18))
 	require.Equal(t, FormatColumnarBlocks, FormatMajorVersion(19))
 	require.Equal(t, FormatWALSyncChunks, FormatMajorVersion(20))
+	require.Equal(t, FormatTableFormatV6, FormatMajorVersion(21))
+	require.Equal(t, formatValueSeparation, FormatMajorVersion(22))
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
 	require.Equal(t, FormatNewest, FormatMajorVersion(21))
-	require.Equal(t, internalFormatNewest, FormatMajorVersion(21))
+	require.Equal(t, internalFormatNewest, FormatMajorVersion(22))
 }
 
 func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
@@ -66,6 +68,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatWALSyncChunks, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatTableFormatV6))
 	require.Equal(t, FormatTableFormatV6, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(formatValueSeparation))
+	require.Equal(t, formatValueSeparation, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -225,6 +229,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatColumnarBlocks:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
 		FormatWALSyncChunks:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
 		FormatTableFormatV6:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
+		formatValueSeparation:            {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
 	}
 
 	// Valid versions.
@@ -277,6 +282,16 @@ func TestFormatMajorVersions_ColumnarBlocks(t *testing.T) {
 		},
 		{
 			fmv:     FormatNewest,
+			colBlks: false,
+			want:    sstable.TableFormatPebblev4,
+		},
+		{
+			fmv:     formatValueSeparation,
+			colBlks: true,
+			want:    sstable.TableFormatPebblev6,
+		},
+		{
+			fmv:     formatValueSeparation,
 			colBlks: false,
 			want:    sstable.TableFormatPebblev4,
 		},

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -286,7 +286,13 @@ func (cm *cleanupManager) deleteObsoleteObject(
 			FileNum: fileNum,
 			Err:     err,
 		})
-		// TODO(jackson): Add BlobFileDeleted event.
+	case base.FileTypeBlob:
+		cm.opts.EventListener.BlobFileDeleted(BlobFileDeleteInfo{
+			JobID:   int(jobID),
+			Path:    path,
+			FileNum: fileNum,
+			Err:     err,
+		})
 	}
 }
 

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -570,14 +570,10 @@ func (d *DB) deleteObsoleteFiles(jobID JobID) {
 	}
 }
 
-func (d *DB) maybeScheduleObsoleteTableDeletion() {
+func (d *DB) maybeScheduleObsoleteObjectDeletion() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	d.maybeScheduleObsoleteTableDeletionLocked()
-}
-
-func (d *DB) maybeScheduleObsoleteTableDeletionLocked() {
-	if len(d.mu.versions.obsoleteTables) > 0 {
+	if len(d.mu.versions.obsoleteTables) > 0 || len(d.mu.versions.obsoleteBlobs) > 0 {
 		d.deleteObsoleteFiles(d.newJobIDLocked())
 	}
 }

--- a/open_test.go
+++ b/open_test.go
@@ -333,7 +333,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000008.021",
+			"marker.format-version.000009.022",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -300,6 +300,13 @@ func TestOptionsParse(t *testing.T) {
 			opts.Experimental.TombstoneDenseCompactionThreshold = 0.2
 			opts.Experimental.FileCacheShards = 500
 			opts.Experimental.SecondaryCacheSizeBytes = 1024
+			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+				return ValueSeparationPolicy{
+					Enabled:               true,
+					MinimumSize:           1024,
+					MaxBlobReferenceDepth: 10,
+				}
+			}
 			opts.EnsureDefaults()
 			str := opts.String()
 

--- a/read_state.go
+++ b/read_state.go
@@ -44,8 +44,8 @@ func (s *readState) unref() {
 	}
 
 	// The last reference to the readState was released. Check to see if there
-	// are new obsolete tables to delete.
-	s.db.maybeScheduleObsoleteTableDeletion()
+	// are new obsolete objects to delete.
+	s.db.maybeScheduleObsoleteObjectDeletion()
 }
 
 // unrefLocked removes a reference to the readState. If this was the last
@@ -62,8 +62,8 @@ func (s *readState) unrefLocked() {
 		mem.readerUnrefLocked(true)
 	}
 
-	// In this code path, the caller is responsible for scheduling obsolete table
-	// deletion as necessary.
+	// In this code path, the caller is responsible for scheduling obsolete
+	// object deletions as necessary.
 }
 
 // loadReadState returns the current readState. The returned readState must be

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -51,6 +51,10 @@ create: db/marker.format-version.000008.021
 close: db/marker.format-version.000008.021
 remove: db/marker.format-version.000007.020
 sync: db
+create: db/marker.format-version.000009.022
+close: db/marker.format-version.000009.022
+remove: db/marker.format-version.000008.021
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -117,9 +121,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.021
-close: checkpoints/checkpoint1/marker.format-version.000001.021
+create: checkpoints/checkpoint1/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.022
+close: checkpoints/checkpoint1/marker.format-version.000001.022
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -161,9 +165,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.021
-close: checkpoints/checkpoint2/marker.format-version.000001.021
+create: checkpoints/checkpoint2/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.022
+close: checkpoints/checkpoint2/marker.format-version.000001.022
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -200,9 +204,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.021
-close: checkpoints/checkpoint3/marker.format-version.000001.021
+create: checkpoints/checkpoint3/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.022
+close: checkpoints/checkpoint3/marker.format-version.000001.022
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -286,7 +290,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -296,7 +300,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.021
+marker.format-version.000001.022
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -363,7 +367,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.021
+marker.format-version.000001.022
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -405,7 +409,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.021
+marker.format-version.000001.022
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -524,9 +528,9 @@ sync-data: checkpoints/checkpoint4/OPTIONS-000003
 close: checkpoints/checkpoint4/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.021
-close: checkpoints/checkpoint4/marker.format-version.000001.021
+create: checkpoints/checkpoint4/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.022
+close: checkpoints/checkpoint4/marker.format-version.000001.022
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -614,7 +618,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -633,9 +637,9 @@ sync-data: checkpoints/checkpoint5/OPTIONS-000003
 close: checkpoints/checkpoint5/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.021
-close: checkpoints/checkpoint5/marker.format-version.000001.021
+create: checkpoints/checkpoint5/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.022
+close: checkpoints/checkpoint5/marker.format-version.000001.022
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -735,9 +739,9 @@ sync-data: checkpoints/checkpoint6/OPTIONS-000003
 close: checkpoints/checkpoint6/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.021
-close: checkpoints/checkpoint6/marker.format-version.000001.021
+create: checkpoints/checkpoint6/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.022
+close: checkpoints/checkpoint6/marker.format-version.000001.022
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -39,6 +39,10 @@ create: db/marker.format-version.000005.021
 close: db/marker.format-version.000005.021
 remove: db/marker.format-version.000004.020
 sync: db
+create: db/marker.format-version.000006.022
+close: db/marker.format-version.000006.022
+remove: db/marker.format-version.000005.021
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -105,9 +109,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.021
-close: checkpoints/checkpoint1/marker.format-version.000001.021
+create: checkpoints/checkpoint1/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.022
+close: checkpoints/checkpoint1/marker.format-version.000001.022
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -158,9 +162,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.021
-close: checkpoints/checkpoint2/marker.format-version.000001.021
+create: checkpoints/checkpoint2/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.022
+close: checkpoints/checkpoint2/marker.format-version.000001.022
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -207,9 +211,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.021
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.021
-close: checkpoints/checkpoint3/marker.format-version.000001.021
+create: checkpoints/checkpoint3/marker.format-version.000001.022
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.022
+close: checkpoints/checkpoint3/marker.format-version.000001.022
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -266,7 +270,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000005.021
+marker.format-version.000006.022
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -276,7 +280,7 @@ list checkpoints/checkpoint1
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.021
+marker.format-version.000001.022
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -328,7 +332,7 @@ list checkpoints/checkpoint2
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.021
+marker.format-version.000001.022
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -1,0 +1,274 @@
+# Test a simple sequence of flushes and compactions where all values are
+# separated.
+
+define value-separation=(true, 0, 3)
+----
+
+batch
+set a 1
+set b 2
+----
+
+compact a-b
+----
+L6:
+  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:766 blobrefs:[(000006: 2); depth:1]
+Blob files:
+  000006: 48 physical bytes, 2 value bytes
+
+batch
+set c 3
+set d 4
+----
+
+compact c-d
+----
+L6:
+  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:766 blobrefs:[(000006: 2); depth:1]
+  000008:[c#12,SET-d#13,SET] seqnums:[12-13] points:[c#12,SET-d#13,SET] size:766 blobrefs:[(000009: 2); depth:1]
+Blob files:
+  000006: 48 physical bytes, 2 value bytes
+  000009: 48 physical bytes, 2 value bytes
+
+batch
+set b 5
+set c 6
+----
+
+compact a-d
+----
+L6:
+  000013:[a#0,SET-d#0,SET] seqnums:[0-0] points:[a#0,SET-d#0,SET] size:793 blobrefs:[(000006: 1), (000012: 2), (000009: 1); depth:2]
+Blob files:
+  000006: 48 physical bytes, 2 value bytes
+  000009: 48 physical bytes, 2 value bytes
+  000012: 48 physical bytes, 2 value bytes
+
+batch
+del-range a e
+----
+
+compact a-d
+----
+
+# Set up a scenario where there's a L6 sstable with a blob reference depth of 3,
+# and the value separation policy is configured to limit the blob reference
+# depth to 3.
+
+define verbose value-separation=(true, 3, 3)
+L6 blob-depth=3
+  a.SET.0:a
+  b.SET.0:blob{fileNum=100002 value=bar}
+  f.SET.0:blob{fileNum=100003 value=foo}
+  k.SET.0:k
+  z.SET.0:blob{fileNum=100004 value=zoo}
+----
+L6:
+  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:795 blobrefs:[(100002: 3), (100003: 3), (100004: 3); depth:3]
+
+batch
+set d hello
+set e world
+----
+
+# Flush should write flushed values to a new blob file.
+
+flush
+----
+L0.0:
+  000006:[d#10,SET-e#11,SET] seqnums:[10-11] points:[d#10,SET-e#11,SET] size:765 blobrefs:[(000007: 10); depth:1]
+L6:
+  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:795 blobrefs:[(100002: 3), (100003: 3), (100004: 3); depth:3]
+Blob files:
+  000007: 56 physical bytes, 10 value bytes
+  100002: 49 physical bytes, 3 value bytes
+  100003: 49 physical bytes, 3 value bytes
+  100004: 49 physical bytes, 3 value bytes
+
+# Compacting these two sstables should result in writing the values to a new
+# blob file and the removal of the no longer referenced blob files.
+
+compact a-z
+----
+L6:
+  000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:815 blobrefs:[(000009: 19); depth:1]
+Blob files:
+  000009: 65 physical bytes, 19 value bytes
+
+# Ensure we can read the separated values by iterating over the database.
+
+iter
+first
+next
+next
+next
+next
+next
+next
+----
+a: (a, .)
+b: (bar, .)
+d: (hello, .)
+e: (world, .)
+f: (foo, .)
+k: (k, .)
+z: (zoo, .)
+
+# Set the minimum size for a separated value to 5.
+
+define value-separation=(true, 5, 3)
+----
+
+batch
+set bar bar
+set foo foo
+set fuzz fuzz
+set yaya yaya
+----
+
+# The flush should not write a blob file because none of the keys have a
+# sufficiently long value to be separated.
+
+flush
+----
+L0.0:
+  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:768
+
+batch
+set a a
+set b b
+set h hello
+set w world
+----
+
+# This flush *should* write a blob file, containing 2 values: "hello" and
+# "world" totalling 10 bytes of logical values.
+
+flush
+----
+L0.1:
+  000007:[a#14,SET-w#17,SET] seqnums:[14-17] points:[a#14,SET-w#17,SET] size:811 blobrefs:[(000008: 10); depth:1]
+L0.0:
+  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:768
+Blob files:
+  000008: 56 physical bytes, 10 value bytes
+
+# Configure the database to require keys in the range [a,m) to be in-place.
+
+define required-in-place=(a,m) value-separation=(true,1,3)
+----
+
+batch
+set a apple
+set b banana
+set c coconut
+set d dragonfruit
+set m mango
+----
+
+# The flush should write a blob file, but only "mango" should be separated. This
+# should be reflected in the 5-byte value bytes of the blob file and the table's
+# blob reference value size.
+
+flush
+----
+L0.0:
+  000005:[a#10,SET-m#14,SET] seqnums:[10-14] points:[a#10,SET-m#14,SET] size:820 blobrefs:[(000006: 5); depth:1]
+Blob files:
+  000006: 51 physical bytes, 5 value bytes
+
+
+define value-separation=(true,5,5) l0-compaction-threshold=1
+----
+
+# Test writing a non-trivial amount of data. With a key length of 4, we'll write
+# 475254 keys each with a 64-byte value, totalling ~30MB of value data.
+
+populate keylen=4 timestamps=(1) vallen=64
+----
+wrote 475254 keys
+
+# Flush the memtable. The resulting L0 sstables should be relatively small, but
+# when their sizes are summed with their corresponding blob files, the sum
+# should be around the target file size of 2MB.
+
+flush
+----
+L0.0:
+  000005:[a@1#10,SET-blof@1#26408,SET] seqnums:[10-26408] points:[a@1#10,SET-blof@1#26408,SET] size:402673 blobrefs:[(000006: 1689536); depth:1]
+  000007:[blog@1#26409,SET-cxcf@1#52799,SET] seqnums:[26409-52799] points:[blog@1#26409,SET-cxcf@1#52799,SET] size:405756 blobrefs:[(000008: 1689024); depth:1]
+  000009:[cxcg@1#52800,SET-einq@1#79120,SET] seqnums:[52800-79120] points:[cxcg@1#52800,SET-einq@1#79120,SET] size:410370 blobrefs:[(000010: 1684544); depth:1]
+  000011:[einr@1#79121,SET-fuau@1#105488,SET] seqnums:[79121-105488] points:[einr@1#79121,SET-fuau@1#105488,SET] size:407440 blobrefs:[(000012: 1687552); depth:1]
+  000013:[fuav@1#105489,SET-hfno@1#131846,SET] seqnums:[105489-131846] points:[fuav@1#105489,SET-hfno@1#131846,SET] size:408549 blobrefs:[(000014: 1686912); depth:1]
+  000015:[hfnp@1#131847,SET-iqzq@1#158184,SET] seqnums:[131847-158184] points:[hfnp@1#131847,SET-iqzq@1#158184,SET] size:408995 blobrefs:[(000016: 1685632); depth:1]
+  000017:[iqzr@1#158185,SET-kchm@1#184410,SET] seqnums:[158185-184410] points:[iqzr@1#158185,SET-kchm@1#184410,SET] size:414699 blobrefs:[(000018: 1678464); depth:1]
+  000019:[kchn@1#184411,SET-lnt@1#210733,SET] seqnums:[184411-210733] points:[kchn@1#184411,SET-lnt@1#210733,SET] size:409800 blobrefs:[(000020: 1684672); depth:1]
+  000021:[lnta@1#210734,SET-mzgo@1#237112,SET] seqnums:[210734-237112] points:[lnta@1#210734,SET-mzgo@1#237112,SET] size:407724 blobrefs:[(000022: 1688256); depth:1]
+  000023:[mzgp@1#237113,SET-okst@1#263454,SET] seqnums:[237113-263454] points:[mzgp@1#237113,SET-okst@1#263454,SET] size:408979 blobrefs:[(000024: 1685888); depth:1]
+  000025:[oksu@1#263455,SET-pwgo@1#289840,SET] seqnums:[263455-289840] points:[oksu@1#263455,SET-pwgo@1#289840,SET] size:403438 blobrefs:[(000026: 1688704); depth:1]
+  000027:[pwgp@1#289841,SET-rhth@1#316197,SET] seqnums:[289841-316197] points:[pwgp@1#289841,SET-rhth@1#316197,SET] size:408839 blobrefs:[(000028: 1686848); depth:1]
+  000029:[rhti@1#316198,SET-stec@1#342502,SET] seqnums:[316198-342502] points:[rhti@1#316198,SET-stec@1#342502,SET] size:411207 blobrefs:[(000030: 1683520); depth:1]
+  000031:[sted@1#342503,SET-uery@1#368888,SET] seqnums:[342503-368888] points:[sted@1#342503,SET-uery@1#368888,SET] size:406286 blobrefs:[(000032: 1688704); depth:1]
+  000033:[uerz@1#368889,SET-vqfq@1#395271,SET] seqnums:[368889-395271] points:[uerz@1#368889,SET-vqfq@1#395271,SET] size:406985 blobrefs:[(000034: 1688512); depth:1]
+  000035:[vqfr@1#395272,SET-xbqj@1#421574,SET] seqnums:[395272-421574] points:[vqfr@1#395272,SET-xbqj@1#421574,SET] size:410632 blobrefs:[(000036: 1683392); depth:1]
+  000037:[xbqk@1#421575,SET-ymzw@1#447842,SET] seqnums:[421575-447842] points:[xbqk@1#421575,SET-ymzw@1#447842,SET] size:412587 blobrefs:[(000038: 1681152); depth:1]
+  000039:[ymzx@1#447843,SET-zyni@1#474219,SET] seqnums:[447843-474219] points:[ymzx@1#447843,SET-zyni@1#474219,SET] size:407748 blobrefs:[(000040: 1688128); depth:1]
+  000041:[zynj@1#474220,SET-zzzz@1#475263,SET] seqnums:[474220-475263] points:[zynj@1#474220,SET-zzzz@1#475263,SET] size:16569 blobrefs:[(000042: 66816); depth:1]
+Blob files:
+  000006: 1694530 physical bytes, 1689536 value bytes
+  000008: 1694018 physical bytes, 1689024 value bytes
+  000010: 1689526 physical bytes, 1684544 value bytes
+  000012: 1692534 physical bytes, 1687552 value bytes
+  000014: 1691894 physical bytes, 1686912 value bytes
+  000016: 1690614 physical bytes, 1685632 value bytes
+  000018: 1683422 physical bytes, 1678464 value bytes
+  000020: 1689654 physical bytes, 1684672 value bytes
+  000022: 1693250 physical bytes, 1688256 value bytes
+  000024: 1690870 physical bytes, 1685888 value bytes
+  000026: 1693698 physical bytes, 1688704 value bytes
+  000028: 1691830 physical bytes, 1686848 value bytes
+  000030: 1688502 physical bytes, 1683520 value bytes
+  000032: 1693698 physical bytes, 1688704 value bytes
+  000034: 1693506 physical bytes, 1688512 value bytes
+  000036: 1688362 physical bytes, 1683392 value bytes
+  000038: 1686122 physical bytes, 1681152 value bytes
+  000040: 1693122 physical bytes, 1688128 value bytes
+  000042: 67041 physical bytes, 66816 value bytes
+
+# Schedule automatic compactions. These compactions should write data to L6. The
+# resulting sstables will reference multiple blob files but maintain a blob
+# reference depth of 1 because L6 has no referenced blob files and all the L0
+# input tables have a reference depth of 1.
+
+auto-compact
+----
+L6:
+  000044:[a@1#0,SET-czma@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-czma@1#0,SET] size:713597 blobrefs:[(000006: 1689536), (000008: 1689024), (000010: 106944); depth:1]
+  000045:[czmb@1#0,SET-fzac@1#0,SET] seqnums:[0-0] points:[czmb@1#0,SET-fzac@1#0,SET] size:710727 blobrefs:[(000010: 1577600), (000012: 1687552), (000014: 223808); depth:1]
+  000046:[fzad@1#0,SET-iyoz@1#0,SET] seqnums:[0-0] points:[fzad@1#0,SET-iyoz@1#0,SET] size:710124 blobrefs:[(000014: 1463104), (000016: 1685632), (000018: 341504); depth:1]
+  000047:[iyp@1#0,SET-lxxp@1#0,SET] seqnums:[0-0] points:[iyp@1#0,SET-lxxp@1#0,SET] size:718439 blobrefs:[(000018: 1336960), (000020: 1684672), (000022: 457856); depth:1]
+  000048:[lxxq@1#0,SET-oxlo@1#0,SET] seqnums:[0-0] points:[lxxq@1#0,SET-oxlo@1#0,SET] size:711593 blobrefs:[(000022: 1230400), (000024: 1685888), (000026: 572480); depth:1]
+  000049:[oxlp@1#0,SET-rwyj@1#0,SET] seqnums:[0-0] points:[oxlp@1#0,SET-rwyj@1#0,SET] size:713709 blobrefs:[(000026: 1116224), (000028: 1686848), (000030: 683648); depth:1]
+  000050:[rwyk@1#0,SET-uwic@1#0,SET] seqnums:[0-0] points:[rwyk@1#0,SET-uwic@1#0,SET] size:718480 blobrefs:[(000030: 999872), (000032: 1688704), (000034: 792896); depth:1]
+  000051:[uwid@1#0,SET-xvqq@1#0,SET] seqnums:[0-0] points:[uwid@1#0,SET-xvqq@1#0,SET] size:720205 blobrefs:[(000034: 895616), (000036: 1683392), (000038: 900288); depth:1]
+  000052:[xvqr@1#0,SET-zzzz@1#0,SET] seqnums:[0-0] points:[xvqr@1#0,SET-zzzz@1#0,SET] size:521418 blobrefs:[(000038: 780864), (000040: 1688128), (000042: 66816); depth:1]
+Blob files:
+  000006: 1694530 physical bytes, 1689536 value bytes
+  000008: 1694018 physical bytes, 1689024 value bytes
+  000010: 1689526 physical bytes, 1684544 value bytes
+  000012: 1692534 physical bytes, 1687552 value bytes
+  000014: 1691894 physical bytes, 1686912 value bytes
+  000016: 1690614 physical bytes, 1685632 value bytes
+  000018: 1683422 physical bytes, 1678464 value bytes
+  000020: 1689654 physical bytes, 1684672 value bytes
+  000022: 1693250 physical bytes, 1688256 value bytes
+  000024: 1690870 physical bytes, 1685888 value bytes
+  000026: 1693698 physical bytes, 1688704 value bytes
+  000028: 1691830 physical bytes, 1686848 value bytes
+  000030: 1688502 physical bytes, 1683520 value bytes
+  000032: 1693698 physical bytes, 1688704 value bytes
+  000034: 1693506 physical bytes, 1688512 value bytes
+  000036: 1688362 physical bytes, 1683392 value bytes
+  000038: 1686122 physical bytes, 1681152 value bytes
+  000040: 1693122 physical bytes, 1688128 value bytes
+  000042: 67041 physical bytes, 66816 value bytes

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -66,6 +66,11 @@ close: db/marker.format-version.000008.021
 remove: db/marker.format-version.000007.020
 sync: db
 upgraded to format version: 021
+create: db/marker.format-version.000009.022
+close: db/marker.format-version.000009.022
+remove: db/marker.format-version.000008.021
+sync: db
+upgraded to format version: 022
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -375,9 +380,9 @@ sync-data: checkpoint/OPTIONS-000003
 close: checkpoint/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.021
-sync-data: checkpoint/marker.format-version.000001.021
-close: checkpoint/marker.format-version.000001.021
+create: checkpoint/marker.format-version.000001.022
+sync-data: checkpoint/marker.format-version.000001.022
+close: checkpoint/marker.format-version.000001.022
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -60,7 +60,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -81,7 +81,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -390,7 +390,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -410,7 +410,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -443,7 +443,7 @@ MANIFEST-000001
 MANIFEST-000011
 OPTIONS-000014
 ext
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000002.MANIFEST-000011
 
 # Make sure that the new mutable memtable can accept writes.
@@ -586,7 +586,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -605,7 +605,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext1
-marker.format-version.000008.021
+marker.format-version.000009.022
 marker.manifest.000001.MANIFEST-000001
 
 open

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -15,6 +15,8 @@ L5:
   000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:893 blobrefs:[(000921: 10); depth:1]
 L6:
   000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:849 blobrefs:[(000921: 6); depth:1]
+Blob files:
+  000921: 62 physical bytes, 16 value bytes
 
 combined-iter
 first
@@ -73,6 +75,9 @@ L5:
   000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:852 blobrefs:[(000039: 14), (000921: 20); depth:2]
 L6:
   000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:861 blobrefs:[(000039: 11), (000921: 13); depth:2]
+Blob files:
+  000039: 71 physical bytes, 25 value bytes
+  000921: 79 physical bytes, 33 value bytes
 
 # The iterator stats should indicate that only the first value from each file
 # should trigger a read of the blob file. Once loaded, subsequent reads of the
@@ -133,6 +138,8 @@ L6
 ----
 L6:
   000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:956 blobrefs:[(000009: 96); depth:1]
+Blob files:
+  000009: 190 physical bytes, 96 value bytes
 
 combined-iter
 first

--- a/testdata/value_separation_policy
+++ b/testdata/value_separation_policy
@@ -134,7 +134,7 @@ RawWriter.AddWithBlobHandle("e#9,SET", "(f0,blk0[4:9])", 5, false)
 
 estimated-sizes
 ----
-file: 0, references: 14
+file: 0, references: 5
 
 close-output
 ----

--- a/value_separation.go
+++ b/value_separation.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"cmp"
+	"maps"
 	"slices"
 	"time"
 
@@ -18,6 +19,120 @@ import (
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/blob"
 )
+
+var neverSeparateValues getValueSeparation = func(JobID, *compaction, sstable.TableFormat) compact.ValueSeparation {
+	return compact.NeverSeparateValues{}
+}
+
+// determineCompactionValueSeparation determines whether a compaction should
+// separate values into blob files. It returns a compact.ValueSeparation
+// implementation that should be used for the compaction.
+func (d *DB) determineCompactionValueSeparation(
+	jobID JobID, c *compaction, tableFormat sstable.TableFormat,
+) compact.ValueSeparation {
+	if tableFormat < sstable.TableFormatPebblev6 || d.FormatMajorVersion() < formatValueSeparation ||
+		d.opts.Experimental.ValueSeparationPolicy == nil {
+		return compact.NeverSeparateValues{}
+	}
+	policy := d.opts.Experimental.ValueSeparationPolicy()
+	if !policy.Enabled {
+		return compact.NeverSeparateValues{}
+	}
+
+	// We're allowed to write blob references. Determine whether we should carry
+	// forward existing blob references, or write new ones.
+	if writeBlobs, outputBlobReferenceDepth := shouldWriteBlobFiles(c, policy); !writeBlobs {
+		// This compaction should preserve existing blob references.
+		return &preserveBlobReferences{
+			inputBlobMetadatas:       uniqueInputBlobMetadatas(c.inputs),
+			outputBlobReferenceDepth: outputBlobReferenceDepth,
+		}
+	}
+
+	// This compaction should write values to new blob files.
+	return &writeNewBlobFiles{
+		comparer: d.opts.Comparer,
+		newBlobObject: func() (objstorage.Writable, objstorage.ObjectMetadata, error) {
+			return d.newCompactionOutputBlob(jobID, c)
+		},
+		shortAttrExtractor: d.opts.Experimental.ShortAttributeExtractor,
+		writerOpts:         d.opts.MakeBlobWriterOptions(c.outputLevel.level),
+		minimumSize:        policy.MinimumSize,
+		// TODO(jackson): Don't propagate these bounds if they don't
+		// overlap with the compaction's bounds.
+		requiredInPlaceValueBound: d.opts.Experimental.RequiredInPlaceValueBound,
+	}
+}
+
+// shouldWriteBlobFiles returns true if the compaction should write new blob
+// files. It also returns the maximum blob reference depth to assign to output
+// sstables (the actual value may be lower iff the output table references fewer
+// distinct blob files).
+func shouldWriteBlobFiles(
+	c *compaction, policy ValueSeparationPolicy,
+) (writeBlobs bool, referenceDepth manifest.BlobReferenceDepth) {
+	// Flushes will have no existing references to blob files and should write
+	// their values to new blob files.
+	if c.kind == compactionKindFlush {
+		return true, 1
+	}
+	inputReferenceDepth := compactionBlobReferenceDepth(c.inputs)
+	if inputReferenceDepth == 0 {
+		// None of the input sstables reference blob files. It may be the case
+		// that these sstables were created before value separation was enabled.
+		// We should try to write to new blob files.
+		return true, 1
+	}
+	// If the compaction's output blob reference depth would be greater than the
+	// configured max, we should rewrite the values into new blob files to
+	// restore locality.
+	if inputReferenceDepth > policy.MaxBlobReferenceDepth {
+		return true, 1
+	}
+	// Otherwise, we won't write any new blob files but will carry forward
+	// existing references.
+	return false, inputReferenceDepth
+}
+
+// compactionBlobReferenceDepth computes the blob reference depth for a
+// compaction. It's computed by finding the maximum blob reference depth of
+// input sstables in each level. These per-level depths are then summed to
+// produce a worst-case approximation of the blob reference locality of the
+// compaction's output sstables.
+//
+// The intuition is that as compactions combine files referencing distinct blob
+// files, outputted sstables begin to reference more and more distinct blob
+// files. In the worst case, these references are evenly distributed across the
+// keyspace and there is very little locality.
+func compactionBlobReferenceDepth(levels []compactionLevel) manifest.BlobReferenceDepth {
+	var depth manifest.BlobReferenceDepth
+	for _, level := range levels {
+		var levelDepth manifest.BlobReferenceDepth
+		for t := range level.files.All() {
+			levelDepth = max(levelDepth, t.BlobReferenceDepth)
+		}
+		depth += levelDepth
+	}
+	return depth
+}
+
+// uniqueInputBlobMetadatas returns a slice of all unique blob file metadata
+// objects referenced by tables in levels.
+func uniqueInputBlobMetadatas(levels []compactionLevel) []*manifest.BlobFileMetadata {
+	m := make(map[*manifest.BlobFileMetadata]struct{})
+	for _, level := range levels {
+		for t := range level.files.All() {
+			for _, ref := range t.BlobReferences {
+				m[ref.Metadata] = struct{}{}
+			}
+		}
+	}
+	metadatas := slices.Collect(maps.Keys(m))
+	slices.SortFunc(metadatas, func(a, b *manifest.BlobFileMetadata) int {
+		return cmp.Compare(a.FileNum, b.FileNum)
+	})
+	return metadatas
+}
 
 // writeNewBlobFiles implements the strategy and mechanics for separating values
 // into external blob files.
@@ -301,6 +416,7 @@ func (vs *preserveBlobReferences) findInputBlobMetadata(fn base.DiskFileNum) (in
 func (vs *preserveBlobReferences) FinishOutput() (compact.ValueSeparationMetadata, error) {
 	references := slices.Clone(vs.currReferences)
 	vs.currReferences = vs.currReferences[:0]
+	vs.totalValueSize = 0
 
 	referenceSize := uint64(0)
 	for _, ref := range references {


### PR DESCRIPTION
Introduce a new experimental option and (unexported) format major verson that
together enable compaction-time separation of values into external blob files.

Informs #112.