### PR TITLE
manifest: optimize sizeof TableMetadata

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2609,7 +2609,7 @@ func (d *DB) runCopyCompaction(
 		SyntheticPrefixAndSuffix: inputMeta.SyntheticPrefixAndSuffix,
 	}
 	if inputMeta.HasPointKeys {
-		newMeta.ExtendPointKeyBounds(c.cmp, inputMeta.SmallestPointKey, inputMeta.LargestPointKey)
+		newMeta.ExtendPointKeyBounds(c.cmp, inputMeta.PointKeyBounds.Smallest(), inputMeta.PointKeyBounds.Largest())
 	}
 	if inputMeta.HasRangeKeys {
 		newMeta.ExtendRangeKeyBounds(c.cmp, inputMeta.RangeKeyBounds.Smallest(), inputMeta.RangeKeyBounds.Largest())

--- a/compaction.go
+++ b/compaction.go
@@ -2612,7 +2612,7 @@ func (d *DB) runCopyCompaction(
 		newMeta.ExtendPointKeyBounds(c.cmp, inputMeta.SmallestPointKey, inputMeta.LargestPointKey)
 	}
 	if inputMeta.HasRangeKeys {
-		newMeta.ExtendRangeKeyBounds(c.cmp, inputMeta.SmallestRangeKey, inputMeta.LargestRangeKey)
+		newMeta.ExtendRangeKeyBounds(c.cmp, inputMeta.RangeKeyBounds.Smallest(), inputMeta.RangeKeyBounds.Largest())
 	}
 	newMeta.FileNum = d.mu.versions.getNextFileNum()
 	if objMeta.IsExternal() {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1716,6 +1716,6 @@ func checkClone(t *testing.T, pc *pickedCompaction) {
 }
 
 func checkTableBoundary(a, b *tableMetadata, cmp base.Compare) (ok bool) {
-	c := cmp(a.LargestPointKey.UserKey, b.SmallestPointKey.UserKey)
-	return c < 0 || (c == 0 && a.LargestPointKey.IsExclusiveSentinel())
+	c := cmp(a.PointKeyBounds.LargestUserKey(), b.PointKeyBounds.SmallestUserKey())
+	return c < 0 || (c == 0 && a.PointKeyBounds.Largest().IsExclusiveSentinel())
 }

--- a/data_test.go
+++ b/data_test.go
@@ -1303,7 +1303,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	props := r.Properties.String()
 	env := sstable.ReadEnv{}
 	if m != nil && m.Virtual {
-		env.Virtual = &m.VirtualParams
+		env.Virtual = m.VirtualParams
 		scaledProps := r.Properties.GetScaledProperties(m.FileBacking.Size, m.Size)
 		props = scaledProps.String()
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -942,12 +942,14 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 		largestSeqNum := d.mu.versions.logSeqNum.Load()
 		ve.NewBlobFiles = append(ve.NewBlobFiles, newVE.NewBlobFiles...)
 		for _, f := range newVE.NewTables {
-			if start != nil {
-				f.Meta.SmallestPointKey = *start
+			if start != nil && end != nil {
+				f.Meta.PointKeyBounds.SetInternalKeyBounds(*start, *end)
+				f.Meta.ExtendPointKeyBounds(DefaultComparer.Compare, *start, *end)
+			} else if start != nil {
+				f.Meta.PointKeyBounds.SetSmallest(*start)
 				f.Meta.ExtendPointKeyBounds(DefaultComparer.Compare, *start, *start)
-			}
-			if end != nil {
-				f.Meta.LargestPointKey = *end
+			} else if end != nil {
+				f.Meta.PointKeyBounds.SetLargest(*end)
 				f.Meta.ExtendPointKeyBounds(DefaultComparer.Compare, *end, *end)
 			}
 			if blobDepth > 0 {

--- a/db.go
+++ b/db.go
@@ -2994,8 +2994,8 @@ func (d *DB) checkVirtualBounds(m *tableMetadata) {
 		if err != nil {
 			panic(err)
 		}
-		if (rangeDel == nil || d.cmp(rangeDel.SmallestKey().UserKey, m.SmallestPointKey.UserKey) != 0) &&
-			(pointKV == nil || d.cmp(pointKV.K.UserKey, m.SmallestPointKey.UserKey) != 0) {
+		if (rangeDel == nil || d.cmp(rangeDel.SmallestKey().UserKey, m.PointKeyBounds.Smallest().UserKey) != 0) &&
+			(pointKV == nil || d.cmp(pointKV.K.UserKey, m.PointKeyBounds.Smallest().UserKey) != 0) {
 			panic(errors.Newf("pebble: virtual sstable %s lower point key bound is not tight", m.FileNum))
 		}
 
@@ -3005,23 +3005,23 @@ func (d *DB) checkVirtualBounds(m *tableMetadata) {
 		if err != nil {
 			panic(err)
 		}
-		if (rangeDel == nil || d.cmp(rangeDel.LargestKey().UserKey, m.LargestPointKey.UserKey) != 0) &&
-			(pointKV == nil || d.cmp(pointKV.K.UserKey, m.LargestPointKey.UserKey) != 0) {
+		if (rangeDel == nil || d.cmp(rangeDel.LargestKey().UserKey, m.PointKeyBounds.LargestUserKey()) != 0) &&
+			(pointKV == nil || d.cmp(pointKV.K.UserKey, m.PointKeyBounds.Largest().UserKey) != 0) {
 			panic(errors.Newf("pebble: virtual sstable %s upper point key bound is not tight", m.FileNum))
 		}
 
 		// Check that iterator keys are within bounds.
 		for kv := pointIter.First(); kv != nil; kv = pointIter.Next() {
-			if d.cmp(kv.K.UserKey, m.SmallestPointKey.UserKey) < 0 || d.cmp(kv.K.UserKey, m.LargestPointKey.UserKey) > 0 {
+			if d.cmp(kv.K.UserKey, m.PointKeyBounds.Smallest().UserKey) < 0 || d.cmp(kv.K.UserKey, m.PointKeyBounds.LargestUserKey()) > 0 {
 				panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, kv.K.UserKey))
 			}
 		}
 		s, err := rangeDelIter.First()
 		for ; s != nil; s, err = rangeDelIter.Next() {
-			if d.cmp(s.SmallestKey().UserKey, m.SmallestPointKey.UserKey) < 0 {
+			if d.cmp(s.SmallestKey().UserKey, m.PointKeyBounds.Smallest().UserKey) < 0 {
 				panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, s.SmallestKey().UserKey))
 			}
-			if d.cmp(s.LargestKey().UserKey, m.LargestPointKey.UserKey) > 0 {
+			if d.cmp(s.LargestKey().UserKey, m.PointKeyBounds.Largest().UserKey) > 0 {
 				panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, s.LargestKey().UserKey))
 			}
 		}

--- a/db.go
+++ b/db.go
@@ -3038,7 +3038,7 @@ func (d *DB) checkVirtualBounds(m *tableMetadata) {
 	// Check that the lower bound is tight.
 	if s, err := rangeKeyIter.First(); err != nil {
 		panic(err)
-	} else if d.cmp(s.SmallestKey().UserKey, m.RangeKeyBounds.SmallestUserKey()) != 0 {
+	} else if m.HasRangeKeys && d.cmp(s.SmallestKey().UserKey, m.RangeKeyBounds.SmallestUserKey()) != 0 {
 		panic(errors.Newf("pebble: virtual sstable %s lower range key bound is not tight", m.FileNum))
 	}
 

--- a/db.go
+++ b/db.go
@@ -3038,23 +3038,23 @@ func (d *DB) checkVirtualBounds(m *tableMetadata) {
 	// Check that the lower bound is tight.
 	if s, err := rangeKeyIter.First(); err != nil {
 		panic(err)
-	} else if d.cmp(s.SmallestKey().UserKey, m.SmallestRangeKey.UserKey) != 0 {
+	} else if d.cmp(s.SmallestKey().UserKey, m.RangeKeyBounds.SmallestUserKey()) != 0 {
 		panic(errors.Newf("pebble: virtual sstable %s lower range key bound is not tight", m.FileNum))
 	}
 
 	// Check that upper bound is tight.
 	if s, err := rangeKeyIter.Last(); err != nil {
 		panic(err)
-	} else if d.cmp(s.LargestKey().UserKey, m.LargestRangeKey.UserKey) != 0 {
+	} else if d.cmp(s.LargestKey().UserKey, m.RangeKeyBounds.LargestUserKey()) != 0 {
 		panic(errors.Newf("pebble: virtual sstable %s upper range key bound is not tight", m.FileNum))
 	}
 
 	s, err := rangeKeyIter.First()
 	for ; s != nil; s, err = rangeKeyIter.Next() {
-		if d.cmp(s.SmallestKey().UserKey, m.SmallestRangeKey.UserKey) < 0 {
+		if d.cmp(s.SmallestKey().UserKey, m.RangeKeyBounds.SmallestUserKey()) < 0 {
 			panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, s.SmallestKey().UserKey))
 		}
-		if d.cmp(s.LargestKey().UserKey, m.LargestRangeKey.UserKey) > 0 {
+		if d.cmp(s.LargestKey().UserKey, m.RangeKeyBounds.LargestUserKey()) > 0 {
 			panic(errors.Newf("pebble: virtual sstable %s point key %s is not within bounds", m.FileNum, s.LargestKey().UserKey))
 		}
 	}

--- a/excise_test.go
+++ b/excise_test.go
@@ -801,7 +801,7 @@ func TestExciseBounds(t *testing.T) {
 			fmt.Fprintf(&buf, "%s:\n", title)
 			fmt.Fprintf(&buf, "  overall: %v - %v\n", m.Smallest(), m.Largest())
 			if m.HasPointKeys {
-				fmt.Fprintf(&buf, "  point:   %v - %v\n", m.SmallestPointKey, m.LargestPointKey)
+				fmt.Fprintf(&buf, "  point:   %v - %v\n", m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest())
 			}
 			if m.HasRangeKeys {
 				fmt.Fprintf(&buf, "  range:   %v - %v\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())

--- a/excise_test.go
+++ b/excise_test.go
@@ -804,7 +804,7 @@ func TestExciseBounds(t *testing.T) {
 				fmt.Fprintf(&buf, "  point:   %v - %v\n", m.SmallestPointKey, m.LargestPointKey)
 			}
 			if m.HasRangeKeys {
-				fmt.Fprintf(&buf, "  range:   %v - %v\n", m.SmallestRangeKey, m.LargestRangeKey)
+				fmt.Fprintf(&buf, "  range:   %v - %v\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
 			}
 		}
 		switch td.Cmd {

--- a/file_cache.go
+++ b/file_cache.go
@@ -737,7 +737,7 @@ func newRangeDelIter(
 			cmp = handle.readerOpts.Comparer.Compare
 		}
 		rangeDelIter = keyspan.AssertBounds(
-			rangeDelIter, file.SmallestPointKey, file.LargestPointKey.UserKey, cmp,
+			rangeDelIter, file.PointKeyBounds.Smallest(), file.PointKeyBounds.LargestUserKey(), cmp,
 		)
 	}
 	return rangeDelIter, nil

--- a/file_cache.go
+++ b/file_cache.go
@@ -320,7 +320,7 @@ func createReader(v *fileCacheValue, meta *tableMetadata) (*sstable.Reader, ssta
 				panic("virtual params not initialized")
 			}
 		}
-		env.Virtual = &meta.VirtualParams
+		env.Virtual = meta.VirtualParams
 		env.IsSharedIngested = v.isShared && meta.SyntheticSeqNum() != 0
 	}
 	return r, env
@@ -349,7 +349,7 @@ func (h *fileCacheHandle) withReader(
 				panic("virtual params not initialized")
 			}
 		}
-		env.Virtual = &meta.VirtualParams
+		env.Virtual = meta.VirtualParams
 		env.IsSharedIngested = v.isShared && meta.SyntheticSeqNum() != 0
 	}
 

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -351,12 +351,12 @@ func TestVirtualReadsWiring(t *testing.T) {
 		SmallestSeqNum:        parentFile.SmallestSeqNum,
 		LargestSeqNum:         parentFile.LargestSeqNum,
 		LargestSeqNumAbsolute: parentFile.LargestSeqNumAbsolute,
-		SmallestPointKey:      base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet),
-		LargestPointKey:       base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet),
 		HasPointKeys:          true,
 		Virtual:               true,
 	}
-	v1.ExtendPointKeyBounds(DefaultComparer.Compare, v1.SmallestPointKey, v1.LargestPointKey)
+	v1.PointKeyBounds.SetInternalKeyBounds(base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet),
+		base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet))
+	v1.ExtendPointKeyBounds(DefaultComparer.Compare, v1.PointKeyBounds.Smallest(), v1.PointKeyBounds.Largest())
 	v1.AttachVirtualBacking(parentFile.FileBacking)
 	v1.Stats.NumEntries = 1
 
@@ -367,23 +367,21 @@ func TestVirtualReadsWiring(t *testing.T) {
 		SmallestSeqNum:        parentFile.SmallestSeqNum,
 		LargestSeqNum:         parentFile.LargestSeqNum,
 		LargestSeqNumAbsolute: parentFile.LargestSeqNumAbsolute,
-		SmallestPointKey:      base.MakeInternalKey([]byte{'d'}, seqNumCEDel, InternalKeyKindRangeDelete),
-		LargestPointKey:       base.MakeInternalKey([]byte{'z'}, seqNumZ, InternalKeyKindSet),
 		HasPointKeys:          true,
 		Virtual:               true,
 	}
+	v2.PointKeyBounds.SetInternalKeyBounds(base.MakeInternalKey([]byte{'d'}, seqNumCEDel, InternalKeyKindRangeDelete),
+		base.MakeInternalKey([]byte{'z'}, seqNumZ, InternalKeyKindSet))
 	v2.RangeKeyBounds.SetInternalKeyBounds(
 		base.MakeInternalKey([]byte{'f'}, seqNumRangeSet, InternalKeyKindRangeKeySet),
 		base.MakeInternalKey([]byte{'k'}, seqNumRangeUnset, InternalKeyKindRangeKeyUnset))
-	v2.ExtendPointKeyBounds(DefaultComparer.Compare, v2.SmallestPointKey, v2.LargestPointKey)
+	v2.ExtendPointKeyBounds(DefaultComparer.Compare, v2.PointKeyBounds.Smallest(), v2.PointKeyBounds.Largest())
 	v2.AttachVirtualBacking(parentFile.FileBacking)
 	v2.Stats.NumEntries = 6
 
-	v1.LargestPointKey = v1.Largest()
-	v1.SmallestPointKey = v1.Smallest()
+	v1.PointKeyBounds.SetInternalKeyBounds(v1.Smallest(), v1.Largest())
 
-	v2.LargestPointKey = v2.Largest()
-	v2.SmallestPointKey = v2.Smallest()
+	v2.PointKeyBounds.SetInternalKeyBounds(v2.Smallest(), v2.Largest())
 
 	v1.ValidateVirtual(parentFile)
 	d.checkVirtualBounds(v1)

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -372,6 +372,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 	}
 	v2.PointKeyBounds.SetInternalKeyBounds(base.MakeInternalKey([]byte{'d'}, seqNumCEDel, InternalKeyKindRangeDelete),
 		base.MakeInternalKey([]byte{'z'}, seqNumZ, InternalKeyKindSet))
+	v2.RangeKeyBounds = &manifest.InternalKeyBounds{}
 	v2.RangeKeyBounds.SetInternalKeyBounds(
 		base.MakeInternalKey([]byte{'f'}, seqNumRangeSet, InternalKeyKindRangeKeySet),
 		base.MakeInternalKey([]byte{'k'}, seqNumRangeUnset, InternalKeyKindRangeKeyUnset))

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -369,11 +369,12 @@ func TestVirtualReadsWiring(t *testing.T) {
 		LargestSeqNumAbsolute: parentFile.LargestSeqNumAbsolute,
 		SmallestPointKey:      base.MakeInternalKey([]byte{'d'}, seqNumCEDel, InternalKeyKindRangeDelete),
 		LargestPointKey:       base.MakeInternalKey([]byte{'z'}, seqNumZ, InternalKeyKindSet),
-		SmallestRangeKey:      base.MakeInternalKey([]byte{'f'}, seqNumRangeSet, InternalKeyKindRangeKeySet),
-		LargestRangeKey:       base.MakeInternalKey([]byte{'k'}, seqNumRangeUnset, InternalKeyKindRangeKeyUnset),
 		HasPointKeys:          true,
 		Virtual:               true,
 	}
+	v2.RangeKeyBounds.SetInternalKeyBounds(
+		base.MakeInternalKey([]byte{'f'}, seqNumRangeSet, InternalKeyKindRangeKeySet),
+		base.MakeInternalKey([]byte{'k'}, seqNumRangeUnset, InternalKeyKindRangeKeyUnset))
 	v2.ExtendPointKeyBounds(DefaultComparer.Compare, v2.SmallestPointKey, v2.LargestPointKey)
 	v2.AttachVirtualBacking(parentFile.FileBacking)
 	v2.Stats.NumEntries = 6

--- a/get_iter.go
+++ b/get_iter.go
@@ -267,7 +267,7 @@ func (g *getIter) getSSTableIterators(
 	}
 	// m is now positioned at the file containing the first point key ≥ `g.key`.
 	// Does it exist and possibly contain point keys with the user key 'g.key'?
-	if m == nil || !m.HasPointKeys || g.comparer.Compare(m.SmallestPointKey.UserKey, g.key) > 0 {
+	if m == nil || !m.HasPointKeys || g.comparer.Compare(m.PointKeyBounds.SmallestUserKey(), g.key) > 0 {
 		return emptyIter, nil, nil
 	}
 	// m may possibly contain point (or range deletion) keys relevant to g.key.

--- a/ingest.go
+++ b/ingest.go
@@ -881,7 +881,7 @@ func setSeqNumInMetadata(
 		m.SmallestPointKey = setSeqFn(m.SmallestPointKey)
 	}
 	if m.HasRangeKeys {
-		m.SmallestRangeKey = setSeqFn(m.SmallestRangeKey)
+		m.RangeKeyBounds.SetSmallest(setSeqFn(m.RangeKeyBounds.Smallest()))
 	}
 	// Only update the seqnum for the largest key if that key is not an
 	// "exclusive sentinel" (i.e. a range deletion sentinel or a range key

--- a/ingest.go
+++ b/ingest.go
@@ -878,7 +878,7 @@ func setSeqNumInMetadata(
 	// NB: we set the fields directly here, rather than via their Extend*
 	// methods, as we are updating sequence numbers.
 	if m.HasPointKeys {
-		m.SmallestPointKey = setSeqFn(m.SmallestPointKey)
+		m.PointKeyBounds.SetSmallest(setSeqFn(m.PointKeyBounds.Smallest()))
 	}
 	if m.HasRangeKeys {
 		m.RangeKeyBounds.SetSmallest(setSeqFn(m.RangeKeyBounds.Smallest()))
@@ -890,8 +890,8 @@ func setSeqNumInMetadata(
 	// table.
 	// NB: as the largest range key is always an exclusive sentinel, it is never
 	// updated.
-	if m.HasPointKeys && !m.LargestPointKey.IsExclusiveSentinel() {
-		m.LargestPointKey = setSeqFn(m.LargestPointKey)
+	if m.HasPointKeys && !m.PointKeyBounds.Largest().IsExclusiveSentinel() {
+		m.PointKeyBounds.SetLargest(setSeqFn(m.PointKeyBounds.Largest()))
 	}
 	// Setting smallestSeqNum == largestSeqNum triggers the setting of
 	// Properties.GlobalSeqNum when an sstable is loaded.

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -155,7 +155,9 @@ func TestIngestLoad(t *testing.T) {
 			for _, m := range lr.local {
 				fmt.Fprintf(&buf, "%d: %s-%s\n", m.FileNum, m.Smallest(), m.Largest())
 				fmt.Fprintf(&buf, "  points: %s-%s\n", m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest())
-				fmt.Fprintf(&buf, "  ranges: %s-%s\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
+				if m.HasRangeKeys {
+					fmt.Fprintf(&buf, "  ranges: %s-%s\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
+				}
 			}
 			return buf.String()
 
@@ -2660,7 +2662,9 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 				fmt.Fprintf(&buf, "file %d:\n", i)
 				fmt.Fprintf(&buf, "  combined: %s-%s\n", m.Smallest(), m.Largest())
 				fmt.Fprintf(&buf, "    points: %s-%s\n", m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest())
-				fmt.Fprintf(&buf, "    ranges: %s-%s\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
+				if m.HasRangeKeys {
+					fmt.Fprintf(&buf, "    ranges: %s-%s\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
+				}
 			}
 
 			return buf.String()

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -154,7 +154,7 @@ func TestIngestLoad(t *testing.T) {
 			var buf bytes.Buffer
 			for _, m := range lr.local {
 				fmt.Fprintf(&buf, "%d: %s-%s\n", m.FileNum, m.Smallest(), m.Largest())
-				fmt.Fprintf(&buf, "  points: %s-%s\n", m.SmallestPointKey, m.LargestPointKey)
+				fmt.Fprintf(&buf, "  points: %s-%s\n", m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest())
 				fmt.Fprintf(&buf, "  ranges: %s-%s\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
 			}
 			return buf.String()
@@ -2659,7 +2659,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 			for i, m := range metas {
 				fmt.Fprintf(&buf, "file %d:\n", i)
 				fmt.Fprintf(&buf, "  combined: %s-%s\n", m.Smallest(), m.Largest())
-				fmt.Fprintf(&buf, "    points: %s-%s\n", m.SmallestPointKey, m.LargestPointKey)
+				fmt.Fprintf(&buf, "    points: %s-%s\n", m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest())
 				fmt.Fprintf(&buf, "    ranges: %s-%s\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
 			}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -155,7 +155,7 @@ func TestIngestLoad(t *testing.T) {
 			for _, m := range lr.local {
 				fmt.Fprintf(&buf, "%d: %s-%s\n", m.FileNum, m.Smallest(), m.Largest())
 				fmt.Fprintf(&buf, "  points: %s-%s\n", m.SmallestPointKey, m.LargestPointKey)
-				fmt.Fprintf(&buf, "  ranges: %s-%s\n", m.SmallestRangeKey, m.LargestRangeKey)
+				fmt.Fprintf(&buf, "  ranges: %s-%s\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
 			}
 			return buf.String()
 
@@ -2660,7 +2660,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 				fmt.Fprintf(&buf, "file %d:\n", i)
 				fmt.Fprintf(&buf, "  combined: %s-%s\n", m.Smallest(), m.Largest())
 				fmt.Fprintf(&buf, "    points: %s-%s\n", m.SmallestPointKey, m.LargestPointKey)
-				fmt.Fprintf(&buf, "    ranges: %s-%s\n", m.SmallestRangeKey, m.LargestRangeKey)
+				fmt.Fprintf(&buf, "    ranges: %s-%s\n", m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
 			}
 
 			return buf.String()

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -292,13 +292,14 @@ func TestLevelIterEquivalence(t *testing.T) {
 					SmallestSeqNum:        2,
 					LargestSeqNum:         2,
 					LargestSeqNumAbsolute: 2,
-					SmallestRangeKey:      base.MakeInternalKey(file[0].Start, file[0].SmallestKey().SeqNum(), file[0].SmallestKey().Kind()),
-					LargestRangeKey:       base.MakeExclusiveSentinelKey(file[len(file)-1].LargestKey().Kind(), file[len(file)-1].End),
 					HasPointKeys:          false,
 					HasRangeKeys:          true,
 				}
 				meta.InitPhysicalBacking()
-				meta.ExtendRangeKeyBounds(base.DefaultComparer.Compare, meta.SmallestRangeKey, meta.LargestRangeKey)
+				meta.RangeKeyBounds.SetInternalKeyBounds(
+					base.MakeInternalKey(file[0].Start, file[0].SmallestKey().SeqNum(), file[0].SmallestKey().Kind()),
+					base.MakeExclusiveSentinelKey(file[len(file)-1].LargestKey().Kind(), file[len(file)-1].End))
+				meta.ExtendRangeKeyBounds(base.DefaultComparer.Compare, meta.RangeKeyBounds.Smallest(), meta.RangeKeyBounds.Largest())
 				metas = append(metas, meta)
 			}
 

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -296,6 +296,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 					HasRangeKeys:          true,
 				}
 				meta.InitPhysicalBacking()
+				meta.RangeKeyBounds = &manifest.InternalKeyBounds{}
 				meta.RangeKeyBounds.SetInternalKeyBounds(
 					base.MakeInternalKey(file[0].Start, file[0].SmallestKey().SeqNum(), file[0].SmallestKey().Kind()),
 					base.MakeExclusiveSentinelKey(file[len(file)-1].LargestKey().Kind(), file[len(file)-1].End))

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -311,13 +311,12 @@ type TableMetadata struct {
 	// sstable bounds.
 	SmallestSeqNum base.SeqNum
 	LargestSeqNum  base.SeqNum
-	// SmallestPointKey and LargestPointKey are the inclusive bounds for the
+	// PointKeyBounds.Smallest() and PointKeyBounds.Largest() are the inclusive bounds for the
 	// internal point keys stored in the table. This includes RANGEDELs, which
 	// alter point keys.
 	// NB: these field should be set using ExtendPointKeyBounds. They are left
 	// exported for reads as an optimization.
-	SmallestPointKey InternalKey
-	LargestPointKey  InternalKey
+	PointKeyBounds InternalKeyBounds
 	// RangeKeyBounds.Smallest() and RangeKeyBounds.Largest() are the inclusive bounds for the
 	// internal range keys stored in the table.
 	// NB: these field should be set using ExtendRangeKeyBounds. They are left
@@ -469,7 +468,7 @@ func (m *TableMetadata) UserKeyBounds() base.UserKeyBounds {
 func (m *TableMetadata) UserKeyBoundsByType(keyType KeyType) base.UserKeyBounds {
 	switch keyType {
 	case KeyTypePoint:
-		return base.UserKeyBoundsFromInternal(m.SmallestPointKey, m.LargestPointKey)
+		return base.UserKeyBoundsFromInternal(m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest())
 	case KeyTypeRange:
 		return base.UserKeyBoundsFromInternal(m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
 	default:
@@ -693,18 +692,21 @@ func (m *TableMetadata) ExtendPointKeyBounds(
 ) *TableMetadata {
 	// Update the point key bounds.
 	if !m.HasPointKeys {
-		m.SmallestPointKey, m.LargestPointKey = smallest, largest
+		m.PointKeyBounds.SetInternalKeyBounds(smallest, largest)
 		m.HasPointKeys = true
 	} else {
-		if base.InternalCompare(cmp, smallest, m.SmallestPointKey) < 0 {
-			m.SmallestPointKey = smallest
-		}
-		if base.InternalCompare(cmp, largest, m.LargestPointKey) > 0 {
-			m.LargestPointKey = largest
+		isSmallestPoint := base.InternalCompare(cmp, smallest, m.PointKeyBounds.Smallest()) < 0
+		isLargestPoint := base.InternalCompare(cmp, largest, m.PointKeyBounds.Largest()) > 0
+		if isSmallestPoint && isLargestPoint {
+			m.PointKeyBounds.SetInternalKeyBounds(smallest, largest)
+		} else if isSmallestPoint {
+			m.PointKeyBounds.SetSmallest(smallest)
+		} else if isLargestPoint {
+			m.PointKeyBounds.SetLargest(largest)
 		}
 	}
 	// Update the overall bounds.
-	m.extendOverallBounds(cmp, m.SmallestPointKey, m.LargestPointKey, boundTypePointKey)
+	m.extendOverallBounds(cmp, m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest(), boundTypePointKey)
 	return m
 }
 
@@ -794,7 +796,7 @@ func (m *TableMetadata) SmallestBound(kt KeyType) (InternalKey, bool) {
 		ik := m.Smallest()
 		return ik, true
 	case KeyTypePoint:
-		return m.SmallestPointKey, m.HasPointKeys
+		return m.PointKeyBounds.Smallest(), m.HasPointKeys
 	case KeyTypeRange:
 		return m.RangeKeyBounds.Smallest(), m.HasRangeKeys
 	default:
@@ -811,7 +813,7 @@ func (m *TableMetadata) LargestBound(kt KeyType) (InternalKey, bool) {
 		ik := m.Largest()
 		return ik, true
 	case KeyTypePoint:
-		return m.LargestPointKey, m.HasPointKeys
+		return m.PointKeyBounds.Largest(), m.HasPointKeys
 	case KeyTypeRange:
 		return m.RangeKeyBounds.Largest(), m.HasRangeKeys
 	default:
@@ -877,7 +879,7 @@ func (m *TableMetadata) DebugString(format base.FormatKey, verbose bool) string 
 	fmt.Fprintf(&b, " seqnums:[%d-%d]", m.SmallestSeqNum, m.LargestSeqNum)
 	if m.HasPointKeys {
 		fmt.Fprintf(&b, " points:[%s-%s]",
-			m.SmallestPointKey.Pretty(format), m.LargestPointKey.Pretty(format))
+			m.PointKeyBounds.Smallest().Pretty(format), m.PointKeyBounds.Largest().Pretty(format))
 	}
 	if m.HasRangeKeys {
 		fmt.Fprintf(&b, " ranges:[%s-%s]",
@@ -950,9 +952,9 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 
 		case "points":
 			p.Expect("[")
-			m.SmallestPointKey = p.InternalKey()
+			smallestPoint := p.InternalKey()
 			p.Expect("-")
-			m.LargestPointKey = p.InternalKey()
+			m.PointKeyBounds.SetInternalKeyBounds(smallestPoint, p.InternalKey())
 			m.HasPointKeys = true
 			p.Expect("]")
 
@@ -993,13 +995,13 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 	}
 
 	cmp := base.DefaultComparer.Compare
-	if base.InternalCompare(cmp, smallest, m.SmallestPointKey) == 0 {
+	if base.InternalCompare(cmp, smallest, m.PointKeyBounds.Smallest()) == 0 {
 		m.boundTypeSmallest = boundTypePointKey
 
 	} else if base.InternalCompare(cmp, smallest, m.RangeKeyBounds.Smallest()) == 0 {
 		m.boundTypeSmallest = boundTypeRangeKey
 	}
-	if base.InternalCompare(cmp, largest, m.LargestPointKey) == 0 {
+	if base.InternalCompare(cmp, largest, m.PointKeyBounds.Largest()) == 0 {
 		m.boundTypeLargest = boundTypePointKey
 	} else if base.InternalCompare(cmp, largest, m.RangeKeyBounds.Largest()) == 0 {
 		m.boundTypeLargest = boundTypeRangeKey
@@ -1009,7 +1011,7 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 	// keys. This preserves backwards compatability with existing test cases that
 	// specify only the overall bounds.
 	if !m.HasPointKeys && !m.HasRangeKeys {
-		m.SmallestPointKey, m.LargestPointKey = smallest, largest
+		m.PointKeyBounds.SetInternalKeyBounds(smallest, largest)
 		m.HasPointKeys = true
 		m.boundTypeSmallest, m.boundTypeLargest = boundTypePointKey, boundTypePointKey
 	}
@@ -1048,25 +1050,25 @@ func (m *TableMetadata) Validate(cmp Compare, formatKey base.FormatKey) error {
 	// Point key validation.
 
 	if m.HasPointKeys {
-		if base.InternalCompare(cmp, m.SmallestPointKey, m.LargestPointKey) > 0 {
+		if base.InternalCompare(cmp, m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest()) > 0 {
 			return base.CorruptionErrorf("file %s has inconsistent point key bounds: %s vs %s",
-				errors.Safe(m.FileNum), m.SmallestPointKey.Pretty(formatKey),
-				m.LargestPointKey.Pretty(formatKey))
+				errors.Safe(m.FileNum), m.PointKeyBounds.Smallest().Pretty(formatKey),
+				m.PointKeyBounds.Largest().Pretty(formatKey))
 		}
-		if base.InternalCompare(cmp, m.SmallestPointKey, m.Smallest()) < 0 ||
-			base.InternalCompare(cmp, m.LargestPointKey, m.Largest()) > 0 {
+		if base.InternalCompare(cmp, m.PointKeyBounds.Smallest(), m.Smallest()) < 0 ||
+			base.InternalCompare(cmp, m.PointKeyBounds.Largest(), m.Largest()) > 0 {
 			return base.CorruptionErrorf(
 				"file %s has inconsistent point key bounds relative to overall bounds: "+
 					"overall = [%s-%s], point keys = [%s-%s]",
 				errors.Safe(m.FileNum),
 				m.Smallest().Pretty(formatKey), m.Largest().Pretty(formatKey),
-				m.SmallestPointKey.Pretty(formatKey), m.LargestPointKey.Pretty(formatKey),
+				m.PointKeyBounds.Smallest().Pretty(formatKey), m.PointKeyBounds.Largest().Pretty(formatKey),
 			)
 		}
-		if !isValidPointBoundKeyKind[m.SmallestPointKey.Kind()] {
+		if !isValidPointBoundKeyKind[m.PointKeyBounds.Smallest().Kind()] {
 			return base.CorruptionErrorf("file %s has invalid smallest point key kind", m)
 		}
-		if !isValidPointBoundKeyKind[m.LargestPointKey.Kind()] {
+		if !isValidPointBoundKeyKind[m.PointKeyBounds.Largest().Kind()] {
 			return base.CorruptionErrorf("file %s has invalid largest point key kind", m)
 		}
 	}
@@ -1186,7 +1188,7 @@ func (m *TableMetadata) cmpSmallestKey(b *TableMetadata, cmp Compare) int {
 func (m *TableMetadata) Smallest() InternalKey {
 	switch m.boundTypeSmallest {
 	case boundTypePointKey:
-		return m.SmallestPointKey
+		return m.PointKeyBounds.Smallest()
 	case boundTypeRangeKey:
 		return m.RangeKeyBounds.Smallest()
 	default:
@@ -1199,7 +1201,7 @@ func (m *TableMetadata) Smallest() InternalKey {
 func (m *TableMetadata) Largest() InternalKey {
 	switch m.boundTypeLargest {
 	case boundTypePointKey:
-		return m.LargestPointKey
+		return m.PointKeyBounds.Largest()
 	case boundTypeRangeKey:
 		return m.RangeKeyBounds.Largest()
 	default:

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -400,7 +400,7 @@ type TableMetadata struct {
 	// table bounds.
 	boundTypeSmallest, boundTypeLargest boundType
 	// VirtualParams are set only when Virtual is true.
-	VirtualParams virtual.VirtualReaderParams
+	VirtualParams *virtual.VirtualReaderParams
 
 	// SyntheticPrefix is used to prepend a prefix to all keys and/or override all
 	// suffixes in a table; used for some virtual tables.
@@ -612,7 +612,7 @@ func (m *TableMetadata) AttachVirtualBacking(backing *FileBacking) {
 	if m.Smallest().UserKey == nil || m.Largest().UserKey == nil {
 		panic("bounds must be set before attaching backing")
 	}
-	m.VirtualParams = virtual.VirtualReaderParams{
+	m.VirtualParams = &virtual.VirtualReaderParams{
 		Lower:   m.Smallest(),
 		Upper:   m.Largest(),
 		FileNum: m.FileNum,

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -29,6 +30,69 @@ type Compare = base.Compare
 
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey
+
+// InternalKeyBounds represents set of keys (smallest, largest) used for the
+// in-memory and on-disk partial DBs that make up a pebble DB.
+//
+// It consists of the smallest, largest keys and their respective trailers.
+// The keys are represented as a single string; their individual representations
+// are given by the userKeySeparatorIdx as:
+//   - smallest: [0, userKeySeparatorIdx)
+//   - largest: [userKeySeparatorIdx, len(userKeyData))
+//
+// This format allows us to save a couple of bytes that will add up
+// proportionally to the amount of sstables we have.
+type InternalKeyBounds struct {
+	userKeyData         string
+	userKeySeparatorIdx int
+	smallestTrailer     base.InternalKeyTrailer
+	largestTrailer      base.InternalKeyTrailer
+}
+
+func (ikr *InternalKeyBounds) SetInternalKeyBounds(smallest, largest InternalKey) {
+	ikr.userKeyData = string(smallest.UserKey) + string(largest.UserKey)
+	ikr.smallestTrailer = smallest.Trailer
+	ikr.largestTrailer = largest.Trailer
+	ikr.userKeySeparatorIdx = len(smallest.UserKey)
+}
+
+func (ikr *InternalKeyBounds) SmallestUserKey() []byte {
+	return unsafe.Slice(unsafe.StringData(ikr.userKeyData), ikr.userKeySeparatorIdx)
+}
+
+func (ikr *InternalKeyBounds) Smallest() InternalKey {
+	return InternalKey{
+		UserKey: ikr.SmallestUserKey(),
+		Trailer: ikr.smallestTrailer,
+	}
+}
+
+func (ikr *InternalKeyBounds) LargestUserKey() []byte {
+	largestStart := unsafe.StringData(ikr.userKeyData[ikr.userKeySeparatorIdx:])
+	return unsafe.Slice(largestStart, len(ikr.userKeyData)-ikr.userKeySeparatorIdx)
+}
+
+func (ikr *InternalKeyBounds) Largest() InternalKey {
+	ik := InternalKey{
+		UserKey: ikr.LargestUserKey(),
+		Trailer: ikr.largestTrailer,
+	}
+	return ik
+}
+
+func (ikr *InternalKeyBounds) SetSmallest(ik InternalKey) {
+	largest := ikr.Largest()
+	ikr.userKeyData = string(ik.UserKey) + string(largest.UserKey)
+	ikr.smallestTrailer = ik.Trailer
+	ikr.userKeySeparatorIdx = len(ik.UserKey)
+}
+
+func (ikr *InternalKeyBounds) SetLargest(ik InternalKey) {
+	smallest := ikr.Smallest()
+	ikr.userKeyData = string(smallest.UserKey) + string(ik.UserKey)
+	ikr.largestTrailer = ik.Trailer
+	ikr.userKeySeparatorIdx = len(smallest.UserKey)
+}
 
 // TableInfo contains the common information for table related events.
 type TableInfo struct {
@@ -254,12 +318,11 @@ type TableMetadata struct {
 	// exported for reads as an optimization.
 	SmallestPointKey InternalKey
 	LargestPointKey  InternalKey
-	// SmallestRangeKey and LargestRangeKey are the inclusive bounds for the
+	// RangeKeyBounds.Smallest() and RangeKeyBounds.Largest() are the inclusive bounds for the
 	// internal range keys stored in the table.
 	// NB: these field should be set using ExtendRangeKeyBounds. They are left
 	// exported for reads as an optimization.
-	SmallestRangeKey InternalKey
-	LargestRangeKey  InternalKey
+	RangeKeyBounds InternalKeyBounds
 	// BlobReferences is a list of blob files containing values that are
 	// referenced by this sstable.
 	BlobReferences BlobReferences
@@ -408,7 +471,7 @@ func (m *TableMetadata) UserKeyBoundsByType(keyType KeyType) base.UserKeyBounds 
 	case KeyTypePoint:
 		return base.UserKeyBoundsFromInternal(m.SmallestPointKey, m.LargestPointKey)
 	case KeyTypeRange:
-		return base.UserKeyBoundsFromInternal(m.SmallestRangeKey, m.LargestRangeKey)
+		return base.UserKeyBoundsFromInternal(m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest())
 	default:
 		return base.UserKeyBoundsFromInternal(m.Smallest(), m.Largest())
 	}
@@ -656,18 +719,21 @@ func (m *TableMetadata) ExtendRangeKeyBounds(
 ) *TableMetadata {
 	// Update the range key bounds.
 	if !m.HasRangeKeys {
-		m.SmallestRangeKey, m.LargestRangeKey = smallest, largest
+		m.RangeKeyBounds.SetInternalKeyBounds(smallest, largest)
 		m.HasRangeKeys = true
 	} else {
-		if base.InternalCompare(cmp, smallest, m.SmallestRangeKey) < 0 {
-			m.SmallestRangeKey = smallest
-		}
-		if base.InternalCompare(cmp, largest, m.LargestRangeKey) > 0 {
-			m.LargestRangeKey = largest
+		isSmallestRange := base.InternalCompare(cmp, smallest, m.RangeKeyBounds.Smallest()) < 0
+		isLargestRange := base.InternalCompare(cmp, largest, m.RangeKeyBounds.Largest()) > 0
+		if isSmallestRange && isLargestRange {
+			m.RangeKeyBounds.SetInternalKeyBounds(smallest, largest)
+		} else if isSmallestRange {
+			m.RangeKeyBounds.SetSmallest(smallest)
+		} else if isLargestRange {
+			m.RangeKeyBounds.SetLargest(largest)
 		}
 	}
 	// Update the overall bounds.
-	m.extendOverallBounds(cmp, m.SmallestRangeKey, m.LargestRangeKey, boundTypeRangeKey)
+	m.extendOverallBounds(cmp, m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest(), boundTypeRangeKey)
 	return m
 }
 
@@ -730,7 +796,7 @@ func (m *TableMetadata) SmallestBound(kt KeyType) (InternalKey, bool) {
 	case KeyTypePoint:
 		return m.SmallestPointKey, m.HasPointKeys
 	case KeyTypeRange:
-		return m.SmallestRangeKey, m.HasRangeKeys
+		return m.RangeKeyBounds.Smallest(), m.HasRangeKeys
 	default:
 		panic("unrecognized key type")
 	}
@@ -747,7 +813,7 @@ func (m *TableMetadata) LargestBound(kt KeyType) (InternalKey, bool) {
 	case KeyTypePoint:
 		return m.LargestPointKey, m.HasPointKeys
 	case KeyTypeRange:
-		return m.LargestRangeKey, m.HasRangeKeys
+		return m.RangeKeyBounds.Largest(), m.HasRangeKeys
 	default:
 		panic("unrecognized key type")
 	}
@@ -815,7 +881,7 @@ func (m *TableMetadata) DebugString(format base.FormatKey, verbose bool) string 
 	}
 	if m.HasRangeKeys {
 		fmt.Fprintf(&b, " ranges:[%s-%s]",
-			m.SmallestRangeKey.Pretty(format), m.LargestRangeKey.Pretty(format))
+			m.RangeKeyBounds.Smallest().Pretty(format), m.RangeKeyBounds.Largest().Pretty(format))
 	}
 	if m.Size != 0 {
 		fmt.Fprintf(&b, " size:%d", m.Size)
@@ -892,9 +958,9 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 
 		case "ranges":
 			p.Expect("[")
-			m.SmallestRangeKey = p.InternalKey()
+			smallest := p.InternalKey()
 			p.Expect("-")
-			m.LargestRangeKey = p.InternalKey()
+			m.RangeKeyBounds.SetInternalKeyBounds(smallest, p.InternalKey())
 			m.HasRangeKeys = true
 			p.Expect("]")
 
@@ -930,12 +996,12 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 	if base.InternalCompare(cmp, smallest, m.SmallestPointKey) == 0 {
 		m.boundTypeSmallest = boundTypePointKey
 
-	} else if base.InternalCompare(cmp, smallest, m.SmallestRangeKey) == 0 {
+	} else if base.InternalCompare(cmp, smallest, m.RangeKeyBounds.Smallest()) == 0 {
 		m.boundTypeSmallest = boundTypeRangeKey
 	}
 	if base.InternalCompare(cmp, largest, m.LargestPointKey) == 0 {
 		m.boundTypeLargest = boundTypePointKey
-	} else if base.InternalCompare(cmp, largest, m.LargestRangeKey) == 0 {
+	} else if base.InternalCompare(cmp, largest, m.RangeKeyBounds.Largest()) == 0 {
 		m.boundTypeLargest = boundTypeRangeKey
 	}
 
@@ -1008,25 +1074,25 @@ func (m *TableMetadata) Validate(cmp Compare, formatKey base.FormatKey) error {
 	// Range key validation.
 
 	if m.HasRangeKeys {
-		if base.InternalCompare(cmp, m.SmallestRangeKey, m.LargestRangeKey) > 0 {
+		if base.InternalCompare(cmp, m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest()) > 0 {
 			return base.CorruptionErrorf("file %s has inconsistent range key bounds: %s vs %s",
-				errors.Safe(m.FileNum), m.SmallestRangeKey.Pretty(formatKey),
-				m.LargestRangeKey.Pretty(formatKey))
+				errors.Safe(m.FileNum), m.RangeKeyBounds.Smallest().Pretty(formatKey),
+				m.RangeKeyBounds.Largest().Pretty(formatKey))
 		}
-		if base.InternalCompare(cmp, m.SmallestRangeKey, m.Smallest()) < 0 ||
-			base.InternalCompare(cmp, m.LargestRangeKey, m.Largest()) > 0 {
+		if base.InternalCompare(cmp, m.RangeKeyBounds.Smallest(), m.Smallest()) < 0 ||
+			base.InternalCompare(cmp, m.RangeKeyBounds.Largest(), m.Largest()) > 0 {
 			return base.CorruptionErrorf(
 				"file %s has inconsistent range key bounds relative to overall bounds: "+
 					"overall = [%s-%s], range keys = [%s-%s]",
 				errors.Safe(m.FileNum),
 				m.Smallest().Pretty(formatKey), m.Largest().Pretty(formatKey),
-				m.SmallestRangeKey.Pretty(formatKey), m.LargestRangeKey.Pretty(formatKey),
+				m.RangeKeyBounds.Smallest().Pretty(formatKey), m.RangeKeyBounds.Largest().Pretty(formatKey),
 			)
 		}
-		if !isValidRangeKeyBoundKeyKind[m.SmallestRangeKey.Kind()] {
+		if !isValidRangeKeyBoundKeyKind[m.RangeKeyBounds.Smallest().Kind()] {
 			return base.CorruptionErrorf("file %s has invalid smallest range key kind", m)
 		}
-		if !isValidRangeKeyBoundKeyKind[m.LargestRangeKey.Kind()] {
+		if !isValidRangeKeyBoundKeyKind[m.RangeKeyBounds.Largest().Kind()] {
 			return base.CorruptionErrorf("file %s has invalid largest range key kind", m)
 		}
 	}
@@ -1122,7 +1188,7 @@ func (m *TableMetadata) Smallest() InternalKey {
 	case boundTypePointKey:
 		return m.SmallestPointKey
 	case boundTypeRangeKey:
-		return m.SmallestRangeKey
+		return m.RangeKeyBounds.Smallest()
 	default:
 		return InternalKey{}
 	}
@@ -1135,7 +1201,7 @@ func (m *TableMetadata) Largest() InternalKey {
 	case boundTypePointKey:
 		return m.LargestPointKey
 	case boundTypeRangeKey:
-		return m.LargestRangeKey
+		return m.RangeKeyBounds.Largest()
 	default:
 		return InternalKey{}
 	}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -722,15 +722,15 @@ func (m *TableMetadata) ContainsKeyType(kt KeyType) bool {
 // SmallestBound returns the file's smallest bound of the key type. It returns a
 // false second return value if the file does not contain any keys of the key
 // type.
-func (m *TableMetadata) SmallestBound(kt KeyType) (*InternalKey, bool) {
+func (m *TableMetadata) SmallestBound(kt KeyType) (InternalKey, bool) {
 	switch kt {
 	case KeyTypePointAndRange:
 		ik := m.Smallest()
-		return &ik, true
+		return ik, true
 	case KeyTypePoint:
-		return &m.SmallestPointKey, m.HasPointKeys
+		return m.SmallestPointKey, m.HasPointKeys
 	case KeyTypeRange:
-		return &m.SmallestRangeKey, m.HasRangeKeys
+		return m.SmallestRangeKey, m.HasRangeKeys
 	default:
 		panic("unrecognized key type")
 	}
@@ -739,15 +739,15 @@ func (m *TableMetadata) SmallestBound(kt KeyType) (*InternalKey, bool) {
 // LargestBound returns the file's largest bound of the key type. It returns a
 // false second return value if the file does not contain any keys of the key
 // type.
-func (m *TableMetadata) LargestBound(kt KeyType) (*InternalKey, bool) {
+func (m *TableMetadata) LargestBound(kt KeyType) (InternalKey, bool) {
 	switch kt {
 	case KeyTypePointAndRange:
 		ik := m.Largest()
-		return &ik, true
+		return ik, true
 	case KeyTypePoint:
-		return &m.LargestPointKey, m.HasPointKeys
+		return m.LargestPointKey, m.HasPointKeys
 	case KeyTypeRange:
-		return &m.LargestRangeKey, m.HasRangeKeys
+		return m.LargestRangeKey, m.HasRangeKeys
 	default:
 		panic("unrecognized key type")
 	}

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -478,6 +478,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 					m.HasPointKeys = true
 				}
 				// Set range key bounds.
+				m.RangeKeyBounds = &InternalKeyBounds{}
 				m.RangeKeyBounds.SetInternalKeyBounds(base.DecodeInternalKey(smallestRangeKey),
 					base.DecodeInternalKey(largestRangeKey))
 				m.HasRangeKeys = true
@@ -775,9 +776,11 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 				e.writeKey(x.Meta.PointKeyBounds.Smallest())
 				e.writeKey(x.Meta.PointKeyBounds.Largest())
 			}
-			// Write range key bounds.
-			e.writeKey(x.Meta.RangeKeyBounds.Smallest())
-			e.writeKey(x.Meta.RangeKeyBounds.Largest())
+			// Write range key bounds (if present).
+			if x.Meta.HasRangeKeys {
+				e.writeKey(x.Meta.RangeKeyBounds.Smallest())
+				e.writeKey(x.Meta.RangeKeyBounds.Largest())
+			}
 		}
 		e.writeUvarint(uint64(x.Meta.SmallestSeqNum))
 		e.writeUvarint(uint64(x.Meta.LargestSeqNum))

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -466,15 +466,15 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			}
 
 			if tag != tagNewFile5 { // no range keys present
-				m.SmallestPointKey = base.DecodeInternalKey(smallestPointKey)
-				m.LargestPointKey = base.DecodeInternalKey(largestPointKey)
+				m.PointKeyBounds.SetInternalKeyBounds(base.DecodeInternalKey(smallestPointKey),
+					base.DecodeInternalKey(largestPointKey))
 				m.HasPointKeys = true
 				m.boundTypeSmallest, m.boundTypeLargest = boundTypePointKey, boundTypePointKey
 			} else { // range keys present
 				// Set point key bounds, if parsed.
 				if parsedPointBounds {
-					m.SmallestPointKey = base.DecodeInternalKey(smallestPointKey)
-					m.LargestPointKey = base.DecodeInternalKey(largestPointKey)
+					m.PointKeyBounds.SetInternalKeyBounds(base.DecodeInternalKey(smallestPointKey),
+						base.DecodeInternalKey(largestPointKey))
 					m.HasPointKeys = true
 				}
 				// Set range key bounds.
@@ -756,8 +756,8 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 		if !x.Meta.HasRangeKeys {
 			// If we have no range keys, preserve the original format and write the
 			// smallest and largest point keys.
-			e.writeKey(x.Meta.SmallestPointKey)
-			e.writeKey(x.Meta.LargestPointKey)
+			e.writeKey(x.Meta.PointKeyBounds.Smallest())
+			e.writeKey(x.Meta.PointKeyBounds.Largest())
 		} else {
 			// When range keys are present, we first write a marker byte that
 			// indicates if the table also contains point keys, in addition to how the
@@ -772,8 +772,8 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 			}
 			// Write point key bounds (if present).
 			if x.Meta.HasPointKeys {
-				e.writeKey(x.Meta.SmallestPointKey)
-				e.writeKey(x.Meta.LargestPointKey)
+				e.writeKey(x.Meta.PointKeyBounds.Smallest())
+				e.writeKey(x.Meta.PointKeyBounds.Largest())
 			}
 			// Write range key bounds.
 			e.writeKey(x.Meta.RangeKeyBounds.Smallest())

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -478,8 +478,8 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 					m.HasPointKeys = true
 				}
 				// Set range key bounds.
-				m.SmallestRangeKey = base.DecodeInternalKey(smallestRangeKey)
-				m.LargestRangeKey = base.DecodeInternalKey(largestRangeKey)
+				m.RangeKeyBounds.SetInternalKeyBounds(base.DecodeInternalKey(smallestRangeKey),
+					base.DecodeInternalKey(largestRangeKey))
 				m.HasRangeKeys = true
 				// Set overall bounds (by default assume range keys).
 				m.boundTypeSmallest, m.boundTypeLargest = boundTypeRangeKey, boundTypeRangeKey
@@ -776,8 +776,8 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 				e.writeKey(x.Meta.LargestPointKey)
 			}
 			// Write range key bounds.
-			e.writeKey(x.Meta.SmallestRangeKey)
-			e.writeKey(x.Meta.LargestRangeKey)
+			e.writeKey(x.Meta.RangeKeyBounds.Smallest())
+			e.writeKey(x.Meta.RangeKeyBounds.Largest())
 		}
 		e.writeUvarint(uint64(x.Meta.SmallestSeqNum))
 		e.writeUvarint(uint64(x.Meta.LargestSeqNum))

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -846,7 +846,7 @@ func TestTableMetadataSize(t *testing.T) {
 	}
 	structSize := unsafe.Sizeof(TableMetadata{})
 
-	const tableMetadataSize = 400
+	const tableMetadataSize = 368
 	if structSize != tableMetadataSize {
 		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableMetadataSize)

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -846,7 +846,7 @@ func TestTableMetadataSize(t *testing.T) {
 	}
 	structSize := unsafe.Sizeof(TableMetadata{})
 
-	const tableMetadataSize = 448 // bytes
+	const tableMetadataSize = 424
 	if structSize != tableMetadataSize {
 		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableMetadataSize)

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -846,7 +846,7 @@ func TestTableMetadataSize(t *testing.T) {
 	}
 	structSize := unsafe.Sizeof(TableMetadata{})
 
-	const tableMetadataSize = 368
+	const tableMetadataSize = 304
 	if structSize != tableMetadataSize {
 		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableMetadataSize)

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -846,7 +846,7 @@ func TestTableMetadataSize(t *testing.T) {
 	}
 	structSize := unsafe.Sizeof(TableMetadata{})
 
-	const tableMetadataSize = 424
+	const tableMetadataSize = 400
 	if structSize != tableMetadataSize {
 		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableMetadataSize)

--- a/iterator.go
+++ b/iterator.go
@@ -848,10 +848,10 @@ func (i *Iterator) sampleRead() {
 				var containsKey bool
 				if i.pos == iterPosNext || i.pos == iterPosCurForward ||
 					i.pos == iterPosCurForwardPaused {
-					containsKey = i.cmp(f.SmallestPointKey.UserKey, i.key) <= 0
+					containsKey = i.cmp(f.PointKeyBounds.SmallestUserKey(), i.key) <= 0
 				} else if i.pos == iterPosPrev || i.pos == iterPosCurReverse ||
 					i.pos == iterPosCurReversePaused {
-					containsKey = i.cmp(f.LargestPointKey.UserKey, i.key) >= 0
+					containsKey = i.cmp(f.PointKeyBounds.LargestUserKey(), i.key) >= 0
 				}
 				// Do nothing if the current key is not contained in f's
 				// bounds. We could seek the LevelIterator at this level
@@ -887,8 +887,8 @@ func (i *Iterator) sampleRead() {
 			topFile.AllowedSeeks.Add(topFile.InitAllowedSeeks)
 
 			read := readCompaction{
-				start:   topFile.SmallestPointKey.UserKey,
-				end:     topFile.LargestPointKey.UserKey,
+				start:   topFile.PointKeyBounds.SmallestUserKey(),
+				end:     topFile.PointKeyBounds.LargestUserKey(),
 				level:   topLevel,
 				fileNum: topFile.FileNum,
 			}

--- a/level_iter.go
+++ b/level_iter.go
@@ -204,8 +204,8 @@ func (l *levelIter) maybeTriggerCombinedIteration(file *tableMetadata, dir int) 
 	// tell us whether the file has any RangeKeySets. Otherwise, we must
 	// fallback to assuming it does if HasRangeKeys=true.
 	if file != nil && file.HasRangeKeys && l.combinedIterState != nil && !l.combinedIterState.initialized &&
-		(l.upper == nil || l.cmp(file.SmallestRangeKey.UserKey, l.upper) < 0) &&
-		(l.lower == nil || l.cmp(file.LargestRangeKey.UserKey, l.lower) > 0) &&
+		(l.upper == nil || l.cmp(file.RangeKeyBounds.SmallestUserKey(), l.upper) < 0) &&
+		(l.lower == nil || l.cmp(file.RangeKeyBounds.LargestUserKey(), l.lower) > 0) &&
 		(!file.StatsValid() || file.Stats.NumRangeKeySets > 0) {
 		// The file contains range keys, and we're not using combined iteration yet.
 		// Trigger a switch to combined iteration. It's possible that a switch has
@@ -223,16 +223,16 @@ func (l *levelIter) maybeTriggerCombinedIteration(file *tableMetadata, dir int) 
 		case +1:
 			if !l.combinedIterState.triggered {
 				l.combinedIterState.triggered = true
-				l.combinedIterState.key = file.SmallestRangeKey.UserKey
-			} else if l.cmp(l.combinedIterState.key, file.SmallestRangeKey.UserKey) > 0 {
-				l.combinedIterState.key = file.SmallestRangeKey.UserKey
+				l.combinedIterState.key = file.RangeKeyBounds.SmallestUserKey()
+			} else if l.cmp(l.combinedIterState.key, file.RangeKeyBounds.SmallestUserKey()) > 0 {
+				l.combinedIterState.key = file.RangeKeyBounds.SmallestUserKey()
 			}
 		case -1:
 			if !l.combinedIterState.triggered {
 				l.combinedIterState.triggered = true
-				l.combinedIterState.key = file.LargestRangeKey.UserKey
-			} else if l.cmp(l.combinedIterState.key, file.LargestRangeKey.UserKey) < 0 {
-				l.combinedIterState.key = file.LargestRangeKey.UserKey
+				l.combinedIterState.key = file.RangeKeyBounds.LargestUserKey()
+			} else if l.cmp(l.combinedIterState.key, file.RangeKeyBounds.LargestUserKey()) < 0 {
+				l.combinedIterState.key = file.RangeKeyBounds.LargestUserKey()
 			}
 		}
 	}

--- a/lsm_view.go
+++ b/lsm_view.go
@@ -203,7 +203,7 @@ func (b *lsmViewBuilder) tableDetails(
 	const maxRangeDels = 10
 	const maxRangeKeys = 10
 	if m.HasPointKeys {
-		outf("points: %s - %s", m.SmallestPointKey.Pretty(b.fmtKey), m.LargestPointKey.Pretty(b.fmtKey))
+		outf("points: %s - %s", m.PointKeyBounds.Smallest().Pretty(b.fmtKey), m.PointKeyBounds.Largest().Pretty(b.fmtKey))
 		if b.scanTables {
 			n := 0
 			if it := iters.point; it != nil {

--- a/lsm_view.go
+++ b/lsm_view.go
@@ -248,7 +248,7 @@ func (b *lsmViewBuilder) tableDetails(
 		}
 	}
 	if m.HasRangeKeys {
-		outf("range keys: %s - %s", m.SmallestRangeKey.Pretty(b.fmtKey), m.LargestRangeKey.Pretty(b.fmtKey))
+		outf("range keys: %s - %s", m.RangeKeyBounds.Smallest().Pretty(b.fmtKey), m.RangeKeyBounds.Largest().Pretty(b.fmtKey))
 		n := 0
 		if it := iters.rangeKey; it != nil {
 			span, err := it.First()

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -93,8 +93,8 @@ func (s *SharedSSTMeta) cloneFromFileMeta(f *tableMetadata) {
 	*s = SharedSSTMeta{
 		Smallest:         f.Smallest().Clone(),
 		Largest:          f.Largest().Clone(),
-		SmallestRangeKey: f.SmallestRangeKey.Clone(),
-		LargestRangeKey:  f.LargestRangeKey.Clone(),
+		SmallestRangeKey: f.RangeKeyBounds.Smallest().Clone(),
+		LargestRangeKey:  f.RangeKeyBounds.Largest().Clone(),
 		SmallestPointKey: f.SmallestPointKey.Clone(),
 		LargestPointKey:  f.LargestPointKey.Clone(),
 		Size:             f.Size,

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -93,12 +93,14 @@ func (s *SharedSSTMeta) cloneFromFileMeta(f *tableMetadata) {
 	*s = SharedSSTMeta{
 		Smallest:         f.Smallest().Clone(),
 		Largest:          f.Largest().Clone(),
-		SmallestRangeKey: f.RangeKeyBounds.Smallest().Clone(),
-		LargestRangeKey:  f.RangeKeyBounds.Largest().Clone(),
 		SmallestPointKey: f.PointKeyBounds.Smallest().Clone(),
 		LargestPointKey:  f.PointKeyBounds.Largest().Clone(),
 		Size:             f.Size,
 		fileNum:          f.FileNum,
+	}
+	if f.HasRangeKeys {
+		s.SmallestRangeKey = f.RangeKeyBounds.Smallest().Clone()
+		s.LargestRangeKey = f.RangeKeyBounds.Largest().Clone()
 	}
 }
 

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -95,8 +95,8 @@ func (s *SharedSSTMeta) cloneFromFileMeta(f *tableMetadata) {
 		Largest:          f.Largest().Clone(),
 		SmallestRangeKey: f.RangeKeyBounds.Smallest().Clone(),
 		LargestRangeKey:  f.RangeKeyBounds.Largest().Clone(),
-		SmallestPointKey: f.SmallestPointKey.Clone(),
-		LargestPointKey:  f.LargestPointKey.Clone(),
+		SmallestPointKey: f.PointKeyBounds.Smallest().Clone(),
+		LargestPointKey:  f.PointKeyBounds.Largest().Clone(),
 		Size:             f.Size,
 		fileNum:          f.FileNum,
 	}

--- a/table_stats.go
+++ b/table_stats.go
@@ -992,7 +992,7 @@ func newCombinedDeletionKeyspanIter(
 		// TODO(jackson): Only use AssertBounds in invariants builds in the
 		// following release.
 		iter = keyspan.AssertBounds(
-			iter, m.SmallestPointKey, m.LargestPointKey.UserKey, comparer.Compare,
+			iter, m.PointKeyBounds.Smallest(), m.PointKeyBounds.LargestUserKey(), comparer.Compare,
 		)
 		dIter := &keyspan.DefragmentingIter{}
 		dIter.Init(comparer, iter, equal, reducer, new(keyspan.DefragmentingBuffers))

--- a/table_stats.go
+++ b/table_stats.go
@@ -1008,7 +1008,7 @@ func newCombinedDeletionKeyspanIter(
 		// Assert expected bounds in tests.
 		if invariants.Sometimes(50) {
 			iter = keyspan.AssertBounds(
-				iter, m.SmallestRangeKey, m.LargestRangeKey.UserKey, comparer.Compare,
+				iter, m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.LargestUserKey(), comparer.Compare,
 			)
 		}
 		// Wrap the range key iterator in a filter that elides keys other than range

--- a/table_stats.go
+++ b/table_stats.go
@@ -1007,9 +1007,11 @@ func newCombinedDeletionKeyspanIter(
 	if iter != nil {
 		// Assert expected bounds in tests.
 		if invariants.Sometimes(50) {
-			iter = keyspan.AssertBounds(
-				iter, m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.LargestUserKey(), comparer.Compare,
-			)
+			if m.HasRangeKeys {
+				iter = keyspan.AssertBounds(
+					iter, m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.LargestUserKey(), comparer.Compare,
+				)
+			}
 		}
 		// Wrap the range key iterator in a filter that elides keys other than range
 		// key deletions.

--- a/testdata/ingest_load
+++ b/testdata/ingest_load
@@ -17,7 +17,6 @@ a.SET.0:
 ----
 1: a#0,SET-a#0,SET
   points: a#0,SET-a#0,SET
-  ranges: #0,DEL-#0,DEL
 
 load
 a.SET.0:
@@ -25,14 +24,12 @@ b.SET.0:
 ----
 1: a#0,SET-b#0,SET
   points: a#0,SET-b#0,SET
-  ranges: #0,DEL-#0,DEL
 
 load
 a.DEL.0:
 ----
 1: a#0,DEL-a#0,DEL
   points: a#0,DEL-a#0,DEL
-  ranges: #0,DEL-#0,DEL
 
 load
 a.DEL.0:
@@ -40,14 +37,12 @@ b.DEL.0:
 ----
 1: a#0,DEL-b#0,DEL
   points: a#0,DEL-b#0,DEL
-  ranges: #0,DEL-#0,DEL
 
 load
 a.MERGE.0:
 ----
 1: a#0,MERGE-a#0,MERGE
   points: a#0,MERGE-a#0,MERGE
-  ranges: #0,DEL-#0,DEL
 
 load
 a.MERGE.0:
@@ -55,22 +50,12 @@ b.MERGE.0:
 ----
 1: a#0,MERGE-b#0,MERGE
   points: a#0,MERGE-b#0,MERGE
-  ranges: #0,DEL-#0,DEL
 
 load
 Span: a-b:{(#0,RANGEDEL)}
 ----
 1: a#0,RANGEDEL-b#inf,RANGEDEL
   points: a#0,RANGEDEL-b#inf,RANGEDEL
-  ranges: #0,DEL-#0,DEL
-
-load
-a.SET.0:
-Span: a-b:{(#0,RANGEDEL)}
-----
-1: a#0,RANGEDEL-b#inf,RANGEDEL
-  points: a#0,RANGEDEL-b#inf,RANGEDEL
-  ranges: #0,DEL-#0,DEL
 
 load
 a.SET.0:
@@ -78,7 +63,13 @@ Span: a-b:{(#0,RANGEDEL)}
 ----
 1: a#0,RANGEDEL-b#inf,RANGEDEL
   points: a#0,RANGEDEL-b#inf,RANGEDEL
-  ranges: #0,DEL-#0,DEL
+
+load
+a.SET.0:
+Span: a-b:{(#0,RANGEDEL)}
+----
+1: a#0,RANGEDEL-b#inf,RANGEDEL
+  points: a#0,RANGEDEL-b#inf,RANGEDEL
 
 load
 b.SET.0:
@@ -86,7 +77,6 @@ Span: a-b:{(#0,RANGEDEL)}
 ----
 1: a#0,RANGEDEL-b#0,SET
   points: a#0,RANGEDEL-b#0,SET
-  ranges: #0,DEL-#0,DEL
 
 # Loading tables at an unsupported table format results in an error.
 # Write a table at version 15 (Pebble,v4) into a DB at version 14 (Pebble,v3).

--- a/testdata/ingest_update_seqnums
+++ b/testdata/ingest_update_seqnums
@@ -38,15 +38,12 @@ update-files
 file 0:
   combined: a#42,SET-c#42,SET
     points: a#42,SET-c#42,SET
-    ranges: #0,DEL-#0,DEL
 file 1:
   combined: a#43,RANGEDEL-c#43,SET
     points: a#43,RANGEDEL-c#43,SET
-    ranges: #0,DEL-#0,DEL
 file 2:
   combined: a#44,SET-c#inf,RANGEDEL
     points: a#44,SET-c#inf,RANGEDEL
-    ranges: #0,DEL-#0,DEL
 
 # Reset to the starting sequence number and reset the slice of files. The
 # following tests consider a single file at a time.


### PR DESCRIPTION
### manifest: use new InternalKeyBounds struct in TableMetadata's range keys
This patch introduces (and uses) a new `InternalKeyBounds` struct to represent
both the smallest, largest range keys (if they exist) in our
`TableMetadata` struct. These keys are now stored as a single string --
spliced by a separator index for individual access.

This allows us to save 24 bytes for our `TableMetadata` struct.

---

### manifest: use InternalKeyBounds struct in TableMetadata's point keys
This patch uses our `InternalKeyBounds` struct to represent
both the smallest, largest point keys in our `TableMetadata` struct.
These keys are now stored as a single string -- spliced by a separator index
for individual access.

This allows us to save 24 bytes for our `TableMetadata` struct.

---

### manifest: make internal range key bound of TableMetadata a pointer
Since range keys are rare, we make our range key bounds a pointer to
save on 32 bytes.

---

### manifest: make virtual params field of TableMetadata a pointer
This field is also rare and only used for virtual sstables.


Fixes: https://github.com/cockroachdb/pebble/issues/2047