### PR TITLE
metamorphic: perform CheckLevels asynchronously

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -578,8 +578,8 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	// when we use --try-to-reduce.
 	for i, db := range m.dbs {
 		if db != nil {
-			fmt.Fprintf(os.Stderr, "\ndb%d:\n%s", i+1, db.DebugString())
-			fmt.Fprintf(os.Stderr, "\n%s\n", db.LSMViewURL())
+			fmt.Fprintf(os.Stderr, "\ndb%d:\n%s", i+1, db.DB.DebugString())
+			fmt.Fprintf(os.Stderr, "\n%s\n", db.DB.LSMViewURL())
 		}
 	}
 	// Don't let the test pass if it issued a Fatalf.


### PR DESCRIPTION
During the metamorphic tests that call CheckLevels, perform the level check asynchronously. The Options.DebugCheck func is invoked while holding the database mutex DB.mu. When the check is performed synchronously, it prevents the scheduling of additional flushes, compactions, etc. This contributed to slow Compact, Download, etc operations in the metamorphic tests which would run the level checker synchronously many times over the course of their compactions.

Informs #4517.
Informs #4338.