### PR TITLE
db: add TestLargeKeys

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1321,6 +1321,29 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	return buf.String()
 }
 
+func runLayoutCmd(t *testing.T, td *datadriven.TestData, d *DB) string {
+	var filename string
+	td.ScanArgs(t, "filename", &filename)
+	f, err := d.opts.FS.Open(filename)
+	if err != nil {
+		return err.Error()
+	}
+	readable, err := sstable.NewSimpleReadable(f)
+	if err != nil {
+		return err.Error()
+	}
+	r, err := sstable.NewReader(context.Background(), readable, d.opts.MakeReaderOptions())
+	if err != nil {
+		return err.Error()
+	}
+	defer r.Close()
+	l, err := r.Layout()
+	if err != nil {
+		return err.Error()
+	}
+	return l.Describe(td.HasArg("verbose"), r, nil)
+}
+
 func runPopulateCmd(t *testing.T, td *datadriven.TestData, b *Batch) {
 	var maxKeyLength, valLength int
 	var timestamps []int

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -5,7 +5,6 @@ package pebble
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -240,28 +239,7 @@ func TestIterHistories(t *testing.T) {
 				}
 				return ""
 			case "layout":
-				var verbose bool
-				var filename string
-				td.ScanArgs(t, "filename", &filename)
-				td.MaybeScanArgs(t, "verbose", &verbose)
-				f, err := opts.FS.Open(filename)
-				if err != nil {
-					return err.Error()
-				}
-				readable, err := sstable.NewSimpleReadable(f)
-				if err != nil {
-					return err.Error()
-				}
-				r, err := sstable.NewReader(context.Background(), readable, opts.MakeReaderOptions())
-				if err != nil {
-					return err.Error()
-				}
-				defer r.Close()
-				l, err := r.Layout()
-				if err != nil {
-					return err.Error()
-				}
-				return l.Describe(verbose, r, nil)
+				return runLayoutCmd(t, td, d)
 			case "lsm":
 				return runLSMCmd(td, d)
 			case "metrics":

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -1,0 +1,285 @@
+# FormatFlushableIngestExcises is format major version 18, which precedes
+# support for columnar blocks.
+#
+# Set a target file size of 4MB.
+
+define target-file-sizes=(4000000) format-major-version=18
+----
+
+# Commit many keys with 1MB-shared prefixes.
+
+batch-commit
+set a(p,1000000)arition
+set a(p,1000000)alling
+set a(p,1000000)eal
+set a(p,1000000)ellate
+set a(p,1000000)endectomy
+set a(p,1000000)etizers
+set a(p,1000000)etizing
+set a(p,1000000)laude
+set a(p,1000000)lauding
+set a(p,1000000)le
+set a(p,1000000)les
+set a(p,1000000)letini
+set a(p,1000000)letinis
+set a(p,1000000)lebottomjeans
+set a(p,1000000)lication
+set a(p,1000000)ly
+set a(p,1000000)lying
+set a(p,1000000)ollo
+set a(p,1000000)raisal
+set a(p,1000000)raisals
+set a(p,1000000)raiser
+set a(p,1000000)raisers
+set a(p,1000000)raising
+set a(p,1000000)rentice
+set a(p,1000000)rentices
+set a(p,1000000)renticing
+set a(p,1000000)roval
+set a(p,1000000)rovals
+set a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+
+layout filename=000005.sst
+----
+sstable
+ ├── data  offset: 0  length: 46944
+ ├── data  offset: 46949  length: 46945
+ ├── data  offset: 93899  length: 46941
+ ├── data  offset: 140845  length: 46944
+ ├── data  offset: 187794  length: 46947
+ ├── data  offset: 234746  length: 46945
+ ├── data  offset: 281696  length: 46945
+ ├── data  offset: 328646  length: 46943
+ ├── data  offset: 375594  length: 46945
+ ├── data  offset: 422544  length: 46940
+ ├── data  offset: 469489  length: 46951
+ ├── data  offset: 516445  length: 46941
+ ├── data  offset: 563391  length: 46944
+ ├── data  offset: 610340  length: 46945
+ ├── data  offset: 657290  length: 46946
+ ├── data  offset: 704241  length: 46940
+ ├── data  offset: 751186  length: 46943
+ ├── data  offset: 798134  length: 46942
+ ├── data  offset: 845081  length: 46944
+ ├── data  offset: 892030  length: 46945
+ ├── data  offset: 938980  length: 46944
+ ├── data  offset: 985929  length: 46945
+ ├── data  offset: 1032879  length: 46945
+ ├── data  offset: 1079829  length: 46945
+ ├── data  offset: 1126779  length: 46946
+ ├── data  offset: 1173730  length: 46947
+ ├── data  offset: 1220682  length: 46943
+ ├── data  offset: 1267630  length: 46944
+ ├── data  offset: 1314579  length: 46942
+ ├── index  offset: 1361526  length: 46942
+ ├── index  offset: 1408473  length: 46946
+ ├── index  offset: 1455424  length: 46942
+ ├── index  offset: 1502371  length: 46945
+ ├── index  offset: 1549321  length: 46948
+ ├── index  offset: 1596274  length: 46946
+ ├── index  offset: 1643225  length: 46946
+ ├── index  offset: 1690176  length: 46944
+ ├── index  offset: 1737125  length: 46946
+ ├── index  offset: 1784076  length: 46941
+ ├── index  offset: 1831022  length: 46952
+ ├── index  offset: 1877979  length: 46942
+ ├── index  offset: 1924926  length: 46945
+ ├── index  offset: 1971876  length: 46946
+ ├── index  offset: 2018827  length: 46947
+ ├── index  offset: 2065779  length: 46941
+ ├── index  offset: 2112725  length: 46944
+ ├── index  offset: 2159674  length: 46943
+ ├── index  offset: 2206622  length: 46945
+ ├── index  offset: 2253572  length: 46946
+ ├── index  offset: 2300523  length: 46945
+ ├── index  offset: 2347473  length: 46946
+ ├── index  offset: 2394424  length: 46946
+ ├── index  offset: 2441375  length: 46946
+ ├── index  offset: 2488326  length: 46947
+ ├── index  offset: 2535278  length: 46948
+ ├── index  offset: 2582231  length: 46944
+ ├── index  offset: 2629180  length: 46945
+ ├── index  offset: 2676130  length: 46943
+ ├── top-index  offset: 2723078  length: 1361225
+ ├── properties  offset: 4084308  length: 490
+ ├── meta-index  offset: 4084803  length: 35
+ └── footer  offset: 4084843  length: 53
+
+properties file=000005
+raw.key.size
+index.size
+index.partitions
+----
+raw.key.size:
+  rocksdb.raw.key.size: 29000440
+index.size:
+  rocksdb.index.size: 58001886
+  rocksdb.top-level.index.size: 29000892
+index.partitions:
+  rocksdb.index.partitions: 29
+
+batch-commit
+del-range a(p,1000000)arition a(p,1000000)eal
+del-range a(p,1000000)ellate a(p,1000000)etizers
+del-range a(p,1000000)etizing a(p,1000000)lauding
+del-range a(p,1000000)le a(p,1000000)lebottomjeans
+del-range a(p,1000000)lebottomjeans a(p,1000000)lication
+del-range a(p,1000000)ly a(p,1000000)lying
+del-range a(p,1000000)raisals a(p,1000000)rentice
+del-range a(p,1000000)rentices a(p,1000000)roval
+del-range a(p,1000000)rovals a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.1:
+  000008:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[39-47] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:18000932
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+
+layout filename=000008.sst
+----
+sstable
+ ├── data  offset: 0  length: 8
+ ├── index  offset: 13  length: 24
+ ├── range-del  offset: 42  length: 18000310
+ ├── properties  offset: 18000357  length: 447
+ ├── meta-index  offset: 18000809  length: 65
+ └── footer  offset: 18000879  length: 53
+
+properties file=000008
+rocksdb.raw
+----
+rocksdb.raw:
+  rocksdb.raw.key.size: 9000139
+  rocksdb.raw.value.size: 9000068
+
+# Repeat the above with columnar blocks.
+
+define target-file-sizes=(4000000) format-major-version=19
+----
+
+# Commit many keys with 1MB-shared prefixes.
+
+batch-commit
+set a(p,1000000)arition
+set a(p,1000000)alling
+set a(p,1000000)eal
+set a(p,1000000)ellate
+set a(p,1000000)endectomy
+set a(p,1000000)etizers
+set a(p,1000000)etizing
+set a(p,1000000)laude
+set a(p,1000000)lauding
+set a(p,1000000)le
+set a(p,1000000)les
+set a(p,1000000)letini
+set a(p,1000000)letinis
+set a(p,1000000)lebottomjeans
+set a(p,1000000)lication
+set a(p,1000000)ly
+set a(p,1000000)lying
+set a(p,1000000)ollo
+set a(p,1000000)raisal
+set a(p,1000000)raisals
+set a(p,1000000)raiser
+set a(p,1000000)raisers
+set a(p,1000000)raising
+set a(p,1000000)rentice
+set a(p,1000000)rentices
+set a(p,1000000)renticing
+set a(p,1000000)roval
+set a(p,1000000)rovals
+set a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:564287
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:564304
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:564298
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:564292
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:564286
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:564299
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:564311
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94575
+
+layout filename=000006.sst
+----
+sstable
+ ├── data  offset: 0  length: 46998
+ ├── data  offset: 47003  length: 46993
+ ├── data  offset: 94001  length: 46993
+ ├── data  offset: 140999  length: 46991
+ ├── index  offset: 187995  length: 46967
+ ├── index  offset: 234967  length: 46969
+ ├── index  offset: 281941  length: 46973
+ ├── index  offset: 328919  length: 46969
+ ├── top-index  offset: 375893  length: 187752
+ ├── properties  offset: 563650  length: 557
+ ├── meta-index  offset: 564212  length: 34
+ └── footer  offset: 564251  length: 53
+
+properties file=000006
+raw.key.size
+index.size
+index.partitions
+----
+raw.key.size:
+  rocksdb.raw.key.size: 4000064
+index.size:
+  rocksdb.index.size: 8000330
+  rocksdb.top-level.index.size: 4000112
+index.partitions:
+  rocksdb.index.partitions: 4
+
+batch-commit
+del-range a(p,1000000)arition a(p,1000000)eal
+del-range a(p,1000000)ellate a(p,1000000)etizers
+del-range a(p,1000000)etizing a(p,1000000)lauding
+del-range a(p,1000000)le a(p,1000000)lebottomjeans
+del-range a(p,1000000)lebottomjeans a(p,1000000)lication
+del-range a(p,1000000)ly a(p,1000000)lying
+del-range a(p,1000000)raisals a(p,1000000)rentice
+del-range a(p,1000000)rentices a(p,1000000)roval
+del-range a(p,1000000)rovals a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.1:
+  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000807
+  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000821
+  000017:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000779
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:564287
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:564304
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:564298
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:564292
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:564286
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:564299
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:564311
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94575
+
+layout filename=000015.sst
+----
+sstable
+ ├── index  offset: 0  length: 28
+ ├── range-del  offset: 33  length: 6000129
+ ├── properties  offset: 6000167  length: 512
+ ├── meta-index  offset: 6000684  length: 65
+ └── footer  offset: 6000754  length: 53
+
+properties file=000015
+rocksdb.raw
+----
+rocksdb.raw:
+  rocksdb.raw.key.size: 6000043
+  rocksdb.raw.value.size: 0


### PR DESCRIPTION
Add a new datadriven unit test that exercises large keys with a long common shared prefix. This test demonstrates the worst-case unbounded block sizes.

Informs #4518.