### PR TITLE
sstable: persist attributes in sstable footer

### DIFF
--- a/cockroachkvs/cockroachkvs_bench_test.go
+++ b/cockroachkvs/cockroachkvs_bench_test.go
@@ -66,6 +66,18 @@ func BenchmarkRandSeekInSST(b *testing.B) {
 			valueLen: 128,        // ~200 KVs per data block
 			version:  sstable.TableFormatPebblev6,
 		},
+		{
+			name:     "v7/single-level",
+			numKeys:  200 * 100, // ~100 data blocks.
+			valueLen: 128,       // ~200 KVs per data block
+			version:  sstable.TableFormatPebblev7,
+		},
+		{
+			name:     "v7/two-level",
+			numKeys:  200 * 5000, // ~5000 data blocks
+			valueLen: 128,        // ~200 KVs per data block
+			version:  sstable.TableFormatPebblev7,
+		},
 	}
 	keyCfg := KeyGenConfig{
 		PrefixAlphabetLen: 26,

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1323,7 +1323,11 @@ func TestCompaction(t *testing.T) {
 		},
 		"set_with_del_sstable_Pebblev6": {
 			minVersion: FormatTableFormatV6,
-			maxVersion: internalFormatNewest,
+			maxVersion: FormatNewest,
+		},
+		"set_with_del_sstable_Pebblev7": {
+			minVersion: formatFooterAttributes,
+			maxVersion: formatFooterAttributes,
 		},
 		"value_separation": {
 			minVersion: FormatExperimentalValueSeparation,

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -236,6 +236,10 @@ const (
 
 	// -- Add experimental versions here --
 
+	// formatFooterAttributes is a format major version that adds support for
+	// writing sstable.Attributes in the footer of sstables.
+	formatFooterAttributes FormatMajorVersion = iota - 1
+
 	// internalFormatNewest is the most recent, possibly experimental format major
 	// version.
 	internalFormatNewest FormatMajorVersion = iota - 2
@@ -268,6 +272,8 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 		return sstable.TableFormatPebblev5
 	case FormatTableFormatV6, FormatExperimentalValueSeparation:
 		return sstable.TableFormatPebblev6
+	case formatFooterAttributes:
+		return sstable.TableFormatPebblev7
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
 	}
@@ -280,7 +286,7 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
 		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix,
 		FormatFlushableIngestExcises, FormatColumnarBlocks, FormatWALSyncChunks,
-		FormatTableFormatV6, FormatExperimentalValueSeparation:
+		FormatTableFormatV6, FormatExperimentalValueSeparation, formatFooterAttributes:
 		return sstable.TableFormatPebblev1
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -331,6 +337,9 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	},
 	FormatExperimentalValueSeparation: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatExperimentalValueSeparation)
+	},
+	formatFooterAttributes: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(formatFooterAttributes)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -30,11 +30,12 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatWALSyncChunks, FormatMajorVersion(20))
 	require.Equal(t, FormatTableFormatV6, FormatMajorVersion(21))
 	require.Equal(t, FormatExperimentalValueSeparation, FormatMajorVersion(22))
+	require.Equal(t, formatFooterAttributes, FormatMajorVersion(23))
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
 	require.Equal(t, FormatNewest, FormatMajorVersion(21))
-	require.Equal(t, internalFormatNewest, FormatMajorVersion(22))
+	require.Equal(t, internalFormatNewest, FormatMajorVersion(23))
 }
 
 func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
@@ -71,6 +72,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, FormatTableFormatV6, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatExperimentalValueSeparation))
 	require.Equal(t, FormatExperimentalValueSeparation, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(formatFooterAttributes))
