### PR TITLE
sstable: fix deletion properties for virtual tables

### DIFF
--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -53,3 +53,17 @@ func (*Value[V]) Set(v V) {}
 // CheckBounds panics if the index is not in the range [0, n). No-op in
 // non-invariant builds.
 func CheckBounds(i int, n int) {}
+
+// SafeSub returns a - b. If a < b, it panics in invariant builds and returns 0
+// in non-invariant builds.
+func SafeSub[T Integer](a, b T) T {
+	if a < b {
+		return 0
+	}
+	return a - b
+}
+
+// Integer is a constraint that permits any integer type.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -83,3 +83,17 @@ func CheckBounds(i int, n int) {
 		panic(fmt.Sprintf("index %d out of bounds [0, %d)", i, n))
 	}
 }
+
+// SafeSub returns a - b. If a < b, it panics in invariant builds and returns 0
+// in non-invariant builds.
+func SafeSub[T Integer](a, b T) T {
+	if a < b {
+		panic(fmt.Sprintf("underflow: %d - %d", a, b))
+	}
+	return a - b
+}
+
+// Integer is a constraint that permits any integer type.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -319,3 +319,29 @@ props:
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
   rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
+
+build
+a.DEL.1:
+b.DELSIZED.1:
+Span: c-d:{(#1,RANGEDEL)}
+----
+point:    [a#1,DEL-b#1,DELSIZED]
+rangedel: [c#1,RANGEDEL-d#inf,RANGEDEL]
+seqnums:  [1-1]
+
+# Verify that we get 3 deletions instead of 1 (because it has to be the sum of
+# its components).
+virtualize lower=a.DEL.1 upper=a0.SET.1 show-props
+----
+bounds:  [a#1,DEL-a0#1,SET]
+filenum: 000009
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 2
+  pebble.raw.point-tombstone.key.size: 1
+  pebble.num.deletions.sized: 1
+  rocksdb.deleted.keys: 3
+  rocksdb.num.range-deletions: 1
+  rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;


### PR DESCRIPTION
The independent scaling of `NumDeletions`, `NumRangeDeletions`,
`NumSizedDeletions` for virtual tables can lead to situations where
`NumRangeDeletions + NumSizedDeletions > NumDeletions`, which causes
underflows in compensated size calculations.

This change fixes the scaling code to scale the three "components" of
`NumDeletions` (range, sized, other) and then sum them.

We also add some safeguards around the subtractions - underflow now
causes panics in invariant builds and is capped to 0 in non-invariant
builds.

Fixes #4670