### PR TITLE
db: export FormatExperimentalValueSeparation

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1232,8 +1232,8 @@ func TestCompaction(t *testing.T) {
 			maxVersion: internalFormatNewest,
 		},
 		"value_separation": {
-			minVersion: formatValueSeparation,
-			maxVersion: formatValueSeparation,
+			minVersion: FormatExperimentalValueSeparation,
+			maxVersion: FormatExperimentalValueSeparation,
 			verbose:    true,
 		},
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -1652,12 +1652,10 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 			if err != nil {
 				return err
 			}
-			var maxDepth int
-			maxDepth, err = strconv.Atoi(cmdArg.Vals[2])
+			policy.MaxBlobReferenceDepth, err = strconv.Atoi(cmdArg.Vals[2])
 			if err != nil {
 				return err
 			}
-			policy.MaxBlobReferenceDepth = manifest.BlobReferenceDepth(maxDepth)
 			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return policy
 			}

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -215,12 +215,16 @@ const (
 	// This format major version does not yet enable use of value separation.
 	FormatTableFormatV6
 
-	// formatValueSeparation enables the use of value separation, separating
-	// values into external blob files that do not participate in every
-	// compaction.
+	// FormatExperimentalValueSeparation enables the use of value separation,
+	// separating values into external blob files that do not participate in
+	// every compaction.
 	//
-	// TODO(jackson): Export this format major version once stable.
-	formatValueSeparation
+	// This format major version is experimental and its physical file formats
+	// are not yet stable. Do not use this format major version in production.
+	//
+	// TODO(jackson): Rename this format major version and update FormatNewest
+	// once stable.
+	FormatExperimentalValueSeparation
 
 	// -- Add new versions here --
 
@@ -262,7 +266,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 		return sstable.TableFormatPebblev4
 	case FormatColumnarBlocks, FormatWALSyncChunks:
 		return sstable.TableFormatPebblev5
-	case FormatTableFormatV6, formatValueSeparation:
+	case FormatTableFormatV6, FormatExperimentalValueSeparation:
 		return sstable.TableFormatPebblev6
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -276,7 +280,7 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
 		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix,
 		FormatFlushableIngestExcises, FormatColumnarBlocks, FormatWALSyncChunks,
-		FormatTableFormatV6, formatValueSeparation:
+		FormatTableFormatV6, FormatExperimentalValueSeparation:
 		return sstable.TableFormatPebblev1
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -325,8 +329,8 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	FormatTableFormatV6: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatTableFormatV6)
 	},
-	formatValueSeparation: func(d *DB) error {
-		return d.finalizeFormatVersUpgrade(formatValueSeparation)
+	FormatExperimentalValueSeparation: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(FormatExperimentalValueSeparation)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -28,7 +28,7 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatColumnarBlocks, FormatMajorVersion(19))
 	require.Equal(t, FormatWALSyncChunks, FormatMajorVersion(20))
 	require.Equal(t, FormatTableFormatV6, FormatMajorVersion(21))
-	require.Equal(t, formatValueSeparation, FormatMajorVersion(22))
+	require.Equal(t, FormatExperimentalValueSeparation, FormatMajorVersion(22))
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
@@ -68,8 +68,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatWALSyncChunks, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatTableFormatV6))
 	require.Equal(t, FormatTableFormatV6, d.FormatMajorVersion())
