### PR TITLE
internal/manifest: specialize LevelIterator seek methods

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -247,6 +247,12 @@ func (t InternalKeyTrailer) Kind() InternalKeyKind {
 	return InternalKeyKind(t & 0xff)
 }
 
+// IsExclusiveSentinel returns true if the trailer is a sentinel for an
+// exclusive boundary.
+func (t InternalKeyTrailer) IsExclusiveSentinel() bool {
+	return t.SeqNum() == SeqNumMax
+}
+
 // InternalKey is a key used for the in-memory and on-disk partial DBs that
 // make up a pebble DB.
 //

--- a/internal/manifest/bench_test.go
+++ b/internal/manifest/bench_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest_test
+
+import (
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/cockroachkvs"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+)
+
+func BenchmarkLevelIteratorSeekGE(b *testing.B) {
+	const countTables = 10_000
+	fileAlloc := make([]manifest.TableMetadata, countTables)
+	files := make([]*manifest.TableMetadata, countTables)
+	rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
+	keys, _ := cockroachkvs.RandomKVs(rng, 2*countTables, cockroachkvs.KeyGenConfig{
+		PrefixAlphabetLen:  26,
+		PrefixLenShared:    2,
+		RoachKeyLen:        16,
+		AvgKeysPerPrefix:   1,
+		BaseWallTime:       uint64(time.Now().UnixNano()),
+		PercentLogical:     0,
+		PercentEmptySuffix: 0,
+		PercentLockSuffix:  0,
+	}, 0)
+	for i := 0; i < countTables; i++ {
+		fileAlloc[i] = manifest.TableMetadata{
+			FileNum: base.FileNum(i),
+		}
+		fileAlloc[i].ExtendPointKeyBounds(cockroachkvs.Compare,
+			base.MakeInternalKey(keys[i*2], base.SeqNum(i), base.InternalKeyKindSet),
+			base.MakeInternalKey(keys[i*2+1], base.SeqNum(i), base.InternalKeyKindSet))
+		fileAlloc[i].InitPhysicalBacking()
+		files[i] = &fileAlloc[i]
+	}
+
+	lm := manifest.MakeLevelMetadata(cockroachkvs.Compare, 0, files)
+	iter := lm.Iter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = iter.SeekGE(cockroachkvs.Compare, keys[i%len(keys)])
+	}
+}

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -163,23 +163,8 @@ func (lm *LevelMetadata) Slice() LevelSlice {
 // that contains just that file; otherwise, returns an empty LevelSlice.
 func (lm *LevelMetadata) Find(cmp base.Compare, m *TableMetadata) LevelSlice {
 	iter := lm.Iter()
-	if lm.level == 0 {
-		// We only need to look at the portion of files that are "equal" to m with
-		// respect to the L0 ordering.
-		f := iter.seek(func(f *TableMetadata) bool {
-			return f.cmpSeqNum(m) >= 0
-		})
-		for ; f != nil && f.cmpSeqNum(m) == 0; f = iter.Next() {
-			if f == m {
-				return iter.Take().slice
-			}
-		}
-	} else {
-		// For levels other than L0, UserKeyBounds in the level are non-overlapping
-		// so we only need to check one file.
-		if f := iter.SeekGE(cmp, m.UserKeyBounds().Start); f == m {
-			return iter.Take().slice
-		}
+	if iter.find(m) {
+		return iter.Take().slice
 	}
 	return LevelSlice{}
 }
@@ -511,6 +496,10 @@ func (i *LevelIterator) empty() bool {
 	return emptyWithBounds(i.iter, i.start, i.end)
 }
 
+func (i *LevelIterator) find(m *TableMetadata) bool {
+	return i.iter.find(m)
+}
+
 // Filter clones the iterator and sets the desired KeyType as the key to filter
 // files on.
 func (i *LevelIterator) Filter(keyType KeyType) LevelIterator {
@@ -603,18 +592,59 @@ func (i *LevelIterator) SeekGE(cmp Compare, userKey []byte) *TableMetadata {
 		return nil
 	}
 	i.assertNotL0Cmp()
-	m := i.seek(func(m *TableMetadata) bool {
-		return m.Largest().IsUpperBoundFor(cmp, userKey)
-	})
-	if i.filter != KeyTypePointAndRange && m != nil {
-		b, ok := m.LargestBound(i.filter)
-		if !ok || !b.IsUpperBoundFor(cmp, userKey) {
-			// The file does not contain any keys of desired key types
-			// that are >= userKey.
-			return i.Next()
+	i.iter.reset()
+	for {
+		// Logic copied from sort.Search.
+		//
+		// INVARIANT A: items[j-1].Largest().IsUpperBoundFor(cmp, userKey) == false
+		// INVARIANT B: items[k].Largest().IsUpperBoundFor(cmp, userKey) == true
+		j, k := 0, int(i.iter.n.count)
+		for j < k {
+			h := int(uint(j+k) >> 1) // avoid overflow when computing h
+			// j ≤ h < k
+			ik := &i.iter.n.items[h].PointKeyBounds
+			if i.iter.n.items[h].boundTypeLargest == boundTypeRangeKey {
+				ik = i.iter.n.items[h].RangeKeyBounds
+			}
+			c := cmp(userKey, ik.LargestUserKey())
+			if c > 0 || (c == 0 && ik.largestTrailer.IsExclusiveSentinel()) {
+				j = h + 1 // preserves INVARIANT A
+			} else {
+				k = h // preserves INVARIANT B
+			}
 		}
+		i.iter.pos = int16(j)
+		if i.iter.n.leaf {
+			if i.iter.pos == i.iter.n.count {
+				// next, which will ascend and descend to move to the next node.
+				i.iter.next()
+			}
+			break
+		}
+		i.iter.descend(i.iter.n, i.iter.pos)
 	}
-	return i.skipFilteredForward(m)
+
+	// If the iterator is filtered or has bounds, we fall into a slow path that
+	// filters based on the current file and constraints the iterator's position
+	// according to the configured bounds.
+	if i.filter != KeyTypePointAndRange || i.start != nil || i.end != nil {
+		m := i.constrainToIteratorBounds()
+		if i.filter != KeyTypePointAndRange && m != nil {
+			b, ok := m.LargestBound(i.filter)
+			if !ok || !b.IsUpperBoundFor(cmp, userKey) {
+				// The file does not contain any keys of desired key types
+				// that are >= userKey.
+				return i.Next()
+			}
+		}
+		return i.skipFilteredForward(m)
+	}
+	// If the iterator is not filtered and has no bounds, we fall into a fast
+	// path that returns the current file.
+	if !i.iter.valid() {
+		return nil
+	}
+	return i.iter.cur()
 }
 
 // SeekLT seeks to the last file with a smallest key (of the desired type) that
@@ -629,10 +659,34 @@ func (i *LevelIterator) SeekLT(cmp Compare, userKey []byte) *TableMetadata {
 		return nil
 	}
 	i.assertNotL0Cmp()
-	i.seek(func(m *TableMetadata) bool {
-		return cmp(m.Smallest().UserKey, userKey) >= 0
-	})
+	i.iter.reset()
+	for {
+		// Logic copied from sort.Search.
+		//
+		// INVARIANT A: items[j].Smallest().UserKey < userKey
+		// INVARIANT B: items[k].Smallest().UserKey >= 0
+		j, k := 0, int(i.iter.n.count)
+		for j < k {
+			h := int(uint(j+k) >> 1) // avoid overflow when computing h
+			// j ≤ h < k
+			if cmp(i.iter.n.items[h].Smallest().UserKey, userKey) < 0 {
+				j = h + 1 // preserves INVARIANT A
+			} else {
+				k = h // preserves INVARIANT B
+			}
+		}
+		i.iter.pos = int16(j)
+		if i.iter.n.leaf {
+			if i.iter.pos == i.iter.n.count {
+				i.iter.next()
+			}
+			break
+		}
+		i.iter.descend(i.iter.n, i.iter.pos)
+	}
+	_ = i.constrainToIteratorBounds()
 	m := i.Prev()
+
 	// Although i.Prev() guarantees that the current file contains keys of the
 	// relevant type, it doesn't guarantee that the keys of the relevant type
 	// are < userKey. For example, say that we have these two files:
@@ -668,8 +722,7 @@ func (i *LevelIterator) assertNotL0Cmp() {
 // skipFilteredForward takes the table metadata at the iterator's current
 // position, and skips forward if the current key-type filter (i.filter)
 // excludes the file. It skips until it finds an unfiltered file or exhausts the
-// level. If lower is != nil, skipFilteredForward skips any files that do not
-// contain keys with the provided key-type ≥ lower.
+// level.
 //
 // skipFilteredForward also enforces the upper bound, returning nil if at any
 // point the upper bound is exceeded.
@@ -692,8 +745,7 @@ func (i *LevelIterator) skipFilteredForward(meta *TableMetadata) *TableMetadata 
 // skipFilteredBackward takes the table metadata at the iterator's current
 // position, and skips backward if the current key-type filter (i.filter)
 // excludes the file. It skips until it finds an unfiltered file or exhausts the
-// level. If upper is != nil, skipFilteredBackward skips any files that do not
-// contain keys with the provided key-type < upper.
+// level.
 //
 // skipFilteredBackward also enforces the lower bound, returning nil if at any
 // point the lower bound is exceeded.
@@ -713,14 +765,10 @@ func (i *LevelIterator) skipFilteredBackward(meta *TableMetadata) *TableMetadata
 	return meta
 }
 
-// seek repositions the iterator over the first file for which fn returns true,
-// mirroring the semantics of the standard library's sort.Search function: fn
-// returns false for some (possibly empty) prefix of the tree's files, and then
-// true for the (possibly empty) remainder.
-func (i *LevelIterator) seek(fn func(*TableMetadata) bool) *TableMetadata {
-	i.iter.seek(fn)
-
-	// i.iter.seek seeked in the unbounded underlying B-Tree. If the iterator
+// constrainToIteratorBounds adjusts the iterator position to ensure it's
+// positioned within the iterator's bounds.
+func (i *LevelIterator) constrainToIteratorBounds() *TableMetadata {
+	// seek operations seek in the unbounded underlying B-Tree. If the iterator
 	// has start or end bounds, we may have exceeded them. Reset to the bounds
 	// if necessary.
 	//

--- a/internal/manifest/level_metadata_test.go
+++ b/internal/manifest/level_metadata_test.go
@@ -7,11 +7,14 @@ package manifest
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/bytealloc"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/stretchr/testify/require"
 )
 
@@ -144,4 +147,118 @@ func runIterCmd(t *testing.T, d *datadriven.TestData, iter LevelIterator, verbos
 		}
 	}
 	return buf.String()
+}
+
+func makeTestTableMetadata() (tables []*TableMetadata, keys [][]byte) {
+	const (
+		countTables  = 10_000
+		maxKeyLength = 5
+	)
+	var (
+		ks          = testkeys.Alpha(maxKeyLength)
+		buf         = make([]byte, ks.MaxLen()+testkeys.MaxSuffixLen)
+		tablesAlloc = make([]TableMetadata, countTables)
+		balloc      = bytealloc.A(make([]byte, 0, 4096))
+	)
+	tables = make([]*TableMetadata, countTables)
+	keys = make([][]byte, 0, 2*countTables)
+
+	// Create 2*countTables keys in order, while constructing a LevelMetadata
+	// with `countTables` tables. Even-indexed keys are appended to keys, but
+	// are not used to construct a table. Odd-indexed keys are used to
+	// synthesize a TableMetadata with a file number matching the key's index.
+	// The smallest and largest boundary keys of synthesized TableMetadata are
+	// identical, using the odd-indexed key as the user key and the index itself
+	// as the sequence number.
+	for i := int64(0); i < countTables; i++ {
+		var userKey []byte
+		var n int
+		// Generate a key. The first key is appended to `keys`, but doesn't
+		// appear within any table metadata.
+		n = testkeys.WriteKey(buf, ks, 2*i)
+		balloc, userKey = balloc.Copy(buf[:n])
+		keys = append(keys, userKey)
+		// Generate the next key. This key is also appended to `keys`, but does
+		// appear within the table metadata as both smallest and largest bounds.
+		n = testkeys.WriteKey(buf, ks, 2*i+1)
+		balloc, userKey = balloc.Copy(buf[:n])
+		keys = append(keys, userKey)
+
+		tablesAlloc[i] = TableMetadata{FileNum: base.FileNum(2*i + 1)}
+		tablesAlloc[i].ExtendPointKeyBounds(testkeys.Comparer.Compare,
+			base.MakeInternalKey(userKey, base.SeqNum(i), base.InternalKeyKindSet),
+			base.MakeInternalKey(userKey, base.SeqNum(i), base.InternalKeyKindSet))
+		tablesAlloc[i].InitPhysicalBacking()
+		tables[i] = &tablesAlloc[i]
+	}
+	return tables, keys
+}
+
+// TestLevelIteratorSeek tests LevelIterator.{SeekGE,SeekLT}.
+func TestLevelIteratorSeek(t *testing.T) {
+	tables, keys := makeTestTableMetadata()
+	lm := MakeLevelMetadata(testkeys.Comparer.Compare, 6 /* L6 */, tables)
+
+	// Test seeking using SeekGE to every key in `keys`.
+	t.Run("SeekGE", func(t *testing.T) {
+		iter := lm.Iter()
+		for i := range keys {
+			m := iter.SeekGE(testkeys.Comparer.Compare, keys[i])
+
+			// Seeking to a key with an odd index should find a table
+			// metadata with a file number of i (and a largest boundary
+			// exactly equal to the seek key).
+			// Seeking to a key with an even index should find a table
+			// metadata with a file number of i+1 (and a largest boundary
+			// exactly equal to the key at index i+1).
+			want := i + (i+1)%2
+			if m == nil {
+				t.Fatalf("SeekGE(%q [%d]) = nil", keys[i], i)
+			} else if int(m.FileNum) != want {
+				t.Fatalf("SeekGE(%q [%d]) = %s", keys[i], i, m.FileNum)
+			}
+		}
+	})
+
+	// Test seeking using SeekLT to every key in `keys`.
+	t.Run("SeekLT", func(t *testing.T) {
+		iter := lm.Iter()
+		// The table with the smallest key has smallest = keys[1]. Neither
+		// keys[0] nor keys[1] is strictly less than keys[1], so SeekLT(keys[0])
+		// and SeekLT(keys[1]) should both return nil.
+		require.Nil(t, iter.SeekLT(testkeys.Comparer.Compare, keys[0]))
+		require.Nil(t, iter.SeekLT(testkeys.Comparer.Compare, keys[1]))
+
+		for i := 2; i < len(keys); i++ {
+			m := iter.SeekLT(testkeys.Comparer.Compare, keys[i])
+
+			// Seeking to a key with an odd index should find a table
+			// metadata with a file number of i-2.
+			// Seeking to a key with an even index should find a table
+			// metadata with a file number of i-1.
+			want := i - 1 - i%2
+			if m == nil {
+				t.Fatalf("SeekLT(%q [%d]) = nil", keys[i], i)
+			} else if int(m.FileNum) != want {
+				t.Fatalf("SeekLT(%q [%d]) = %s", keys[i], i, m.FileNum)
+			}
+		}
+	})
+}
+
+func TestLevelIteratorFind(t *testing.T) {
+	tables, _ := makeTestTableMetadata()
+	for _, level := range []int{0, 1, 6} {
+		t.Run(fmt.Sprintf("level%d", level), func(t *testing.T) {
+			lm := MakeLevelMetadata(testkeys.Comparer.Compare, level, tables)
+			for _, m := range tables {
+				got := slices.Collect(lm.Find(testkeys.Comparer.Compare, m).All())
+				if len(got) != 1 {
+					t.Fatalf("Find(%s) = %s", m, got)
+				} else if got[0].FileNum != m.FileNum {
+					t.Fatalf("Find(%s) = %s", m, got)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Previously LevelIterator's seek methods accepted an opaque
func(*TableMetadata)bool to perform comparisons. This commit specializes each
instance as separate functions, ensuring comparisons can be inlined where
possible. Special attention is given to SeekGE, which is the hot path for point
lookups.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble/internal/manifest
cpu: Apple M1 Pro
                       │   old.txt   │             newest2.txt             │
                       │   sec/op    │   sec/op     vs base                │
LevelIteratorSeekGE-10   144.3n ± 2%   110.0n ± 1%  -23.74% (p=0.000 n=10)
```