### PR TITLE
db: track aggregate size, inclusive of separated values

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -407,7 +407,7 @@ func TestCompactionPickerEstimatedCompactionDebt(t *testing.T) {
 
 				vb := manifest.MakeVirtualBackings()
 				p := newCompactionPickerByScore(vers, l0Organizer, &vb, opts, nil)
-				return fmt.Sprintf("%d\n", p.estimatedCompactionDebt(0))
+				return fmt.Sprintf("%d\n", p.estimatedCompactionDebt())
 
 			default:
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
@@ -1417,7 +1417,7 @@ func TestCompactionPickerCompensatedSize(t *testing.T) {
 			f.InitPhysicalBacking()
 			f.Stats.PointDeletionsBytesEstimate = tc.pointDelEstimateBytes
 			f.Stats.RangeDeletionsBytesEstimate = tc.rangeDelEstimateBytes
-			gotBytes := compensatedSize(f)
+			gotBytes := tableCompensatedSize(f)
 			require.Equal(t, tc.wantBytes, gotBytes)
 		})
 	}
@@ -1690,7 +1690,7 @@ func TestCompactionPickerScores(t *testing.T) {
 			buf.Reset()
 			fmt.Fprintf(&buf, "L       Size   Score\n")
 			for l, lm := range d.Metrics().Levels {
-				fmt.Fprintf(&buf, "L%-3d\t%-7s%.1f\n", l, humanize.Bytes.Int64(lm.TablesSize), lm.CompensatedScore)
+				fmt.Fprintf(&buf, "L%-3d\t%-7s%.1f\n", l, humanize.Bytes.Int64(lm.AggregateSize()), lm.CompensatedScore)
 			}
 			return buf.String()
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -80,7 +80,7 @@ func (p *compactionPickerForTesting) getBaseLevel() int {
 	return p.baseLevel
 }
 
-func (p *compactionPickerForTesting) estimatedCompactionDebt(l0ExtraSize uint64) uint64 {
+func (p *compactionPickerForTesting) estimatedCompactionDebt() uint64 {
 	return 0
 }
 

--- a/db.go
+++ b/db.go
@@ -2056,7 +2056,7 @@ func (d *DB) Metrics() *Metrics {
 	d.mu.Lock()
 	vers := d.mu.versions.currentVersion()
 	*metrics = d.mu.versions.metrics
-	metrics.Compact.EstimatedDebt = d.mu.versions.picker.estimatedCompactionDebt(0)
+	metrics.Compact.EstimatedDebt = d.mu.versions.picker.estimatedCompactionDebt()
 	metrics.Compact.InProgressBytes = d.mu.versions.atomicInProgressBytes.Load()
 	// TODO(radu): split this to separate the download compactions.
 	metrics.Compact.NumInProgress = int64(d.mu.compact.compactingCount + d.mu.compact.downloadingCount)

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -400,6 +400,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 			}
 			metrics[de.Level].TablesCount--
 			metrics[de.Level].TablesSize -= int64(f.Size)
+			metrics[de.Level].EstimatedReferencesSize -= f.EstimatedReferenceSize()
 		}
 		return metrics
 	}

--- a/ingest.go
+++ b/ingest.go
@@ -2070,6 +2070,7 @@ func (d *DB) ingestApply(
 			}
 			levelMetrics.TablesCount++
 			levelMetrics.TablesSize += int64(m.Size)
+			levelMetrics.EstimatedReferencesSize += m.EstimatedReferenceSize()
 			levelMetrics.BytesIngested += m.Size
 			levelMetrics.TablesIngested++
 		}
@@ -2088,9 +2089,11 @@ func (d *DB) ingestApply(
 			}
 			levelMetrics.TablesCount--
 			levelMetrics.TablesSize -= int64(m.Size)
