### PR TITLE
manifest: avoid BlobReferences interface allocation

### DIFF
--- a/external_test.go
+++ b/external_test.go
@@ -12,7 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/cockroachkvs"
 	"github.com/cockroachdb/pebble/metamorphic"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/stretchr/testify/require"
@@ -116,4 +120,137 @@ type testWriter struct {
 func (w *testWriter) Write(b []byte) (int, error) {
 	w.t.Log(string(bytes.TrimSpace(b)))
 	return len(b), nil
+}
+
+func BenchmarkPointLookupSeparatedValues(b *testing.B) {
+	type config struct {
+		name string
+		buildSeparatedValuesDBOpts
+	}
+	configs := []config{
+		{
+			name: "keys=10m,valueLen=100",
+			buildSeparatedValuesDBOpts: buildSeparatedValuesDBOpts{
+				KeyCount: 10_000_000,
+				ValueLen: 100,
+			},
+		},
+		{
+			name: "keys=10m,valueLen=1024",
+			buildSeparatedValuesDBOpts: buildSeparatedValuesDBOpts{
+				KeyCount: 10_000_000,
+				ValueLen: 1024,
+			},
+		},
+	}
+
+	for _, c := range configs {
+		b.Run(c.name, func(b *testing.B) {
+			db, keys := buildSeparatedValuesDB(b, c.buildSeparatedValuesDBOpts)
+			defer func() { require.NoError(b, db.Close()) }()
+			m := db.Metrics()
+			b.Logf("%s\n", m.String())
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				func() {
+					iter, err := db.NewIter(nil)
+					if err != nil {
+						b.Fatal(err)
+					}
+					defer iter.Close()
+					iter.SeekGE(keys[i%len(keys)])
+					if !iter.Valid() {
+						b.Fatal("no key found")
+					}
+					_, err = iter.ValueAndErr()
+					if err != nil {
+						b.Fatal(err)
+					}
+				}()
+			}
+		})
+	}
+}
+
+type buildSeparatedValuesDBOpts struct {
+	KeyCount int
+	ValueLen int
+}
+
+func buildSeparatedValuesDB(
+	tb testing.TB, opts buildSeparatedValuesDBOpts,
+) (db *pebble.DB, keys [][]byte) {
+	o := &pebble.Options{
+		Comparer:                &cockroachkvs.Comparer,
+		BlockPropertyCollectors: cockroachkvs.BlockPropertyCollectors,
+		FormatMajorVersion:      pebble.FormatExperimentalValueSeparation,
+		FS:                      vfs.NewMem(),
+		KeySchema:               cockroachkvs.KeySchema.Name,
+		KeySchemas:              sstable.MakeKeySchemas(&cockroachkvs.KeySchema),
+		Levels:                  make([]pebble.LevelOptions, 7),
+		MemTableSize:            2 << 20,
+		L0CompactionThreshold:   2,
+	}
+	o.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+		return pebble.ValueSeparationPolicy{
+			Enabled:               true,
+			MinimumSize:           50,
+			MaxBlobReferenceDepth: 10,
+		}
+	}
+	for i := 0; i < len(o.Levels); i++ {
+		l := &o.Levels[i]
+		l.BlockSize = 32 << 10       // 32 KB
+		l.IndexBlockSize = 256 << 10 // 256 KB
+		l.FilterPolicy = bloom.FilterPolicy(10)
+		l.FilterType = pebble.TableFilter
+		if i > 0 {
+			l.TargetFileSize = o.Levels[i-1].TargetFileSize * 2
+		}
+		l.EnsureDefaults()
+	}
+	db, err := pebble.Open("", o)
+	require.NoError(tb, err)
+
+	rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
+	keys, vals := cockroachkvs.RandomKVs(rng, opts.KeyCount, cockroachkvs.KeyGenConfig{
+		PrefixAlphabetLen:  26,
+		PrefixLenShared:    2,
+		RoachKeyLen:        10,
+		AvgKeysPerPrefix:   10,
+		BaseWallTime:       uint64(time.Now().UnixNano()),
+		PercentLogical:     0,
+		PercentEmptySuffix: 0,
+		PercentLockSuffix:  0,
+	}, opts.ValueLen)
+
+	keysToWrite := keys
+	for len(keysToWrite) > 0 {
+		b := db.NewBatch()
+		n := min(len(keysToWrite), 100)
+		for i := 0; i < n; i++ {
+			require.NoError(tb, b.Set(keysToWrite[i], vals[i], nil))
+		}
+		require.NoError(tb, b.Commit(nil))
+		keysToWrite = keysToWrite[n:]
+	}
+	require.NoError(tb, db.Flush())
+
+	// Wait until compaction scores stabilize.
+	for {
+		m := db.Metrics()
+		var maxScore float64
+		for l := range m.Levels {
+			if m.Levels[l].Score > maxScore {
+				maxScore = m.Levels[l].Score
+			}
+		}
+		if maxScore <= 1.0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return db, keys
 }

