### PR TITLE
db: deflake TestCompactionCorruption

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2902,15 +2902,13 @@ func TestCompactionCorruption(t *testing.T) {
 			},
 		},
 		L0CompactionThreshold:     1,
-		L0CompactionFileThreshold: 10,
+		L0CompactionFileThreshold: 5,
 	}
 	opts.WithFSDefaults()
 	remoteStorage := remote.NewInMem()
 	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		"external-locator": remoteStorage,
 	})
-	opts.EnsureDefaults()
-	opts.Levels[0].TargetFileSize = 8192
 	d, err := Open("", opts)
 	require.NoError(t, err)
 
@@ -2928,16 +2926,17 @@ func TestCompactionCorruption(t *testing.T) {
 			defer workloadWG.Done()
 			for !stopWorkload.Load() {
 				b := d.NewBatch()
-				// Write some random keys of the form a012345.
-				for i := 0; i < 100; i++ {
-					v := make([]byte, 100+rand.IntN(100))
-					for i := range v {
-						v[i] = byte(rand.Uint32())
-					}
-					key := fmt.Sprintf("%c%06d", 'a'+byte(rand.IntN(int('z'-'a'+1))), rand.IntN(1000000))
-					if err := b.Set([]byte(key), v, nil); err != nil {
-						panic(err)
-					}
+				// Write a random key of the form a012345 and flush it. This will result
+				// in (mostly) non-overlapping tables in L0.
+				var valSeed [32]byte
+				for i := range valSeed {
+					valSeed[i] = byte(rand.Uint32())
+				}
+				v := make([]byte, 1024+rand.IntN(10240))
+				_, _ = rand.NewChaCha8(valSeed).Read(v)
+				key := fmt.Sprintf("%c%06d", 'a'+byte(rand.IntN(int('z'-'a'+1))), rand.IntN(1000000))
+				if err := b.Set([]byte(key), v, nil); err != nil {
+					panic(err)
 				}
 				if err := b.Commit(nil); err != nil {
 					panic(err)


### PR DESCRIPTION
This test can still be flaky in CI. Tweaking it to generate many
non-overlapping L0 files instead of many L0 sublevels; this way there
are no intra-L0 compactions that compete with the compactions we care
about.

I ran it under stress locally for a few hours (700k runs) with the 2
minute internal timeout reduced to 15s.

Fixes #4634