+			levelMetrics.EstimatedReferencesSize -= m.EstimatedReferenceSize()
 			for i := range added {
 				levelMetrics.TablesCount++
 				levelMetrics.TablesSize += int64(added[i].Meta.Size)
+				levelMetrics.EstimatedReferencesSize += added[i].Meta.EstimatedReferenceSize()
 			}
 		}
 		if exciseSpan.Valid() {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -100,6 +100,7 @@ func exampleMetrics() Metrics {
 		l.VirtualTablesCount = uint64(base) + 1
 		l.VirtualTablesSize = base + 3
 		l.TablesSize = int64(base) + 2
+		l.EstimatedReferencesSize = base + 14
 		if i < numLevels-1 {
 			l.Score = 1.0 + float64(i+1)*0.1
 		}

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -326,8 +326,9 @@ func (d *DB) getDeletionPacerInfo() deletionPacerInfo {
 	pacerInfo.freeBytes = d.calculateDiskAvailableBytes()
 	d.mu.Lock()
 	pacerInfo.obsoleteBytes = d.mu.versions.metrics.Table.ObsoleteSize
-	pacerInfo.liveBytes = uint64(d.mu.versions.metrics.Total().TablesSize)
+	total := d.mu.versions.metrics.Total()
 	d.mu.Unlock()
+	pacerInfo.liveBytes = uint64(total.AggregateSize())
 	return pacerInfo
 }
 

--- a/table_stats.go
+++ b/table_stats.go
@@ -133,7 +133,7 @@ func (d *DB) collectTableStats() bool {
 	maybeCompact := false
 	for _, c := range collected {
 		c.tableMetadata.Stats = c.TableStats
-		maybeCompact = maybeCompact || fileCompensation(c.tableMetadata) > 0
+		maybeCompact = maybeCompact || tableTombstoneCompensation(c.tableMetadata) > 0
 		sanityCheckStats(c.tableMetadata, d.opts.Logger, "collected stats")
 		c.tableMetadata.StatsMarkValid()
 	}

--- a/value_separation.go
+++ b/value_separation.go
@@ -299,21 +299,23 @@ func (vs *writeNewBlobFiles) FinishOutput() (compact.ValueSeparationMetadata, er
 		return compact.ValueSeparationMetadata{}, err
 	}
 	vs.writer = nil
+	meta := &manifest.BlobFileMetadata{
+		FileNum:      vs.objMeta.DiskFileNum,
+		Size:         stats.FileLen,
+		ValueSize:    stats.UncompressedValueBytes,
+		CreationTime: uint64(time.Now().Unix()),
+	}
 	return compact.ValueSeparationMetadata{
 		BlobReferences: manifest.BlobReferences{{
 			FileNum:   vs.objMeta.DiskFileNum,
 			ValueSize: stats.UncompressedValueBytes,
+			Metadata:  meta,
 		}},
 		BlobReferenceSize:  stats.UncompressedValueBytes,
 		BlobReferenceDepth: 1,
 		BlobFileStats:      stats,
 		BlobFileObject:     vs.objMeta,
-		BlobFileMetadata: &manifest.BlobFileMetadata{
-			FileNum:      vs.objMeta.DiskFileNum,
-			Size:         stats.FileLen,
-			ValueSize:    stats.UncompressedValueBytes,
-			CreationTime: uint64(time.Now().Unix()),
-		},
+		BlobFileMetadata:   meta,
 	}, nil
 }
 

--- a/value_separation_test.go
+++ b/value_separation_test.go
@@ -228,15 +228,20 @@ func (vs *defineDBValueSeparator) Add(
 	lv := iv.LazyValue()
 	// If we haven't seen this blob file before, fabricate a metadata for it.
 	fileNum := lv.Fetcher.BlobFileNum
-	if _, ok := vs.metas[fileNum]; !ok {
-		vs.metas[fileNum] = &manifest.BlobFileMetadata{
+	meta, ok := vs.metas[fileNum]
+	if !ok {
+		meta = &manifest.BlobFileMetadata{
 			FileNum:      fileNum,
 			CreationTime: uint64(time.Now().Unix()),
 		}
+		vs.metas[fileNum] = meta
 	}
+	meta.Size += uint64(lv.Fetcher.Attribute.ValueLen)
+	meta.ValueSize += uint64(lv.Fetcher.Attribute.ValueLen)
+
 	// If it's not already in pbr.inputBlobMetadatas, add it.
-	if !slices.Contains(vs.pbr.inputBlobMetadatas, vs.metas[fileNum]) {
-		vs.pbr.inputBlobMetadatas = append(vs.pbr.inputBlobMetadatas, vs.metas[fileNum])
+	if !slices.Contains(vs.pbr.inputBlobMetadatas, meta) {
+		vs.pbr.inputBlobMetadatas = append(vs.pbr.inputBlobMetadatas, meta)
 	}
 	// Return a KV that uses the original key but our constructed blob reference.
 	vs.kv.K = kv.K


### PR DESCRIPTION
Add estimation of the physical size of a table's separated values and use this to compute an 'aggregate size' of a level. Use this size when determining level scores.

Informs #112.