-	require.NoError(t, d.RatchetFormatMajorVersion(formatValueSeparation))
-	require.Equal(t, formatValueSeparation, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatExperimentalValueSeparation))
+	require.Equal(t, FormatExperimentalValueSeparation, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -219,17 +219,17 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 	// fixture is intentionally verbose.
 
 	m := map[FormatMajorVersion][2]sstable.TableFormat{
-		FormatDefault:                    {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
-		FormatFlushableIngest:            {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
-		FormatPrePebblev1MarkedCompacted: {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
-		FormatDeleteSizedAndObsolete:     {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
-		FormatVirtualSSTables:            {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
-		FormatSyntheticPrefixSuffix:      {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
-		FormatFlushableIngestExcises:     {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
-		FormatColumnarBlocks:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
-		FormatWALSyncChunks:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
-		FormatTableFormatV6:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
-		formatValueSeparation:            {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
+		FormatDefault:                     {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
+		FormatFlushableIngest:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
+		FormatPrePebblev1MarkedCompacted:  {sstable.TableFormatPebblev1, sstable.TableFormatPebblev3},
+		FormatDeleteSizedAndObsolete:      {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
+		FormatVirtualSSTables:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
+		FormatSyntheticPrefixSuffix:       {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
+		FormatFlushableIngestExcises:      {sstable.TableFormatPebblev1, sstable.TableFormatPebblev4},
+		FormatColumnarBlocks:              {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
+		FormatWALSyncChunks:               {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
+		FormatTableFormatV6:               {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
+		FormatExperimentalValueSeparation: {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
 	}
 
 	// Valid versions.
@@ -286,12 +286,12 @@ func TestFormatMajorVersions_ColumnarBlocks(t *testing.T) {
 			want:    sstable.TableFormatPebblev4,
 		},
 		{
-			fmv:     formatValueSeparation,
+			fmv:     FormatExperimentalValueSeparation,
 			colBlks: true,
 			want:    sstable.TableFormatPebblev6,
 		},
 		{
-			fmv:     formatValueSeparation,
+			fmv:     FormatExperimentalValueSeparation,
 			colBlks: false,
 			want:    sstable.TableFormatPebblev4,
 		},

--- a/options.go
+++ b/options.go
@@ -1140,7 +1140,7 @@ type ValueSeparationPolicy struct {
 	// compaction may produce an output sstable referencing more than this many
 	// overlapping blob files, the compaction will instead rewrite referenced
 	// values into new blob files.
-	MaxBlobReferenceDepth manifest.BlobReferenceDepth
+	MaxBlobReferenceDepth int
 }
 
 // WALFailoverOptions configures the WAL failover mechanics to use during
@@ -1928,9 +1928,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				minimumSize, err = strconv.Atoi(value)
 				valSepPolicy.MinimumSize = minimumSize
 			case "max_blob_reference_depth":
-				var maxBlobReferenceDepth int
-				maxBlobReferenceDepth, err = strconv.Atoi(value)
-				valSepPolicy.MaxBlobReferenceDepth = manifest.BlobReferenceDepth(maxBlobReferenceDepth)
+				valSepPolicy.MaxBlobReferenceDepth, err = strconv.Atoi(value)
 			default:
 				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil

--- a/value_separation.go
+++ b/value_separation.go
@@ -30,7 +30,7 @@ var neverSeparateValues getValueSeparation = func(JobID, *compaction, sstable.Ta
 func (d *DB) determineCompactionValueSeparation(
 	jobID JobID, c *compaction, tableFormat sstable.TableFormat,
 ) compact.ValueSeparation {
-	if tableFormat < sstable.TableFormatPebblev6 || d.FormatMajorVersion() < formatValueSeparation ||
+	if tableFormat < sstable.TableFormatPebblev6 || d.FormatMajorVersion() < FormatExperimentalValueSeparation ||
 		d.opts.Experimental.ValueSeparationPolicy == nil {
 		return compact.NeverSeparateValues{}
 	}


### PR DESCRIPTION
Export the format major version that allows use of value separation, but
leaving FormatNewest pointing to the previous format major version. Exporting
the format allows us to use the format major version from other packages (eg,
the metamorphic tests, the tool package, etc).

**db: avoid use of internal type in ValueSeparationPolicy**

Avoid use of the internal/manifest.BlobReferenceDepth type in the external
ValueSeparationPolicy type. Users are expected to construct a
ValueSeparationPolicy and must be able to construct a MaxBlobReferenceDepth
value.

Also, sneak in a small change to address this comment while we're here: https://github.com/cockroachdb/pebble/pull/4564#pullrequestreview-2778613182