### PR TITLE
manifest: remove redundant smallest, largest bounds in TableMetadata

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -315,8 +315,8 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 					if c.inputs[0].level == 0 {
 						iter := c.inputs[0].files.Iter()
 						l0InProgress = append(l0InProgress, manifest.L0Compaction{
-							Smallest:  iter.First().Smallest,
-							Largest:   iter.Last().Largest,
+							Smallest:  iter.First().Smallest(),
+							Largest:   iter.Last().Largest(),
 							IsIntraL0: c.outputLevel == 0,
 						})
 					}
@@ -426,8 +426,8 @@ func TestCompactionPickerL0(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		)
-		m.SmallestSeqNum = m.Smallest.SeqNum()
-		m.LargestSeqNum = m.Largest.SeqNum()
+		m.SmallestSeqNum = m.Smallest().SeqNum()
+		m.LargestSeqNum = m.Largest().SeqNum()
 		if m.SmallestSeqNum > m.LargestSeqNum {
 			m.SmallestSeqNum, m.LargestSeqNum = m.LargestSeqNum, m.SmallestSeqNum
 		}
@@ -517,11 +517,11 @@ func TestCompactionPickerL0(t *testing.T) {
 							return fmt.Sprintf("cannot find compaction file %s", base.FileNum(fileNum))
 						}
 						compactFile.CompactionState = manifest.CompactionStateCompacting
-						if first || base.InternalCompare(DefaultComparer.Compare, info.largest, compactFile.Largest) < 0 {
-							info.largest = compactFile.Largest
+						if first || base.InternalCompare(DefaultComparer.Compare, info.largest, compactFile.Largest()) < 0 {
+							info.largest = compactFile.Largest()
 						}
-						if first || base.InternalCompare(DefaultComparer.Compare, info.smallest, compactFile.Smallest) > 0 {
-							info.smallest = compactFile.Smallest
+						if first || base.InternalCompare(DefaultComparer.Compare, info.smallest, compactFile.Smallest()) > 0 {
+							info.smallest = compactFile.Smallest()
 						}
 						first = false
 						compactionFiles[level] = append(compactionFiles[level], compactFile)
@@ -658,9 +658,9 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 				m.Size = uint64(v)
 			}
 		}
-		m.SmallestSeqNum = m.Smallest.SeqNum()
-		m.LargestSeqNum = m.Largest.SeqNum()
-		m.LargestSeqNumAbsolute = m.Largest.SeqNum()
+		m.SmallestSeqNum = m.Smallest().SeqNum()
+		m.LargestSeqNum = m.Largest().SeqNum()
+		m.LargestSeqNumAbsolute = m.Largest().SeqNum()
 		return m, nil
 	}
 
@@ -740,11 +740,11 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 							return fmt.Sprintf("cannot find compaction file %s", base.FileNum(fileNum))
 						}
 						compactFile.CompactionState = manifest.CompactionStateCompacting
-						if first || base.InternalCompare(DefaultComparer.Compare, info.largest, compactFile.Largest) < 0 {
-							info.largest = compactFile.Largest
+						if first || base.InternalCompare(DefaultComparer.Compare, info.largest, compactFile.Largest()) < 0 {
+							info.largest = compactFile.Largest()
 						}
-						if first || base.InternalCompare(DefaultComparer.Compare, info.smallest, compactFile.Smallest) > 0 {
-							info.smallest = compactFile.Smallest
+						if first || base.InternalCompare(DefaultComparer.Compare, info.smallest, compactFile.Smallest()) > 0 {
+							info.smallest = compactFile.Smallest()
 						}
 						first = false
 						compactionFiles[level] = append(compactionFiles[level], compactFile)
@@ -861,9 +861,9 @@ func TestCompactionPickerPickReadTriggered(t *testing.T) {
 				m.Size = uint64(v)
 			}
 		}
-		m.SmallestSeqNum = m.Smallest.SeqNum()
-		m.LargestSeqNum = m.Largest.SeqNum()
-		m.LargestSeqNumAbsolute = m.Largest.SeqNum()
+		m.SmallestSeqNum = m.Smallest().SeqNum()
+		m.LargestSeqNum = m.Largest().SeqNum()
+		m.LargestSeqNumAbsolute = m.Largest().SeqNum()
 		return m, nil
 	}
 
@@ -1017,8 +1017,8 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(tableParts[0])),
 			base.ParseInternalKey(strings.TrimSpace(tableParts[1])),
 		)
-		m.SmallestSeqNum = m.Smallest.SeqNum()
-		m.LargestSeqNum = m.Largest.SeqNum()
+		m.SmallestSeqNum = m.Smallest().SeqNum()
+		m.LargestSeqNum = m.Largest().SeqNum()
 		if m.SmallestSeqNum > m.LargestSeqNum {
 			m.SmallestSeqNum, m.LargestSeqNum = m.LargestSeqNum, m.SmallestSeqNum
 		}
@@ -1232,7 +1232,7 @@ func TestPickedCompactionExpandInputs(t *testing.T) {
 
 				var buf bytes.Buffer
 				for f := range iter.Take().Slice().All() {
-					fmt.Fprintf(&buf, "%d: %s-%s\n", f.FileNum, f.Smallest, f.Largest)
+					fmt.Fprintf(&buf, "%d: %s-%s\n", f.FileNum, f.Smallest(), f.Largest())
 				}
 				return buf.String()
 
@@ -1284,8 +1284,8 @@ func TestCompactionOutputFileSize(t *testing.T) {
 				m.StatsMarkValid()
 			}
 		}
-		m.SmallestSeqNum = m.Smallest.SeqNum()
-		m.LargestSeqNum = m.Largest.SeqNum()
+		m.SmallestSeqNum = m.Smallest().SeqNum()
+		m.LargestSeqNum = m.Largest().SeqNum()
 		m.LargestSeqNumAbsolute = m.LargestSeqNum
 		return m, nil
 	}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2014,8 +2014,8 @@ func TestCompactionErrorOnUserKeyOverlap(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		)
-		m.SmallestSeqNum = m.Smallest.SeqNum()
-		m.LargestSeqNum = m.Largest.SeqNum()
+		m.SmallestSeqNum = m.Smallest().SeqNum()
+		m.LargestSeqNum = m.Largest().SeqNum()
 		m.LargestSeqNumAbsolute = m.LargestSeqNum
 		m.InitPhysicalBacking()
 		return m
@@ -2146,8 +2146,8 @@ func TestCompactionCheckOrdering(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		)
-		m.SmallestSeqNum = m.Smallest.SeqNum()
-		m.LargestSeqNum = m.Largest.SeqNum()
+		m.SmallestSeqNum = m.Smallest().SeqNum()
+		m.LargestSeqNum = m.Largest().SeqNum()
 		m.LargestSeqNumAbsolute = m.LargestSeqNum
 		m.InitPhysicalBacking()
 		return m

