### PR TITLE
crl-release-25.2: sstable: only support MinLZ for v6+ tables

### DIFF
--- a/db.go
+++ b/db.go
@@ -2084,7 +2084,7 @@ func (d *DB) Metrics() *Metrics {
 		metrics.Table.CompressedCountUnknown += int64(compressionTypes.unknown)
 		metrics.Table.CompressedCountSnappy += int64(compressionTypes.snappy)
 		metrics.Table.CompressedCountZstd += int64(compressionTypes.zstd)
-		metrics.Table.CompressedCountMinlz += int64(compressionTypes.minlz)
+		metrics.Table.CompressedCountMinLZ += int64(compressionTypes.minlz)
 		metrics.Table.CompressedCountNone += int64(compressionTypes.none)
 	}
 

--- a/metrics.go
+++ b/metrics.go
@@ -304,7 +304,7 @@ type Metrics struct {
 		// The number of sstables that are compressed with zstd.
 		CompressedCountZstd int64
 		// The number of sstables that are compressed with minlz.
-		CompressedCountMinlz int64
+		CompressedCountMinLZ int64
 		// The number of sstables that are uncompressed.
 		CompressedCountNone int64
 
@@ -649,7 +649,7 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 	if count := m.Table.CompressedCountZstd; count > 0 {
 		w.Printf(" zstd: %d", redact.Safe(count))
 	}
-	if count := m.Table.CompressedCountMinlz; count > 0 {
+	if count := m.Table.CompressedCountMinLZ; count > 0 {
 		w.Printf(" minlz: %d", redact.Safe(count))
 	}
 	if count := m.Table.CompressedCountNone; count > 0 {

--- a/options.go
+++ b/options.go
@@ -48,7 +48,7 @@ const (
 	NoCompression      = block.NoCompression
 	SnappyCompression  = block.SnappyCompression
 	ZstdCompression    = block.ZstdCompression
-	MinlzCompression   = block.MinlzCompression
+	MinLZCompression   = block.MinLZCompression
 )
 
 // FilterType exports the base.FilterType type.
@@ -1949,8 +1949,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 					l.Compression = func() Compression { return SnappyCompression }
 				case "ZSTD":
 					l.Compression = func() Compression { return ZstdCompression }
-				case "Minlz":
-					l.Compression = func() Compression { return MinlzCompression }
+				case "MinLZ":
+					l.Compression = func() Compression { return MinLZCompression }
 				default:
 					return errors.Errorf("pebble: unknown compression: %q", errors.Safe(value))
 				}

--- a/options.go
+++ b/options.go
@@ -48,7 +48,9 @@ const (
 	NoCompression      = block.NoCompression
 	SnappyCompression  = block.SnappyCompression
 	ZstdCompression    = block.ZstdCompression
-	MinLZCompression   = block.MinLZCompression
+	// MinLZCompression is only supported with table formats v6+. Older formats
+	// fall back to snappy.
+	MinLZCompression = block.MinLZCompression
 )
 
 // FilterType exports the base.FilterType type.

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -25,7 +25,7 @@ const (
 	NoCompression
 	SnappyCompression
 	ZstdCompression
-	MinlzCompression
+	MinLZCompression
 	NCompression
 )
 
@@ -41,8 +41,8 @@ func (c Compression) String() string {
 		return "Snappy"
 	case ZstdCompression:
 		return "ZSTD"
-	case MinlzCompression:
-		return "Minlz"
+	case MinLZCompression:
+		return "MinLZ"
 	default:
 		return "Unknown"
 	}
@@ -60,8 +60,8 @@ func CompressionFromString(s string) Compression {
 		return SnappyCompression
 	case "ZSTD":
 		return ZstdCompression
-	case "Minlz":
-		return MinlzCompression
+	case "MinLZ":
+		return MinLZCompression
 	default:
 		return DefaultCompression
 	}
@@ -89,7 +89,7 @@ const (
 	Lz4hcCompressionIndicator  CompressionIndicator = 5
 	XpressCompressionIndicator CompressionIndicator = 6
 	ZstdCompressionIndicator   CompressionIndicator = 7
-	MinlzCompressionIndicator  CompressionIndicator = 8
+	MinLZCompressionIndicator  CompressionIndicator = 8
 )
 
 // String implements fmt.Stringer.

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -25,6 +25,8 @@ const (
 	NoCompression
 	SnappyCompression
 	ZstdCompression
+	// MinLZCompression is only supported with table formats v6+. Older formats
+	// fall back to snappy.
 	MinLZCompression
 	NCompression
 )

--- a/sstable/block/compression_test.go
+++ b/sstable/block/compression_test.go
@@ -140,8 +140,8 @@ func TestBufferRandomized(t *testing.T) {
 	}
 }
 
-func TestMinlzEncodingLimit(t *testing.T) {
-	// Tests that Minlz compression has a strict limit of minlz.MaxBlockSize: 8<<20 (8MiB)
+func TestMinLZEncodingLimit(t *testing.T) {
+	// Tests that MinLZ compression has a strict limit of minlz.MaxBlockSize: 8<<20 (8MiB)
 	_, err := minlz.Encode([]byte{}, bytes.Repeat([]byte{0}, minlz.MaxBlockSize-1), minlz.LevelFastest)
 	require.NoError(t, err)
 	_, err = minlz.Encode([]byte{}, bytes.Repeat([]byte{0}, minlz.MaxBlockSize), minlz.LevelFastest)
@@ -151,12 +151,12 @@ func TestMinlzEncodingLimit(t *testing.T) {
 		require.Fail(t, "Expected minlz.ErrTooLarge Error")
 	}
 
-	c := GetCompressor(MinlzCompression)
+	c := GetCompressor(MinLZCompression)
 	defer c.Close()
 	algo, _ := c.Compress([]byte{}, bytes.Repeat([]byte{0}, minlz.MaxBlockSize-1))
-	require.Equal(t, algo, MinlzCompressionIndicator)
+	require.Equal(t, algo, MinLZCompressionIndicator)
 	algo, _ = c.Compress([]byte{}, bytes.Repeat([]byte{0}, minlz.MaxBlockSize))
-	require.Equal(t, algo, MinlzCompressionIndicator)
+	require.Equal(t, algo, MinLZCompressionIndicator)
 	algo, _ = c.Compress([]byte{}, bytes.Repeat([]byte{0}, minlz.MaxBlockSize+1))
 	require.Equal(t, algo, SnappyCompressionIndicator)
 }

--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -38,7 +38,7 @@ func (snappyCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte)
 func (snappyCompressor) Close() {}
 
 func (minlzCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte) {
-	// Minlz cannot encode blocks greater than 8MB. Fall back to Snappy in those cases.
+	// MinLZ cannot encode blocks greater than 8MB. Fall back to Snappy in those cases.
 	if len(src) > minlz.MaxBlockSize {
 		return (snappyCompressor{}).Compress(dst, src)
 	}
@@ -47,7 +47,7 @@ func (minlzCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte) 
 	if err != nil {
 		panic(errors.Wrap(err, "minlz compression"))
 	}
-	return MinlzCompressionIndicator, compressed
+	return MinLZCompressionIndicator, compressed
 }
 
 func (minlzCompressor) Close() {}
@@ -60,7 +60,7 @@ func GetCompressor(c Compression) Compressor {
 		return snappyCompressor{}
 	case ZstdCompression:
 		return getZstdCompressor()
-	case MinlzCompression:
+	case MinLZCompression:
 		return minlzCompressor{}
 	default:
 		panic("Invalid compression type.")
@@ -155,7 +155,7 @@ func GetDecompressor(c CompressionIndicator) Decompressor {
 		return snappyDecompressor{}
 	case ZstdCompressionIndicator:
 		return getZstdDecompressor()
-	case MinlzCompressionIndicator:
+	case MinLZCompressionIndicator:
 		return minlzDecompressor{}
 	default:
 		panic("Invalid compression type.")

--- a/sstable/format.go
+++ b/sstable/format.go
@@ -29,7 +29,7 @@ const (
 	TableFormatPebblev3 // Value blocks.
 	TableFormatPebblev4 // DELSIZED tombstones.
 	TableFormatPebblev5 // Columnar blocks.
-	TableFormatPebblev6 // Checksum footer + blob value handles + columnar metaindex.
+	TableFormatPebblev6 // Checksum footer + blob value handles + columnar metaindex + MinLZ compression support.
 	NumTableFormats
 
 	TableFormatMax = NumTableFormats - 1

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -330,9 +330,6 @@ func (o WriterOptions) ensureDefaults() WriterOptions {
 	if o.Comparer == nil {
 		o.Comparer = base.DefaultComparer
 	}
-	if o.Compression <= block.DefaultCompression || o.Compression >= block.NCompression {
-		o.Compression = block.SnappyCompression
-	}
 	if o.IndexBlockSize <= 0 {
 		o.IndexBlockSize = o.BlockSize
 	}
@@ -356,6 +353,10 @@ func (o WriterOptions) ensureDefaults() WriterOptions {
 	if o.KeySchema == nil && o.TableFormat.BlockColumnar() {
 		s := colblk.DefaultKeySchema(o.Comparer, 16 /* bundle size */)
 		o.KeySchema = &s
+	}
+	if o.Compression <= block.DefaultCompression || o.Compression >= block.NCompression ||
+		(o.Compression == block.MinLZCompression && o.TableFormat < TableFormatPebblev6) {
+		o.Compression = block.SnappyCompression
 	}
 	return o
 }

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -308,6 +308,16 @@ func ParseWriterOptions[StringOrStringer any](o *WriterOptions, args ...StringOr
 		case "format", "leveldb":
 			return errors.Errorf("%q is deprecated", key)
 
+		case "compression":
+			o.Compression, err = func() (block.Compression, error) {
+				for c := block.DefaultCompression; c < block.NCompression; c++ {
+					if strings.EqualFold(c.String(), value) {
+						return c, nil
+					}
+				}
+				return 0, errors.Errorf("unknown compression %q", value)
+			}()
+
 		default:
 			// TODO(radu): ignoring unknown keys is error-prone; we need to find an
 			// easy way for the upper layer to extract its own arguments.

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -342,3 +342,24 @@ close
 ----
 point:    [a@2#1,SET-b@2#1,SET]
 seqnums:  [1-1]
+
+build compression=zstd
+a.SET.1:thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydog
+----
+point:    [a#1,SET-a#1,SET]
+seqnums:  [1-1]
+
+props rocksdb.compression
+----
+rocksdb.compression: ZSTD
+
+# MinLZ is not supported in v5; we should fall back to Snappy.
+build compression=minlz
+a.SET.1:thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydog
+----
+point:    [a#1,SET-a#1,SET]
+seqnums:  [1-1]
+
+props rocksdb.compression
+----
+rocksdb.compression: Snappy

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -365,3 +365,24 @@ close
 ----
 point:    [a@2#1,SET-b@2#1,SET]
 seqnums:  [1-1]
+
+build compression=zstd
+a.SET.1:thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydog
+----
+point:    [a#1,SET-a#1,SET]
+seqnums:  [1-1]
+
+props rocksdb.compression
+----
+rocksdb.compression: ZSTD
+
+# MinLZ is supported in v6.
+build compression=minlz
+a.SET.1:thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydog
+----
+point:    [a#1,SET-a#1,SET]
+seqnums:  [1-1]
+
+props rocksdb.compression
+----
+rocksdb.compression: MinLZ

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -1240,7 +1240,7 @@ func runWriterBench(b *testing.B, keys [][]byte, comparer *base.Comparer, format
 		b.Run(fmt.Sprintf("block=%s", humanize.Bytes.Int64(int64(bs))), func(b *testing.B) {
 			for _, filter := range []bool{true, false} {
 				b.Run(fmt.Sprintf("filter=%t", filter), func(b *testing.B) {
-					for _, comp := range []block.Compression{block.NoCompression, block.SnappyCompression, block.ZstdCompression, block.MinlzCompression} {
+					for _, comp := range []block.Compression{block.NoCompression, block.SnappyCompression, block.ZstdCompression, block.MinLZCompression} {
 						b.Run(fmt.Sprintf("compression=%s", comp), func(b *testing.B) {
 							opts := WriterOptions{
 								BlockRestartInterval: 16,

--- a/table_stats.go
+++ b/table_stats.go
@@ -1078,7 +1078,7 @@ func (a compressionTypeAggregator) Accumulate(
 		dst.snappy++
 	case ZstdCompression:
 		dst.zstd++
-	case MinlzCompression:
+	case MinLZCompression:
 		dst.minlz++
 	case NoCompression:
 		dst.none++


### PR DESCRIPTION
#### rename Minlz to MinLZ


#### sstable: only support MinLZ for v6+ tables

We fall back to Snappy for older formats.

Fixes #4633