### PR TITLE
db: surface missized DELSIZED tombstones via PossibleAPIMisuse

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3157,9 +3157,9 @@ func (d *DB) compactAndWrite(
 				UserKey: slices.Clone(userKey),
 			})
 		},
-		MissizedDELSIZEDCallback: func(userKey []byte) {
+		MissizedDeleteCallback: func(userKey []byte) {
 			d.opts.EventListener.PossibleAPIMisuse(PossibleAPIMisuseInfo{
-				Kind:    MissizedDELSIZED,
+				Kind:    MissizedDelete,
 				UserKey: slices.Clone(userKey),
 			})
 		},

--- a/compaction.go
+++ b/compaction.go
@@ -3157,10 +3157,11 @@ func (d *DB) compactAndWrite(
 				UserKey: slices.Clone(userKey),
 			})
 		},
-		MissizedDeleteCallback: func(userKey []byte) {
+		MissizedDeleteCallback: func(userKey []byte, elidedSize, expectedSize uint64) {
 			d.opts.EventListener.PossibleAPIMisuse(PossibleAPIMisuseInfo{
-				Kind:    MissizedDelete,
-				UserKey: slices.Clone(userKey),
+				Kind:      MissizedDelete,
+				UserKey:   slices.Clone(userKey),
+				ExtraInfo: fmt.Sprintf("elidedSize=%d,expectedSize=%d", elidedSize, expectedSize),
 			})
 		},
 	}

--- a/compaction.go
+++ b/compaction.go
@@ -3157,6 +3157,12 @@ func (d *DB) compactAndWrite(
 				UserKey: slices.Clone(userKey),
 			})
 		},
+		MissizedDELSIZEDCallback: func(userKey []byte) {
+			d.opts.EventListener.PossibleAPIMisuse(PossibleAPIMisuseInfo{
+				Kind:    MissizedDELSIZED,
+				UserKey: slices.Clone(userKey),
+			})
+		},
 	}
 	iter := compact.NewIter(cfg, pointIter, rangeDelIter, rangeKeyIter)
 

--- a/event.go
+++ b/event.go
@@ -645,8 +645,8 @@ type PossibleAPIMisuseInfo struct {
 
 	// UserKey is set for the following kinds:
 	//  - IneffectualSingleDelete,
-	//  - NondeterministicSingleDelete.
-	//  - MissizedDELSIZED
+	//  - NondeterministicSingleDelete,
+	//  - MissizedDelete.
 	UserKey []byte
 }
 
