### PR TITLE
crl-release-24.1: sstable: fix deletion properties for virtual tables

### DIFF
--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -9,3 +9,17 @@ package invariants
 
 // Enabled is true if we were built with the "invariants" or "race" build tags.
 const Enabled = false
+
+// SafeSub returns a - b. If a < b, it panics in invariant builds and returns 0
+// in non-invariant builds.
+func SafeSub[T Integer](a, b T) T {
+	if a < b {
+		return 0
+	}
+	return a - b
+}
+
+// Integer is a constraint that permits any integer type.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -7,5 +7,21 @@
 
 package invariants
 
+import "fmt"
+
 // Enabled is true if we were built with the "invariants" or "race" build tags.
 const Enabled = true
+
+// SafeSub returns a - b. If a < b, it panics in invariant builds and returns 0
+// in non-invariant builds.
+func SafeSub[T Integer](a, b T) T {
+	if a < b {
+		panic(fmt.Sprintf("underflow: %d - %d", a, b))
+	}
+	return a - b
+}
+
+// Integer is a constraint that permits any integer type.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/pebble/internal/intern"
+	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
 const propertiesBlockRestartInterval = math.MaxInt32
@@ -117,7 +118,7 @@ func (c *CommonProperties) String() string {
 // NumPointDeletions is the number of point deletions in the sstable. For virtual
 // sstables, this is an estimate.
 func (c *CommonProperties) NumPointDeletions() uint64 {
-	return c.NumDeletions - c.NumRangeDeletions
+	return invariants.SafeSub(c.NumDeletions, c.NumRangeDeletions)
 }
 
 // Properties holds the sstable property values. The properties are

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -143,3 +143,27 @@ props:
   rocksdb.num.entries: 1
   rocksdb.raw.key.size: 10
   rocksdb.raw.value.size: 2
+
+build
+a.DEL.1:
+b.DELSIZED.1:
+c.RANGEDEL.1:d
+----
+point:    [a#1,DEL-b#1,DELSIZED]
+rangedel: [c#1,RANGEDEL-d#72057594037927935,RANGEDEL]
+seqnums:  [1-1]
+
+# Verify that we get 3 deletions instead of 1 (because it has to be the sum of
+# its components).
+virtualize lower=a.DEL.1 upper=a0.SET.1 show-props
+----
+bounds:  [a#1,DEL-a0#1,SET]
+filenum: 000005
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 2
+  rocksdb.raw.value.size: 1
+  pebble.raw.point-tombstone.key.size: 1
+  pebble.num.deletions.sized: 1
+  rocksdb.deleted.keys: 3
+  rocksdb.num.range-deletions: 1

--- a/table_stats.go
+++ b/table_stats.go
@@ -649,6 +649,13 @@ func sanityCheckStats(meta *fileMetadata, logger Logger, info string) {
 
 	if meta.Stats.PointDeletionsBytesEstimate > maxDeletionBytesEstimate ||
 		meta.Stats.RangeDeletionsBytesEstimate > maxDeletionBytesEstimate {
+		if invariants.Enabled {
+			panic(fmt.Sprintf("%s: table %s has extreme deletion bytes estimates: point=%d range=%d",
+				info, meta.FileNum,
+				redact.Safe(meta.Stats.PointDeletionsBytesEstimate),
+				redact.Safe(meta.Stats.RangeDeletionsBytesEstimate),
+			))
+		}
 		if v := lastSanityCheckStatsLog.Load(); v == 0 || time.Since(processStartTime)-time.Duration(v) > 30*time.Second {
 			logger.Errorf("%s: table %s has extreme deletion bytes estimates: point=%d range=%d",
 				info, meta.FileNum,
@@ -770,7 +777,7 @@ func pointDeletionsBytesEstimate(
 
 	// 2b. Calculate the contribution of the KV entries shadowed by ordinary DEL
 	// keys.
-	numUnsizedDels := numPointDels - props.NumSizedDeletions
+	numUnsizedDels := invariants.SafeSub(numPointDels, props.NumSizedDeletions)
 	{
 		// The shadowed keys have the same exact user keys as the tombstones
 		// themselves, so we can use the `tombstonesLogicalSize` we computed


### PR DESCRIPTION
The independent scaling of `NumDeletions`, `NumRangeDeletions`,
`NumSizedDeletions` for virtual tables can lead to situations where
`NumRangeDeletions + NumSizedDeletions > NumDeletions`, which causes
underflows in compensated size calculations.

This change fixes the scaling code to scale the three "components" of
`NumDeletions` (range, sized, other) and then sum them.

We also add some safeguards around the subtractions - underflow now
causes panics in invariant builds and is capped to 0 in non-invariant
builds.

Fixes #4670