### PR TITLE
colblk: add more bound checks

### DIFF
--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -49,3 +49,7 @@ func (*Value[V]) Get() V {
 
 // Set the value; no-op in non-invariant builds.
 func (*Value[V]) Set(v V) {}
+
+// CheckBounds panics if the index is not in the range [0, n). No-op in
+// non-invariant builds.
+func CheckBounds(i int, n int) {}

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -6,7 +6,10 @@
 
 package invariants
 
-import "math/rand/v2"
+import (
+	"fmt"
+	"math/rand/v2"
+)
 
 // Sometimes returns true percent% of the time if invariants are Enabled (i.e.
 // we were built with the "invariants" or "race" build tags). Otherwise, always
@@ -71,4 +74,12 @@ func (v *Value[V]) Get() V {
 // Set the value; no-op in non-invariant builds.
 func (v *Value[V]) Set(inner V) {
 	v.v = inner
+}
+
+// CheckBounds panics if the index is not in the range [0, n). No-op in
+// non-invariant builds.
+func CheckBounds(i int, n int) {
+	if i < 0 || i >= n {
+		panic(fmt.Sprintf("index %d out of bounds [0, %d)", i, n))
+	}
 }

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -1336,6 +1336,7 @@ func (i *DataBlockIter) Next() *base.InternalKV {
 			i.kv.K.SetSeqNum(base.SeqNum(n))
 		}
 	}
+	invariants.CheckBounds(i.row, i.d.values.slices)
 	// Inline i.d.values.At(row).
 	v := i.d.values.slice(i.d.values.offsets.At2(i.row))
 	if i.d.isValueExternal.At(i.row) {
@@ -1504,9 +1505,10 @@ func (i *DataBlockIter) decodeRow() *base.InternalKV {
 				i.kv.K.SetSeqNum(base.SeqNum(n))
 			}
 		}
+		invariants.CheckBounds(i.row, i.d.values.slices)
 		// Inline i.d.values.At(row).
-		startOffset := i.d.values.offsets.At(i.row)
-		v := unsafe.Slice((*byte)(i.d.values.ptr(startOffset)), i.d.values.offsets.At(i.row+1)-startOffset)
+		v := i.d.values.slice(i.d.values.offsets.At2(i.row))
+		invariants.CheckBounds(i.row, i.d.values.slices)
 		if i.d.isValueExternal.At(i.row) {
 			i.kv.V = i.getLazyValuer.GetInternalValueForPrefixAndValueHandle(v)
 		} else {

--- a/sstable/colblk/raw_bytes.go
+++ b/sstable/colblk/raw_bytes.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/pebble/internal/binfmt"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 )
 
@@ -117,6 +118,7 @@ func (b *RawBytes) slice(start, end uint32) []byte {
 
 // At returns the []byte at index i. The returned slice should not be mutated.
 func (b RawBytes) At(i int) []byte {
+	invariants.CheckBounds(i, b.slices)
 	return b.slice(b.offsets.At2(i))
 }
 


### PR DESCRIPTION
Add invariants-only bound checking, especially before accessing
`UnsafeOffset`s. We also change to using `At2()` instead of two `At()`
calls in a few places.