### PR TITLE
db: run score-based compactions before manual compactions

### DIFF
--- a/compaction_scheduler.go
+++ b/compaction_scheduler.go
@@ -125,18 +125,20 @@ var scheduledCompactionMap map[compactionKind]compactionOptionalAndPriority
 var manualCompactionPriority int
 
 func init() {
-	// Manual compactions have the highest priority since DB.pickAnyCompaction
-	// first picks a manual compaction, before calling
-	// compactionPickerByScore.pickAuto.
-	manualCompactionPriority = 100
+	// Manual compactions have priority just below the score-rebased
+	// compactions, since DB.pickAnyCompaction first picks score-based
+	// compactions, and then manual compactions.
+	manualCompactionPriority = 70
 	scheduledCompactionMap = map[compactionKind]compactionOptionalAndPriority{}
+	// Score-based-compactions have priorities {100, 90, 80}.
+	//
 	// We don't actually know if it is a compactionKindMove or
 	// compactionKindCopy until a compactionKindDefault is turned from a
 	// pickedCompaction into a compaction struct. So we will never see those
 	// values here, but for completeness we include them.
-	scheduledCompactionMap[compactionKindMove] = compactionOptionalAndPriority{priority: 90}
-	scheduledCompactionMap[compactionKindCopy] = compactionOptionalAndPriority{priority: 80}
-	scheduledCompactionMap[compactionKindDefault] = compactionOptionalAndPriority{priority: 70}
+	scheduledCompactionMap[compactionKindMove] = compactionOptionalAndPriority{priority: 100}
+	scheduledCompactionMap[compactionKindCopy] = compactionOptionalAndPriority{priority: 90}
+	scheduledCompactionMap[compactionKindDefault] = compactionOptionalAndPriority{priority: 80}
 	scheduledCompactionMap[compactionKindTombstoneDensity] =
 		compactionOptionalAndPriority{optional: true, priority: 60}
 	scheduledCompactionMap[compactionKindElisionOnly] =

--- a/testdata/compaction/score_compaction_picked_before_manual
+++ b/testdata/compaction/score_compaction_picked_before_manual
@@ -1,0 +1,67 @@
+# Do a manual compaction when auto compaction is disabled.
+define disable-multi-level lbase-max-bytes=1
+L5
+  a.SET.2:v c.SET.4:v
+----
+L5:
+  000004:[a#2,SET-c#4,SET]
+
+compact a-b L5
+----
+L6:
+  000004:[a#2,SET-c#4,SET]
+
+# The score is 0.00 even though L2 score was high, since this was a manual
+# compaction.
+compaction-log
+----
+[JOB 1] compacted(move) L5 [000004] (760B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (760B), in 1.0s (1.0s total), output rate 760B/s
+
+# Do an auto score-based compaction with the same LSM as the previous test.
+define disable-multi-level lbase-max-bytes=1
+L5
+  a.SET.2:v c.SET.4:v
+----
+L5:
+  000004:[a#2,SET-c#4,SET]
+
+auto-compact
+----
+L6:
+  000004:[a#2,SET-c#4,SET]
+
+# Note the score is > 1.0 since these is a score-based compaction.
+compaction-log
+----
+[JOB 1] compacted(move) L5 [000004] (760B) Score=974.36 + L6 [] (0B) Score=0.00 -> L6 [000004] (760B), in 1.0s (1.0s total), output rate 760B/s
+
+# With the same LSM as the previous test, try to do both a manual and
+# score-based compaction. The score-based compaction runs first.
+define disable-multi-level lbase-max-bytes=1
+L5
+  a.SET.2:v c.SET.4:v
+----
+L5:
+  000004:[a#2,SET-c#4,SET]
+
+
+# Enable auto compactions. But it won't start until maybeScheduleCompaction is
+# called when compact command is run.
+set-disable-auto-compact v=false
+----
+
+compaction-log
+----
+
+compact a-b L5
+----
+L6:
+  000004:[a#2,SET-c#4,SET]
+
+set-disable-auto-compact v=true
+----
+
+# The score-based compaction ran first.
+compaction-log
+----
+[JOB 1] compacted(move) L5 [000004] (760B) Score=974.36 + L6 [] (0B) Score=0.00 -> L6 [000004] (760B), in 1.0s (1.0s total), output rate 760B/s

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -426,7 +426,13 @@ mark-for-compaction file=000049
 ----
 marked L0.000049
 
+# No-score based compaction
 pick-auto l0_compaction_threshold=1000
+----
+nil
+
+# Marked for compaction file is picked using a non-score compaction.
+pick-auto non-score l0_compaction_threshold=1000
 ----
 L0 -> L0
 L0: 000049

--- a/testdata/compaction_picker_read_triggered
+++ b/testdata/compaction_picker_read_triggered
@@ -30,6 +30,7 @@ show-read-compactions
 
 pick-auto
 ----
+picked non-score-based compaction:
 L5 -> L6
 L5: 000101
 L6: 000010
@@ -62,6 +63,7 @@ show-read-compactions
 
 pick-auto
 ----
+picked score-based compaction:
 L5 -> L6
 L5: 000101
 L6: 000010


### PR DESCRIPTION
Score-based compactions are important for maintaining LSM health.

Fixes #4571