### PR TITLE
crl-release-24.3: db: change MaxConcurrentCompactions() to return a range

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -74,8 +74,8 @@ func newPebbleDB(dir string) DB {
 		Merger: &pebble.Merger{
 			Name: "cockroach_merge_operator",
 		},
-		MaxConcurrentCompactions: func() int {
-			return 3
+		CompactionConcurrencyRange: func() (int, int) {
+			return 1, 3
 		},
 	}
 	// In FormatColumnarBlocks (the value of FormatNewest at the time of

--- a/cmd/pebble/replay_test.go
+++ b/cmd/pebble/replay_test.go
@@ -22,7 +22,15 @@ func TestParseOptionsStr(t *testing.T) {
 	testCases := []testCase{
 		{
 			c:       replayConfig{optionsString: `[Options] max_concurrent_compactions=9`},
-			options: &pebble.Options{MaxConcurrentCompactions: func() int { return 9 }},
+			options: &pebble.Options{CompactionConcurrencyRange: func() (int, int) { return 1, 9 }},
+		},
+		{
+			c:       replayConfig{optionsString: `[Options] concurrent_compactions=4`},
+			options: &pebble.Options{CompactionConcurrencyRange: func() (int, int) { return 4, 4 }},
+		},
+		{
+			c:       replayConfig{optionsString: `[Options] concurrent_compactions=4 max_concurrent_compactions=9`},
+			options: &pebble.Options{CompactionConcurrencyRange: func() (int, int) { return 4, 9 }},
 		},
 		{
 			c:       replayConfig{optionsString: `[Options] bytes_per_sync=90000`},

--- a/compaction.go
+++ b/compaction.go
@@ -51,7 +51,8 @@ func expandedCompactionByteSizeLimit(opts *Options, level int, availBytes uint64
 	// compactions to half of available disk space. Note that this will not
 	// prevent compaction picking from pursuing compactions that are larger
 	// than this threshold before expansion.
-	diskMax := (availBytes / 2) / uint64(opts.MaxConcurrentCompactions())
+	_, maxConcurrency := opts.CompactionConcurrencyRange()
+	diskMax := (availBytes / 2) / uint64(maxConcurrency)
 	if v > diskMax {
 		v = diskMax
 	}
@@ -1713,7 +1714,7 @@ func (d *DB) maybeScheduleCompactionPicker(
 	if d.closed.Load() != nil || d.opts.ReadOnly {
 		return
 	}
-	maxCompactions := d.opts.MaxConcurrentCompactions()
+	_, maxCompactions := d.opts.CompactionConcurrencyRange()
 	maxDownloads := d.opts.MaxConcurrentDownloads()
 
 	if d.mu.compact.compactingCount >= maxCompactions &&

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1181,7 +1181,8 @@ func (p *compactionPickerByScore) pickAuto(env compactionEnv) (pc *pickedCompact
 	// debt as a second signal to prevent compaction concurrency from dropping
 	// significantly right after a base compaction finishes, and before those
 	// bytes have been compacted further down the LSM.
-	if n := len(env.inProgressCompactions); n > 0 {
+	lower, _ := p.opts.CompactionConcurrencyRange()
+	if n := len(env.inProgressCompactions); n >= lower {
 		l0ReadAmp := p.vers.L0Sublevels.MaxDepthAfterOngoingCompactions()
 		compactionDebt := p.estimatedCompactionDebt(0)
 		ccSignal1 := n * p.opts.Experimental.L0CompactionConcurrency

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1199,10 +1199,12 @@ func TestManualCompaction(t *testing.T) {
 				return ""
 
 			case "set-concurrent-compactions":
-				var concurrentCompactions int
-				td.ScanArgs(t, "num", &concurrentCompactions)
-				d.opts.MaxConcurrentCompactions = func() int {
-					return concurrentCompactions
+				lower := 1
+				upper := 1
+				td.MaybeScanArgs(t, "max", &upper)
+				td.MaybeScanArgs(t, "range", &lower, upper)
+				d.opts.CompactionConcurrencyRange = func() (int, int) {
+					return lower, upper
 				}
 				return ""
 

--- a/db_test.go
+++ b/db_test.go
@@ -1163,8 +1163,8 @@ func TestDBConcurrentCompactClose(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		opts := &Options{
 			FS: mem,
-			MaxConcurrentCompactions: func() int {
-				return 2
+			CompactionConcurrencyRange: func() (int, int) {
+				return 1, 2
 			},
 		}
 		d, err := Open("", testingRandomized(t, opts))
@@ -1498,8 +1498,8 @@ func TestMemtableIngestInversion(t *testing.T) {
 		MemTableStopWritesThreshold: 1000,
 		L0StopWritesThreshold:       1000,
 		L0CompactionThreshold:       2,
-		MaxConcurrentCompactions: func() int {
-			return 1000
+		CompactionConcurrencyRange: func() (int, int) {
+			return 1, 1000
 		},
 	}
 

--- a/error_test.go
+++ b/error_test.go
@@ -459,7 +459,7 @@ func TestDBCompactionCrash(t *testing.T) {
 			FS:                          fs,
 			Logger:                      testLogger{t: t},
 			MemTableSize:                128 << 10,
-			MaxConcurrentCompactions:    func() int { return maxConcurrentCompactions },
+			CompactionConcurrencyRange:  func() (int, int) { return 1, maxConcurrentCompactions },
 			LBaseMaxBytes:               64 << 10,
 			L0CompactionThreshold:       2,
 			L0CompactionFileThreshold:   2,

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2111,10 +2111,10 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 	maxProcs := runtime.GOMAXPROCS(0)
 
 	opts1 := &Options{
-		FS:                       vfs.NewCrashableMem(),
-		Comparer:                 testkeys.Comparer,
-		FormatMajorVersion:       FormatNewest,
-		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
+		FS:                         vfs.NewCrashableMem(),
+		Comparer:                   testkeys.Comparer,
+		FormatMajorVersion:         FormatNewest,
+		CompactionConcurrencyRange: func() (int, int) { return 1, maxProcs/2 + 1 },
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			sstable.NewTestKeysBlockPropertyCollector,
 		},
@@ -2124,10 +2124,10 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 	require.NoError(t, err)
 
 	opts2 := &Options{
-		FS:                       vfs.NewCrashableMem(),
-		Comparer:                 testkeys.Comparer,
-		FormatMajorVersion:       FormatNewest,
-		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
+		FS:                         vfs.NewCrashableMem(),
+		Comparer:                   testkeys.Comparer,
+		FormatMajorVersion:         FormatNewest,
+		CompactionConcurrencyRange: func() (int, int) { return 1, maxProcs/2 + 1 },
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			sstable.NewTestKeysBlockPropertyCollector,
 		},
@@ -2286,10 +2286,10 @@ func BenchmarkIterator_RangeKeyMasking(b *testing.B) {
 	mem := vfs.NewMem()
 	maxProcs := runtime.GOMAXPROCS(0)
 	opts := &Options{
-		FS:                       mem,
-		Comparer:                 testkeys.Comparer,
-		FormatMajorVersion:       FormatNewest,
-		MaxConcurrentCompactions: func() int { return maxProcs/2 + 1 },
+		FS:                         mem,
+		Comparer:                   testkeys.Comparer,
+		FormatMajorVersion:         FormatNewest,
+		CompactionConcurrencyRange: func() (int, int) { return 1, maxProcs/2 + 1 },
 		BlockPropertyCollectors: []func() BlockPropertyCollector{
 			sstable.NewTestKeysBlockPropertyCollector,
 		},

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -659,8 +659,12 @@ func RandomOptions(
 	}
 	opts.LBaseMaxBytes = 1 << uint(rng.IntN(30)) // 1B - 1GB
 	maxConcurrentCompactions := rng.IntN(3) + 1  // 1-3
-	opts.MaxConcurrentCompactions = func() int {
-		return maxConcurrentCompactions
+	minConcurrentCompactions := 1
+	if rng.IntN(4) == 0 {
+		minConcurrentCompactions = rng.IntN(maxConcurrentCompactions) + 1
+	}
+	opts.CompactionConcurrencyRange = func() (int, int) {
+		return minConcurrentCompactions, maxConcurrentCompactions
 	}
 	maxConcurrentDownloads := rng.IntN(3) + 1 // 1-3
 	opts.MaxConcurrentDownloads = func() int {

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -70,7 +70,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		// Function pointers
 		"BlockPropertyCollectors:",
 		"EventListener:",
-		"MaxConcurrentCompactions:",
+		"CompactionConcurrencyRange:",
 		"MaxConcurrentDownloads:",
 		"Experimental.DisableIngestAsFlushable:",
 		"Experimental.EnableColumnarBlocks:",
@@ -125,7 +125,12 @@ func TestOptionsRoundtrip(t *testing.T) {
 		if o.Opts.Experimental.IngestSplit != nil && o.Opts.Experimental.IngestSplit() {
 			require.Equal(t, o.Opts.Experimental.IngestSplit(), parsed.Opts.Experimental.IngestSplit())
 		}
-		require.Equal(t, o.Opts.MaxConcurrentCompactions(), parsed.Opts.MaxConcurrentCompactions())
+
+		expBaseline, expUpper := o.Opts.CompactionConcurrencyRange()
+		parsedBaseline, parsedUpper := parsed.Opts.CompactionConcurrencyRange()
+		require.Equal(t, expBaseline, parsedBaseline)
+		require.Equal(t, expUpper, parsedUpper)
+
 		require.Equal(t, o.Opts.MaxConcurrentDownloads(), parsed.Opts.MaxConcurrentDownloads())
 		require.Equal(t, len(o.Opts.BlockPropertyCollectors), len(parsed.Opts.BlockPropertyCollectors))
 

--- a/options.go
+++ b/options.go
@@ -558,7 +558,7 @@ type Options struct {
 		// The threshold of L0 read-amplification at which compaction concurrency
 		// is enabled (if CompactionDebtConcurrency was not already exceeded).
 		// Every multiple of this value enables another concurrent
-		// compaction up to MaxConcurrentCompactions.
+		// compaction up to the upper value returned by CompactionConcurrencyRange.
 		L0CompactionConcurrency int
 
 		// CompactionDebtConcurrency controls the threshold of compaction debt
@@ -998,25 +998,31 @@ type Options struct {
 	// The default merger concatenates values.
 	Merger *Merger
 
-	// MaxConcurrentCompactions specifies the maximum number of concurrent
-	// compactions (not including download compactions).
+	// CompactionConcurrencyRange returns a [lower, upper] range for the number of
+	// compactions Pebble runs in parallel, not including download compactions
+	// (which have a separate limit specified by MaxConcurrentDownloads).
+	//
+	// The lower value is the concurrency allowed under normal circumstances.
+	// Pebble can dynamically increase the concurrency based on heuristics (like
+	// high read amplification or compaction debt) up to the maximum.
 	//
 	// Concurrent compactions are performed:
 	//  - when L0 read-amplification passes the L0CompactionConcurrency threshold;
 	//  - for automatic background compactions;
 	//  - when a manual compaction for a level is split and parallelized.
 	//
-	// MaxConcurrentCompactions() must be greater than 0.
+	// lower and upper must be greater than 0. If lower > upper, then upper is
+	// used for both.
 	//
-	// The default value is 1.
-	MaxConcurrentCompactions func() int
+	// The default values are 1, 1.
+	CompactionConcurrencyRange func() (lower, upper int)
 
 	// MaxConcurrentDownloads specifies the maximum number of download
 	// compactions. These are compactions that copy an external file to the local
 	// store.
 	//
-	// This limit is independent of MaxConcurrentCompactions; at any point in
-	// time, we may be running MaxConcurrentCompactions non-download compactions
+	// This limit is independent of CompactionConcurrencyRange; at any point in
+	// time, we may be running CompactionConcurrencyRange non-download compactions
 	// and MaxConcurrentDownloads download compactions.
 	//
 	// MaxConcurrentDownloads() must be greater than 0.
@@ -1309,8 +1315,8 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Merger == nil {
 		o.Merger = DefaultMerger
 	}
-	if o.MaxConcurrentCompactions == nil {
-		o.MaxConcurrentCompactions = func() int { return 1 }
+	if o.CompactionConcurrencyRange == nil {
+		o.CompactionConcurrencyRange = func() (int, int) { return 1, 1 }
 	}
 	if o.MaxConcurrentDownloads == nil {
 		o.MaxConcurrentDownloads = func() int { return 1 }
@@ -1471,7 +1477,9 @@ func (o *Options) String() string {
 	if o.Experimental.LevelMultiplier != defaultLevelMultiplier {
 		fmt.Fprintf(&buf, "  level_multiplier=%d\n", o.Experimental.LevelMultiplier)
 	}
-	fmt.Fprintf(&buf, "  max_concurrent_compactions=%d\n", o.MaxConcurrentCompactions())
+	lower, upper := o.CompactionConcurrencyRange()
+	fmt.Fprintf(&buf, "  concurrent_compactions=%d\n", lower)
+	fmt.Fprintf(&buf, "  max_concurrent_compactions=%d\n", upper)
 	fmt.Fprintf(&buf, "  max_concurrent_downloads=%d\n", o.MaxConcurrentDownloads())
 	fmt.Fprintf(&buf, "  max_manifest_file_size=%d\n", o.MaxManifestFileSize)
 	fmt.Fprintf(&buf, "  max_open_files=%d\n", o.MaxOpenFiles)
@@ -1643,6 +1651,13 @@ type ParseHooks struct {
 // options cannot be parsed into populated fields. For example, comparer and
 // merger.
 func (o *Options) Parse(s string, hooks *ParseHooks) error {
+	var concurrencyLimit struct {
+		lower    int
+		lowerSet bool
+		upper    int
+		upperSet bool
+	}
+
 	visitKeyValue := func(i, j int, section, key, value string) error {
 		// WARNING: DO NOT remove entries from the switches below because doing so
 		// causes a key previously written to the OPTIONS file to be considered unknown,
@@ -1797,14 +1812,12 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				o.LBaseMaxBytes, err = strconv.ParseInt(value, 10, 64)
 			case "level_multiplier":
 				o.Experimental.LevelMultiplier, err = strconv.Atoi(value)
+			case "concurrent_compactions":
+				concurrencyLimit.lowerSet = true
+				concurrencyLimit.lower, err = strconv.Atoi(value)
 			case "max_concurrent_compactions":
-				var concurrentCompactions int
-				concurrentCompactions, err = strconv.Atoi(value)
-				if concurrentCompactions <= 0 {
-					err = errors.New("max_concurrent_compactions cannot be <= 0")
-				} else {
-					o.MaxConcurrentCompactions = func() int { return concurrentCompactions }
-				}
+				concurrencyLimit.upperSet = true
+				concurrencyLimit.upper, err = strconv.Atoi(value)
 			case "max_concurrent_downloads":
 				var concurrentDownloads int
 				concurrentDownloads, err = strconv.Atoi(value)
@@ -2022,9 +2035,27 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 		}
 		return errors.Errorf("pebble: unknown section: %q", errors.Safe(section))
 	}
-	return parseOptions(s, parseOptionsFuncs{
+	if err := parseOptions(s, parseOptionsFuncs{
 		visitKeyValue: visitKeyValue,
-	})
+	}); err != nil {
+		return err
+	}
+	if concurrencyLimit.lowerSet || concurrencyLimit.upperSet {
+		if !concurrencyLimit.lowerSet {
+			concurrencyLimit.lower = 1
+		} else if concurrencyLimit.lower < 1 {
+			return errors.New("baseline_concurrent_compactions cannot be <= 0")
+		}
+		if !concurrencyLimit.upperSet {
+			concurrencyLimit.upper = concurrencyLimit.lower
+		} else if concurrencyLimit.upper < concurrencyLimit.lower {
+			return errors.Newf("max_concurrent_compactions cannot be < %d", concurrencyLimit.lower)
+		}
+		o.CompactionConcurrencyRange = func() (int, int) {
+			return concurrencyLimit.lower, concurrencyLimit.upper
+		}
+	}
+	return nil
 }
 
 // ErrMissingWALRecoveryDir is an error returned when a database is attempted to be

--- a/options_test.go
+++ b/options_test.go
@@ -97,6 +97,7 @@ func TestOptionsString(t *testing.T) {
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
   lbase_max_bytes=67108864
+  concurrent_compactions=1
   max_concurrent_compactions=1
   max_concurrent_downloads=1
   max_manifest_file_size=134217728

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -11,7 +11,7 @@ tree
      614      000007.sst
        0      LOCK
      133      MANIFEST-000001
-    1418      OPTIONS-000003
+    1445      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000001.MANIFEST-000001
             simple/
@@ -21,7 +21,7 @@ tree
       25        000004.log
      586        000005.sst
       85        MANIFEST-000001
-    1418        OPTIONS-000003
+    1445        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -48,6 +48,7 @@ cat build/OPTIONS-000003
   l0_compaction_threshold=4
   l0_stop_writes_threshold=12
   lbase_max_bytes=67108864
+  concurrent_compactions=1
   max_concurrent_compactions=1
   max_concurrent_downloads=1
   max_manifest_file_size=96

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -14,7 +14,7 @@ tree
        0      LOCK
      133      MANIFEST-000001
      205      MANIFEST-000010
-    1418      OPTIONS-000003
+    1445      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000002.MANIFEST-000010
             high_read_amp/
@@ -26,7 +26,7 @@ tree
       39        000008.log
      560        000009.sst
      157        MANIFEST-000010
-    1418        OPTIONS-000003
+    1445        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000010
 

--- a/testdata/compaction_picker_concurrency
+++ b/testdata/compaction_picker_concurrency
@@ -157,14 +157,14 @@ pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=5120000
 ----
 nil
 
-pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=512000
+pick-auto l0_compaction_concurrency=10 compaction_debt_concurrency=5120000 concurrency=(2,4)
 ----
 L0 -> L1
 L0: 000301,000302,000303,000304,000305
 L1: 000201
 grandparents: 000101
 
-pick-auto l0_compaction_concurrency=5 compaction_debt_concurrency=5120000
+pick-auto l0_compaction_concurrency=5 compaction_debt_concurrency=5120000 concurrency=(1,5)
 ----
 L0 -> L1
 L0: 000301,000302,000303,000304,000305

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev4
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev4
@@ -643,7 +643,7 @@ L3:
 add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 ----
 
-set-concurrent-compactions num=2
+set-concurrent-compactions max=2
 ----
 
 async-compact a-b L3

--- a/testdata/manual_compaction_set_with_del_sstable_Pebblev5
+++ b/testdata/manual_compaction_set_with_del_sstable_Pebblev5
@@ -645,7 +645,7 @@ L3:
 add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 ----
 
-set-concurrent-compactions num=2
+set-concurrent-compactions max=2
 ----
 
 async-compact a-b L3

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -93,7 +93,7 @@ Iter category stats:
 
 disk-usage
 ----
-2.0KB
+2.1KB
 
 batch
 set b 2
@@ -157,7 +157,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.3KB
+3.4KB
 
 # Closing iter a will release one of the zombie memtables.
 


### PR DESCRIPTION
Backport of #4635.

`MaxConcurrentCompactions()` returns an upper limit on the compaction
concurrency. Within this upper limit, Pebble decides what the
concurrency limit is (depending on L0 amplification and compaction debt).

There are cases where we want more concurrency for other reasons (like
space amp). Having a knob can be useful to tweak things in a
production environment.

This change changes `MaxConcurrentCompactions()` to
`CompactionConcurrencyRange()` which returns both a lower and upper
value. The lower limit is the "baseline" value for the concurrency,
which Pebble can increase dynamically up to the upper limit. Prior to
this change, the (implicit) lower limit was always 1.