--- a/data_test.go
+++ b/data_test.go
@@ -944,11 +944,11 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 		for _, f := range newVE.NewTables {
 			if start != nil {
 				f.Meta.SmallestPointKey = *start
-				f.Meta.Smallest = *start
+				f.Meta.ExtendPointKeyBounds(DefaultComparer.Compare, *start, *start)
 			}
 			if end != nil {
 				f.Meta.LargestPointKey = *end
-				f.Meta.Largest = *end
+				f.Meta.ExtendPointKeyBounds(DefaultComparer.Compare, *end, *end)
 			}
 			if blobDepth > 0 {
 				f.Meta.BlobReferenceDepth = blobDepth
@@ -999,8 +999,8 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 		}
 		c := &compaction{
 			inputs:   []compactionLevel{{}, {level: outputLevel}},
-			smallest: m.Smallest,
-			largest:  m.Largest,
+			smallest: m.Smallest(),
+			largest:  m.Largest(),
 		}
 		c.startLevel, c.outputLevel = &c.inputs[0], &c.inputs[1]
 		return c, nil

--- a/download.go
+++ b/download.go
@@ -252,8 +252,8 @@ func (d *DB) newDownloadSpanTask(vers *version, sp DownloadSpan) (_ *downloadSpa
 		iter := ls.Iter()
 		if f := iter.SeekGE(d.cmp, sp.StartKey); f != nil &&
 			objstorage.IsExternalTable(d.objProvider, f.FileBacking.DiskFileNum) &&
-			d.cmp(f.Smallest.UserKey, bounds.Start) < 0 {
-			bounds.Start = f.Smallest.UserKey
+			d.cmp(f.Smallest().UserKey, bounds.Start) < 0 {
+			bounds.Start = f.Smallest().UserKey
 		}
 	}
 	startCursor := downloadCursor{
@@ -313,7 +313,7 @@ func (c downloadCursor) String() string {
 func makeCursorAtFile(f *tableMetadata, level int) downloadCursor {
 	return downloadCursor{
 		level:  level,
-		key:    f.Smallest.UserKey,
+		key:    f.Smallest().UserKey,
 		seqNum: f.LargestSeqNum,
 	}
 }
@@ -323,7 +323,7 @@ func makeCursorAtFile(f *tableMetadata, level int) downloadCursor {
 func makeCursorAfterFile(f *tableMetadata, level int) downloadCursor {
 	return downloadCursor{
 		level:  level,
-		key:    f.Smallest.UserKey,
+		key:    f.Smallest().UserKey,
 		seqNum: f.LargestSeqNum + 1,
 	}
 }
@@ -380,7 +380,7 @@ func (c downloadCursor) NextExternalFileOnLevel(
 				firstCursor = c
 			}
 			// Trim the end bound as an optimization.
-			endBound = base.UserKeyInclusive(f.Smallest.UserKey)
+			endBound = base.UserKeyInclusive(f.Smallest().UserKey)
 		}
 	}
 	return first
@@ -402,7 +402,7 @@ func firstExternalFileInLevelIter(
 	for f != nil && !cursor.FileIsAfterCursor(cmp, f, cursor.level) {
 		f = it.Next()
 	}
-	for ; f != nil && endBound.IsUpperBoundFor(cmp, f.Smallest.UserKey); f = it.Next() {
+	for ; f != nil && endBound.IsUpperBoundFor(cmp, f.Smallest().UserKey); f = it.Next() {
 		if f.Virtual && objstorage.IsExternalTable(objProvider, f.FileBacking.DiskFileNum) {
 			return f
 		}
@@ -532,7 +532,7 @@ func (d *DB) tryLaunchDownloadCompaction(
 
 		download.bookmarks = append(download.bookmarks, downloadBookmark{
 			start:    makeCursorAtFile(f, level),
-			endBound: base.UserKeyInclusive(f.Largest.UserKey),
+			endBound: base.UserKeyInclusive(f.Largest().UserKey),
 		})
 		doneCh, ok := d.tryLaunchDownloadForFile(vers, l0Organizer, env, download, level, f)
 		if ok {

--- a/excise.go
+++ b/excise.go
@@ -87,7 +87,7 @@ func (d *DB) exciseTable(
 		return nil, nil, base.AssertionFailedf("excise span does not overlap table")
 	}
 	// Fast path: m sits entirely within the exciseSpan, so just delete it.
-	if exciseBounds.ContainsInternalKey(d.cmp, m.Smallest) && exciseBounds.ContainsInternalKey(d.cmp, m.Largest) {
+	if exciseBounds.ContainsInternalKey(d.cmp, m.Smallest()) && exciseBounds.ContainsInternalKey(d.cmp, m.Largest()) {
 		return nil, nil, nil
 	}
 
@@ -137,7 +137,7 @@ func (d *DB) exciseTable(
 	// files, then grab the lock again and recalculate for just the files that
 	// have changed since our previous calculation. Do this optimiaztino as part of
 	// https://github.com/cockroachdb/pebble/issues/2112 .
-	if d.cmp(m.Smallest.UserKey, exciseBounds.Start) < 0 {
+	if d.cmp(m.Smallest().UserKey, exciseBounds.Start) < 0 {
 		leftTable = &tableMetadata{
 			Virtual: true,
 			FileNum: d.mu.versions.getNextFileNum(),
@@ -168,7 +168,7 @@ func (d *DB) exciseTable(
 		}
 	}
 	// Create a file to the right, if necessary.
-	if !exciseBounds.End.IsUpperBoundForInternalKey(d.cmp, m.Largest) {
+	if !exciseBounds.End.IsUpperBoundForInternalKey(d.cmp, m.Largest()) {
 		// Create a new file, rightFile, between [firstKeyAfter(exciseSpan.End), m.Largest].
 		//
 		// See comment before the definition of leftFile for the motivation behind
@@ -419,7 +419,7 @@ func determineRightTableBounds(
 func determineExcisedTableSize(
 	fc *fileCacheHandle, originalTable, excisedTable *tableMetadata,
 ) error {
-	size, err := fc.estimateSize(originalTable, excisedTable.Smallest.UserKey, excisedTable.Largest.UserKey)
+	size, err := fc.estimateSize(originalTable, excisedTable.Smallest().UserKey, excisedTable.Largest().UserKey)
 	if err != nil {
 		return err
 	}

--- a/excise_test.go
+++ b/excise_test.go
@@ -300,7 +300,7 @@ func TestExcise(t *testing.T) {
 			exciseBounds := exciseSpan.UserKeyBounds()
 			for l, ls := range current.AllLevelsAndSublevels() {
 				iter := ls.Iter()
-				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
+				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest().UserKey, exciseSpan.End) < 0; m = iter.Next() {
 					leftTable, rightTable, err := d.exciseTable(context.Background(), exciseBounds, m, l.Level(), tightExciseBounds)
 					if err != nil {
 						td.Fatalf(t, "error when excising %s: %s", m.FileNum, err.Error())
@@ -682,7 +682,7 @@ func TestConcurrentExcise(t *testing.T) {
 			exciseBounds := exciseSpan.UserKeyBounds()
 			for level := range current.Levels {
 				iter := current.Levels[level].Iter()
-				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest.UserKey, exciseSpan.End) < 0; m = iter.Next() {
+				for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest().UserKey, exciseSpan.End) < 0; m = iter.Next() {
 					leftTable, rightTable, err := d.exciseTable(context.Background(), exciseBounds, m, level, tightExciseBounds)
 					if err != nil {
 						d.mu.Lock()
@@ -799,7 +799,7 @@ func TestExciseBounds(t *testing.T) {
 		var buf strings.Builder
 		printBounds := func(title string, m *tableMetadata) {
 			fmt.Fprintf(&buf, "%s:\n", title)
-			fmt.Fprintf(&buf, "  overall: %v - %v\n", m.Smallest, m.Largest)
+			fmt.Fprintf(&buf, "  overall: %v - %v\n", m.Smallest(), m.Largest())
 			if m.HasPointKeys {
 				fmt.Fprintf(&buf, "  point:   %v - %v\n", m.SmallestPointKey, m.LargestPointKey)
 			}
@@ -850,7 +850,7 @@ func TestExciseBounds(t *testing.T) {
 			}
 
 			exciseSpan := base.ParseUserKeyBounds(td.Input)
-			if cmp(m.Smallest.UserKey, exciseSpan.Start) < 0 {
+			if cmp(m.Smallest().UserKey, exciseSpan.Start) < 0 {
 				var t manifest.TableMetadata
 				checkErr(determineLeftTableBounds(cmp, m, &t, exciseSpan.Start, iters))
 				printBounds("Left table bounds", &t)
@@ -859,7 +859,7 @@ func TestExciseBounds(t *testing.T) {
 				printBounds("Left table bounds (loose)", &t)
 			}
 
-			if !exciseSpan.End.IsUpperBoundForInternalKey(cmp, m.Largest) {
+			if !exciseSpan.End.IsUpperBoundForInternalKey(cmp, m.Largest()) {
 				var t manifest.TableMetadata
 				err := func() (err error) {
 					// determineRightTableBounds can return assertion errors which we want

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -329,7 +329,6 @@ func TestVirtualReadsWiring(t *testing.T) {
 	d.mu.Lock()
 
 	// Virtualize the single sstable in the lsm.
-
 	currVersion := d.mu.versions.currentVersion()
 	l6 := currVersion.Levels[6]
 	l6FileIter := l6.Iter()
@@ -338,7 +337,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	f2 := f1 + 1
 	d.mu.versions.nextFileNum.Add(2)
 
-	seqNumA := parentFile.Smallest.SeqNum()
+	seqNumA := parentFile.Smallest().SeqNum()
 	// See SeqNum comments above.
 	seqNumCEDel := seqNumA + 2
 	seqNumRangeSet := seqNumA + 4
@@ -352,13 +351,12 @@ func TestVirtualReadsWiring(t *testing.T) {
 		SmallestSeqNum:        parentFile.SmallestSeqNum,
 		LargestSeqNum:         parentFile.LargestSeqNum,
 		LargestSeqNumAbsolute: parentFile.LargestSeqNumAbsolute,
-		Smallest:              base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet),
-		Largest:               base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet),
 		SmallestPointKey:      base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet),
 		LargestPointKey:       base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet),
 		HasPointKeys:          true,
 		Virtual:               true,
 	}
+	v1.ExtendPointKeyBounds(DefaultComparer.Compare, v1.SmallestPointKey, v1.LargestPointKey)
 	v1.AttachVirtualBacking(parentFile.FileBacking)
 	v1.Stats.NumEntries = 1
 
@@ -369,8 +367,6 @@ func TestVirtualReadsWiring(t *testing.T) {
 		SmallestSeqNum:        parentFile.SmallestSeqNum,
 		LargestSeqNum:         parentFile.LargestSeqNum,
 		LargestSeqNumAbsolute: parentFile.LargestSeqNumAbsolute,
-		Smallest:              base.MakeInternalKey([]byte{'d'}, seqNumCEDel, InternalKeyKindRangeDelete),
-		Largest:               base.MakeInternalKey([]byte{'z'}, seqNumZ, InternalKeyKindSet),
 		SmallestPointKey:      base.MakeInternalKey([]byte{'d'}, seqNumCEDel, InternalKeyKindRangeDelete),
 		LargestPointKey:       base.MakeInternalKey([]byte{'z'}, seqNumZ, InternalKeyKindSet),
 		SmallestRangeKey:      base.MakeInternalKey([]byte{'f'}, seqNumRangeSet, InternalKeyKindRangeKeySet),
@@ -378,14 +374,15 @@ func TestVirtualReadsWiring(t *testing.T) {
 		HasPointKeys:          true,
 		Virtual:               true,
 	}
+	v2.ExtendPointKeyBounds(DefaultComparer.Compare, v2.SmallestPointKey, v2.LargestPointKey)
 	v2.AttachVirtualBacking(parentFile.FileBacking)
 	v2.Stats.NumEntries = 6
 
-	v1.LargestPointKey = v1.Largest
-	v1.SmallestPointKey = v1.Smallest
+	v1.LargestPointKey = v1.Largest()
+	v1.SmallestPointKey = v1.Smallest()
 
-	v2.LargestPointKey = v2.Largest
-	v2.SmallestPointKey = v2.Smallest
+	v2.LargestPointKey = v2.Largest()
+	v2.SmallestPointKey = v2.Smallest()
 
 	v1.ValidateVirtual(parentFile)
 	d.checkVirtualBounds(v1)

--- a/ingest.go
+++ b/ingest.go
@@ -610,14 +610,14 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 	// Verify that all the shared files (i.e. files in sharedMeta)
 	// fit within the exciseSpan.
 	for _, f := range lr.shared {
-		if !exciseSpan.Contains(cmp, f.Smallest) || !exciseSpan.Contains(cmp, f.Largest) {
+		if !exciseSpan.Contains(cmp, f.Smallest()) || !exciseSpan.Contains(cmp, f.Largest()) {
 			return errors.Newf("pebble: shared file outside of excise span, span [%s-%s), file = %s", exciseSpan.Start, exciseSpan.End, f.String())
 		}
 	}
 
 	if lr.externalFilesHaveLevel {
 		for _, f := range lr.external {
-			if !exciseSpan.Contains(cmp, f.Smallest) || !exciseSpan.Contains(cmp, f.Largest) {
+			if !exciseSpan.Contains(cmp, f.Smallest()) || !exciseSpan.Contains(cmp, f.Largest()) {
 				return base.AssertionFailedf("pebble: external file outside of excise span, span [%s-%s), file = %s", exciseSpan.Start, exciseSpan.End, f.String())
 			}
 		}
@@ -632,10 +632,10 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 
 		// Sort according to the smallest key.
 		slices.SortFunc(lr.external, func(a, b ingestExternalMeta) int {
-			return cmp(a.Smallest.UserKey, b.Smallest.UserKey)
+			return cmp(a.Smallest().UserKey, b.Smallest().UserKey)
 		})
 		for i := 1; i < len(lr.external); i++ {
-			if sstableKeyCompare(cmp, lr.external[i-1].Largest, lr.external[i].Smallest) >= 0 {
+			if sstableKeyCompare(cmp, lr.external[i-1].Largest(), lr.external[i].Smallest()) >= 0 {
 				return errors.Newf("pebble: external sstables have overlapping ranges")
 			}
 		}
@@ -647,11 +647,11 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 
 	// Sort according to the smallest key.
 	slices.SortFunc(lr.local, func(a, b ingestLocalMeta) int {
-		return cmp(a.Smallest.UserKey, b.Smallest.UserKey)
+		return cmp(a.Smallest().UserKey, b.Smallest().UserKey)
 	})
 
 	for i := 1; i < len(lr.local); i++ {
-		if sstableKeyCompare(cmp, lr.local[i-1].Largest, lr.local[i].Smallest) >= 0 {
+		if sstableKeyCompare(cmp, lr.local[i-1].Largest(), lr.local[i].Smallest()) >= 0 {
 			return errors.Newf("pebble: local ingestion sstables have overlapping ranges")
 		}
 	}
@@ -672,10 +672,10 @@ func ingestSortAndVerify(cmp Compare, lr ingestLoadResult, exciseSpan KeyRange) 
 			}
 		}
 		slices.SortFunc(filesInLevel, func(a, b *tableMetadata) int {
-			return cmp(a.Smallest.UserKey, b.Smallest.UserKey)
+			return cmp(a.Smallest().UserKey, b.Smallest().UserKey)
 		})
 		for i := 1; i < len(filesInLevel); i++ {
-			if sstableKeyCompare(cmp, filesInLevel[i-1].Largest, filesInLevel[i].Smallest) >= 0 {
+			if sstableKeyCompare(cmp, filesInLevel[i-1].Largest(), filesInLevel[i].Smallest()) >= 0 {
 				return base.AssertionFailedf("pebble: external shared sstables have overlapping ranges")
 			}
 		}
@@ -883,7 +883,6 @@ func setSeqNumInMetadata(
 	if m.HasRangeKeys {
 		m.SmallestRangeKey = setSeqFn(m.SmallestRangeKey)
 	}
-	m.Smallest = setSeqFn(m.Smallest)
 	// Only update the seqnum for the largest key if that key is not an
 	// "exclusive sentinel" (i.e. a range deletion sentinel or a range key
 	// boundary), as doing so effectively drops the exclusive sentinel (by
@@ -893,9 +892,6 @@ func setSeqNumInMetadata(
 	// updated.
 	if m.HasPointKeys && !m.LargestPointKey.IsExclusiveSentinel() {
 		m.LargestPointKey = setSeqFn(m.LargestPointKey)
-	}
-	if !m.Largest.IsExclusiveSentinel() {
-		m.Largest = setSeqFn(m.Largest)
 	}
 	// Setting smallestSeqNum == largestSeqNum triggers the setting of
 	// Properties.GlobalSeqNum when an sstable is loaded.
@@ -1067,8 +1063,8 @@ func ingestTargetLevel(
 			if c.outputLevel == nil || level != c.outputLevel.level {
 				continue
 			}
-			if cmp(meta.Smallest.UserKey, c.largest.UserKey) <= 0 &&
-				cmp(meta.Largest.UserKey, c.smallest.UserKey) >= 0 {
+			if cmp(meta.Smallest().UserKey, c.largest.UserKey) <= 0 &&
+				cmp(meta.Largest().UserKey, c.smallest.UserKey) >= 0 {
 				overlaps = true
 				break
 			}
@@ -1887,7 +1883,7 @@ func (d *DB) ingestSplit(
 		// as we're guaranteed to not have any data overlap between splitFile and
 		// s.ingestFile. d.excise will return an error if we pass an inclusive user
 		// key bound _and_ we end up seeing data overlap at the end key.
-		exciseBounds := base.UserKeyBoundsFromInternal(s.ingestFile.Smallest, s.ingestFile.Largest)
+		exciseBounds := base.UserKeyBoundsFromInternal(s.ingestFile.Smallest(), s.ingestFile.Largest())
 		leftTable, rightTable, err := d.exciseTable(ctx, exciseBounds, splitFile, s.level, tightExciseBounds)
 		if err != nil {
 			return err
@@ -2014,7 +2010,7 @@ func (d *DB) ingestApply(
 				f.Level = specifiedLevel
 			} else {
 				var splitTable *tableMetadata
-				if exciseSpan.Valid() && exciseSpan.Contains(d.cmp, m.Smallest) && exciseSpan.Contains(d.cmp, m.Largest) {
+				if exciseSpan.Valid() && exciseSpan.Contains(d.cmp, m.Smallest()) && exciseSpan.Contains(d.cmp, m.Largest()) {
 					// This file fits perfectly within the excise span. We can slot it at
 					// L6, or sharedLevelsStart - 1 if we have shared files.
 					if len(lr.shared) > 0 || lr.externalFilesHaveLevel {

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -386,14 +386,14 @@ func (r *Runner) TableSplitLimit(startKey []byte) []byte {
 	var overlappedBytes uint64
 	f := iter.SeekGE(r.cmp, startKey)
 	// Handle an overlapping table.
-	if f != nil && r.cmp(f.Smallest.UserKey, startKey) <= 0 {
+	if f != nil && r.cmp(f.Smallest().UserKey, startKey) <= 0 {
 		overlappedBytes += f.Size
 		f = iter.Next()
 	}
 	for ; f != nil; f = iter.Next() {
 		overlappedBytes += f.Size
 		if overlappedBytes > r.cfg.MaxGrandparentOverlapBytes {
-			limitKey = f.Smallest.UserKey
+			limitKey = f.Smallest().UserKey
 			break
 		}
 	}

--- a/internal/compact/splitting.go
+++ b/internal/compact/splitting.go
@@ -151,7 +151,7 @@ func NewOutputSplitter(
 	}
 	// Find the first grandparent that starts at or after startKey.
 	grandparent := s.grandparentLevel.SeekGE(cmp, startKey)
-	if grandparent != nil && cmp(grandparent.Smallest.UserKey, startKey) <= 0 {
+	if grandparent != nil && cmp(grandparent.Smallest().UserKey, startKey) <= 0 {
 		grandparent = s.grandparentLevel.Next()
 	}
 	s.setNextBoundary(grandparent)
@@ -180,9 +180,9 @@ func (s *OutputSplitter) boundaryReached(key []byte) (nextBoundary []byte) {
 }
 
 func (s *OutputSplitter) setNextBoundary(nextGrandparent *manifest.TableMetadata) {
-	if nextGrandparent != nil && (s.limit == nil || s.cmp(nextGrandparent.Smallest.UserKey, s.limit) < 0) {
+	if nextGrandparent != nil && (s.limit == nil || s.cmp(nextGrandparent.Smallest().UserKey, s.limit) < 0) {
 		s.nextBoundary = splitterBoundary{
-			key:           nextGrandparent.Smallest.UserKey,
+			key:           nextGrandparent.Smallest().UserKey,
 			isGrandparent: true,
 		}
 	} else {

--- a/internal/manifest/annotator.go
+++ b/internal/manifest/annotator.go
@@ -176,14 +176,14 @@ func (a *Annotator[T]) accumulateRangeAnnotation(
 	if !fullyWithinLowerBound {
 		// leftItem is the index of the first item that overlaps the lower bound.
 		leftItem = sort.Search(int(n.count), func(i int) bool {
-			return cmp(bounds.Start, n.items[i].Largest.UserKey) <= 0
+			return cmp(bounds.Start, n.items[i].Largest().UserKey) <= 0
 		})
 	}
 	if !fullyWithinUpperBound {
 		// rightItem is the index of the first item that does not overlap the
 		// upper bound.
 		rightItem = sort.Search(int(n.count), func(i int) bool {
-			return !bounds.End.IsUpperBoundFor(cmp, n.items[i].Smallest.UserKey)
+			return !bounds.End.IsUpperBoundFor(cmp, n.items[i].Smallest().UserKey)
 		})
 	}
 
@@ -208,12 +208,12 @@ func (a *Annotator[T]) accumulateRangeAnnotation(
 		leftChild, rightChild := leftItem, rightItem
 		// If the lower bound overlaps with the child at leftItem, there is no
 		// need to accumulate annotations from the child to its left.
-		if leftItem < int(n.count) && cmp(bounds.Start, n.items[leftItem].Smallest.UserKey) >= 0 {
+		if leftItem < int(n.count) && cmp(bounds.Start, n.items[leftItem].Smallest().UserKey) >= 0 {
 			leftChild++
 		}
 		// If the upper bound spans beyond the child at rightItem, we must also
 		// accumulate annotations from the child to its right.
-		if rightItem < int(n.count) && bounds.End.IsUpperBoundFor(cmp, n.items[rightItem].Largest.UserKey) {
+		if rightItem < int(n.count) && bounds.End.IsUpperBoundFor(cmp, n.items[rightItem].Largest().UserKey) {
 			rightChild++
 		}
 
@@ -312,13 +312,13 @@ func (a *Annotator[T]) VersionRangeAnnotation(v *Version, bounds base.UserKeyBou
 	return dst
 }
 
-// InvalidateAnnotation clears any cached annotations defined by Annotator. A
-// pointer to the Annotator is used as the key for pre-calculated values, so
+// InvalidateLevelAnnotation clears any cached annotations defined by Annotator.
+// A pointer to the Annotator is used as the key for pre-calculated values, so
 // the same Annotator must be used to clear the appropriate cached annotation.
 // Calls to InvalidateLevelAnnotation are *not* concurrent-safe with any other
-// calls to Annotator methods for the same Annotator (concurrent calls from other
-// annotators are fine). Any calls to this function must have some externally-guaranteed
-// mutual exclusion.
+// calls to Annotator methods for the same Annotator (concurrent calls from
+// other annotators are fine). Any calls to this function must have some
+// externally-guaranteed mutual exclusion.
 func (a *Annotator[T]) InvalidateLevelAnnotation(lm LevelMetadata) {
 	if lm.Empty() {
 		return

--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -59,7 +59,7 @@ func TestPickFileAggregator(t *testing.T) {
 				return true, true
 			},
 			Compare: func(f1 *TableMetadata, f2 *TableMetadata) bool {
-				return base.DefaultComparer.Compare(f1.Smallest.UserKey, f2.Smallest.UserKey) < 0
+				return base.DefaultComparer.Compare(f1.Smallest().UserKey, f2.Smallest().UserKey) < 0
 			},
 		},
 	}

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -29,7 +29,7 @@ func newItem(k InternalKey) *TableMetadata {
 }
 
 func cmp(a, b *TableMetadata) int {
-	return cmpKey(a.Smallest, b.Smallest)
+	return cmpKey(a.Smallest(), b.Smallest())
 }
 
 func cmpKey(a, b InternalKey) int {
@@ -166,8 +166,8 @@ func checkIterRelative(t *testing.T, it *iterator, start, end int, keyMemo map[i
 	for ; it.valid(); it.next() {
 		item := it.cur()
 		expected := keyWithMemo(i, keyMemo)
-		if cmpKey(expected, item.Smallest) != 0 {
-			t.Fatalf("expected %s, but found %s", expected, item.Smallest)
+		if cmpKey(expected, item.Smallest()) != 0 {
+			t.Fatalf("expected %s, but found %s", expected, item.Smallest())
 		}
 		i++
 	}
@@ -182,8 +182,8 @@ func checkIter(t *testing.T, it iterator, start, end int, keyMemo map[int]Intern
 	for it.first(); it.valid(); it.next() {
 		item := it.cur()
 		expected := keyWithMemo(i, keyMemo)
-		if cmpKey(expected, item.Smallest) != 0 {
-			t.Fatalf("expected %s, but found %s", expected, item.Smallest)
+		if cmpKey(expected, item.Smallest()) != 0 {
+			t.Fatalf("expected %s, but found %s", expected, item.Smallest())
 		}
 		require.Equal(t, i-start, it.countLeft())
 		i++
@@ -196,8 +196,8 @@ func checkIter(t *testing.T, it iterator, start, end int, keyMemo map[int]Intern
 		i--
 		item := it.cur()
 		expected := keyWithMemo(i, keyMemo)
-		if cmpKey(expected, item.Smallest) != 0 {
-			t.Fatalf("expected %s, but found %s", expected, item.Smallest)
+		if cmpKey(expected, item.Smallest()) != 0 {
+			t.Fatalf("expected %s, but found %s", expected, item.Smallest())
 		}
 		require.Equal(t, i-start, it.countLeft())
 	}
@@ -379,8 +379,8 @@ func TestBTreeSeek(t *testing.T) {
 			t.Fatalf("%d: expected valid iterator", i)
 		}
 		expected := key(2 * ((i + 1) / 2))
-		if cmpKey(expected, item.Smallest) != 0 {
-			t.Fatalf("%d: expected %s, but found %s", i, expected, item.Smallest)
+		if cmpKey(expected, item.Smallest()) != 0 {
+			t.Fatalf("%d: expected %s, but found %s", i, expected, item.Smallest())
 		}
 	}
 	it.SeekGE(base.DefaultComparer.Compare, key(2*count-1).UserKey)
@@ -394,8 +394,8 @@ func TestBTreeSeek(t *testing.T) {
 			t.Fatalf("%d: expected valid iterator", i)
 		}
 		expected := key(2 * ((i - 1) / 2))
-		if cmpKey(expected, item.Smallest) != 0 {
-			t.Fatalf("%d: expected %s, but found %s", i, expected, item.Smallest)
+		if cmpKey(expected, item.Smallest()) != 0 {
+			t.Fatalf("%d: expected %s, but found %s", i, expected, item.Smallest())
 		}
 	}
 	it.SeekLT(base.DefaultComparer.Compare, key(0).UserKey)
@@ -844,8 +844,8 @@ func BenchmarkBTreeIterSeekGE(b *testing.B) {
 				if f == nil {
 					b.Fatal("expected to find key")
 				}
-				if cmpKey(k, f.Smallest) != 0 {
-					b.Fatalf("expected %s, but found %s", k, f.Smallest)
+				if cmpKey(k, f.Smallest()) != 0 {
+					b.Fatalf("expected %s, but found %s", k, f.Smallest())
 				}
 			}
 		}
@@ -885,8 +885,8 @@ func BenchmarkBTreeIterSeekLT(b *testing.B) {
 						b.Fatal("expected to find key")
 					}
 					k := keys[j-1]
-					if cmpKey(k, f.Smallest) != 0 {
-						b.Fatalf("expected %s, but found %s", k, f.Smallest)
+					if cmpKey(k, f.Smallest()) != 0 {
+						b.Fatalf("expected %s, but found %s", k, f.Smallest())
 					}
 				}
 			}

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -284,14 +284,14 @@ func newL0Sublevels(
 	for i, f := 0, iter.First(); f != nil; i, f = i+1, iter.Next() {
 		f.L0Index = i
 		keys = append(keys, intervalKeyTemp{
-			intervalKey: intervalKey{key: f.Smallest.UserKey},
+			intervalKey: intervalKey{key: f.Smallest().UserKey},
 			fileMeta:    f,
 			isEndKey:    false,
 		})
 		keys = append(keys, intervalKeyTemp{
 			intervalKey: intervalKey{
-				key:                 f.Largest.UserKey,
-				isInclusiveEndBound: !f.Largest.IsExclusiveSentinel(),
+				key:                 f.Largest().UserKey,
+				isInclusiveEndBound: !f.Largest().IsExclusiveSentinel(),
 			},
 			fileMeta: f,
 			isEndKey: true,
@@ -484,13 +484,13 @@ func (s *l0Sublevels) addL0Files(
 	fileKeys := make([]intervalKeyTemp, 0, 2*len(files))
 	for _, f := range files {
 		left := intervalKeyTemp{
-			intervalKey: intervalKey{key: f.Smallest.UserKey},
+			intervalKey: intervalKey{key: f.Smallest().UserKey},
 			fileMeta:    f,
 		}
 		right := intervalKeyTemp{
 			intervalKey: intervalKey{
-				key:                 f.Largest.UserKey,
-				isInclusiveEndBound: !f.Largest.IsExclusiveSentinel(),
+				key:                 f.Largest().UserKey,
+				isInclusiveEndBound: !f.Largest().IsExclusiveSentinel(),
 			},
 			fileMeta: f,
 			isEndKey: true,
@@ -728,23 +728,24 @@ func (s *l0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 
 	for f := range s.levelMetadata.All() {
 		if invariants.Enabled {
-			if !bytes.Equal(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest.UserKey) {
+			if !bytes.Equal(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest().UserKey) {
 				panic(fmt.Sprintf("f.minIntervalIndex in TableMetadata out of sync with intervals in L0Sublevels: %s != %s",
-					s.formatKey(s.orderedIntervals[f.minIntervalIndex].startKey.key), s.formatKey(f.Smallest.UserKey)))
+					s.formatKey(s.orderedIntervals[f.minIntervalIndex].startKey.key), s.formatKey(f.Smallest().UserKey)))
 			}
-			if !bytes.Equal(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest.UserKey) {
+			if !bytes.Equal(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest().UserKey) {
 				panic(fmt.Sprintf("f.maxIntervalIndex in TableMetadata out of sync with intervals in L0Sublevels: %s != %s",
-					s.formatKey(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key), s.formatKey(f.Smallest.UserKey)))
+					s.formatKey(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key), s.formatKey(f.Smallest().UserKey)))
 			}
 		}
 		if !f.IsCompacting() {
 			continue
 		}
 		if invariants.Enabled {
-			if s.cmp(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest.UserKey) != 0 || s.cmp(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest.UserKey) != 0 {
+			if s.cmp(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest().UserKey) != 0 ||
+				s.cmp(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest().UserKey) != 0 {
 				panic(fmt.Sprintf("file %s has inconsistent L0 Sublevel interval bounds: %s-%s, %s-%s", f.FileNum,
 					s.orderedIntervals[f.minIntervalIndex].startKey.key, s.orderedIntervals[f.maxIntervalIndex+1].startKey.key,
-					f.Smallest.UserKey, f.Largest.UserKey))
+					f.Smallest().UserKey, f.Largest().UserKey))
 			}
 		}
 		for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {
@@ -1485,7 +1486,7 @@ func (s *l0Sublevels) PickBaseCompaction(
 
 			var baseCompacting bool
 			for ; m != nil && !baseCompacting; m = baseIter.Next() {
-				cmp := s.cmp(m.Smallest.UserKey, s.orderedIntervals[c.maxIntervalIndex+1].startKey.key)
+				cmp := s.cmp(m.Smallest().UserKey, s.orderedIntervals[c.maxIntervalIndex+1].startKey.key)
 				// Compaction is ending at exclusive bound of c.maxIntervalIndex+1
 				if cmp > 0 || (cmp == 0 && !s.orderedIntervals[c.maxIntervalIndex+1].startKey.isInclusiveEndBound) {
 					break

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -77,11 +77,11 @@ func visualizeSublevels(
 			buf.WriteByte(' ')
 		}
 		for j, f := range files {
-			for lastChar < f.Smallest.UserKey[0] {
+			for lastChar < f.Smallest().UserKey[0] {
 				buf.WriteString("   ")
 				lastChar++
 			}
-			buf.WriteByte(f.Smallest.UserKey[0])
+			buf.WriteByte(f.Smallest().UserKey[0])
 			middleChar := byte('-')
 			if isL0 {
 				if compactionFiles[f.L0Index] {
@@ -96,11 +96,11 @@ func visualizeSublevels(
 			} else if f.IsCompacting() {
 				middleChar = '='
 			}
-			if largestChar < f.Largest.UserKey[0] {
-				largestChar = f.Largest.UserKey[0]
+			if largestChar < f.Largest().UserKey[0] {
+				largestChar = f.Largest().UserKey[0]
 			}
-			if f.Smallest.UserKey[0] == f.Largest.UserKey[0] {
-				buf.WriteByte(f.Largest.UserKey[0])
+			if f.Smallest().UserKey[0] == f.Largest().UserKey[0] {
+				buf.WriteByte(f.Largest().UserKey[0])
 				if compactionFiles[f.L0Index] {
 					buf.WriteByte('+')
 				} else if j < len(files)-1 {
@@ -112,14 +112,14 @@ func visualizeSublevels(
 			buf.WriteByte(middleChar)
 			buf.WriteByte(middleChar)
 			lastChar++
-			for lastChar < f.Largest.UserKey[0] {
+			for lastChar < f.Largest().UserKey[0] {
 				buf.WriteByte(middleChar)
 				buf.WriteByte(middleChar)
 				buf.WriteByte(middleChar)
 				lastChar++
 			}
-			if f.Largest.IsExclusiveSentinel() &&
-				j < len(files)-1 && files[j+1].Smallest.UserKey[0] == f.Largest.UserKey[0] {
+			if f.Largest().IsExclusiveSentinel() &&
+				j < len(files)-1 && files[j+1].Smallest().UserKey[0] == f.Largest().UserKey[0] {
 				// This case happens where two successive files have
 				// matching end/start user keys but where the left-side file
 				// has the sentinel key as its end key trailer. In this case
@@ -130,7 +130,7 @@ func visualizeSublevels(
 				continue
 			}
 			buf.WriteByte(middleChar)
-			buf.WriteByte(f.Largest.UserKey[0])
+			buf.WriteByte(f.Largest().UserKey[0])
 			if j < len(files)-1 {
 				buf.WriteByte(' ')
 			}
@@ -176,9 +176,9 @@ func TestL0Sublevels(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(keyRange[0])),
 			base.ParseInternalKey(strings.TrimSpace(keyRange[1])),
 		)
-		m.SmallestSeqNum = m.Smallest.SeqNum()
-		m.LargestSeqNum = m.Largest.SeqNum()
-		if m.Largest.IsExclusiveSentinel() {
+		m.SmallestSeqNum = m.Smallest().SeqNum()
+		m.LargestSeqNum = m.Largest().SeqNum()
+		if m.Largest().IsExclusiveSentinel() {
 			m.LargestSeqNum = m.SmallestSeqNum
 		}
 		m.LargestSeqNumAbsolute = m.LargestSeqNum
@@ -368,18 +368,18 @@ func TestL0Sublevels(t *testing.T) {
 					// the compactor is expected to implement.
 					baseFiles := fileMetas[baseLevel]
 					firstFile := sort.Search(len(baseFiles), func(i int) bool {
-						return sublevels.cmp(baseFiles[i].Largest.UserKey, sublevels.orderedIntervals[lcf.minIntervalIndex].startKey.key) >= 0
+						return sublevels.cmp(baseFiles[i].Largest().UserKey, sublevels.orderedIntervals[lcf.minIntervalIndex].startKey.key) >= 0
 					})
 					lastFile := sort.Search(len(baseFiles), func(i int) bool {
-						return sublevels.cmp(baseFiles[i].Smallest.UserKey, sublevels.orderedIntervals[lcf.maxIntervalIndex+1].startKey.key) >= 0
+						return sublevels.cmp(baseFiles[i].Smallest().UserKey, sublevels.orderedIntervals[lcf.maxIntervalIndex+1].startKey.key) >= 0
 					})
 					startKey := base.InvalidInternalKey
 					endKey := base.InvalidInternalKey
 					if firstFile > 0 {
-						startKey = baseFiles[firstFile-1].Largest
+						startKey = baseFiles[firstFile-1].Largest()
 					}
 					if lastFile < len(baseFiles) {
-						endKey = baseFiles[lastFile].Smallest
+						endKey = baseFiles[lastFile].Smallest()
 					}
 					sublevels.ExtendL0ForBaseCompactionTo(
 						startKey,

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -388,7 +388,7 @@ func (ls LevelSlice) Overlaps(cmp Compare, bounds base.UserKeyBounds) LevelSlice
 	endIterFile := endIter.SeekGE(cmp, bounds.End.Key)
 	// The first file that ends at/after bounds.End.Key might or might not overlap
 	// the bounds; we need to check the start key.
-	if endIterFile == nil || !bounds.End.IsUpperBoundFor(cmp, endIterFile.Smallest.UserKey) {
+	if endIterFile == nil || !bounds.End.IsUpperBoundFor(cmp, endIterFile.Smallest().UserKey) {
 		endIter.Prev()
 	}
 	return newBoundedLevelSlice(startIter.iter.clone(), &startIter.iter, &endIter.iter)
@@ -573,7 +573,7 @@ func (i *LevelIterator) SeekGE(cmp Compare, userKey []byte) *TableMetadata {
 	}
 	i.assertNotL0Cmp()
 	m := i.seek(func(m *TableMetadata) bool {
-		return m.Largest.IsUpperBoundFor(cmp, userKey)
+		return m.Largest().IsUpperBoundFor(cmp, userKey)
 	})
 	if i.filter != KeyTypePointAndRange && m != nil {
 		b, ok := m.LargestBound(i.filter)
@@ -599,7 +599,7 @@ func (i *LevelIterator) SeekLT(cmp Compare, userKey []byte) *TableMetadata {
 	}
 	i.assertNotL0Cmp()
 	i.seek(func(m *TableMetadata) bool {
-		return cmp(m.Smallest.UserKey, userKey) >= 0
+		return cmp(m.Smallest().UserKey, userKey) >= 0
 	})
 	m := i.Prev()
 	// Although i.Prev() guarantees that the current file contains keys of the

--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -45,8 +45,8 @@ func TestLevelIterator(t *testing.T) {
 							base.ParseInternalKey(strings.TrimSpace(parts[0])),
 							base.ParseInternalKey(strings.TrimSpace(parts[1])),
 						)
-						m.SmallestSeqNum = m.Smallest.SeqNum()
-						m.LargestSeqNum = m.Largest.SeqNum()
+						m.SmallestSeqNum = m.Smallest().SeqNum()
+						m.LargestSeqNum = m.Largest().SeqNum()
 						m.LargestSeqNumAbsolute = m.LargestSeqNum
 						m.InitPhysicalBacking()
 						files = append(files, m)

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -471,7 +471,6 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				m.SmallestPointKey = base.DecodeInternalKey(smallestPointKey)
 				m.LargestPointKey = base.DecodeInternalKey(largestPointKey)
 				m.HasPointKeys = true
-				m.Smallest, m.Largest = m.SmallestPointKey, m.LargestPointKey
 				m.boundTypeSmallest, m.boundTypeLargest = boundTypePointKey, boundTypePointKey
 			} else { // range keys present
 				// Set point key bounds, if parsed.
@@ -485,14 +484,11 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				m.LargestRangeKey = base.DecodeInternalKey(largestRangeKey)
 				m.HasRangeKeys = true
 				// Set overall bounds (by default assume range keys).
-				m.Smallest, m.Largest = m.SmallestRangeKey, m.LargestRangeKey
 				m.boundTypeSmallest, m.boundTypeLargest = boundTypeRangeKey, boundTypeRangeKey
 				if boundsMarker&maskSmallest == maskSmallest {
-					m.Smallest = m.SmallestPointKey
 					m.boundTypeSmallest = boundTypePointKey
 				}
 				if boundsMarker&maskLargest == maskLargest {
-					m.Largest = m.LargestPointKey
 					m.boundTypeLargest = boundTypePointKey
 				}
 			}
@@ -1246,11 +1242,11 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 			}
 			// Track the keys with the smallest and largest keys, so that we can
 			// check consistency of the modified span.
-			if sm == nil || base.InternalCompare(comparer.Compare, sm.Smallest, f.Smallest) > 0 {
+			if sm == nil || base.InternalCompare(comparer.Compare, sm.Smallest(), f.Smallest()) > 0 {
 
 				sm = f
 			}
-			if la == nil || base.InternalCompare(comparer.Compare, la.Largest, f.Largest) < 0 {
+			if la == nil || base.InternalCompare(comparer.Compare, la.Largest(), f.Largest()) < 0 {
 				la = f
 			}
 		}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -301,8 +303,8 @@ func TestCheckOrdering(t *testing.T) {
 				// L0 files compare on sequence numbers. Use the seqnums from the
 				// smallest / largest bounds for the table.
 				for m := range v.Levels[0].All() {
-					m.SmallestSeqNum = m.Smallest.SeqNum()
-					m.LargestSeqNum = m.Largest.SeqNum()
+					m.SmallestSeqNum = m.Smallest().SeqNum()
+					m.LargestSeqNum = m.Largest().SeqNum()
 					m.LargestSeqNumAbsolute = m.LargestSeqNum
 				}
 				if err = v.CheckOrdering(); err != nil {
@@ -708,8 +710,8 @@ func TestCalculateInuseKeyRangesRandomized(t *testing.T) {
 				makeIK(level, start),
 				makeIK(level, end),
 			)
-			m.SmallestSeqNum = m.Smallest.SeqNum()
-			m.LargestSeqNum = m.Largest.SeqNum()
+			m.SmallestSeqNum = m.Smallest().SeqNum()
+			m.LargestSeqNum = m.Largest().SeqNum()
 			m.LargestSeqNumAbsolute = m.LargestSeqNum
 			m.InitPhysicalBacking()
 			return m
@@ -729,7 +731,7 @@ func TestCalculateInuseKeyRangesRandomized(t *testing.T) {
 				// within this level.
 				var o bool
 				for _, f := range files[l] {
-					o = o || overlaps(sKey, eKey, f.Smallest.UserKey, f.Largest.UserKey)
+					o = o || overlaps(sKey, eKey, f.Smallest().UserKey, f.Largest().UserKey)
 				}
 				if o {
 					continue
@@ -737,7 +739,7 @@ func TestCalculateInuseKeyRangesRandomized(t *testing.T) {
 				files[l] = append(files[l], makeFile(l, s, e))
 			}
 			slices.SortFunc(files[l], func(a, b *TableMetadata) int {
-				return cmp(a.Smallest.UserKey, b.Smallest.UserKey)
+				return cmp(a.Smallest().UserKey, b.Smallest().UserKey)
 			})
 		}
 		l0Organizer := NewL0Organizer(base.DefaultComparer, 64*1024 /* flushSplitBytes */)
@@ -756,14 +758,14 @@ func TestCalculateInuseKeyRangesRandomized(t *testing.T) {
 
 			for level := l; level < NumLevels; level++ {
 				for _, f := range files[level] {
-					if !overlaps(sKey, eKey, f.Smallest.UserKey, f.Largest.UserKey) {
+					if !overlaps(sKey, eKey, f.Smallest().UserKey, f.Largest().UserKey) {
 						// This file doesn't overlap the queried range. Skip it.
 						continue
 					}
 					// This file does overlap the queried range. The key range
 					// [MAX(f.Smallest, sKey), MIN(f.Largest, eKey)] must be fully
 					// contained by a key range in keyRanges.
-					checkStart, checkEnd := f.Smallest.UserKey, f.Largest.UserKey
+					checkStart, checkEnd := f.Smallest().UserKey, f.Largest().UserKey
 					if cmp(checkStart, sKey) < 0 {
 						checkStart = sKey
 					}
@@ -832,4 +834,21 @@ func TestIterAllocs(t *testing.T) {
 			t.Fatalf("allocs=%f", allocs)
 		}
 	})
+}
+
+// TestTableMetadataSize tests the expected size of our TableMetadata struct.
+// This test exists as a callout for whoever changes the TableMetadata struct to
+// be mindful of its size increasing -- as the cost of TableMetadata is
+// proportional to the amount of files that exist.
+func TestTableMetadataSize(t *testing.T) {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		t.Skip("Test only supported on amd64 and arm64 architectures")
+	}
+	structSize := unsafe.Sizeof(TableMetadata{})
+
+	const tableMetadataSize = 448 // bytes
+	if structSize != tableMetadataSize {
+		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
+			structSize, tableMetadataSize)
+	}
 }

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -253,7 +253,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 			for i, l := range levels {
 				fmt.Fprintf(&buf, "Level %d\n", i+1)
 				for j, f := range l {
-					fmt.Fprintf(&buf, "  file %d: [%s-%s]\n", j, f.Smallest.String(), f.Largest.String())
+					fmt.Fprintf(&buf, "  file %d: [%s-%s]\n", j, f.Smallest().String(), f.Largest().String())
 				}
 			}
 			return buf.String()

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -317,7 +317,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 
 	var buf bytes.Buffer
 	for _, f := range lt.metas {
-		fmt.Fprintf(&buf, "%d: %s-%s\n", f.FileNum, f.Smallest, f.Largest)
+		fmt.Fprintf(&buf, "%d: %s-%s\n", f.FileNum, f.Smallest(), f.Largest())
 	}
 	return buf.String()
 }

--- a/lsm_view.go
+++ b/lsm_view.go
@@ -98,8 +98,8 @@ func (b *lsmViewBuilder) PopulateKeys() {
 	keys := make(map[string]int)
 	for _, l := range b.levels {
 		for _, f := range l {
-			keys[string(f.Smallest.UserKey)] = -1
-			keys[string(f.Largest.UserKey)] = -1
+			keys[string(f.Smallest().UserKey)] = -1
+			keys[string(f.Largest().UserKey)] = -1
 		}
 	}
 
@@ -149,8 +149,8 @@ func (b *lsmViewBuilder) Build(
 			}
 
 			t.Size = f.Size
-			t.SmallestKey = b.keys[string(f.Smallest.UserKey)]
-			t.LargestKey = b.keys[string(f.Largest.UserKey)]
+			t.SmallestKey = b.keys[string(f.Smallest().UserKey)]
+			t.LargestKey = b.keys[string(f.Largest().UserKey)]
 			t.Details = b.tableDetails(f, objProvider, newIters)
 		}
 	}
@@ -165,7 +165,7 @@ func (b *lsmViewBuilder) tableDetails(
 		res = append(res, fmt.Sprintf(format, args...))
 	}
 
-	outf("%s: %s - %s", m.FileNum, m.Smallest.Pretty(b.fmtKey), m.Largest.Pretty(b.fmtKey))
+	outf("%s: %s - %s", m.FileNum, m.Smallest().Pretty(b.fmtKey), m.Largest().Pretty(b.fmtKey))
 	outf("size: %s", humanize.Bytes.Uint64(m.Size))
 	if m.Virtual {
 		meta, err := objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)

--- a/table_stats.go
+++ b/table_stats.go
@@ -601,9 +601,9 @@ func (d *DB) estimateReclaimedSizeBeneath(
 			default:
 				panic(fmt.Sprintf("pebble: unknown hint type %s", hintType))
 			}
-			startCmp := d.cmp(start, file.Smallest.UserKey)
-			endCmp := d.cmp(file.Largest.UserKey, end)
-			if startCmp <= 0 && (endCmp < 0 || endCmp == 0 && file.Largest.IsExclusiveSentinel()) {
+			startCmp := d.cmp(start, file.Smallest().UserKey)
+			endCmp := d.cmp(file.Largest().UserKey, end)
+			if startCmp <= 0 && (endCmp < 0 || endCmp == 0 && file.Largest().IsExclusiveSentinel()) {
 				// The range fully contains the file, so skip looking it up in table
 				// cache/looking at its indexes and add the full file size.
 				if updateEstimates {
@@ -612,7 +612,7 @@ func (d *DB) estimateReclaimedSizeBeneath(
 				if updateHints && hintSeqNum > file.SmallestSeqNum {
 					hintSeqNum = file.SmallestSeqNum
 				}
-			} else if d.cmp(file.Smallest.UserKey, end) <= 0 && d.cmp(start, file.Largest.UserKey) <= 0 {
+			} else if d.cmp(file.Smallest().UserKey, end) <= 0 && d.cmp(start, file.Largest().UserKey) <= 0 {
 				// Partial overlap.
 				if hintType == deleteCompactionHintTypeRangeKeyOnly {
 					// If the hint that generated this overlap contains only range keys,

--- a/tool/find.go
+++ b/tool/find.go
@@ -151,7 +151,9 @@ func (f *findT) run(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(stdout, "%s", r.filename)
 			if m := f.tableMeta[r.fileNum]; m != nil {
 				fmt.Fprintf(stdout, " ")
-				formatKeyRange(stdout, f.fmtKey, &m.Smallest, &m.Largest)
+				smallest := m.Smallest()
+				largest := m.Largest()
+				formatKeyRange(stdout, f.fmtKey, &smallest, &largest)
 			}
 			fmt.Fprintf(stdout, "\n")
 			if p := f.tableProvenance(r.fileNum); p != "" {

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -245,8 +245,8 @@ func (l *lsmT) buildKeys(edits []*manifest.VersionEdit) {
 	for _, ve := range edits {
 		for i := range ve.NewTables {
 			nf := &ve.NewTables[i]
-			keys = append(keys, nf.Meta.Smallest)
-			keys = append(keys, nf.Meta.Largest)
+			keys = append(keys, nf.Meta.Smallest())
+			keys = append(keys, nf.Meta.Largest())
 		}
 	}
 
@@ -301,8 +301,8 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 			if _, ok := l.state.Files[nf.Meta.FileNum]; !ok {
 				l.state.Files[nf.Meta.FileNum] = lsmTableMetadata{
 					Size:           nf.Meta.Size,
-					Smallest:       l.findKey(nf.Meta.Smallest),
-					Largest:        l.findKey(nf.Meta.Largest),
+					Smallest:       l.findKey(nf.Meta.Smallest()),
+					Largest:        l.findKey(nf.Meta.Largest()),
 					SmallestSeqNum: nf.Meta.SmallestSeqNum,
 					LargestSeqNum:  nf.Meta.LargestSeqNum,
 					Virtual:        nf.Meta.Virtual,

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -113,7 +113,9 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 					}
 					fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 					formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
-					formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
+					smallest := f.Smallest()
+					largest := f.Largest()
+					formatKeyRange(stdout, m.fmtKey, &smallest, &largest)
 					if f.Virtual {
 						fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
 					}
@@ -129,7 +131,9 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 			}
 			fmt.Fprintf(stdout, "  %s:%d", f.FileNum, f.Size)
 			formatSeqNumRange(stdout, f.SmallestSeqNum, f.LargestSeqNum)
-			formatKeyRange(stdout, m.fmtKey, &f.Smallest, &f.Largest)
+			smallest := f.Smallest()
+			largest := f.Largest()
+			formatKeyRange(stdout, m.fmtKey, &smallest, &largest)
 			if f.Virtual {
 				fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
 			}
@@ -236,7 +240,9 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 					fmt.Fprintf(stdout, "  added:         L%d %s:%d",
 						nf.Level, nf.Meta.FileNum, nf.Meta.Size)
 					formatSeqNumRange(stdout, nf.Meta.SmallestSeqNum, nf.Meta.LargestSeqNum)
-					formatKeyRange(stdout, m.fmtKey, &nf.Meta.Smallest, &nf.Meta.Largest)
+					smallest := nf.Meta.Smallest()
+					largest := nf.Meta.Largest()
+					formatKeyRange(stdout, m.fmtKey, &smallest, &largest)
 					if nf.Meta.CreationTime != 0 {
 						fmt.Fprintf(stdout, " (%s)",
 							time.Unix(nf.Meta.CreationTime, 0).UTC().Format(time.RFC3339))
@@ -289,13 +295,13 @@ func anyOverlapFile(cmp base.Compare, f *manifest.TableMetadata, start, end key)
 		return true
 	}
 	if start != nil {
-		if v := cmp(f.Largest.UserKey, start); v < 0 {
+		if v := cmp(f.Largest().UserKey, start); v < 0 {
 			return false
-		} else if f.Largest.IsExclusiveSentinel() && v == 0 {
+		} else if f.Largest().IsExclusiveSentinel() && v == 0 {
 			return false
 		}
 	}
-	if end != nil && cmp(f.Smallest.UserKey, end) >= 0 {
+	if end != nil && cmp(f.Smallest().UserKey, end) >= 0 {
 		return false
 	}
 	return true
@@ -655,7 +661,9 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 						fmt.Fprintf(stdout, "  added: L%d %s:%d",
 							nf.Level, nf.Meta.FileNum, nf.Meta.Size)
 						formatSeqNumRange(stdout, nf.Meta.SmallestSeqNum, nf.Meta.LargestSeqNum)
-						formatKeyRange(stdout, m.fmtKey, &nf.Meta.Smallest, &nf.Meta.Largest)
+						smallest := nf.Meta.Smallest()
+						largest := nf.Meta.Largest()
+						formatKeyRange(stdout, m.fmtKey, &smallest, &largest)
 						fmt.Fprintf(stdout, "\n")
 					}
 					ok = false


### PR DESCRIPTION
We already have something that determines the `boundType` of the smallest & largest keys. This saves us 64 bytes (32 bytes for each InternalKey) per TableMetadata.

Informs: #2047