### PR TITLE
db: clean up level compaction scoring

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -6,9 +6,11 @@ package pebble
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"iter"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -48,11 +50,9 @@ type compactionEnv struct {
 
 type compactionPickerMetrics struct {
 	levels [numLevels]struct {
-		// needsCompaction indicates if compensatedScoreRatio is >= compactionScoreThreshold.
-		shouldCompact           bool
-		uncompensatedScoreRatio float64
-		uncompensatedScore      float64
-		compensatedScore        float64
+		score                 float64
+		fillFactor            float64
+		compensatedFillFactor float64
 	}
 }
 
@@ -104,41 +104,6 @@ func (info compactionInfo) String() string {
 		fmt.Fprintf(&buf, " -> L%d", info.outputLevel)
 	}
 	return buf.String()
-}
-
-type sortCompactionLevelsByPriority []candidateLevelInfo
-
-func (s sortCompactionLevelsByPriority) Len() int {
-	return len(s)
-}
-
-// A level should be picked for compaction if the compensatedScoreRatio is >= the
-// compactionScoreThreshold.
-const compactionScoreThreshold = 1
-
-// Less should return true if s[i] must be placed earlier than s[j] in the final
-// sorted list. The candidateLevelInfo for the level placed earlier is more likely
-// to be picked for a compaction.
-func (s sortCompactionLevelsByPriority) Less(i, j int) bool {
-	iShouldCompact := s[i].compensatedScoreRatio >= compactionScoreThreshold
-	jShouldCompact := s[j].compensatedScoreRatio >= compactionScoreThreshold
-	// Ordering is defined as decreasing on (shouldCompact, uncompensatedScoreRatio)
-	// where shouldCompact is 1 for true and 0 for false.
-	if iShouldCompact && !jShouldCompact {
-		return true
-	}
-	if !iShouldCompact && jShouldCompact {
-		return false
-	}
-
-	if s[i].uncompensatedScoreRatio != s[j].uncompensatedScoreRatio {
-		return s[i].uncompensatedScoreRatio > s[j].uncompensatedScoreRatio
-	}
-	return s[i].level < s[j].level
-}
-
-func (s sortCompactionLevelsByPriority) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
 }
 
 // sublevelInfo is used to tag a LevelSlice for an L0 sublevel with the
