### PR TITLE
db: reduce comparisons in mergingIterHeap

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -2413,7 +2413,7 @@ func (i *Iterator) Close() error {
 			keyBuf               []byte
 			boundsBuf            [2][]byte
 			prefixOrFullSeekKey  []byte
-			mergingIterHeapItems []*mergingIterLevel
+			mergingIterHeapItems []mergingIterHeapItem
 		)
 
 		// Avoid caching the key buf if it is overly large. The constant is fairly

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1726,7 +1726,7 @@ func setupForTwoLevelBloomTombstone(b *testing.B, keyOffset int) twoLevelBloomTo
 					levels = 1
 				}
 				readers[index], levelSlices[index], keys = buildLevelsForMergingIterSeqSeek(
-					b, ch, blockSize, restartInterval, levels, keyOffset, withTombstone, bloom, twoLevelIndex)
+					b, ch, blockSize, restartInterval, levels, nil, keyOffset, withTombstone, bloom, twoLevelIndex)
 			}
 		}
 	}
@@ -1892,7 +1892,7 @@ func BenchmarkIteratorSeqSeekGEWithBounds(b *testing.B) {
 				ch := c.NewHandle()
 				defer ch.Close()
 				readers, levelSlices, keys := buildLevelsForMergingIterSeqSeek(
-					b, ch, blockSize, restartInterval, levelCount, 0, /* keyOffset */
+					b, ch, blockSize, restartInterval, levelCount, nil, 0, /* keyOffset */
 					false, false, twoLevelIndex)
 				m := buildMergingIter(readers, levelSlices)
 				iter := Iterator{
@@ -1935,7 +1935,7 @@ func BenchmarkIteratorSeekGENoop(b *testing.B) {
 	ch := c.NewHandle()
 	defer ch.Close()
 	readers, levelSlices, _ := buildLevelsForMergingIterSeqSeek(
-		b, ch, blockSize, restartInterval, levelCount, keyOffset, false, false, false)
+		b, ch, blockSize, restartInterval, levelCount, nil, keyOffset, false, false, false)
 	var keys [][]byte
 	for i := 0; i < keyOffset; i++ {
 		keys = append(keys, []byte(fmt.Sprintf("%08d", i)))

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -314,7 +314,7 @@ func (m *mergingIter) init(
 	m.split = split
 	m.stats = stats
 	if cap(m.heap.items) < len(levels) {
-		m.heap.items = make([]*mergingIterLevel, 0, len(levels))
+		m.heap.items = make([]mergingIterHeapItem, 0, len(levels))
 	} else {
 		m.heap.items = m.heap.items[:0]
 	}
@@ -327,7 +327,7 @@ func (m *mergingIter) initHeap() {
 	m.heap.items = m.heap.items[:0]
 	for i := range m.levels {
 		if l := &m.levels[i]; l.iterKV != nil {
-			m.heap.items = append(m.heap.items, l)
+			m.heap.items = append(m.heap.items, mergingIterHeapItem{mergingIterLevel: l})
 		}
 	}
 	m.heap.init()
@@ -419,7 +419,7 @@ func (m *mergingIter) switchToMinHeap() error {
 	// iteration, we want to return a key that is greater than a:2.
 
 	key := m.heap.items[0].iterKV.K
-	cur := m.heap.items[0]
+	cur := m.heap.items[0].mergingIterLevel
 
 	for i := range m.levels {
 		l := &m.levels[i]
@@ -471,7 +471,7 @@ func (m *mergingIter) switchToMaxHeap() error {
 	// The current key is b:2 and i2 is pointing at b:1. When we switch to
 	// reverse iteration, we want to return a key that is less than b:2.
 	key := m.heap.items[0].iterKV.K
-	cur := m.heap.items[0]
+	cur := m.heap.items[0].mergingIterLevel
 
 	for i := range m.levels {
 		l := &m.levels[i]
@@ -697,7 +697,7 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterLevel) (bool, error) {
 // returns a nil internal key.
 func (m *mergingIter) findNextEntry() *base.InternalKV {
 	for m.heap.len() > 0 && m.err == nil {
-		item := m.heap.items[0]
+		item := m.heap.items[0].mergingIterLevel
 
 		// The levelIter internal iterator will interleave exclusive sentinel
 		// keys to keep files open until their range deletions are no longer
@@ -861,7 +861,7 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterLevel) (bool, error) {
 // returns a nil internal key.
 func (m *mergingIter) findPrevEntry() *base.InternalKV {
 	for m.heap.len() > 0 && m.err == nil {
-		item := m.heap.items[0]
+		item := m.heap.items[0].mergingIterLevel
 
 		// The levelIter internal iterator will interleave exclusive sentinel
 		// keys to keep files open until their range deletions are no longer
@@ -1186,7 +1186,7 @@ func (m *mergingIter) Next() *base.InternalKV {
 	// mode. During prefix iteration mode, we rely on the caller to not call
 	// Next if the iterator has already advanced beyond the iteration prefix.
 	// See the comment above the base.InternalIterator interface.
-	if m.err = m.nextEntry(m.heap.items[0], nil /* succKey */); m.err != nil {
+	if m.err = m.nextEntry(m.heap.items[0].mergingIterLevel, nil /* succKey */); m.err != nil {
 		return nil
 	}
 
@@ -1216,7 +1216,7 @@ func (m *mergingIter) NextPrefix(succKey []byte) *base.InternalKV {
 
 	// The heap root necessarily must be positioned at a key < succKey, because
 	// NextPrefix was invoked.
-	root := m.heap.items[0]
+	root := m.heap.items[0].mergingIterLevel
 	if invariants.Enabled && m.heap.cmp((*root).iterKV.K.UserKey, succKey) >= 0 {
 		m.logger.Fatalf("pebble: invariant violation: NextPrefix(%q) called on merging iterator already positioned at %q",
 			succKey, (*root).iterKV)
@@ -1234,7 +1234,7 @@ func (m *mergingIter) NextPrefix(succKey []byte) *base.InternalKV {
 	m.levelsPositioned[root.index] = root.iterKV == nil || !root.iterKV.K.IsExclusiveSentinel()
 
 	for m.heap.len() > 0 {
-		root := m.heap.items[0]
+		root := m.heap.items[0].mergingIterLevel
 		if m.levelsPositioned[root.index] {
 			// A level we've previously positioned is at the top of the heap, so
 			// there are no other levels positioned at keys < succKey. We've
@@ -1288,7 +1288,7 @@ func (m *mergingIter) Prev() *base.InternalKV {
 	if m.heap.len() == 0 {
 		return nil
 	}
-	if m.err = m.prevEntry(m.heap.items[0]); m.err != nil {
+	if m.err = m.prevEntry(m.heap.items[0].mergingIterLevel); m.err != nil {
 		return nil
 	}
 	return m.findPrevEntry()

--- a/merging_iter_heap.go
+++ b/merging_iter_heap.go
@@ -4,15 +4,32 @@
 
 package pebble
 
+import "github.com/cockroachdb/pebble/internal/invariants"
+
 // mergingIterHeap is a heap of mergingIterLevels. It only reads
 // mergingIterLevel.iterKV.K.
 //
 // REQUIRES: Every mergingIterLevel.iterKV is non-nil.
+//
+// TODO(sumeer): consider using golang generics.
 type mergingIterHeap struct {
 	cmp     Compare
 	reverse bool
-	items   []*mergingIterLevel
+	items   []mergingIterHeapItem
 }
+
+type mergingIterHeapItem struct {
+	*mergingIterLevel
+	winnerChild winnerChild
+}
+
+type winnerChild uint8
+
+const (
+	winnerChildUnknown winnerChild = iota
+	winnerChildLeft
+	winnerChildRight
+)
 
 // len returns the number of elements in the heap.
 func (h *mergingIterHeap) len() int {
@@ -41,7 +58,8 @@ func (h *mergingIterHeap) less(i, j int) bool {
 
 // swap is an internal method, used to swap the elements at i and j.
 func (h *mergingIterHeap) swap(i, j int) {
-	h.items[i], h.items[j] = h.items[j], h.items[i]
+	h.items[i].mergingIterLevel, h.items[j].mergingIterLevel =
+		h.items[j].mergingIterLevel, h.items[i].mergingIterLevel
 }
 
 // init initializes the heap.
@@ -63,10 +81,14 @@ func (h *mergingIterHeap) fixTop() {
 func (h *mergingIterHeap) pop() *mergingIterLevel {
 	n := h.len() - 1
 	h.swap(0, n)
+	// Parent of n does not know which child is the winner. But since index n is
+	// removed, the parent of n will have at most one child, and so the value of
+	// winnerChild is irrelevant, and we don't need to do:
+	//  h.items[(n-1)/2].winnerChild = winnerChildUnknown
 	h.down(0, n)
 	item := h.items[n]
 	h.items = h.items[:n]
-	return item
+	return item.mergingIterLevel
 }
 
 // down is an internal method. It moves i down the heap, which has length n,
@@ -78,13 +100,34 @@ func (h *mergingIterHeap) down(i, n int) {
 			break
 		}
 		j := j1 // left child
-		if j2 := j1 + 1; j2 < n && h.less(j2, j1) {
-			j = j2 // = 2*i + 2  // right child
+		if j2 := j1 + 1; j2 < n {
+			if h.items[i].winnerChild == winnerChildUnknown {
+				if h.less(j2, j1) {
+					h.items[i].winnerChild = winnerChildRight
+				} else {
+					h.items[i].winnerChild = winnerChildLeft
+				}
+			} else if invariants.Enabled {
+				wc := winnerChildUnknown
+				if h.less(j1, j2) {
+					wc = winnerChildLeft
+				} else if h.less(j2, j1) {
+					wc = winnerChildRight
+				}
+				if wc != winnerChildUnknown && wc != h.items[i].winnerChild {
+					panic("winnerChild mismatch")
+				}
+			}
+			if h.items[i].winnerChild == winnerChildRight {
+				j = j2 // = 2*i + 2  // right child
+			}
 		}
 		if !h.less(j, i) {
 			break
 		}
+		// NB: j is a child of i.
 		h.swap(i, j)
+		h.items[i].winnerChild = winnerChildUnknown
 		i = j
 	}
 }

--- a/merging_iter_heap_test.go
+++ b/merging_iter_heap_test.go
@@ -31,9 +31,11 @@ func TestMergingIterHeap(t *testing.T) {
 			}
 		}
 	}
-	levels := make([]*mergingIterLevel, 2+rng.IntN(15))
+	// Memtable + 5 populated levels = 6 is the baseline. All levels populated +
+	// memtable + batch = 9.
+	levels := make([]mergingIterHeapItem, 6+rng.IntN(6))
 	for i := range levels {
-		levels[i] = &mergingIterLevel{
+		levels[i].mergingIterLevel = &mergingIterLevel{
 			index: i,
 			iterKV: &base.InternalKV{
 				K: InternalKey{
@@ -78,17 +80,99 @@ func TestMergingIterHeap(t *testing.T) {
 	}
 	heap.init()
 	checkHeap()
-	for i := 0; i < 50 && heap.len() > 0; i++ {
+	for i := 0; i < 400 && heap.len() > 0; i++ {
 		t.Logf("heap len: %d", heap.len())
-		if rng.IntN(10) == 0 {
+		if rn := rng.IntN(100); rn <= 1 {
+			// 1% of the cases, the iterator is exhausted.
 			t.Logf("%d: popping heap index %d", i, heap.items[0].index)
 			heap.items[0].iterKV = nil
 			heap.pop()
-		} else {
+		} else if rn <= 16 {
+			// 15% of the cases, change the key of the top element. It will stay the
+			// top in only 25% of these, so 11.25% will change the top of the heap.
 			t.Logf("%d: fixing heap", i)
 			heap.items[0].iterKV.K.UserKey = makeKey()
 			heap.fixTop()
+		} else {
+			t.Logf("%d: noop fixing heap", i)
+			heap.fixTop()
 		}
+		checkHeap()
+	}
+}
+
+// TestMergingIterHeapInit only measures the comparison savings during init,
+// with uniform random keys. There is a ~3.7% saving, with the following being
+// a representative result: cmp needed=104325 called=100416(frac=0.9625).
+func TestMergingIterHeapInit(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Logf("Using seed %d", seed)
+	rng := rand.New(rand.NewPCG(0, uint64(seed)))
+
+	generatedKeys := map[string]struct{}{}
+	// Generates unique keys.
+	makeKey := func() []byte {
+		n := 10 + rng.IntN(20)
+		key := make([]byte, n)
+		for {
+			randStr(key, rng)
+			if _, ok := generatedKeys[string(key)]; ok {
+				continue
+			} else {
+				generatedKeys[string(key)] = struct{}{}
+				return key
+			}
+		}
+	}
+	for k := 0; k < 10000; k++ {
+		// Memtable + 5 populated levels = 6 is the baseline. All levels populated +
+		// memtable + batch = 9.
+		levels := make([]mergingIterHeapItem, 6+rng.IntN(6))
+		for i := range levels {
+			levels[i].mergingIterLevel = &mergingIterLevel{
+				index: i,
+				iterKV: &base.InternalKV{
+					K: InternalKey{
+						UserKey: makeKey(),
+					},
+				},
+			}
+		}
+		heap := mergingIterHeap{
+			cmp:     base.DefaultComparer.Compare,
+			reverse: rng.IntN(2) != 0,
+			items:   slices.Clone(levels),
+		}
+		checkHeap := func() {
+			for _, item := range heap.items {
+				require.NotNil(t, levels[item.index].iterKV)
+			}
+			count := 0
+			minIndex := 0
+			for i, item := range levels {
+				if item.iterKV == nil {
+					continue
+				}
+				if count == 0 {
+					minIndex = i
+				} else {
+					cmp := heap.cmp(item.iterKV.K.UserKey, levels[minIndex].iterKV.K.UserKey)
+					if (cmp < 0 && !heap.reverse) || (cmp > 0 && heap.reverse) {
+						minIndex = i
+					} else if cmp == 0 {
+						panic("test generated duplicate keys")
+					}
+				}
+				count++
+			}
+			if count == 0 {
+				require.Equal(t, 0, heap.len())
+			} else {
+				require.Equal(t, count, heap.len())
+				require.Equal(t, levels[minIndex].index, heap.items[0].index)
+			}
+		}
+		heap.init()
 		checkHeap()
 	}
 }


### PR DESCRIPTION
The comparisons are reduced by remembering which child was the winner in the comparison between two children. This can help both in the case where the top of the heap advances, and needs to compare with the children (and wins against the children), and when pushing down due to a loss. The latter happens in two cases:

- When building the heap, since the building starts from the lowest interior nodes and proceed upwards -- a node that loses to an interior child node will be pushed down, and that interior child node already knows which of its children is the winner. TestMergingIterHeapInit shows that this can save ~3.7% of the comparisons.
- When fixing the top that loses to one of the children and is pushed down.

To never do more comparisons than a regular heap, we allow for the case where the winning child is unknown.

With TestMergingIterHeap, one can see cmp reductions of ~40%.

There are some low-level cons with this optimization:
- The heap element sizeof increases to 16 bytes.
- There is more branching because we have to accommodate the case of the winning chid being unknown.
- There is more writing to record the state.

The existing benchmarks use tiny 8 byte keys, so are more susceptible to these cons, and don't show any improvement. In contrast, the new benchmark MergingIterSeekAndNextWithDominantL6AndLongKey shows an improvement even with tiny keys since L6 stays at the top of the heap, and shows an improvement of 45% with longer keys.

                                                               │     sec/op      │    sec/op     vs base                │
MergingIterSeekGE/restart=16/count=1-10                              463.4n ± 8%   464.1n ±  4%        ~ (p=0.542 n=10)
MergingIterSeekGE/restart=16/count=2-10                              939.7n ± 2%   991.2n ±  4%   +5.49% (p=0.000 n=10)
MergingIterSeekGE/restart=16/count=3-10                              1.604µ ± 3%   1.512µ ±  7%        ~ (p=0.138 n=10)
MergingIterSeekGE/restart=16/count=4-10                              2.101µ ± 5%   2.126µ ±  3%        ~ (p=0.739 n=10)
MergingIterSeekGE/restart=16/count=5-10                              2.726µ ± 2%   2.864µ ±  8%   +5.04% (p=0.034 n=10)
MergingIterNext/restart=16/count=1-10                                21.07n ± 4%   20.72n ±  2%   -1.68% (p=0.012 n=10)
MergingIterNext/restart=16/count=2-10                                31.69n ± 0%   31.95n ±  0%   +0.82% (p=0.001 n=10)
MergingIterNext/restart=16/count=3-10                                40.27n ± 3%   40.35n ±  1%        ~ (p=0.754 n=10)
MergingIterNext/restart=16/count=4-10                                45.36n ± 1%   45.86n ±  1%   +1.11% (p=0.001 n=10)
MergingIterNext/restart=16/count=5-10                                52.72n ± 1%   52.79n ±  1%        ~ (p=0.447 n=10)
MergingIterPrev/restart=16/count=1-10                                29.41n ± 0%   29.02n ±  1%   -1.34% (p=0.001 n=10)
MergingIterPrev/restart=16/count=2-10                                41.59n ± 2%   41.56n ±  1%        ~ (p=0.726 n=10)
MergingIterPrev/restart=16/count=3-10                                49.33n ± 1%   49.75n ±  3%   +0.85% (p=0.019 n=10)
MergingIterPrev/restart=16/count=4-10                                54.37n ± 1%   55.01n ±  1%   +1.18% (p=0.000 n=10)
MergingIterPrev/restart=16/count=5-10                                59.40n ± 1%   60.77n ±  3%   +2.31% (p=0.000 n=10)
MergingIterSeqSeekGEWithBounds/levelCount=5-10                       452.6n ± 1%   451.2n ±  0%   -0.30% (p=0.045 n=10)
MergingIterSeqSeekPrefixGE/skip=1/use-next=false-10                  358.1n ± 2%   363.4n ±  2%        ~ (p=0.075 n=10)
MergingIterSeqSeekPrefixGE/skip=1/use-next=true-10                   227.4n ± 2%   228.9n ±  0%        ~ (p=0.109 n=10)
MergingIterSeqSeekPrefixGE/skip=2/use-next=false-10                  358.6n ± 0%   364.7n ±  2%   +1.73% (p=0.009 n=10)
MergingIterSeqSeekPrefixGE/skip=2/use-next=true-10                   226.9n ± 0%   228.4n ±  4%   +0.64% (p=0.002 n=10)
MergingIterSeqSeekPrefixGE/skip=4/use-next=false-10                  358.8n ± 1%   360.4n ±  0%   +0.43% (p=0.022 n=10)
MergingIterSeqSeekPrefixGE/skip=4/use-next=true-10                   226.9n ± 0%   231.5n ±  8%   +2.05% (p=0.000 n=10)
MergingIterSeqSeekPrefixGE/skip=8/use-next=false-10                  360.1n ± 0%   369.2n ±  1%   +2.51% (p=0.000 n=10)
MergingIterSeqSeekPrefixGE/skip=8/use-next=true-10                   227.5n ± 1%   233.9n ±  2%   +2.79% (p=0.000 n=10)
MergingIterSeqSeekPrefixGE/skip=16/use-next=false-10                 373.4n ± 3%   370.2n ±  1%        ~ (p=0.470 n=10)
MergingIterSeqSeekPrefixGE/skip=16/use-next=true-10                  231.2n ± 1%   234.3n ±  1%   +1.32% (p=0.007 n=10)

MergingIterSeekAndNextWithDominantL6AndLongKey/key-prefix=0-10       8.811m ± 1%   6.030m ± 0%  -31.56% (p=0.000 n=10)
MergingIterSeekAndNextWithDominantL6AndLongKey/key-prefix=20-10     11.735m ± 0%   7.379m ± 0%  -37.13% (p=0.000 n=10)
MergingIterSeekAndNextWithDominantL6AndLongKey/key-prefix=50-10     16.932m ± 1%   9.082m ± 0%  -46.36% (p=0.000 n=10)
MergingIterSeekAndNextWithDominantL6AndLongKey/key-prefix=100-10     24.20m ± 1%   13.08m ± 0%  -45.94% (p=0.000 n=10)

Fixes #2202