### PR TITLE
db: add option for CompactionGarbageFractionForMaxConcurrency

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -80,6 +80,10 @@ func newPebbleDB(dir string) DB {
 	// writing), columnar blocks are only written if explicitly opted into.
 	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 
+	// Running the tool should not start compactions due to garbage.
+	opts.Experimental.CompactionGarbageFractionForMaxConcurrency = func() float64 {
+		return -1.0
+	}
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]
 		l.BlockSize = 32 << 10       // 32 KB

--- a/db.go
+++ b/db.go
@@ -2068,6 +2068,11 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Keys.RangeKeySetsCount = *rangeKeySetsAnnotator.MultiLevelAnnotation(vers.RangeKeyLevels[:])
 	metrics.Keys.TombstoneCount = *tombstonesAnnotator.MultiLevelAnnotation(vers.Levels[:])
 
+	metrics.Table.Garbage.PointDeletionsBytesEstimate =
+		*pointDeletionsBytesEstimateAnnotator.MultiLevelAnnotation(vers.Levels[:])
+	metrics.Table.Garbage.RangeDeletionsBytesEstimate =
+		*rangeDeletionsBytesEstimateAnnotator.MultiLevelAnnotation(vers.Levels[:])
+
 	d.mu.versions.logLock()
 	metrics.private.manifestFileSize = uint64(d.mu.versions.manifest.Size())
 	backingCount, backingTotalSize := d.mu.versions.virtualBackings.Stats()

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -690,6 +690,11 @@ func RandomOptions(
 	opts.MaxConcurrentCompactions = func() int {
 		return maxConcurrentCompactions
 	}
+	// [-0.2, 0.4], in steps of 0.2.
+	garbageFrac := float64(rng.IntN(5))/5.0 - 0.2
+	opts.Experimental.CompactionGarbageFractionForMaxConcurrency = func() float64 {
+		return garbageFrac
+	}
 	maxConcurrentDownloads := rng.IntN(3) + 1 // 1-3
 	opts.MaxConcurrentDownloads = func() int {
 		return maxConcurrentDownloads

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -73,6 +73,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"EventListener:",
 		"MaxConcurrentCompactions:",
 		"MaxConcurrentDownloads:",
+		"Experimental.CompactionGarbageFractionForMaxConcurrency:",
 		"Experimental.DisableIngestAsFlushable:",
 		"Experimental.EnableColumnarBlocks:",
 		"Experimental.EnableValueBlocks:",
@@ -116,6 +117,12 @@ func TestOptionsRoundtrip(t *testing.T) {
 		}
 		if o.Opts.Experimental.IngestSplit != nil && o.Opts.Experimental.IngestSplit() {
 			require.Equal(t, o.Opts.Experimental.IngestSplit(), parsed.Opts.Experimental.IngestSplit())
+		}
+		require.Equal(t, o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency == nil,
+			parsed.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency == nil)
+		if o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency != nil {
+			require.InDelta(t, o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency(),
+				parsed.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency(), 1e-5)
 		}
 		require.Equal(t, o.Opts.MaxConcurrentCompactions(), parsed.Opts.MaxConcurrentCompactions())
 		require.Equal(t, o.Opts.MaxConcurrentDownloads(), parsed.Opts.MaxConcurrentDownloads())

--- a/metrics.go
+++ b/metrics.go
@@ -319,6 +319,20 @@ type Metrics struct {
 			ZombieCount uint64
 		}
 
+		// Garbage bytes.
+		Garbage struct {
+			// PointDeletionsBytesEstimate is the estimated file bytes that will be
+			// saved by compacting all point deletions. This is dependent on table
+			// stats collection, so can be very incomplete until
+			// InitialStatsCollectionComplete becomes true.
+			PointDeletionsBytesEstimate uint64
+			// RangeDeletionsBytesEstimate is the estimated file bytes that will be
+			// saved by compacting all range deletions. This is dependent on table
+			// stats collection, so can be very incomplete until
+			// InitialStatsCollectionComplete becomes true.
+			RangeDeletionsBytesEstimate uint64
+		}
+
 		// Whether the initial stats collection (for existing tables on Open) is
 		// complete.
 		InitialStatsCollectionComplete bool
@@ -725,7 +739,11 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 		w.Printf(" unknown: %d", redact.Safe(count))
 	}
 	w.Printf("\n")
-
+	if m.Table.Garbage.PointDeletionsBytesEstimate > 0 || m.Table.Garbage.RangeDeletionsBytesEstimate > 0 {
+		w.Printf("Garbage bytes: point-deletions %s range-deletions %s\n",
+			humanize.Bytes.Uint64(m.Table.Garbage.PointDeletionsBytesEstimate),
+			humanize.Bytes.Uint64(m.Table.Garbage.RangeDeletionsBytesEstimate))
+	}
 	w.Printf("Table stats: ")
 	if !m.Table.InitialStatsCollectionComplete {
 		w.Printf("initial load in progress")

--- a/options.go
+++ b/options.go
@@ -571,6 +571,14 @@ type Options struct {
 		// concurrency slots as determined by the two options is chosen.
 		CompactionDebtConcurrency uint64
 
+		// CompactionGarbageFractionForMaxConcurrency is the fraction of garbage
+		// due to DELs and RANGEDELs that causes MaxConcurrentCompactions to be
+		// allowed. Concurrent compactions are allowed beyond those permitted due
+		// to L0 read-amplification and compaction debt, in a linear fashion upto
+		// this limit being reached. A value <= 0.0 disables adding concurrency
+		// due to garbage.
+		CompactionGarbageFractionForMaxConcurrency func() float64
+
 		// IngestSplit, if it returns true, allows for ingest-time splitting of
 		// existing sstables into two virtual sstables to allow ingestion sstables to
 		// slot into a lower level than they otherwise would have.
@@ -1208,6 +1216,11 @@ func (o *Options) EnsureDefaults() {
 	if o.Experimental.CompactionDebtConcurrency <= 0 {
 		o.Experimental.CompactionDebtConcurrency = 1 << 30 // 1 GB
 	}
+	if o.Experimental.CompactionGarbageFractionForMaxConcurrency == nil {
+		// When 40% of the DB is garbage, the compaction concurrency is at the
+		// maximum permitted.
+		o.Experimental.CompactionGarbageFractionForMaxConcurrency = func() float64 { return 0.4 }
+	}
 	if o.KeySchema == "" && len(o.KeySchemas) == 0 {
 		ks := colblk.DefaultKeySchema(o.Comparer, 16 /* bundleSize */)
 		o.KeySchema = ks.Name
@@ -1434,6 +1447,8 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  cache_size=%d\n", cacheSize)
 	fmt.Fprintf(&buf, "  cleaner=%s\n", o.Cleaner)
 	fmt.Fprintf(&buf, "  compaction_debt_concurrency=%d\n", o.Experimental.CompactionDebtConcurrency)
+	fmt.Fprintf(&buf, "  compaction_garbage_fraction_for_max_concurrency=%.2f\n",
+		o.Experimental.CompactionGarbageFractionForMaxConcurrency())
 	fmt.Fprintf(&buf, "  comparer=%s\n", o.Comparer.Name)
 	fmt.Fprintf(&buf, "  disable_wal=%t\n", o.DisableWAL)
 	if o.Experimental.DisableIngestAsFlushable != nil && o.Experimental.DisableIngestAsFlushable() {
@@ -1698,6 +1713,13 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				}
 			case "compaction_debt_concurrency":
 				o.Experimental.CompactionDebtConcurrency, err = strconv.ParseUint(value, 10, 64)
+			case "compaction_garbage_fraction_for_max_concurrency":
+				var frac float64
+				frac, err = strconv.ParseFloat(value, 64)
+				if err == nil {
+					o.Experimental.CompactionGarbageFractionForMaxConcurrency =
+						func() float64 { return frac }
+				}
 			case "delete_range_flush_delay":
 				// NB: This is a deprecated serialization of the
 				// `flush_delay_delete_range`.

--- a/options_test.go
+++ b/options_test.go
@@ -84,6 +84,7 @@ func TestDefaultOptionsString(t *testing.T) {
   cache_size=8388608
   cleaner=delete
   compaction_debt_concurrency=1073741824
+  compaction_garbage_fraction_for_max_concurrency=0.40
   comparer=leveldb.BytewiseComparator
   disable_wal=false
   enable_columnar_blocks=true

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -11,7 +11,7 @@ tree
      614      000007.sst
        0      LOCK
      133      MANIFEST-000001
-    1524      OPTIONS-000003
+    1579      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000001.MANIFEST-000001
             simple/
@@ -21,7 +21,7 @@ tree
       25        000004.log
      586        000005.sst
       85        MANIFEST-000001
-    1524        OPTIONS-000003
+    1579        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -36,6 +36,7 @@ cat build/OPTIONS-000003
   cache_size=8388608
   cleaner=replay.WorkloadCollector("delete")
   compaction_debt_concurrency=1073741824
+  compaction_garbage_fraction_for_max_concurrency=0.40
   comparer=pebble.internal.testkeys
   disable_wal=false
   enable_columnar_blocks=true

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -14,7 +14,7 @@ tree
        0      LOCK
      133      MANIFEST-000001
      205      MANIFEST-000010
-    1524      OPTIONS-000003
+    1579      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000002.MANIFEST-000010
             high_read_amp/
@@ -26,7 +26,7 @@ tree
       39        000008.log
      560        000009.sst
      157        MANIFEST-000010
-    1524        OPTIONS-000003
+    1579        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000010
 

--- a/testdata/compaction_picker_estimated_debt
+++ b/testdata/compaction_picker_estimated_debt
@@ -1,18 +1,18 @@
-init 1
+init l-base-max-bytes=1
 ----
 0
 
-init 1
+init l-base-max-bytes=1
 6: 1
 ----
 0
 
-init 1
+init l-base-max-bytes=1
 6: 2
 ----
 0
 
-init 1
+init l-base-max-bytes=1
 3: 1
 4: 1
 5: 1
@@ -20,7 +20,7 @@ init 1
 ----
 0
 
-init 1
+init l-base-max-bytes=1
 1: 1
 2: 1
 3: 1
@@ -30,7 +30,7 @@ init 1
 ----
 0
 
-init 1
+init l-base-max-bytes=1
 1: 1
 2: 10
 3: 100
@@ -40,26 +40,26 @@ init 1
 ----
 0
 
-init 1
+init l-base-max-bytes=1
 5: 10
 6: 10
 ----
 18
 
-init 1
+init l-base-max-bytes=1
 0: 10
 5: 10
 6: 10
 ----
 39
 
-init 1
+init l-base-max-bytes=1
 0: 10
 6: 100
 ----
 0
 
-init 1
+init l-base-max-bytes=1
 0: 10
 4: 1
 5: 10
@@ -67,30 +67,30 @@ init 1
 ----
 90
 
-init 1
+init l-base-max-bytes=1
 0: 10
 6: 1000
 ----
 0
 
-init 1
+init l-base-max-bytes=1
 5: 101
 6: 1000
 ----
 21
 
-init 1000
+init l-base-max-bytes=1000
 6: 10000
 ----
 0
 
-init 1000
+init l-base-max-bytes=1000
 5: 1
 6: 10000
 ----
 0
 
-init 1000
+init l-base-max-bytes=1000
 5: 2000
 6: 10000
 ----
@@ -99,7 +99,7 @@ init 1000
 # Regression test case which was previously computing an overly large
 # estimated debt due to faulty handling of L0.
 
-init 64
+init l-base-max-bytes=64
 0: 236
 4: 113
 5: 480

--- a/testdata/compaction_picker_level_max_bytes
+++ b/testdata/compaction_picker_level_max_bytes
@@ -1,25 +1,25 @@
-init 1
+init l-base-max-bytes=1
 ----
 6: 9223372036854775807
 
-init 1
+init l-base-max-bytes=1
 6: 1
 ----
 6: 1
 
-init 1
+init l-base-max-bytes=1
 6: 2
 ----
 5: 1
 6: 2
 
-init 1
+init l-base-max-bytes=1
 6: 2
 ----
 5: 1
 6: 2
 
-init 1
+init l-base-max-bytes=1
 3: 1
 4: 1
 5: 1
@@ -30,7 +30,7 @@ init 1
 5: 3
 6: 4
 
-init 1
+init l-base-max-bytes=1
 1: 1
 2: 1
 3: 1
@@ -45,7 +45,7 @@ init 1
 5: 4
 6: 6
 
-init 1
+init l-base-max-bytes=1
 1: 1
 2: 10
 3: 100
@@ -60,20 +60,20 @@ init 1
 5: 10000
 6: 100000
 
-init 1
+init l-base-max-bytes=1
 6: 10
 ----
 5: 1
 6: 9
 
-init 1
+init l-base-max-bytes=1
 6: 100
 ----
 4: 1
 5: 9
 6: 90
 
-init 1
+init l-base-max-bytes=1
 6: 1000
 ----
 3: 1
@@ -81,7 +81,7 @@ init 1
 5: 93
 6: 900
 
-init 1
+init l-base-max-bytes=1
 6: 10000
 ----
 2: 1
@@ -90,7 +90,7 @@ init 1
 5: 924
 6: 9000
 
-init 1
+init l-base-max-bytes=1
 6: 100000
 ----
 1: 1
@@ -110,7 +110,7 @@ init 1
 # size(L5) = size(L4) * 1000000^(1/5) ~= 63096
 # size(L6) = size(L5) * 1000000^(1/5) ~= 1000000
 
-init 1
+init l-base-max-bytes=1
 6: 1000000
 ----
 1: 1
@@ -130,7 +130,7 @@ init 1
 # size(L5) = size(L4) * 1000000^(1/5) ~= 4038127
 # size(L6) = size(L5) * 1000000^(1/5) ~= 64000000
 
-init 64
+init l-base-max-bytes=64
 6: 64000000
 ----
 1: 64
@@ -140,7 +140,7 @@ init 64
 5: 3711710
 6: 57600000
 
-init 1
+init l-base-max-bytes=1
 0: 4
 6: 10
 ----

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -92,7 +92,7 @@ wait-pending-table-stats
 num-entries: 5
 num-deletions: 5
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 164798
+point-deletions-bytes-estimate: 163850
 range-deletions-bytes-estimate: 0
 
 scores
@@ -145,7 +145,7 @@ wait-pending-table-stats
 num-entries: 5
 num-deletions: 5
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 164806
+point-deletions-bytes-estimate: 163860
 range-deletions-bytes-estimate: 0
 
 maybe-compact

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -1,4 +1,4 @@
-init 1
+init l-base-max-bytes=1
 ----
 
 init_cp
@@ -8,7 +8,7 @@ base: 6
 queue
 ----
 
-init 1
+init l-base-max-bytes=1
 6: 1
 ----
 L6:
@@ -21,7 +21,7 @@ base: 6
 queue
 ----
 
-init 1
+init l-base-max-bytes=1
 6: 1000000
 ----
 L6:
@@ -34,7 +34,7 @@ base: 1
 queue
 ----
 
-init 1
+init l-base-max-bytes=1
 5: 1
 6: 10
 ----
@@ -62,7 +62,7 @@ L5->L6: 1.0
   500001:[0001#1,SET-0001#1,SET] marked as compacting
   600001:[0001#1,SET-0001#1,SET] marked as compacting
 
-init 1
+init l-base-max-bytes=1
 5: 2
 6: 10
 ----
@@ -98,7 +98,7 @@ L5->L6: 2.2
 # size(L5) = size(L4) * 30^(1/2) ~= 5
 # size(L6) = size(L5) * 30^(1/2) = 30
 
-init 1
+init l-base-max-bytes=1
 5: 2
 6: 30
 ----
@@ -144,7 +144,7 @@ base: 4
 queue
 ----
 
-init 1
+init l-base-max-bytes=1
 4: 2
 5: 2
 6: 100
@@ -168,7 +168,7 @@ L4->L5: 10.0
   400001:[0001#1,SET-0001#1,SET] marked as compacting
   500001:[0001#1,SET-0001#1,SET] marked as compacting
 
-init 1
+init l-base-max-bytes=1
 4: 1
 5: 2
 6: 100
@@ -191,7 +191,7 @@ L4->L5: 5.0
   400001:[0001#1,SET-0001#1,SET] marked as compacting
   500001:[0001#1,SET-0001#1,SET] marked as compacting
 
-init 1
+init l-base-max-bytes=1
 4: 1
 5: 11
 6: 100
@@ -233,7 +233,7 @@ L5->L6: 1.1
   500011:[0011#11,SET-0011#11,SET] marked as compacting
   600001:[0001#1,SET-0100#1,SET] marked as compacting
 
-init 1
+init l-base-max-bytes=1
 4: 1
 5: 11 50
 6: 100
@@ -275,7 +275,7 @@ L5->L6: 6.2
   500011:[0011#11,SET-0011#11,SET] marked as compacting
   600001:[0001#1,SET-0100#1,SET] marked as compacting
 
-init 1
+init l-base-max-bytes=1
 4: 2
 5: 11
 6: 100
@@ -308,7 +308,7 @@ L4->L5: 1.8
   400001:[0001#1,SET-0001#1,SET] marked as compacting
   500001:[0001#1,SET-0001#1,SET] marked as compacting
 
-init 1
+init l-base-max-bytes=1
 0: 4
 ----
 L0:
@@ -329,7 +329,7 @@ L0->L6: 200.0
   000003:[0001#3,SET-0001#3,SET] marked as compacting
   000004:[0001#4,SET-0001#4,SET] marked as compacting
 
-init 1
+init l-base-max-bytes=1
 0: 5
 ----
 L0:
@@ -352,7 +352,7 @@ L0->L6: 250.0
   000004:[0001#4,SET-0001#4,SET] marked as compacting
   000005:[0001#5,SET-0001#5,SET] marked as compacting
 
-init 1
+init l-base-max-bytes=1
 0: 5
 5: 2
 6: 10
@@ -438,7 +438,7 @@ L6:
   600010:[0010#10,SET-0010#10,SET]: 1 bytes (1B)
 Picked: no compaction
 
-init 1
+init l-base-max-bytes=1
 0: 10
 4: 10
 5: 6
@@ -682,7 +682,7 @@ L6:
   600010:[0010#10,SET-0010#10,SET]: 1 bytes (1B)
 Picked: no compaction
 
-init 1
+init l-base-max-bytes=1
 0: 20
 6: 10
 ----
@@ -824,7 +824,7 @@ Picked: L0->L0: 950.0
 # We'll only pick a concurrent compaction if it is "high" priority
 # (i.e. has a score >= highPriorityThreshold).
 
-init 1
+init l-base-max-bytes=1
 0: 20
 5: 1
 6: 10
@@ -973,7 +973,7 @@ Picked: L0->L4: 1000.0
 # Verify we can start concurrent Ln->Ln+1 compactions given sufficient
 # priority.
 
-init 1
+init l-base-max-bytes=1
 5: 4
 6: 10
 ----
@@ -1048,7 +1048,7 @@ Picked: no compaction
 
 # Verify that L0 score doesn't change with respect to L5's compensation.
 
-init 5
+init l-base-max-bytes=5
 0: 10
 5: 5 1
 6: 5
@@ -1099,7 +1099,7 @@ L5->L6: 11.5
   500005:[0005#5,SET-0005#5,SET] marked as compacting
   600005:[0005#5,SET-0005#5,SET] marked as compacting
 
-init 5
+init l-base-max-bytes=5
 0: 10
 5: 5 0
 6: 5
@@ -1153,7 +1153,7 @@ L5->L6: 10.8
 # Verify that successive manual compactions interleaved with an automatic
 # compaction does not trigger an error.
 
-init 5
+init l-base-max-bytes=5
 0: 10
 5: 10
 6: 5
@@ -1240,7 +1240,7 @@ Picked: L5->L6: 9.2
 # still going to try running a manual compaction from L5 -> L6 since L5 was the
 # output of the last manual compaction. No compaction should be picked.
 
-init 5
+init l-base-max-bytes=5
 0: 7
 6: 5
 ----
@@ -1272,7 +1272,7 @@ nil, retryLater = false
 # Prior to prioritizing levels by the score instead of rawSmoothed score, L5
 # would be picked for compaction over L0, because of its absurdly high compensated
 # score.
-init 5
+init l-base-max-bytes=5 max-concurrent-compactions=1
 0: 7
 5: 4 10000
 6: 5
@@ -1312,3 +1312,56 @@ L0->L5: 4.4
   000006:[0001#6,SET-0001#6,SET] marked as compacting
   000007:[0001#7,SET-0001#7,SET] marked as compacting
   500001:[0001#1,SET-0001#1,SET] marked as compacting
+
+# Repeat the previous test case, but allow up to 6 concurrent compactions. In
+# addition to the L0 => L5 compaction, three L5 => L6 compactions are picked,
+# due to the massive amount of garbage in the LSM.
+init l-base-max-bytes=5 max-concurrent-compactions=6
+0: 7
+5: 4 10000
+6: 5
+----
+L0:
+  000001:[0001#1,SET-0001#1,SET]: 1 bytes (1B)
+  000002:[0001#2,SET-0001#2,SET]: 1 bytes (1B)
+  000003:[0001#3,SET-0001#3,SET]: 1 bytes (1B)
+  000004:[0001#4,SET-0001#4,SET]: 1 bytes (1B)
+  000005:[0001#5,SET-0001#5,SET]: 1 bytes (1B)
+  000006:[0001#6,SET-0001#6,SET]: 1 bytes (1B)
+  000007:[0001#7,SET-0001#7,SET]: 1 bytes (1B)
+L5:
+  500001:[0001#1,SET-0001#1,SET]: 1 bytes (1B)
+  500002:[0002#2,SET-0002#2,SET]: 1 bytes (1B)
+  500003:[0003#3,SET-0003#3,SET]: 1 bytes (1B)
+  500004:[0004#4,SET-0004#4,SET]: 1 bytes (1B)
+L6:
+  600001:[0001#1,SET-0001#1,SET]: 1 bytes (1B)
+  600002:[0002#2,SET-0002#2,SET]: 1 bytes (1B)
+  600003:[0003#3,SET-0003#3,SET]: 1 bytes (1B)
+  600004:[0004#4,SET-0004#4,SET]: 1 bytes (1B)
+  600005:[0005#5,SET-0005#5,SET]: 1 bytes (1B)
+
+init_cp
+----
+base: 5
+
+queue
+----
+L0->L5: 4.4
+  000001:[0001#1,SET-0001#1,SET] marked as compacting
+  000002:[0001#2,SET-0001#2,SET] marked as compacting
+  000003:[0001#3,SET-0001#3,SET] marked as compacting
+  000004:[0001#4,SET-0001#4,SET] marked as compacting
+  000005:[0001#5,SET-0001#5,SET] marked as compacting
+  000006:[0001#6,SET-0001#6,SET] marked as compacting
+  000007:[0001#7,SET-0001#7,SET] marked as compacting
+  500001:[0001#1,SET-0001#1,SET] marked as compacting
+L5->L6: 6006.6
+  500004:[0004#4,SET-0004#4,SET] marked as compacting
+  600004:[0004#4,SET-0004#4,SET] marked as compacting
+L5->L6: 5.0
+  500002:[0002#2,SET-0002#2,SET] marked as compacting
+  600002:[0002#2,SET-0002#2,SET] marked as compacting
+L5->L6: 3.9
+  500003:[0003#3,SET-0003#3,SET] marked as compacting
+  600003:[0003#3,SET-0003#3,SET] marked as compacting

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -80,7 +80,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 100
+point-deletions-bytes-estimate: 2
 range-deletions-bytes-estimate: 0
 
 maybe-compact
@@ -119,7 +119,7 @@ wait-pending-table-stats
 num-entries: 6
 num-deletions: 2
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 47
+point-deletions-bytes-estimate: 2
 range-deletions-bytes-estimate: 101
 
 maybe-compact
@@ -152,7 +152,7 @@ wait-pending-table-stats
 num-entries: 11
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 23
+point-deletions-bytes-estimate: 2
 range-deletions-bytes-estimate: 0
 
 close-snapshot
@@ -233,7 +233,7 @@ wait-pending-table-stats
 num-entries: 3
 num-deletions: 3
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 6988
+point-deletions-bytes-estimate: 6150
 range-deletions-bytes-estimate: 0
 
 # By plain file size, 000005 should be picked because it is larger and
@@ -243,7 +243,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (771B) Score=13.77 + L6 [000006] (13KB) Score=0.92 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(default) L5 [000004] (771B) Score=12.86 + L6 [000006] (13KB) Score=0.92 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -359,7 +359,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 2795
+point-deletions-bytes-estimate: 2459
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -376,7 +376,7 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (763B) Score=24.34 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(default) L5 [000004] (763B) Score=23.70 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -405,7 +405,7 @@ wait-pending-table-stats
 num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 2795
+point-deletions-bytes-estimate: 2459
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -422,4 +422,4 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (763B) Score=24.34 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(default) L5 [000004] (763B) Score=23.70 + L6 [000006] (13KB) Score=0.52 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -1141,3 +1141,86 @@ Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:342 BlockBytesInCache:0 BlockReadDuration:30ms}
+
+init
+----
+
+batch
+set a 1
+set b 2
+----
+
+flush
+----
+L0.0:
+  000005:[a#10,SET-a#10,SET]
+  000006:[b#11,SET-b#11,SET]
+
+batch
+del-sized c 500
+----
+
+flush
+----
+L0.0:
+  000005:[a#10,SET-a#10,SET]
+  000006:[b#11,SET-b#11,SET]
+  000008:[c#12,DELSIZED-c#12,DELSIZED]
+
+compact a-z parallel
+----
+L6:
+  000005:[a#10,SET-a#10,SET]
+  000006:[b#11,SET-b#11,SET]
+  000008:[c#12,DELSIZED-c#12,DELSIZED]
+
+batch
+del-range a c
+----
+
+flush
+----
+L0.0:
+  000010:[a#13,RANGEDEL-b#inf,RANGEDEL]
+  000011:[b#13,RANGEDEL-c#inf,RANGEDEL]
+L6:
+  000005:[a#10,SET-a#10,SET]
+  000006:[b#11,SET-b#11,SET]
+  000008:[c#12,DELSIZED-c#12,DELSIZED]
+
+metrics
+----
+      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
+level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w
+------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
+    0 |     2  1.5KB     0B       0 |    - 0.25 0.25 |  106B |     0     0B |     0     0B |     5  3.7KB |    0B |   1 35.7
+    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 |    0B |     0     0B |     3  2.2KB |     0     0B |    0B |   1    0
+total |     5  3.7KB     0B       0 |    -    -    - |  106B |     0     0B |     3  2.2KB |     5  3.8KB |    0B |   2 36.7
+----------------------------------------------------------------------------------------------------------------------------
+WAL: 1 files (0B)  in: 57B  written: 106B (86% overhead)
+Flushes: 3
+Compactions: 3  estimated debt: 3.7KB  in progress: 0 (0B)
+             default: 0  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
+MemTables: 1 (256KB)  zombie: 1 (256KB)
+Zombie tables: 0 (0B, local: 0B)
+Backing tables: 0 (0B)
+Virtual tables: 0 (0B)
+Local tables size: 3.7KB
+Compression types: snappy: 5
+Garbage bytes: point-deletions 502B range-deletions 1.5KB
+Table stats: all loaded
+Block cache: 2 entries (774B)  hit rate: 0.0%
+Table cache: 2 entries (1.6KB)  hit rate: 0.0%
+Range key sets: 0  Tombstones: 3  Total missized tombstones encountered: 0
+Snapshots: 0  earliest seq num: 0
+Table iters: 0
+Filter utility: 0.0%
+Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
+Iter category stats:
+   pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -92,7 +92,7 @@ Iter category stats:
 
 disk-usage
 ----
-2.3KB
+2.4KB
 
 batch
 set b 2
@@ -299,7 +299,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.2KB
+3.3KB
 
 additional-metrics
 ----

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -15,7 +15,7 @@ wait-pending-table-stats
 num-entries: 3
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 57
+point-deletions-bytes-estimate: 2
 range-deletions-bytes-estimate: 0
 
 compact a-c
@@ -546,7 +546,7 @@ wait-pending-table-stats
 num-entries: 5
 num-deletions: 2
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 112572
+point-deletions-bytes-estimate: 111127
 range-deletions-bytes-estimate: 0
 
 # Try a missized point tombstone. It should appear in the Metrics after the
@@ -676,7 +676,7 @@ wait-pending-table-stats
 num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 39
+point-deletions-bytes-estimate: 3
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -685,7 +685,7 @@ wait-pending-table-stats
 num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 39
+point-deletions-bytes-estimate: 3
 range-deletions-bytes-estimate: 0
 
 # Create an sstable with a range key set.


### PR DESCRIPTION
This increases the compaction concurrency up to the maximum concurrency
based on the fraction of garbage. The default is 0.4, i.e., if 40% of
the DB is garbage, it will allow up to MaxConcurrentCompactions.

The assumption is that compensated level sizes used in scoring have
captured this garbage state, so the levels responsible for garbage
have scores > 1.0, so will eventually get picked for compactions.

Informs https://github.com/cockroachdb/pebble/issues/4602