+	require.Equal(t, formatFooterAttributes, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -231,6 +234,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatWALSyncChunks:               {sstable.TableFormatPebblev1, sstable.TableFormatPebblev5},
 		FormatTableFormatV6:               {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
 		FormatExperimentalValueSeparation: {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
+		formatFooterAttributes:            {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 	}
 
 	// Valid versions.

--- a/open_test.go
+++ b/open_test.go
@@ -335,7 +335,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000009.022",
+			"marker.format-version.000010.023",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1052,6 +1052,10 @@ func (w *RawColumnWriter) Close() (err error) {
 		}
 	}
 
+	if w.opts.TableFormat >= TableFormatPebblev7 {
+		w.layout.attributes = w.props.toAttributes()
+	}
+
 	// Write the table footer.
 	w.meta.Size, err = w.layout.Finish()
 	if err != nil {

--- a/sstable/format.go
+++ b/sstable/format.go
@@ -50,7 +50,7 @@ var footerSizes [NumTableFormats]int = [NumTableFormats]int{
 	TableFormatPebblev4:  rocksDBFooterLen,
 	TableFormatPebblev5:  rocksDBFooterLen,
 	TableFormatPebblev6:  checkedPebbleDBFooterLen,
-	TableFormatPebblev7:  checkedPebbleDBFooterLen,
+	TableFormatPebblev7:  pebbleDBv7FooterLen,
 }
 
 // TableFormatPebblev4, in addition to DELSIZED, introduces the use of

--- a/sstable/format.go
+++ b/sstable/format.go
@@ -30,6 +30,7 @@ const (
 	TableFormatPebblev4 // DELSIZED tombstones.
 	TableFormatPebblev5 // Columnar blocks.
 	TableFormatPebblev6 // Checksum footer + blob value handles + columnar metaindex/properties + MinLZ compression support.
+	TableFormatPebblev7 // Footer attributes.
 	NumTableFormats
 
 	TableFormatMax = NumTableFormats - 1
@@ -49,6 +50,7 @@ var footerSizes [NumTableFormats]int = [NumTableFormats]int{
 	TableFormatPebblev4:  rocksDBFooterLen,
 	TableFormatPebblev5:  rocksDBFooterLen,
 	TableFormatPebblev6:  checkedPebbleDBFooterLen,
+	TableFormatPebblev7:  checkedPebbleDBFooterLen,
 }
 
 // TableFormatPebblev4, in addition to DELSIZED, introduces the use of
@@ -250,6 +252,8 @@ func parseTableFormat(magic []byte, version uint32) (TableFormat, error) {
 			return TableFormatPebblev5, nil
 		case 6:
 			return TableFormatPebblev6, nil
+		case 7:
+			return TableFormatPebblev7, nil
 		default:
 			return TableFormatUnspecified, base.CorruptionErrorf(
 				"(unsupported pebble format version %d)", errors.Safe(version))
@@ -297,6 +301,8 @@ func (f TableFormat) AsTuple() (string, uint32) {
 		return pebbleDBMagic, 5
 	case TableFormatPebblev6:
 		return pebbleDBMagic, 6
+	case TableFormatPebblev7:
+		return pebbleDBMagic, 7
 	default:
 		panic("sstable: unknown table format version tuple")
 	}
@@ -323,6 +329,8 @@ func (f TableFormat) String() string {
 		return "(Pebble,v5)"
 	case TableFormatPebblev6:
 		return "(Pebble,v6)"
+	case TableFormatPebblev7:
+		return "(Pebble,v7)"
 	default:
 		panic("sstable: unknown table format version tuple")
 	}

--- a/sstable/format_test.go
+++ b/sstable/format_test.go
@@ -71,6 +71,12 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 			version: 6,
 			want:    TableFormatPebblev6,
 		},
+		{
+			name:    "PebbleDBv7",
+			magic:   pebbleDBMagic,
+			version: 7,
+			want:    TableFormatPebblev7,
+		},
 		// Invalid cases.
 		{
 			name:    "Invalid RocksDB version",
@@ -81,8 +87,8 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 		{
 			name:    "Invalid PebbleDB version",
 			magic:   pebbleDBMagic,
-			version: 7,
-			wantErr: "pebble/table: invalid table 000001: (unsupported pebble format version 7)",
+			version: 8,
+			wantErr: "pebble/table: invalid table 000001: (unsupported pebble format version 8)",
 		},
 		{
 			name:    "Unknown magic string",

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -510,6 +510,34 @@ func (p *Properties) saveToColWriter(tblFormat TableFormat, w *colblk.KeyValueBl
 	}
 }
 
+func (p *Properties) toAttributes() Attributes {
+	var attributes Attributes
+
+	if p.NumValueBlocks > 0 || p.NumValuesInValueBlocks > 0 {
+		attributes.Add(AttributeValueBlocks)
+	}
+	if p.NumRangeKeySets > 0 {
+		attributes.Add(AttributeRangeKeySets)
+	}
+	if p.NumRangeKeyUnsets > 0 {
+		attributes.Add(AttributeRangeKeyUnsets)
+	}
+	if p.NumRangeKeyDels > 0 {
+		attributes.Add(AttributeRangeKeyDels)
+	}
+	if p.NumRangeDeletions > 0 {
+		attributes.Add(AttributeRangeDels)
+	}
+	if p.IndexType == twoLevelIndex {
+		attributes.Add(AttributeTwoLevelIndex)
+	}
+	if p.NumValuesInBlobFiles > 0 {
+		attributes.Add(AttributeBlobValues)
+	}
+
+	return attributes
+}
+
 var (
 	singleZeroSlice = []byte{0x00}
 	maxInt32Slice   = binary.AppendUvarint([]byte(nil), math.MaxInt32)

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -561,13 +561,18 @@ func TestReaderWithBlockPropertyFilter(t *testing.T) {
 func TestReaderAttributes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	opts := WriterOptions{
-		// Use format supporting blob handles.
-		TableFormat:    TableFormatPebblev6,
 		BlockSize:      math.MaxInt32,
 		IndexBlockSize: math.MaxInt32,
 		Comparer:       testkeys.Comparer,
 	}
-	runTestReader(t, opts, "testdata/reader_attributes", nil /* Reader */, false)
+	// Iterate through TableFormats >= TableFormatPebblev6, which
+	// introduces blob handles.
+	for tf := TableFormatPebblev6; tf <= TableFormatMax; tf++ {
+		opts.TableFormat = tf
+		t.Run(tf.String(), func(t *testing.T) {
+			runTestReader(t, opts, "testdata/reader_attributes", nil /* Reader */, false)
+		})
+	}
 }
 
 func TestInjectedErrors(t *testing.T) {

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -441,7 +441,8 @@ func supportsTwoLevelIndex(format TableFormat) bool {
 	switch format {
 	case TableFormatLevelDB:
 		return false
-	case TableFormatRocksDBv2, TableFormatPebblev1, TableFormatPebblev2, TableFormatPebblev3, TableFormatPebblev4, TableFormatPebblev5, TableFormatPebblev6:
+	case TableFormatRocksDBv2, TableFormatPebblev1, TableFormatPebblev2, TableFormatPebblev3, TableFormatPebblev4,
+		TableFormatPebblev5, TableFormatPebblev6, TableFormatPebblev7:
 		return true
 	default:
 		panic("sstable: unspecified table format version")

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -195,18 +195,16 @@ const (
 	// exceed this length.
 	blockHandleLikelyMaxLen = blockHandleMaxLenWithoutProperties + 100
 
-	checksumLen = 4
-	magicLen    = 8
-	versionLen  = 4
+	checksumLen   = 4
+	magicLen      = 8
+	versionLen    = 4
+	attributesLen = 4
 
-	levelDBFooterLen   = 48
-	levelDBMagic       = "\x57\xfb\x80\x8b\x24\x75\x47\xdb"
-	levelDBMagicOffset = levelDBFooterLen - magicLen
+	levelDBFooterLen = 48
+	levelDBMagic     = "\x57\xfb\x80\x8b\x24\x75\x47\xdb"
 
 	rocksDBFooterLen             = 1 + 2*blockHandleMaxLenWithoutProperties + versionLen + magicLen
 	rocksDBMagic                 = "\xf7\xcf\xf4\x85\xb7\x41\xe2\x88"
-	rocksDBMagicOffset           = rocksDBFooterLen - magicLen
-	rocksDBVersionOffset         = rocksDBMagicOffset - versionLen
 	rocksDBExternalFormatVersion = 2
 
 	pebbleDBMagic = "\xf0\x9f\xaa\xb3\xf0\x9f\xaa\xb3" // 🪳🪳
@@ -216,8 +214,13 @@ const (
 	checkedPebbleDBVersionOffset  = checkedPebbleDBMagicOffset - versionLen
 	checkedPebbleDBChecksumOffset = checkedPebbleDBVersionOffset - checksumLen
 
+	// TableFormatPebblev7 footer introduces the Attributes bitset.
+	pebbleDBv7FooterLen              = checkedPebbleDBFooterLen + attributesLen
+	pebbleDBv7FooterChecksumOffset   = pebbleDBv7FooterLen - magicLen - versionLen - checksumLen
+	pebbleDBV7FooterAttributesOffset = pebbleDBv7FooterChecksumOffset - attributesLen
+
 	minFooterLen = levelDBFooterLen
-	maxFooterLen = checkedPebbleDBFooterLen
+	maxFooterLen = pebbleDBv7FooterLen
 
 	levelDBFormatVersion  = 0
 	rocksDBFormatVersion2 = 2
@@ -244,6 +247,9 @@ const (
 	rocksDBCompressionOptions = "window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; "
 )
 
+// footer formats. Note that much of the existing footer parsing code assumes
+// that the version (for non-legacy formats) and magic number are at the end.
+//
 // legacy (LevelDB) footer format:
 //
 //	metaindex handle (varint64 offset, varint64 size)
@@ -269,8 +275,20 @@ const (
 //	checksum: CRC over footer data (4 bytes)
 //	footer version (4 bytes)
 //	table_magic_number (8 bytes)
+//
+// (RocksDB + checksum + attributes) footer format [applies to TableFormatPebblev7 and later]
+//
+//	checksum type (char, 1 byte)
+//	metaindex handle (varint64 offset, varint64 size)
+//	index handle     (varint64 offset, varint64 size)
+//	<padding> to make the total size 2 * BlockHandle::kMaxEncodedLength + 1
+//	attributes: feature bitset (4 bytes)
+//	checksum: CRC over footer data (4 bytes)
+//	footer version (4 bytes)
+//	table_magic_number (8 bytes)
 type footer struct {
 	format      TableFormat
+	attributes  Attributes
 	checksum    block.ChecksumType
 	metaindexBH block.Handle
 	indexBH     block.Handle
@@ -312,7 +330,7 @@ func readFooter(
 
 func parseFooter(buf []byte, off, size int64) (footer, error) {
 	var footer footer
-	switch magic := buf[len(buf)-len(rocksDBMagic):]; string(magic) {
+	switch magic := buf[len(buf)-magicLen:]; string(magic) {
 	case levelDBMagic:
 		if len(buf) < levelDBFooterLen {
 			return footer, base.CorruptionErrorf("(footer too short): %d", errors.Safe(len(buf)))
@@ -356,15 +374,21 @@ func parseFooter(buf []byte, off, size int64) (footer, error) {
 		}
 
 		if format >= TableFormatPebblev6 {
-			encodedChecksum := binary.LittleEndian.Uint32(buf[checkedPebbleDBChecksumOffset:])
+			checksumOffset := checkedPebbleDBChecksumOffset
+			if format >= TableFormatPebblev7 {
+				checksumOffset = pebbleDBv7FooterChecksumOffset
+				footer.attributes = Attributes(binary.LittleEndian.Uint32(buf[pebbleDBV7FooterAttributesOffset:]))
+			}
+			encodedChecksum := binary.LittleEndian.Uint32(buf[checksumOffset:])
 			computedChecksum := crc.CRC(0).
-				Update(buf[:checkedPebbleDBChecksumOffset]).
-				Update(buf[checkedPebbleDBVersionOffset:]).
+				Update(buf[:checksumOffset]).
+				Update(buf[checksumOffset+checksumLen:]).
 				Value()
 			if encodedChecksum != computedChecksum {
 				return footer, base.CorruptionErrorf("(footer corrupted, checksum mismatch)")
 			}
 		}
+
 		buf = buf[1:]
 	default:
 		return footer, base.CorruptionErrorf("(bad magic number: 0x%x)", magic)
@@ -399,10 +423,6 @@ func (f footer) encode(buf []byte) []byte {
 		copy(buf[len(buf)-len(levelDBMagic):], levelDBMagic)
 
 	case rocksDBMagic, pebbleDBMagic:
-		versionOffset := checkedPebbleDBVersionOffset
-		if f.format < TableFormatPebblev6 {
-			versionOffset = rocksDBVersionOffset
-		}
 		buf = buf[:footerLen]
 		clear(buf)
 		switch f.checksum {
@@ -420,16 +440,25 @@ func (f footer) encode(buf []byte) []byte {
 		n := 1
 		n += f.metaindexBH.EncodeVarints(buf[n:])
 		n += f.indexBH.EncodeVarints(buf[n:])
-		binary.LittleEndian.PutUint32(buf[versionOffset:], version)
-		copy(buf[len(buf)-len(rocksDBMagic):], magic)
+
+		binary.LittleEndian.PutUint32(buf[len(buf)-magicLen-versionLen:], version)
+		copy(buf[len(buf)-magicLen:], magic)
 
 		if f.format >= TableFormatPebblev6 {
+			checksumOffset := checkedPebbleDBChecksumOffset
+			if f.format >= TableFormatPebblev7 {
+				checksumOffset = pebbleDBv7FooterChecksumOffset
+				// Write the attributes bitset.
+				binary.LittleEndian.PutUint32(buf[pebbleDBV7FooterAttributesOffset:], uint32(f.attributes))
+			}
+
 			computedChecksum := crc.CRC(0).
-				Update(buf[:checkedPebbleDBChecksumOffset]).
-				Update(buf[checkedPebbleDBVersionOffset:]).
+				Update(buf[:checksumOffset]).
+				Update(buf[checksumOffset+checksumLen:]).
 				Value()
-			binary.LittleEndian.PutUint32(buf[checkedPebbleDBChecksumOffset:], computedChecksum)
+			binary.LittleEndian.PutUint32(buf[checksumOffset:], computedChecksum)
 		}
+
 	default:
 		panic("sstable: unspecified table format version")
 	}

--- a/sstable/testdata/rewriter_v7
+++ b/sstable/testdata/rewriter_v7
@@ -1,0 +1,246 @@
+build block-size=1 index-block-size=1 filter
+a@xyz.SET.1:a
+b@xyz.SET.1:b
+c@xyz.SET.1:c
+----
+point:    [a@xyz#1,SET-c@xyz#1,SET]
+seqnums:  [1-1]
+
+rewrite from=@xyz to=@123 block-size=1 index-block-size=1 filter comparer=split-4b-suffix
+----
+rewrite failed: mismatched Comparer pebble.internal.testkeys vs comparer-split-4b-suffix, replacement requires same splitter to copy filters
+
+build block-size=1 index-block-size=1 filter
+aa@xyz.SET.1:a
+ba@xyz.SET.1:b
+ca@xyz.SET.1:c
+----
+point:    [aa@xyz#1,SET-ca@xyz#1,SET]
+seqnums:  [1-1]
+
+rewrite from=yz to=23 block-size=1 index-block-size=1 filter
+----
+rewrite failed: rewriting data blocks: key aa@xyz#1,SET has suffix 0x4078797a; require 0x797a
+
+rewrite from=a@xyz to=a@123 block-size=1 index-block-size=1 filter
+----
+rewrite failed: rewriting data blocks: key aa@xyz#1,SET has suffix 0x4078797a; require 0x614078797a
+
+build block-size=1 index-block-size=1 filter
+a@0.SET.1:a
+b@0.SET.1:b
+c@0.SET.1:c
+----
+point:    [a@0#1,SET-c@0#1,SET]
+seqnums:  [1-1]
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 87
+ ├── data  offset: 92  length: 87
+ ├── data  offset: 184  length: 87
+ ├── index  offset: 276  length: 38
+ ├── index  offset: 319  length: 39
+ ├── index  offset: 363  length: 37
+ ├── top-index  offset: 405  length: 52
+ ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
+ ├── properties  offset: 536  length: 572
+ ├── meta-index  offset: 1113  length: 88
+ └── footer  offset: 1206  length: 61
+
+scan
+----
+a@0#1,SET:a
+b@0#1,SET:b
+c@0#1,SET:c
+
+get
+b@0
+f@0
+c@0
+----
+b
+get f@0: pebble: not found
+c
+
+rewrite from=@0 to=@123 block-size=1 index-block-size=1 filter
+----
+point:    [a@123#1,SET-c@123#1,SET]
+seqnums:  [1-1]
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 87
+ ├── data  offset: 92  length: 87
+ ├── data  offset: 184  length: 87
+ ├── index  offset: 276  length: 40
+ ├── index  offset: 321  length: 41
+ ├── index  offset: 367  length: 37
+ ├── top-index  offset: 409  length: 56
+ ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
+ ├── properties  offset: 544  length: 572
+ ├── meta-index  offset: 1121  length: 88
+ └── footer  offset: 1214  length: 61
+
+scan
+----
+a@123#1,SET:a
+b@123#1,SET:b
+c@123#1,SET:c
+
+get
+b@123
+f@123
+c@123
+----
+b
+get f@123: pebble: not found
+c
+
+rewrite from=@123 to=@456 block-size=1 index-block-size=1 filter concurrency=2
+----
+point:    [a@456#1,SET-c@456#1,SET]
+seqnums:  [1-1]
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 87
+ ├── data  offset: 92  length: 87
+ ├── data  offset: 184  length: 87
+ ├── index  offset: 276  length: 40
+ ├── index  offset: 321  length: 41
+ ├── index  offset: 367  length: 37
+ ├── top-index  offset: 409  length: 56
+ ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
+ ├── properties  offset: 544  length: 572
+ ├── meta-index  offset: 1121  length: 88
+ └── footer  offset: 1214  length: 61
+
+scan
+----
+a@456#1,SET:a
+b@456#1,SET:b
+c@456#1,SET:c
+
+get
+b@456
+f@456
+c@456
+----
+b
+get f@456: pebble: not found
+c
+
+rewrite from=@456 to=@123 block-size=1 index-block-size=1 filter concurrency=3
+----
+point:    [a@123#1,SET-c@123#1,SET]
+seqnums:  [1-1]
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 87
+ ├── data  offset: 92  length: 87
+ ├── data  offset: 184  length: 87
+ ├── index  offset: 276  length: 40
+ ├── index  offset: 321  length: 41
+ ├── index  offset: 367  length: 37
+ ├── top-index  offset: 409  length: 56
+ ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
+ ├── properties  offset: 544  length: 572
+ ├── meta-index  offset: 1121  length: 88
+ └── footer  offset: 1214  length: 61
+
+scan
+----
+a@123#1,SET:a
+b@123#1,SET:b
+c@123#1,SET:c
+
+get
+b@123
+f@123
+c@123
+----
+b
+get f@123: pebble: not found
+c
+
+
+rewrite from=@123 to=@0 block-size=1 index-block-size=1 filter concurrency=4
+----
+point:    [a@0#1,SET-c@0#1,SET]
+seqnums:  [1-1]
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 87
+ ├── data  offset: 92  length: 87
+ ├── data  offset: 184  length: 87
+ ├── index  offset: 276  length: 38
+ ├── index  offset: 319  length: 39
+ ├── index  offset: 363  length: 37
+ ├── top-index  offset: 405  length: 52
+ ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
+ ├── properties  offset: 536  length: 572
+ ├── meta-index  offset: 1113  length: 88
+ └── footer  offset: 1206  length: 61
+
+scan
+----
+a@0#1,SET:a
+b@0#1,SET:b
+c@0#1,SET:c
+
+get
+b@0
+f@0
+c@0
+----
+b
+get f@0: pebble: not found
+c
+
+# Rewrite a table that contain only range keys.
+
+build block-size=1 index-block-size=1 filter
+Span: a-b:{(#1,RANGEKEYSET,@0)}
+Span: b-c:{(#1,RANGEKEYSET,@0)}
+Span: c-d:{(#1,RANGEKEYSET,@0)}
+----
+rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+seqnums:  [1-1]
+
+scan-range-key
+----
+a-b:{(#1,RANGEKEYSET,@0)}
+b-c:{(#1,RANGEKEYSET,@0)}
+c-d:{(#1,RANGEKEYSET,@0)}
+
+rewrite from=@0 to=@123 block-size=1 index-block-size=1 filter
+----
+rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+seqnums:  [1-1]
+
+scan-range-key
+----
+a-b:{(#1,RANGEKEYSET,@123)}
+b-c:{(#1,RANGEKEYSET,@123)}
+c-d:{(#1,RANGEKEYSET,@123)}
+
+build block-size=1 index-block-size=1 filter
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+----
+point:    [a#1,SET-c#1,SET]
+seqnums:  [1-1]
+
+rewrite from= to=@123 block-size=1 index-block-size=1 filter
+----
+point:    [a@123#1,SET-c@123#1,SET]
+seqnums:  [1-1]

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -145,5 +145,154 @@ sstable
       ├── 045  version: 6
       └── 049  magic number: 0xf09faab3f09faab3
 
+build table-format=Pebble,v7
+a@2.SET.1:blob{fileNum=1 blockNum=1 offset=10 valueLen=10}attr=7
+b@5.SET.7:blob{fileNum=1 blockNum=2 offset=110 value=foo valueLen=200}attr=7
+b@4.DEL.3:
+b@3.SET.2:blob{fileNum=2 blockNum=0 offset=0 valueLen=200}attr=7
+b@2.SET.1:blob{fileNum=2 blockNum=1 offset=294 valueLen=103}attr=7
+----
+blob-separated-values: num-values 4
+
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 154
+ │    ├── data block header
+ │    │    ├── columnar block header
+ │    │    │    ├── 000-004: x 03000000 # maximum key length: 3
+ │    │    │    ├── 004-005: x 01       # version 1
+ │    │    │    ├── 005-007: x 0700     # 7 columns
+ │    │    │    ├── 007-011: x 05000000 # 5 rows
+ │    │    │    ├── 011-012: b 00000100 # col 0: prefixbytes
+ │    │    │    ├── 012-016: x 2e000000 # col 0: page start 46
+ │    │    │    ├── 016-017: b 00000011 # col 1: bytes
+ │    │    │    ├── 017-021: x 39000000 # col 1: page start 57
+ │    │    │    ├── 021-022: b 00000010 # col 2: uint
+ │    │    │    ├── 022-026: x 4a000000 # col 2: page start 74
+ │    │    │    ├── 026-027: b 00000001 # col 3: bool
+ │    │    │    ├── 027-031: x 56000000 # col 3: page start 86
+ │    │    │    ├── 031-032: b 00000011 # col 4: bytes
+ │    │    │    ├── 032-036: x 68000000 # col 4: page start 104
+ │    │    │    ├── 036-037: b 00000001 # col 5: bool
+ │    │    │    ├── 037-041: x 86000000 # col 5: page start 134
+ │    │    │    ├── 041-042: b 00000001 # col 6: bool
+ │    │    │    └── 042-046: x 98000000 # col 6: page start 152
+ │    │    ├── data for column 0 (prefixbytes)
+ │    │    │    ├── 046-047: x 04 # bundle size: 16
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 047-048: x 01 # encoding: 1b
+ │    │    │    │    ├── 048-049: x 00 # data[0] = 0 [55 overall]
+ │    │    │    │    ├── 049-050: x 00 # data[1] = 0 [55 overall]
+ │    │    │    │    ├── 050-051: x 01 # data[2] = 1 [56 overall]
+ │    │    │    │    ├── 051-052: x 02 # data[3] = 2 [57 overall]
+ │    │    │    │    ├── 052-053: x 02 # data[4] = 2 [57 overall]
+ │    │    │    │    ├── 053-054: x 02 # data[5] = 2 [57 overall]
+ │    │    │    │    └── 054-055: x 02 # data[6] = 2 [57 overall]
+ │    │    │    └── data
+ │    │    │         ├── 055-055: x    # data[00]:  (block prefix)
+ │    │    │         ├── 055-055: x    # data[01]:  (bundle prefix)
+ │    │    │         ├── 055-056: x 61 # data[02]: a
+ │    │    │         ├── 056-057: x 62 # data[03]: b
+ │    │    │         ├── 057-057: x    # data[04]: .
+ │    │    │         ├── 057-057: x    # data[05]: .
+ │    │    │         └── 057-057: x    # data[06]: .
+ │    │    ├── data for column 1 (bytes)
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 057-058: x 01 # encoding: 1b
+ │    │    │    │    ├── 058-059: x 00 # data[0] = 0 [64 overall]
+ │    │    │    │    ├── 059-060: x 02 # data[1] = 2 [66 overall]
+ │    │    │    │    ├── 060-061: x 04 # data[2] = 4 [68 overall]
+ │    │    │    │    ├── 061-062: x 06 # data[3] = 6 [70 overall]
+ │    │    │    │    ├── 062-063: x 08 # data[4] = 8 [72 overall]
+ │    │    │    │    └── 063-064: x 0a # data[5] = 10 [74 overall]
+ │    │    │    └── data
+ │    │    │         ├── 064-066: x 4032 # data[0]: @2
+ │    │    │         ├── 066-068: x 4035 # data[1]: @5
+ │    │    │         ├── 068-070: x 4034 # data[2]: @4
+ │    │    │         ├── 070-072: x 4033 # data[3]: @3
+ │    │    │         └── 072-074: x 4032 # data[4]: @2
+ │    │    ├── data for column 2 (uint)
+ │    │    │    ├── 074-075: x 02   # encoding: 2b
+ │    │    │    ├── 075-076: x 00   # padding (aligning to 16-bit boundary)
+ │    │    │    ├── 076-078: x 0101 # data[0] = 257
+ │    │    │    ├── 078-080: x 0107 # data[1] = 1793
+ │    │    │    ├── 080-082: x 0003 # data[2] = 768
+ │    │    │    ├── 082-084: x 0102 # data[3] = 513
+ │    │    │    └── 084-086: x 0101 # data[4] = 257
+ │    │    ├── data for column 3 (bool)
+ │    │    │    ├── 086-087: x 00                                                               # default bitmap encoding
+ │    │    │    ├── 087-088: x 00                                                               # padding to align to 64-bit boundary
+ │    │    │    ├── 088-096: b 0000001100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+ │    │    │    └── 096-104: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+ │    │    ├── data for column 4 (bytes)
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 104-105: x 01 # encoding: 1b
+ │    │    │    │    ├── 105-106: x 00 # data[0] = 0 [111 overall]
+ │    │    │    │    ├── 106-107: x 05 # data[1] = 5 [116 overall]
+ │    │    │    │    ├── 107-108: x 0b # data[2] = 11 [122 overall]
+ │    │    │    │    ├── 108-109: x 0b # data[3] = 11 [122 overall]
+ │    │    │    │    ├── 109-110: x 11 # data[4] = 17 [128 overall]
+ │    │    │    │    └── 110-111: x 17 # data[5] = 23 [134 overall]
+ │    │    │    └── data
+ │    │    │         ├── 111-116: x 47000a010a   # data[0]: "G\x00\n\x01\n"
+ │    │    │         ├── 116-122: x 4700c801026e # data[1]: "G\x00\xc8\x01\x02n"
+ │    │    │         ├── 122-122: x              # data[2]:
+ │    │    │         ├── 122-128: x 6701c8010000 # data[3]: "g\x01\xc8\x01\x00\x00"
+ │    │    │         └── 128-134: x 67016701a602 # data[4]: "g\x01g\x01\xa6\x02"
+ │    │    ├── data for column 5 (bool)
+ │    │    │    ├── 134-135: x 00                                                               # default bitmap encoding
+ │    │    │    ├── 135-136: x 00                                                               # padding to align to 64-bit boundary
+ │    │    │    ├── 136-144: b 0001101100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+ │    │    │    └── 144-152: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+ │    │    ├── data for column 6 (bool)
+ │    │    │    └── 152-153: x 01 # zero bitmap encoding
+ │    │    └── 153-154: x 00 # block padding byte
+ │    ├── a@2#1,SET:blob handle (f0,blk1[10:20])
+ │    ├── b@5#7,SET:blob handle (f0,blk2[110:310])
+ │    ├── b@4#3,DEL:
+ │    ├── b@3#2,SET:blob handle (f1,blk0[0:200])
+ │    ├── b@2#1,SET:blob handle (f1,blk1[294:397])
+ │    └── trailer [compression=none checksum=0x834a75d7]
+ ├── index  offset: 159  length: 36
+ │    ├── 00000    block:0/154
+ │    │   
+ │    └── trailer [compression=none checksum=0xda1c8436]
+ ├── properties  offset: 200  length: 562
+ │    ├── 00000    obsolete-key (13)
+ │    ├── 00013    pebble.colblk.schema (65)
+ │    ├── 00078    pebble.num.values.in.blob-files (32)
+ │    ├── 00110    pebble.raw.point-tombstone.key.size (36)
+ │    ├── 00146    rocksdb.block.based.table.index.type (40)
+ │    ├── 00186    rocksdb.comparator (42)
+ │    ├── 00228    rocksdb.compression (25)
+ │    ├── 00253    rocksdb.compression_options (122)
+ │    ├── 00375    rocksdb.data.size (19)
+ │    ├── 00394    rocksdb.deleted.keys (21)
+ │    ├── 00415    rocksdb.filter.size (20)
+ │    ├── 00435    rocksdb.index.size (19)
+ │    ├── 00454    rocksdb.merge.operands (23)
+ │    ├── 00477    rocksdb.merge.operator (40)
+ │    ├── 00517    rocksdb.num.data.blocks (24)
+ │    ├── 00541    rocksdb.num.entries (20)
+ │    ├── 00561    rocksdb.num.range-deletions (28)
+ │    ├── 00589    rocksdb.property.collectors (41)
+ │    ├── 00630    rocksdb.raw.key.size (21)
+ │    ├── 00651    rocksdb.raw.value.size (24)
+ │    └── trailer [compression=snappy checksum=0x277c72db]
+ ├── meta-index  offset: 767  length: 46
+ │    ├── 0000    rocksdb.properties block:200/562
+ │    │   
+ │    └── trailer [compression=none checksum=0xaa86f2de]
+ └── footer  offset: 818  length: 61
+      ├── 000  checksum type: crc32c
+      ├── 001  meta: offset=767, length=46
+      ├── 004  index: offset=159, length=36
+      ├── 041  attributes: [RangeKeySets,RangeKeyUnsets,RangeKeyDels,TwoLevelIndex]
+      ├── 045  footer checksum: 0x2ee54544
+      ├── 049  version: 7
+      └── 053  magic number: 0xf09faab3f09faab3
+
 # TODO(jackson): Test iteration over the blob-separated values when that's
 # supported.

--- a/sstable/testdata/writer_v7
+++ b/sstable/testdata/writer_v7
@@ -1,0 +1,388 @@
+build
+a.SET.1:a
+----
+point:    [a#1,SET-a#1,SET]
+seqnums:  [1-1]
+
+scan
+----
+a#1,SET:a
+
+scan-range-del
+----
+
+scan-range-key
+----
+
+build
+a.SET.1:a
+b.DEL.2:
+c.MERGE.3:c
+Span: d-e:{(#4,RANGEDEL)}
+f.SET.5:f
+g.DEL.6:
+h.MERGE.7:h
+Span: i-j:{(#8,RANGEDEL)}
+Span: j-k:{(#9,RANGEKEYDEL)}
+Span: k-l:{(#10,RANGEKEYUNSET,@5)}
+Span: l-m:{(#11,RANGEKEYSET,@10,foo)}
+----
+point:    [a#1,SET-h#7,MERGE]
+rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
+rangekey: [j#9,RANGEKEYDEL-m#inf,RANGEKEYSET]
+seqnums:  [1-11]
+
+build
+a.SET.1:a
+b.DEL.2:
+c.MERGE.3:c
+Span: d-e:{(#4,RANGEDEL)}
+f.SET.5:f
+g.DEL.6:
+h.MERGE.7:h
+Span: i-j:{(#8,RANGEDEL)}
+----
+point:    [a#1,SET-h#7,MERGE]
+rangedel: [d#4,RANGEDEL-j#inf,RANGEDEL]
+seqnums:  [1-8]
+
+scan
+----
+a#1,SET:a
+b#2,DEL:
+c#3,MERGE:c
+f#5,SET:f
+g#6,DEL:
+h#7,MERGE:h
+
+scan-range-del
+----
+d-e:{(#4,RANGEDEL)}
+i-j:{(#8,RANGEDEL)}
+
+# 3: a-----------m
+# 2:      f------------s
+# 1:          j---------------z
+
+build
+Span: a-f:{(#3,RANGEDEL)}
+Span: f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
+Span: j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+Span: m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
+Span: s-z:{(#1,RANGEDEL)}
+----
+rangedel: [a#3,RANGEDEL-z#inf,RANGEDEL]
+seqnums:  [1-3]
+
+scan
+----
+
+scan-range-del
+----
+a-f:{(#3,RANGEDEL)}
+f-j:{(#3,RANGEDEL) (#2,RANGEDEL)}
+j-m:{(#3,RANGEDEL) (#2,RANGEDEL) (#1,RANGEDEL)}
+m-s:{(#2,RANGEDEL) (#1,RANGEDEL)}
+s-z:{(#1,RANGEDEL)}
+
+scan-range-key
+----
+
+props
+----
+rocksdb.num.entries: 9
+rocksdb.raw.key.size: 10
+rocksdb.raw.value.size: 0
+rocksdb.deleted.keys: 9
+rocksdb.num.range-deletions: 9
+rocksdb.num.data.blocks: 0
+rocksdb.compression: Snappy
+rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
+rocksdb.comparator: pebble.internal.testkeys
+rocksdb.data.size: 0
+rocksdb.filter.size: 0
+rocksdb.index.size: 28
+rocksdb.block.based.table.index.type: 0
+pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
+rocksdb.merge.operator: pebble.concatenate
+rocksdb.merge.operands: 0
+rocksdb.property.collectors: [obsolete-key]
+obsolete-key: hex:0074
+
+# The range tombstone upper bound is exclusive, so a point operation
+# on that same key will be the actual boundary.
+
+build
+Span: a-b:{(#3,RANGEDEL)}
+b.SET.4:c
+----
+point:    [b#4,SET-b#4,SET]
+rangedel: [a#3,RANGEDEL-b#inf,RANGEDEL]
+seqnums:  [3-4]
+
+build
+Span: a-b:{(#3,RANGEDEL)}
+b.SET.2:c
+----
+point:    [b#2,SET-b#2,SET]
+rangedel: [a#3,RANGEDEL-b#inf,RANGEDEL]
+seqnums:  [2-3]
+
+build
+Span: a-c:{(#3,RANGEDEL)}
+b.SET.2:c
+----
+point:    [b#2,SET-b#2,SET]
+rangedel: [a#3,RANGEDEL-c#inf,RANGEDEL]
+seqnums:  [2-3]
+
+# Keys must be added in order.
+
+build
+a.SET.1:b
+a.SET.2:c
+----
+failed to write a#2,SET = c: pebble: keys must be added in strictly increasing order: a#1,SET, a#2,SET
+
+build
+b.SET.1:a
+a.SET.2:b
+----
+failed to write a#2,SET = b: pebble: keys must be added in strictly increasing order: b#1,SET, a#2,SET
+
+build
+b.RANGEDEL.1:c
+a.RANGEDEL.2:b
+----
+failed to write b#1,RANGEDEL = c: RANGEDEL must be added through EncodeSpan
+
+build
+Span: b-c:{(#1,RANGEDEL)}
+Span: a-b:{(#2,RANGEDEL)}
+----
+failed to write Span: a-b:{(#2,RANGEDEL)}: pebble: keys must be added in order: b-c:{(#1,RANGEDEL)}, a-b:{(#2,RANGEDEL)}
+
+build-raw
+Span: a-c:{(#1,RANGEDEL)}
+Span: a-c:{(#2,RANGEDEL)}
+----
+pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
+
+build-raw
+Span: a-c:{(#1,RANGEDEL)}
+Span: b-d:{(#2,RANGEDEL)}
+----
+pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, b-d:{(#2,RANGEDEL)}
+
+build-raw
+Span: a-c:{(#2,RANGEDEL)}
+Span: a-d:{(#1,RANGEDEL)}
+----
+pebble: keys must be added in order: a-c:{(#2,RANGEDEL)}, a-d:{(#1,RANGEDEL)}
+
+build-raw
+Span: a-c:{(#1,RANGEDEL)}
+Span: c-d:{(#2,RANGEDEL)}
+----
+rangedel: [a#1,RANGEDEL-d#inf,RANGEDEL]
+seqnums:  [1-2]
+
+build-raw
+Span: a-b:{(#2,RANGEKEYSET,@10,foo) (#1,RANGEKEYSET,@10,foo)}
+----
+rangekey: [a#2,RANGEKEYSET-b#inf,RANGEKEYSET]
+seqnums:  [1-2]
+
+build-raw
+Span: b-c:{(#2,RANGEKEYSET,@10,foo)}
+Span: a-b:{(#1,RANGEKEYSET,@10,foo)}
+----
+pebble: keys must be added in order: b-c:{(#2,RANGEKEYSET)}, a-b:{(#1,RANGEKEYSET,@10,foo)}
+
+build-raw
+Span: a-c:{(#1,RANGEKEYSET,@10,foo)}
+Span: c-d:{(#2,RANGEKEYSET,@10,foo)}
+----
+rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+seqnums:  [1-2]
+
+# Range keys may have perfectly aligned spans (including sequence numbers),
+# though the key kinds must be ordered (descending).
+
+build-raw
+Span: a-b:{(#1,RANGEKEYSET,@10,foo) (#1,RANGEKEYUNSET,@10) (#1,RANGEKEYDEL)}
+----
+rangekey: [a#1,RANGEKEYSET-b#inf,RANGEKEYDEL]
+seqnums:  [1-1]
+
+# Setting a very small index-block-size results in a two-level index.
+
+build block-size=1 index-block-size=1
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+----
+point:    [a#1,SET-c#1,SET]
+seqnums:  [1-1]
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 74
+ ├── data  offset: 79  length: 74
+ ├── data  offset: 158  length: 74
+ ├── index  offset: 237  length: 36
+ ├── index  offset: 278  length: 37
+ ├── index  offset: 320  length: 37
+ ├── top-index  offset: 362  length: 48
+ ├── properties  offset: 415  length: 554
+ ├── meta-index  offset: 974  length: 46
+ └── footer  offset: 1025  length: 61
+
+props
+----
+rocksdb.num.entries: 3
+rocksdb.raw.key.size: 27
+rocksdb.raw.value.size: 3
+rocksdb.deleted.keys: 0
+rocksdb.num.range-deletions: 0
+rocksdb.num.data.blocks: 3
+rocksdb.compression: Snappy
+rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
+rocksdb.comparator: pebble.internal.testkeys
+rocksdb.data.size: 237
+rocksdb.filter.size: 0
+rocksdb.index.partitions: 3
+rocksdb.index.size: 158
+rocksdb.block.based.table.index.type: 2
+pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
+rocksdb.merge.operator: pebble.concatenate
+rocksdb.merge.operands: 0
+rocksdb.property.collectors: [obsolete-key]
+rocksdb.top-level.index.size: 48
+obsolete-key: hex:00
+
+# Exercise the non-Reader layout-decoding codepath.
+
+decode-layout
+----
+sstable
+ ├── data  offset: 0  length: 74
+ ├── data  offset: 79  length: 74
+ ├── data  offset: 158  length: 74
+ ├── index  offset: 237  length: 36
+ ├── index  offset: 278  length: 37
+ ├── index  offset: 320  length: 37
+ ├── top-index  offset: 362  length: 48
+ ├── properties  offset: 415  length: 554
+ ├── meta-index  offset: 974  length: 46
+ └── footer  offset: 1025  length: 61
+
+scan
+----
+a#1,SET:a
+b#1,SET:b
+c#1,SET:c
+
+# Enabling leveldb format disables the creation of a two-level index
+# (the input data here mirrors the test case above).
+
+build table-format=LevelDB block-size=1 index-block-size=1
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+----
+point:    [a#1,SET-c#1,SET]
+seqnums:  [1-1]
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 21
+ ├── data  offset: 26  length: 21
+ ├── data  offset: 52  length: 21
+ ├── index  offset: 78  length: 45
+ ├── properties  offset: 128  length: 549
+ ├── meta-index  offset: 682  length: 33
+ └── leveldb-footer  offset: 720  length: 48
+
+# Range keys, if present, are shown in the layout.
+
+build
+Span: a-b:{(#3,RANGEKEYSET,@3,foo)}
+Span: b-c:{(#2,RANGEKEYSET,@2,bar)}
+Span: c-d:{(#1,RANGEKEYSET,@1,baz)}
+----
+rangekey: [a#3,RANGEKEYSET-d#inf,RANGEKEYSET]
+seqnums:  [1-3]
+
+layout
+----
+sstable
+ ├── index  offset: 0  length: 28
+ ├── range-key  offset: 33  length: 84
+ ├── properties  offset: 122  length: 577
+ ├── meta-index  offset: 704  length: 65
+ └── footer  offset: 774  length: 61
+
+props
+----
+rocksdb.num.entries: 0
+rocksdb.raw.key.size: 0
+rocksdb.raw.value.size: 0
+rocksdb.deleted.keys: 0
+rocksdb.num.range-deletions: 0
+pebble.num.range-key-dels: 0
+pebble.num.range-key-sets: 3
+rocksdb.num.data.blocks: 0
+rocksdb.compression: Snappy
+rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
+rocksdb.comparator: pebble.internal.testkeys
+rocksdb.data.size: 0
+rocksdb.filter.size: 0
+rocksdb.index.size: 28
+rocksdb.block.based.table.index.type: 0
+pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
+rocksdb.merge.operator: pebble.concatenate
+rocksdb.merge.operands: 0
+pebble.num.range-key-unsets: 0
+rocksdb.property.collectors: [obsolete-key]
+pebble.raw.range-key.key.size: 6
+pebble.raw.range-key.value.size: 9
+obsolete-key: hex:0074
+
+open-writer disable-value-blocks
+----
+
+write-kvs
+a@2.SET.1:a2
+a@1.SET.1:a1
+b@2.SET.1:b2
+----
+EstimatedSize()=171
+
+close
+----
+point:    [a@2#1,SET-b@2#1,SET]
+seqnums:  [1-1]
+
+build compression=zstd
+a.SET.1:thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydog
+----
+point:    [a#1,SET-a#1,SET]
+seqnums:  [1-1]
+
+props rocksdb.compression
+----
+rocksdb.compression: ZSTD
+
+# MinLZ is supported in v6.
+build compression=minlz
+a.SET.1:thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydog
+----
+point:    [a#1,SET-a#1,SET]
+seqnums:  [1-1]
+
+props rocksdb.compression
+----
+rocksdb.compression: MinLZ

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -1047,3 +1047,146 @@ sstable
       ├── 041  footer checksum: 0x29ebd1c0
       ├── 045  version: 6
       └── 049  magic number: 0xf09faab3f09faab3
+
+# Same as above but with (Pebble,v7) [footer attributes].
+build table-format=Pebble,v7
+b@5.SET.7:b5
+b@3.SET.2:
+c@6.DEL.7:
+c@5.DEL.6:
+----
+value-blocks: num-values 0, num-blocks: 0, size: 0
+
+scan
+----
+b@5#7,SET:b5
+b@3#2,SET:
+c@6#7,DEL:
+c@5#6,DEL:
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 100
+ │    ├── data block header
+ │    │    ├── columnar block header
+ │    │    │    ├── 000-004: x 03000000 # maximum key length: 3
+ │    │    │    ├── 004-005: x 01       # version 1
+ │    │    │    ├── 005-007: x 0700     # 7 columns
+ │    │    │    ├── 007-011: x 04000000 # 4 rows
+ │    │    │    ├── 011-012: b 00000100 # col 0: prefixbytes
+ │    │    │    ├── 012-016: x 2e000000 # col 0: page start 46
+ │    │    │    ├── 016-017: b 00000011 # col 1: bytes
+ │    │    │    ├── 017-021: x 38000000 # col 1: page start 56
+ │    │    │    ├── 021-022: b 00000010 # col 2: uint
+ │    │    │    ├── 022-026: x 46000000 # col 2: page start 70
+ │    │    │    ├── 026-027: b 00000001 # col 3: bool
+ │    │    │    ├── 027-031: x 50000000 # col 3: page start 80
+ │    │    │    ├── 031-032: b 00000011 # col 4: bytes
+ │    │    │    ├── 032-036: x 68000000 # col 4: page start 104
+ │    │    │    ├── 036-037: b 00000001 # col 5: bool
+ │    │    │    ├── 037-041: x 70000000 # col 5: page start 112
+ │    │    │    ├── 041-042: b 00000001 # col 6: bool
+ │    │    │    └── 042-046: x 71000000 # col 6: page start 113
+ │    │    ├── data for column 0 (prefixbytes)
+ │    │    │    ├── 046-047: x 04 # bundle size: 16
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 047-048: x 01 # encoding: 1b
+ │    │    │    │    ├── 048-049: x 00 # data[0] = 0 [54 overall]
+ │    │    │    │    ├── 049-050: x 00 # data[1] = 0 [54 overall]
+ │    │    │    │    ├── 050-051: x 01 # data[2] = 1 [55 overall]
+ │    │    │    │    ├── 051-052: x 01 # data[3] = 1 [55 overall]
+ │    │    │    │    ├── 052-053: x 02 # data[4] = 2 [56 overall]
+ │    │    │    │    └── 053-054: x 02 # data[5] = 2 [56 overall]
+ │    │    │    └── data
+ │    │    │         ├── 054-054: x    # data[00]:  (block prefix)
+ │    │    │         ├── 054-054: x    # data[01]:  (bundle prefix)
+ │    │    │         ├── 054-055: x 62 # data[02]: b
+ │    │    │         ├── 055-055: x    # data[03]: .
+ │    │    │         ├── 055-056: x 63 # data[04]: c
+ │    │    │         └── 056-056: x    # data[05]: .
+ │    │    ├── data for column 1 (bytes)
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 056-057: x 01 # encoding: 1b
+ │    │    │    │    ├── 057-058: x 00 # data[0] = 0 [62 overall]
+ │    │    │    │    ├── 058-059: x 02 # data[1] = 2 [64 overall]
+ │    │    │    │    ├── 059-060: x 04 # data[2] = 4 [66 overall]
+ │    │    │    │    ├── 060-061: x 06 # data[3] = 6 [68 overall]
+ │    │    │    │    └── 061-062: x 08 # data[4] = 8 [70 overall]
+ │    │    │    └── data
+ │    │    │         ├── 062-064: x 4035 # data[0]: @5
+ │    │    │         ├── 064-066: x 4033 # data[1]: @3
+ │    │    │         ├── 066-068: x 4036 # data[2]: @6
+ │    │    │         └── 068-070: x 4035 # data[3]: @5
+ │    │    ├── data for column 2 (uint)
+ │    │    │    ├── 070-071: x 02   # encoding: 2b
+ │    │    │    ├── 071-072: x 00   # padding (aligning to 16-bit boundary)
+ │    │    │    ├── 072-074: x 0107 # data[0] = 1793
+ │    │    │    ├── 074-076: x 0102 # data[1] = 513
+ │    │    │    ├── 076-078: x 0007 # data[2] = 1792
+ │    │    │    └── 078-080: x 0006 # data[3] = 1536
+ │    │    ├── data for column 3 (bool)
+ │    │    │    ├── 080-081: x 00                                                               # default bitmap encoding
+ │    │    │    ├── 081-088: x 00000000000000                                                   # padding to align to 64-bit boundary
+ │    │    │    ├── 088-096: b 0000010100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+ │    │    │    └── 096-104: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+ │    │    ├── data for column 4 (bytes)
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 104-105: x 01 # encoding: 1b
+ │    │    │    │    ├── 105-106: x 00 # data[0] = 0 [110 overall]
+ │    │    │    │    ├── 106-107: x 02 # data[1] = 2 [112 overall]
+ │    │    │    │    ├── 107-108: x 02 # data[2] = 2 [112 overall]
+ │    │    │    │    ├── 108-109: x 02 # data[3] = 2 [112 overall]
+ │    │    │    │    └── 109-110: x 02 # data[4] = 2 [112 overall]
+ │    │    │    └── data
+ │    │    │         ├── 110-112: x 6235 # data[0]: b5
+ │    │    │         ├── 112-112: x      # data[1]:
+ │    │    │         ├── 112-112: x      # data[2]:
+ │    │    │         └── 112-112: x      # data[3]:
+ │    │    ├── data for column 5 (bool)
+ │    │    │    └── 112-113: x 01 # zero bitmap encoding
+ │    │    ├── data for column 6 (bool)
+ │    │    │    └── 113-114: x 01 # zero bitmap encoding
+ │    │    └── 114-115: x 00 # block padding byte
+ │    ├── b@5#7,SET:b5
+ │    ├── b@3#2,SET:
+ │    ├── c@6#7,DEL:
+ │    ├── c@5#6,DEL:
+ │    └── trailer [compression=snappy checksum=0x73ac4dc7]
+ ├── index  offset: 105  length: 36
+ │    ├── 00000    block:0/100
+ │    │   
+ │    └── trailer [compression=none checksum=0x760132f1]
+ ├── properties  offset: 146  length: 525
+ │    ├── 00000    obsolete-key (13)
+ │    ├── 00013    pebble.colblk.schema (65)
+ │    ├── 00078    pebble.raw.point-tombstone.key.size (36)
+ │    ├── 00114    rocksdb.block.based.table.index.type (40)
+ │    ├── 00154    rocksdb.comparator (42)
+ │    ├── 00196    rocksdb.compression (25)
+ │    ├── 00221    rocksdb.compression_options (122)
+ │    ├── 00343    rocksdb.data.size (18)
+ │    ├── 00361    rocksdb.deleted.keys (21)
+ │    ├── 00382    rocksdb.filter.size (20)
+ │    ├── 00402    rocksdb.index.size (19)
+ │    ├── 00421    rocksdb.merge.operands (23)
+ │    ├── 00444    rocksdb.merge.operator (40)
+ │    ├── 00484    rocksdb.num.data.blocks (24)
+ │    ├── 00508    rocksdb.num.entries (20)
+ │    ├── 00528    rocksdb.num.range-deletions (28)
+ │    ├── 00556    rocksdb.property.collectors (41)
+ │    ├── 00597    rocksdb.raw.key.size (21)
+ │    ├── 00618    rocksdb.raw.value.size (23)
+ │    └── trailer [compression=snappy checksum=0x5d7f7403]
+ ├── meta-index  offset: 676  length: 46
+ │    ├── 0000    rocksdb.properties block:146/525
+ │    │   
+ │    └── trailer [compression=none checksum=0xf5a62be1]
+ └── footer  offset: 727  length: 61
+      ├── 000  checksum type: crc32c
+      ├── 001  meta: offset=676, length=46
+      ├── 004  index: offset=105, length=36
+      ├── 041  attributes: [ValueBlocks,RangeKeyUnsets,RangeDels,TwoLevelIndex]
+      ├── 045  footer checksum: 0xbcb59445
+      ├── 049  version: 7
+      └── 053  magic number: 0xf09faab3f09faab3

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -49,6 +49,7 @@ func TestWriter(t *testing.T) {
 		{TableFormat: TableFormatPebblev3, File: "testdata/writer_v3"},
 		{TableFormat: TableFormatPebblev5, File: "testdata/writer_v5"},
 		{TableFormat: TableFormatPebblev6, File: "testdata/writer_v6"},
+		{TableFormat: TableFormatPebblev7, File: "testdata/writer_v7"},
 	}
 	for _, tff := range formatFiles {
 		t.Run(tff.TableFormat.String(), func(t *testing.T) {
@@ -64,6 +65,7 @@ func TestRewriter(t *testing.T) {
 		{TableFormat: TableFormatPebblev3, File: "testdata/rewriter_v3"},
 		{TableFormat: TableFormatPebblev5, File: "testdata/rewriter_v5"},
 		{TableFormat: TableFormatPebblev6, File: "testdata/rewriter_v6"},
+		{TableFormat: TableFormatPebblev7, File: "testdata/rewriter_v7"},
 	}
 	for _, tff := range formatFiles {
 		t.Run(tff.TableFormat.String(), func(t *testing.T) {

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -55,6 +55,10 @@ create: db/marker.format-version.000009.022
 close: db/marker.format-version.000009.022
 remove: db/marker.format-version.000008.021
 sync: db
+create: db/marker.format-version.000010.023
+close: db/marker.format-version.000010.023
+remove: db/marker.format-version.000009.022
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -121,9 +125,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.022
-close: checkpoints/checkpoint1/marker.format-version.000001.022
+create: checkpoints/checkpoint1/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.023
+close: checkpoints/checkpoint1/marker.format-version.000001.023
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -165,9 +169,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.022
-close: checkpoints/checkpoint2/marker.format-version.000001.022
+create: checkpoints/checkpoint2/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.023
+close: checkpoints/checkpoint2/marker.format-version.000001.023
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -204,9 +208,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.022
-close: checkpoints/checkpoint3/marker.format-version.000001.022
+create: checkpoints/checkpoint3/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.023
+close: checkpoints/checkpoint3/marker.format-version.000001.023
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -290,7 +294,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -300,7 +304,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -367,7 +371,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -409,7 +413,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -528,9 +532,9 @@ sync-data: checkpoints/checkpoint4/OPTIONS-000003
 close: checkpoints/checkpoint4/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.022
-close: checkpoints/checkpoint4/marker.format-version.000001.022
+create: checkpoints/checkpoint4/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.023
+close: checkpoints/checkpoint4/marker.format-version.000001.023
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -618,7 +622,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -637,9 +641,9 @@ sync-data: checkpoints/checkpoint5/OPTIONS-000003
 close: checkpoints/checkpoint5/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.022
-close: checkpoints/checkpoint5/marker.format-version.000001.022
+create: checkpoints/checkpoint5/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.023
+close: checkpoints/checkpoint5/marker.format-version.000001.023
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -739,9 +743,9 @@ sync-data: checkpoints/checkpoint6/OPTIONS-000003
 close: checkpoints/checkpoint6/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.022
-close: checkpoints/checkpoint6/marker.format-version.000001.022
+create: checkpoints/checkpoint6/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.023
+close: checkpoints/checkpoint6/marker.format-version.000001.023
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst
@@ -910,6 +914,10 @@ create: valsepdb/marker.format-version.000009.022
 close: valsepdb/marker.format-version.000009.022
 remove: valsepdb/marker.format-version.000008.021
 sync: valsepdb
+create: valsepdb/marker.format-version.000010.023
+close: valsepdb/marker.format-version.000010.023
+remove: valsepdb/marker.format-version.000009.022
+sync: valsepdb
 create: valsepdb/temporary.000003.dbtmp
 sync: valsepdb/temporary.000003.dbtmp
 close: valsepdb/temporary.000003.dbtmp
@@ -958,9 +966,9 @@ sync-data: checkpoints/checkpoint8/OPTIONS-000003
 close: checkpoints/checkpoint8/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint8
-create: checkpoints/checkpoint8/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint8/marker.format-version.000001.022
-close: checkpoints/checkpoint8/marker.format-version.000001.022
+create: checkpoints/checkpoint8/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint8/marker.format-version.000001.023
+close: checkpoints/checkpoint8/marker.format-version.000001.023
 sync: checkpoints/checkpoint8
 close: checkpoints/checkpoint8
 link: valsepdb/000006.blob -> checkpoints/checkpoint8/000006.blob
@@ -1072,9 +1080,9 @@ sync-data: checkpoints/checkpoint9/OPTIONS-000003
 close: checkpoints/checkpoint9/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint9
-create: checkpoints/checkpoint9/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint9/marker.format-version.000001.022
-close: checkpoints/checkpoint9/marker.format-version.000001.022
+create: checkpoints/checkpoint9/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint9/marker.format-version.000001.023
+close: checkpoints/checkpoint9/marker.format-version.000001.023
 sync: checkpoints/checkpoint9
 close: checkpoints/checkpoint9
 link: valsepdb/000006.blob -> checkpoints/checkpoint9/000006.blob

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -246,15 +246,15 @@ close: db/000009.sst
 sync: db
 sync: db/MANIFEST-000001
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): db/000005.sst
+read-at(700, 61): db/000005.sst
 read-at(649, 51): db/000005.sst
 read-at(132, 517): db/000005.sst
 open: db/000009.sst (options: *vfs.randomReadsOption)
-read-at(704, 57): db/000009.sst
+read-at(704, 61): db/000009.sst
 read-at(653, 51): db/000009.sst
 read-at(136, 517): db/000009.sst
 open: db/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): db/000007.sst
+read-at(700, 61): db/000007.sst
 read-at(649, 51): db/000007.sst
 read-at(132, 517): db/000007.sst
 read-at(91, 41): db/000005.sst
@@ -326,13 +326,13 @@ close: checkpoints/checkpoint1/000006.log
 scan checkpoints/checkpoint1
 ----
 open: checkpoints/checkpoint1/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint1/000007.sst
+read-at(700, 61): checkpoints/checkpoint1/000007.sst
 read-at(649, 51): checkpoints/checkpoint1/000007.sst
 read-at(132, 517): checkpoints/checkpoint1/000007.sst
 read-at(91, 41): checkpoints/checkpoint1/000007.sst
 read-at(0, 91): checkpoints/checkpoint1/000007.sst
 open: checkpoints/checkpoint1/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint1/000005.sst
+read-at(700, 61): checkpoints/checkpoint1/000005.sst
 read-at(649, 51): checkpoints/checkpoint1/000005.sst
 read-at(132, 517): checkpoints/checkpoint1/000005.sst
 read-at(91, 41): checkpoints/checkpoint1/000005.sst
@@ -349,7 +349,7 @@ g 10
 scan db
 ----
 open: db/000010.sst (options: *vfs.randomReadsOption)
-read-at(709, 57): db/000010.sst
+read-at(709, 61): db/000010.sst
 read-at(658, 51): db/000010.sst
 read-at(141, 517): db/000010.sst
 read-at(100, 41): db/000010.sst
@@ -393,7 +393,7 @@ close: checkpoints/checkpoint2/000006.log
 scan checkpoints/checkpoint2
 ----
 open: checkpoints/checkpoint2/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint2/000007.sst
+read-at(700, 61): checkpoints/checkpoint2/000007.sst
 read-at(649, 51): checkpoints/checkpoint2/000007.sst
 read-at(132, 517): checkpoints/checkpoint2/000007.sst
 read-at(91, 41): checkpoints/checkpoint2/000007.sst
@@ -435,13 +435,13 @@ close: checkpoints/checkpoint3/000006.log
 scan checkpoints/checkpoint3
 ----
 open: checkpoints/checkpoint3/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint3/000007.sst
+read-at(700, 61): checkpoints/checkpoint3/000007.sst
 read-at(649, 51): checkpoints/checkpoint3/000007.sst
 read-at(132, 517): checkpoints/checkpoint3/000007.sst
 read-at(91, 41): checkpoints/checkpoint3/000007.sst
 read-at(0, 91): checkpoints/checkpoint3/000007.sst
 open: checkpoints/checkpoint3/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 57): checkpoints/checkpoint3/000005.sst
+read-at(700, 61): checkpoints/checkpoint3/000005.sst
 read-at(649, 51): checkpoints/checkpoint3/000005.sst
 read-at(132, 517): checkpoints/checkpoint3/000005.sst
 read-at(91, 41): checkpoints/checkpoint3/000005.sst
@@ -512,7 +512,7 @@ h 11
 i i
 k k
 open: db/000014.sst (options: *vfs.randomReadsOption)
-read-at(505, 57): db/000014.sst
+read-at(501, 61): db/000014.sst
 read-at(472, 37): db/000014.sst
 read-at(53, 419): db/000014.sst
 z z
@@ -578,7 +578,7 @@ close: checkpoints/checkpoint4/000008.log
 scan checkpoints/checkpoint4
 ----
 open: checkpoints/checkpoint4/000010.sst (options: *vfs.randomReadsOption)
-read-at(709, 57): checkpoints/checkpoint4/000010.sst
+read-at(709, 61): checkpoints/checkpoint4/000010.sst
 read-at(658, 51): checkpoints/checkpoint4/000010.sst
 read-at(141, 517): checkpoints/checkpoint4/000010.sst
 read-at(100, 41): checkpoints/checkpoint4/000010.sst
@@ -590,7 +590,7 @@ e 8
 f 9
 g 10
 open: checkpoints/checkpoint4/000011.sst (options: *vfs.randomReadsOption)
-read-at(522, 57): checkpoints/checkpoint4/000011.sst
+read-at(518, 61): checkpoints/checkpoint4/000011.sst
 read-at(489, 37): checkpoints/checkpoint4/000011.sst
 read-at(70, 419): checkpoints/checkpoint4/000011.sst
 read-at(43, 27): checkpoints/checkpoint4/000011.sst
@@ -599,7 +599,7 @@ h 11
 i i
 k k
 open: checkpoints/checkpoint4/000014.sst (options: *vfs.randomReadsOption)
-read-at(505, 57): checkpoints/checkpoint4/000014.sst
+read-at(501, 61): checkpoints/checkpoint4/000014.sst
 read-at(472, 37): checkpoints/checkpoint4/000014.sst
 read-at(53, 419): checkpoints/checkpoint4/000014.sst
 read-at(26, 27): checkpoints/checkpoint4/000014.sst
@@ -1015,7 +1015,7 @@ close: checkpoints/checkpoint8/000004.log
 scan checkpoints/checkpoint8
 ----
 open: checkpoints/checkpoint8/000005.sst (options: *vfs.randomReadsOption)
-read-at(750, 57): checkpoints/checkpoint8/000005.sst
+read-at(750, 61): checkpoints/checkpoint8/000005.sst
 read-at(699, 51): checkpoints/checkpoint8/000005.sst
 read-at(172, 527): checkpoints/checkpoint8/000005.sst
 read-at(131, 41): checkpoints/checkpoint8/000005.sst
@@ -1125,7 +1125,7 @@ close: checkpoints/checkpoint9/000007.log
 scan checkpoints/checkpoint9
 ----
 open: checkpoints/checkpoint9/000005.sst (options: *vfs.randomReadsOption)
-read-at(750, 57): checkpoints/checkpoint9/000005.sst
+read-at(750, 61): checkpoints/checkpoint9/000005.sst
 read-at(699, 51): checkpoints/checkpoint9/000005.sst
 read-at(172, 527): checkpoints/checkpoint9/000005.sst
 read-at(131, 41): checkpoints/checkpoint9/000005.sst

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -43,6 +43,10 @@ create: db/marker.format-version.000006.022
 close: db/marker.format-version.000006.022
 remove: db/marker.format-version.000005.021
 sync: db
+create: db/marker.format-version.000007.023
+close: db/marker.format-version.000007.023
+remove: db/marker.format-version.000006.022
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -109,9 +113,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.022
-close: checkpoints/checkpoint1/marker.format-version.000001.022
+create: checkpoints/checkpoint1/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.023
+close: checkpoints/checkpoint1/marker.format-version.000001.023
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -162,9 +166,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.022
-close: checkpoints/checkpoint2/marker.format-version.000001.022
+create: checkpoints/checkpoint2/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.023
+close: checkpoints/checkpoint2/marker.format-version.000001.023
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -211,9 +215,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.022
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.022
-close: checkpoints/checkpoint3/marker.format-version.000001.022
+create: checkpoints/checkpoint3/marker.format-version.000001.023
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.023
+close: checkpoints/checkpoint3/marker.format-version.000001.023
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -270,7 +274,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000006.022
+marker.format-version.000007.023
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -280,7 +284,7 @@ list checkpoints/checkpoint1
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -332,7 +336,7 @@ list checkpoints/checkpoint2
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.022
+marker.format-version.000001.023
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -75,11 +75,11 @@ sync: db/MANIFEST-000001
 mkdir-all: db_wal/archive 0755
 rename: db_wal/000004.log -> db_wal/archive/000004.log
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(531, 57): db/000005.sst
+read-at(527, 61): db/000005.sst
 read-at(498, 37): db/000005.sst
 read-at(79, 419): db/000005.sst
 open: db/000007.sst (options: *vfs.randomReadsOption)
-read-at(505, 57): db/000007.sst
+read-at(501, 61): db/000007.sst
 read-at(472, 37): db/000007.sst
 read-at(53, 419): db/000007.sst
 read-at(52, 27): db/000005.sst

--- a/testdata/compaction/set_with_del_sstable_Pebblev7
+++ b/testdata/compaction/set_with_del_sstable_Pebblev7
@@ -1,0 +1,818 @@
+batch
+set a 1
+set b 2
+----
+
+compact a-b
+----
+L6:
+  000005:[a#10,SET-b#11,SET]
+
+batch
+set c 3
+set d 4
+----
+
+compact c-d
+----
+L6:
+  000005:[a#10,SET-b#11,SET]
+  000007:[c#12,SET-d#13,SET]
+
+batch
+set b 5
+set c 6
+----
+
+compact a-d
+----
+L6:
+  000010:[a#0,SET-d#0,SET]
+
+# This also tests flushing a memtable that only contains range
+# deletions.
+
+batch
+del-range a e
+----
+
+compact a-d
+----
+
+# Test that a multi-output-file compaction generates non-overlapping files.
+
+define target-file-sizes=(100, 1)
+L0
+  b.SET.1:v
+L0
+  a.SET.2:v
+----
+L0.0:
+  000005:[a#2,SET-a#2,SET]
+  000004:[b#1,SET-b#1,SET]
+
+compact a-b
+----
+L1:
+  000006:[a#0,SET-a#0,SET]
+  000007:[b#0,SET-b#0,SET]
+
+# A range tombstone extends past the grandparent file boundary used to limit the
+# size of future compactions. Verify the range tombstone is split at that file
+# boundary.
+
+define target-file-sizes=(1, 1, 1, 1)
+L1
+  a.SET.3:v
+L2
+  a.RANGEDEL.2:e
+L3
+  a.SET.0:v
+  b.SET.0:v
+L3
+  c.SET.0:v
+  d.SET.0:v
+----
+L1:
+  000004:[a#3,SET-a#3,SET]
+L2:
+  000005:[a#2,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+
+wait-pending-table-stats
+000005
+----
+num-entries: 1
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 1502
+
+compact a-e L1
+----
+L2:
+  000008:[a#3,SET-c#inf,RANGEDEL]
+  000009:[c#2,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+
+wait-pending-table-stats
+000008
+----
+num-entries: 2
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 751
+
+# Same as above, except range tombstone covers multiple grandparent file boundaries.
+
+define target-file-sizes=(1, 1, 1, 1)
+L1
+  a.SET.3:v
+L2
+  a.RANGEDEL.2:g
+L3
+  a.SET.0:v
+  b.SET.0:v
+L3
+  c.SET.0:v
+  d.SET.0:v
+L3
+  e.SET.0:v
+  f.SET.1:v
+L3
+  g.SET.1:v
+  g.SET.0:v
+----
+L1:
+  000004:[a#3,SET-a#3,SET]
+L2:
+  000005:[a#2,RANGEDEL-g#inf,RANGEDEL]
+L3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+  000008:[e#0,SET-f#1,SET]
+  000009:[g#1,SET-g#1,SET]
+
+compact a-e L1
+----
+L2:
+  000010:[a#3,SET-c#inf,RANGEDEL]
+  000011:[c#2,RANGEDEL-e#inf,RANGEDEL]
+  000012:[e#2,RANGEDEL-g#inf,RANGEDEL]
+L3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+  000008:[e#0,SET-f#1,SET]
+  000009:[g#1,SET-g#1,SET]
+
+# A range tombstone covers multiple grandparent file boundaries between point keys,
+# rather than after all point keys.
+
+define target-file-sizes=(1, 1, 1, 1)
+L1
+  a.SET.3:v
+  h.SET.3:v
+L2
+  a.RANGEDEL.2:g
+L3
+  a.SET.0:v
+  b.SET.0:v
+L3
+  c.SET.0:v
+  d.SET.0:v
+L3
+  e.SET.0:v
+  f.SET.1:v
+----
+L1:
+  000004:[a#3,SET-h#3,SET]
+L2:
+  000005:[a#2,RANGEDEL-g#inf,RANGEDEL]
+L3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+  000008:[e#0,SET-f#1,SET]
+
+compact a-e L1
+----
+L2:
+  000009:[a#3,SET-c#inf,RANGEDEL]
+  000010:[c#2,RANGEDEL-e#inf,RANGEDEL]
+  000011:[e#2,RANGEDEL-g#inf,RANGEDEL]
+  000012:[h#3,SET-h#3,SET]
+L3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+  000008:[e#0,SET-f#1,SET]
+
+# A range tombstone is the first and only item output by a compaction, and it
+# extends past the grandparent file boundary used to limit the size of future
+# compactions. Verify the range tombstone is split at that file boundary.
+
+define target-file-sizes=(1, 1, 1, 1)
+L1
+  a.RANGEDEL.3:e
+L2
+  a.SET.2:v
+L3
+  a.SET.0:v
+  b.SET.0:v
+L3
+  c.SET.0:v
+  d.SET.0:v
+----
+L1:
+  000004:[a#3,RANGEDEL-e#inf,RANGEDEL]
+L2:
+  000005:[a#2,SET-a#2,SET]
+L3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+
+compact a-e L1
+----
+L2:
+  000008:[a#3,RANGEDEL-c#inf,RANGEDEL]
+  000009:[c#3,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000006:[a#0,SET-b#0,SET]
+  000007:[c#0,SET-d#0,SET]
+
+# An elided range tombstone is the first item encountered by a compaction,
+# and the grandparent limit set by it extends to the next item, also a range
+# tombstone. The first item should be elided, and the second item should
+# reset the grandparent limit.
+
+define target-file-sizes=(100, 100, 100, 100)
+L1
+  a.RANGEDEL.4:d
+L1
+  grandparent.RANGEDEL.2:z
+  h.SET.3:v
+L2
+  grandparent.SET.1:v
+L3
+  grandparent.SET.0:v
+L3
+  m.SET.0:v
+----
+L1:
+  000004:[a#4,RANGEDEL-d#inf,RANGEDEL]
+  000005:[grandparent#2,RANGEDEL-z#inf,RANGEDEL]
+L2:
+  000006:[grandparent#1,SET-grandparent#1,SET]
+L3:
+  000007:[grandparent#0,SET-grandparent#0,SET]
+  000008:[m#0,SET-m#0,SET]
+
+compact a-h L1
+----
+L2:
+  000009:[grandparent#2,RANGEDEL-h#inf,RANGEDEL]
+  000010:[h#3,SET-z#inf,RANGEDEL]
+L3:
+  000007:[grandparent#0,SET-grandparent#0,SET]
+  000008:[m#0,SET-m#0,SET]
+
+# Regression test for a bug where compaction would stop process range
+# tombstones for an input level upon finding an sstable in the input
+# level with no range tombstones. In the scenario below, sstable 6
+# does not contain any range tombstones while sstable 7 does. Both are
+# compacted together with sstable 5.
+
+reset
+----
+
+batch
+set a 1
+set b 1
+set c 1
+set d 1
+set z 1
+----
+
+compact a-z
+----
+L6:
+  000005:[a#10,SET-z#14,SET]
+
+build ext1
+set a 2
+----
+
+build ext2
+set b 2
+del-range c z
+----
+
+ingest ext1 ext2
+----
+L0.0:
+  000006:[a#15,SET-a#15,SET]
+  000007:[b#16,SET-z#inf,RANGEDEL]
+L6:
+  000005:[a#10,SET-z#14,SET]
+
+iter
+first
+next
+next
+next
+----
+a: (2, .)
+b: (2, .)
+z: (1, .)
+.
+
+compact a-z
+----
+L6:
+  000008:[a#0,SET-z#0,SET]
+
+iter
+first
+next
+next
+next
+----
+a: (2, .)
+b: (2, .)
+z: (1, .)
+.
+
+# Regression test for a bug in sstable smallest boundary generation
+# where the smallest key for an sstable was set to a key "larger" than
+# the start key of the first range tombstone. This in turn fouled up
+# the processing logic of range tombstones used by mergingIter which
+# allowed stepping out of an sstable even though it contained a range
+# tombstone that covered keys in lower levels.
+
+define target-file-sizes=(1, 1, 1, 1)
+L0
+  c.SET.4:4
+L1
+  a.SET.3:3
+L2
+  a.RANGEDEL.2:e
+L3
+  b.SET.1:1
+----
+L0.0:
+  000004:[c#4,SET-c#4,SET]
+L1:
+  000005:[a#3,SET-a#3,SET]
+L2:
+  000006:[a#2,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000007:[b#1,SET-b#1,SET]
+
+compact a-e L1
+----
+L0.0:
+  000004:[c#4,SET-c#4,SET]
+L2:
+  000008:[a#3,SET-b#inf,RANGEDEL]
+  000009:[b#2,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000007:[b#1,SET-b#1,SET]
+
+# We should only see a:3 and c:4 at this point.
+
+iter
+first
+next
+next
+----
+a: (3, .)
+c: (4, .)
+.
+
+# The bug allowed seeing b:1 during reverse iteration.
+
+iter
+last
+prev
+prev
+----
+c: (4, .)
+a: (3, .)
+.
+
+# This is a similar scenario to the one above. In older versions of Pebble this
+# case necessitated adjusting the seqnum of the range tombstone to
+# prev.LargestKey.SeqNum-1. We no longer allow user keys to be split across
+# sstables, and the seqnum adjustment is no longer necessary.
+#
+# Note the target-file-size of 26 is specially tailored to get the
+# desired compaction output.
+
+define target-file-sizes=(26, 26, 26, 26) snapshots=(1, 2, 3)
+L1
+  a.SET.4:4
+L1
+  b.SET.2:2
+  b.RANGEDEL.3:e
+L3
+  b.SET.1:1
+----
+L1:
+  000004:[a#4,SET-a#4,SET]
+  000005:[b#3,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000006:[b#1,SET-b#1,SET]
+
+compact a-e L1
+----
+L2:
+  000007:[a#4,SET-a#4,SET]
+  000008:[b#3,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000006:[b#1,SET-b#1,SET]
+
+iter
+first
+next
+last
+prev
+----
+a: (4, .)
+.
+a: (4, .)
+.
+
+# Similar to the preceding scenario, except the range tombstone has
+# the same seqnum as the largest key in the preceding file.
+
+define target-file-sizes=(26, 26, 26, 26) snapshots=(1, 2, 3)
+L1
+  a.SET.4:4
+L1
+  b.SET.3:3
+  b.RANGEDEL.3:e
+L3
+  b.SET.1:1
+----
+L1:
+  000004:[a#4,SET-a#4,SET]
+  000005:[b#3,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000006:[b#1,SET-b#1,SET]
+
+compact a-e L1
+----
+L2:
+  000007:[a#4,SET-a#4,SET]
+  000008:[b#3,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000006:[b#1,SET-b#1,SET]
+
+iter
+first
+next
+next
+last
+prev
+prev
+----
+a: (4, .)
+b: (3, .)
+.
+b: (3, .)
+a: (4, .)
+.
+
+# Similar to the preceding scenario, except the range tombstone has
+# a smaller seqnum than the largest key in the preceding file.
+
+define target-file-sizes=(26, 26, 26, 26) snapshots=(1, 2, 3)
+L1
+  a.SET.4:4
+L1
+  b.SET.4:4
+  b.RANGEDEL.2:e
+L3
+  b.SET.1:1
+----
+L1:
+  000004:[a#4,SET-a#4,SET]
+  000005:[b#4,SET-e#inf,RANGEDEL]
+L3:
+  000006:[b#1,SET-b#1,SET]
+
+compact a-e L1
+----
+L2:
+  000007:[a#4,SET-a#4,SET]
+  000008:[b#4,SET-e#inf,RANGEDEL]
+L3:
+  000006:[b#1,SET-b#1,SET]
+
+iter
+first
+next
+next
+last
+prev
+prev
+----
+a: (4, .)
+b: (4, .)
+.
+b: (4, .)
+a: (4, .)
+.
+
+# Test a scenario where the last point key in an sstable has a seqnum
+# of 0.
+
+define target-file-sizes=(1, 1, 26) snapshots=(2)
+L1
+  a.SET.3:3
+  b.RANGEDEL.3:e
+  b.SET.0:0
+L3
+  a.RANGEDEL.2:b
+L3
+  c.SET.0:0
+  d.SET.0:0
+----
+L1:
+  000004:[a#3,SET-e#inf,RANGEDEL]
+L3:
+  000005:[a#2,RANGEDEL-b#inf,RANGEDEL]
+  000006:[c#0,SET-d#0,SET]
+
+iter
+last
+prev
+----
+a: (3, .)
+.
+
+compact a-e L1
+----
+L2:
+  000007:[a#3,SET-a#3,SET]
+  000008:[b#3,RANGEDEL-c#inf,RANGEDEL]
+  000009:[c#3,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000005:[a#2,RANGEDEL-b#inf,RANGEDEL]
+  000006:[c#0,SET-d#0,SET]
+
+iter
+last
+prev
+----
+a: (3, .)
+.
+
+# Test a scenario where the last point key in an sstable before the
+# grandparent limit is reached has a seqnum of 0. We want to cut the
+# sstable after the next point key is added, rather than continuing to
+# add keys indefinitely (or till the size limit is reached).
+
+define target-file-sizes=(100, 1, 52) snapshots=(2)
+L1
+  a.SET.3:3
+  b.RANGEDEL.3:e
+  b.SET.0:0
+  c.SET.3:1
+  d.SET.1:1
+L3
+  c.RANGEDEL.2:d
+----
+L1:
+  000004:[a#3,SET-e#inf,RANGEDEL]
+L3:
+  000005:[c#2,RANGEDEL-d#inf,RANGEDEL]
+
+compact a-f L1
+----
+L2:
+  000006:[a#3,SET-a#3,SET]
+  000007:[b#3,RANGEDEL-c#inf,RANGEDEL]
+  000008:[c#3,RANGEDEL-d#inf,RANGEDEL]
+  000009:[d#3,RANGEDEL-e#inf,RANGEDEL]
+L3:
+  000005:[c#2,RANGEDEL-d#inf,RANGEDEL]
+
+
+# Test a scenario where we the last point key in an sstable has a
+# seqnum of 0, but there is another range tombstone later in the
+# compaction. This scenario was previously triggering an assertion due
+# to the rangedel.Fragmenter being finished prematurely.
+
+define target-file-sizes=(1, 1, 1)
+L1
+  a.SET.0:0
+  c.RANGEDEL.1:d
+L3
+  b.SET.0:0
+----
+L1:
+  000004:[a#0,SET-d#inf,RANGEDEL]
+L3:
+  000005:[b#0,SET-b#0,SET]
+
+compact a-e L1
+----
+L2:
+  000006:[a#0,SET-a#0,SET]
+L3:
+  000005:[b#0,SET-b#0,SET]
+
+define target-file-sizes=(1, 1, 1, 1)
+L0
+  b.SET.1:v
+L0
+  a.SET.2:v
+----
+L0.0:
+  000005:[a#2,SET-a#2,SET]
+  000004:[b#1,SET-b#1,SET]
+
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
+----
+
+async-compact a-b L0
+----
+manual compaction blocked until ongoing finished
+L1:
+  000006:[a#0,SET-a#0,SET]
+  000007:[b#0,SET-b#0,SET]
+
+compact a-b L1
+----
+L2:
+  000008:[a#0,SET-a#0,SET]
+  000009:[b#0,SET-b#0,SET]
+
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
+----
+
+async-compact a-b L2
+----
+manual compaction blocked until ongoing finished
+L3:
+  000010:[a#0,SET-a#0,SET]
+  000011:[b#0,SET-b#0,SET]
+
+add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
+----
+
+set-concurrent-compactions max=2
+----
+
+async-compact a-b L3
+----
+manual compaction did not block for ongoing
+L4:
+  000012:[a#0,SET-a#0,SET]
+  000013:[b#0,SET-b#0,SET]
+
+remove-ongoing-compaction
+----
+
+add-ongoing-compaction startLevel=4 outputLevel=5 start=a end=b
+----
+
+async-compact a-b L4
+----
+manual compaction blocked until ongoing finished
+L5:
+  000014:[a#0,SET-a#0,SET]
+  000015:[b#0,SET-b#0,SET]
+
+# Test of a scenario where consecutive elided range tombstones and grandparent
+# boundaries could result in an invariant violation in the rangedel fragmenter.
+
+define target-file-sizes=(1, 1, 1, 1)
+L1
+  a.RANGEDEL.4:b
+  c.RANGEDEL.4:d
+  e.RANGEDEL.4:f
+L1
+  g.RANGEDEL.6:h
+  i.RANGEDEL.4:j
+L1
+  k.RANGEDEL.5:q
+  m.RANGEDEL.4:q
+L2
+  a.SET.2:foo
+L3
+  a.SET.1:foo
+  c.SET.1:foo
+L3
+  ff.SET.1:v
+L3
+  k.SET.1:foo
+----
+L1:
+  000004:[a#4,RANGEDEL-f#inf,RANGEDEL]
+  000005:[g#6,RANGEDEL-j#inf,RANGEDEL]
+  000006:[k#5,RANGEDEL-q#inf,RANGEDEL]
+L2:
+  000007:[a#2,SET-a#2,SET]
+L3:
+  000008:[a#1,SET-c#1,SET]
+  000009:[ff#1,SET-ff#1,SET]
+  000010:[k#1,SET-k#1,SET]
+
+compact a-q L1
+----
+L2:
+  000011:[a#4,RANGEDEL-b#inf,RANGEDEL]
+  000012:[c#4,RANGEDEL-d#inf,RANGEDEL]
+  000013:[k#5,RANGEDEL-m#inf,RANGEDEL]
+L3:
+  000008:[a#1,SET-c#1,SET]
+  000009:[ff#1,SET-ff#1,SET]
+  000010:[k#1,SET-k#1,SET]
+
+# Test a case where a new output file is started, there are no previous output
+# files, there are no additional keys (key = nil) and the rangedel fragmenter
+# is non-empty.
+define target-file-sizes=(1, 1, 1)
+L1
+  a.RANGEDEL.10:b
+  d.RANGEDEL.9:e
+  q.RANGEDEL.8:r
+L2
+  g.RANGEDEL.7:h
+L3
+  q.SET.6:6
+----
+L1:
+  000004:[a#10,RANGEDEL-r#inf,RANGEDEL]
+L2:
+  000005:[g#7,RANGEDEL-h#inf,RANGEDEL]
+L3:
+  000006:[q#6,SET-q#6,SET]
+
+compact a-r L1
+----
+L2:
+  000007:[q#8,RANGEDEL-r#inf,RANGEDEL]
+L3:
+  000006:[q#6,SET-q#6,SET]
+
+# Test a snapshot that separates a range deletion from all the data that it
+# deletes. Ensure that we respect the target-file-size and split into multiple
+# outputs.
+
+define target-file-sizes=(1, 1, 1) snapshots=(14)
+L1
+  a.RANGEDEL.15:z
+  b.SET.11:foo
+  c.SET.11:foo
+L2
+  c.SET.0:foo
+  d.SET.0:foo
+----
+L1:
+  000004:[a#15,RANGEDEL-z#inf,RANGEDEL]
+L2:
+  000005:[c#0,SET-d#0,SET]
+
+compact a-z L1
+----
+L2:
+  000006:[a#15,RANGEDEL-b#inf,RANGEDEL]
+  000007:[b#15,RANGEDEL-c#inf,RANGEDEL]
+  000008:[c#15,RANGEDEL-d#inf,RANGEDEL]
+  000009:[d#15,RANGEDEL-z#inf,RANGEDEL]
+
+# Test an interaction between a range deletion that will be elided with
+# output splitting. Ensure that the output is still split (previous versions
+# of the code did not, because of intricacies around preventing a zero
+# sequence number in an output's largest key).
+
+define target-file-sizes=(1, 1, 1)
+L1
+  a.RANGEDEL.10:z
+  b.SET.11:foo
+  c.SET.11:foo
+L2
+  c.SET.0:foo
+  d.SET.0:foo
+----
+L1:
+  000004:[a#10,RANGEDEL-z#inf,RANGEDEL]
+L2:
+  000005:[c#0,SET-d#0,SET]
+
+compact a-z L1
+----
+L2:
+  000006:[b#0,SET-b#0,SET]
+  000007:[c#0,SET-c#0,SET]
+
+define snapshots=(10)
+L1
+  a.MERGE.15:a15
+L2
+  a.SET.5:a5
+----
+L1:
+  000004:[a#15,MERGE-a#15,MERGE]
+L2:
+  000005:[a#5,SET-a#5,SET]
+
+compact a-z
+----
+L3:
+  000006:[a#15,MERGE-a#0,SET]
+
+# Fix for #2705. When snapshotPinned was used to set force obsolete, the
+# merged value would be a15 since the SET was incorrectly ignored.
+iter
+first
+next
+----
+a: (a5a15, .)
+.

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -88,7 +88,7 @@ maybe-compact
 Deletion hints:
   L0.000004 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel L2 [000005] (760B) Score=0.00 + L3 [000006] (760B) Score=0.00 + L4 [000007] (760B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel L2 [000005] (764B) Score=0.00 + L3 [000006] (764B) Score=0.00 + L4 [000007] (764B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # Verify that compaction correctly handles the presence of multiple
 # overlapping hints which might delete a file multiple times. All of the
@@ -127,7 +127,7 @@ maybe-compact
 Deletion hints:
   L1.000005 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel L2 [000005] (760B) Score=0.00 + L3 [000006] (760B) Score=0.00 + L4 [000007] (760B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel L2 [000005] (764B) Score=0.00 + L3 [000006] (764B) Score=0.00 + L4 [000007] (764B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # Test a range tombstone that is already compacted into L6.
 
@@ -206,7 +206,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel L2 [000005] (760B) Score=0.00 + L3 [000006] (760B) Score=0.00 + L4 [000007] (760B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel L2 [000005] (764B) Score=0.00 + L3 [000006] (764B) Score=0.00 + L4 [000007] (764B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # A deletion hint present on an sstable in a higher level should NOT result in a
 # deletion-only compaction incorrectly removing an sstable in L6 following an
@@ -255,7 +255,7 @@ L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
 close-snapshot
 10
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (825B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (749B), in 1.0s (2.0s total), output rate 749B/s
+[JOB 100] compacted(elision-only) L6 [000004] (829B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (753B), in 1.0s (2.0s total), output rate 753B/s
 
 # In previous versions of the code, the deletion hint was removed by the
 # elision-only compaction because it zeroed sequence numbers of keys with
@@ -474,7 +474,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel L1 [000005] (752B) Score=0.00 + L2 [000006] (760B) Score=0.00 + L3 [000007] (760B) Score=0.00 + L4 [000008] (760B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
+  [JOB 100] compacted(delete-only) multilevel L1 [000005] (756B) Score=0.00 + L2 [000006] (764B) Score=0.00 + L3 [000007] (764B) Score=0.00 + L4 [000008] (764B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
 
 describe-lsm
 ----
@@ -542,7 +542,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000005] (747B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+  [JOB 100] compacted(delete-only) L6 [000005] (751B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 describe-lsm
 ----
@@ -608,7 +608,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000004] (897B) Score=0.00 -> L6 [000007 000008] (186B), in 1.0s (2.0s total), output rate 186B/s
+  [JOB 100] compacted(delete-only) L6 [000004] (901B) Score=0.00 -> L6 [000007 000008] (186B), in 1.0s (2.0s total), output rate 186B/s
 
 describe-lsm
 ----
@@ -753,4 +753,4 @@ L0.000006 c-h seqnums(tombstone=11-12, file-smallest=10, type=point-and-range-ke
 close-snapshot
 11
 ----
-[JOB 100] compacted(delete-only) L6 [000004] (966B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000004] (970B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -41,7 +41,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (752B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (756B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that straddles a snapshot. It should not be compacted.
 define snapshots=(50) auto-compactions=off
@@ -85,7 +85,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (767B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (749B), in 1.0s (2.0s total), output rate 749B/s
+[JOB 100] compacted(elision-only) L6 [000004] (771B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (753B), in 1.0s (2.0s total), output rate 753B/s
 
 version
 ----
@@ -134,7 +134,7 @@ close-snapshot
 close-snapshot
 103
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (906B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (910B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that contains both deletions and non-deletions, but whose
 # non-deletions well outnumber its deletions. The table should not be
@@ -208,7 +208,7 @@ range-deletions-bytes-estimate: 16824
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=89.06 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
+[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=89.09 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
 
 define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
@@ -243,7 +243,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (771B) Score=6.14 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(default) L5 [000004] (775B) Score=6.15 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -323,7 +323,7 @@ range-deletions-bytes-estimate: 94
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (968B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (747B), in 1.0s (2.0s total), output rate 747B/s
+[JOB 100] compacted(elision-only) L6 [000004] (972B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (751B), in 1.0s (2.0s total), output rate 751B/s
 
 # Close the DB, asserting that the reference counts balance.
 close
@@ -376,7 +376,7 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (763B) Score=3.02 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(default) L5 [000004] (767B) Score=3.04 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -422,4 +422,4 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (763B) Score=3.02 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(default) L5 [000004] (767B) Score=3.04 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -104,7 +104,7 @@ close: db/marker.manifest.000002.MANIFEST-000006
 remove: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 [JOB 3] MANIFEST created 000006
-[JOB 3] flushed 1 memtable (100B) to L0 [000005] (743B), in 1.0s (2.0s total), output rate 743B/s
+[JOB 3] flushed 1 memtable (100B) to L0 [000005] (747B), in 1.0s (2.0s total), output rate 747B/s
 
 compact
 ----
@@ -128,16 +128,16 @@ close: db/marker.manifest.000003.MANIFEST-000009
 remove: db/marker.manifest.000002.MANIFEST-000006
 sync: db
 [JOB 5] MANIFEST created 000009
-[JOB 5] flushed 1 memtable (100B) to L0 [000008] (743B), in 1.0s (2.0s total), output rate 743B/s
+[JOB 5] flushed 1 memtable (100B) to L0 [000008] (747B), in 1.0s (2.0s total), output rate 747B/s
 remove: db/MANIFEST-000001
 [JOB 5] MANIFEST deleted 000001
 [JOB 6] compacting(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00; OverlappingRatio: Single 0.00, Multi 0.00
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(686, 57): db/000005.sst
+read-at(686, 61): db/000005.sst
 read-at(636, 50): db/000005.sst
 read-at(119, 517): db/000005.sst
 open: db/000008.sst (options: *vfs.randomReadsOption)
-read-at(686, 57): db/000008.sst
+read-at(686, 61): db/000008.sst
 read-at(636, 50): db/000008.sst
 read-at(119, 517): db/000008.sst
 read-at(78, 41): db/000005.sst
@@ -161,7 +161,7 @@ close: db/marker.manifest.000004.MANIFEST-000011
 remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
 [JOB 6] MANIFEST created 000011
-[JOB 6] compacted(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (746B), in 1.0s (3.0s total), output rate 746B/s
+[JOB 6] compacted(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (750B), in 1.0s (3.0s total), output rate 750B/s
 close: db/000005.sst
 close: db/000008.sst
 remove: db/MANIFEST-000006
@@ -196,7 +196,7 @@ close: db/marker.manifest.000005.MANIFEST-000014
 remove: db/marker.manifest.000004.MANIFEST-000011
 sync: db
 [JOB 8] MANIFEST created 000014
-[JOB 8] flushed 1 memtable (100B) to L0 [000013] (743B), in 1.0s (2.0s total), output rate 743B/s
+[JOB 8] flushed 1 memtable (100B) to L0 [000013] (747B), in 1.0s (2.0s total), output rate 747B/s
 
 enable-file-deletions
 ----
@@ -206,7 +206,7 @@ remove: db/MANIFEST-000009
 ingest
 ----
 open: ext/0
-read-at(689, 57): ext/0
+read-at(689, 61): ext/0
 read-at(639, 50): ext/0
 read-at(122, 517): ext/0
 read-at(81, 41): ext/0
@@ -226,21 +226,21 @@ sync: db
 remove: db/MANIFEST-000011
 [JOB 10] MANIFEST deleted 000011
 remove: ext/0
-[JOB 10] ingested L0:000015 (746B)
+[JOB 10] ingested L0:000015 (750B)
 
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |    - 0.40 0.40 |   97B |     1   746B |     0     0B |     3  2.2KB |    0B |   2 23.0
+    0 |     2  1.5KB     0B       0 |    - 0.40 0.40 |   97B |     1   750B |     0     0B |     3  2.2KB |    0B |   2 23.1
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   746B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   746B | 1.5KB |   1 0.50
-total |     3  2.2KB     0B       0 |    -    -    - |  843B |     1   746B |     0     0B |     4  3.7KB | 1.5KB |   3 4.53
+    6 |     1   750B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   750B | 1.5KB |   1 0.50
+total |     3  2.2KB     0B       0 |    -    -    - |  847B |     1   750B |     0     0B |     4  3.7KB | 1.5KB |   3 4.53
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 48B  written: 97B (102% overhead)
 Flushes: 3
@@ -270,14 +270,14 @@ ingest-flushable
 ----
 sync-data: wal/000012.log
 open: ext/a
-read-at(689, 57): ext/a
+read-at(689, 61): ext/a
 read-at(639, 50): ext/a
 read-at(122, 517): ext/a
 read-at(81, 41): ext/a
 read-at(0, 81): ext/a
 close: ext/a
 open: ext/b
-read-at(689, 57): ext/b
+read-at(689, 61): ext/b
 read-at(639, 50): ext/b
 read-at(122, 517): ext/b
 read-at(81, 41): ext/b
@@ -301,7 +301,7 @@ sync: wal
 [JOB 13] WAL created 000020
 remove: ext/a
 remove: ext/b
-[JOB 11] ingested as flushable 000017 (746B), 000018 (746B)
+[JOB 11] ingested as flushable 000017 (750B), 000018 (750B)
 sync-data: wal/000020.log
 close: wal/000020.log
 create: wal/000021.log
@@ -314,7 +314,7 @@ sync-data: db/000022.sst
 close: db/000022.sst
 sync: db
 sync: db/MANIFEST-000016
-[JOB 15] flushed 1 memtable (100B) to L0 [000022] (743B), in 1.0s (2.0s total), output rate 743B/s
+[JOB 15] flushed 1 memtable (100B) to L0 [000022] (747B), in 1.0s (2.0s total), output rate 747B/s
 [JOB 16] flushing 2 ingested tables
 create: db/MANIFEST-000023
 close: db/MANIFEST-000016
@@ -324,7 +324,7 @@ close: db/marker.manifest.000007.MANIFEST-000023
 remove: db/marker.manifest.000006.MANIFEST-000016
 sync: db
 [JOB 16] MANIFEST created 000023
-[JOB 16] flushed 2 ingested flushables L0:000017 (746B) + L6:000018 (746B) in 1.0s (2.0s total), output rate 1.5KB/s
+[JOB 16] flushed 2 ingested flushables L0:000017 (750B) + L6:000018 (750B) in 1.0s (2.0s total), output rate 1.5KB/s
 remove: db/MANIFEST-000014
 [JOB 16] MANIFEST deleted 000014
 [JOB 17] flushing 1 memtable (100B) to L0
@@ -336,14 +336,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.9KB     0B       0 |    - 0.80 0.80 |  132B |     2  1.5KB |     0     0B |     4  2.9KB |    0B |   4 22.5
+    0 |     4  2.9KB     0B       0 |    - 0.80 0.80 |  132B |     2  1.5KB |     0     0B |     4  2.9KB |    0B |   4 22.6
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     1   746B |     0     0B |     1   746B | 1.5KB |   1 0.50
-total |     6  4.4KB     0B       0 |    -    -    - | 2.3KB |     3  2.2KB |     0     0B |     5  5.9KB | 1.5KB |   5 2.57
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     1   750B |     0     0B |     1   750B | 1.5KB |   1 0.50
+total |     6  4.4KB     0B       0 |    -    -    - | 2.3KB |     3  2.2KB |     0     0B |     5  6.0KB | 1.5KB |   5 2.57
 ----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 82B  written: 132B (61% overhead)
 Flushes: 6

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -71,6 +71,11 @@ close: db/marker.format-version.000009.022
 remove: db/marker.format-version.000008.021
 sync: db
 upgraded to format version: 022
+create: db/marker.format-version.000010.023
+close: db/marker.format-version.000010.023
+remove: db/marker.format-version.000009.022
+sync: db
+upgraded to format version: 023
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -384,9 +389,9 @@ sync-data: checkpoint/OPTIONS-000003
 close: checkpoint/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.022
-sync-data: checkpoint/marker.format-version.000001.022
-close: checkpoint/marker.format-version.000001.022
+create: checkpoint/marker.format-version.000001.023
+sync-data: checkpoint/marker.format-version.000001.023
+close: checkpoint/marker.format-version.000001.023
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -60,7 +60,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -81,7 +81,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -390,7 +390,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -410,7 +410,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -443,7 +443,7 @@ MANIFEST-000001
 MANIFEST-000011
 OPTIONS-000014
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000002.MANIFEST-000011
 
 # Make sure that the new mutable memtable can accept writes.
@@ -586,7 +586,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -605,7 +605,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext1
-marker.format-version.000009.022
+marker.format-version.000010.023
 marker.manifest.000001.MANIFEST-000001
 
 open

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -360,7 +360,7 @@ num-entries: 2
 num-deletions: 2
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1316
+range-deletions-bytes-estimate: 1320
 
 # A set operation takes precedence over a range deletion at the same
 # sequence number as can occur during ingestion.

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -6,9 +6,9 @@ L1
   d.SET.0:foo
 ----
 L0.0:
-  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:740
+  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:744
 L1:
-  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:751
+  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:755
 
 mark-for-compaction file=000005
 ----
@@ -20,9 +20,9 @@ marked L0.000004
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000005] (751B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (751B), in 1.0s (2.0s total), output rate 751B/s
-[JOB 100] compacted(rewrite) L0 [000004] (740B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (740B), in 1.0s (2.0s total), output rate 740B/s
+[JOB 100] compacted(rewrite) L1 [000005] (755B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (755B), in 1.0s (2.0s total), output rate 755B/s
+[JOB 100] compacted(rewrite) L0 [000004] (744B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (744B), in 1.0s (2.0s total), output rate 744B/s
 L0.0:
-  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:740
+  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:744
 L1:
-  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:751
+  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:755

--- a/testdata/tracing
+++ b/testdata/tracing
@@ -5,7 +5,7 @@ set hello foo
 get
 hello
 ----
-reading footer of 57 bytes took 5ms
+reading footer of 61 bytes took 5ms
 reading block of 37 bytes took 5ms (<redacted>)
 reading block of 417 bytes took 5ms (<redacted>)
 reading block of 31 bytes took 5ms (<redacted>)
@@ -48,7 +48,7 @@ range-key-set a z @4 foo2
 get
 hello@2
 ----
-reading footer of 57 bytes took 5ms
+reading footer of 61 bytes took 5ms
 reading block of 62 bytes took 5ms (<redacted>)
 reading block of 504 bytes took 5ms (<redacted>)
 reading block of 27 bytes took 5ms (<redacted>)


### PR DESCRIPTION
## sstable: add TableFormatPebblev7 and FMV to support footer attributes

Add new sstable format version `TableFormatPebblev7` and internal format major
version to write attributes in sstable footer.

## sstable: persist attributes in sstable  footer

Persists sstable.Attributes to the footer for table formats greater than or
equal to `TableFormatPebblev7`. For now we continue to derive the attributes
from the properties when loading the sstable, and simply validate that the
attributes read from the footer are equivalent.

Closes: https://github.com/cockroachdb/pebble/issues/4652