### PR TITLE
sstable: fix IndexSize, TopLevelIndexSize and NumDataBlocks

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -845,7 +845,7 @@ func (w *RawColumnWriter) flushBufferedIndexBlocks() (rootIndex block.Handle, er
 		if err != nil {
 			return rootIndex, err
 		}
-		w.props.IndexSize = rootIndex.Length + block.TrailerLen
+		w.props.IndexSize = uint64(len(w.indexBuffering.partitions[0].block))
 		w.props.NumDataBlocks = uint64(w.indexBuffering.partitions[0].nEntries)
 		w.props.IndexType = binarySearchIndex
 	default:
@@ -855,15 +855,17 @@ func (w *RawColumnWriter) flushBufferedIndexBlocks() (rootIndex block.Handle, er
 			if err != nil {
 				return block.Handle{}, err
 			}
-			w.props.IndexSize += bh.Length + block.TrailerLen
-			w.props.NumDataBlocks += uint64(w.indexBuffering.partitions[0].nEntries)
+			w.props.IndexSize += uint64(len(part.block))
+			w.props.NumDataBlocks += uint64(part.nEntries)
 			w.topLevelIndexBlock.AddBlockHandle(part.sep.UserKey, bh, part.properties)
 		}
-		rootIndex, err = w.layout.WriteIndexBlock(w.topLevelIndexBlock.Finish(w.topLevelIndexBlock.Rows()))
+		topLevelIndex := w.topLevelIndexBlock.Finish(w.topLevelIndexBlock.Rows())
+		rootIndex, err = w.layout.WriteIndexBlock(topLevelIndex)
 		if err != nil {
 			return block.Handle{}, err
 		}
-		w.props.IndexSize += rootIndex.Length + block.TrailerLen
+		w.props.TopLevelIndexSize = uint64(len(topLevelIndex))
+		w.props.IndexSize += uint64(len(topLevelIndex))
 		w.props.IndexType = twoLevelIndex
 		w.props.IndexPartitions = uint64(len(w.indexBuffering.partitions))
 	}

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -153,7 +153,7 @@ type Properties struct {
 	FilterSize uint64 `prop:"rocksdb.filter.size"`
 	// Total number of index partitions if kTwoLevelIndexSearch is used.
 	IndexPartitions uint64 `prop:"rocksdb.index.partitions"`
-	// The size of index block.
+	// The size (uncompressed) of index block.
 	IndexSize uint64 `prop:"rocksdb.index.size"`
 	// The index type. TODO(peter): add a more detailed description.
 	IndexType uint32 `prop:"rocksdb.block.based.table.index.type"`
@@ -190,7 +190,7 @@ type Properties struct {
 	// The cumulative bytes of values in this table that were pinned by
 	// open snapshots. This value is comparable to RawValueSize.
 	SnapshotPinnedValueSize uint64 `prop:"pebble.raw.snapshot-pinned-values.size"`
-	// Size of the top-level index if kTwoLevelIndexSearch is used.
+	// Size (uncompressed) of the top-level index if kTwoLevelIndexSearch is used.
 	TopLevelIndexSize uint64 `prop:"rocksdb.top-level.index.size"`
 	// User collected properties. Currently, we only use them to store block
 	// properties aggregated at the table level.

--- a/sstable/testdata/columnar_writer/simple_binary
+++ b/sstable/testdata/columnar_writer/simple_binary
@@ -103,7 +103,7 @@ sstable
  │    ├── 00600    rocksdb.raw.value.size (14)
  │    ├── restart points
  │    │    └── 00614 [restart 0]
- │    └── trailer [compression=none checksum=0xf75fa767]
+ │    └── trailer [compression=none checksum=0x38193e35]
  ├── meta-index  offset: 776  length: 33
  │    ├── 0000    rocksdb.properties block:149/622 [restart]
  │    ├── restart points
@@ -130,7 +130,7 @@ rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_
 rocksdb.comparator: pebble.internal.testkeys
 rocksdb.data.size: 93
 rocksdb.filter.size: 0
-rocksdb.index.size: 56
+rocksdb.index.size: 51
 rocksdb.block.based.table.index.type: 0
 pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
@@ -250,7 +250,7 @@ sstable
  │    ├── 00568    rocksdb.raw.value.size (14)
  │    ├── restart points
  │    │    └── 00582 [restart 0]
- │    └── trailer [compression=none checksum=0x54772987]
+ │    └── trailer [compression=none checksum=0x1341bc55]
  ├── meta-index  offset: 772  length: 33
  │    ├── 0000    rocksdb.properties block:177/590 [restart]
  │    ├── restart points
@@ -645,7 +645,7 @@ sstable
  │    ├── 00570    rocksdb.raw.value.size (15)
  │    ├── restart points
  │    │    └── 00585 [restart 0]
- │    └── trailer [compression=none checksum=0x98e2c466]
+ │    └── trailer [compression=none checksum=0xa3e92c5a]
  ├── meta-index  offset: 1295  length: 33
  │    ├── 0000    rocksdb.properties block:697/593 [restart]
  │    ├── restart points
@@ -675,7 +675,7 @@ rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_
 rocksdb.comparator: pebble.internal.testkeys
 rocksdb.data.size: 582
 rocksdb.filter.size: 0
-rocksdb.index.size: 115
+rocksdb.index.size: 110
 rocksdb.block.based.table.index.type: 0
 pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
@@ -1036,7 +1036,7 @@ sstable
  │    ├── 00570    rocksdb.raw.value.size (15)
  │    ├── restart points
  │    │    └── 00585 [restart 0]
- │    └── trailer [compression=none checksum=0x98e2c466]
+ │    └── trailer [compression=none checksum=0xa3e92c5a]
  ├── meta-index  offset: 1295  length: 33
  │    ├── 0000    rocksdb.properties block:697/593 [restart]
  │    ├── restart points
@@ -1133,7 +1133,7 @@ sstable
  │    ├── 00558    rocksdb.raw.value.size (14)
  │    ├── restart points
  │    │    └── 00572 [restart 0]
- │    └── trailer [compression=none checksum=0xd4a2d9f6]
+ │    └── trailer [compression=none checksum=0x50f07e7e]
  ├── meta-index  offset: 674  length: 59
  │    ├── 0000    rocksdb.properties block:89/580 [restart]
  │    ├── 0024    rocksdb.range_del2 block:33/51 [restart]
@@ -1251,7 +1251,7 @@ sstable
  │    ├── 00640    rocksdb.raw.value.size (14)
  │    ├── restart points
  │    │    └── 00654 [restart 0]
- │    └── trailer [compression=none checksum=0xbdc87030]
+ │    └── trailer [compression=none checksum=0x29bae4b8]
  ├── meta-index  offset: 773  length: 57
  │    ├── 0000    pebble.range_key block:33/68 [restart]
  │    ├── 0021    rocksdb.properties block:106/662 [restart]

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -132,7 +132,7 @@ sstable
  │    ├── 00589    rocksdb.property.collectors (41)
  │    ├── 00630    rocksdb.raw.key.size (21)
  │    ├── 00651    rocksdb.raw.value.size (24)
- │    └── trailer [compression=snappy checksum=0xf0c5768d]
+ │    └── trailer [compression=snappy checksum=0x277c72db]
  ├── meta-index  offset: 767  length: 46
  │    ├── 0000    rocksdb.properties block:200/562
  │    │   

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -101,7 +101,7 @@ rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_
 rocksdb.comparator: pebble.internal.testkeys
 rocksdb.data.size: 0
 rocksdb.filter.size: 0
-rocksdb.index.size: 33
+rocksdb.index.size: 28
 rocksdb.block.based.table.index.type: 0
 pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
@@ -317,7 +317,7 @@ rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_
 rocksdb.comparator: pebble.internal.testkeys
 rocksdb.data.size: 0
 rocksdb.filter.size: 0
-rocksdb.index.size: 33
+rocksdb.index.size: 28
 rocksdb.block.based.table.index.type: 0
 pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -101,7 +101,7 @@ rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_
 rocksdb.comparator: pebble.internal.testkeys
 rocksdb.data.size: 0
 rocksdb.filter.size: 0
-rocksdb.index.size: 33
+rocksdb.index.size: 28
 rocksdb.block.based.table.index.type: 0
 pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
@@ -239,6 +239,29 @@ sstable
  ├── meta-index  offset: 974  length: 46
  └── footer  offset: 1025  length: 57
 
+props
+----
+rocksdb.num.entries: 3
+rocksdb.raw.key.size: 27
+rocksdb.raw.value.size: 3
+rocksdb.deleted.keys: 0
+rocksdb.num.range-deletions: 0
+rocksdb.num.data.blocks: 3
+rocksdb.compression: Snappy
+rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
+rocksdb.comparator: pebble.internal.testkeys
+rocksdb.data.size: 237
+rocksdb.filter.size: 0
+rocksdb.index.partitions: 3
+rocksdb.index.size: 158
+rocksdb.block.based.table.index.type: 2
+pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
+rocksdb.merge.operator: pebble.concatenate
+rocksdb.merge.operands: 0
+rocksdb.property.collectors: [obsolete-key]
+rocksdb.top-level.index.size: 48
+obsolete-key: hex:00
+
 # Exercise the non-Reader layout-decoding codepath.
 
 decode-layout
@@ -317,7 +340,7 @@ rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_
 rocksdb.comparator: pebble.internal.testkeys
 rocksdb.data.size: 0
 rocksdb.filter.size: 0
-rocksdb.index.size: 33
+rocksdb.index.size: 28
 rocksdb.block.based.table.index.type: 0
 pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -669,7 +669,7 @@ sstable
  │    ├── 00578    rocksdb.top-level.index.size (24)
  │    ├── restart points
  │    │    └── 00602 [restart 0]
- │    └── trailer [compression=none checksum=0x307b671a]
+ │    └── trailer [compression=none checksum=0xc70b061b]
  ├── meta-index  offset: 1308  length: 64
  │    ├── 0000    pebble.value_index block:680/8 value-blocks-index-lengths: 1(num), 2(offset), 1(length) [restart]
  │    ├── 0027    rocksdb.properties block:693/610 [restart]
@@ -961,7 +961,7 @@ sstable
  │    ├── 00518    rocksdb.raw.value.size (14)
  │    ├── restart points
  │    │    └── 00532 [restart 0]
- │    └── trailer [compression=none checksum=0x62079e3b]
+ │    └── trailer [compression=none checksum=0x9b925786]
  ├── meta-index  offset: 691  length: 33
  │    ├── 0000    rocksdb.properties block:146/540 [restart]
  │    ├── restart points
@@ -1103,7 +1103,7 @@ sstable
  │    ├── 00556    rocksdb.property.collectors (41)
  │    ├── 00597    rocksdb.raw.key.size (21)
  │    ├── 00618    rocksdb.raw.value.size (23)
- │    └── trailer [compression=snappy checksum=0x6a5dbad6]
+ │    └── trailer [compression=snappy checksum=0x5d7f7403]
  ├── meta-index  offset: 676  length: 46
  │    ├── 0000    rocksdb.properties block:146/525
  │    │   


### PR DESCRIPTION
The RawColumnWriter has several bugs related to setting properties:

IndexSize: In previous table formats, IndexSize recorded the _uncompressed_ size of the index block.  The RawColumnWriter incorrectly totalled the compressed sizes of all index blocks.

TopLevelIndexSize: The RawColumnWriter did not set this property at all.

NumDataBlocks: When a table had a two-level index, the RawColumnWriter miscalculated NumDataBlocks. It improperly set the value to the number of entries in the first index block multipled by the count of bottom-level index blocks.