@@ -657,7 +657,7 @@ func (i PossibleAPIMisuseInfo) String() string {
 // SafeFormat implements redact.SafeFormatter.
 func (i PossibleAPIMisuseInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	switch i.Kind {
-	case IneffectualSingleDelete, NondeterministicSingleDelete, MissizedDELSIZED:
+	case IneffectualSingleDelete, NondeterministicSingleDelete, MissizedDelete:
 		w.Printf("possible API misuse: %s (key=%q)", redact.Safe(i.Kind), i.UserKey)
 	default:
 		if invariants.Enabled {
@@ -749,10 +749,10 @@ const (
 	// happens, resulting in the invariant violation callback.
 	NondeterministicSingleDelete
 
-	// MissizedDELSIZED is emitted when a DELSIZED tombstone is found that did
+	// MissizedDelete is emitted when a DELSIZED tombstone is found that did
 	// not accurately record the size of the value it deleted. This can lead to
 	// incorrect behavior in compactions.
-	MissizedDELSIZED
+	MissizedDelete
 )
 
 func (k APIMisuseKind) String() string {
@@ -761,7 +761,7 @@ func (k APIMisuseKind) String() string {
 		return "ineffectual SINGLEDEL"
 	case NondeterministicSingleDelete:
 		return "nondeterministic SINGLEDEL"
-	case MissizedDELSIZED:
+	case MissizedDelete:
 		return "missized DELSIZED"
 	default:
 		return "unknown"

--- a/event.go
+++ b/event.go
@@ -648,6 +648,10 @@ type PossibleAPIMisuseInfo struct {
 	//  - NondeterministicSingleDelete,
 	//  - MissizedDelete.
 	UserKey []byte
+
+	// ExtraInfo is set for the following kinds:
+	//  - MissizedDelete: contains "elidedSize=<size>,expectedSize=<size>"
+	ExtraInfo string
 }
 
 func (i PossibleAPIMisuseInfo) String() string {
@@ -657,8 +661,10 @@ func (i PossibleAPIMisuseInfo) String() string {
 // SafeFormat implements redact.SafeFormatter.
 func (i PossibleAPIMisuseInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	switch i.Kind {
-	case IneffectualSingleDelete, NondeterministicSingleDelete, MissizedDelete:
+	case IneffectualSingleDelete, NondeterministicSingleDelete:
 		w.Printf("possible API misuse: %s (key=%q)", redact.Safe(i.Kind), i.UserKey)
+	case MissizedDelete:
+		w.Printf("possible API misuse: %s (key=%q, %s)", redact.Safe(i.Kind), i.UserKey, redact.Safe(i.ExtraInfo))
 	default:
 		if invariants.Enabled {
 			panic("invalid API misuse event")

--- a/internal/compact/iterator.go
+++ b/internal/compact/iterator.go
@@ -286,10 +286,10 @@ type IterConfig struct {
 	// delete-only compactions).
 	NondeterministicSingleDeleteCallback func(userKey []byte)
 
-	// MissizedDELSIZEDCallback is called in compactions/flushes when a DELSIZED
+	// MissizedDeleteCallback is called in compactions/flushes when a DELSIZED
 	// tombstone is found that did not accurately record the size of the value it
 	// deleted. This can lead to incorrect behavior in compactions.
-	MissizedDELSIZEDCallback func(userKey []byte)
+	MissizedDeleteCallback func(userKey []byte)
 }
 
 func (c *IterConfig) ensureDefaults() {
@@ -299,8 +299,8 @@ func (c *IterConfig) ensureDefaults() {
 	if c.NondeterministicSingleDeleteCallback == nil {
 		c.NondeterministicSingleDeleteCallback = func(userKey []byte) {}
 	}
-	if c.MissizedDELSIZEDCallback == nil {
-		c.MissizedDELSIZEDCallback = func(userKey []byte) {}
+	if c.MissizedDeleteCallback == nil {
+		c.MissizedDeleteCallback = func(userKey []byte) {}
 	}
 }
 
@@ -1175,7 +1175,7 @@ func (i *Iter) deleteSizedNext() *base.InternalKV {
 				// The original DELSIZED key was missized. The key that the user
 				// thought they were deleting does not exist.
 				i.stats.CountMissizedDels++
-				i.cfg.MissizedDELSIZEDCallback(i.kv.K.UserKey)
+				i.cfg.MissizedDeleteCallback(i.kv.K.UserKey)
 			}
 			// If the tombstone has a value, it must be in-place. To save it, we
 			// can just copy the in-place value directly.
@@ -1250,7 +1250,7 @@ func (i *Iter) deleteSizedNext() *base.InternalKV {
 				// user-provided size for accuracy, so ordinary DEL heuristics
 				// are safer.
 				i.stats.CountMissizedDels++
-				i.cfg.MissizedDELSIZEDCallback(i.kv.K.UserKey)
+				i.cfg.MissizedDeleteCallback(i.kv.K.UserKey)
 				i.kv.K.SetKind(base.InternalKeyKindDelete)
 				i.kv.V = base.InternalValue{}
 				// NB: We skipInStripe now, rather than returning leaving

--- a/internal/compact/testdata/iter_delete_sized
+++ b/internal/compact/testdata/iter_delete_sized
@@ -1824,3 +1824,56 @@ a#2,SET:a2
 b#4,SETWITHDEL:b4
 .
 invariant-violation-single-deletes: a,b
+
+# Add a test specifically for MissizedDeleteCallback
+# This test creates a scenario where a DELSIZED tombstone's expected size
+# doesn't match the actual size of the deleted entry.
+
+define
+a.DELSIZED.8:varint(25)
+a.SET.5:hello
+----
+
+iter print-missized-dels print-missized-del-info
+first
+next
+----
+a#8,DEL:
+.
+missized-dels=1
+missized-delete-info: a (elided=6, expected=25)
+
+# Test a DELSIZED that never deletes a key (key doesn't exist)
+define
+a.DELSIZED.8:varint(10)
+b.SET.5:hello
+----
+
+iter print-missized-dels print-missized-del-info
+first
+next
+----
+a#8,DELSIZED:varint(10)
+b#5,SET:hello
+missized-dels=0
+
+# Test multiple missized DELSIZEDs in the same run
+define
+a.DELSIZED.9:varint(20)
+a.SET.8:foo
+b.DELSIZED.7:varint(15)
+b.SET.5:bar
+c.DELSIZED.6:varint(4)
+c.SET.3:xyz
+----
+
+iter print-missized-dels print-missized-del-info
+first
+next
+next
+----
+a#9,DEL:
+b#7,DEL:
+c#6,DELSIZED:
+missized-dels=2
+missized-delete-info: a (elided=4, expected=20); b (elided=4, expected=15)


### PR DESCRIPTION
Introduces a new `APIMisuseKind` event type `MissizedDelete` and corresponding `MissizedDeleteCallback` method to address #4234.