### PR TITLE
crl-release-25.2: sstable: improve writer EstimatedSize

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1346,6 +1346,29 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	return buf.String()
 }
 
+func runLayoutCmd(t *testing.T, td *datadriven.TestData, d *DB) string {
+	var filename string
+	td.ScanArgs(t, "filename", &filename)
+	f, err := d.opts.FS.Open(filename)
+	if err != nil {
+		return err.Error()
+	}
+	readable, err := sstable.NewSimpleReadable(f)
+	if err != nil {
+		return err.Error()
+	}
+	r, err := sstable.NewReader(context.Background(), readable, d.opts.MakeReaderOptions())
+	if err != nil {
+		return err.Error()
+	}
+	defer r.Close()
+	l, err := r.Layout()
+	if err != nil {
+		return err.Error()
+	}
+	return l.Describe(td.HasArg("verbose"), r, nil)
+}
+
 func runPopulateCmd(t *testing.T, td *datadriven.TestData, b *Batch) {
 	var maxKeyLength, valLength int
 	var timestamps []int

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -5,7 +5,6 @@ package pebble
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -240,28 +239,7 @@ func TestIterHistories(t *testing.T) {
 				}
 				return ""
 			case "layout":
-				var verbose bool
-				var filename string
-				td.ScanArgs(t, "filename", &filename)
-				td.MaybeScanArgs(t, "verbose", &verbose)
-				f, err := opts.FS.Open(filename)
-				if err != nil {
-					return err.Error()
-				}
-				readable, err := sstable.NewSimpleReadable(f)
-				if err != nil {
-					return err.Error()
-				}
-				r, err := sstable.NewReader(context.Background(), readable, opts.MakeReaderOptions())
-				if err != nil {
-					return err.Error()
-				}
-				defer r.Close()
-				l, err := r.Layout()
-				if err != nil {
-					return err.Error()
-				}
-				return l.Describe(verbose, r, nil)
+				return runLayoutCmd(t, td, d)
 			case "lsm":
 				return runLSMCmd(td, d)
 			case "metrics":

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -336,7 +336,7 @@ a@2.SET.1:a2
 a@1.SET.1:a1
 b@2.SET.1:b2
 ----
-EstimatedSize()=53
+EstimatedSize()=163
 
 close
 ----

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -359,7 +359,7 @@ a@2.SET.1:a2
 a@1.SET.1:a1
 b@2.SET.1:b2
 ----
-EstimatedSize()=57
+EstimatedSize()=167
 
 close
 ----

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -43,7 +43,14 @@ set a(p,1000000)rove
 flush verbose
 ----
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563939
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563957
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563948
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563942
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563939
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563954
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563957
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94435
 
 layout filename=000005.sst
 ----
@@ -52,64 +59,14 @@ sstable
  ├── data  offset: 46949  length: 46945
  ├── data  offset: 93899  length: 46941
  ├── data  offset: 140845  length: 46944
- ├── data  offset: 187794  length: 46947
- ├── data  offset: 234746  length: 46945
- ├── data  offset: 281696  length: 46945
- ├── data  offset: 328646  length: 46943
- ├── data  offset: 375594  length: 46945
- ├── data  offset: 422544  length: 46940
- ├── data  offset: 469489  length: 46951
- ├── data  offset: 516445  length: 46941
- ├── data  offset: 563391  length: 46944
- ├── data  offset: 610340  length: 46945
- ├── data  offset: 657290  length: 46946
- ├── data  offset: 704241  length: 46940
- ├── data  offset: 751186  length: 46943
- ├── data  offset: 798134  length: 46942
- ├── data  offset: 845081  length: 46944
- ├── data  offset: 892030  length: 46945
- ├── data  offset: 938980  length: 46944
- ├── data  offset: 985929  length: 46945
- ├── data  offset: 1032879  length: 46945
- ├── data  offset: 1079829  length: 46945
- ├── data  offset: 1126779  length: 46946
- ├── data  offset: 1173730  length: 46947
- ├── data  offset: 1220682  length: 46943
- ├── data  offset: 1267630  length: 46944
- ├── data  offset: 1314579  length: 46942
- ├── index  offset: 1361526  length: 46942
- ├── index  offset: 1408473  length: 46946
- ├── index  offset: 1455424  length: 46942
- ├── index  offset: 1502371  length: 46945
- ├── index  offset: 1549321  length: 46948
- ├── index  offset: 1596274  length: 46946
- ├── index  offset: 1643225  length: 46946
- ├── index  offset: 1690176  length: 46944
- ├── index  offset: 1737125  length: 46946
- ├── index  offset: 1784076  length: 46941
- ├── index  offset: 1831022  length: 46952
- ├── index  offset: 1877979  length: 46942
- ├── index  offset: 1924926  length: 46945
- ├── index  offset: 1971876  length: 46946
- ├── index  offset: 2018827  length: 46947
- ├── index  offset: 2065779  length: 46941
- ├── index  offset: 2112725  length: 46944
- ├── index  offset: 2159674  length: 46943
- ├── index  offset: 2206622  length: 46945
- ├── index  offset: 2253572  length: 46946
- ├── index  offset: 2300523  length: 46945
- ├── index  offset: 2347473  length: 46946
- ├── index  offset: 2394424  length: 46946
- ├── index  offset: 2441375  length: 46946
- ├── index  offset: 2488326  length: 46947
- ├── index  offset: 2535278  length: 46948
- ├── index  offset: 2582231  length: 46944
- ├── index  offset: 2629180  length: 46945
- ├── index  offset: 2676130  length: 46943
- ├── top-index  offset: 2723078  length: 1361225
- ├── properties  offset: 4084308  length: 490
- ├── meta-index  offset: 4084803  length: 35
- └── footer  offset: 4084843  length: 53
+ ├── index  offset: 187794  length: 46942
+ ├── index  offset: 234741  length: 46946
+ ├── index  offset: 281692  length: 46942
+ ├── index  offset: 328639  length: 46945
+ ├── top-index  offset: 375589  length: 187759
+ ├── properties  offset: 563353  length: 489
+ ├── meta-index  offset: 563847  length: 34
+ └── footer  offset: 563886  length: 53
 
 properties file=000005
 raw.key.size
@@ -117,12 +74,12 @@ index.size
 index.partitions
 ----
 raw.key.size:
-  rocksdb.raw.key.size: 29000440
+  rocksdb.raw.key.size: 4000058
 index.size:
-  rocksdb.index.size: 58001886
-  rocksdb.top-level.index.size: 29000892
+  rocksdb.index.size: 8000259
+  rocksdb.top-level.index.size: 4000122
 index.partitions:
-  rocksdb.index.partitions: 29
+  rocksdb.index.partitions: 4
 
 batch-commit
 del-range a(p,1000000)arition a(p,1000000)eal
@@ -139,26 +96,35 @@ del-range a(p,1000000)rovals a(p,1000000)rove
 flush verbose
 ----
 L0.1:
-  000008:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[39-47] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:18000932
+  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000726
+  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] seqnums:[42-44] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] size:6000732
+  000017:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[45-47] points:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:6000726
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563939
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563957
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563948
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563942
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563939
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563954
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563957
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94435
 
