### PR TITLE
crl-release-25.1: sstable: improve writer EstimatedSize

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1210,6 +1210,29 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	return buf.String()
 }
 
+func runLayoutCmd(t *testing.T, td *datadriven.TestData, d *DB) string {
+	var filename string
+	td.ScanArgs(t, "filename", &filename)
+	f, err := d.opts.FS.Open(filename)
+	if err != nil {
+		return err.Error()
+	}
+	readable, err := sstable.NewSimpleReadable(f)
+	if err != nil {
+		return err.Error()
+	}
+	r, err := sstable.NewReader(context.Background(), readable, d.opts.MakeReaderOptions())
+	if err != nil {
+		return err.Error()
+	}
+	defer r.Close()
+	l, err := r.Layout()
+	if err != nil {
+		return err.Error()
+	}
+	return l.Describe(td.HasArg("verbose"), r, nil)
+}
+
 func runPopulateCmd(t *testing.T, td *datadriven.TestData, b *Batch) {
 	var maxKeyLength, valLength int
 	var timestamps []int

--- a/internal/strparse/strparse.go
+++ b/internal/strparse/strparse.go
@@ -1,0 +1,173 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package strparse provides facilities for parsing strings, intended for use in
+// tests and debug input.
+package strparse
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+// Parser is a helper used to implement parsing of strings, like
+// manifest.ParseFileMetadataDebug.
+//
+// It takes a string and splits it into tokens. Tokens are separated by
+// whitespace; in addition user-specified separators are also always separate
+// tokens. For example, when passed the separators `:-[]();` the string
+// `000001:[a - b]` results in tokens `000001`, `:`, `[`, `a`, `-`, `b`, `]`, .
+//
+// All Parser methods throw panics instead of returning errors. The code
+// that uses a Parser can recover them and convert them to errors.
+type Parser struct {
+	original  string
+	tokens    []string
+	lastToken string
+}
+
+// MakeParser constructs a new Parser that converts any instance of the runes
+// contained in [separators] into separate tokens, and consumes the provided
+// input string.
+func MakeParser(separators string, input string) Parser {
+	p := Parser{
+		original: input,
+	}
+	for _, f := range strings.Fields(input) {
+		for f != "" {
+			pos := strings.IndexAny(f, separators)
+			if pos == -1 {
+				p.tokens = append(p.tokens, f)
+				break
+			}
+			if pos > 0 {
+				p.tokens = append(p.tokens, f[:pos])
+			}
+			p.tokens = append(p.tokens, f[pos:pos+1])
+			f = f[pos+1:]
+		}
+	}
+	return p
+}
+
+// Done returns true if there are no more tokens.
+func (p *Parser) Done() bool {
+	return len(p.tokens) == 0
+}
+
+// Peek returns the next token, without consuming the token. Returns "" if there
+// are no more tokens.
+func (p *Parser) Peek() string {
+	if p.Done() {
+		p.lastToken = ""
+		return ""
+	}
+	p.lastToken = p.tokens[0]
+	return p.tokens[0]
+}
+
+// Next returns the next token, or "" if there are no more tokens.
+func (p *Parser) Next() string {
+	res := p.Peek()
+	if res != "" {
+		p.tokens = p.tokens[1:]
+	}
+	return res
+}
+
+// Remaining returns all the remaining tokens, separated by spaces.
+func (p *Parser) Remaining() string {
+	res := strings.Join(p.tokens, " ")
+	p.tokens = nil
+	return res
+}
+
+// Expect consumes the next tokens, verifying that they exactly match the
+// arguments.
+func (p *Parser) Expect(tokens ...string) {
+	for _, tok := range tokens {
+		if res := p.Next(); res != tok {
+			p.Errf("expected %q, got %q", tok, res)
+		}
+	}
+}
+
+// TryLevel tries to parse a token as a level (e.g. L1, L0.2). If successful,
+// the token is consumed.
+func (p *Parser) TryLevel() (level int, ok bool) {
+	t := p.Peek()
+	if regexp.MustCompile(`^L[0-9](|\.[0-9]+)$`).MatchString(t) {
+		p.Next()
+		return int(t[1] - '0'), true
+	}
+	return 0, false
+}
+
+// Level parses the next token as a level.
+func (p *Parser) Level() int {
+	level, ok := p.TryLevel()
+	if !ok {
+		p.Errf("cannot parse level")
+	}
+	return level
+}
+
+// Int parses the next token as an integer.
+func (p *Parser) Int() int {
+	x, err := strconv.Atoi(p.Next())
+	if err != nil {
+		p.Errf("cannot parse number: %v", err)
+	}
+	return x
+}
+
+// Uint64 parses the next token as an uint64.
+func (p *Parser) Uint64() uint64 {
+	x, err := strconv.ParseUint(p.Next(), 10, 64)
+	if err != nil {
+		p.Errf("cannot parse number: %v", err)
+	}
+	return x
+}
+
+// Uint32 parses the next token as an uint32.
+func (p *Parser) Uint32() uint32 {
+	x, err := strconv.ParseUint(p.Next(), 10, 32)
+	if err != nil {
+		p.Errf("cannot parse number: %v", err)
+	}
+	return uint32(x)
+}
+
+// Uint64 parses the next token as a sequence number.
+func (p *Parser) SeqNum() base.SeqNum {
+	return base.ParseSeqNum(p.Next())
+}
+
+// FileNum parses the next token as a FileNum.
+func (p *Parser) FileNum() base.FileNum {
+	return base.FileNum(p.Int())
+}
+
+// DiskFileNum parses the next token as a DiskFileNum.
+func (p *Parser) DiskFileNum() base.DiskFileNum {
+	return base.DiskFileNum(p.Int())
+}
+
+// InternalKey parses the next token as an internal key.
+func (p *Parser) InternalKey() base.InternalKey {
+	return base.ParseInternalKey(p.Next())
+}
+
+// Errf panics with an error which includes the original string and the last
+// token.
+func (p *Parser) Errf(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	panic(errors.Errorf("error parsing %q at token %q: %s", p.original, p.lastToken, msg))
+}

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -5,7 +5,6 @@ package pebble
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -240,28 +239,7 @@ func TestIterHistories(t *testing.T) {
 				}
 				return ""
 			case "layout":
-				var verbose bool
-				var filename string
-				td.ScanArgs(t, "filename", &filename)
-				td.MaybeScanArgs(t, "verbose", &verbose)
-				f, err := opts.FS.Open(filename)
-				if err != nil {
-					return err.Error()
-				}
-				readable, err := sstable.NewSimpleReadable(f)
-				if err != nil {
-					return err.Error()
-				}
-				r, err := sstable.NewReader(context.Background(), readable, opts.MakeReaderOptions())
-				if err != nil {
-					return err.Error()
-				}
-				defer r.Close()
-				l, err := r.Layout()
-				if err != nil {
-					return err.Error()
-				}
-				return l.Describe(verbose, r, nil)
+				return runLayoutCmd(t, td, d)
 			case "lsm":
 				return runLSMCmd(td, d)
 			case "metrics":

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -78,8 +78,14 @@ type RawColumnWriter struct {
 	// flushed in order after all the data blocks, and the top-level index block
 	// is constructed to point to all the individual index blocks.
 	indexBuffering struct {
-		// partitions holds all the completed index blocks.
+		// partitions holds all the completed, uncompressed index blocks.
+		//
+		// TODO(jackson): We should consider compressing these index blocks now,
+		// while buffering, to reduce the memory usage of the writer.
 		partitions []bufferedIndexBlock
+		// partitionSizeSum is the sum of the sizes of all the completed index
+		// blocks (in `partitions`).
+		partitionSizeSum uint64
 		// blockAlloc is used to bulk-allocate byte slices used to store index
 		// blocks in partitions. These live until the sstable is finished.
 		blockAlloc []byte
@@ -188,27 +194,38 @@ func (w *RawColumnWriter) Error() error {
 // EstimatedSize returns the estimated size of the sstable being written if
 // a call to Close() was made without adding additional keys.
 func (w *RawColumnWriter) EstimatedSize() uint64 {
+	// Start with the size of the footer, which is fixed, and the size of all
+	// the finished data blocks. The size of the finished data blocks is all
+	// post-compression and the footer is not compressed, so this initial
+	// quantity is exact.
 	sz := rocksDBFooterLen + w.queuedDataSize
-	// TODO(jackson): Avoid iterating over partitions by incrementally
-	// maintaining the size contribution of all buffered partitions.
-	for _, bib := range w.indexBuffering.partitions {
-		// We include the separator user key to account for its bytes in the
-		// top-level index block.
-		//
-		// TODO(jackson): We could incrementally build the top-level index block
-		// and produce an exact calculation of the current top-level index
-		// block's size.
-		sz += uint64(len(bib.block) + block.TrailerLen + len(bib.sep.UserKey))
+
+	// Add the size of value blocks. If any value blocks have already been
+	// finished, these blocks will contribute post-compression size. If there is
+	// currently an unfinished value block, it will contribute its pre-compression
+	// size.
+	if w.valueBlock != nil {
+		sz += w.valueBlock.Size()
 	}
+
+	// Add the size of the completed but unflushed index partitions, the
+	// unfinished data block, the unfinished index block, the unfinished range
+	// deletion block, and the unfinished range key block.
+	//
+	// All of these sizes are uncompressed sizes. It's okay to be pessimistic
+	// here and use the uncompressed size because all this memory is buffered
+	// until the sstable is finished.  Including the uncompressed size bounds
+	// the memory usage used by the writer to the physical size limit.
+	sz += w.indexBuffering.partitionSizeSum
+	sz += uint64(w.dataBlock.Size())
+	sz += uint64(w.indexBlockSize)
 	if w.rangeDelBlock.KeyCount() > 0 {
 		sz += uint64(w.rangeDelBlock.Size())
 	}
 	if w.rangeKeyBlock.KeyCount() > 0 {
 		sz += uint64(w.rangeKeyBlock.Size())
 	}
-	if w.valueBlock != nil {
-		sz += w.valueBlock.Size()
-	}
+
 	// TODO(jackson): Include an estimate of the properties, filter and meta
 	// index blocks sizes.
 	return sz
@@ -756,16 +773,23 @@ func (w *RawColumnWriter) finishIndexBlock(rows int) error {
 		w.indexBlock.UnsafeSeparator(rows - 1))
 
 	// Finish the index block and copy it so that w.indexBlock may be reused.
-	block := w.indexBlock.Finish(rows)
-	if len(w.indexBuffering.blockAlloc) < len(block) {
+	blk := w.indexBlock.Finish(rows)
+	if len(w.indexBuffering.blockAlloc) < len(blk) {
 		// Allocate enough bytes for approximately 16 index blocks.
-		w.indexBuffering.blockAlloc = make([]byte, len(block)*16)
+		w.indexBuffering.blockAlloc = make([]byte, len(blk)*16)
 	}
-	n := copy(w.indexBuffering.blockAlloc, block)
+	n := copy(w.indexBuffering.blockAlloc, blk)
 	bib.block = w.indexBuffering.blockAlloc[:n:n]
 	w.indexBuffering.blockAlloc = w.indexBuffering.blockAlloc[n:]
 
 	w.indexBuffering.partitions = append(w.indexBuffering.partitions, bib)
+	// We include the separator user key to account for its bytes in the
+	// top-level index block.
+	//
+	// TODO(jackson): We could incrementally build the top-level index block
+	// and produce an exact calculation of the current top-level index
+	// block's size.
+	w.indexBuffering.partitionSizeSum += uint64(len(blk) + block.TrailerLen + len(bib.sep.UserKey))
 	return nil
 }
 

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -90,6 +91,9 @@ type RawRowWriter struct {
 	// nil, or the full keys otherwise.
 	filter          filterWriter
 	indexPartitions []bufferedIndexBlock
+	// indexPartitionsSizeSum is the sum of the sizes of all index blocks in
+	// indexPartitions.
+	indexPartitionsSizeSum atomic.Uint64
 
 	// indexBlockAlloc is used to bulk-allocate byte slices used to store index
 	// blocks in indexPartitions. These live until the index finishes.
@@ -1376,6 +1380,7 @@ func (w *RawRowWriter) finishIndexBlock(indexBuf *indexBlockBuf, props []byte) e
 	part.block = w.indexBlockAlloc[:n:n]
 	w.indexBlockAlloc = w.indexBlockAlloc[n:]
 	w.indexPartitions = append(w.indexPartitions, part)
+	w.indexPartitionsSizeSum.Add(uint64(len(bk)))
 	return nil
 }
 
@@ -1702,9 +1707,33 @@ func (w *RawRowWriter) EstimatedSize() uint64 {
 	if w == nil {
 		return 0
 	}
-	return w.coordination.sizeEstimate.size() +
-		uint64(w.dataBlockBuf.dataBlock.EstimatedSize()) +
-		w.indexBlock.estimatedSize()
+
+	// Begin with the estimated size of the data blocks that have already been
+	// flushed to the file.
+	size := w.coordination.sizeEstimate.size()
+	// Add the size of value blocks. If any value blocks have already been
+	// finished, these blocks will contribute post-compression size. If there is
+	// currently an unfinished value block, it will contribute its pre-compression
+	// size.
+	if w.valueBlockWriter != nil {
+		size += w.valueBlockWriter.Size()
+	}
+
+	// Add the size of the completed but unflushed index partitions, the
+	// unfinished data block, the unfinished index block, the unfinished range
+	// deletion block, and the unfinished range key block.
+	//
+	// All of these sizes are uncompressed sizes. It's okay to be pessimistic
+	// here and use the uncompressed size because all this memory is buffered
+	// until the sstable is finished.  Including the uncompressed size bounds
+	// the memory usage used by the writer to the physical size limit.
+	size += w.indexPartitionsSizeSum.Load()
+	size += uint64(w.dataBlockBuf.dataBlock.EstimatedSize())
+	size += w.indexBlock.estimatedSize()
+	size += uint64(w.rangeDelBlock.EstimatedSize())
+	size += uint64(w.rangeKeyBlock.EstimatedSize())
+	// TODO(jackson): Account for the size of the filter block.
+	return size
 }
 
 // Metadata returns the metadata for the finished sstable. Only valid to call

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -336,7 +336,7 @@ a@2.SET.1:a2
 a@1.SET.1:a1
 b@2.SET.1:b2
 ----
-EstimatedSize()=53
+EstimatedSize()=163
 
 close
 ----

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -1,0 +1,320 @@
+# FormatFlushableIngestExcises is format major version 18, which precedes
+# support for columnar blocks.
+#
+# Set a target file size of 4MB.
+
+define target-file-sizes=(4000000) format-major-version=18
+----
+
+# Commit many keys with 1MB-shared prefixes.
+
+batch-commit
+set a(p,1000000)arition
+set a(p,1000000)alling
+set a(p,1000000)eal
+set a(p,1000000)ellate
+set a(p,1000000)endectomy
+set a(p,1000000)etizers
+set a(p,1000000)etizing
+set a(p,1000000)laude
+set a(p,1000000)lauding
+set a(p,1000000)le
+set a(p,1000000)les
+set a(p,1000000)letini
+set a(p,1000000)letinis
+set a(p,1000000)lebottomjeans
+set a(p,1000000)lication
+set a(p,1000000)ly
+set a(p,1000000)lying
+set a(p,1000000)ollo
+set a(p,1000000)raisal
+set a(p,1000000)raisals
+set a(p,1000000)raiser
+set a(p,1000000)raisers
+set a(p,1000000)raising
+set a(p,1000000)rentice
+set a(p,1000000)rentices
+set a(p,1000000)renticing
+set a(p,1000000)roval
+set a(p,1000000)rovals
+set a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+
+layout filename=000005.sst
+----
+sstable
+ ├── data  offset: 0  length: 46944
+ ├── data  offset: 46949  length: 46945
+ ├── data  offset: 93899  length: 46941
+ ├── data  offset: 140845  length: 46944
+ ├── data  offset: 187794  length: 46947
+ ├── data  offset: 234746  length: 46945
+ ├── data  offset: 281696  length: 46945
+ ├── data  offset: 328646  length: 46943
+ ├── data  offset: 375594  length: 46945
+ ├── data  offset: 422544  length: 46940
+ ├── data  offset: 469489  length: 46951
+ ├── data  offset: 516445  length: 46941
+ ├── data  offset: 563391  length: 46944
+ ├── data  offset: 610340  length: 46945
+ ├── data  offset: 657290  length: 46946
+ ├── data  offset: 704241  length: 46940
+ ├── data  offset: 751186  length: 46943
+ ├── data  offset: 798134  length: 46942
+ ├── data  offset: 845081  length: 46944
+ ├── data  offset: 892030  length: 46945
+ ├── data  offset: 938980  length: 46944
+ ├── data  offset: 985929  length: 46945
+ ├── data  offset: 1032879  length: 46945
+ ├── data  offset: 1079829  length: 46945
+ ├── data  offset: 1126779  length: 46946
+ ├── data  offset: 1173730  length: 46947
+ ├── data  offset: 1220682  length: 46943
+ ├── data  offset: 1267630  length: 46944
+ ├── data  offset: 1314579  length: 46942
+ ├── index  offset: 1361526  length: 46942
+ ├── index  offset: 1408473  length: 46946
+ ├── index  offset: 1455424  length: 46942
+ ├── index  offset: 1502371  length: 46945
+ ├── index  offset: 1549321  length: 46948
+ ├── index  offset: 1596274  length: 46946
+ ├── index  offset: 1643225  length: 46946
+ ├── index  offset: 1690176  length: 46944
+ ├── index  offset: 1737125  length: 46946
+ ├── index  offset: 1784076  length: 46941
+ ├── index  offset: 1831022  length: 46952
+ ├── index  offset: 1877979  length: 46942
+ ├── index  offset: 1924926  length: 46945
+ ├── index  offset: 1971876  length: 46946
+ ├── index  offset: 2018827  length: 46947
+ ├── index  offset: 2065779  length: 46941
+ ├── index  offset: 2112725  length: 46944
+ ├── index  offset: 2159674  length: 46943
+ ├── index  offset: 2206622  length: 46945
+ ├── index  offset: 2253572  length: 46946
+ ├── index  offset: 2300523  length: 46945
+ ├── index  offset: 2347473  length: 46946
+ ├── index  offset: 2394424  length: 46946
+ ├── index  offset: 2441375  length: 46946
+ ├── index  offset: 2488326  length: 46947
+ ├── index  offset: 2535278  length: 46948
+ ├── index  offset: 2582231  length: 46944
+ ├── index  offset: 2629180  length: 46945
+ ├── index  offset: 2676130  length: 46943
+ ├── top-index  offset: 2723078  length: 1361225
+ ├── properties  offset: 4084308  length: 490
+ ├── meta-index  offset: 4084803  length: 35
+ └── footer  offset: 4084843  length: 53
+
+properties file=000005
+raw.key.size
+index.size
+index.partitions
+----
+raw.key.size:
+  rocksdb.raw.key.size: 29000440
+index.size:
+  rocksdb.index.size: 58001886
+  rocksdb.top-level.index.size: 29000892
+index.partitions:
+  rocksdb.index.partitions: 29
+
+batch-commit
+del-range a(p,1000000)arition a(p,1000000)eal
+del-range a(p,1000000)ellate a(p,1000000)etizers
+del-range a(p,1000000)etizing a(p,1000000)lauding
+del-range a(p,1000000)le a(p,1000000)lebottomjeans
+del-range a(p,1000000)lebottomjeans a(p,1000000)lication
+del-range a(p,1000000)ly a(p,1000000)lying
+del-range a(p,1000000)raisals a(p,1000000)rentice
+del-range a(p,1000000)rentices a(p,1000000)roval
+del-range a(p,1000000)rovals a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.1:
+  000008:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[39-47] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:18000932
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+
+layout filename=000008.sst
+----
+sstable
+ ├── data  offset: 0  length: 8
+ ├── index  offset: 13  length: 24
+ ├── range-del  offset: 42  length: 18000310
+ ├── properties  offset: 18000357  length: 447
+ ├── meta-index  offset: 18000809  length: 65
+ └── footer  offset: 18000879  length: 53
+
+properties file=000008
+rocksdb.raw
+----
+rocksdb.raw:
+  rocksdb.raw.key.size: 9000139
+  rocksdb.raw.value.size: 9000068
+
+# Repeat the above with columnar blocks.
+
+define target-file-sizes=(4000000) format-major-version=19
+----
+
+# Commit many keys with 1MB-shared prefixes.
+
+batch-commit
+set a(p,1000000)arition
+set a(p,1000000)alling
+set a(p,1000000)eal
+set a(p,1000000)ellate
+set a(p,1000000)endectomy
+set a(p,1000000)etizers
+set a(p,1000000)etizing
+set a(p,1000000)laude
+set a(p,1000000)lauding
+set a(p,1000000)le
+set a(p,1000000)les
+set a(p,1000000)letini
+set a(p,1000000)letinis
+set a(p,1000000)lebottomjeans
+set a(p,1000000)lication
+set a(p,1000000)ly
+set a(p,1000000)lying
+set a(p,1000000)ollo
+set a(p,1000000)raisal
+set a(p,1000000)raisals
+set a(p,1000000)raiser
+set a(p,1000000)raisers
+set a(p,1000000)raising
+set a(p,1000000)rentice
+set a(p,1000000)rentices
+set a(p,1000000)renticing
+set a(p,1000000)roval
+set a(p,1000000)rovals
+set a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+
+layout filename=000005.sst
+----
+sstable
+ ├── data  offset: 0  length: 46944
+ ├── data  offset: 46949  length: 46945
+ ├── data  offset: 93899  length: 46941
+ ├── data  offset: 140845  length: 46944
+ ├── data  offset: 187794  length: 46947
+ ├── data  offset: 234746  length: 46945
+ ├── data  offset: 281696  length: 46945
+ ├── data  offset: 328646  length: 46943
+ ├── data  offset: 375594  length: 46945
+ ├── data  offset: 422544  length: 46940
+ ├── data  offset: 469489  length: 46951
+ ├── data  offset: 516445  length: 46941
+ ├── data  offset: 563391  length: 46944
+ ├── data  offset: 610340  length: 46945
+ ├── data  offset: 657290  length: 46946
+ ├── data  offset: 704241  length: 46940
+ ├── data  offset: 751186  length: 46943
+ ├── data  offset: 798134  length: 46942
+ ├── data  offset: 845081  length: 46944
+ ├── data  offset: 892030  length: 46945
+ ├── data  offset: 938980  length: 46944
+ ├── data  offset: 985929  length: 46945
+ ├── data  offset: 1032879  length: 46945
+ ├── data  offset: 1079829  length: 46945
+ ├── data  offset: 1126779  length: 46946
+ ├── data  offset: 1173730  length: 46947
+ ├── data  offset: 1220682  length: 46943
+ ├── data  offset: 1267630  length: 46944
+ ├── data  offset: 1314579  length: 46942
+ ├── index  offset: 1361526  length: 46942
+ ├── index  offset: 1408473  length: 46946
+ ├── index  offset: 1455424  length: 46942
+ ├── index  offset: 1502371  length: 46945
+ ├── index  offset: 1549321  length: 46948
+ ├── index  offset: 1596274  length: 46946
+ ├── index  offset: 1643225  length: 46946
+ ├── index  offset: 1690176  length: 46944
+ ├── index  offset: 1737125  length: 46946
+ ├── index  offset: 1784076  length: 46941
+ ├── index  offset: 1831022  length: 46952
+ ├── index  offset: 1877979  length: 46942
+ ├── index  offset: 1924926  length: 46945
+ ├── index  offset: 1971876  length: 46946
+ ├── index  offset: 2018827  length: 46947
+ ├── index  offset: 2065779  length: 46941
+ ├── index  offset: 2112725  length: 46944
+ ├── index  offset: 2159674  length: 46943
+ ├── index  offset: 2206622  length: 46945
+ ├── index  offset: 2253572  length: 46946
+ ├── index  offset: 2300523  length: 46945
+ ├── index  offset: 2347473  length: 46946
+ ├── index  offset: 2394424  length: 46946
+ ├── index  offset: 2441375  length: 46946
+ ├── index  offset: 2488326  length: 46947
+ ├── index  offset: 2535278  length: 46948
+ ├── index  offset: 2582231  length: 46944
+ ├── index  offset: 2629180  length: 46945
+ ├── index  offset: 2676130  length: 46943
+ ├── top-index  offset: 2723078  length: 1361225
+ ├── properties  offset: 4084308  length: 490
+ ├── meta-index  offset: 4084803  length: 35
+ └── footer  offset: 4084843  length: 53
+
+properties file=000005
+raw.key.size
+index.size
+index.partitions
+----
+raw.key.size:
+  rocksdb.raw.key.size: 29000440
+index.size:
+  rocksdb.index.size: 58001886
+  rocksdb.top-level.index.size: 29000892
+index.partitions:
+  rocksdb.index.partitions: 29
+
+batch-commit
+del-range a(p,1000000)arition a(p,1000000)eal
+del-range a(p,1000000)ellate a(p,1000000)etizers
+del-range a(p,1000000)etizing a(p,1000000)lauding
+del-range a(p,1000000)le a(p,1000000)lebottomjeans
+del-range a(p,1000000)lebottomjeans a(p,1000000)lication
+del-range a(p,1000000)ly a(p,1000000)lying
+del-range a(p,1000000)raisals a(p,1000000)rentice
+del-range a(p,1000000)rentices a(p,1000000)roval
+del-range a(p,1000000)rovals a(p,1000000)rove
+----
+
+flush verbose
+----
+L0.1:
+  000008:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[39-47] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:18000932
+L0.0:
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+
+layout filename=000008.sst
+----
+sstable
+ ├── data  offset: 0  length: 8
+ ├── index  offset: 13  length: 24
+ ├── range-del  offset: 42  length: 18000310
+ ├── properties  offset: 18000357  length: 447
+ ├── meta-index  offset: 18000809  length: 65
+ └── footer  offset: 18000879  length: 53
+
+properties file=000008
+rocksdb.raw
+----
+rocksdb.raw:
+  rocksdb.raw.key.size: 9000139
+  rocksdb.raw.value.size: 9000068

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -43,7 +43,14 @@ set a(p,1000000)rove
 flush verbose
 ----
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563939
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563957
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563948
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563942
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563939
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563954
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563957
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94435
 
 layout filename=000005.sst
 ----
@@ -52,64 +59,14 @@ sstable
  ├── data  offset: 46949  length: 46945
  ├── data  offset: 93899  length: 46941
  ├── data  offset: 140845  length: 46944
- ├── data  offset: 187794  length: 46947
- ├── data  offset: 234746  length: 46945
- ├── data  offset: 281696  length: 46945
- ├── data  offset: 328646  length: 46943
- ├── data  offset: 375594  length: 46945
- ├── data  offset: 422544  length: 46940
- ├── data  offset: 469489  length: 46951
- ├── data  offset: 516445  length: 46941
- ├── data  offset: 563391  length: 46944
- ├── data  offset: 610340  length: 46945
- ├── data  offset: 657290  length: 46946
- ├── data  offset: 704241  length: 46940
- ├── data  offset: 751186  length: 46943
- ├── data  offset: 798134  length: 46942
- ├── data  offset: 845081  length: 46944
- ├── data  offset: 892030  length: 46945
- ├── data  offset: 938980  length: 46944
- ├── data  offset: 985929  length: 46945
- ├── data  offset: 1032879  length: 46945
- ├── data  offset: 1079829  length: 46945
- ├── data  offset: 1126779  length: 46946
- ├── data  offset: 1173730  length: 46947
- ├── data  offset: 1220682  length: 46943
- ├── data  offset: 1267630  length: 46944
- ├── data  offset: 1314579  length: 46942
- ├── index  offset: 1361526  length: 46942
- ├── index  offset: 1408473  length: 46946
- ├── index  offset: 1455424  length: 46942
- ├── index  offset: 1502371  length: 46945
- ├── index  offset: 1549321  length: 46948
- ├── index  offset: 1596274  length: 46946
- ├── index  offset: 1643225  length: 46946
- ├── index  offset: 1690176  length: 46944
- ├── index  offset: 1737125  length: 46946
- ├── index  offset: 1784076  length: 46941
- ├── index  offset: 1831022  length: 46952
- ├── index  offset: 1877979  length: 46942
- ├── index  offset: 1924926  length: 46945
- ├── index  offset: 1971876  length: 46946
- ├── index  offset: 2018827  length: 46947
- ├── index  offset: 2065779  length: 46941
- ├── index  offset: 2112725  length: 46944
- ├── index  offset: 2159674  length: 46943
- ├── index  offset: 2206622  length: 46945
- ├── index  offset: 2253572  length: 46946
- ├── index  offset: 2300523  length: 46945
- ├── index  offset: 2347473  length: 46946
- ├── index  offset: 2394424  length: 46946
- ├── index  offset: 2441375  length: 46946
- ├── index  offset: 2488326  length: 46947
- ├── index  offset: 2535278  length: 46948
- ├── index  offset: 2582231  length: 46944
- ├── index  offset: 2629180  length: 46945
- ├── index  offset: 2676130  length: 46943
- ├── top-index  offset: 2723078  length: 1361225
- ├── properties  offset: 4084308  length: 490
- ├── meta-index  offset: 4084803  length: 35
- └── footer  offset: 4084843  length: 53
+ ├── index  offset: 187794  length: 46942
+ ├── index  offset: 234741  length: 46946
+ ├── index  offset: 281692  length: 46942
+ ├── index  offset: 328639  length: 46945
+ ├── top-index  offset: 375589  length: 187759
+ ├── properties  offset: 563353  length: 489
+ ├── meta-index  offset: 563847  length: 34
+ └── footer  offset: 563886  length: 53
 
 properties file=000005
 raw.key.size
@@ -117,12 +74,12 @@ index.size
 index.partitions
 ----
 raw.key.size:
-  rocksdb.raw.key.size: 29000440
+  rocksdb.raw.key.size: 4000058
 index.size:
-  rocksdb.index.size: 58001886
-  rocksdb.top-level.index.size: 29000892
+  rocksdb.index.size: 8000259
+  rocksdb.top-level.index.size: 4000122
 index.partitions:
-  rocksdb.index.partitions: 29
+  rocksdb.index.partitions: 4
 
 batch-commit
 del-range a(p,1000000)arition a(p,1000000)eal
@@ -139,26 +96,35 @@ del-range a(p,1000000)rovals a(p,1000000)rove
 flush verbose
 ----
 L0.1:
-  000008:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[39-47] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:18000932
+  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000726
+  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] seqnums:[42-44] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] size:6000732
+  000017:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[45-47] points:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:6000726
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563939
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563957
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563948
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563942
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563939
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563954
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563957
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94435
 
-layout filename=000008.sst
+layout filename=000015.sst
 ----
 sstable
  ├── data  offset: 0  length: 8
  ├── index  offset: 13  length: 24
- ├── range-del  offset: 42  length: 18000310
- ├── properties  offset: 18000357  length: 447
- ├── meta-index  offset: 18000809  length: 65
- └── footer  offset: 18000879  length: 53
+ ├── range-del  offset: 42  length: 6000104
+ ├── properties  offset: 6000151  length: 447
+ ├── meta-index  offset: 6000603  length: 65
+ └── footer  offset: 6000673  length: 53
 
 properties file=000008
 rocksdb.raw
 ----
 rocksdb.raw:
-  rocksdb.raw.key.size: 9000139
-  rocksdb.raw.value.size: 9000068
+  rocksdb.raw.key.size: 4000059
+  rocksdb.raw.value.size: 20
 
 # Repeat the above with columnar blocks.
 
@@ -202,7 +168,14 @@ set a(p,1000000)rove
 flush verbose
 ----
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563939
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563957
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563948
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563942
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563939
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563954
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563957
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94435
 
 layout filename=000005.sst
 ----
@@ -211,64 +184,14 @@ sstable
  ├── data  offset: 46949  length: 46945
  ├── data  offset: 93899  length: 46941
  ├── data  offset: 140845  length: 46944
- ├── data  offset: 187794  length: 46947
- ├── data  offset: 234746  length: 46945
- ├── data  offset: 281696  length: 46945
- ├── data  offset: 328646  length: 46943
- ├── data  offset: 375594  length: 46945
- ├── data  offset: 422544  length: 46940
- ├── data  offset: 469489  length: 46951
- ├── data  offset: 516445  length: 46941
- ├── data  offset: 563391  length: 46944
- ├── data  offset: 610340  length: 46945
- ├── data  offset: 657290  length: 46946
- ├── data  offset: 704241  length: 46940
- ├── data  offset: 751186  length: 46943
- ├── data  offset: 798134  length: 46942
- ├── data  offset: 845081  length: 46944
- ├── data  offset: 892030  length: 46945
- ├── data  offset: 938980  length: 46944
- ├── data  offset: 985929  length: 46945
- ├── data  offset: 1032879  length: 46945
- ├── data  offset: 1079829  length: 46945
- ├── data  offset: 1126779  length: 46946
- ├── data  offset: 1173730  length: 46947
- ├── data  offset: 1220682  length: 46943
- ├── data  offset: 1267630  length: 46944
- ├── data  offset: 1314579  length: 46942
- ├── index  offset: 1361526  length: 46942
- ├── index  offset: 1408473  length: 46946
- ├── index  offset: 1455424  length: 46942
- ├── index  offset: 1502371  length: 46945
- ├── index  offset: 1549321  length: 46948
- ├── index  offset: 1596274  length: 46946
- ├── index  offset: 1643225  length: 46946
- ├── index  offset: 1690176  length: 46944
- ├── index  offset: 1737125  length: 46946
- ├── index  offset: 1784076  length: 46941
- ├── index  offset: 1831022  length: 46952
- ├── index  offset: 1877979  length: 46942
- ├── index  offset: 1924926  length: 46945
- ├── index  offset: 1971876  length: 46946
- ├── index  offset: 2018827  length: 46947
- ├── index  offset: 2065779  length: 46941
- ├── index  offset: 2112725  length: 46944
- ├── index  offset: 2159674  length: 46943
- ├── index  offset: 2206622  length: 46945
- ├── index  offset: 2253572  length: 46946
- ├── index  offset: 2300523  length: 46945
- ├── index  offset: 2347473  length: 46946
- ├── index  offset: 2394424  length: 46946
- ├── index  offset: 2441375  length: 46946
- ├── index  offset: 2488326  length: 46947
- ├── index  offset: 2535278  length: 46948
- ├── index  offset: 2582231  length: 46944
- ├── index  offset: 2629180  length: 46945
- ├── index  offset: 2676130  length: 46943
- ├── top-index  offset: 2723078  length: 1361225
- ├── properties  offset: 4084308  length: 490
- ├── meta-index  offset: 4084803  length: 35
- └── footer  offset: 4084843  length: 53
+ ├── index  offset: 187794  length: 46942
+ ├── index  offset: 234741  length: 46946
+ ├── index  offset: 281692  length: 46942
+ ├── index  offset: 328639  length: 46945
+ ├── top-index  offset: 375589  length: 187759
+ ├── properties  offset: 563353  length: 489
+ ├── meta-index  offset: 563847  length: 34
+ └── footer  offset: 563886  length: 53
 
 properties file=000005
 raw.key.size
@@ -276,12 +199,12 @@ index.size
 index.partitions
 ----
 raw.key.size:
-  rocksdb.raw.key.size: 29000440
+  rocksdb.raw.key.size: 4000058
 index.size:
-  rocksdb.index.size: 58001886
-  rocksdb.top-level.index.size: 29000892
+  rocksdb.index.size: 8000259
+  rocksdb.top-level.index.size: 4000122
 index.partitions:
-  rocksdb.index.partitions: 29
+  rocksdb.index.partitions: 4
 
 batch-commit
 del-range a(p,1000000)arition a(p,1000000)eal
@@ -298,23 +221,32 @@ del-range a(p,1000000)rovals a(p,1000000)rove
 flush verbose
 ----
 L0.1:
-  000008:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[39-47] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:18000932
+  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000726
+  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] seqnums:[42-44] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] size:6000732
+  000017:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[45-47] points:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:6000726
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] seqnums:[10-38] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)rove#38,SET] size:4084896
+  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[10-13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563939
+  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[14-17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563957
+  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[18-23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563948
+  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[21-25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563942
+  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[26-29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563939
+  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[30-33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563954
+  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[34-37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563957
+  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[38-38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94435
 
-layout filename=000008.sst
+layout filename=000015.sst
 ----
 sstable
  ├── data  offset: 0  length: 8
  ├── index  offset: 13  length: 24
- ├── range-del  offset: 42  length: 18000310
- ├── properties  offset: 18000357  length: 447
- ├── meta-index  offset: 18000809  length: 65
- └── footer  offset: 18000879  length: 53
+ ├── range-del  offset: 42  length: 6000104
+ ├── properties  offset: 6000151  length: 447
+ ├── meta-index  offset: 6000603  length: 65
+ └── footer  offset: 6000673  length: 53
 
-properties file=000008
+properties file=000017
 rocksdb.raw
 ----
 rocksdb.raw:
-  rocksdb.raw.key.size: 9000139
-  rocksdb.raw.value.size: 9000068
+  rocksdb.raw.key.size: 3000048
+  rocksdb.raw.value.size: 3000019

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev5
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev5
@@ -253,8 +253,8 @@ L3:
 compact a-h L1
 ----
 L2:
-  000009:[grandparent#2,RANGEDEL-m#inf,RANGEDEL]
-  000010:[m#2,RANGEDEL-z#inf,RANGEDEL]
+  000009:[grandparent#2,RANGEDEL-h#inf,RANGEDEL]
+  000010:[h#3,SET-z#inf,RANGEDEL]
 L3:
   000007:[grandparent#0,SET-grandparent#0,SET]
   000008:[m#0,SET-m#0,SET]

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -310,9 +310,10 @@ set c@14 c14
 flush
 ----
 L0.0:
-  000010:[c@20#12,SET-c@18#14,SET]
-  000011:[c@17#15,SET-c@15#17,SET]
-  000012:[c@14#18,SET-c@14#18,SET]
+  000010:[c@20#12,SET-c@19#13,SET]
+  000011:[c@18#14,SET-c@17#15,SET]
+  000012:[c@16#16,SET-c@15#17,SET]
+  000013:[c@14#18,SET-c@14#18,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
 
@@ -321,25 +322,25 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     3  2.0KB    38B       0 |  0.25 |  149B |     0     0B |     0     0B |     5  3.2KB |    0B |   1 21.8
+    0 |     4  2.7KB    48B       0 |  0.25 |  149B |     0     0B |     0     0B |     6  3.9KB |    0B |   1 26.5
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     6 |     1   595B     0B       0 |     - | 1.2KB |     0     0B |     0     0B |     1   595B | 1.2KB |   1  0.5
-total |     4  2.6KB    38B       0 |     - |  149B |     0     0B |     0     0B |     6  3.9KB | 1.2KB |   2 26.8
+total |     5  3.3KB    48B       0 |     - |  149B |     0     0B |     0     0B |     7  4.6KB | 1.2KB |   2 31.5
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
-Compactions: 1  estimated debt: 2.6KB  in progress: 0 (0B)
+Compactions: 1  estimated debt: 3.3KB  in progress: 0 (0B)
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 2.6KB
-Compression types: snappy: 4
+Local tables size: 3.3KB
+Compression types: snappy: 5
 Block cache: 0 entries (0B)  hit rate: 33.3%
 Table cache: 0 entries (0B)  hit rate: 66.7%
 Snapshots: 0  earliest seq num: 0
@@ -357,7 +358,7 @@ additional-metrics
 ----
 block bytes written:
  __level___data-block__value-block
-      0         198B          38B
+      0         236B          48B
       1           0B           0B
       2           0B           0B
       3           0B           0B
@@ -369,22 +370,22 @@ compact a-z
 ----
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
+  000014:[c@20#0,SET-c@17#0,SET]
+  000015:[c@16#0,SET-c@14#0,SET]
 
 metrics
 ----
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  149B |     0     0B |     0     0B |     5  3.2KB |    0B |   0 21.8
+    0 |     0     0B     0B       0 |  0.00 |  149B |     0     0B |     0     0B |     6  3.9KB |    0B |   0 26.5
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |     3  2.0KB    41B       0 |     - |  149B |     0     0B |     0     0B |     8  5.3KB | 3.2KB |   1 36.7
+    6 |     3  2.0KB    41B       0 |     - | 3.9KB |     0     0B |     0     0B |     3  2.0KB | 3.9KB |   1  0.5
+total |     3  2.0KB    41B       0 |     - |  149B |     0     0B |     0     0B |     9  6.0KB | 3.9KB |   1 41.4
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 149B (28% overhead)
 Flushes: 3
@@ -396,15 +397,15 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 2.0KB
 Compression types: snappy: 3
-Block cache: 0 entries (0B)  hit rate: 14.3%
-Table cache: 0 entries (0B)  hit rate: 58.3%
+Block cache: 0 entries (0B)  hit rate: 11.8%
+Table cache: 0 entries (0B)  hit rate: 57.1%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:356 BlockBytesInCache:44 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
                    c, non-latency: {BlockBytes:44 BlockBytesInCache:44 BlockReadDuration:0s}
@@ -413,13 +414,13 @@ additional-metrics
 ----
 block bytes written:
  __level___data-block__value-block
-      0         198B          38B
+      0         236B          48B
       1           0B           0B
       2           0B           0B
       3           0B           0B
       4           0B           0B
       5           0B           0B
-      6         143B          41B
+      6         144B          41B
 
 # Flushable ingestion metrics. This requires there be data in a memtable that
 # would overlap with the ingested table(s). Delayed flushes are disabled here to
@@ -462,15 +463,15 @@ disable
 flush
 ----
 L0.1:
-  000015:[d#22,SET-d#22,SET]
-  000016:[e#23,SET-e#23,SET]
-  000019:[f#24,SET-f#24,SET]
+  000016:[d#22,SET-d#22,SET]
+  000017:[e#23,SET-e#23,SET]
+  000020:[f#24,SET-f#24,SET]
 L0.0:
-  000023:[d#19,SET-f#21,SET]
+  000024:[d#19,SET-f#21,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
+  000014:[c@20#0,SET-c@17#0,SET]
+  000015:[c@16#0,SET-c@14#0,SET]
 
 # We expect the ingested-as-flushable count to be three (one for each ingested
 # table). The unknown category in the iter category stats is because of a gap
@@ -482,14 +483,14 @@ metrics
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.3KB     0B       0 |  0.50 |  187B |     3  1.7KB |     0     0B |     6  3.8KB |    0B |   2 20.6
+    0 |     4  2.3KB     0B       0 |  0.50 |  187B |     3  1.7KB |     0     0B |     7  4.5KB |    0B |   2 24.4
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |     7  4.3KB    41B       0 |     - | 1.9KB |     3  1.7KB |     0     0B |     9  7.7KB | 3.2KB |   3  4.0
+    6 |     3  2.0KB    41B       0 |     - | 3.9KB |     0     0B |     0     0B |     3  2.0KB | 3.9KB |   1  0.5
+total |     7  4.3KB    41B       0 |     - | 1.9KB |     3  1.7KB |     0     0B |    10  8.4KB | 3.9KB |   3  4.4
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 176B  written: 187B (6% overhead)
 Flushes: 8
@@ -501,15 +502,15 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 4.3KB
 Compression types: snappy: 7
-Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (920B)  hit rate: 53.8%
+Block cache: 8 entries (2.8KB)  hit rate: 8.0%
+Table cache: 1 entries (920B)  hit rate: 53.3%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:356 BlockBytesInCache:44 BlockReadDuration:80ms}
        pebble-ingest,     latency: {BlockBytes:64 BlockBytesInCache:0 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -528,32 +529,32 @@ set m m
 flush
 ----
 L0.1:
-  000015:[d#22,SET-d#22,SET]
-  000016:[e#23,SET-e#23,SET]
-  000019:[f#24,SET-f#24,SET]
+  000016:[d#22,SET-d#22,SET]
+  000017:[e#23,SET-e#23,SET]
+  000020:[f#24,SET-f#24,SET]
 L0.0:
-  000023:[d#19,SET-f#21,SET]
-  000025:[g#25,SET-i#27,SET]
-  000026:[j#28,SET-l#30,SET]
-  000027:[m#31,SET-m#31,SET]
+  000024:[d#19,SET-f#21,SET]
+  000026:[g#25,SET-i#27,SET]
+  000027:[j#28,SET-l#30,SET]
+  000028:[m#31,SET-m#31,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
+  000014:[c@20#0,SET-c@17#0,SET]
+  000015:[c@16#0,SET-c@14#0,SET]
 
 metrics
 ----
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  4.1KB     0B       0 |  0.50 |  245B |     3  1.7KB |     0     0B |     9  5.5KB |    0B |   2 23.1
+    0 |     7  4.1KB     0B       0 |  0.50 |  245B |     3  1.7KB |     0     0B |    10  6.2KB |    0B |   2 26.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     3  2.0KB    41B       0 |     - | 3.2KB |     0     0B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |    10  6.1KB    41B       0 |     - | 2.0KB |     3  1.7KB |     0     0B |    12  9.5KB | 3.2KB |   3  4.8
+    6 |     3  2.0KB    41B       0 |     - | 3.9KB |     0     0B |     0     0B |     3  2.0KB | 3.9KB |   1  0.5
+total |    10  6.1KB    41B       0 |     - | 2.0KB |     3  1.7KB |     0     0B |    13   10KB | 3.9KB |   3  5.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
@@ -565,15 +566,15 @@ Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 6.1KB
 Compression types: snappy: 10
-Block cache: 8 entries (2.8KB)  hit rate: 9.1%
-Table cache: 1 entries (920B)  hit rate: 53.8%
+Block cache: 8 entries (2.8KB)  hit rate: 8.0%
+Table cache: 1 entries (920B)  hit rate: 53.3%
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
 Filter utility: 0.0%
 Ingestions: 2  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:356 BlockBytesInCache:44 BlockReadDuration:80ms}
        pebble-ingest,     latency: {BlockBytes:64 BlockBytesInCache:0 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -590,19 +591,19 @@ ingest-and-excise ext1 excise=i-k
 lsm
 ----
 L0.1:
-  000015:[d#22,SET-d#22,SET]
-  000016:[e#23,SET-e#23,SET]
-  000019:[f#24,SET-f#24,SET]
+  000016:[d#22,SET-d#22,SET]
+  000017:[e#23,SET-e#23,SET]
+  000020:[f#24,SET-f#24,SET]
 L0.0:
-  000023:[d#19,SET-f#21,SET]
-  000029(000025):[g#25,SET-h#26,SET]
-  000030(000026):[k#29,SET-l#30,SET]
-  000027:[m#31,SET-m#31,SET]
+  000024:[d#19,SET-f#21,SET]
+  000030(000026):[g#25,SET-h#26,SET]
+  000031(000027):[k#29,SET-l#30,SET]
+  000028:[m#31,SET-m#31,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
-  000028:[z#33,SET-z#33,SET]
+  000014:[c@20#0,SET-c@17#0,SET]
+  000015:[c@16#0,SET-c@14#0,SET]
+  000029:[z#33,SET-z#33,SET]
 
 # There should be 2 backing tables. Note that tiny sstables have inaccurate
 # virtual sstable sizes.
@@ -624,14 +625,14 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  3.0KB     0B       2 |  0.50 |  245B |     3  1.7KB |     0     0B |     9  5.5KB |    0B |   2 23.1
+    0 |     7  3.0KB     0B       2 |  0.50 |  245B |     3  1.7KB |     0     0B |    10  6.2KB |    0B |   2 26.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     4  2.6KB    41B       0 |     - | 3.2KB |     1   589B |     0     0B |     3  2.0KB | 3.2KB |   1  0.6
-total |    11  5.6KB    41B       2 |     - | 2.5KB |     4  2.3KB |     0     0B |    12   10KB | 3.2KB |   3  4.0
+    6 |     4  2.6KB    41B       0 |     - | 3.9KB |     1   589B |     0     0B |     3  2.0KB | 3.9KB |   1  0.5
+total |    11  5.6KB    41B       2 |     - | 2.5KB |     4  2.3KB |     0     0B |    13   11KB | 3.9KB |   3  4.2
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
@@ -651,7 +652,7 @@ Filter utility: 0.0%
 Ingestions: 3  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:301 BlockBytesInCache:44 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:356 BlockBytesInCache:44 BlockReadDuration:80ms}
        pebble-ingest,     latency: {BlockBytes:200 BlockBytesInCache:0 BlockReadDuration:30ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -670,20 +671,20 @@ ingest-and-excise ext1 excise=k-l
 lsm
 ----
 L0.1:
-  000015:[d#22,SET-d#22,SET]
-  000016:[e#23,SET-e#23,SET]
-  000019:[f#24,SET-f#24,SET]
+  000016:[d#22,SET-d#22,SET]
+  000017:[e#23,SET-e#23,SET]
+  000020:[f#24,SET-f#24,SET]
 L0.0:
-  000023:[d#19,SET-f#21,SET]
-  000029(000025):[g#25,SET-h#26,SET]
-  000032(000026):[l#30,SET-l#30,SET]
-  000027:[m#31,SET-m#31,SET]
+  000024:[d#19,SET-f#21,SET]
+  000030(000026):[g#25,SET-h#26,SET]
+  000033(000027):[l#30,SET-l#30,SET]
+  000028:[m#31,SET-m#31,SET]
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
-  000028:[z#33,SET-z#33,SET]
-  000031:[zz#35,SET-zz#35,SET]
+  000014:[c@20#0,SET-c@17#0,SET]
+  000015:[c@16#0,SET-c@14#0,SET]
+  000029:[z#33,SET-z#33,SET]
+  000032:[zz#35,SET-zz#35,SET]
 
 metrics-value
 num-backing
@@ -702,11 +703,12 @@ compact a-z
 ----
 L6:
   000008:[a#0,SET-b#0,SET]
-  000013:[c@20#0,SET-c@16#0,SET]
-  000014:[c@15#0,SET-c@14#0,SET]
-  000033:[d#0,SET-m#0,SET]
-  000028:[z#33,SET-z#33,SET]
-  000031:[zz#35,SET-zz#35,SET]
+  000014:[c@20#0,SET-c@17#0,SET]
+  000015:[c@16#0,SET-c@14#0,SET]
+  000034:[d#0,SET-l#0,SET]
+  000035:[m#0,SET-m#0,SET]
+  000029:[z#33,SET-z#33,SET]
+  000032:[zz#35,SET-zz#35,SET]
 
 # Virtual sstables metrics should be gone after the compaction.
 metrics-value
@@ -727,14 +729,14 @@ metrics zero-cache-hits-misses
       |                             |       |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |  0.00 |  245B |     3  1.7KB |     0     0B |     9  5.5KB |    0B |   0 23.1
+    0 |     0     0B     0B       0 |  0.00 |  245B |     3  1.7KB |     0     0B |    10  6.2KB |    0B |   0 26.0
     1 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     2 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     3 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     4 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
     5 |     0     0B     0B       0 |  0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-    6 |     6  3.8KB    41B       0 |     - | 6.2KB |     2  1.2KB |     0     0B |     4  2.6KB | 6.2KB |   1  0.4
-total |     6  3.8KB    41B       0 |     - | 3.1KB |     5  2.9KB |     0     0B |    13   11KB | 6.2KB |   1  3.6
+    6 |     7  4.4KB    41B       0 |     - | 6.9KB |     2  1.2KB |     0     0B |     5  3.2KB | 6.9KB |   1  0.5
+total |     7  4.4KB    41B       0 |     - | 3.1KB |     5  2.9KB |     0     0B |    15   13KB | 6.9KB |   1  4.0
 -------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 245B (10% overhead)
 Flushes: 9
@@ -744,8 +746,8 @@ MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 3.8KB
-Compression types: snappy: 6
+Local tables size: 4.4KB
+Compression types: snappy: 7
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%
 Snapshots: 0  earliest seq num: 0
@@ -754,7 +756,7 @@ Filter utility: 0.0%
 Ingestions: 4  as flushable: 2 (1.7KB in 3 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:677 BlockBytesInCache:376 BlockReadDuration:70ms}
+   pebble-compaction, non-latency: {BlockBytes:732 BlockBytesInCache:376 BlockReadDuration:90ms}
        pebble-ingest,     latency: {BlockBytes:272 BlockBytesInCache:72 BlockReadDuration:30ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:44 BlockBytesInCache:0 BlockReadDuration:10ms}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -16,10 +16,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"unsafe"
 
+	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/strparse"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/record"
@@ -394,4 +398,137 @@ func TestCrashDuringManifestWrite_LargeKeys(t *testing.T) {
 			require.NoError(t, d.Close())
 		}()
 	}
+}
+
+// TestLargeKeys is a datadriven test that exercises large keys with shared
+// prefixes. These keys can be problematic, in part because they cannot be
+// shortened by an index separator.
+//
+// See #4518.
+func TestLargeKeys(t *testing.T) {
+	var largeKeyComparer = func() base.Comparer {
+		c := *testkeys.Comparer
+		c.FormatKey = func(key []byte) fmt.Formatter {
+			return formatAbbreviatedKey(key)
+		}
+		return c
+	}()
+
+	opts := &Options{
+		Comparer:                    &largeKeyComparer,
+		FormatMajorVersion:          internalFormatNewest,
+		FS:                          vfs.NewMem(),
+		Logger:                      testLogger{t: t},
+		MemTableStopWritesThreshold: 4,
+		DisableTableStats:           true,
+	}
+	var d *DB
+	defer func() { require.NoError(t, d.Close()) }()
+	datadriven.RunTest(t, "testdata/large_keys", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			var err error
+			d, err = runDBDefineCmd(td, opts)
+			require.NoError(t, err)
+			return runLSMCmd(td, d)
+		case "batch-commit":
+			b := d.NewBatch()
+			for _, line := range crstrings.Lines(td.Input) {
+				op, rest := splitAt(line, " ")
+				switch op {
+				case "set":
+					k := parseLargeKey(rest)
+					require.NoError(t, b.Set(k, []byte("value"), nil))
+				case "delete":
+					k := parseLargeKey(rest)
+					require.NoError(t, b.Delete(k, nil))
+				case "del-range":
+					var firstKey string
+					firstKey, rest = splitAt(rest, " ")
+					start := parseLargeKey(firstKey)
+					end := parseLargeKey(rest)
+					require.NoError(t, b.DeleteRange(start, end, nil))
+				default:
+					panic(fmt.Sprintf("unknown op: %s", op))
+				}
+			}
+			require.NoError(t, b.Commit(Sync))
+			return ""
+		case "flush":
+			require.NoError(t, d.Flush())
+			return runLSMCmd(td, d)
+		case "layout":
+			return runLayoutCmd(t, td, d)
+		case "properties":
+			return runSSTablePropertiesCmd(t, td, d)
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
+// formatAbbreviatedKey formats a key using the test key formatter, and then
+// abbreviates sequences of repeated bytes.
+type formatAbbreviatedKey []byte
+
+// Format implements the fmt.Formatter interface.
+func (p formatAbbreviatedKey) Format(s fmt.State, c rune) {
+	formattedStr := fmt.Sprint(testkeys.Comparer.FormatKey(p))
+	s.Write(abbreviateLargeKey(unsafe.Slice(unsafe.StringData(formattedStr), len(formattedStr))))
+}
+
+// parseLargeKey parses a key from a string, allowing for repetition of
+// a byte. Examples:
+//
+// (a,10) -> aaaaaaaaaa
+// f(o,5)bar -> fooooobar
+func parseLargeKey(s string) []byte {
+	var buf bytes.Buffer
+	p := strparse.MakeParser("(,)", s)
+	for !p.Done() {
+		t := p.Next()
+		if t != "(" {
+			buf.WriteString(t)
+			continue
+		}
+		repeat := p.Next()
+		p.Expect(",")
+		count := p.Int()
+		p.Expect(")")
+		for i := 0; i < count; i++ {
+			buf.WriteString(repeat)
+		}
+	}
+	return buf.Bytes()
+}
+
+// abbreviateLargeKey abbreviates a large key by replacing repeated bytes with
+// a tuple of the byte and the count. Examples:
+//
+// aaaaaaaaaa -> (a,10)
+// fooooobar -> f(o,5)bar
+func abbreviateLargeKey(k []byte) []byte {
+	var buf bytes.Buffer
+	var duplicateCount int
+	for i, b := range k {
+		if i+1 < len(k) && k[i+1] == b {
+			duplicateCount++
+		} else {
+			if duplicateCount > 0 {
+				buf.WriteString(fmt.Sprintf("(%s,%d)", string(b), duplicateCount+1))
+			} else {
+				buf.WriteByte(b)
+			}
+			duplicateCount = 0
+		}
+	}
+	return buf.Bytes()
+}
+
+func splitAt(s string, chars string) (string, string) {
+	i := strings.IndexAny(s, chars)
+	if i == -1 {
+		return s, ""
+	}
+	return s[:i], s[i+1:]
 }


### PR DESCRIPTION
25.1 backport of https://github.com/cockroachdb/pebble/pull/4583 and https://github.com/cockroachdb/pebble/pull/4618.