### PR TITLE
crl-release-25.2: db: change MaxConcurrentCompactions() to return a range

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -72,8 +72,8 @@ func newPebbleDB(dir string) DB {
 		Merger: &pebble.Merger{
 			Name: "cockroach_merge_operator",
 		},
-		MaxConcurrentCompactions: func() int {
-			return 3
+		CompactionConcurrencyRange: func() (int, int) {
+			return 1, 3
 		},
 	}
 	// In FormatColumnarBlocks (the value of FormatNewest at the time of

--- a/cmd/pebble/replay_test.go
+++ b/cmd/pebble/replay_test.go
@@ -21,7 +21,15 @@ func TestParseOptionsStr(t *testing.T) {
 	testCases := []testCase{
 		{
 			c:       replayConfig{optionsString: `[Options] max_concurrent_compactions=9`},
-			options: &pebble.Options{MaxConcurrentCompactions: func() int { return 9 }},
+			options: &pebble.Options{CompactionConcurrencyRange: func() (int, int) { return 1, 9 }},
+		},
+		{
+			c:       replayConfig{optionsString: `[Options] concurrent_compactions=4`},
+			options: &pebble.Options{CompactionConcurrencyRange: func() (int, int) { return 4, 4 }},
+		},
+		{
+			c:       replayConfig{optionsString: `[Options] concurrent_compactions=4 max_concurrent_compactions=9`},
+			options: &pebble.Options{CompactionConcurrencyRange: func() (int, int) { return 4, 9 }},
 		},
 		{
 			c:       replayConfig{optionsString: `[Options] bytes_per_sync=90000`},

--- a/compaction.go
+++ b/compaction.go
@@ -57,8 +57,9 @@ func expandedCompactionByteSizeLimit(opts *Options, level int, availBytes uint64
 	// than this threshold before expansion.
 	//
 	// NB: this heuristic is an approximation since we may run more compactions
-	// than MaxConcurrentCompactions.
-	diskMax := (availBytes / 2) / uint64(opts.MaxConcurrentCompactions())
+	// than the upper concurrency limit.
+	_, maxConcurrency := opts.CompactionConcurrencyRange()
+	diskMax := (availBytes / 2) / uint64(maxConcurrency)
 	if v > diskMax {
 		v = diskMax
 	}
@@ -1910,7 +1911,7 @@ func (d *DB) GetAllowedWithoutPermission() int {
 	allowedBasedOnManual := 0
 	manualBacklog := int(d.mu.compact.manualLen.Load())
 	if manualBacklog > 0 {
-		maxAllowed := d.opts.MaxConcurrentCompactions()
+		_, maxAllowed := d.opts.CompactionConcurrencyRange()
 		allowedBasedOnManual = min(maxAllowed, manualBacklog+allowedBasedOnBacklog)
 	}
 	return max(allowedBasedOnBacklog, allowedBasedOnManual)
@@ -1974,8 +1975,10 @@ func (d *DB) pickManualCompaction(env compactionEnv) (pc *pickedCompaction) {
 // Returns true iff a compaction was started.
 func (d *DB) tryScheduleDeleteOnlyCompaction() bool {
 	if d.opts.private.disableDeleteOnlyCompactions || d.opts.DisableAutomaticCompactions ||
-		d.mu.compact.compactingCount >= d.opts.MaxConcurrentCompactions() ||
 		len(d.mu.compact.deletionHints) == 0 {
+		return false
+	}
+	if _, maxConcurrency := d.opts.CompactionConcurrencyRange(); d.mu.compact.compactingCount >= maxConcurrency {
 		return false
 	}
 	v := d.mu.versions.currentVersion()

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1220,7 +1220,10 @@ func responsibleForGarbageBytes(
 }
 
 func (p *compactionPickerByScore) getCompactionConcurrency() int {
-	maxConcurrentCompactions := p.opts.MaxConcurrentCompactions()
+	lower, upper := p.opts.CompactionConcurrencyRange()
+	if lower >= upper {
+		return upper
+	}
 	// Compaction concurrency is controlled by L0 read-amp. We allow one
 	// additional compaction per L0CompactionConcurrency sublevels, as well as
 	// one additional compaction per CompactionDebtConcurrency bytes of
@@ -1237,24 +1240,28 @@ func (p *compactionPickerByScore) getCompactionConcurrency() int {
 	// Rearranging,
 	// n <= l0ReadAmp / p.opts.Experimental.L0CompactionConcurrency.
 	// So we can run up to
-	// l0ReadAmp / p.opts.Experimental.L0CompactionConcurrency + 1 compactions
-	l0ReadAmpCompactions := 1
+	// l0ReadAmp / p.opts.Experimental.L0CompactionConcurrency extra compactions.
+	l0ReadAmpCompactions := 0
 	if p.opts.Experimental.L0CompactionConcurrency > 0 {
 		l0ReadAmp := p.l0Organizer.MaxDepthAfterOngoingCompactions()
-		l0ReadAmpCompactions = (l0ReadAmp / p.opts.Experimental.L0CompactionConcurrency) + 1
+		l0ReadAmpCompactions = (l0ReadAmp / p.opts.Experimental.L0CompactionConcurrency)
 	}
 	// compactionDebt >= ccSignal2 then can run another compaction, where
 	// ccSignal2 = uint64(n) * p.opts.Experimental.CompactionDebtConcurrency
 	// Rearranging,
 	// n <= compactionDebt / p.opts.Experimental.CompactionDebtConcurrency
 	// So we can run up to
-	// compactionDebt / p.opts.Experimental.CompactionDebtConcurrency + 1 compactions.
-	compactionDebtCompactions := 1
+	// compactionDebt / p.opts.Experimental.CompactionDebtConcurrency extra
+	// compactions.
+	compactionDebtCompactions := 0
 	if p.opts.Experimental.CompactionDebtConcurrency > 0 {
 		compactionDebt := p.estimatedCompactionDebt(0)
-		compactionDebtCompactions = int(compactionDebt/p.opts.Experimental.CompactionDebtConcurrency) + 1
+		compactionDebtCompactions = int(compactionDebt / p.opts.Experimental.CompactionDebtConcurrency)
 	}
-	return max(min(maxConcurrentCompactions, max(l0ReadAmpCompactions, compactionDebtCompactions)), 1)
+
+	extraCompactions := max(l0ReadAmpCompactions, compactionDebtCompactions, 0)
+
+	return min(lower+extraCompactions, upper)
 }
 
 // pickAuto picks the best compaction, if any.

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -216,13 +216,13 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 				// <level>: <size> [compensation]
 				var errMsg string
 				vers, l0Organizer, opts, errMsg = loadVersion(t, d)
-				opts.MaxConcurrentCompactions = func() int {
+				opts.CompactionConcurrencyRange = func() (int, int) {
 					// This test only limits the count based on the L0 read amp and
 					// compaction debt, so we would like to return math.MaxInt. But we
 					// don't since it is also used in expandedCompactionByteSizeLimit,
 					// and causes the expanded bytes to reduce. The test cases never
 					// pick more than 4 compactions, so we use 4.
-					return 4
+					return 1, 4
 				}
 				if errMsg != "" {
 					return errMsg
@@ -627,7 +627,8 @@ func TestCompactionPickerL0(t *testing.T) {
 func TestCompactionPickerConcurrency(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Experimental.L0CompactionConcurrency = 1
-	opts.MaxConcurrentCompactions = func() int { return 4 }
+	lowerConcurrencyLimit, upperConcurrencyLimit := 1, 4
+	opts.CompactionConcurrencyRange = func() (int, int) { return lowerConcurrencyLimit, upperConcurrencyLimit }
 
 	parseMeta := func(s string) (*tableMetadata, error) {
 		parts := strings.Split(s, ":")
@@ -795,6 +796,7 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 			td.MaybeScanArgs(t, "l0_compaction_threshold", &opts.L0CompactionThreshold)
 			td.MaybeScanArgs(t, "l0_compaction_concurrency", &opts.Experimental.L0CompactionConcurrency)
 			td.MaybeScanArgs(t, "compaction_debt_concurrency", &opts.Experimental.CompactionDebtConcurrency)
+			td.MaybeScanArgs(t, "concurrency", &lowerConcurrencyLimit, &upperConcurrencyLimit)
 
 			env := compactionEnv{
 				earliestUnflushedSeqNum: math.MaxUint64,
@@ -822,8 +824,10 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 				fmt.Fprintf(&result, "nil")
 			}
 			return result.String()
+
+		default:
+			return fmt.Sprintf("unrecognized command: %s", td.Cmd)
 		}
-		return fmt.Sprintf("unrecognized command: %s", td.Cmd)
 	})
 }
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1157,10 +1157,12 @@ func TestManualCompaction(t *testing.T) {
 				return ""
 
 			case "set-concurrent-compactions":
-				var concurrentCompactions int
-				td.ScanArgs(t, "num", &concurrentCompactions)
-				d.opts.MaxConcurrentCompactions = func() int {
-					return concurrentCompactions
+				lower := 1
+				upper := 1
+				td.MaybeScanArgs(t, "max", &upper)
+				td.MaybeScanArgs(t, "range", &lower, upper)
+				d.opts.CompactionConcurrencyRange = func() (int, int) {
+					return lower, upper
 				}
 				return ""
 

--- a/db_test.go
+++ b/db_test.go
@@ -1187,8 +1187,8 @@ func TestDBConcurrentCompactClose(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		opts := &Options{
 			FS: mem,
-			MaxConcurrentCompactions: func() int {
-				return 2
+			CompactionConcurrencyRange: func() (int, int) {
+				return 1, 2
 			},
 		}
 		d, err := Open("", testingRandomized(t, opts))
@@ -1522,8 +1522,8 @@ func TestMemtableIngestInversion(t *testing.T) {
 		MemTableStopWritesThreshold: 1000,
 		L0StopWritesThreshold:       1000,
 		L0CompactionThreshold:       2,
-		MaxConcurrentCompactions: func() int {
-			return 1000
+		CompactionConcurrencyRange: func() (int, int) {
+			return 1, 1000
 		},
 	}
 

--- a/error_test.go
+++ b/error_test.go
@@ -460,7 +460,7 @@ func TestDBCompactionCrash(t *testing.T) {
 			FS:                          fs,
 			Logger:                      testLogger{t: t},
 			MemTableSize:                128 << 10,
-			MaxConcurrentCompactions:    func() int { return maxConcurrentCompactions },
+			CompactionConcurrencyRange:  func() (int, int) { return 1, maxConcurrentCompactions },
 			LBaseMaxBytes:               64 << 10,
 			L0CompactionThreshold:       2,
 			L0CompactionFileThreshold:   2,

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2130,10 +2130,10 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 	maxProcs := runtime.GOMAXPROCS(0)
 
 	opts1 := &Options{
-		FS:                       vfs.NewCrashableMem(),
-		Comparer:                 testkeys.Comparer,
-		FormatMajorVersion:       FormatNewest,
-		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
+		FS:                         vfs.NewCrashableMem(),
+		Comparer:                   testkeys.Comparer,
+		FormatMajorVersion:         FormatNewest,
+		CompactionConcurrencyRange: func() (int, int) { return 1, maxProcs/2 + 1 },
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			sstable.NewTestKeysBlockPropertyCollector,
 		},
@@ -2143,10 +2143,10 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 	require.NoError(t, err)
 
 	opts2 := &Options{
-		FS:                       vfs.NewCrashableMem(),
-		Comparer:                 testkeys.Comparer,
-		FormatMajorVersion:       FormatNewest,
-		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
+		FS:                         vfs.NewCrashableMem(),
+		Comparer:                   testkeys.Comparer,
+		FormatMajorVersion:         FormatNewest,
+		CompactionConcurrencyRange: func() (int, int) { return 1, maxProcs/2 + 1 },
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			sstable.NewTestKeysBlockPropertyCollector,
 		},
@@ -2305,10 +2305,10 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 	mem := vfs.NewMem()
 	maxProcs := runtime.GOMAXPROCS(0)
 	opts := &Options{
-		FS:                       mem,
-		Comparer:                 testkeys.Comparer,
-		FormatMajorVersion:       FormatNewest,
-		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
+		FS:                         mem,
+		Comparer:                   testkeys.Comparer,
+		FormatMajorVersion:         FormatNewest,
+		CompactionConcurrencyRange: func() (int, int) { return 1, maxProcs/2 + 1 },
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			sstable.NewTestKeysBlockPropertyCollector,
 		},

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -685,8 +685,12 @@ func RandomOptions(
 	}
 	opts.LBaseMaxBytes = 1 << uint(rng.IntN(30)) // 1B - 1GB
 	maxConcurrentCompactions := rng.IntN(3) + 1  // 1-3
-	opts.MaxConcurrentCompactions = func() int {
-		return maxConcurrentCompactions
+	minConcurrentCompactions := 1
+	if rng.IntN(4) == 0 {
+		minConcurrentCompactions = rng.IntN(maxConcurrentCompactions) + 1
+	}
+	opts.CompactionConcurrencyRange = func() (int, int) {
+		return minConcurrentCompactions, maxConcurrentCompactions
 	}
 	maxConcurrentDownloads := rng.IntN(3) + 1 // 1-3
 	opts.MaxConcurrentDownloads = func() int {

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -71,7 +71,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		// Function pointers
 		"BlockPropertyCollectors:",
 		"EventListener:",
-		"MaxConcurrentCompactions:",
+		"CompactionConcurrencyRange:",
 		"MaxConcurrentDownloads:",
 		"Experimental.DisableIngestAsFlushable:",
 		"Experimental.EnableColumnarBlocks:",
@@ -117,7 +117,12 @@ func TestOptionsRoundtrip(t *testing.T) {
 		if o.Opts.Experimental.IngestSplit != nil && o.Opts.Experimental.IngestSplit() {
 			require.Equal(t, o.Opts.Experimental.IngestSplit(), parsed.Opts.Experimental.IngestSplit())
 		}
-		require.Equal(t, o.Opts.MaxConcurrentCompactions(), parsed.Opts.MaxConcurrentCompactions())
+
+		expBaseline, expUpper := o.Opts.CompactionConcurrencyRange()
+		parsedBaseline, parsedUpper := parsed.Opts.CompactionConcurrencyRange()
+		require.Equal(t, expBaseline, parsedBaseline)
+		require.Equal(t, expUpper, parsedUpper)
+
 		require.Equal(t, o.Opts.MaxConcurrentDownloads(), parsed.Opts.MaxConcurrentDownloads())
 		require.Equal(t, len(o.Opts.BlockPropertyCollectors), len(parsed.Opts.BlockPropertyCollectors))
 

--- a/options.go
+++ b/options.go
@@ -559,7 +559,7 @@ type Options struct {
 		// The threshold of L0 read-amplification at which compaction concurrency
 		// is enabled (if CompactionDebtConcurrency was not already exceeded).
 		// Every multiple of this value enables another concurrent
-		// compaction up to MaxConcurrentCompactions.
+		// compaction up to CompactionConcurrencyRange.
 		L0CompactionConcurrency int
 
 		// CompactionDebtConcurrency controls the threshold of compaction debt
@@ -893,15 +893,18 @@ type Options struct {
 	// The default merger concatenates values.
 	Merger *Merger
 
-	// MaxConcurrentCompactions is the upper bound on the value returned by
-	// DB.GetAllowedWithoutPermission (reported to the CompactionScheduler).
-	// More abstractly, it is a rough upper bound on the number of concurrent
-	// compactions, not including download compactions (which have a separate
-	// limit specified by MaxConcurrentDownloads).
+	// CompactionConcurrencyRange returns a [lower, upper] range for the number of
+	// compactions Pebble runs in parallel (with the caveats below), not including
+	// download compactions (which have a separate limit specified by
+	// MaxConcurrentDownloads).
 	//
-	// This is a rough upper bound since delete-only compactions (a) do not use
-	// the CompactionScheduler, and (b) the CompactionScheduler may use other
-	// criteria to decide on how many compactions to permit.
+	// The lower value is the concurrency allowed under normal circumstances.
+	// Pebble can dynamically increase the concurrency based on heuristics (like
+	// high read amplification or compaction debt) up to the maximum.
+	//
+	// The upper value is a rough upper bound since delete-only compactions (a) do
+	// not use the CompactionScheduler, and (b) the CompactionScheduler may use
+	// other criteria to decide on how many compactions to permit.
 	//
 	// Elaborating on (b), when the ConcurrencyLimitScheduler is being used, the
 	// value returned by DB.GetAllowedWithoutPermission fully controls how many
@@ -912,29 +915,30 @@ type Options struct {
 	// delete-only compactions since they are expected to be almost free from a
 	// CPU and disk usage perspective. Since the CompactionScheduler does not
 	// know about their existence, the total running count can exceed this
-	// value. For example, consider MaxConcurrentCompactions returns 3, and the
+	// value. For example, consider CompactionConcurrencyRange returns 3, and the
 	// current value returned from DB.GetAllowedWithoutPermission is also 3. Say
 	// 3 delete-only compactions are also running. Then the
 	// ConcurrencyLimitScheduler can also start 3 other compactions, for a total
 	// of 6.
 	//
-	// DB.GetAllowedWithoutPermission returns a value in the interval [1,
-	// MaxConcurrentCompactions]. A value > 1 is returned:
+	// DB.GetAllowedWithoutPermission returns a value in the interval
+	// [lower, upper]. A value > lower is returned:
 	//  - when L0 read-amplification passes the L0CompactionConcurrency threshold;
 	//  - when compaction debt passes the CompactionDebtConcurrency threshold;
 	//  - when there are multiple manual compactions waiting to run.
 	//
-	// MaxConcurrentCompactions() must be greater than 0.
+	// lower and upper must be greater than 0. If lower > upper, then upper is
+	// used for both.
 	//
-	// The default value is 1.
-	MaxConcurrentCompactions func() int
+	// The default values are 1, 1.
+	CompactionConcurrencyRange func() (lower, upper int)
 
 	// MaxConcurrentDownloads specifies the maximum number of download
 	// compactions. These are compactions that copy an external file to the local
 	// store.
 	//
-	// This limit is independent of MaxConcurrentCompactions; at any point in
-	// time, we may be running MaxConcurrentCompactions non-download compactions
+	// This limit is independent of CompactionConcurrencyRange; at any point in
+	// time, we may be running CompactionConcurrencyRange non-download compactions
 	// and MaxConcurrentDownloads download compactions.
 	//
 	// MaxConcurrentDownloads() must be greater than 0.
@@ -1262,8 +1266,8 @@ func (o *Options) EnsureDefaults() {
 	if o.Merger == nil {
 		o.Merger = DefaultMerger
 	}
-	if o.MaxConcurrentCompactions == nil {
-		o.MaxConcurrentCompactions = func() int { return 1 }
+	if o.CompactionConcurrencyRange == nil {
+		o.CompactionConcurrencyRange = func() (int, int) { return 1, 1 }
 	}
 	if o.MaxConcurrentDownloads == nil {
 		o.MaxConcurrentDownloads = func() int { return 1 }
@@ -1429,7 +1433,9 @@ func (o *Options) String() string {
 	if o.Experimental.LevelMultiplier != defaultLevelMultiplier {
 		fmt.Fprintf(&buf, "  level_multiplier=%d\n", o.Experimental.LevelMultiplier)
 	}
-	fmt.Fprintf(&buf, "  max_concurrent_compactions=%d\n", o.MaxConcurrentCompactions())
+	lower, upper := o.CompactionConcurrencyRange()
+	fmt.Fprintf(&buf, "  concurrent_compactions=%d\n", lower)
+	fmt.Fprintf(&buf, "  max_concurrent_compactions=%d\n", upper)
 	fmt.Fprintf(&buf, "  max_concurrent_downloads=%d\n", o.MaxConcurrentDownloads())
 	fmt.Fprintf(&buf, "  max_manifest_file_size=%d\n", o.MaxManifestFileSize)
 	fmt.Fprintf(&buf, "  max_open_files=%d\n", o.MaxOpenFiles)
@@ -1602,6 +1608,13 @@ type ParseHooks struct {
 // options cannot be parsed into populated fields. For example, comparer and
 // merger.
 func (o *Options) Parse(s string, hooks *ParseHooks) error {
+	var concurrencyLimit struct {
+		lower    int
+		lowerSet bool
+		upper    int
+		upperSet bool
+	}
+
 	visitKeyValue := func(i, j int, section, key, value string) error {
 		// WARNING: DO NOT remove entries from the switches below because doing so
 		// causes a key previously written to the OPTIONS file to be considered unknown,
@@ -1747,14 +1760,12 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				o.LBaseMaxBytes, err = strconv.ParseInt(value, 10, 64)
 			case "level_multiplier":
 				o.Experimental.LevelMultiplier, err = strconv.Atoi(value)
+			case "concurrent_compactions":
+				concurrencyLimit.lowerSet = true
+				concurrencyLimit.lower, err = strconv.Atoi(value)
 			case "max_concurrent_compactions":
-				var concurrentCompactions int
-				concurrentCompactions, err = strconv.Atoi(value)
-				if concurrentCompactions <= 0 {
-					err = errors.New("max_concurrent_compactions cannot be <= 0")
-				} else {
-					o.MaxConcurrentCompactions = func() int { return concurrentCompactions }
-				}
+				concurrencyLimit.upperSet = true
+				concurrencyLimit.upper, err = strconv.Atoi(value)
 			case "max_concurrent_downloads":
 				var concurrentDownloads int
 				concurrentDownloads, err = strconv.Atoi(value)
@@ -1982,9 +1993,28 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 		}
 		return errors.Errorf("pebble: unknown section: %q", errors.Safe(section))
 	}
-	return parseOptions(s, parseOptionsFuncs{
+	err := parseOptions(s, parseOptionsFuncs{
 		visitKeyValue: visitKeyValue,
 	})
+	if err != nil {
+		return err
+	}
+	if concurrencyLimit.lowerSet || concurrencyLimit.upperSet {
+		if !concurrencyLimit.lowerSet {
+			concurrencyLimit.lower = 1
+		} else if concurrencyLimit.lower < 1 {
+			return errors.New("baseline_concurrent_compactions cannot be <= 0")
+		}
+		if !concurrencyLimit.upperSet {
+			concurrencyLimit.upper = concurrencyLimit.lower
+		} else if concurrencyLimit.upper < concurrencyLimit.lower {
+			return errors.Newf("max_concurrent_compactions cannot be < %d", concurrencyLimit.lower)
+		}
+		o.CompactionConcurrencyRange = func() (int, int) {
+			return concurrencyLimit.lower, concurrencyLimit.upper
+		}
+	}
+	return nil
 }
 
 // ErrMissingWALRecoveryDir is an error returned when a database is attempted to be

--- a/options_test.go
+++ b/options_test.go
@@ -97,6 +97,7 @@ func TestDefaultOptionsString(t *testing.T) {
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
   lbase_max_bytes=67108864
+  concurrent_compactions=1
   max_concurrent_compactions=1
   max_concurrent_downloads=1
   max_manifest_file_size=134217728

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -11,7 +11,7 @@ tree
      614      000007.sst
        0      LOCK
      133      MANIFEST-000001
-    1524      OPTIONS-000003
+    1551      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000001.MANIFEST-000001
             simple/
@@ -21,7 +21,7 @@ tree
       25        000004.log
      586        000005.sst
       85        MANIFEST-000001
-    1524        OPTIONS-000003
+    1551        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -49,6 +49,7 @@ cat build/OPTIONS-000003
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
   lbase_max_bytes=67108864
+  concurrent_compactions=1
   max_concurrent_compactions=1
   max_concurrent_downloads=1
   max_manifest_file_size=96

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -14,7 +14,7 @@ tree
        0      LOCK
      133      MANIFEST-000001
      205      MANIFEST-000010
-    1524      OPTIONS-000003
+    1551      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000002.MANIFEST-000010
             high_read_amp/
@@ -26,7 +26,7 @@ tree
       39        000008.log
      560        000009.sst
      157        MANIFEST-000010
-    1524        OPTIONS-000003
+    1551        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000010
 

--- a/testdata/compaction_picker_concurrency
+++ b/testdata/compaction_picker_concurrency
@@ -162,17 +162,49 @@ pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=5120000
 picker.getCompactionConcurrency: 1
 nil
 
-pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=512000
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=5120000 concurrency=(2,4)
 ----
-picker.getCompactionConcurrency: 4
+picker.getCompactionConcurrency: 2
 L0 -> L1
 L0: 000301,000302,000303,000304,000305
 L1: 000201
 grandparents: 000101
 
-pick-auto l0_compaction_concurrency=5 compaction_debt_concurrency=5120000
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=512000 concurrency=(1,10)
+----
+picker.getCompactionConcurrency: 5
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=512000 concurrency=(2,10)
+----
+picker.getCompactionConcurrency: 6
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=512000 concurrency=(2,5)
+----
+picker.getCompactionConcurrency: 5
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+pick-auto l0_compaction_concurrency=5 compaction_debt_concurrency=5120000 concurrency=(1,5)
 ----
 picker.getCompactionConcurrency: 2
+L0 -> L1
+L0: 000301,000302,000303,000304,000305
+L1: 000201
+grandparents: 000101
+
+pick-auto l0_compaction_concurrency=5 compaction_debt_concurrency=5120000 concurrency=(2,5)
+----
+picker.getCompactionConcurrency: 3
 L0 -> L1
 L0: 000301,000302,000303,000304,000305
 L1: 000201

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev4
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev4
@@ -643,7 +643,7 @@ L3:
 add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 ----
 
-set-concurrent-compactions num=2
+set-concurrent-compactions max=2
 ----
 
 async-compact a-b L3

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev5
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev5
@@ -645,7 +645,7 @@ L3:
 add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 ----
 
-set-concurrent-compactions num=2
+set-concurrent-compactions max=2
 ----
 
 async-compact a-b L3

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev6
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev6
@@ -645,7 +645,7 @@ L3:
 add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 ----
 
-set-concurrent-compactions num=2
+set-concurrent-compactions max=2
 ----
 
 async-compact a-b L3

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -158,7 +158,7 @@ Iter category stats:
 
 disk-usage
 ----
-4.6KB
+4.7KB
 
 # Closing iter a will release one of the zombie memtables.
 


### PR DESCRIPTION
`MaxConcurrentCompactions()` returns an upper limit on the compaction
concurrency. Within this upper limit, Pebble decides what the
concurrency limit is (depending on L0 amplification and compaction debt).

There are cases where we want more concurrency for other reasons (like
space amp). Having a knob can be useful to tweak things in a
production environment.

This change changes `MaxConcurrentCompactions()` to
`CompactionConcurrencyRange()` which returns both a lower and upper
value. The lower limit is the "baseline" value for the concurrency,
which Pebble can increase dynamically up to the upper limit. Prior to
this change, the (implicit) lower limit was always 1.