### PR TITLE
objstorageprovider: support remote blob files

### DIFF
--- a/objstorage/objstorageprovider/remote_backing_test.go
+++ b/objstorage/objstorageprovider/remote_backing_test.go
@@ -15,13 +15,100 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var supportedFileTypes = []base.FileType{
+	base.FileTypeTable,
+	base.FileTypeBlob,
+}
+
 func TestSharedObjectBacking(t *testing.T) {
 	for _, cleanup := range []objstorage.SharedCleanupMethod{objstorage.SharedRefTracking, objstorage.SharedNoCleanup} {
 		name := "ref-tracking"
 		if cleanup == objstorage.SharedNoCleanup {
 			name = "no-cleanup"
 		}
-		t.Run(name, func(t *testing.T) {
+		for _, fileType := range supportedFileTypes {
+			t.Run(fileType.String(), func(t *testing.T) {
+				t.Run(name, func(t *testing.T) {
+					st := DefaultSettings(vfs.NewMem(), "")
+					sharedStorage := remote.NewInMem()
+					st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+						"foo": sharedStorage,
+					})
+					p, err := Open(st)
+					require.NoError(t, err)
+					defer p.Close()
+
+					const creatorID = objstorage.CreatorID(99)
+					require.NoError(t, p.SetCreatorID(creatorID))
+					meta := objstorage.ObjectMetadata{
+						DiskFileNum: base.DiskFileNum(1),
+						FileType:    fileType,
+					}
+					meta.Remote.CreatorID = 100
+					meta.Remote.CreatorFileNum = base.DiskFileNum(200)
+					meta.Remote.CleanupMethod = cleanup
+					meta.Remote.Locator = "foo"
+					meta.Remote.CustomObjectName = "obj-name"
+					meta.Remote.Storage = sharedStorage
+
+					h, err := p.RemoteObjectBacking(&meta)
+					require.NoError(t, err)
+					buf, err := h.Get()
+					require.NoError(t, err)
+					h.Close()
+					_, err = h.Get()
+					require.Error(t, err)
+
+					d1, err := decodeRemoteObjectBacking(fileType, base.DiskFileNum(100), buf)
+					require.NoError(t, err)
+					require.Equal(t, uint64(100), uint64(d1.meta.DiskFileNum))
+					require.Equal(t, fileType, d1.meta.FileType)
+					d1.meta.Remote.Storage = sharedStorage
+					require.Equal(t, meta.Remote, d1.meta.Remote)
+					if cleanup == objstorage.SharedRefTracking {
+						require.Equal(t, creatorID, d1.refToCheck.creatorID)
+						require.Equal(t, base.DiskFileNum(1), d1.refToCheck.fileNum)
+					} else {
+						require.Equal(t, objstorage.CreatorID(0), d1.refToCheck.creatorID)
+						require.Equal(t, base.DiskFileNum(0), d1.refToCheck.fileNum)
+					}
+
+					t.Run("unknown-tags", func(t *testing.T) {
+						// Append a tag that is safe to ignore.
+						buf2 := buf
+						buf2 = binary.AppendUvarint(buf2, 13)
+						buf2 = binary.AppendUvarint(buf2, 2)
+						buf2 = append(buf2, 1, 1)
+
+						d2, err := decodeRemoteObjectBacking(fileType, base.DiskFileNum(100), buf2)
+						require.NoError(t, err)
+						require.Equal(t, uint64(100), uint64(d2.meta.DiskFileNum))
+						require.Equal(t, fileType, d2.meta.FileType)
+						d2.meta.Remote.Storage = sharedStorage
+						require.Equal(t, meta.Remote, d2.meta.Remote)
+						if cleanup == objstorage.SharedRefTracking {
+							require.Equal(t, creatorID, d2.refToCheck.creatorID)
+							require.Equal(t, base.DiskFileNum(1), d2.refToCheck.fileNum)
+						} else {
+							require.Equal(t, objstorage.CreatorID(0), d2.refToCheck.creatorID)
+							require.Equal(t, base.DiskFileNum(0), d2.refToCheck.fileNum)
+						}
+
+						buf3 := buf2
+						buf3 = binary.AppendUvarint(buf3, tagNotSafeToIgnoreMask+5)
+						_, err = decodeRemoteObjectBacking(meta.FileType, meta.DiskFileNum, buf3)
+						require.Error(t, err)
+						require.Contains(t, err.Error(), "unknown tag")
+					})
+				})
+			})
+		}
+	}
+}
+
+func TestCreateSharedObjectBacking(t *testing.T) {
+	for _, fileType := range supportedFileTypes {
+		t.Run(fileType.String(), func(t *testing.T) {
 			st := DefaultSettings(vfs.NewMem(), "")
 			sharedStorage := remote.NewInMem()
 			st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
@@ -31,128 +118,58 @@ func TestSharedObjectBacking(t *testing.T) {
 			require.NoError(t, err)
 			defer p.Close()
 
-			const creatorID = objstorage.CreatorID(99)
-			require.NoError(t, p.SetCreatorID(creatorID))
-			meta := objstorage.ObjectMetadata{
-				DiskFileNum: base.DiskFileNum(1),
-				FileType:    base.FileTypeTable,
-			}
-			meta.Remote.CreatorID = 100
-			meta.Remote.CreatorFileNum = base.DiskFileNum(200)
-			meta.Remote.CleanupMethod = cleanup
-			meta.Remote.Locator = "foo"
-			meta.Remote.CustomObjectName = "obj-name"
-			meta.Remote.Storage = sharedStorage
+			require.NoError(t, p.SetCreatorID(1))
 
-			h, err := p.RemoteObjectBacking(&meta)
+			backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
 			require.NoError(t, err)
-			buf, err := h.Get()
+			d, err := decodeRemoteObjectBacking(fileType, base.DiskFileNum(100), backing)
 			require.NoError(t, err)
-			h.Close()
-			_, err = h.Get()
-			require.Error(t, err)
-
-			d1, err := decodeRemoteObjectBacking(base.FileTypeTable, base.DiskFileNum(100), buf)
-			require.NoError(t, err)
-			require.Equal(t, uint64(100), uint64(d1.meta.DiskFileNum))
-			require.Equal(t, base.FileTypeTable, d1.meta.FileType)
-			d1.meta.Remote.Storage = sharedStorage
-			require.Equal(t, meta.Remote, d1.meta.Remote)
-			if cleanup == objstorage.SharedRefTracking {
-				require.Equal(t, creatorID, d1.refToCheck.creatorID)
-				require.Equal(t, base.DiskFileNum(1), d1.refToCheck.fileNum)
-			} else {
-				require.Equal(t, objstorage.CreatorID(0), d1.refToCheck.creatorID)
-				require.Equal(t, base.DiskFileNum(0), d1.refToCheck.fileNum)
-			}
-
-			t.Run("unknown-tags", func(t *testing.T) {
-				// Append a tag that is safe to ignore.
-				buf2 := buf
-				buf2 = binary.AppendUvarint(buf2, 13)
-				buf2 = binary.AppendUvarint(buf2, 2)
-				buf2 = append(buf2, 1, 1)
-
-				d2, err := decodeRemoteObjectBacking(base.FileTypeTable, base.DiskFileNum(100), buf2)
-				require.NoError(t, err)
-				require.Equal(t, uint64(100), uint64(d2.meta.DiskFileNum))
-				require.Equal(t, base.FileTypeTable, d2.meta.FileType)
-				d2.meta.Remote.Storage = sharedStorage
-				require.Equal(t, meta.Remote, d2.meta.Remote)
-				if cleanup == objstorage.SharedRefTracking {
-					require.Equal(t, creatorID, d2.refToCheck.creatorID)
-					require.Equal(t, base.DiskFileNum(1), d2.refToCheck.fileNum)
-				} else {
-					require.Equal(t, objstorage.CreatorID(0), d2.refToCheck.creatorID)
-					require.Equal(t, base.DiskFileNum(0), d2.refToCheck.fileNum)
-				}
-
-				buf3 := buf2
-				buf3 = binary.AppendUvarint(buf3, tagNotSafeToIgnoreMask+5)
-				_, err = decodeRemoteObjectBacking(meta.FileType, meta.DiskFileNum, buf3)
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "unknown tag")
-			})
+			require.Equal(t, uint64(100), uint64(d.meta.DiskFileNum))
+			require.Equal(t, fileType, d.meta.FileType)
+			require.Equal(t, remote.Locator("foo"), d.meta.Remote.Locator)
+			require.Equal(t, "custom-obj-name", d.meta.Remote.CustomObjectName)
+			require.Equal(t, objstorage.SharedNoCleanup, d.meta.Remote.CleanupMethod)
 		})
 	}
 }
 
