### PR TITLE
record: add sync offsets to manifest writer

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -494,7 +494,7 @@ func (d *DB) writeCheckpointManifest(
 		// append a record after a raw data copy; see
 		// https://github.com/cockroachdb/cockroach/issues/100935).
 		r := record.NewReader(&io.LimitedReader{R: src, N: manifestSize}, manifestFileNum)
-		w := record.NewWriter(dst)
+		w := record.NewWriter(dst, manifestFileNum, d.FormatMajorVersion() >= FormatManifestSyncChunks)
 		for {
 			rr, err := r.Next()
 			if err != nil {

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -226,6 +226,10 @@ const (
 	// once stable.
 	FormatExperimentalValueSeparation
 
+	// FormatManifestSyncChunks is a format major version enabling the writing of
+	// sync offset chunks for Manifest files. See comment for FormatWALSyncChunks.
+	FormatManifestSyncChunks
+
 	// -- Add new versions here --
 
 	// FormatNewest is the most recent format major version.
@@ -266,7 +270,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 		return sstable.TableFormatPebblev4
 	case FormatColumnarBlocks, FormatWALSyncChunks:
 		return sstable.TableFormatPebblev5
-	case FormatTableFormatV6, FormatExperimentalValueSeparation:
+	case FormatTableFormatV6, FormatExperimentalValueSeparation, FormatManifestSyncChunks:
 		return sstable.TableFormatPebblev6
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -280,7 +284,7 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
 		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix,
 		FormatFlushableIngestExcises, FormatColumnarBlocks, FormatWALSyncChunks,
-		FormatTableFormatV6, FormatExperimentalValueSeparation:
+		FormatTableFormatV6, FormatExperimentalValueSeparation, FormatManifestSyncChunks:
 		return sstable.TableFormatPebblev1
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -331,6 +335,9 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	},
 	FormatExperimentalValueSeparation: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatExperimentalValueSeparation)
+	},
+	FormatManifestSyncChunks: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(FormatManifestSyncChunks)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -29,11 +29,12 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatWALSyncChunks, FormatMajorVersion(20))
 	require.Equal(t, FormatTableFormatV6, FormatMajorVersion(21))
 	require.Equal(t, FormatExperimentalValueSeparation, FormatMajorVersion(22))
+	require.Equal(t, FormatManifestSyncChunks, FormatMajorVersion(23))
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
 	require.Equal(t, FormatNewest, FormatMajorVersion(21))
-	require.Equal(t, internalFormatNewest, FormatMajorVersion(22))
+	require.Equal(t, internalFormatNewest, FormatMajorVersion(23))
 }
 
 func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
@@ -70,6 +71,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatTableFormatV6, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatExperimentalValueSeparation))
 	require.Equal(t, FormatExperimentalValueSeparation, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatManifestSyncChunks))
