### PR TITLE
db: test replica removal of snapshot sstable

### DIFF
--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -702,3 +702,55 @@ o: (o, .)
 get-hints
 ----
 (none)
+
+# Reset the database.
+
+reset
+----
+
+# Simulate an ingestion of a CockroachDB snapshot sstable with a range delete and a
+# range key delete covering the keyspace.
+
+ingest ext
+set c c
+set d d
+set e e
+set f f
+set g g
+del-range c h
+range-key-del c h
+----
+OK
+
+describe-lsm
+----
+L6:
+  000004:[c#10,RANGEKEYDEL-h#inf,RANGEDEL]
+
+snapshot
+----
+snapshot seqnum: 11
+
+# Simulate a replica removal of the previously ingested snapshot through a range
+# delete and range key delete.
+
+batch
+del-range c h
+range-key-del c h
+----
+
+flush
+----
+L0.0:
+  000006:[c#12,RANGEKEYDEL-h#inf,RANGEDEL]
+L6:
+  000004:[c#10,RANGEKEYDEL-h#inf,RANGEDEL]
+
+get-hints
+----
+L0.000006 c-h seqnums(tombstone=11-12, file-smallest=10, type=point-and-range-key)
+
+close-snapshot
+11
+----
+[JOB 100] compacted(delete-only) L6 [000004] (966B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s


### PR DESCRIPTION
In CockroachDB snapshot reception ingests sstables. In some circumstances and verisons of CockroachDB, these sstables have RANGEDEL and RANGEKEYDEL keys spanning the entirety of the KV range's span in order to clear any previous range state.

When a replica is destroyed, CockroachDB may choose to write a RANGEDEL (and possibly a RANGEKEYDEL) over the replica's span to delete the data. If an original sstable from snapshot reception still exists, we would like this sstable to be dropped by a simple deletion-only compaction. This commit adds a unit test that demonstrates this behavior.