### PR TITLE
crl-release-25.2: sstable: fix deletion properties for virtual tables

### DIFF
--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -53,3 +53,17 @@ func (*Value[V]) Set(v V) {}
 // CheckBounds panics if the index is not in the range [0, n). No-op in
 // non-invariant builds.
 func CheckBounds(i int, n int) {}
+
+// SafeSub returns a - b. If a < b, it panics in invariant builds and returns 0
+// in non-invariant builds.
+func SafeSub[T Integer](a, b T) T {
+	if a < b {
+		return 0
+	}
+	return a - b
+}
+
+// Integer is a constraint that permits any integer type.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -83,3 +83,17 @@ func CheckBounds(i int, n int) {
 		panic(fmt.Sprintf("index %d out of bounds [0, %d)", i, n))
 	}
 }
+
+// SafeSub returns a - b. If a < b, it panics in invariant builds and returns 0
+// in non-invariant builds.
+func SafeSub[T Integer](a, b T) T {
+	if a < b {
+		panic(fmt.Sprintf("underflow: %d - %d", a, b))
+	}
+	return a - b
+}
+
+// Integer is a constraint that permits any integer type.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -15,6 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/pebble/internal/intern"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
 )
 
@@ -126,7 +127,7 @@ func (c *CommonProperties) String() string {
 // NumPointDeletions is the number of point deletions in the sstable. For virtual
 // sstables, this is an estimate.
 func (c *CommonProperties) NumPointDeletions() uint64 {
-	return c.NumDeletions - c.NumRangeDeletions
+	return invariants.SafeSub(c.NumDeletions, c.NumRangeDeletions)
 }
 
 // Properties holds the sstable property values. The properties are

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -70,24 +71,35 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 	scale := func(a uint64) uint64 {
 		return (a*p.Size + p.BackingSize - 1) / p.BackingSize
 	}
+	// It's important that no non-zero fields (like NumDeletions, NumRangeKeySets)
+	// become zero (or vice-versa).
+	if invariants.Enabled && (scale(1) != 1 || scale(0) != 0) {
+		panic("bad scale()")
+	}
 
-	v.Properties.RawKeySize = scale(reader.Properties.RawKeySize)
-	v.Properties.RawValueSize = scale(reader.Properties.RawValueSize)
-	v.Properties.NumEntries = scale(reader.Properties.NumEntries)
-	v.Properties.NumDeletions = scale(reader.Properties.NumDeletions)
-	v.Properties.NumRangeDeletions = scale(reader.Properties.NumRangeDeletions)
-	v.Properties.NumRangeKeyDels = scale(reader.Properties.NumRangeKeyDels)
-	v.Properties.NumDataBlocks = scale(reader.Properties.NumDataBlocks)
-	v.Properties.NumTombstoneDenseBlocks = scale(reader.Properties.NumTombstoneDenseBlocks)
+	physical := &reader.Properties
+	virtual := &v.Properties
 
-	// Note that we rely on NumRangeKeySets for correctness. If the sstable may
-	// contain range keys, then NumRangeKeySets must be > 0. ceilDiv works because
-	// meta.Size will not be 0 for virtual sstables.
-	v.Properties.NumRangeKeySets = scale(reader.Properties.NumRangeKeySets)
-	v.Properties.ValueBlocksSize = scale(reader.Properties.ValueBlocksSize)
-	v.Properties.NumSizedDeletions = scale(reader.Properties.NumSizedDeletions)
-	v.Properties.RawPointTombstoneKeySize = scale(reader.Properties.RawPointTombstoneKeySize)
-	v.Properties.RawPointTombstoneValueSize = scale(reader.Properties.RawPointTombstoneValueSize)
+	virtual.RawKeySize = scale(physical.RawKeySize)
+	virtual.RawValueSize = scale(physical.RawValueSize)
+	virtual.NumEntries = scale(physical.NumEntries)
+	virtual.NumDataBlocks = scale(physical.NumDataBlocks)
+	virtual.NumTombstoneDenseBlocks = scale(physical.NumTombstoneDenseBlocks)
+
+	virtual.NumRangeDeletions = scale(physical.NumRangeDeletions)
+	virtual.NumSizedDeletions = scale(physical.NumSizedDeletions)
+	// We cannot directly scale NumDeletions, because it is supposed to be the sum
+	// of various types of deletions. See #4670.
+	numOtherDeletions := scale(invariants.SafeSub(physical.NumDeletions, physical.NumRangeDeletions) + physical.NumSizedDeletions)
+	virtual.NumDeletions = numOtherDeletions + virtual.NumRangeDeletions + virtual.NumSizedDeletions
+
+	virtual.NumRangeKeyDels = scale(physical.NumRangeKeyDels)
+	virtual.NumRangeKeySets = scale(physical.NumRangeKeySets)
+
+	virtual.ValueBlocksSize = scale(physical.ValueBlocksSize)
+
+	virtual.RawPointTombstoneKeySize = scale(physical.RawPointTombstoneKeySize)
+	virtual.RawPointTombstoneValueSize = scale(physical.RawPointTombstoneValueSize)
 
 	v.Properties.CompressionName = reader.Properties.CompressionName
 

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -311,3 +311,28 @@ props:
   rocksdb.raw.value.size: 2
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
+
+build
+a.DEL.1:
+b.DELSIZED.1:
+Span: c-d:{(#1,RANGEDEL)}
+----
+point:    [a#1,DEL-b#1,DELSIZED]
+rangedel: [c#1,RANGEDEL-d#inf,RANGEDEL]
+seqnums:  [1-1]
+
+# Verify that we get 3 deletions instead of 1 (because it has to be the sum of
+# its components).
+virtualize lower=a.DEL.1 upper=a0.SET.1 show-props
+----
+bounds:  [a#1,DEL-a0#1,SET]
+filenum: 000009
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 2
+  pebble.raw.point-tombstone.key.size: 1
+  pebble.num.deletions.sized: 1
+  rocksdb.deleted.keys: 3
+  rocksdb.num.range-deletions: 1
+  rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy

--- a/table_stats.go
+++ b/table_stats.go
@@ -657,6 +657,13 @@ func sanityCheckStats(meta *tableMetadata, logger Logger, info string) {
 
 	if meta.Stats.PointDeletionsBytesEstimate > maxDeletionBytesEstimate ||
 		meta.Stats.RangeDeletionsBytesEstimate > maxDeletionBytesEstimate {
+		if invariants.Enabled {
+			panic(fmt.Sprintf("%s: table %s has extreme deletion bytes estimates: point=%d range=%d",
+				info, meta.FileNum,
+				redact.Safe(meta.Stats.PointDeletionsBytesEstimate),
+				redact.Safe(meta.Stats.RangeDeletionsBytesEstimate),
+			))
+		}
 		if v := lastSanityCheckStatsLog.Load(); v == 0 || v.Elapsed() > 30*time.Second {
 			logger.Errorf("%s: table %s has extreme deletion bytes estimates: point=%d range=%d",
 				info, meta.FileNum,
@@ -778,7 +785,7 @@ func pointDeletionsBytesEstimate(
 
 	// 2b. Calculate the contribution of the KV entries shadowed by ordinary DEL
 	// keys.
-	numUnsizedDels := numPointDels - props.NumSizedDeletions
+	numUnsizedDels := invariants.SafeSub(numPointDels, props.NumSizedDeletions)
 	{
 		// The shadowed keys have the same exact user keys as the tombstones
 		// themselves, so we can use the `tombstonesLogicalSize` we computed


### PR DESCRIPTION
The independent scaling of `NumDeletions`, `NumRangeDeletions`,
`NumSizedDeletions` for virtual tables can lead to situations where
`NumRangeDeletions + NumSizedDeletions > NumDeletions`, which causes
underflows in compensated size calculations.

This change fixes the scaling code to scale the three "components" of
`NumDeletions` (range, sized, other) and then sum them.

We also add some safeguards around the subtractions - underflow now
causes panics in invariant builds and is capped to 0 in non-invariant
builds.

Fixes #4670