### PR TITLE
db: support reading separated values from DB.Get

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1027,6 +1027,9 @@ func TestCompaction(t *testing.T) {
 				}
 				return describeLSM(d, verbose)
 
+			case "get":
+				return runGetCmd(t, td, d)
+
 			case "ingest":
 				if err := runIngestCmd(td, d, mem); err != nil {
 					return err.Error()

--- a/db.go
+++ b/db.go
@@ -612,6 +612,9 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 		readState:    readState,
 		keyBuf:       buf.keyBuf,
 	}
+	// Set up a blob value fetcher to use for retrieving values from blob files.
+	i.blobValueFetcher.Init(d.fileCache, block.NoReadEnv)
+	get.iiopts.blobValueFetcher = &i.blobValueFetcher
 
 	if !i.First() {
 		err := i.Close()

--- a/get_iter.go
+++ b/get_iter.go
@@ -23,6 +23,7 @@ type getIter struct {
 	newIters tableNewIters
 	snapshot base.SeqNum
 	iterOpts IterOptions
+	iiopts   internalIterOpts
 	key      []byte
 	prefix   []byte
 	iter     internalIterator
@@ -271,7 +272,7 @@ func (g *getIter) getSSTableIterators(
 	}
 	// m may possibly contain point (or range deletion) keys relevant to g.key.
 	g.iterOpts.layer = level
-	iters, err := g.newIters(context.Background(), m, &g.iterOpts, internalIterOpts{}, iterPointKeys|iterRangeDeletions)
+	iters, err := g.newIters(context.Background(), m, &g.iterOpts, g.iiopts, iterPointKeys|iterRangeDeletions)
 	if err != nil {
 		return emptyIter, nil, err
 	}

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -153,6 +153,17 @@ L0.0:
 Blob files:
   000008: 56 physical bytes, 10 value bytes
 
+get
+a
+b
+h
+w
+----
+a:a
+b:b
+h:hello
+w:world
+
 # Configure the database to require keys in the range [a,m) to be in-place.
 
 define required-in-place=(a,m) value-separation=(true,1,3)


### PR DESCRIPTION
Adapt the getIter (used within the implementation of DB.Get) to initialize a blob value fetcher and propagate it down the iterator tree, ensuring we can retrieve the value of a blob-file separated value.

Informs #112.