### PR TITLE
sstable: improve writer EstimatedSize

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -79,8 +79,14 @@ type RawColumnWriter struct {
 	// flushed in order after all the data blocks, and the top-level index block
 	// is constructed to point to all the individual index blocks.
 	indexBuffering struct {
-		// partitions holds all the completed index blocks.
+		// partitions holds all the completed, uncompressed index blocks.
+		//
+		// TODO(jackson): We should consider compressing these index blocks now,
+		// while buffering, to reduce the memory usage of the writer.
 		partitions []bufferedIndexBlock
+		// partitionSizeSum is the sum of the sizes of all the completed index
+		// blocks (in `partitions`).
+		partitionSizeSum uint64
 		// blockAlloc is used to bulk-allocate byte slices used to store index
 		// blocks in partitions. These live until the sstable is finished.
 		blockAlloc []byte
@@ -200,27 +206,38 @@ func (w *RawColumnWriter) Error() error {
 // EstimatedSize returns the estimated size of the sstable being written if
 // a call to Close() was made without adding additional keys.
 func (w *RawColumnWriter) EstimatedSize() uint64 {
+	// Start with the size of the footer, which is fixed, and the size of all
+	// the finished data blocks. The size of the finished data blocks is all
+	// post-compression and the footer is not compressed, so this initial
+	// quantity is exact.
 	sz := uint64(w.opts.TableFormat.FooterSize()) + w.queuedDataSize
-	// TODO(jackson): Avoid iterating over partitions by incrementally
-	// maintaining the size contribution of all buffered partitions.
-	for _, bib := range w.indexBuffering.partitions {
-		// We include the separator user key to account for its bytes in the
-		// top-level index block.
-		//
-		// TODO(jackson): We could incrementally build the top-level index block
-		// and produce an exact calculation of the current top-level index
-		// block's size.
-		sz += uint64(len(bib.block) + block.TrailerLen + len(bib.sep.UserKey))
+
+	// Add the size of value blocks. If any value blocks have already been
+	// finished, these blocks will contribute post-compression size. If there is
+	// currently an unfinished value block, it will contribute its pre-compression
+	// size.
+	if w.valueBlock != nil {
+		sz += w.valueBlock.Size()
 	}
+
+	// Add the size of the completed but unflushed index partitions, the
+	// unfinished data block, the unfinished index block, the unfinished range
+	// deletion block, and the unfinished range key block.
+	//
+	// All of these sizes are uncompressed sizes. It's okay to be pessimistic
+	// here and use the uncompressed size because all this memory is buffered
+	// until the sstable is finished.  Including the uncompressed size bounds
+	// the memory usage used by the writer to the physical size limit.
+	sz += w.indexBuffering.partitionSizeSum
+	sz += uint64(w.dataBlock.Size())
+	sz += uint64(w.indexBlockSize)
 	if w.rangeDelBlock.KeyCount() > 0 {
 		sz += uint64(w.rangeDelBlock.Size())
 	}
 	if w.rangeKeyBlock.KeyCount() > 0 {
 		sz += uint64(w.rangeKeyBlock.Size())
 	}
-	if w.valueBlock != nil {
-		sz += w.valueBlock.Size()
-	}
+
 	// TODO(jackson): Include an estimate of the properties, filter and meta
 	// index blocks sizes.
 	return sz
@@ -803,16 +820,23 @@ func (w *RawColumnWriter) finishIndexBlock(rows int) error {
 		w.indexBlock.UnsafeSeparator(rows - 1))
 
 	// Finish the index block and copy it so that w.indexBlock may be reused.
-	block := w.indexBlock.Finish(rows)
-	if len(w.indexBuffering.blockAlloc) < len(block) {
+	blk := w.indexBlock.Finish(rows)
+	if len(w.indexBuffering.blockAlloc) < len(blk) {
 		// Allocate enough bytes for approximately 16 index blocks.
-		w.indexBuffering.blockAlloc = make([]byte, len(block)*16)
+		w.indexBuffering.blockAlloc = make([]byte, len(blk)*16)
 	}
-	n := copy(w.indexBuffering.blockAlloc, block)
+	n := copy(w.indexBuffering.blockAlloc, blk)
 	bib.block = w.indexBuffering.blockAlloc[:n:n]
 	w.indexBuffering.blockAlloc = w.indexBuffering.blockAlloc[n:]
 
 	w.indexBuffering.partitions = append(w.indexBuffering.partitions, bib)
+	// We include the separator user key to account for its bytes in the
+	// top-level index block.
+	//
+	// TODO(jackson): We could incrementally build the top-level index block
+	// and produce an exact calculation of the current top-level index
+	// block's size.
+	w.indexBuffering.partitionSizeSum += uint64(len(blk) + block.TrailerLen + len(bib.sep.UserKey))
 	return nil
 }
 

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -336,7 +336,7 @@ a@2.SET.1:a2
 a@1.SET.1:a1
 b@2.SET.1:b2
 ----
-EstimatedSize()=53
+EstimatedSize()=163
 
 close
 ----

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -359,7 +359,7 @@ a@2.SET.1:a2
 a@1.SET.1:a1
 b@2.SET.1:b2
 ----
-EstimatedSize()=57
+EstimatedSize()=167
 
 close
 ----

--- a/testdata/compaction/set_with_del_sstable_Pebblev5
+++ b/testdata/compaction/set_with_del_sstable_Pebblev5
@@ -253,8 +253,8 @@ L3:
 compact a-h L1
 ----
 L2:
-  000009:[grandparent#2,RANGEDEL-m#inf,RANGEDEL]
-  000010:[m#2,RANGEDEL-z#inf,RANGEDEL]
+  000009:[grandparent#2,RANGEDEL-h#inf,RANGEDEL]
+  000010:[h#3,SET-z#inf,RANGEDEL]
 L3:
   000007:[grandparent#0,SET-grandparent#0,SET]
   000008:[m#0,SET-m#0,SET]

--- a/testdata/compaction/set_with_del_sstable_Pebblev6
+++ b/testdata/compaction/set_with_del_sstable_Pebblev6
@@ -253,8 +253,8 @@ L3:
 compact a-h L1
 ----
 L2:
-  000009:[grandparent#2,RANGEDEL-m#inf,RANGEDEL]
-  000010:[m#2,RANGEDEL-z#inf,RANGEDEL]
+  000009:[grandparent#2,RANGEDEL-h#inf,RANGEDEL]
+  000010:[h#3,SET-z#inf,RANGEDEL]
 L3:
   000007:[grandparent#0,SET-grandparent#0,SET]
   000008:[m#0,SET-m#0,SET]

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -206,45 +206,45 @@ wrote 475254 keys
 flush
 ----
 L0.0:
-  000005:[a@1#10,SET-blof@1#26408,SET] seqnums:[10-26408] points:[a@1#10,SET-blof@1#26408,SET] size:402673 blobrefs:[(000006: 1689536); depth:1]
-  000007:[blog@1#26409,SET-cxcf@1#52799,SET] seqnums:[26409-52799] points:[blog@1#26409,SET-cxcf@1#52799,SET] size:405756 blobrefs:[(000008: 1689024); depth:1]
-  000009:[cxcg@1#52800,SET-einq@1#79120,SET] seqnums:[52800-79120] points:[cxcg@1#52800,SET-einq@1#79120,SET] size:410370 blobrefs:[(000010: 1684544); depth:1]
-  000011:[einr@1#79121,SET-fuau@1#105488,SET] seqnums:[79121-105488] points:[einr@1#79121,SET-fuau@1#105488,SET] size:407440 blobrefs:[(000012: 1687552); depth:1]
-  000013:[fuav@1#105489,SET-hfno@1#131846,SET] seqnums:[105489-131846] points:[fuav@1#105489,SET-hfno@1#131846,SET] size:408549 blobrefs:[(000014: 1686912); depth:1]
-  000015:[hfnp@1#131847,SET-iqzq@1#158184,SET] seqnums:[131847-158184] points:[hfnp@1#131847,SET-iqzq@1#158184,SET] size:408995 blobrefs:[(000016: 1685632); depth:1]
-  000017:[iqzr@1#158185,SET-kchm@1#184410,SET] seqnums:[158185-184410] points:[iqzr@1#158185,SET-kchm@1#184410,SET] size:414699 blobrefs:[(000018: 1678464); depth:1]
-  000019:[kchn@1#184411,SET-lnt@1#210733,SET] seqnums:[184411-210733] points:[kchn@1#184411,SET-lnt@1#210733,SET] size:409800 blobrefs:[(000020: 1684672); depth:1]
-  000021:[lnta@1#210734,SET-mzgo@1#237112,SET] seqnums:[210734-237112] points:[lnta@1#210734,SET-mzgo@1#237112,SET] size:407724 blobrefs:[(000022: 1688256); depth:1]
-  000023:[mzgp@1#237113,SET-okst@1#263454,SET] seqnums:[237113-263454] points:[mzgp@1#237113,SET-okst@1#263454,SET] size:408979 blobrefs:[(000024: 1685888); depth:1]
-  000025:[oksu@1#263455,SET-pwgo@1#289840,SET] seqnums:[263455-289840] points:[oksu@1#263455,SET-pwgo@1#289840,SET] size:403438 blobrefs:[(000026: 1688704); depth:1]
-  000027:[pwgp@1#289841,SET-rhth@1#316197,SET] seqnums:[289841-316197] points:[pwgp@1#289841,SET-rhth@1#316197,SET] size:408839 blobrefs:[(000028: 1686848); depth:1]
-  000029:[rhti@1#316198,SET-stec@1#342502,SET] seqnums:[316198-342502] points:[rhti@1#316198,SET-stec@1#342502,SET] size:411207 blobrefs:[(000030: 1683520); depth:1]
-  000031:[sted@1#342503,SET-uery@1#368888,SET] seqnums:[342503-368888] points:[sted@1#342503,SET-uery@1#368888,SET] size:406286 blobrefs:[(000032: 1688704); depth:1]
-  000033:[uerz@1#368889,SET-vqfq@1#395271,SET] seqnums:[368889-395271] points:[uerz@1#368889,SET-vqfq@1#395271,SET] size:406985 blobrefs:[(000034: 1688512); depth:1]
-  000035:[vqfr@1#395272,SET-xbqj@1#421574,SET] seqnums:[395272-421574] points:[vqfr@1#395272,SET-xbqj@1#421574,SET] size:410632 blobrefs:[(000036: 1683392); depth:1]
-  000037:[xbqk@1#421575,SET-ymzw@1#447842,SET] seqnums:[421575-447842] points:[xbqk@1#421575,SET-ymzw@1#447842,SET] size:412585 blobrefs:[(000038: 1681152); depth:1]
-  000039:[ymzx@1#447843,SET-zyni@1#474219,SET] seqnums:[447843-474219] points:[ymzx@1#447843,SET-zyni@1#474219,SET] size:407748 blobrefs:[(000040: 1688128); depth:1]
-  000041:[zynj@1#474220,SET-zzzz@1#475263,SET] seqnums:[474220-475263] points:[zynj@1#474220,SET-zzzz@1#475263,SET] size:16569 blobrefs:[(000042: 66816); depth:1]
+  000005:[a@1#10,SET-blnp@1#26391,SET] seqnums:[10-26391] points:[a@1#10,SET-blnp@1#26391,SET] size:401455 blobrefs:[(000006: 1688448); depth:1]
+  000007:[blnq@1#26392,SET-cwxx@1#52681,SET] seqnums:[26392-52681] points:[blnq@1#26392,SET-cwxx@1#52681,SET] size:408199 blobrefs:[(000008: 1682560); depth:1]
+  000009:[cwxy@1#52682,SET-eijb@1#78997,SET] seqnums:[52682-78997] points:[cwxy@1#52682,SET-eijb@1#78997,SET] size:406091 blobrefs:[(000010: 1684224); depth:1]
+  000011:[eijc@1#78998,SET-ftuk@1#105315,SET] seqnums:[78998-105315] points:[eijc@1#78998,SET-ftuk@1#105315,SET] size:406439 blobrefs:[(000012: 1684352); depth:1]
+  000013:[ftul@1#105316,SET-hfdy@1#131586,SET] seqnums:[105316-131586] points:[ftul@1#105316,SET-hfdy@1#131586,SET] size:409052 blobrefs:[(000014: 1681344); depth:1]
+  000015:[hfdz@1#131587,SET-iqps@1#157916,SET] seqnums:[131587-157916] points:[hfdz@1#131587,SET-iqps@1#157916,SET] size:405662 blobrefs:[(000016: 1685120); depth:1]
+  000017:[iqpt@1#157917,SET-kbyh@1#184161,SET] seqnums:[157917-184161] points:[iqpt@1#157917,SET-kbyh@1#184161,SET] size:410750 blobrefs:[(000018: 1679680); depth:1]
+  000019:[kbyi@1#184162,SET-lniy@1#210461,SET] seqnums:[184162-210461] points:[kbyi@1#184162,SET-lniy@1#210461,SET] size:407160 blobrefs:[(000020: 1683200); depth:1]
+  000021:[lniz@1#210462,SET-myto@1#236760,SET] seqnums:[210462-236760] points:[lniz@1#210462,SET-myto@1#236760,SET] size:407072 blobrefs:[(000022: 1683136); depth:1]
+  000023:[mytp@1#236761,SET-okdt@1#263049,SET] seqnums:[236761-263049] points:[mytp@1#236761,SET-okdt@1#263049,SET] size:407864 blobrefs:[(000024: 1682496); depth:1]
+  000025:[okdu@1#263050,SET-pvrc@1#289422,SET] seqnums:[263050-289422] points:[okdu@1#263050,SET-pvrc@1#289422,SET] size:402863 blobrefs:[(000026: 1687872); depth:1]
+  000027:[pvrd@1#289423,SET-rhcn@1#315744,SET] seqnums:[289423-315744] points:[pvrd@1#289423,SET-rhcn@1#315744,SET] size:405669 blobrefs:[(000028: 1684608); depth:1]
+  000029:[rhco@1#315745,SET-ssmh@1#342020,SET] seqnums:[315745-342020] points:[rhco@1#315745,SET-ssmh@1#342020,SET] size:408791 blobrefs:[(000030: 1681664); depth:1]
+  000031:[ssmi@1#342021,SET-udu@1#368241,SET] seqnums:[342021-368241] points:[ssmi@1#342021,SET-udu@1#368241,SET] size:412544 blobrefs:[(000032: 1678144); depth:1]
+  000033:[udua@1#368242,SET-vpea@1#394525,SET] seqnums:[368242-394525] points:[udua@1#368242,SET-vpea@1#394525,SET] size:408211 blobrefs:[(000034: 1682176); depth:1]
+  000035:[vpeb@1#394526,SET-xaqb@1#420863,SET] seqnums:[394526-420863] points:[vpeb@1#394526,SET-xaqb@1#420863,SET] size:404561 blobrefs:[(000036: 1685632); depth:1]
+  000037:[xaqc@1#420864,SET-ylzx@1#447140,SET] seqnums:[420864-447140] points:[xaqc@1#420864,SET-ylzx@1#447140,SET] size:408711 blobrefs:[(000038: 1681728); depth:1]
+  000039:[ylzy@1#447141,SET-zxmm@1#473493,SET] seqnums:[447141-473493] points:[ylzy@1#447141,SET-zxmm@1#473493,SET] size:404164 blobrefs:[(000040: 1686592); depth:1]
+  000041:[zxmn@1#473494,SET-zzzz@1#475263,SET] seqnums:[473494-475263] points:[zxmn@1#473494,SET-zzzz@1#475263,SET] size:28413 blobrefs:[(000042: 113280); depth:1]
 Blob files:
-  000006: 1694530 physical bytes, 1689536 value bytes
-  000008: 1694018 physical bytes, 1689024 value bytes
-  000010: 1689526 physical bytes, 1684544 value bytes
-  000012: 1692534 physical bytes, 1687552 value bytes
-  000014: 1691894 physical bytes, 1686912 value bytes
-  000016: 1690614 physical bytes, 1685632 value bytes
-  000018: 1683422 physical bytes, 1678464 value bytes
-  000020: 1689654 physical bytes, 1684672 value bytes
-  000022: 1693250 physical bytes, 1688256 value bytes
-  000024: 1690870 physical bytes, 1685888 value bytes
-  000026: 1693698 physical bytes, 1688704 value bytes
-  000028: 1691830 physical bytes, 1686848 value bytes
-  000030: 1688502 physical bytes, 1683520 value bytes
-  000032: 1693698 physical bytes, 1688704 value bytes
-  000034: 1693506 physical bytes, 1688512 value bytes
-  000036: 1688362 physical bytes, 1683392 value bytes
-  000038: 1686122 physical bytes, 1681152 value bytes
-  000040: 1693122 physical bytes, 1688128 value bytes
-  000042: 67041 physical bytes, 66816 value bytes
+  000006: 1693442 physical bytes, 1688448 value bytes
+  000008: 1687530 physical bytes, 1682560 value bytes
+  000010: 1689206 physical bytes, 1684224 value bytes
+  000012: 1689334 physical bytes, 1684352 value bytes
+  000014: 1686314 physical bytes, 1681344 value bytes
+  000016: 1690102 physical bytes, 1685120 value bytes
+  000018: 1684650 physical bytes, 1679680 value bytes
+  000020: 1688170 physical bytes, 1683200 value bytes
+  000022: 1688106 physical bytes, 1683136 value bytes
+  000024: 1687466 physical bytes, 1682496 value bytes
+  000026: 1692866 physical bytes, 1687872 value bytes
+  000028: 1689590 physical bytes, 1684608 value bytes
+  000030: 1686634 physical bytes, 1681664 value bytes
+  000032: 1683102 physical bytes, 1678144 value bytes
+  000034: 1687146 physical bytes, 1682176 value bytes
+  000036: 1690614 physical bytes, 1685632 value bytes
+  000038: 1686698 physical bytes, 1681728 value bytes
+  000040: 1691574 physical bytes, 1686592 value bytes
+  000042: 113626 physical bytes, 113280 value bytes
 
 # Schedule automatic compactions. These compactions should write data to L6. The
 # resulting sstables will reference multiple blob files but maintain a blob
@@ -254,32 +254,32 @@ Blob files:
 auto-compact
 ----
 L6:
-  000044:[a@1#0,SET-czma@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-czma@1#0,SET] size:713597 blobrefs:[(000006: 1689536), (000008: 1689024), (000010: 106944); depth:1]
-  000045:[czmb@1#0,SET-fzac@1#0,SET] seqnums:[0-0] points:[czmb@1#0,SET-fzac@1#0,SET] size:710726 blobrefs:[(000010: 1577600), (000012: 1687552), (000014: 223808); depth:1]
-  000046:[fzad@1#0,SET-iyoz@1#0,SET] seqnums:[0-0] points:[fzad@1#0,SET-iyoz@1#0,SET] size:710124 blobrefs:[(000014: 1463104), (000016: 1685632), (000018: 341504); depth:1]
-  000047:[iyp@1#0,SET-lxxp@1#0,SET] seqnums:[0-0] points:[iyp@1#0,SET-lxxp@1#0,SET] size:718439 blobrefs:[(000018: 1336960), (000020: 1684672), (000022: 457856); depth:1]
-  000048:[lxxq@1#0,SET-oxlo@1#0,SET] seqnums:[0-0] points:[lxxq@1#0,SET-oxlo@1#0,SET] size:711593 blobrefs:[(000022: 1230400), (000024: 1685888), (000026: 572480); depth:1]
-  000049:[oxlp@1#0,SET-rwyj@1#0,SET] seqnums:[0-0] points:[oxlp@1#0,SET-rwyj@1#0,SET] size:713709 blobrefs:[(000026: 1116224), (000028: 1686848), (000030: 683648); depth:1]
-  000050:[rwyk@1#0,SET-uwic@1#0,SET] seqnums:[0-0] points:[rwyk@1#0,SET-uwic@1#0,SET] size:718480 blobrefs:[(000030: 999872), (000032: 1688704), (000034: 792896); depth:1]
-  000051:[uwid@1#0,SET-xvqq@1#0,SET] seqnums:[0-0] points:[uwid@1#0,SET-xvqq@1#0,SET] size:720205 blobrefs:[(000034: 895616), (000036: 1683392), (000038: 900288); depth:1]
-  000052:[xvqr@1#0,SET-zzzz@1#0,SET] seqnums:[0-0] points:[xvqr@1#0,SET-zzzz@1#0,SET] size:521418 blobrefs:[(000038: 780864), (000040: 1688128), (000042: 66816); depth:1]
+  000044:[a@1#0,SET-czks@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-czks@1#0,SET] size:711466 blobrefs:[(000006: 1688448), (000008: 1682560), (000010: 112192); depth:1]
+  000045:[czkt@1#0,SET-fytv@1#0,SET] seqnums:[0-0] points:[czkt@1#0,SET-fytv@1#0,SET] size:714446 blobrefs:[(000010: 1572032), (000012: 1684352), (000014: 223936); depth:1]
+  000046:[fytw@1#0,SET-iyfv@1#0,SET] seqnums:[0-0] points:[fytw@1#0,SET-iyfv@1#0,SET] size:709232 blobrefs:[(000014: 1457408), (000016: 1685120), (000018: 342848); depth:1]
+  000047:[iyfw@1#0,SET-lxqc@1#0,SET] seqnums:[0-0] points:[iyfw@1#0,SET-lxqc@1#0,SET] size:712611 blobrefs:[(000018: 1336832), (000020: 1683200), (000022: 462336); depth:1]
+  000048:[lxqd@1#0,SET-owzk@1#0,SET] seqnums:[0-0] points:[lxqd@1#0,SET-owzk@1#0,SET] size:714339 blobrefs:[(000022: 1220800), (000024: 1682496), (000026: 577344); depth:1]
+  000049:[owzl@1#0,SET-rwhd@1#0,SET] seqnums:[0-0] points:[owzl@1#0,SET-rwhd@1#0,SET] size:716618 blobrefs:[(000026: 1110528), (000028: 1684608), (000030: 682880); depth:1]
+  000050:[rwhe@1#0,SET-uvp@1#0,SET] seqnums:[0-0] points:[rwhe@1#0,SET-uvp@1#0,SET] size:716297 blobrefs:[(000030: 998784), (000032: 1678144), (000034: 801216); depth:1]
+  000051:[uvpa@1#0,SET-xuza@1#0,SET] seqnums:[0-0] points:[uvpa@1#0,SET-xuza@1#0,SET] size:712319 blobrefs:[(000034: 880960), (000036: 1685632), (000038: 915328); depth:1]
+  000052:[xuzb@1#0,SET-zzzz@1#0,SET] seqnums:[0-0] points:[xuzb@1#0,SET-zzzz@1#0,SET] size:530353 blobrefs:[(000038: 766400), (000040: 1686592), (000042: 113280); depth:1]
 Blob files:
-  000006: 1694530 physical bytes, 1689536 value bytes
-  000008: 1694018 physical bytes, 1689024 value bytes
-  000010: 1689526 physical bytes, 1684544 value bytes
-  000012: 1692534 physical bytes, 1687552 value bytes
-  000014: 1691894 physical bytes, 1686912 value bytes
-  000016: 1690614 physical bytes, 1685632 value bytes
-  000018: 1683422 physical bytes, 1678464 value bytes
-  000020: 1689654 physical bytes, 1684672 value bytes
-  000022: 1693250 physical bytes, 1688256 value bytes
-  000024: 1690870 physical bytes, 1685888 value bytes
-  000026: 1693698 physical bytes, 1688704 value bytes
-  000028: 1691830 physical bytes, 1686848 value bytes
-  000030: 1688502 physical bytes, 1683520 value bytes
-  000032: 1693698 physical bytes, 1688704 value bytes
-  000034: 1693506 physical bytes, 1688512 value bytes
-  000036: 1688362 physical bytes, 1683392 value bytes
-  000038: 1686122 physical bytes, 1681152 value bytes
-  000040: 1693122 physical bytes, 1688128 value bytes
-  000042: 67041 physical bytes, 66816 value bytes
+  000006: 1693442 physical bytes, 1688448 value bytes
+  000008: 1687530 physical bytes, 1682560 value bytes
+  000010: 1689206 physical bytes, 1684224 value bytes
+  000012: 1689334 physical bytes, 1684352 value bytes
+  000014: 1686314 physical bytes, 1681344 value bytes
+  000016: 1690102 physical bytes, 1685120 value bytes
+  000018: 1684650 physical bytes, 1679680 value bytes
+  000020: 1688170 physical bytes, 1683200 value bytes
+  000022: 1688106 physical bytes, 1683136 value bytes
+  000024: 1687466 physical bytes, 1682496 value bytes
+  000026: 1692866 physical bytes, 1687872 value bytes
+  000028: 1689590 physical bytes, 1684608 value bytes
+  000030: 1686634 physical bytes, 1681664 value bytes
+  000032: 1683102 physical bytes, 1678144 value bytes
+  000034: 1687146 physical bytes, 1682176 value bytes
+  000036: 1690614 physical bytes, 1685632 value bytes
+  000038: 1686698 physical bytes, 1681728 value bytes
+  000040: 1691574 physical bytes, 1686592 value bytes
+  000042: 113626 physical bytes, 113280 value bytes

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -43,7 +43,14 @@ set a(p,1000000)rove
 flush verbose
 ----
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563939
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563957
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563948
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563942
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563939
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563954
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563957
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94435
 
 layout filename=000005.sst
 ----
@@ -52,64 +59,14 @@ sstable
  ├── data  offset: 46949  length: 46945
  ├── data  offset: 93899  length: 46941
  ├── data  offset: 140845  length: 46944
- ├── data  offset: 187794  length: 46947
- ├── data  offset: 234746  length: 46945
- ├── data  offset: 281696  length: 46945
- ├── data  offset: 328646  length: 46943
- ├── data  offset: 375594  length: 46945
- ├── data  offset: 422544  length: 46940
- ├── data  offset: 469489  length: 46951
- ├── data  offset: 516445  length: 46941
- ├── data  offset: 563391  length: 46944
- ├── data  offset: 610340  length: 46945
- ├── data  offset: 657290  length: 46946
- ├── data  offset: 704241  length: 46940
- ├── data  offset: 751186  length: 46943
- ├── data  offset: 798134  length: 46942
- ├── data  offset: 845081  length: 46944
- ├── data  offset: 892030  length: 46945
- ├── data  offset: 938980  length: 46944
- ├── data  offset: 985929  length: 46945
- ├── data  offset: 1032879  length: 46945
- ├── data  offset: 1079829  length: 46945
- ├── data  offset: 1126779  length: 46946
- ├── data  offset: 1173730  length: 46947
- ├── data  offset: 1220682  length: 46943
- ├── data  offset: 1267630  length: 46944
- ├── data  offset: 1314579  length: 46942
- ├── index  offset: 1361526  length: 46942
- ├── index  offset: 1408473  length: 46946
- ├── index  offset: 1455424  length: 46942
- ├── index  offset: 1502371  length: 46945
- ├── index  offset: 1549321  length: 46948
- ├── index  offset: 1596274  length: 46946
- ├── index  offset: 1643225  length: 46946
- ├── index  offset: 1690176  length: 46944
- ├── index  offset: 1737125  length: 46946
- ├── index  offset: 1784076  length: 46941
- ├── index  offset: 1831022  length: 46952
- ├── index  offset: 1877979  length: 46942
- ├── index  offset: 1924926  length: 46945
- ├── index  offset: 1971876  length: 46946
- ├── index  offset: 2018827  length: 46947
- ├── index  offset: 2065779  length: 46941
- ├── index  offset: 2112725  length: 46944
- ├── index  offset: 2159674  length: 46943
- ├── index  offset: 2206622  length: 46945
- ├── index  offset: 2253572  length: 46946
- ├── index  offset: 2300523  length: 46945
- ├── index  offset: 2347473  length: 46946
- ├── index  offset: 2394424  length: 46946
- ├── index  offset: 2441375  length: 46946
- ├── index  offset: 2488326  length: 46947
- ├── index  offset: 2535278  length: 46948
- ├── index  offset: 2582231  length: 46944
- ├── index  offset: 2629180  length: 46945
- ├── index  offset: 2676130  length: 46943
- ├── top-index  offset: 2723078  length: 1361225
- ├── properties  offset: 4084308  length: 490
- ├── meta-index  offset: 4084803  length: 35
- └── footer  offset: 4084843  length: 53
+ ├── index  offset: 187794  length: 46942
+ ├── index  offset: 234741  length: 46946
+ ├── index  offset: 281692  length: 46942
+ ├── index  offset: 328639  length: 46945
+ ├── top-index  offset: 375589  length: 187759
+ ├── properties  offset: 563353  length: 489
+ ├── meta-index  offset: 563847  length: 34
+ └── footer  offset: 563886  length: 53
 
 properties file=000005
 raw.key.size
@@ -117,12 +74,12 @@ index.size
 index.partitions
 ----
 raw.key.size:
-  rocksdb.raw.key.size: 29000440
+  rocksdb.raw.key.size: 4000058
 index.size:
-  rocksdb.index.size: 58001886
-  rocksdb.top-level.index.size: 29000892
+  rocksdb.index.size: 8000259
+  rocksdb.top-level.index.size: 4000122
 index.partitions:
-  rocksdb.index.partitions: 29
+  rocksdb.index.partitions: 4
 
 batch-commit
 del-range a(p,1000000)arition a(p,1000000)eal
@@ -139,26 +96,35 @@ del-range a(p,1000000)rovals a(p,1000000)rove
 flush verbose
 ----
 L0.1:
-  000008:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[39-47] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:18000932
+  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000726
+  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] seqnums:[42-44] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] size:6000732
+  000017:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[45-47] points:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:6000726
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563939
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563957
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563948
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563942
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563939
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563954
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563957
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94435
 
-layout filename=000008.sst
+layout filename=000015.sst
 ----
 sstable
  ├── data  offset: 0  length: 8
  ├── index  offset: 13  length: 24
- ├── range-del  offset: 42  length: 18000310
- ├── properties  offset: 18000357  length: 447
- ├── meta-index  offset: 18000809  length: 65
- └── footer  offset: 18000879  length: 53
+ ├── range-del  offset: 42  length: 6000104
+ ├── properties  offset: 6000151  length: 447
+ ├── meta-index  offset: 6000603  length: 65
+ └── footer  offset: 6000673  length: 53
 
 properties file=000008
 rocksdb.raw
 ----
 rocksdb.raw:
-  rocksdb.raw.key.size: 9000139
-  rocksdb.raw.value.size: 9000068
+  rocksdb.raw.key.size: 4000059
+  rocksdb.raw.value.size: 20
 
 # Repeat the above with columnar blocks.
 
@@ -202,30 +168,30 @@ set a(p,1000000)rove
 flush verbose
 ----
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:564287
-  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:564304
-  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:564298
-  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:564292
-  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:564286
-  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:564299
-  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:564311
-  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94575
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] seqnums:[10-12] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] size:423391
+  000006:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] seqnums:[13-15] points:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] size:423412
+  000007:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] seqnums:[16-18] points:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] size:423397
+  000008:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] seqnums:[19-23] points:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] size:423401
+  000009:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] seqnums:[21-24] points:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] size:423412
+  000010:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] seqnums:[25-27] points:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] size:423377
+  000011:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] seqnums:[28-30] points:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] size:423397
+  000012:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] seqnums:[31-33] points:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] size:423403
+  000013:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] seqnums:[34-36] points:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] size:423410
+  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[37-38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282487
 
 layout filename=000006.sst
 ----
 sstable
- ├── data  offset: 0  length: 46998
- ├── data  offset: 47003  length: 46993
- ├── data  offset: 94001  length: 46993
- ├── data  offset: 140999  length: 46991
- ├── index  offset: 187995  length: 46967
- ├── index  offset: 234967  length: 46969
- ├── index  offset: 281941  length: 46973
- ├── index  offset: 328919  length: 46969
- ├── top-index  offset: 375893  length: 187752
- ├── properties  offset: 563650  length: 557
- ├── meta-index  offset: 564212  length: 34
- └── footer  offset: 564251  length: 53
+ ├── data  offset: 0  length: 46995
+ ├── data  offset: 47000  length: 46998
+ ├── data  offset: 94003  length: 46993
+ ├── index  offset: 141001  length: 46965
+ ├── index  offset: 187971  length: 46971
+ ├── index  offset: 234947  length: 46973
+ ├── top-index  offset: 281925  length: 140828
+ ├── properties  offset: 422758  length: 557
+ ├── meta-index  offset: 423320  length: 34
+ └── footer  offset: 423359  length: 53
 
 properties file=000006
 raw.key.size
@@ -233,12 +199,12 @@ index.size
 index.partitions
 ----
 raw.key.size:
-  rocksdb.raw.key.size: 4000064
+  rocksdb.raw.key.size: 3000049
 index.size:
-  rocksdb.index.size: 8000330
-  rocksdb.top-level.index.size: 4000112
+  rocksdb.index.size: 6000258
+  rocksdb.top-level.index.size: 3000094
 index.partitions:
-  rocksdb.index.partitions: 4
+  rocksdb.index.partitions: 3
 
 batch-commit
 del-range a(p,1000000)arition a(p,1000000)eal
@@ -255,20 +221,22 @@ del-range a(p,1000000)rovals a(p,1000000)rove
 flush verbose
 ----
 L0.1:
-  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000807
-  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000821
-  000017:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000779
+  000017:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000807
+  000018:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000821
+  000019:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000779
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:564287
-  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:564304
-  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:564298
-  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:564292
-  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:564286
-  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:564299
-  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:564311
-  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94575
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] seqnums:[10-12] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] size:423391
+  000006:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] seqnums:[13-15] points:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] size:423412
+  000007:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] seqnums:[16-18] points:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] size:423397
+  000008:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] seqnums:[19-23] points:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] size:423401
+  000009:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] seqnums:[21-24] points:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] size:423412
+  000010:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] seqnums:[25-27] points:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] size:423377
+  000011:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] seqnums:[28-30] points:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] size:423397
+  000012:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] seqnums:[31-33] points:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] size:423403
+  000013:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] seqnums:[34-36] points:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] size:423410
+  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[37-38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282487
 
-layout filename=000015.sst
+layout filename=000017.sst
 ----
 sstable
  ├── index  offset: 0  length: 28
@@ -277,7 +245,7 @@ sstable
  ├── meta-index  offset: 6000684  length: 65
  └── footer  offset: 6000754  length: 53
 
-properties file=000015
+properties file=000017
 rocksdb.raw
 ----
 rocksdb.raw:

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -109,10 +109,13 @@ L0.0:
 iter-new c category=c
 ----
 
+# Two files, since the target file size is set to 50.
+
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-b#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
 
 metrics
 ----
@@ -125,8 +128,8 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   752B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1 0.50
-total |     1   752B     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
+total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.0
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -136,8 +139,8 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.5KB, local: 1.5KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 752B
-Compression types: snappy: 1
+Local tables size: 1.5KB
+Compression types: snappy: 2
 Table stats: all loaded
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
@@ -155,7 +158,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.9KB
+4.7KB
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -173,8 +176,8 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   752B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1 0.50
-total |     1   752B     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
+total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.0
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -184,8 +187,8 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.5KB, local: 1.5KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 752B
-Compression types: snappy: 1
+Local tables size: 1.5KB
+Compression types: snappy: 2
 Table stats: all loaded
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
@@ -218,8 +221,8 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   752B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1 0.50
-total |     1   752B     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
+total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.0
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -229,8 +232,8 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 1 (751B, local: 751B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 752B
-Compression types: snappy: 1
+Local tables size: 1.5KB
+Compression types: snappy: 2
 Table stats: all loaded
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 1 entries (832B)  hit rate: 66.7%
@@ -248,7 +251,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.2KB
+4.0KB
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -266,8 +269,8 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   752B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1 0.50
-total |     1   752B     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     3  2.3KB | 1.5KB |   1 36.2
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
+total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.0
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -277,8 +280,8 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 752B
-Compression types: snappy: 1
+Local tables size: 1.5KB
+Compression types: snappy: 2
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
@@ -296,7 +299,7 @@ Iter category stats:
 
 disk-usage
 ----
-2.4KB
+3.2KB
 
 additional-metrics
 ----
@@ -308,7 +311,7 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6          82B           0B
+      6         168B           0B
 
 batch
 set c@20 c20
@@ -323,15 +326,16 @@ set c@14 c14
 flush
 ----
 L0.0:
-  000010:[c@20#12,SET-c@20#12,SET]
-  000011:[c@19#13,SET-c@19#13,SET]
-  000012:[c@18#14,SET-c@18#14,SET]
-  000013:[c@17#15,SET-c@17#15,SET]
-  000014:[c@16#16,SET-c@16#16,SET]
-  000015:[c@15#17,SET-c@15#17,SET]
-  000016:[c@14#18,SET-c@14#18,SET]
+  000011:[c@20#12,SET-c@20#12,SET]
+  000012:[c@19#13,SET-c@19#13,SET]
+  000013:[c@18#14,SET-c@18#14,SET]
+  000014:[c@17#15,SET-c@17#15,SET]
+  000015:[c@16#16,SET-c@16#16,SET]
+  000016:[c@15#17,SET-c@15#17,SET]
+  000017:[c@14#18,SET-c@14#18,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
 
 metrics
 ----
@@ -344,19 +348,19 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   752B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   752B | 1.5KB |   1 0.50
-total |     8  6.0KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    10  7.6KB | 1.5KB |   2 47.1
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
+total |     9  6.7KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    11  8.3KB | 1.5KB |   2 51.7
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
 Flushes: 3
-Compactions: 1  estimated debt: 6.0KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 6.7KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 6.0KB
-Compression types: snappy: 8
+Local tables size: 6.7KB
+Compression types: snappy: 9
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
@@ -382,13 +386,20 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6          82B           0B
+      6         168B           0B
 
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
 
 metrics
 ----
@@ -401,8 +412,8 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.6KB    31B       0 |    - 0.00 0.00 | 6.7KB |     0     0B |     0     0B |     2  1.6KB | 6.7KB |   1 0.24
-total |     2  1.6KB    31B       0 |    -    -    - |  165B |     0     0B |     0     0B |    11  8.5KB | 6.7KB |   1 52.5
+    6 |     9  6.6KB     0B       0 |    - 0.00 0.00 | 6.7KB |     0     0B |     0     0B |     9  6.6KB | 6.7KB |   1 0.99
+total |     9  6.6KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    18   14KB | 6.7KB |   1 83.7
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
 Flushes: 3
@@ -412,8 +423,8 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 1.6KB
-Compression types: snappy: 2
+Local tables size: 6.6KB
+Compression types: snappy: 9
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 10.0%
 Table cache: 0 entries (0B)  hit rate: 55.0%
@@ -439,7 +450,7 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6         220B          31B
+      6         754B           0B
 
 # Flushable ingestion metrics. This requires there be data in a memtable that
 # would overlap with the ingested table(s). Delayed flushes are disabled here to
@@ -482,16 +493,23 @@ disable
 flush
 ----
 L0.1:
-  000018:[d#22,SET-d#22,SET]
-  000019:[e#23,SET-e#23,SET]
-  000022:[f#24,SET-f#24,SET]
+  000025:[d#22,SET-d#22,SET]
+  000026:[e#23,SET-e#23,SET]
+  000029:[f#24,SET-f#24,SET]
 L0.0:
-  000026:[d#19,SET-d#19,SET]
-  000027:[e#20,SET-e#20,SET]
-  000028:[f#21,SET-f#21,SET]
+  000033:[d#19,SET-d#19,SET]
+  000034:[e#20,SET-e#20,SET]
+  000035:[f#21,SET-f#21,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
 
 # We expect the ingested-as-flushable count to be three (one for each ingested
 # table). The unknown category in the iter category stats is because of a gap
@@ -509,19 +527,19 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.6KB    31B       0 |    - 0.00 0.00 | 6.7KB |     0     0B |     0     0B |     2  1.6KB | 6.7KB |   1 0.24
-total |     8  6.0KB    31B       0 |    -    -    - | 2.4KB |     3  2.2KB |     0     0B |    14   13KB | 6.7KB |   3 5.35
+    6 |     9  6.6KB     0B       0 |    - 0.00 0.00 | 6.7KB |     0     0B |     0     0B |     9  6.6KB | 6.7KB |   1 0.99
+total |    15   11KB     0B       0 |    -    -    - | 2.4KB |     3  2.2KB |     0     0B |    21   18KB | 6.7KB |   3 7.43
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 176B  written: 211B (20% overhead)
 Flushes: 8
-Compactions: 2  estimated debt: 6.0KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 11KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 6.0KB
-Compression types: snappy: 8
+Local tables size: 11KB
+Compression types: snappy: 15
 Table stats: all loaded
 Block cache: 6 entries (2.3KB)  hit rate: 7.7%
 Table cache: 0 entries (0B)  hit rate: 55.0%
@@ -550,23 +568,30 @@ set m m
 flush
 ----
 L0.1:
-  000018:[d#22,SET-d#22,SET]
-  000019:[e#23,SET-e#23,SET]
-  000022:[f#24,SET-f#24,SET]
+  000025:[d#22,SET-d#22,SET]
+  000026:[e#23,SET-e#23,SET]
+  000029:[f#24,SET-f#24,SET]
 L0.0:
-  000026:[d#19,SET-d#19,SET]
-  000027:[e#20,SET-e#20,SET]
-  000028:[f#21,SET-f#21,SET]
-  000030:[g#25,SET-g#25,SET]
-  000031:[h#26,SET-h#26,SET]
-  000032:[i#27,SET-i#27,SET]
-  000033:[j#28,SET-j#28,SET]
-  000034:[k#29,SET-k#29,SET]
-  000035:[l#30,SET-l#30,SET]
-  000036:[m#31,SET-m#31,SET]
+  000033:[d#19,SET-d#19,SET]
+  000034:[e#20,SET-e#20,SET]
+  000035:[f#21,SET-f#21,SET]
+  000037:[g#25,SET-g#25,SET]
+  000038:[h#26,SET-h#26,SET]
+  000039:[i#27,SET-i#27,SET]
+  000040:[j#28,SET-j#28,SET]
+  000041:[k#29,SET-k#29,SET]
+  000042:[l#30,SET-l#30,SET]
+  000043:[m#31,SET-m#31,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
 
 metrics
 ----
@@ -579,19 +604,19 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.6KB    31B       0 |    - 0.00 0.00 | 6.7KB |     0     0B |     0     0B |     2  1.6KB | 6.7KB |   1 0.24
-total |    15   11KB    31B       0 |    -    -    - | 2.5KB |     3  2.2KB |     0     0B |    21   18KB | 6.7KB |   3 7.31
+    6 |     9  6.6KB     0B       0 |    - 0.00 0.00 | 6.7KB |     0     0B |     0     0B |     9  6.6KB | 6.7KB |   1 0.99
+total |    22   16KB     0B       0 |    -    -    - | 2.5KB |     3  2.2KB |     0     0B |    28   23KB | 6.7KB |   3 9.33
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
-Compactions: 2  estimated debt: 11KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 16KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 11KB
-Compression types: snappy: 15
+Local tables size: 16KB
+Compression types: snappy: 22
 Table stats: all loaded
 Block cache: 6 entries (2.3KB)  hit rate: 7.7%
 Table cache: 0 entries (0B)  hit rate: 55.0%
@@ -618,22 +643,29 @@ ingest-and-excise ext1 excise=i-k
 lsm
 ----
 L0.1:
-  000018:[d#22,SET-d#22,SET]
-  000019:[e#23,SET-e#23,SET]
-  000022:[f#24,SET-f#24,SET]
+  000025:[d#22,SET-d#22,SET]
+  000026:[e#23,SET-e#23,SET]
+  000029:[f#24,SET-f#24,SET]
 L0.0:
-  000026:[d#19,SET-d#19,SET]
-  000027:[e#20,SET-e#20,SET]
-  000028:[f#21,SET-f#21,SET]
-  000030:[g#25,SET-g#25,SET]
-  000031:[h#26,SET-h#26,SET]
-  000034:[k#29,SET-k#29,SET]
-  000035:[l#30,SET-l#30,SET]
-  000036:[m#31,SET-m#31,SET]
+  000033:[d#19,SET-d#19,SET]
+  000034:[e#20,SET-e#20,SET]
+  000035:[f#21,SET-f#21,SET]
+  000037:[g#25,SET-g#25,SET]
+  000038:[h#26,SET-h#26,SET]
+  000041:[k#29,SET-k#29,SET]
+  000042:[l#30,SET-l#30,SET]
+  000043:[m#31,SET-m#31,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
-  000037:[z#33,SET-z#33,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
+  000044:[z#33,SET-z#33,SET]
 
 # There should be 2 backing tables. Note that tiny sstables have inaccurate
 # virtual sstable sizes.
@@ -661,19 +693,19 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     3  2.3KB    31B       0 |    - 0.00 0.00 | 6.7KB |     1   754B |     0     0B |     2  1.6KB | 6.7KB |   1 0.24
-total |    14   10KB    31B       0 |    -    -    - | 3.2KB |     4  2.9KB |     0     0B |    21   19KB | 6.7KB |   3 5.86
+    6 |    10  7.4KB     0B       0 |    - 0.00 0.00 | 6.7KB |     1   754B |     0     0B |     9  6.6KB | 6.7KB |   1 0.99
+total |    21   15KB     0B       0 |    -    -    - | 3.2KB |     4  2.9KB |     0     0B |    28   24KB | 6.7KB |   3 7.42
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
-Compactions: 2  estimated debt: 10KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 15KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 10KB
-Compression types: snappy: 14
+Local tables size: 15KB
+Compression types: snappy: 21
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
@@ -702,22 +734,29 @@ ingest-and-excise ext1 excise=k-l
 lsm
 ----
 L0.1:
-  000018:[d#22,SET-d#22,SET]
-  000019:[e#23,SET-e#23,SET]
-  000022:[f#24,SET-f#24,SET]
+  000025:[d#22,SET-d#22,SET]
+  000026:[e#23,SET-e#23,SET]
+  000029:[f#24,SET-f#24,SET]
 L0.0:
-  000026:[d#19,SET-d#19,SET]
-  000027:[e#20,SET-e#20,SET]
-  000028:[f#21,SET-f#21,SET]
-  000030:[g#25,SET-g#25,SET]
-  000031:[h#26,SET-h#26,SET]
-  000035:[l#30,SET-l#30,SET]
-  000036:[m#31,SET-m#31,SET]
+  000033:[d#19,SET-d#19,SET]
+  000034:[e#20,SET-e#20,SET]
+  000035:[f#21,SET-f#21,SET]
+  000037:[g#25,SET-g#25,SET]
+  000038:[h#26,SET-h#26,SET]
+  000042:[l#30,SET-l#30,SET]
+  000043:[m#31,SET-m#31,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
-  000037:[z#33,SET-z#33,SET]
-  000038:[zz#35,SET-zz#35,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
+  000044:[z#33,SET-z#33,SET]
+  000045:[zz#35,SET-zz#35,SET]
 
 metrics-value
 num-backing
@@ -735,11 +774,24 @@ virtual-size
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
-  000039:[d#0,SET-m#0,SET]
-  000037:[z#33,SET-z#33,SET]
-  000038:[zz#35,SET-zz#35,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
+  000046:[d#0,SET-d#0,SET]
+  000047:[e#0,SET-e#0,SET]
+  000048:[f#0,SET-f#0,SET]
+  000049:[g#0,SET-g#0,SET]
+  000050:[h#0,SET-h#0,SET]
+  000051:[l#0,SET-l#0,SET]
+  000052:[m#0,SET-m#0,SET]
+  000044:[z#33,SET-z#33,SET]
+  000045:[zz#35,SET-zz#35,SET]
 
 # Virtual sstables metrics should be gone after the compaction.
 metrics-value
@@ -766,8 +818,8 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     5  3.8KB    31B       0 |    - 0.00 0.00 |  14KB |     2  1.5KB |     0     0B |     3  2.3KB |  14KB |   1 0.17
-total |     5  3.8KB    31B       0 |    -    -    - | 3.9KB |     5  3.7KB |     0     0B |    22   20KB |  14KB |   1 5.16
+    6 |    18   13KB     0B       0 |    - 0.00 0.00 |  14KB |     2  1.5KB |     0     0B |    16   12KB |  14KB |   1 0.84
+total |    18   13KB     0B       0 |    -    -    - | 3.9KB |     5  3.7KB |     0     0B |    35   30KB |  14KB |   1 7.55
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
@@ -777,8 +829,8 @@ MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 3.8KB
-Compression types: snappy: 5
+Local tables size: 13KB
+Compression types: snappy: 18
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
@@ -852,7 +904,9 @@ Iter category stats:
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-c#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
 
 # Table becomes shared, so local table size becomes 0.
 metrics
@@ -866,8 +920,8 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   767B     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     1   767B | 2.2KB |   1 0.34
-total |     1   767B     0B       0 |    -    -    - |   38B |     0     0B |     0     0B |     4  3.0KB | 2.2KB |   1 80.5
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.00
+total |     3  2.2KB     0B       0 |    -    -    - |   38B |     0     0B |     0     0B |     6  4.4KB | 2.2KB |   1  120
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -878,7 +932,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
-Compression types: snappy: 1
+Compression types: snappy: 3
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
@@ -902,15 +956,17 @@ metrics-value
 remote-count
 remote-size
 ----
-2
-1.5KB
+4
+2.9KB
 
 lsm
 ----
 L0.0:
-  000009:[b#13,SET-b#13,SET]
+  000011:[b#13,SET-b#13,SET]
 L6:
-  000008:[a#0,SET-c#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
 
 # Ingest is also shared table, so local table size stays 0.
 metrics
@@ -924,22 +980,22 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   767B     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     1   767B | 2.2KB |   1 0.34
-total |     2  1.5KB     0B       0 |    -    -    - |  792B |     1   754B |     0     0B |     4  3.7KB | 2.2KB |   2 4.81
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.00
+total |     4  2.9KB     0B       0 |    -    -    - |  792B |     1   754B |     0     0B |     6  5.2KB | 2.2KB |   2 6.70
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
-Compactions: 1  estimated debt: 1.5KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 2.9KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
-Compression types: snappy: 2
+Compression types: snappy: 4
 Table stats: all loaded
-Block cache: 4 entries (1.5KB)  hit rate: 0.0%
-Table cache: 1 entries (832B)  hit rate: 42.9%
+Block cache: 2 entries (787B)  hit rate: 0.0%
+Table cache: 0 entries (0B)  hit rate: 50.0%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -948,7 +1004,6 @@ Ingestions: 1  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
-       pebble-ingest,     latency: {BlockBytes:127 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 batch
 set b 3
@@ -957,11 +1012,13 @@ set b 3
 flush
 ----
 L0.1:
-  000011:[b#14,SET-b#14,SET]
+  000013:[b#14,SET-b#14,SET]
 L0.0:
-  000009:[b#13,SET-b#13,SET]
+  000011:[b#13,SET-b#13,SET]
 L6:
-  000008:[a#0,SET-c#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
 
 # Local table size increases due to flush.
 metrics
@@ -975,22 +1032,22 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   767B     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     1   767B | 2.2KB |   1 0.34
-total |     3  2.2KB     0B       0 |    -    -    - |  828B |     1   754B |     0     0B |     5  4.5KB | 2.2KB |   3 5.55
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.00
+total |     5  3.7KB     0B       0 |    -    -    - |  828B |     1   754B |     0     0B |     7  6.0KB | 2.2KB |   3 7.36
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 44B  written: 74B (68% overhead)
 Flushes: 2
-Compactions: 1  estimated debt: 2.2KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 3.7KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 751B
-Compression types: snappy: 3
+Compression types: snappy: 5
 Table stats: all loaded
-Block cache: 4 entries (1.5KB)  hit rate: 0.0%
-Table cache: 1 entries (832B)  hit rate: 42.9%
+Block cache: 2 entries (787B)  hit rate: 0.0%
+Table cache: 0 entries (0B)  hit rate: 50.0%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -999,7 +1056,6 @@ Ingestions: 1  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
-       pebble-ingest,     latency: {BlockBytes:127 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 # Reopen DB, to ensure stats are consistent. Also, reopened DB is not
 # configured to write shared tables.
@@ -1017,19 +1073,19 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   767B     0B       0 |    - 0.00 0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   1    0
-total |     3  2.2KB     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     0     0B |    0B |   3    0
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   1    0
+total |     5  3.7KB     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     0     0B |    0B |   3    0
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 1
-Compactions: 0  estimated debt: 2.2KB  in progress: 0 (0B)
+Compactions: 0  estimated debt: 3.7KB  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 751B
-Compression types: snappy: 3
+Compression types: snappy: 5
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
@@ -1045,7 +1101,9 @@ Iter category stats:
 compact a-z
 ----
 L6:
-  000016:[a#0,SET-c#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000018:[b#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
 
 # All tables are local after compaction.
 metrics zero-cache-hits-misses
@@ -1059,8 +1117,8 @@ level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   767B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   767B | 2.2KB |   1 0.51
-total |     1   767B     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     1   767B | 2.2KB |   1    0
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   754B | 2.2KB |   1 0.50
+total |     3  2.2KB     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     1   754B | 2.2KB |   1    0
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 1
@@ -1070,8 +1128,8 @@ MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 767B
-Compression types: snappy: 1
+Local tables size: 754B
+Compression types: snappy: 3
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
@@ -1082,4 +1140,4 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:354 BlockBytesInCache:0 BlockReadDuration:30ms}
+   pebble-compaction, non-latency: {BlockBytes:342 BlockBytesInCache:0 BlockReadDuration:30ms}


### PR DESCRIPTION
When computing the estimated size of a sstable being built, incorporate size of the pending index blocks, value blocks, range deletion block and range key block. None of these quantities were incorporated into the RawRowWriter's estimated size.

The RawColumnWriter incorporated these, but did not incorporate the current pending data block or current pending index block.

Most of these quantities are uncompressed. We consider this pessimism to be acceptable, because these quantities are expected to be small most of the time. When they're not, they increase memory usage and splitting earlier than we otherwise would have helps bound memory usage.

Informs #4518.