-func TestCreateSharedObjectBacking(t *testing.T) {
-	st := DefaultSettings(vfs.NewMem(), "")
-	sharedStorage := remote.NewInMem()
-	st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"foo": sharedStorage,
-	})
-	p, err := Open(st)
-	require.NoError(t, err)
-	defer p.Close()
-
-	require.NoError(t, p.SetCreatorID(1))
-
-	backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
-	require.NoError(t, err)
-	d, err := decodeRemoteObjectBacking(base.FileTypeTable, base.DiskFileNum(100), backing)
-	require.NoError(t, err)
-	require.Equal(t, uint64(100), uint64(d.meta.DiskFileNum))
-	require.Equal(t, base.FileTypeTable, d.meta.FileType)
-	require.Equal(t, remote.Locator("foo"), d.meta.Remote.Locator)
-	require.Equal(t, "custom-obj-name", d.meta.Remote.CustomObjectName)
-	require.Equal(t, objstorage.SharedNoCleanup, d.meta.Remote.CleanupMethod)
-}
-
 func TestAttachRemoteObjects(t *testing.T) {
-	st := DefaultSettings(vfs.NewMem(), "")
-	sharedStorage := remote.NewInMem()
-	st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"foo": sharedStorage,
-	})
-	p, err := Open(st)
-	require.NoError(t, err)
-	defer p.Close()
-	require.NoError(t, p.SetCreatorID(1))
-	backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
-	require.NoError(t, err)
-	_, err = p.AttachRemoteObjects([]objstorage.RemoteObjectToAttach{{
-		FileType: base.FileTypeTable,
-		FileNum:  100,
-		Backing:  backing,
-	}})
-	require.NoError(t, err)
+	for _, fileType := range supportedFileTypes {
+		t.Run(fileType.String(), func(t *testing.T) {
+			st := DefaultSettings(vfs.NewMem(), "")
+			sharedStorage := remote.NewInMem()
+			st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+				"foo": sharedStorage,
+			})
+			p, err := Open(st)
+			require.NoError(t, err)
+			defer p.Close()
+			require.NoError(t, p.SetCreatorID(1))
+			backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
+			require.NoError(t, err)
+			_, err = p.AttachRemoteObjects([]objstorage.RemoteObjectToAttach{{
+				FileType: fileType,
+				FileNum:  100,
+				Backing:  backing,
+			}})
+			require.NoError(t, err)
 
-	// Sync, close, and reopen the provider and expect that we see
-	// our object.
-	require.NoError(t, p.Sync())
-	require.NoError(t, p.Close())
+			// Sync, close, and reopen the provider and expect that we see
+			// our object.
+			require.NoError(t, p.Sync())
+			require.NoError(t, p.Close())
 
-	p, err = Open(st)
-	require.NoError(t, err)
-	defer p.Close()
-	require.NoError(t, p.SetCreatorID(1))
-	objs := p.List()
-	require.Len(t, objs, 1)
-	o := objs[0]
-	require.Equal(t, remote.Locator("foo"), o.Remote.Locator)
-	require.Equal(t, "custom-obj-name", o.Remote.CustomObjectName)
-	require.Equal(t, uint64(100), uint64(o.DiskFileNum))
-	require.Equal(t, base.FileTypeTable, o.FileType)
+			p, err = Open(st)
+			require.NoError(t, err)
+			defer p.Close()
+			require.NoError(t, p.SetCreatorID(1))
+			objs := p.List()
+			require.Len(t, objs, 1)
+			o := objs[0]
+			require.Equal(t, remote.Locator("foo"), o.Remote.Locator)
+			require.Equal(t, "custom-obj-name", o.Remote.CustomObjectName)
+			require.Equal(t, uint64(100), uint64(o.DiskFileNum))
+			require.Equal(t, fileType, o.FileType)
+		})
+	}
 }

