### PR TITLE
db: preserve blob reference metadata across excise

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1004,6 +1004,13 @@ func TestCompaction(t *testing.T) {
 				}
 				return s
 
+			case "excise-dryrun":
+				ve, err := runExciseDryRunCmd(td, d)
+				if err != nil {
+					td.Fatalf(t, err.Error())
+				}
+				return fmt.Sprintf("would excise %d files.\n%s", len(ve.DeletedTables), ve.DebugString(base.DefaultFormatter))
+
 			case "file-sizes":
 				return runTableFileSizesCmd(td, d)
 

--- a/data_test.go
+++ b/data_test.go
@@ -1410,6 +1410,42 @@ func runExciseCmd(td *datadriven.TestData, d *DB) error {
 	return d.Excise(context.Background(), exciseSpan)
 }
 
+func runExciseDryRunCmd(td *datadriven.TestData, d *DB) (*versionEdit, error) {
+	ve := &versionEdit{
+		DeletedTables: map[deletedFileEntry]*tableMetadata{},
+	}
+	var exciseSpan KeyRange
+	if len(td.CmdArgs) != 2 {
+		panic("insufficient args for excise-dryrun command")
+	}
+	exciseSpan.Start = []byte(td.CmdArgs[0].Key)
+	exciseSpan.End = []byte(td.CmdArgs[1].Key)
+
+	d.mu.Lock()
+	d.mu.versions.logLock()
+	defer func() {
+		d.mu.Lock()
+		d.mu.versions.logUnlock()
+		d.mu.Unlock()
+	}()
+	d.mu.Unlock()
+	current := d.mu.versions.currentVersion()
+
+	exciseBounds := exciseSpan.UserKeyBounds()
+	for l, ls := range current.AllLevelsAndSublevels() {
+		iter := ls.Iter()
+		for m := iter.SeekGE(d.cmp, exciseSpan.Start); m != nil && d.cmp(m.Smallest().UserKey, exciseSpan.End) < 0; m = iter.Next() {
+			leftTable, rightTable, err := d.exciseTable(context.Background(), exciseBounds, m, l.Level(), tightExciseBounds)
+			if err != nil {
+				return nil, errors.Errorf("error when excising %s: %s", m.FileNum, err.Error())
+			}
+			applyExciseToVersionEdit(ve, m, leftTable, rightTable, l.Level())
+		}
+	}
+
+	return ve, nil
+}
+
 func runIngestAndExciseCmd(td *datadriven.TestData, d *DB) error {
 	var exciseSpan KeyRange
 	paths := make([]string, 0, len(td.CmdArgs))

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -25,7 +25,9 @@ type BlobReference struct {
 	// FileNum identifies the referenced blob file.
 	FileNum base.DiskFileNum
 	// ValueSize is the sum of the lengths of the uncompressed values within the
-	// blob file for which there exists a reference in the sstable.
+	// blob file for which there exists a reference in the sstable. Note that if
+	// any of the referencing tables are virtualized tables, the ValueSize may
+	// be approximate.
 	//
 	// INVARIANT: ValueSize <= Metadata.ValueSize
 	ValueSize uint64

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -342,3 +342,12 @@ Blob files:
   000038: 1686698 physical bytes, 1681728 value bytes
   000040: 1691574 physical bytes, 1686592 value bytes
   000042: 113626 physical bytes, 113280 value bytes
+
+
+excise-dryrun b c
+----
+would excise 1 files.
+  del-table:     L6 000044
+  add-table:     L6 000053(000044):[a@1#0,SET-azzz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azzz@1#0,SET] size:238596 blobrefs:[(000006: 566234), (000008: 564260), (000010: 37624); depth:1]
+  add-table:     L6 000054(000044):[c@1#0,SET-czks@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-czks@1#0,SET] size:235737 blobrefs:[(000006: 559450), (000008: 557499), (000010: 37173); depth:1]
+  add-backing:   000044


### PR DESCRIPTION
During excise, we now preserve the top-level blob references
across virtual ssts created. The value size of each blob
reference is approximated by the proportion of the virtual table's
size to the original table's size.

Fixes: #4595