### PR TITLE
manifest: ensure TableMetadata.{Smallest,Largest} inline

### DIFF
--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -728,24 +728,26 @@ func (s *l0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 
 	for f := range s.levelMetadata.All() {
 		if invariants.Enabled {
-			if !bytes.Equal(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest().UserKey) {
+			bounds := f.UserKeyBounds()
+			if !bytes.Equal(s.orderedIntervals[f.minIntervalIndex].startKey.key, bounds.Start) {
 				panic(fmt.Sprintf("f.minIntervalIndex in TableMetadata out of sync with intervals in L0Sublevels: %s != %s",
-					s.formatKey(s.orderedIntervals[f.minIntervalIndex].startKey.key), s.formatKey(f.Smallest().UserKey)))
+					s.formatKey(s.orderedIntervals[f.minIntervalIndex].startKey.key), s.formatKey(bounds.Start)))
 			}
-			if !bytes.Equal(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest().UserKey) {
+			if !bytes.Equal(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, bounds.End.Key) {
 				panic(fmt.Sprintf("f.maxIntervalIndex in TableMetadata out of sync with intervals in L0Sublevels: %s != %s",
-					s.formatKey(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key), s.formatKey(f.Smallest().UserKey)))
+					s.formatKey(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key), s.formatKey(bounds.Start)))
 			}
 		}
 		if !f.IsCompacting() {
 			continue
 		}
 		if invariants.Enabled {
-			if s.cmp(s.orderedIntervals[f.minIntervalIndex].startKey.key, f.Smallest().UserKey) != 0 ||
-				s.cmp(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, f.Largest().UserKey) != 0 {
+			bounds := f.UserKeyBounds()
+			if s.cmp(s.orderedIntervals[f.minIntervalIndex].startKey.key, bounds.Start) != 0 ||
+				s.cmp(s.orderedIntervals[f.maxIntervalIndex+1].startKey.key, bounds.End.Key) != 0 {
 				panic(fmt.Sprintf("file %s has inconsistent L0 Sublevel interval bounds: %s-%s, %s-%s", f.FileNum,
 					s.orderedIntervals[f.minIntervalIndex].startKey.key, s.orderedIntervals[f.maxIntervalIndex+1].startKey.key,
-					f.Smallest().UserKey, f.Largest().UserKey))
+					bounds.Start, bounds.End.Key))
 			}
 		}
 		for i := f.minIntervalIndex; i <= f.maxIntervalIndex; i++ {

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -56,10 +56,12 @@ func (ikr *InternalKeyBounds) SetInternalKeyBounds(smallest, largest InternalKey
 	ikr.userKeySeparatorIdx = len(smallest.UserKey)
 }
 
+//gcassert:inline
 func (ikr *InternalKeyBounds) SmallestUserKey() []byte {
 	return unsafe.Slice(unsafe.StringData(ikr.userKeyData), ikr.userKeySeparatorIdx)
 }
 
+//gcassert:inline
 func (ikr *InternalKeyBounds) Smallest() InternalKey {
 	return InternalKey{
 		UserKey: ikr.SmallestUserKey(),
@@ -67,11 +69,13 @@ func (ikr *InternalKeyBounds) Smallest() InternalKey {
 	}
 }
 
+//gcassert:inline
 func (ikr *InternalKeyBounds) LargestUserKey() []byte {
 	largestStart := unsafe.StringData(ikr.userKeyData[ikr.userKeySeparatorIdx:])
 	return unsafe.Slice(largestStart, len(ikr.userKeyData)-ikr.userKeySeparatorIdx)
 }
 
+//gcassert:inline
 func (ikr *InternalKeyBounds) Largest() InternalKey {
 	ik := InternalKey{
 		UserKey: ikr.LargestUserKey(),
@@ -1195,34 +1199,26 @@ func (m *TableMetadata) cmpSmallestKey(b *TableMetadata, cmp Compare) int {
 
 // Smallest returns the smallest key based on the bound type of
 // boundTypeSmallest.
+//
+//gcassert:inline
 func (m *TableMetadata) Smallest() InternalKey {
-	switch m.boundTypeSmallest {
-	case boundTypePointKey:
-		return m.PointKeyBounds.Smallest()
-	case boundTypeRangeKey:
-		if !m.HasRangeKeys {
-			return InternalKey{}
-		}
-		return m.RangeKeyBounds.Smallest()
-	default:
-		return InternalKey{}
+	x := &m.PointKeyBounds
+	if m.boundTypeSmallest == boundTypeRangeKey {
+		x = m.RangeKeyBounds
 	}
+	return x.Smallest()
 }
 
 // Largest returns the largest key based on the bound type of
 // boundTypeLargest.
+//
+//gcassert:inline
 func (m *TableMetadata) Largest() InternalKey {
-	switch m.boundTypeLargest {
-	case boundTypePointKey:
-		return m.PointKeyBounds.Largest()
-	case boundTypeRangeKey:
-		if !m.HasRangeKeys {
-			return InternalKey{}
-		}
-		return m.RangeKeyBounds.Largest()
-	default:
-		return InternalKey{}
+	x := &m.PointKeyBounds
+	if m.boundTypeLargest == boundTypeRangeKey {
+		x = m.RangeKeyBounds
 	}
+	return x.Largest()
 }
 
 // KeyRange returns the minimum smallest and maximum largest internalKey for

--- a/open_test.go
+++ b/open_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
@@ -1417,6 +1418,11 @@ func TestCheckConsistency(t *testing.T) {
 			FileNum: base.FileNum(fileNum),
 			Size:    uint64(size),
 		}
+		ik := base.InternalKey{
+			UserKey: binary.AppendUvarint([]byte(nil), uint64(fileNum)),
+			Trailer: base.MakeTrailer(base.SeqNum(fileNum), base.InternalKeyKindSet),
+		}
+		m.ExtendPointKeyBounds(testkeys.Comparer.Compare, ik, ik)
 		m.InitPhysicalBacking()
 		return m, nil
 	}


### PR DESCRIPTION
In a Pebble ycsb/C benchmark, 1.83% of CPU was spent in (*TableMetadata).Largest. These functions were just barely over the budget to be inlined. This commit refactors these functions to ensure they're inlined and adds gcassert assertions to ensure they remain inlined.