--- a/objstorage/objstorageprovider/remote_obj_name.go
+++ b/objstorage/objstorageprovider/remote_obj_name.go
@@ -25,6 +25,11 @@ func remoteObjectName(meta objstorage.ObjectMetadata) string {
 			"%04x-%d-%06d.sst",
 			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum,
 		)
+	case base.FileTypeBlob:
+		return fmt.Sprintf(
+			"%04x-%d-%06d.blob",
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum,
+		)
 	}
 	panic("unknown FileType")
 }
@@ -51,6 +56,11 @@ func sharedObjectRefName(
 			"%04x-%d-%06d.sst.ref.%d.%06d",
 			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum, refCreatorID, refFileNum,
 		)
+	case base.FileTypeBlob:
+		return fmt.Sprintf(
+			"%04x-%d-%06d.blob.ref.%d.%06d",
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum, refCreatorID, refFileNum,
+		)
 	}
 	panic("unknown FileType")
 }
@@ -63,6 +73,11 @@ func sharedObjectRefPrefix(meta objstorage.ObjectMetadata) string {
 	case base.FileTypeTable:
 		return fmt.Sprintf(
 			"%04x-%d-%06d.sst.ref.",
+			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum,
+		)
+	case base.FileTypeBlob:
+		return fmt.Sprintf(
+			"%04x-%d-%06d.blob.ref.",
 			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum,
 		)
 	}