+	require.Equal(t, FormatManifestSyncChunks, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -230,6 +233,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatWALSyncChunks:               {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
 		FormatTableFormatV6:               {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
 		FormatExperimentalValueSeparation: {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
+		FormatManifestSyncChunks:          {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
 	}
 
 	// Valid versions.

--- a/objstorage/objstorageprovider/remoteobjcat/catalog.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog.go
@@ -339,7 +339,7 @@ func (c *Catalog) createNewCatalogFileLocked() (outErr error) {
 	if err != nil {
 		return err
 	}
-	recWriter := record.NewWriter(file)
+	recWriter := record.NewWriter(file, 0, false)
 	err = func() error {
 		// Create a VersionEdit that gets us from an empty catalog to the current state.
 		var ve VersionEdit

--- a/open_test.go
+++ b/open_test.go
@@ -333,7 +333,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000009.022",
+			"marker.format-version.000010.023",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -55,6 +55,10 @@ create: db/marker.format-version.000009.022
 close: db/marker.format-version.000009.022
 remove: db/marker.format-version.000008.021
 sync: db
+create: db/marker.format-version.000010.023
+close: db/marker.format-version.000010.023
+remove: db/marker.format-version.000009.022
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -121,9 +125,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.022
-close: checkpoints/checkpoint1/marker.format-version.000001.022
+create: checkpoints/checkpoint1/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.023
+close: checkpoints/checkpoint1/marker.format-version.000001.023
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -165,9 +169,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.022
-close: checkpoints/checkpoint2/marker.format-version.000001.022
+create: checkpoints/checkpoint2/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.023
+close: checkpoints/checkpoint2/marker.format-version.000001.023
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -204,9 +208,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.022
-close: checkpoints/checkpoint3/marker.format-version.000001.022
+create: checkpoints/checkpoint3/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.023
+close: checkpoints/checkpoint3/marker.format-version.000001.023
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -290,7 +294,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -300,7 +304,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -367,7 +371,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -409,7 +413,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -528,9 +532,9 @@ sync-data: checkpoints/checkpoint4/OPTIONS-000003
 close: checkpoints/checkpoint4/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.022
-close: checkpoints/checkpoint4/marker.format-version.000001.022
+create: checkpoints/checkpoint4/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.023
+close: checkpoints/checkpoint4/marker.format-version.000001.023
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -618,7 +622,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -637,9 +641,9 @@ sync-data: checkpoints/checkpoint5/OPTIONS-000003
 close: checkpoints/checkpoint5/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.022
-close: checkpoints/checkpoint5/marker.format-version.000001.022
+create: checkpoints/checkpoint5/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.023
+close: checkpoints/checkpoint5/marker.format-version.000001.023
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -739,9 +743,9 @@ sync-data: checkpoints/checkpoint6/OPTIONS-000003
 close: checkpoints/checkpoint6/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.022
-close: checkpoints/checkpoint6/marker.format-version.000001.022
+create: checkpoints/checkpoint6/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.023
+close: checkpoints/checkpoint6/marker.format-version.000001.023
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst
@@ -910,6 +914,10 @@ create: valsepdb/marker.format-version.000009.022
 close: valsepdb/marker.format-version.000009.022
 remove: valsepdb/marker.format-version.000008.021
 sync: valsepdb
+create: valsepdb/marker.format-version.000010.023
+close: valsepdb/marker.format-version.000010.023
+remove: valsepdb/marker.format-version.000009.022
+sync: valsepdb
 create: valsepdb/temporary.000003.dbtmp
 sync: valsepdb/temporary.000003.dbtmp
 close: valsepdb/temporary.000003.dbtmp
@@ -958,9 +966,9 @@ sync-data: checkpoints/checkpoint8/OPTIONS-000003
 close: checkpoints/checkpoint8/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint8
-create: checkpoints/checkpoint8/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint8/marker.format-version.000001.022
-close: checkpoints/checkpoint8/marker.format-version.000001.022
+create: checkpoints/checkpoint8/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint8/marker.format-version.000001.023
+close: checkpoints/checkpoint8/marker.format-version.000001.023
 sync: checkpoints/checkpoint8
 close: checkpoints/checkpoint8
 link: valsepdb/000006.blob -> checkpoints/checkpoint8/000006.blob
@@ -1072,9 +1080,9 @@ sync-data: checkpoints/checkpoint9/OPTIONS-000003
 close: checkpoints/checkpoint9/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint9
-create: checkpoints/checkpoint9/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint9/marker.format-version.000001.022
-close: checkpoints/checkpoint9/marker.format-version.000001.022
+create: checkpoints/checkpoint9/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint9/marker.format-version.000001.023
+close: checkpoints/checkpoint9/marker.format-version.000001.023
 sync: checkpoints/checkpoint9
 close: checkpoints/checkpoint9
 link: valsepdb/000006.blob -> checkpoints/checkpoint9/000006.blob

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -43,6 +43,10 @@ create: db/marker.format-version.000006.022
 close: db/marker.format-version.000006.022
 remove: db/marker.format-version.000005.021
 sync: db
+create: db/marker.format-version.000007.023
+close: db/marker.format-version.000007.023
+remove: db/marker.format-version.000006.022
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -109,9 +113,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.022
-close: checkpoints/checkpoint1/marker.format-version.000001.022
+create: checkpoints/checkpoint1/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.023
+close: checkpoints/checkpoint1/marker.format-version.000001.023
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -162,9 +166,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.022
-close: checkpoints/checkpoint2/marker.format-version.000001.022
+create: checkpoints/checkpoint2/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.023
+close: checkpoints/checkpoint2/marker.format-version.000001.023
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -211,9 +215,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.022
-close: checkpoints/checkpoint3/marker.format-version.000001.022
+create: checkpoints/checkpoint3/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.023
+close: checkpoints/checkpoint3/marker.format-version.000001.023
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -270,7 +274,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000006.022
+marker.format-version.000007.023
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -280,7 +284,7 @@ list checkpoints/checkpoint1
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -332,7 +336,7 @@ list checkpoints/checkpoint2
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -71,6 +71,11 @@ close: db/marker.format-version.000009.022
 remove: db/marker.format-version.000008.021
 sync: db
 upgraded to format version: 022
+create: db/marker.format-version.000010.023
+close: db/marker.format-version.000010.023
+remove: db/marker.format-version.000009.022
+sync: db
+upgraded to format version: 023
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -380,9 +385,9 @@ sync-data: checkpoint/OPTIONS-000003
 close: checkpoint/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.022
-sync-data: checkpoint/marker.format-version.000001.022
-close: checkpoint/marker.format-version.000001.022
+create: checkpoint/marker.format-version.000001.023
+sync-data: checkpoint/marker.format-version.000001.023
+close: checkpoint/marker.format-version.000001.023
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -60,7 +60,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -81,7 +81,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -390,7 +390,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -410,7 +410,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -443,7 +443,7 @@ MANIFEST-000001
 MANIFEST-000011
 OPTIONS-000014
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000002.MANIFEST-000011
 
 # Make sure that the new mutable memtable can accept writes.
@@ -586,7 +586,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -605,7 +605,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext1
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 open

--- a/version_set.go
+++ b/version_set.go
@@ -242,23 +242,28 @@ func (vs *versionSet) load(
 			errors.Safe(manifestFilename), dirname)
 	}
 	defer manifestFile.Close()
-	rr := record.NewReader(manifestFile, 0 /* logNum */)
+	rr := record.NewReader(manifestFile, manifestFileNum)
 	for {
 		r, err := rr.Next()
-		if err == io.EOF || record.IsInvalidRecord(err) {
+		if errors.Is(err, io.EOF) || errors.Is(err, record.ErrUnexpectedEOF) {
 			break
-		}
-		if err != nil {
+		} else if errors.Is(err, record.ErrInvalidChunk) || errors.Is(err, record.ErrZeroedChunk) {
+			// If a read-ahead returns one of these errors, they should be marked with corruption.
+			// Other I/O related errors should not be marked with corruption and simply returned.
+			err = errors.Mark(err, ErrCorruption)
 			return errors.Wrapf(err, "pebble: error when loading manifest file %q",
 				errors.Safe(manifestFilename))
 		}
 		var ve versionEdit
 		err = ve.Decode(r)
 		if err != nil {
-			// Break instead of returning an error if the record is corrupted
-			// or invalid.
-			if err == io.EOF || record.IsInvalidRecord(err) {
+			if errors.Is(err, io.EOF) || errors.Is(err, record.ErrUnexpectedEOF) {
 				break
+			} else if errors.Is(err, record.ErrInvalidChunk) || errors.Is(err, record.ErrZeroedChunk) {
+				// If a read-ahead returns one of these errors, they should be marked with corruption.
+				// Other I/O related errors should not be marked with corruption and simply returned.
+				err = errors.Mark(err, ErrCorruption)
+				return errors.Wrap(err, "pebble: error when loading manifest")
 			}
 			return err
 		}
@@ -1013,7 +1018,7 @@ func (vs *versionSet) createManifest(
 	if err != nil {
 		return err
 	}
-	manifestWriter = record.NewWriter(manifestFile)
+	manifestWriter = record.NewWriter(manifestFile, fileNum, vs.getFormatMajorVersion() >= FormatManifestSyncChunks)
 
 	snapshot := manifest.VersionEdit{
 		ComparerName: vs.cmp.Name,


### PR DESCRIPTION
Add sync offsets to manifest writer to enable read ahead and detect corruption.