@@ -631,23 +596,31 @@ func newCompactionPickerByScore(
 // Information about a candidate compaction level that has been identified by
 // the compaction picker.
 type candidateLevelInfo struct {
-	// The compensatedScore of the level after adjusting according to the other
-	// levels' sizes. For L0, the compensatedScoreRatio is equivalent to the
-	// uncompensatedScoreRatio as we don't account for level size compensation in
-	// L0.
-	compensatedScoreRatio float64
-	// The score of the level after accounting for level size compensation before
-	// adjusting according to other levels' sizes. For L0, the compensatedScore
-	// is equivalent to the uncompensatedScore as we don't account for level
-	// size compensation in L0.
-	compensatedScore float64
-	// The score of the level to be compacted, calculated using uncompensated file
-	// sizes and without any adjustments.
-	uncompensatedScore float64
-	// uncompensatedScoreRatio is the uncompensatedScore adjusted according to
-	// the other levels' sizes.
-	uncompensatedScoreRatio float64
-	level                   int
+	// The fill factor of the level, calculated using uncompensated file sizes and
+	// without any adjustments. A factor > 1 means that the level has more data
+	// than the ideal size for that level.
+	fillFactor float64
+
+	// The score of the level, used to rank levels.
+	//
+	// If the level doesn't require compaction, the score is 0.
+	// Otherwise:
+	//  - for L6, or if the fillFactor is < 1, the score is equal to the fillFactor.
+	//  - for L0-L5 with fillFactor >= 1, the score is the ratio between the
+	//    fillFactor and the next level's fillFactor.
+	score float64
+
+	// The fill factor of the level after accounting for level size compensation (i.e.
+	// including the estimated savings in the lower levels because of deletions).
+	//
+	// For L0, the compensatedFillFactor is equal to the fillFactor as we don't
+	// account for level size compensation in L0.
+	//
+	// The compensated fill factor is used to determine if the level should be
+	// compacted (by comparing it to 1).
+	compensatedFillFactor float64
+
+	level int
 	// The level to compact to.
 	outputLevel int
 	// The file in level that will be compacted. Additional files may be
@@ -657,7 +630,7 @@ type candidateLevelInfo struct {
 }
 
 func (c *candidateLevelInfo) shouldCompact() bool {
-	return c.compensatedScoreRatio >= compactionScoreThreshold
+	return c.score > 0
 }
 
 func fileCompensation(f *tableMetadata) uint64 {
@@ -721,10 +694,9 @@ var _ compactionPicker = &compactionPickerByScore{}
 func (p *compactionPickerByScore) getMetrics(inProgress []compactionInfo) compactionPickerMetrics {
 	var m compactionPickerMetrics
 	for _, info := range p.calculateLevelScores(inProgress) {
-		m.levels[info.level].shouldCompact = info.shouldCompact()
-		m.levels[info.level].uncompensatedScoreRatio = info.uncompensatedScoreRatio
-		m.levels[info.level].uncompensatedScore = info.uncompensatedScore
-		m.levels[info.level].compensatedScore = info.compensatedScore
+		m.levels[info.level].score = info.score
+		m.levels[info.level].fillFactor = info.fillFactor
+		m.levels[info.level].compensatedFillFactor = info.compensatedFillFactor
 	}
 	return m
 }
@@ -931,6 +903,8 @@ func calculateSizeAdjust(inProgressCompactions []compactionInfo) [numLevels]leve
 	return sizeAdjust
 }
 
+// calculateLevelScores calculates the candidateLevelInfo for all levels and
+// returns them in decreasing score order.
 func (p *compactionPickerByScore) calculateLevelScores(
 	inProgressCompactions []compactionInfo,
 ) [numLevels]candidateLevelInfo {
@@ -941,73 +915,63 @@ func (p *compactionPickerByScore) calculateLevelScores(
 	}
 	l0UncompensatedScore := calculateL0UncompensatedScore(p.vers, p.l0Organizer, p.opts, inProgressCompactions)
 	scores[0] = candidateLevelInfo{
-		outputLevel:        p.baseLevel,
-		uncompensatedScore: l0UncompensatedScore,
-		compensatedScore:   l0UncompensatedScore, /* No level size compensation for L0 */
+		outputLevel:           p.baseLevel,
+		fillFactor:            l0UncompensatedScore,
+		compensatedFillFactor: l0UncompensatedScore, /* No level size compensation for L0 */
 	}
 	sizeAdjust := calculateSizeAdjust(inProgressCompactions)
 	for level := 1; level < numLevels; level++ {
 		compensatedLevelSize := *compensatedSizeAnnotator.LevelAnnotation(p.vers.Levels[level]) + sizeAdjust[level].compensated()
-		scores[level].compensatedScore = float64(compensatedLevelSize) / float64(p.levelMaxBytes[level])
-		scores[level].uncompensatedScore = float64(p.vers.Levels[level].Size()+sizeAdjust[level].actual()) / float64(p.levelMaxBytes[level])
+		scores[level].compensatedFillFactor = float64(compensatedLevelSize) / float64(p.levelMaxBytes[level])
+		scores[level].fillFactor = float64(p.vers.Levels[level].Size()+sizeAdjust[level].actual()) / float64(p.levelMaxBytes[level])
 	}
 
-	// Adjust each level's {compensated, uncompensated}Score by the uncompensatedScore
-	// of the next level to get a {compensated, uncompensated}ScoreRatio. If the
-	// next level has a high uncompensatedScore, and is thus a priority for compaction,
-	// this reduces the priority for compacting the current level. If the next level
-	// has a low uncompensatedScore (i.e. it is below its target size), this increases
-	// the priority for compacting the current level.
+	// Adjust each level's fill factor by the fill factor of the next level to get
+	// a score. If the next level has a high fill factor, and is thus a priority
+	// for compaction, this reduces the priority for compacting the current level.
+	// If the next level has a low fill factor (i.e. it is below its target size),
+	// this increases the priority for compacting the current level.
 	//
 	// The effect of this adjustment is to help prioritize compactions in lower
-	// levels. The following example shows the compensatedScoreRatio and the
-	// compensatedScore. In this scenario, L0 has 68 sublevels. L3 (a.k.a. Lbase)
-	// is significantly above its target size. The original score prioritizes
-	// compactions from those two levels, but doing so ends up causing a future
-	// problem: data piles up in the higher levels, starving L5->L6 compactions,
-	// and to a lesser degree starving L4->L5 compactions.
+	// levels. The following example shows the scores and the fill ratios. In this
+	// scenario, L0 has 68 sublevels. L3 (a.k.a. Lbase) is significantly above its
+	// target size. The original score prioritizes compactions from those two
+	// levels, but doing so ends up causing a future problem: data piles up in the
+	// higher levels, starving L5->L6 compactions, and to a lesser degree starving
+	// L4->L5 compactions.
 	//
 	// Note that in the example shown there is no level size compensation so the
 	// compensatedScore and the uncompensatedScore is the same for each level.
 	//
-	//        compensatedScoreRatio   compensatedScore   uncompensatedScore   size   max-size
-	//   L0                     3.2               68.0                 68.0  2.2 G          -
-	//   L3                     3.2               21.1                 21.1  1.3 G       64 M
-	//   L4                     3.4                6.7                  6.7  3.1 G      467 M
-	//   L5                     3.4                2.0                  2.0  6.6 G      3.3 G
-	//   L6                     0.6                0.6                  0.6   14 G       24 G
-	var prevLevel int
-	for level := p.baseLevel; level < numLevels; level++ {
-		// The compensated scores, and uncompensated scores will be turned into
-		// ratios as they're adjusted according to other levels' sizes.
-		scores[prevLevel].compensatedScoreRatio = scores[prevLevel].compensatedScore
-		scores[prevLevel].uncompensatedScoreRatio = scores[prevLevel].uncompensatedScore
-
-		// Avoid absurdly large scores by placing a floor on the score that we'll
-		// adjust a level by. The value of 0.01 was chosen somewhat arbitrarily.
-		const minScore = 0.01
-		if scores[prevLevel].compensatedScoreRatio >= compactionScoreThreshold {
-			if scores[level].uncompensatedScore >= minScore {
-				scores[prevLevel].compensatedScoreRatio /= scores[level].uncompensatedScore
-			} else {
-				scores[prevLevel].compensatedScoreRatio /= minScore
-			}
+	//        score   fillFactor   compensatedFillFactor   size   max-size
+	//   L0     3.2         68.0                    68.0  2.2 G          -
+	//   L3     3.2         21.1                    21.1  1.3 G       64 M
+	//   L4     3.4          6.7                     6.7  3.1 G      467 M
+	//   L5     3.4          2.0                     2.0  6.6 G      3.3 G
+	//   L6       0          0.6                     0.6   14 G       24 G
+	for level := 0; level < numLevels; level++ {
+		if level > 0 && level < p.baseLevel {
+			continue
 		}
-		if scores[prevLevel].uncompensatedScoreRatio >= compactionScoreThreshold {
-			if scores[level].uncompensatedScore >= minScore {
-				scores[prevLevel].uncompensatedScoreRatio /= scores[level].uncompensatedScore
-			} else {
-				scores[prevLevel].uncompensatedScoreRatio /= minScore
-			}
+		if scores[level].compensatedFillFactor < 1 {
+			continue
 		}
-		prevLevel = level
+		scores[level].score = scores[level].fillFactor
+		if level < numLevels-1 && scores[level].fillFactor >= 1.0 {
+			nextLevel := scores[level].outputLevel
+			// Avoid absurdly large scores by placing a floor on the factor that we'll
+			// adjust a level by. The value of 0.01 was chosen somewhat arbitrarily.
+			const minDenominator = 0.01
+			scores[level].score /= max(minDenominator, scores[nextLevel].fillFactor)
+		}
 	}
-	// Set the score ratios for the lowest level.
-	// INVARIANT: prevLevel == numLevels-1
-	scores[prevLevel].compensatedScoreRatio = scores[prevLevel].compensatedScore
-	scores[prevLevel].uncompensatedScoreRatio = scores[prevLevel].uncompensatedScore
-
-	sort.Sort(sortCompactionLevelsByPriority(scores[:]))
+	// Sort by score (decreasing) and break ties by level (increasing).
+	slices.SortFunc(scores[:], func(a, b candidateLevelInfo) int {
+		if a.score != b.score {
+			return cmp.Compare(b.score, a.score)
+		}
+		return cmp.Compare(a.level, b.level)
+	})
 	return scores
 }
 
@@ -1277,9 +1241,8 @@ func (p *compactionPickerByScore) logCompactionForTesting(
 		if pc.startLevel.level == info.level {
 			marker = "*"
 		}
-		fmt.Fprintf(&buf, "  %sL%d: %5.1f  %5.1f  %5.1f  %5.1f %8s  %8s",
-			marker, info.level, info.compensatedScoreRatio, info.compensatedScore,
-			info.uncompensatedScoreRatio, info.uncompensatedScore,
+		fmt.Fprintf(&buf, "  %sL%d: score:%5.1f  fillFactor:%5.1f  compensatedFillFactor:%5.1f %8s  %8s",
+			marker, info.level, info.score, info.fillFactor, info.compensatedFillFactor,
 			humanize.Bytes.Int64(int64(totalCompensatedSize(
 				p.vers.Levels[info.level].All(),
 			))),
@@ -1339,7 +1302,7 @@ func (p *compactionPickerByScore) pickAutoScore(env compactionEnv) (pc *pickedCo
 			// concurrently.
 			if pc != nil && !inputRangeAlreadyCompacting(env, pc) {
 				p.addScoresToPickedCompactionMetrics(pc, scores)
-				pc.score = info.compensatedScoreRatio
+				pc.score = info.score
 				if false {
 					p.logCompactionForTesting(env, scores, pc)
 				}
@@ -1359,7 +1322,7 @@ func (p *compactionPickerByScore) pickAutoScore(env compactionEnv) (pc *pickedCo
 		// Fail-safe to protect against compacting the same sstable concurrently.
 		if pc != nil && !inputRangeAlreadyCompacting(env, pc) {
 			p.addScoresToPickedCompactionMetrics(pc, scores)
-			pc.score = info.compensatedScoreRatio
+			pc.score = info.score
 			if false {
 				p.logCompactionForTesting(env, scores, pc)
 			}
@@ -1445,7 +1408,7 @@ func (p *compactionPickerByScore) addScoresToPickedCompactionMetrics(
 	inputIdx := 0
 	for i := range infoByLevel {
 		if pc.inputs[inputIdx].level == infoByLevel[i].level {
-			pc.pickerMetrics.scores[inputIdx] = infoByLevel[i].compensatedScoreRatio
+			pc.pickerMetrics.scores[inputIdx] = infoByLevel[i].score
 			inputIdx++
 		}
 		if inputIdx == len(pc.inputs) {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1684,7 +1684,7 @@ func TestCompactionPickerScores(t *testing.T) {
 			buf.Reset()
 			fmt.Fprintf(&buf, "L       Size   Score\n")
 			for l, lm := range d.Metrics().Levels {
-				fmt.Fprintf(&buf, "L%-3d\t%-7s%.1f\n", l, humanize.Bytes.Int64(lm.TablesSize), lm.CompensatedScore)
+				fmt.Fprintf(&buf, "L%-3d\t%-7s%.1f\n", l, humanize.Bytes.Int64(lm.TablesSize), lm.Score)
 			}
 			return buf.String()
 

--- a/db.go
+++ b/db.go
@@ -2052,11 +2052,9 @@ func (d *DB) Metrics() *Metrics {
 		m := p.getMetrics(compactions)
 		for level, lm := range m.levels {
 			metrics.Levels[level].Score = 0
-			if lm.shouldCompact {
-				metrics.Levels[level].Score = lm.uncompensatedScoreRatio
-			}
-			metrics.Levels[level].UncompensatedScore = lm.uncompensatedScore
-			metrics.Levels[level].CompensatedScore = lm.compensatedScore
+			metrics.Levels[level].Score = lm.score
+			metrics.Levels[level].FillFactor = lm.fillFactor
+			metrics.Levels[level].CompensatedFillFactor = lm.compensatedFillFactor
 		}
 	}
 	metrics.Table.ZombieCount = int64(d.mu.versions.zombieTables.Count())

--- a/metrics.go
+++ b/metrics.go
@@ -55,16 +55,13 @@ type LevelMetrics struct {
 	// The total size of the virtual sstables in the level.
 	VirtualTablesSize uint64
 	// The level's compaction score, used to rank levels (0 if the level doesn't
-	// need compaction). This is equal to the uncompensatedScoreRatio in the
-	// candidateLevel or 0 depending on when candidateLevel.shouldCompact().
+	// need compaction). See candidateLevelInfo.
 	Score float64
-	// The level's compaction score. This is the uncompensatedStore in the
-	// candidateLevelInfo.
-	UncompensatedScore float64
-	// The level's compaction score, compensated with an estimate of the disk
-	// space that can be reclaimed. This is the compensatedScore in the
-	// candidateLevelInfo.
-	CompensatedScore float64
+	// The level's fill factor (the ratio between the size of the level and the
+	// ideal size). See candidateLevelInfo.
+	FillFactor float64
+	// The level's compensated fill factor. See candidateLevelInfo.
+	CompensatedFillFactor float64
 	// The number of incoming bytes from other levels read during
 	// compactions. This excludes bytes moved and bytes ingested. For L0 this is
 	// the bytes written to the WAL.
@@ -590,7 +587,7 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.SafeString("      |                             |                |       |   ingested   |     moved    |    written   |       |    amp")
 	appendIfMulti("   |     multilevel")
 	newline()
-	w.SafeString("level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w")
+	w.SafeString("level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w")
 	appendIfMulti("  |    top   in  read")
 	newline()
 	w.SafeString("------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------")
@@ -610,8 +607,8 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 			humanize.Bytes.Uint64(m.Additional.ValueBlocksSize),
 			humanize.Count.Uint64(m.VirtualTablesCount),
 			humanizeFloat(score, 4),
-			humanizeFloat(m.UncompensatedScore, 4),
-			humanizeFloat(m.CompensatedScore, 4),
+			humanizeFloat(m.FillFactor, 4),
+			humanizeFloat(m.CompensatedFillFactor, 4),
 			humanize.Bytes.Uint64(m.BytesIn),
 			humanize.Count.Uint64(m.TablesIngested),
 			humanize.Bytes.Uint64(m.BytesIngested),
@@ -648,8 +645,8 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 	// ingested.
 	total.BytesFlushed += total.BytesIn
 	total.Score = math.NaN()
-	total.CompensatedScore = math.NaN()
-	total.UncompensatedScore = math.NaN()
+	total.FillFactor = math.NaN()
+	total.CompensatedFillFactor = math.NaN()
 	w.SafeString("total ")
 	formatRow(&total)
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -94,8 +94,8 @@ func exampleMetrics() Metrics {
 		if i < numLevels-1 {
 			l.Score = 1.0 + float64(i+1)*0.1
 		}
-		l.UncompensatedScore = 2.0 + float64(i+1)*0.1
-		l.CompensatedScore = 3.0 * +float64(i+1) * 0.1
+		l.FillFactor = 2.0 + float64(i+1)*0.1
+		l.CompensatedFillFactor = 3.0 * +float64(i+1) * 0.1
 		l.BytesIn = base + 4
 		l.BytesIngested = base + 4
 		l.BytesMoved = base + 6

--- a/testdata/compaction_picker_concurrency
+++ b/testdata/compaction_picker_concurrency
@@ -49,7 +49,9 @@ compactions
 pick-auto l0_compaction_threshold=10
 ----
 picker.getCompactionConcurrency: 4
-nil
+L0 -> L0
+L0: 000301,000302,000303,000304,000305
+grandparents: 000201
 
 # Test that lowering L0CompactionConcurrency opens up more compaction slots.
 

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -47,7 +47,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	750B   5.0
+L5  	750B   0.0
 L6  	321KB  1.1
 
 # Ensure that point deletions in a higher level result in a compensated level
@@ -103,7 +103,7 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	776B   2.5
+L5  	776B   0.0
 L6  	321KB  1.1
 
 # Run a similar test as above, but this time the table containing the DELs is
@@ -206,8 +206,8 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	642KB  2.6
-L6  	386KB  0.4
+L5  	642KB  6.3
+L6  	386KB  0.0
 
 lsm verbose
 ----
@@ -238,8 +238,8 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	129KB  0.5
-L6  	898KB  1.0
+L5  	129KB  0.0
+L6  	898KB  0.0
 
 lsm
 ----
@@ -260,5 +260,5 @@ L1  	0B     0.0
 L2  	0B     0.0
 L3  	0B     0.0
 L4  	0B     0.0
-L5  	129KB  0.5
-L6  	898KB  1.0
+L5  	129KB  0.0
+L6  	898KB  0.0

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -1095,9 +1095,6 @@ L0->L5: 5.0
   000009:[0001#9,SET-0001#9,SET] marked as compacting
   000010:[0001#10,SET-0001#10,SET] marked as compacting
   500001:[0001#1,SET-0001#1,SET] marked as compacting
-L5->L6: 11.5
-  500005:[0005#5,SET-0005#5,SET] marked as compacting
-  600005:[0005#5,SET-0005#5,SET] marked as compacting
 
 init 5
 0: 10
@@ -1146,9 +1143,6 @@ L0->L5: 5.0
   000009:[0001#9,SET-0001#9,SET] marked as compacting
   000010:[0001#10,SET-0001#10,SET] marked as compacting
   500001:[0001#1,SET-0001#1,SET] marked as compacting
-L5->L6: 10.8
-  500002:[0002#2,SET-0002#2,SET] marked as compacting
-  600002:[0002#2,SET-0002#2,SET] marked as compacting
 
 # Verify that successive manual compactions interleaved with an automatic
 # compaction does not trigger an error.

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -261,7 +261,7 @@ base: 4
 
 queue
 ----
-L5->L6: 6.2
+L5->L6: 1.1
   500001:[0001#1,SET-0001#1,SET] marked as compacting
   500002:[0002#2,SET-0002#2,SET] marked as compacting
   500003:[0003#3,SET-0003#3,SET] marked as compacting

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -208,7 +208,7 @@ range-deletions-bytes-estimate: 16824
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=89.06 + L6 [000007] (17KB) Score=0.73 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
+[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=89.06 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
 
 define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
@@ -243,7 +243,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (771B) Score=13.77 + L6 [000006] (13KB) Score=0.92 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(default) L5 [000004] (771B) Score=6.14 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -376,7 +376,7 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (763B) Score=24.34 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(default) L5 [000004] (763B) Score=3.02 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -422,4 +422,4 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (763B) Score=24.34 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(default) L5 [000004] (763B) Score=3.02 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -226,7 +226,7 @@ remove: ext/0
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     2  1.5KB     0B       0 |    - 0.40 0.40 |   97B |     1   746B |     0     0B |     3  2.2KB |    0B |   2 23.0
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -329,7 +329,7 @@ sync: db/MANIFEST-000023
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     4  2.9KB     0B       0 |    - 0.80 0.80 |  132B |     2  1.5KB |     0     0B |     4  2.9KB |    0B |   4 22.5
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -32,7 +32,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -1,7 +1,7 @@
 example
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |     multilevel
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w  |    top   in  read
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  |    top   in  read
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+------------------
     0 |   101   102B     0B     101 | 1.10 2.10 0.30 |  104B |   112   104B |   113   106B |   221   217B |  107B |   1 2.09 |  104B  104B  104B
     1 |   201   202B     0B     201 | 1.20 2.20 0.60 |  204B |   212   204B |   213   206B |   421   417B |  207B |   2 2.04 |  204B  204B  204B
@@ -55,7 +55,7 @@ iter-new b category=b
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     1   751B     0B       0 |    - 0.25 0.25 |   28B |     0     0B |     0     0B |     1   751B |    0B |   1 26.8
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -120,7 +120,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.5
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -168,7 +168,7 @@ iter-close a
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.5
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -213,7 +213,7 @@ iter-close c
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.5
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -261,7 +261,7 @@ iter-close b
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.5
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -340,7 +340,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     7  5.2KB     0B       0 |    - 0.25 0.25 |  165B |     0     0B |     0     0B |     9  6.7KB |    0B |   1 41.6
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -404,7 +404,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |  165B |     0     0B |     0     0B |     9  6.7KB |    0B |   0 41.6
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -519,7 +519,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     6  4.4KB     0B       0 |    - 0.50 0.50 |  211B |     3  2.2KB |     0     0B |    12  8.9KB |    0B |   2 43.2
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -596,7 +596,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |    13  9.5KB     0B       0 |    - 0.50 0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 51.9
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -685,7 +685,7 @@ virtual-size
 metrics zero-cache-hits-misses
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |    11  8.1KB     0B       0 |    - 0.50 0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 51.9
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -810,7 +810,7 @@ virtual-size
 metrics zero-cache-hits-misses
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   0 51.9
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -868,7 +868,7 @@ L0.0:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     3  2.2KB     0B       0 |    - 0.25 0.25 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 59.3
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -912,7 +912,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   0 59.3
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -972,7 +972,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     1   754B     0B       0 |    - 0.25 0.25 |   38B |     1   754B |     0     0B |     3  2.2KB |    0B |   1 59.3
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -1024,7 +1024,7 @@ L6:
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     2  1.5KB     0B       0 |    - 0.50 0.50 |   74B |     1   754B |     0     0B |     4  2.9KB |    0B |   2 40.6
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -1065,7 +1065,7 @@ init reopen
 metrics zero-cache-hits-misses
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     2  1.5KB     0B       0 |    - 0.50 0.50 |    0B |     0     0B |     0     0B |     0     0B |    0B |   2    0
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -1109,7 +1109,7 @@ L6:
 metrics zero-cache-hits-misses
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -11,7 +11,7 @@ db lsm
 ../testdata/db-stage-4
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     1   709B     0B       0 |    - 0.50 0.50 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
@@ -47,7 +47,7 @@ db lsm --url
 ----
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
     0 |     1   709B     0B       0 |    - 0.50 0.50 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0


### PR DESCRIPTION
#### db: fix for TestCompactionPickerTargetLevel

In the "queue" case, we weren't updating the L0 organizer, which can
lead to panics in the test if compaction heuristics change.

#### db: clean up level compaction scoring

This commit renames "score" to "fill factor" and "score ratio" to
"score".

We no longer calculate a "compensated score ratio"; it was used only
to determine whether the level is eligible for a compaction (and not
used for ranking the levels). We now use the compensated fill factor
(note that this can result in levels being more frequently eligible
for compaction, but not the other way around).