--- a/objstorage/objstorageprovider/remote_obj_name_test.go
+++ b/objstorage/objstorageprovider/remote_obj_name_test.go
@@ -16,9 +16,6 @@ import (
 
 func TestSharedObjectNames(t *testing.T) {
 	t.Run("crosscheck", func(t *testing.T) {
-		supportedFileTypes := []base.FileType{
-			base.FileTypeTable,
-		}
 		for it := 0; it < 100; it++ {
 			var meta objstorage.ObjectMetadata
 			meta.DiskFileNum = base.DiskFileNum(rand.IntN(100000))
@@ -59,6 +56,21 @@ func TestSharedObjectNames(t *testing.T) {
 		require.Equal(
 			t, sharedObjectRefName(meta, refCreatorID, meta.DiskFileNum),
 			"0e17-456-000789.sst.ref.101112.000123",
+		)
+	})
+	t.Run("example-blobfile", func(t *testing.T) {
+		var meta objstorage.ObjectMetadata
+		meta.DiskFileNum = base.DiskFileNum(123)
+		meta.FileType = base.FileTypeBlob
+		meta.Remote.CreatorID = objstorage.CreatorID(456)
+		meta.Remote.CreatorFileNum = base.DiskFileNum(789)
+		require.Equal(t, remoteObjectName(meta), "0e17-456-000789.blob")
+		require.Equal(t, sharedObjectRefPrefix(meta), "0e17-456-000789.blob.ref.")
+
+		refCreatorID := objstorage.CreatorID(101112)
+		require.Equal(
+			t, sharedObjectRefName(meta, refCreatorID, meta.DiskFileNum),
+			"0e17-456-000789.blob.ref.101112.000123",
 		)
 	})
 }

--- a/objstorage/objstorageprovider/remoteobjcat/testdata/catalog
+++ b/objstorage/objstorageprovider/remoteobjcat/testdata/catalog
@@ -21,7 +21,7 @@ marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
 batch
 add 2 20 200
-add 3 30 300
+add 3 30 300 blob
 ----
 sync: test/REMOTE-OBJ-CATALOG-000001
 

--- a/objstorage/objstorageprovider/remoteobjcat/version_edit.go
+++ b/objstorage/objstorageprovider/remoteobjcat/version_edit.go
@@ -48,12 +48,15 @@ const (
 // more general (and we want freedom to change it in the future).
 const (
 	objTypeTable = 1
+	objTypeBlob  = 2
 )
 
 func objTypeToFileType(objType uint64) (base.FileType, error) {
 	switch objType {
 	case objTypeTable:
 		return base.FileTypeTable, nil
+	case objTypeBlob:
+		return base.FileTypeBlob, nil
 	default:
 		return 0, errors.Newf("unknown object type %d", objType)
 	}
@@ -63,7 +66,8 @@ func fileTypeToObjType(fileType base.FileType) (uint64, error) {
 	switch fileType {
 	case base.FileTypeTable:
 		return objTypeTable, nil
-
+	case base.FileTypeBlob:
+		return objTypeBlob, nil
 	default:
 		return 0, errors.Newf("unknown object type for file type %d", fileType)
 	}

--- a/objstorage/objstorageprovider/remoteobjcat/version_edit_test.go
+++ b/objstorage/objstorageprovider/remoteobjcat/version_edit_test.go
@@ -35,6 +35,19 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			},
 		},
 		{
+			NewObjects: []RemoteObjectMetadata{
+				{
+					FileNum:          base.DiskFileNum(1),
+					FileType:         base.FileTypeBlob,
+					CreatorID:        12,
+					CreatorFileNum:   base.DiskFileNum(123),
+					CleanupMethod:    objstorage.SharedNoCleanup,
+					Locator:          "",
+					CustomObjectName: "foo",
+				},
+			},
+		},
+		{
 			DeletedObjects: []base.DiskFileNum{base.DiskFileNum(1)},
 		},
 		{
@@ -60,6 +73,38 @@ func TestVersionEditRoundTrip(t *testing.T) {
 				{
 					FileNum:          base.DiskFileNum(3),
 					FileType:         base.FileTypeTable,
+					CreatorID:        32,
+					CreatorFileNum:   base.DiskFileNum(323),
+					CleanupMethod:    objstorage.SharedRefTracking,
+					Locator:          "baz",
+					CustomObjectName: "obj2",
+				},
+			},
+			DeletedObjects: []base.DiskFileNum{base.DiskFileNum(4), base.DiskFileNum(5)},
+		},
+		{
+			CreatorID: 12345,
+			NewObjects: []RemoteObjectMetadata{
+				{
+					FileNum:          base.DiskFileNum(1),
+					FileType:         base.FileTypeBlob,
+					CreatorID:        12,
+					CreatorFileNum:   base.DiskFileNum(123),
+					CleanupMethod:    objstorage.SharedRefTracking,
+					Locator:          "foo",
+					CustomObjectName: "",
+				},
+				{
+					FileNum:          base.DiskFileNum(2),
+					FileType:         base.FileTypeBlob,
+					CreatorID:        22,
+					CreatorFileNum:   base.DiskFileNum(223),
+					Locator:          "bar",
+					CustomObjectName: "obj1",
+				},
+				{
+					FileNum:          base.DiskFileNum(3),
+					FileType:         base.FileTypeBlob,
 					CreatorID:        32,
 					CreatorFileNum:   base.DiskFileNum(323),
 					CleanupMethod:    objstorage.SharedRefTracking,


### PR DESCRIPTION
Extend the objstorageprovider implementation to support files of type FileTypeBlob.

Close #4582.