### PR TITLE
db: deflake TestCheckpoint

### DIFF
--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -829,6 +829,11 @@ open db wal-failover=/failover-logs nondeterministic
 checkpoint db checkpoints/checkpoint7 nondeterministic
 ----
 
+# Close the database.
+
+close db
+----
+
 # Validate that we can open the checkpoint.
 
 open checkpoints/checkpoint7 readonly nondeterministic


### PR DESCRIPTION
A spurious log rotation on the `db` database was showing up in the logs during later test cases that use different databases.

Example failure: https://github.com/cockroachdb/pebble/actions/runs/14539220052/job/40793696777