--- a/file_cache.go
+++ b/file_cache.go
@@ -659,11 +659,15 @@ func (h *fileCacheHandle) newPointIter(
 	if internalOpts.readEnv.Block.IterStats == nil && opts != nil {
 		internalOpts.readEnv.Block.IterStats = handle.SSTStatsCollector().Accumulator(uint64(uintptr(unsafe.Pointer(r))), opts.Category)
 	}
+	var blobReferences sstable.BlobReferences
+	if r.Attributes.Has(sstable.AttributeBlobValues) {
+		blobReferences = &file.BlobReferences
+	}
 	if internalOpts.compaction {
 		iter, err = reader.NewCompactionIter(transforms, internalOpts.readEnv,
 			&v.readerProvider, sstable.TableBlobContext{
 				ValueFetcher: internalOpts.blobValueFetcher,
-				References:   file.BlobReferences,
+				References:   blobReferences,
 			})
 	} else {
 		iter, err = reader.NewPointIter(ctx, sstable.IterOptions{
@@ -676,7 +680,7 @@ func (h *fileCacheHandle) newPointIter(
 			ReaderProvider:       &v.readerProvider,
 			BlobContext: sstable.TableBlobContext{
 				ValueFetcher: internalOpts.blobValueFetcher,
-				References:   file.BlobReferences,
+				References:   blobReferences,
 			},
 		})
 	}

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -181,24 +181,24 @@ type BlobReferenceDepth int
 // persisted to the manifest.
 type BlobReferences []BlobReference
 
-// Assert that BlobReferences implements sstable.BlobReferences.
-var _ sstable.BlobReferences = BlobReferences{}
+// Assert that *BlobReferences implements sstable.BlobReferences.
+var _ sstable.BlobReferences = (*BlobReferences)(nil)
 
 // FileNumByID returns the FileNum for the identified BlobReference.
-func (br BlobReferences) FileNumByID(i blob.ReferenceID) base.DiskFileNum {
-	return br[i].FileNum
+func (br *BlobReferences) FileNumByID(i blob.ReferenceID) base.DiskFileNum {
+	return (*br)[i].FileNum
 }
 
 // IDByFileNum returns the reference ID for the given FileNum. If the file
 // number is not found, the second return value is false. IDByFileNum is linear
 // in the length of the BlobReferences slice.
-func (br BlobReferences) IDByFileNum(fileNum base.DiskFileNum) (blob.ReferenceID, bool) {
-	for i, ref := range br {
+func (br *BlobReferences) IDByFileNum(fileNum base.DiskFileNum) (blob.ReferenceID, bool) {
+	for i, ref := range *br {
 		if ref.FileNum == fileNum {
 			return blob.ReferenceID(i), true
 		}
 	}
-	return blob.ReferenceID(len(br)), false
+	return blob.ReferenceID(len(*br)), false
 }
 
 // AggregateBlobFileStats records cumulative stats across blob files.

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -192,7 +192,7 @@ func (lt *levelIterTest) newIters(
 			ReaderProvider:       sstable.MakeTrivialReaderProvider(lt.readers[file.FileNum]),
 			BlobContext: sstable.TableBlobContext{
 				ValueFetcher: iio.blobValueFetcher,
-				References:   file.BlobReferences,
+				References:   &file.BlobReferences,
 			},
 		})
 		if err != nil {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -186,7 +186,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 					ReaderProvider:       sstable.MakeTrivialReaderProvider(r),
 					BlobContext: sstable.TableBlobContext{
 						ValueFetcher: iio.blobValueFetcher,
-						References:   file.BlobReferences,
+						References:   &file.BlobReferences,
 					},
 				})
 				if err != nil {

--- a/tool/find.go
+++ b/tool/find.go
@@ -501,7 +501,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 				}
 				f.fmtValue.mustSet("[%s]")
 				var vf *blob.ValueFetcher
-				vf, blobContext = sstable.LoadValBlobContext(&provider, f.blobRefs)
+				vf, blobContext = sstable.LoadValBlobContext(&provider, &f.blobRefs)
 				defer func() { _ = vf.Close() }()
 			default:
 				blobContext = sstable.AssertNoBlobHandles

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -370,7 +370,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 			}
 			s.fmtValue.mustSet("[%s]")
 			var vf *blob.ValueFetcher
-			vf, blobContext = sstable.LoadValBlobContext(&provider, blobRefs)
+			vf, blobContext = sstable.LoadValBlobContext(&provider, &blobRefs)
 			defer func() { _ = vf.Close() }()
 		default:
 			blobContext = sstable.AssertNoBlobHandles


### PR DESCRIPTION
**db: add BenchmarkPointLookupSeparatedValues**

Add a microbenchmark that exercises a point lookup wihtin a database with
separated values.

Informs #112.

**manifest: avoid BlobReferences interface allocation**

The manifest.BlobReferences type is used to satisfy the sstable.BlobReferences
interface. Previously the interface was implemented on the slice receiver type.
This caused an allocation whenever we used this type to satisfy the
sstable.BlobReferences interface. This commit moves the implementation onto the
pointer type, avoiding the need to heap-allocate a copy of the slice header.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble
cpu: Apple M1 Pro
                                                    │ before.txt  │              after.txt               │
                                                    │   sec/op    │   sec/op     vs base                 │
PointLookupSeparatedValues/keys=1m,valueLen=100-10    1.636µ ± 8%   1.585µ ± 2%  -3.09% (p=0.001 n=10)
PointLookupSeparatedValues/keys=1m,valueLen=1024-10   2.452µ ± 4%   2.373µ ± 4%  -3.22% (p=0.007 n=10+6)
geomean                                               2.003µ        1.939µ       -3.15%

                                                    │ before.txt  │               after.txt               │
                                                    │    B/op     │    B/op      vs base                  │
PointLookupSeparatedValues/keys=1m,valueLen=100-10    32.000 ± 0%   8.000 ±  0%  -75.00% (p=0.000 n=10)
PointLookupSeparatedValues/keys=1m,valueLen=1024-10    265.5 ± 7%   210.0 ± 22%  -20.90% (p=0.001 n=10+6)
geomean                                                92.17        40.99        -55.53%

                                                    │ before.txt │                after.txt                │
                                                    │ allocs/op  │ allocs/op   vs base                     │
PointLookupSeparatedValues/keys=1m,valueLen=100-10    1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
PointLookupSeparatedValues/keys=1m,valueLen=1024-10   1.000 ± 0%   0.000 ± 0%  -100.00% (n=10+6)
geomean                                               1.000                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

Fix https://github.com/cockroachdb/pebble/issues/4668.
