### PR TITLE
crl-release-24.1: fix deletion-only compaction bound comparison

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1889,8 +1889,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 
 					h := deleteCompactionHint{
 						hintType:                hintType,
-						start:                   start,
-						end:                     end,
+						bounds:                  base.UserKeyBoundsEndExclusive(start, end),
 						fileSmallestSeqNum:      parseUint64(parts[4]),
 						tombstoneLevel:          tombstoneLevel,
 						tombstoneFile:           tombstoneFile,

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1825,6 +1825,17 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 	datadriven.RunTest(t, "testdata/compaction_delete_only_hints",
 		func(t *testing.T, td *datadriven.TestData) string {
 			switch td.Cmd {
+			case "batch":
+				b := d.NewBatch()
+				err := runBatchDefineCmd(td, b)
+				if err != nil {
+					return err.Error()
+				}
+				if err = b.Commit(Sync); err != nil {
+					return err.Error()
+				}
+				return ""
+
 			case "define":
 				opts, err = reset()
 				if err != nil {
@@ -1838,6 +1849,12 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				s := d.mu.versions.currentVersion().String()
 				d.mu.Unlock()
 				return s
+
+			case "flush":
+				if err := d.Flush(); err != nil {
+					return err.Error()
+				}
+				return runLSMCmd(td, d)
 
 			case "force-set-hints":
 				d.mu.Lock()
@@ -1991,6 +2008,13 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 					return err.Error()
 				}
 				return ""
+
+			case "snapshot":
+				// NB: It's okay that we're letting the snapshot out of scope
+				// without closing it; the close snapshot command will pull the
+				// relevant seqnum off the DB to close it.
+				s := d.NewSnapshot()
+				return fmt.Sprintf("snapshot seqnum: %d", s.seqNum)
 
 			case "ingest":
 				if err = runBuildCmd(td, d, d.opts.FS); err != nil {

--- a/table_stats.go
+++ b/table_stats.go
@@ -7,6 +7,7 @@ package pebble
 import (
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -447,18 +448,16 @@ func (d *DB) loadTableRangeDelStats(
 		if hintSeqNum == math.MaxUint64 {
 			continue
 		}
+		bounds := base.UserKeyBoundsEndExclusive(slices.Clone(start), slices.Clone(end))
 		hint := deleteCompactionHint{
 			hintType:                hintType,
-			start:                   make([]byte, len(start)),
-			end:                     make([]byte, len(end)),
+			bounds:                  bounds,
 			tombstoneFile:           meta,
 			tombstoneLevel:          level,
 			tombstoneLargestSeqNum:  s.LargestSeqNum(),
 			tombstoneSmallestSeqNum: s.SmallestSeqNum(),
 			fileSmallestSeqNum:      hintSeqNum,
 		}
-		copy(hint.start, start)
-		copy(hint.end, end)
 		compactionHints = append(compactionHints, hint)
 	}
 	if err != nil {

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -415,3 +415,62 @@ Deletion hints:
   (none)
 Compactions:
   [JOB 100] compacted(delete-only) L6 [000006 000007 000008 000009 000011] (3.5KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+
+# Reset the database.
+
+reset
+----
+
+# Simulate an ingestion of a CockroachDB snapshot sstable with a range delete and a
+# range key delete covering the keyspace.
+
+ingest ext
+set c c
+set d d
+set e e
+set f f
+set g g
+del-range c h
+range-key-del c h
+----
+OK
+
+describe-lsm
+----
+L6:
+  000004:[c#10,RANGEKEYDEL-h#inf,RANGEDEL]
+
+snapshot
+----
+snapshot seqnum: 11
+
+# Simulate a replica removal of the previously ingested snapshot through a range
+# delete and range key delete.
+
+batch
+del-range c h
+range-key-del c h
+----
+
+flush
+----
+L0.0:
+  000006:[c#12,RANGEKEYDEL-h#inf,RANGEDEL]
+L6:
+  000004:[c#10,RANGEKEYDEL-h#inf,RANGEDEL]
+
+get-hints
+----
+L0.000006 c-h seqnums(tombstone=11-12, file-smallest=10, type=point-and-range-key)
+
+close-snapshot
+11
+----
+[JOB 100] compacted(elision-only) L6 [000004] (871B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000007] (621B), in 1.0s (2.0s total), output rate 621B/s
+
+maybe-compact
+----
+Deletion hints:
+  (none)
+Compactions:
+  (none)

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -49,12 +49,12 @@ L4:
 
 get-hints
 ----
-L0.000004 b-r seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
+L0.000004 [b, r) seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
 
 maybe-compact
 ----
 Deletion hints:
-  L0.000004 b-r seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
+  L0.000004 [b, r) seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
 Compactions:
   (none)
 
@@ -81,7 +81,7 @@ L4:
 
 get-hints
 ----
-L0.000004 b-r seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
+L0.000004 [b, r) seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
 
 maybe-compact
 ----
@@ -119,8 +119,8 @@ L4:
 
 get-hints
 ----
-L0.000004 a-k seqnums(tombstone=300-300, file-smallest=110, type=point-key-only)
-L1.000005 b-r seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
+L0.000004 [a, k) seqnums(tombstone=300-300, file-smallest=110, type=point-key-only)
+L1.000005 [b, r) seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
 
 maybe-compact
 ----
@@ -152,7 +152,7 @@ L4:
 
 get-hints
 ----
-L0.000004 b-r seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
+L0.000004 [b, r) seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
 
 compact a-z
 ----
@@ -194,7 +194,7 @@ L4:
 
 get-hints
 ----
-L1.000004 b-r seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
+L1.000004 [b, r) seqnums(tombstone=200-230, file-smallest=90, type=point-key-only)
 
 # Tables 000005 and 000006 can be deleted as their largest sequence numbers fall
 # below the smallest sequence number of the range del. Table 000007 falls
@@ -240,13 +240,13 @@ get-hints
 force-set-hints
 L0.000001 a-z 0 5-27 point_key_only
 ----
-L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
+L0.000001 [a, z) seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
 
 # Hints on the table are unchanged, as the new sstable is at L6, and hints are
 # not generated on tables at this level.
 get-hints
 ----
-L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
+L0.000001 [a, z) seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
 
 # Closing snapshot 10 triggers an elision-only compaction in L6 rather than a
 # deletion-only compaction, as the earliest snapshot that remains open is 25,
@@ -405,9 +405,9 @@ L6:
 
 get-hints
 ----
-L0.000013 a-i seqnums(tombstone=19-19, file-smallest=12, type=point-key-only)
-L0.000013 i-r seqnums(tombstone=19-19, file-smallest=13, type=point-and-range-key)
-L0.000013 r-z seqnums(tombstone=19-19, file-smallest=17, type=range-key-only)
+L0.000013 [a, i) seqnums(tombstone=19-19, file-smallest=12, type=point-key-only)
+L0.000013 [i, r) seqnums(tombstone=19-19, file-smallest=13, type=point-and-range-key)
+L0.000013 [r, z) seqnums(tombstone=19-19, file-smallest=17, type=range-key-only)
 
 maybe-compact
 ----
@@ -461,12 +461,12 @@ L6:
 
 get-hints
 ----
-L0.000006 c-h seqnums(tombstone=11-12, file-smallest=10, type=point-and-range-key)
+L0.000006 [c, h) seqnums(tombstone=11-12, file-smallest=10, type=point-and-range-key)
 
 close-snapshot
 11
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (871B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000007] (621B), in 1.0s (2.0s total), output rate 621B/s
+[JOB 100] compacted(delete-only) L6 [000004] (871B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 maybe-compact
 ----


### PR DESCRIPTION
Previously resolving a deletion-only compaction hints did not consider an
sstable with an end boundary that's exclusive. This prevented the hint from
being applied in circumstances where it could have been used. In particular, in
the context of CockroachDB this bug prevented the range deletions of replica
removals from removing a sstable that was ingested as a part of snapshot
reception with bounds exactly equal to the range's bounds.