### PR TITLE
crl-release-24.3: db: test replica removal of snapshot sstable

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1384,6 +1384,17 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 	datadriven.RunTest(t, "testdata/compaction_delete_only_hints",
 		func(t *testing.T, td *datadriven.TestData) string {
 			switch td.Cmd {
+			case "batch":
+				b := d.NewBatch()
+				err := runBatchDefineCmd(td, b)
+				if err != nil {
+					return err.Error()
+				}
+				if err = b.Commit(Sync); err != nil {
+					return err.Error()
+				}
+				return ""
+
 			case "define":
 				opts, err = reset()
 				if err != nil {
@@ -1397,6 +1408,12 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				s := d.mu.versions.currentVersion().String()
 				d.mu.Unlock()
 				return s
+
+			case "flush":
+				if err := d.Flush(); err != nil {
+					return err.Error()
+				}
+				return runLSMCmd(td, d)
 
 			case "force-set-hints":
 				d.mu.Lock()
@@ -1547,6 +1564,13 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 					return err.Error()
 				}
 				return ""
+
+			case "snapshot":
+				// NB: It's okay that we're letting the snapshot out of scope
+				// without closing it; the close snapshot command will pull the
+				// relevant seqnum off the DB to close it.
+				s := d.NewSnapshot()
+				return fmt.Sprintf("snapshot seqnum: %d", s.seqNum)
 
 			case "ingest":
 				if err = runBuildCmd(td, d, d.opts.FS); err != nil {

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -702,3 +702,56 @@ o: (o, .)
 get-hints
 ----
 (none)
+
+
+# Reset the database.
+
+reset
+----
+
+# Simulate an ingestion of a CockroachDB snapshot sstable with a range delete and a
+# range key delete covering the keyspace.
+
+ingest ext
+set c c
+set d d
+set e e
+set f f
+set g g
+del-range c h
+range-key-del c h
+----
+OK
+
+describe-lsm
+----
+L6:
+  000004:[c#10,RANGEKEYDEL-h#inf,RANGEDEL]
+
+snapshot
+----
+snapshot seqnum: 11
+
+# Simulate a replica removal of the previously ingested snapshot through a range
+# delete and range key delete.
+
+batch
+del-range c h
+range-key-del c h
+----
+
+flush
+----
+L0.0:
+  000006:[c#12,RANGEKEYDEL-h#inf,RANGEDEL]
+L6:
+  000004:[c#10,RANGEKEYDEL-h#inf,RANGEDEL]
+
+get-hints
+----
+L0.000006 c-h seqnums(tombstone=11-12, file-smallest=10, type=point-and-range-key)
+
+close-snapshot
+11
+----
+[JOB 100] compacted(delete-only) L6 [000004] (987B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s


### PR DESCRIPTION
In CockroachDB snapshot reception ingests sstables. In some circumstances and verisons of CockroachDB, these sstables have RANGEDEL and RANGEKEYDEL keys spanning the entirety of the KV range's span in order to clear any previous range state.

When a replica is destroyed, CockroachDB may choose to write a RANGEDEL (and possibly a RANGEKEYDEL) over the replica's span to delete the data. If an original sstable from snapshot reception still exists, we would like this sstable to be dropped by a simple deletion-only compaction. This commit adds a unit test that demonstrates this behavior.