-layout filename=000008.sst
+layout filename=000015.sst
 ----
 sstable
  ├── data  offset: 0  length: 8
  ├── index  offset: 13  length: 24
- ├── range-del  offset: 42  length: 18000310
- ├── properties  offset: 18000357  length: 447
- ├── meta-index  offset: 18000809  length: 65
- └── footer  offset: 18000879  length: 53
+ ├── range-del  offset: 42  length: 6000104
+ ├── properties  offset: 6000151  length: 447
+ ├── meta-index  offset: 6000603  length: 65
+ └── footer  offset: 6000673  length: 53
 
 properties file=000008
 rocksdb.raw
 ----
 rocksdb.raw:
-  rocksdb.raw.key.size: 9000139
-  rocksdb.raw.value.size: 9000068
+  rocksdb.raw.key.size: 4000059
+  rocksdb.raw.value.size: 20
 
 # Repeat the above with columnar blocks.
 
@@ -202,30 +168,30 @@ set a(p,1000000)rove
 flush verbose
 ----
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:564287
-  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:564304
-  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:564298
-  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:564292
-  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:564286
-  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:564299
-  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:564311
-  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94575
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] seqnums:[10-12] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] size:423391
+  000006:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] seqnums:[13-15] points:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] size:423412
+  000007:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] seqnums:[16-18] points:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] size:423397
+  000008:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] seqnums:[19-23] points:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] size:423401
+  000009:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] seqnums:[21-24] points:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] size:423412
+  000010:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] seqnums:[25-27] points:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] size:423377
+  000011:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] seqnums:[28-30] points:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] size:423397
+  000012:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] seqnums:[31-33] points:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] size:423403
+  000013:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] seqnums:[34-36] points:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] size:423410
+  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[37-38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282487
 
 layout filename=000006.sst
 ----
 sstable
- ├── data  offset: 0  length: 46998
- ├── data  offset: 47003  length: 46993
- ├── data  offset: 94001  length: 46993
- ├── data  offset: 140999  length: 46991
- ├── index  offset: 187995  length: 46967
- ├── index  offset: 234967  length: 46969
- ├── index  offset: 281941  length: 46973
- ├── index  offset: 328919  length: 46969
- ├── top-index  offset: 375893  length: 187752
- ├── properties  offset: 563650  length: 557
- ├── meta-index  offset: 564212  length: 34
- └── footer  offset: 564251  length: 53
+ ├── data  offset: 0  length: 46995
+ ├── data  offset: 47000  length: 46998
+ ├── data  offset: 94003  length: 46993
+ ├── index  offset: 141001  length: 46965
+ ├── index  offset: 187971  length: 46971
+ ├── index  offset: 234947  length: 46973
+ ├── top-index  offset: 281925  length: 140828
+ ├── properties  offset: 422758  length: 557
+ ├── meta-index  offset: 423320  length: 34
+ └── footer  offset: 423359  length: 53
 
 properties file=000006
 raw.key.size
@@ -233,12 +199,12 @@ index.size
 index.partitions
 ----
 raw.key.size:
-  rocksdb.raw.key.size: 4000064
+  rocksdb.raw.key.size: 3000049
 index.size:
-  rocksdb.index.size: 8000330
-  rocksdb.top-level.index.size: 4000112
+  rocksdb.index.size: 6000258
+  rocksdb.top-level.index.size: 3000094
 index.partitions:
-  rocksdb.index.partitions: 4
+  rocksdb.index.partitions: 3
 
 batch-commit
 del-range a(p,1000000)arition a(p,1000000)eal
@@ -255,20 +221,22 @@ del-range a(p,1000000)rovals a(p,1000000)rove
 flush verbose
 ----
 L0.1:
-  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000807
-  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000821
-  000017:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000779
+  000017:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000807
+  000018:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000821
+  000019:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000779
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:564287
-  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:564304
-  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:564298
-  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:564292
-  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:564286
-  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:564299
-  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:564311
-  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94575
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] seqnums:[10-12] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] size:423391
+  000006:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] seqnums:[13-15] points:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] size:423412
+  000007:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] seqnums:[16-18] points:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] size:423397
+  000008:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] seqnums:[19-23] points:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] size:423401
+  000009:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] seqnums:[21-24] points:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] size:423412
+  000010:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] seqnums:[25-27] points:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] size:423377
+  000011:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] seqnums:[28-30] points:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] size:423397
+  000012:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] seqnums:[31-33] points:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] size:423403
+  000013:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] seqnums:[34-36] points:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] size:423410
+  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[37-38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282487
 
-layout filename=000015.sst
+layout filename=000017.sst
 ----
 sstable
  ├── index  offset: 0  length: 28
@@ -277,7 +245,7 @@ sstable
  ├── meta-index  offset: 6000684  length: 65
  └── footer  offset: 6000754  length: 53
 
-properties file=000015
+properties file=000017
 rocksdb.raw
 ----
 rocksdb.raw:

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -1,0 +1,285 @@
+# FormatFlushableIngestExcises is format major version 18, which precedes
+# support for columnar blocks.
+#
+# Set a target file size of 4MB.
+
+define target-file-sizes=(4000000) format-major-version=18
+----
+
+# Commit many keys with 1MB-shared prefixes.
+
+batch-commit
+set a(p,1000000)arition
+set a(p,1000000)alling
+set a(p,1000000)eal
+set a(p,1000000)ellate
+set a(p,1000000)endectomy
+set a(p,1000000)etizers
+set a(p,1000000)etizing
+set a(p,1000000)laude
+set a(p,1000000)lauding
+set a(p,1000000)le
+set a(p,1000000)les
+set a(p,1000000)letini
+set a(p,1000000)letinis
+set a(p,1000000)lebottomjeans
+set a(p,1000000)lication
+set a(p,1000000)ly
+set a(p,1000000)lying
+set a(p,1000000)ollo
+set a(p,1000000)raisal
+set a(p,1000000)raisals
+set a(p,1000000)raiser
+set a(p,1000000)raisers
+set a(p,1000000)raising
+set a(p,1000000)rentice
+set a(p,1000000)rentices
+set a(p,1000000)renticing
+set a(p,1000000)roval
+set a(p,1000000)rovals
+set a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+
+layout filename=000005.sst
+----
+sstable
+ ├── data  offset: 0  length: 46944
+ ├── data  offset: 46949  length: 46945
+ ├── data  offset: 93899  length: 46941
+ ├── data  offset: 140845  length: 46944
+ ├── data  offset: 187794  length: 46947
+ ├── data  offset: 234746  length: 46945
+ ├── data  offset: 281696  length: 46945
+ ├── data  offset: 328646  length: 46943
+ ├── data  offset: 375594  length: 46945
+ ├── data  offset: 422544  length: 46940
+ ├── data  offset: 469489  length: 46951
+ ├── data  offset: 516445  length: 46941
+ ├── data  offset: 563391  length: 46944
+ ├── data  offset: 610340  length: 46945
+ ├── data  offset: 657290  length: 46946
+ ├── data  offset: 704241  length: 46940
+ ├── data  offset: 751186  length: 46943
+ ├── data  offset: 798134  length: 46942
+ ├── data  offset: 845081  length: 46944
+ ├── data  offset: 892030  length: 46945
+ ├── data  offset: 938980  length: 46944
+ ├── data  offset: 985929  length: 46945
+ ├── data  offset: 1032879  length: 46945
+ ├── data  offset: 1079829  length: 46945
+ ├── data  offset: 1126779  length: 46946
+ ├── data  offset: 1173730  length: 46947
+ ├── data  offset: 1220682  length: 46943
+ ├── data  offset: 1267630  length: 46944
+ ├── data  offset: 1314579  length: 46942
+ ├── index  offset: 1361526  length: 46942
+ ├── index  offset: 1408473  length: 46946
+ ├── index  offset: 1455424  length: 46942
+ ├── index  offset: 1502371  length: 46945
+ ├── index  offset: 1549321  length: 46948
+ ├── index  offset: 1596274  length: 46946
+ ├── index  offset: 1643225  length: 46946
+ ├── index  offset: 1690176  length: 46944
+ ├── index  offset: 1737125  length: 46946
+ ├── index  offset: 1784076  length: 46941
+ ├── index  offset: 1831022  length: 46952
+ ├── index  offset: 1877979  length: 46942
+ ├── index  offset: 1924926  length: 46945
+ ├── index  offset: 1971876  length: 46946
+ ├── index  offset: 2018827  length: 46947
+ ├── index  offset: 2065779  length: 46941
+ ├── index  offset: 2112725  length: 46944
+ ├── index  offset: 2159674  length: 46943
+ ├── index  offset: 2206622  length: 46945
+ ├── index  offset: 2253572  length: 46946
+ ├── index  offset: 2300523  length: 46945
+ ├── index  offset: 2347473  length: 46946
+ ├── index  offset: 2394424  length: 46946
+ ├── index  offset: 2441375  length: 46946
+ ├── index  offset: 2488326  length: 46947
+ ├── index  offset: 2535278  length: 46948
+ ├── index  offset: 2582231  length: 46944
+ ├── index  offset: 2629180  length: 46945
+ ├── index  offset: 2676130  length: 46943
+ ├── top-index  offset: 2723078  length: 1361225
+ ├── properties  offset: 4084308  length: 490
+ ├── meta-index  offset: 4084803  length: 35
+ └── footer  offset: 4084843  length: 53
+
+properties file=000005
+raw.key.size
+index.size
+index.partitions
+----
+raw.key.size:
+  rocksdb.raw.key.size: 29000440
+index.size:
+  rocksdb.index.size: 58001886
+  rocksdb.top-level.index.size: 29000892
+index.partitions:
+  rocksdb.index.partitions: 29
+
+batch-commit
+del-range a(p,1000000)arition a(p,1000000)eal
+del-range a(p,1000000)ellate a(p,1000000)etizers
+del-range a(p,1000000)etizing a(p,1000000)lauding
+del-range a(p,1000000)le a(p,1000000)lebottomjeans
+del-range a(p,1000000)lebottomjeans a(p,1000000)lication
+del-range a(p,1000000)ly a(p,1000000)lying
+del-range a(p,1000000)raisals a(p,1000000)rentice
+del-range a(p,1000000)rentices a(p,1000000)roval
+del-range a(p,1000000)rovals a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.1:
+  000008:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[39-47] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:18000932
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+
+layout filename=000008.sst
+----
+sstable
+ ├── data  offset: 0  length: 8
+ ├── index  offset: 13  length: 24
+ ├── range-del  offset: 42  length: 18000310
+ ├── properties  offset: 18000357  length: 447
+ ├── meta-index  offset: 18000809  length: 65
+ └── footer  offset: 18000879  length: 53
+
+properties file=000008
+rocksdb.raw
+----
+rocksdb.raw:
+  rocksdb.raw.key.size: 9000139
+  rocksdb.raw.value.size: 9000068
+
+# Repeat the above with columnar blocks.
+
+define target-file-sizes=(4000000) format-major-version=19
+----
+
+# Commit many keys with 1MB-shared prefixes.
+
+batch-commit
+set a(p,1000000)arition
+set a(p,1000000)alling
+set a(p,1000000)eal
+set a(p,1000000)ellate
+set a(p,1000000)endectomy
+set a(p,1000000)etizers
+set a(p,1000000)etizing
+set a(p,1000000)laude
+set a(p,1000000)lauding
+set a(p,1000000)le
+set a(p,1000000)les
+set a(p,1000000)letini
+set a(p,1000000)letinis
+set a(p,1000000)lebottomjeans
+set a(p,1000000)lication
+set a(p,1000000)ly
+set a(p,1000000)lying
+set a(p,1000000)ollo
+set a(p,1000000)raisal
+set a(p,1000000)raisals
+set a(p,1000000)raiser
+set a(p,1000000)raisers
+set a(p,1000000)raising
+set a(p,1000000)rentice
+set a(p,1000000)rentices
+set a(p,1000000)renticing
+set a(p,1000000)roval
+set a(p,1000000)rovals
+set a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:564287
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:564304
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:564298
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:564292
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:564286
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:564299
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:564311
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94575
+
+layout filename=000006.sst
+----
+sstable
+ ├── data  offset: 0  length: 46998
+ ├── data  offset: 47003  length: 46993
+ ├── data  offset: 94001  length: 46993
+ ├── data  offset: 140999  length: 46991
+ ├── index  offset: 187995  length: 46967
+ ├── index  offset: 234967  length: 46969
+ ├── index  offset: 281941  length: 46973
+ ├── index  offset: 328919  length: 46969
+ ├── top-index  offset: 375893  length: 187752
+ ├── properties  offset: 563650  length: 557
+ ├── meta-index  offset: 564212  length: 34
+ └── footer  offset: 564251  length: 53
+
+properties file=000006
+raw.key.size
+index.size
+index.partitions
+----
+raw.key.size:
+  rocksdb.raw.key.size: 4000064
+index.size:
+  rocksdb.index.size: 8000330
+  rocksdb.top-level.index.size: 4000112
+index.partitions:
+  rocksdb.index.partitions: 4
+
+batch-commit
+del-range a(p,1000000)arition a(p,1000000)eal
+del-range a(p,1000000)ellate a(p,1000000)etizers
+del-range a(p,1000000)etizing a(p,1000000)lauding
+del-range a(p,1000000)le a(p,1000000)lebottomjeans
+del-range a(p,1000000)lebottomjeans a(p,1000000)lication
+del-range a(p,1000000)ly a(p,1000000)lying
+del-range a(p,1000000)raisals a(p,1000000)rentice
+del-range a(p,1000000)rentices a(p,1000000)roval
+del-range a(p,1000000)rovals a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.1:
+  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000807
+  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000821
+  000017:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000779
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:564287
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:564304
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:564298
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:564292
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:564286
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:564299
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:564311
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94575
+
+layout filename=000015.sst
+----
+sstable
+ ├── index  offset: 0  length: 28
+ ├── range-del  offset: 33  length: 6000129
+ ├── properties  offset: 6000167  length: 512
+ ├── meta-index  offset: 6000684  length: 65
+ └── footer  offset: 6000754  length: 53
+
+properties file=000015
+rocksdb.raw
+----
+rocksdb.raw:
+  rocksdb.raw.key.size: 6000043
+  rocksdb.raw.value.size: 0

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev5
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev5
@@ -253,8 +253,8 @@ L3:
 compact a-h L1
 ----
 L2:
-  000009:[grandparent#2,RANGEDEL-m#inf,RANGEDEL]
-  000010:[m#2,RANGEDEL-z#inf,RANGEDEL]
+  000009:[grandparent#2,RANGEDEL-h#inf,RANGEDEL]
+  000010:[h#3,SET-z#inf,RANGEDEL]
 L3:
   000007:[grandparent#0,SET-grandparent#0,SET]
   000008:[m#0,SET-m#0,SET]

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev6
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev6
@@ -253,8 +253,8 @@ L3:
 compact a-h L1
 ----
 L2:
-  000009:[grandparent#2,RANGEDEL-m#inf,RANGEDEL]
-  000010:[m#2,RANGEDEL-z#inf,RANGEDEL]
+  000009:[grandparent#2,RANGEDEL-h#inf,RANGEDEL]
+  000010:[h#3,SET-z#inf,RANGEDEL]
 L3:
   000007:[grandparent#0,SET-grandparent#0,SET]
   000008:[m#0,SET-m#0,SET]

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -105,10 +105,13 @@ L0.0:
 iter-new c category=c
 ----
 
+# Two files, since the target file size is set to 50.
+
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-b#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
 
 metrics
 ----
@@ -121,8 +124,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     1   743B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.8
+    6 |     2  1.5KB     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     2  1.5KB | 1.4KB |   1  1.0
+total |     2  1.5KB     0B       0 |     - |   56B |     0     0B |     0     0B |     4  3.0KB | 1.4KB |   1 54.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
@@ -132,8 +135,8 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.4KB, local: 1.4KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 743B
-Compression types: snappy: 1
+Local tables size: 1.5KB
+Compression types: snappy: 2
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -149,7 +152,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.9KB
+4.6KB
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -167,8 +170,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     1   743B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.8
+    6 |     2  1.5KB     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     2  1.5KB | 1.4KB |   1  1.0
+total |     2  1.5KB     0B       0 |     - |   56B |     0     0B |     0     0B |     4  3.0KB | 1.4KB |   1 54.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
@@ -178,8 +181,8 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 2 (1.4KB, local: 1.4KB)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 743B
-Compression types: snappy: 1
+Local tables size: 1.5KB
+Compression types: snappy: 2
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 2 entries (1.6KB)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -210,8 +213,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     1   743B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.8
+    6 |     2  1.5KB     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     2  1.5KB | 1.4KB |   1  1.0
+total |     2  1.5KB     0B       0 |     - |   56B |     0     0B |     0     0B |     4  3.0KB | 1.4KB |   1 54.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
@@ -221,8 +224,8 @@ MemTables: 1 (256KB)  zombie: 2 (512KB)
 Zombie tables: 1 (742B, local: 742B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 743B
-Compression types: snappy: 1
+Local tables size: 1.5KB
+Compression types: snappy: 2
 Block cache: 2 entries (795B)  hit rate: 33.3%
 Table cache: 1 entries (832B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -238,7 +241,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.2KB
+3.9KB
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -256,8 +259,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     1   743B     0B       0 |     - |   56B |     0     0B |     0     0B |     3  2.2KB | 1.4KB |   1 40.8
+    6 |     2  1.5KB     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     2  1.5KB | 1.4KB |   1  1.0
+total |     2  1.5KB     0B       0 |     - |   56B |     0     0B |     0     0B |     4  3.0KB | 1.4KB |   1 54.1
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 56B (65% overhead)
 Flushes: 2
@@ -267,8 +270,8 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 743B
-Compression types: snappy: 1
+Local tables size: 1.5KB
+Compression types: snappy: 2
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -284,7 +287,7 @@ Iter category stats:
 
 disk-usage
 ----
-2.4KB
+3.2KB
 
 additional-metrics
 ----
@@ -296,7 +299,7 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6          82B           0B
+      6         168B           0B
 
 batch
 set c@20 c20
@@ -311,15 +314,16 @@ set c@14 c14
 flush
 ----
 L0.0:
-  000010:[c@20#12,SET-c@20#12,SET]
-  000011:[c@19#13,SET-c@19#13,SET]
-  000012:[c@18#14,SET-c@18#14,SET]
-  000013:[c@17#15,SET-c@17#15,SET]
-  000014:[c@16#16,SET-c@16#16,SET]
-  000015:[c@15#17,SET-c@15#17,SET]
-  000016:[c@14#18,SET-c@14#18,SET]
+  000011:[c@20#12,SET-c@20#12,SET]
+  000012:[c@19#13,SET-c@19#13,SET]
+  000013:[c@18#14,SET-c@18#14,SET]
+  000014:[c@17#15,SET-c@17#15,SET]
+  000015:[c@16#16,SET-c@16#16,SET]
+  000016:[c@15#17,SET-c@15#17,SET]
+  000017:[c@14#18,SET-c@14#18,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
 
 metrics
 ----
@@ -332,19 +336,19 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   743B     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     1   743B | 1.4KB |   1  0.5
-total |     8  5.9KB     0B       0 |     - |  149B |     0     0B |     0     0B |    10  7.5KB | 1.4KB |   2 51.5
+    6 |     2  1.5KB     0B       0 |     - | 1.4KB |     0     0B |     0     0B |     2  1.5KB | 1.4KB |   1  1.0
+total |     9  6.6KB     0B       0 |     - |  149B |     0     0B |     0     0B |    11  8.2KB | 1.4KB |   2 56.5
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
-Compactions: 1  estimated debt: 5.9KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 6.6KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 5.9KB
-Compression types: snappy: 8
+Local tables size: 6.6KB
+Compression types: snappy: 9
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -368,13 +372,20 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6          82B           0B
+      6         168B           0B
 
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
 
 metrics
 ----
@@ -387,8 +398,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     2  1.6KB    31B       0 |     - | 6.6KB |     0     0B |     0     0B |     2  1.6KB | 6.6KB |   1  0.2
-total |     2  1.6KB    31B       0 |     - |  149B |     0     0B |     0     0B |    11  8.4KB | 6.6KB |   1 57.6
+    6 |     9  6.5KB     0B       0 |     - | 6.6KB |     0     0B |     0     0B |     9  6.5KB | 6.6KB |   1  1.0
+total |     9  6.5KB     0B       0 |     - |  149B |     0     0B |     0     0B |    18   13KB | 6.6KB |   1 91.5
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
@@ -398,8 +409,8 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 1.6KB
-Compression types: snappy: 2
+Local tables size: 6.5KB
+Compression types: snappy: 9
 Block cache: 0 entries (0B)  hit rate: 10.0%
 Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
@@ -423,7 +434,7 @@ block bytes written:
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6         220B          31B
+      6         754B           0B
 
 # Flushable ingestion metrics. This requires there be data in a memtable that
 # would overlap with the ingested table(s). Delayed flushes are disabled here to
@@ -466,16 +477,23 @@ disable
 flush
 ----
 L0.1:
-  000018:[d#22,SET-d#22,SET]
-  000019:[e#23,SET-e#23,SET]
-  000022:[f#24,SET-f#24,SET]
+  000025:[d#22,SET-d#22,SET]
+  000026:[e#23,SET-e#23,SET]
+  000029:[f#24,SET-f#24,SET]
 L0.0:
-  000026:[d#19,SET-d#19,SET]
-  000027:[e#20,SET-e#20,SET]
-  000028:[f#21,SET-f#21,SET]
+  000033:[d#19,SET-d#19,SET]
+  000034:[e#20,SET-e#20,SET]
+  000035:[f#21,SET-f#21,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
 
 # We expect the ingested-as-flushable count to be three (one for each ingested
 # table). The unknown category in the iter category stats is because of a gap
@@ -493,19 +511,19 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     2  1.6KB    31B       0 |     - | 6.6KB |     0     0B |     0     0B |     2  1.6KB | 6.6KB |   1  0.2
-total |     8  6.0KB    31B       0 |     - | 2.4KB |     3  2.2KB |     0     0B |    14   13KB | 6.6KB |   3  5.4
+    6 |     9  6.5KB     0B       0 |     - | 6.6KB |     0     0B |     0     0B |     9  6.5KB | 6.6KB |   1  1.0
+total |    15   11KB     0B       0 |     - | 2.4KB |     3  2.2KB |     0     0B |    21   18KB | 6.6KB |   3  7.5
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 176B  written: 187B (6% overhead)
 Flushes: 8
-Compactions: 2  estimated debt: 6.0KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 11KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 6.0KB
-Compression types: snappy: 8
+Local tables size: 11KB
+Compression types: snappy: 15
 Block cache: 6 entries (2.3KB)  hit rate: 7.7%
 Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
@@ -532,23 +550,30 @@ set m m
 flush
 ----
 L0.1:
-  000018:[d#22,SET-d#22,SET]
-  000019:[e#23,SET-e#23,SET]
-  000022:[f#24,SET-f#24,SET]
+  000025:[d#22,SET-d#22,SET]
+  000026:[e#23,SET-e#23,SET]
+  000029:[f#24,SET-f#24,SET]
 L0.0:
-  000026:[d#19,SET-d#19,SET]
-  000027:[e#20,SET-e#20,SET]
-  000028:[f#21,SET-f#21,SET]
-  000030:[g#25,SET-g#25,SET]
-  000031:[h#26,SET-h#26,SET]
-  000032:[i#27,SET-i#27,SET]
-  000033:[j#28,SET-j#28,SET]
-  000034:[k#29,SET-k#29,SET]
-  000035:[l#30,SET-l#30,SET]
-  000036:[m#31,SET-m#31,SET]
+  000033:[d#19,SET-d#19,SET]
+  000034:[e#20,SET-e#20,SET]
+  000035:[f#21,SET-f#21,SET]
+  000037:[g#25,SET-g#25,SET]
+  000038:[h#26,SET-h#26,SET]
+  000039:[i#27,SET-i#27,SET]
+  000040:[j#28,SET-j#28,SET]
+  000041:[k#29,SET-k#29,SET]
+  000042:[l#30,SET-l#30,SET]
+  000043:[m#31,SET-m#31,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
 
 metrics
 ----
@@ -561,19 +586,19 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     2  1.6KB    31B       0 |     - | 6.6KB |     0     0B |     0     0B |     2  1.6KB | 6.6KB |   1  0.2
-total |    15   11KB    31B       0 |     - | 2.4KB |     3  2.2KB |     0     0B |    21   18KB | 6.6KB |   3  7.4
+    6 |     9  6.5KB     0B       0 |     - | 6.6KB |     0     0B |     0     0B |     9  6.5KB | 6.6KB |   1  1.0
+total |    22   16KB     0B       0 |     - | 2.4KB |     3  2.2KB |     0     0B |    28   23KB | 6.6KB |   3  9.4
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
-Compactions: 2  estimated debt: 11KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 16KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 11KB
-Compression types: snappy: 15
+Local tables size: 16KB
+Compression types: snappy: 22
 Block cache: 6 entries (2.3KB)  hit rate: 7.7%
 Table cache: 0 entries (0B)  hit rate: 55.0%
 Snapshots: 0  earliest seq num: 0
@@ -598,22 +623,29 @@ ingest-and-excise ext1 excise=i-k
 lsm
 ----
 L0.1:
-  000018:[d#22,SET-d#22,SET]
-  000019:[e#23,SET-e#23,SET]
-  000022:[f#24,SET-f#24,SET]
+  000025:[d#22,SET-d#22,SET]
+  000026:[e#23,SET-e#23,SET]
+  000029:[f#24,SET-f#24,SET]
 L0.0:
-  000026:[d#19,SET-d#19,SET]
-  000027:[e#20,SET-e#20,SET]
-  000028:[f#21,SET-f#21,SET]
-  000030:[g#25,SET-g#25,SET]
-  000031:[h#26,SET-h#26,SET]
-  000034:[k#29,SET-k#29,SET]
-  000035:[l#30,SET-l#30,SET]
-  000036:[m#31,SET-m#31,SET]
+  000033:[d#19,SET-d#19,SET]
+  000034:[e#20,SET-e#20,SET]
+  000035:[f#21,SET-f#21,SET]
+  000037:[g#25,SET-g#25,SET]
+  000038:[h#26,SET-h#26,SET]
+  000041:[k#29,SET-k#29,SET]
+  000042:[l#30,SET-l#30,SET]
+  000043:[m#31,SET-m#31,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
-  000037:[z#33,SET-z#33,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
+  000044:[z#33,SET-z#33,SET]
 
 # There should be 2 backing tables. Note that tiny sstables have inaccurate
 # virtual sstable sizes.
@@ -641,19 +673,19 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     3  2.4KB    31B       0 |     - | 6.6KB |     1   745B |     0     0B |     2  1.6KB | 6.6KB |   1  0.2
-total |    14   10KB    31B       0 |     - | 3.1KB |     4  2.9KB |     0     0B |    21   19KB | 6.6KB |   3  5.9
+    6 |    10  7.3KB     0B       0 |     - | 6.6KB |     1   745B |     0     0B |     9  6.5KB | 6.6KB |   1  1.0
+total |    21   15KB     0B       0 |     - | 3.1KB |     4  2.9KB |     0     0B |    28   24KB | 6.6KB |   3  7.5
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
-Compactions: 2  estimated debt: 10KB  in progress: 0 (0B)
+Compactions: 2  estimated debt: 15KB  in progress: 0 (0B)
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 10KB
-Compression types: snappy: 14
+Local tables size: 15KB
+Compression types: snappy: 21
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -680,22 +712,29 @@ ingest-and-excise ext1 excise=k-l
 lsm
 ----
 L0.1:
-  000018:[d#22,SET-d#22,SET]
-  000019:[e#23,SET-e#23,SET]
-  000022:[f#24,SET-f#24,SET]
+  000025:[d#22,SET-d#22,SET]
+  000026:[e#23,SET-e#23,SET]
+  000029:[f#24,SET-f#24,SET]
 L0.0:
-  000026:[d#19,SET-d#19,SET]
-  000027:[e#20,SET-e#20,SET]
-  000028:[f#21,SET-f#21,SET]
-  000030:[g#25,SET-g#25,SET]
-  000031:[h#26,SET-h#26,SET]
-  000035:[l#30,SET-l#30,SET]
-  000036:[m#31,SET-m#31,SET]
+  000033:[d#19,SET-d#19,SET]
+  000034:[e#20,SET-e#20,SET]
+  000035:[f#21,SET-f#21,SET]
+  000037:[g#25,SET-g#25,SET]
+  000038:[h#26,SET-h#26,SET]
+  000042:[l#30,SET-l#30,SET]
+  000043:[m#31,SET-m#31,SET]
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
-  000037:[z#33,SET-z#33,SET]
-  000038:[zz#35,SET-zz#35,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
+  000044:[z#33,SET-z#33,SET]
+  000045:[zz#35,SET-zz#35,SET]
 
 metrics-value
 num-backing
@@ -713,11 +752,24 @@ virtual-size
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-b#0,SET]
-  000017:[c@20#0,SET-c@14#0,SET]
-  000039:[d#0,SET-m#0,SET]
-  000037:[z#33,SET-z#33,SET]
-  000038:[zz#35,SET-zz#35,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000018:[c@20#0,SET-c@20#0,SET]
+  000019:[c@19#0,SET-c@19#0,SET]
+  000020:[c@18#0,SET-c@18#0,SET]
+  000021:[c@17#0,SET-c@17#0,SET]
+  000022:[c@16#0,SET-c@16#0,SET]
+  000023:[c@15#0,SET-c@15#0,SET]
+  000024:[c@14#0,SET-c@14#0,SET]
+  000046:[d#0,SET-d#0,SET]
+  000047:[e#0,SET-e#0,SET]
+  000048:[f#0,SET-f#0,SET]
+  000049:[g#0,SET-g#0,SET]
+  000050:[h#0,SET-h#0,SET]
+  000051:[l#0,SET-l#0,SET]
+  000052:[m#0,SET-m#0,SET]
+  000044:[z#33,SET-z#33,SET]
+  000045:[zz#35,SET-zz#35,SET]
 
 # Virtual sstables metrics should be gone after the compaction.
 metrics-value
@@ -744,8 +796,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     5  3.8KB    31B       0 |     - |  14KB |     2  1.4KB |     0     0B |     3  2.4KB |  14KB |   1  0.2
-total |     5  3.8KB    31B       0 |     - | 3.9KB |     5  3.6KB |     0     0B |    22   20KB |  14KB |   1  5.2
+    6 |    18   13KB     0B       0 |     - |  14KB |     2  1.4KB |     0     0B |    16   12KB |  14KB |   1  0.8
+total |    18   13KB     0B       0 |     - | 3.9KB |     5  3.6KB |     0     0B |    35   29KB |  14KB |   1  7.6
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
@@ -755,8 +807,8 @@ MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 3.8KB
-Compression types: snappy: 5
+Local tables size: 13KB
+Compression types: snappy: 18
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -826,7 +878,9 @@ Iter category stats:
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-c#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
 
 # Table becomes shared, so local table size becomes 0.
 metrics
@@ -840,8 +894,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   758B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   758B | 2.2KB |   1  0.3
-total |     1   758B     0B       0 |     - |   38B |     0     0B |     0     0B |     4  3.0KB | 2.2KB |   1 79.5
+    6 |     3  2.2KB     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1  1.0
+total |     3  2.2KB     0B       0 |     - |   38B |     0     0B |     0     0B |     6  4.4KB | 2.2KB |   1  118
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -852,7 +906,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
-Compression types: snappy: 1
+Compression types: snappy: 3
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
@@ -870,12 +924,18 @@ set b 2
 ingest ext1.sst
 ----
 
+<<<<<<< HEAD
+=======
+metrics-value
+remote-count
+remote-size
+----
+unknown command: <<<<<<<
+
+>>>>>>> 73c27550 (sstable: improve writer EstimatedSize)
 lsm
 ----
-L0.0:
-  000009:[b#13,SET-b#13,SET]
-L6:
-  000008:[a#0,SET-c#0,SET]
+unknown command: >>>>>>>
 
 # Ingest is also shared table, so local table size stays 0.
 metrics
@@ -889,21 +949,21 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   758B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   758B | 2.2KB |   1  0.3
-total |     2  1.5KB     0B       0 |     - |  783B |     1   745B |     0     0B |     4  3.7KB | 2.2KB |   2  4.8
+    6 |     3  2.2KB     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1  1.0
+total |     4  2.9KB     0B       0 |     - |  783B |     1   745B |     0     0B |     6  5.1KB | 2.2KB |   2  6.7
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
-Compactions: 1  estimated debt: 1.5KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 2.9KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 0B
-Compression types: snappy: 2
-Block cache: 4 entries (1.5KB)  hit rate: 0.0%
-Table cache: 1 entries (832B)  hit rate: 42.9%
+Compression types: snappy: 4
+Block cache: 2 entries (787B)  hit rate: 0.0%
+Table cache: 0 entries (0B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -911,7 +971,6 @@ Ingestions: 1  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
-       pebble-ingest,     latency: {BlockBytes:127 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 batch
 set b 3
@@ -920,11 +979,13 @@ set b 3
 flush
 ----
 L0.1:
-  000011:[b#14,SET-b#14,SET]
+  000013:[b#14,SET-b#14,SET]
 L0.0:
-  000009:[b#13,SET-b#13,SET]
+  000011:[b#13,SET-b#13,SET]
 L6:
-  000008:[a#0,SET-c#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
 
 # Local table size increases due to flush.
 metrics
@@ -938,21 +999,21 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   758B     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     1   758B | 2.2KB |   1  0.3
-total |     3  2.2KB     0B       0 |     - |  811B |     1   745B |     0     0B |     5  4.4KB | 2.2KB |   3  5.6
+    6 |     3  2.2KB     0B       0 |     - | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1  1.0
+total |     5  3.6KB     0B       0 |     - |  811B |     1   745B |     0     0B |     7  5.9KB | 2.2KB |   3  7.4
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 44B  written: 66B (50% overhead)
 Flushes: 2
-Compactions: 1  estimated debt: 2.2KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 3.6KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 742B
-Compression types: snappy: 3
-Block cache: 4 entries (1.5KB)  hit rate: 0.0%
-Table cache: 1 entries (832B)  hit rate: 42.9%
+Compression types: snappy: 5
+Block cache: 2 entries (787B)  hit rate: 0.0%
+Table cache: 0 entries (0B)  hit rate: 50.0%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
@@ -960,7 +1021,6 @@ Ingestions: 1  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
-       pebble-ingest,     latency: {BlockBytes:127 BlockBytesInCache:0 BlockReadDuration:10ms}
 
 # Reopen DB, to ensure stats are consistent. Also, reopened DB is not
 # configured to write shared tables.
@@ -978,19 +1038,19 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   758B     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   1  0.0
-total |     3  2.2KB     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   3  0.0
+    6 |     3  2.2KB     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   1  0.0
+total |     5  3.6KB     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   3  0.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 1
-Compactions: 0  estimated debt: 2.2KB  in progress: 0 (0B)
+Compactions: 0  estimated debt: 3.6KB  in progress: 0 (0B)
              default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 742B
-Compression types: snappy: 3
+Compression types: snappy: 5
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -1004,7 +1064,9 @@ Iter category stats:
 compact a-z
 ----
 L6:
-  000016:[a#0,SET-c#0,SET]
+  000008:[a#0,SET-a#0,SET]
+  000018:[b#0,SET-b#0,SET]
+  000010:[c#0,SET-c#0,SET]
 
 # All tables are local after compaction.
 metrics zero-cache-hits-misses
@@ -1018,8 +1080,8 @@ level | tables  size val-bl vtables | score |   in  | tables  size | tables  siz
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     1   758B     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   758B | 2.2KB |   1  0.5
-total |     1   758B     0B       0 |     - |    0B |     0     0B |     0     0B |     1   758B | 2.2KB |   1  0.0
+    6 |     3  2.2KB     0B       0 |     - | 1.5KB |     0     0B |     0     0B |     1   745B | 2.2KB |   1  0.5
+total |     3  2.2KB     0B       0 |     - |    0B |     0     0B |     0     0B |     1   745B | 2.2KB |   1  0.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 1
@@ -1029,8 +1091,8 @@ MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 758B
-Compression types: snappy: 1
+Local tables size: 745B
+Compression types: snappy: 3
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -1039,4 +1101,4 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:354 BlockBytesInCache:0 BlockReadDuration:30ms}
+   pebble-compaction, non-latency: {BlockBytes:342 BlockBytesInCache:0 BlockReadDuration:30ms}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -17,10 +17,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"unsafe"
 
+	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/strparse"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/record"
@@ -391,4 +395,137 @@ func TestCrashDuringManifestWrite_LargeKeys(t *testing.T) {
 			require.NoError(t, d.Close())
 		}()
 	}
+}
+
+// TestLargeKeys is a datadriven test that exercises large keys with shared
+// prefixes. These keys can be problematic, in part because they cannot be
+// shortened by an index separator.
+//
+// See #4518.
+func TestLargeKeys(t *testing.T) {
+	var largeKeyComparer = func() base.Comparer {
+		c := *testkeys.Comparer
+		c.FormatKey = func(key []byte) fmt.Formatter {
+			return formatAbbreviatedKey(key)
+		}
+		return c
+	}()
+
+	opts := &Options{
+		Comparer:                    &largeKeyComparer,
+		FormatMajorVersion:          internalFormatNewest,
+		FS:                          vfs.NewMem(),
+		Logger:                      testLogger{t: t},
+		MemTableStopWritesThreshold: 4,
+		DisableTableStats:           true,
+	}
+	var d *DB
+	defer func() { require.NoError(t, d.Close()) }()
+	datadriven.RunTest(t, "testdata/large_keys", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			var err error
+			d, err = runDBDefineCmd(td, opts)
+			require.NoError(t, err)
+			return runLSMCmd(td, d)
+		case "batch-commit":
+			b := d.NewBatch()
+			for _, line := range crstrings.Lines(td.Input) {
+				op, rest := splitAt(line, " ")
+				switch op {
+				case "set":
+					k := parseLargeKey(rest)
+					require.NoError(t, b.Set(k, []byte("value"), nil))
+				case "delete":
+					k := parseLargeKey(rest)
+					require.NoError(t, b.Delete(k, nil))
+				case "del-range":
+					var firstKey string
+					firstKey, rest = splitAt(rest, " ")
+					start := parseLargeKey(firstKey)
+					end := parseLargeKey(rest)
+					require.NoError(t, b.DeleteRange(start, end, nil))
+				default:
+					panic(fmt.Sprintf("unknown op: %s", op))
+				}
+			}
+			require.NoError(t, b.Commit(Sync))
+			return ""
+		case "flush":
+			require.NoError(t, d.Flush())
+			return runLSMCmd(td, d)
+		case "layout":
+			return runLayoutCmd(t, td, d)
+		case "properties":
+			return runSSTablePropertiesCmd(t, td, d)
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
+// formatAbbreviatedKey formats a key using the test key formatter, and then
+// abbreviates sequences of repeated bytes.
+type formatAbbreviatedKey []byte
+
+// Format implements the fmt.Formatter interface.
+func (p formatAbbreviatedKey) Format(s fmt.State, c rune) {
+	formattedStr := fmt.Sprint(testkeys.Comparer.FormatKey(p))
+	s.Write(abbreviateLargeKey(unsafe.Slice(unsafe.StringData(formattedStr), len(formattedStr))))
+}
+
+// parseLargeKey parses a key from a string, allowing for repetition of
+// a byte. Examples:
+//
+// (a,10) -> aaaaaaaaaa
+// f(o,5)bar -> fooooobar
+func parseLargeKey(s string) []byte {
+	var buf bytes.Buffer
+	p := strparse.MakeParser("(,)", s)
+	for !p.Done() {
+		t := p.Next()
+		if t != "(" {
+			buf.WriteString(t)
+			continue
+		}
+		repeat := p.Next()
+		p.Expect(",")
+		count := p.Int()
+		p.Expect(")")
+		for i := 0; i < count; i++ {
+			buf.WriteString(repeat)
+		}
+	}
+	return buf.Bytes()
+}
+
+// abbreviateLargeKey abbreviates a large key by replacing repeated bytes with
+// a tuple of the byte and the count. Examples:
+//
+// aaaaaaaaaa -> (a,10)
+// fooooobar -> f(o,5)bar
+func abbreviateLargeKey(k []byte) []byte {
+	var buf bytes.Buffer
+	var duplicateCount int
+	for i, b := range k {
+		if i+1 < len(k) && k[i+1] == b {
+			duplicateCount++
+		} else {
+			if duplicateCount > 0 {
+				buf.WriteString(fmt.Sprintf("(%s,%d)", string(b), duplicateCount+1))
+			} else {
+				buf.WriteByte(b)
+			}
+			duplicateCount = 0
+		}
+	}
+	return buf.Bytes()
+}
+
+func splitAt(s string, chars string) (string, string) {
+	i := strings.IndexAny(s, chars)
+	if i == -1 {
+		return s, ""
+	}
+	return s[:i], s[i+1:]
 }


### PR DESCRIPTION
25.2 backport of #4583 and #4618.