### PR TITLE
compression: move low level compression code to separate package

### DIFF
--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -1,0 +1,90 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package compression
+
+import "fmt"
+
+type Algorithm uint8
+
+// The available compression types.
+const (
+	None Algorithm = iota
+	Snappy
+	Zstd
+	MinLZ
+	nAlgorithms
+)
+
+// String implements fmt.Stringer, returning a human-readable name for the
+// compression algorithm.
+func (a Algorithm) String() string {
+	switch a {
+	case None:
+		return "NoCompression"
+	case Snappy:
+		return "Snappy"
+	case Zstd:
+		return "ZSTD"
+	case MinLZ:
+		return "MinLZ"
+	default:
+		return fmt.Sprintf("unknown(%d)", a)
+	}
+}
+
+type Compressor interface {
+	// Compress a block, appending the compressed data to dst[:0].
+	Compress(dst, src []byte) []byte
+
+	// Close must be called when the Compressor is no longer needed.
+	// After Close is called, the Compressor must not be used again.
+	Close()
+}
+
+func GetCompressor(a Algorithm) Compressor {
+	switch a {
+	case None:
+		return noopCompressor{}
+	case Snappy:
+		return snappyCompressor{}
+	case Zstd:
+		return getZstdCompressor()
+	case MinLZ:
+		return minlzCompressor{}
+	default:
+		panic("Invalid compression type.")
+	}
+}
+
+type Decompressor interface {
+	// DecompressInto decompresses compressed into buf. The buf slice must have the
+	// exact size as the decompressed value. Callers may use DecompressedLen to
+	// determine the correct size.
+	DecompressInto(buf, compressed []byte) error
+
+	// DecompressedLen returns the length of the provided block once decompressed,
+	// allowing the caller to allocate a buffer exactly sized to the decompressed
+	// payload.
+	DecompressedLen(b []byte) (decompressedLen int, err error)
+
+	// Close must be called when the Decompressor is no longer needed.
+	// After Close is called, the Decompressor must not be used again.
+	Close()
+}
+
+func GetDecompressor(a Algorithm) Decompressor {
+	switch a {
+	case None:
+		return noopDecompressor{}
+	case Snappy:
+		return snappyDecompressor{}
+	case Zstd:
+		return getZstdDecompressor()
+	case MinLZ:
+		return minlzDecompressor{}
+	default:
+		panic("Invalid compression type.")
+	}
+}

--- a/internal/compression/compression_test.go
+++ b/internal/compression/compression_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package compression
+
+import (
+	"encoding/binary"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/crlib/testutils/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressionRoundtrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	seed := uint64(time.Now().UnixNano())
+	t.Logf("seed %d", seed)
+	rng := rand.New(rand.NewPCG(0, seed))
+
+	for algo := None; algo < nAlgorithms; algo++ {
+		t.Run(algo.String(), func(t *testing.T) {
+			payload := make([]byte, 1+rng.IntN(10<<10 /* 10 KiB */))
+			for i := range payload {
+				payload[i] = byte(rng.Uint32())
+			}
+			// Create a randomly-sized buffer to house the compressed output. If it's
+			// not sufficient, Compress should allocate one that is.
+			compressedBuf := make([]byte, 1+rng.IntN(1<<10 /* 1 KiB */))
+			compressor := GetCompressor(algo)
+			defer compressor.Close()
+			compressed := compressor.Compress(compressedBuf, payload)
+			got, err := decompress(algo, compressed)
+			require.NoError(t, err)
+			require.Equal(t, payload, got)
+		})
+	}
+}
+
+// TestDecompressionError tests that a decompressing a value that does not
+// decompress returns an error.
+func TestDecompressionError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rng := rand.New(rand.NewPCG(0, 1 /* fixed seed */))
+
+	// Create a buffer to represent a faux zstd compressed block. It's prefixed
+	// with a uvarint of the appropriate length, followed by garabge.
+	fauxCompressed := make([]byte, rng.IntN(10<<10 /* 10 KiB */))
+	compressedPayloadLen := len(fauxCompressed) - binary.MaxVarintLen64
+	n := binary.PutUvarint(fauxCompressed, uint64(compressedPayloadLen))
+	fauxCompressed = fauxCompressed[:n+compressedPayloadLen]
+	for i := range fauxCompressed[:n] {
+		fauxCompressed[i] = byte(rng.Uint32())
+	}
+
+	v, err := decompress(Zstd, fauxCompressed)
+	t.Log(err)
+	require.Error(t, err)
+	require.Nil(t, v)
+}
+
+// decompress decompresses an sstable block into memory manually allocated with
+// `cache.Alloc`.  NB: If Decompress returns (nil, nil), no decompression was
+// necessary and the caller may use `b` directly.
+func decompress(algo Algorithm, b []byte) ([]byte, error) {
+	decompressor := GetDecompressor(algo)
+	defer decompressor.Close()
+	// first obtain the decoded length.
+	decodedLen, err := decompressor.DecompressedLen(b)
+	if err != nil {
+		return nil, err
+	}
+	// Allocate sufficient space from the cache.
+	decodedBuf := make([]byte, decodedLen)
+	if err := decompressor.DecompressInto(decodedBuf, b); err != nil {
+		return nil, err
+	}
+	return decodedBuf, nil
+}

--- a/internal/compression/minlz.go
+++ b/internal/compression/minlz.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package compression
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/minio/minlz"
+)
+
+type minlzCompressor struct{}
+
+var _ Compressor = minlzCompressor{}
+
+func (minlzCompressor) Compress(dst, src []byte) []byte {
+	// MinLZ cannot encode blocks greater than 8MB. Fall back to Snappy in those
+	// cases. Note that MinLZ can decode the Snappy compressed block.
+	if len(src) > minlz.MaxBlockSize {
+		return (snappyCompressor{}).Compress(dst, src)
+	}
+
+	compressed, err := minlz.Encode(dst, src, minlz.LevelFastest)
+	if err != nil {
+		panic(errors.Wrap(err, "minlz compression"))
+	}
+	return compressed
+}
+
+func (minlzCompressor) Close() {}
+
+type minlzDecompressor struct{}
+
+var _ Decompressor = minlzDecompressor{}
+
+func (minlzDecompressor) DecompressInto(buf, compressed []byte) error {
+	result, err := minlz.Decode(buf, compressed)
+	if len(result) != len(buf) || (len(result) > 0 && &result[0] != &buf[0]) {
+		return base.CorruptionErrorf("pebble/table: decompressed into unexpected buffer: %p != %p",
+			errors.Safe(result), errors.Safe(buf))
+	}
+	return err
+}
+
+func (minlzDecompressor) DecompressedLen(b []byte) (decompressedLen int, err error) {
+	l, err := minlz.DecodedLen(b)
+	return l, err
+}
+
+func (minlzDecompressor) Close() {}

--- a/internal/compression/minlz_test.go
+++ b/internal/compression/minlz_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package compression
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/minio/minlz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinLZLargeBlock(t *testing.T) {
+	for _, delta := range []int{-1, 0, 1, 1 << rand.IntN(24)} {
+		b := make([]byte, minlz.MaxBlockSize+delta)
+		for i := range b {
+			b[i] = byte(i)
+		}
+		c := GetCompressor(MinLZ)
+		defer c.Close()
+		compressed := c.Compress(nil, b)
+		d := GetDecompressor(MinLZ)
+		decompressed := make([]byte, len(b))
+		defer d.Close()
+
+		require.NoError(t, d.DecompressInto(decompressed, compressed))
+		require.Equal(t, b, decompressed)
+	}
+}

--- a/internal/compression/noop.go
+++ b/internal/compression/noop.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package compression
+
+type noopCompressor struct{}
+
+var _ Compressor = noopCompressor{}
+
+func (noopCompressor) Compress(dst, src []byte) []byte {
+	return append(dst[:0], src...)
+}
+func (noopCompressor) Close() {}
+
+type noopDecompressor struct{}
+
+var _ Decompressor = noopDecompressor{}
+
+func (noopDecompressor) DecompressInto(dst, src []byte) error {
+	dst = dst[:len(src)]
+	copy(dst, src)
+	return nil
+}
+
+func (noopDecompressor) DecompressedLen(b []byte) (decompressedLen int, err error) {
+	return len(b), nil
+}
+
+func (noopDecompressor) Close() {}

--- a/internal/compression/snappy.go
+++ b/internal/compression/snappy.go
@@ -1,0 +1,44 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package compression
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/golang/snappy"
+)
+
+type snappyCompressor struct{}
+
+var _ Compressor = snappyCompressor{}
+
+func (snappyCompressor) Compress(dst, src []byte) []byte {
+	dst = dst[:cap(dst):cap(dst)]
+	return snappy.Encode(dst, src)
+}
+
+func (snappyCompressor) Close() {}
+
+type snappyDecompressor struct{}
+
+var _ Decompressor = snappyDecompressor{}
+
+func (snappyDecompressor) DecompressInto(buf, compressed []byte) error {
+	result, err := snappy.Decode(buf, compressed)
+	if err != nil {
+		return err
+	}
+	if len(result) != len(buf) || (len(result) > 0 && &result[0] != &buf[0]) {
+		return base.CorruptionErrorf("pebble: decompressed into unexpected buffer: %p != %p",
+			errors.Safe(result), errors.Safe(buf))
+	}
+	return nil
+}
+
+func (snappyDecompressor) DecompressedLen(b []byte) (decompressedLen int, err error) {
+	return snappy.DecodedLen(b)
+}
+
+func (snappyDecompressor) Close() {}

--- a/sstable/block/compression_test.go
+++ b/sstable/block/compression_test.go
@@ -5,96 +5,13 @@
 package block
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math/rand/v2"
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/crlib/testutils/leaktest"
-	"github.com/cockroachdb/pebble/internal/cache"
-	"github.com/minio/minlz"
 	"github.com/stretchr/testify/require"
 )
-
-func TestCompressionRoundtrip(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	seed := uint64(time.Now().UnixNano())
-	t.Logf("seed %d", seed)
-	rng := rand.New(rand.NewPCG(0, seed))
-
-	for compression := DefaultCompression + 1; compression < NCompression; compression++ {
-		if compression == NoCompression {
-			continue
-		}
-		t.Run(compression.String(), func(t *testing.T) {
-			payload := make([]byte, 1+rng.IntN(10<<10 /* 10 KiB */))
-			for i := range payload {
-				payload[i] = byte(rng.Uint32())
-			}
-			// Create a randomly-sized buffer to house the compressed output. If it's
-			// not sufficient, Compress should allocate one that is.
-			compressedBuf := make([]byte, 1+rng.IntN(1<<10 /* 1 KiB */))
-			compressor := GetCompressor(compression)
-			defer compressor.Close()
-			btyp, compressed := compressor.Compress(compressedBuf, payload)
-			v, err := decompress(btyp, compressed)
-			require.NoError(t, err)
-			got := payload
-			if v != nil {
-				got = v.RawBuffer()
-				require.Equal(t, payload, got)
-				cache.Free(v)
-			}
-		})
-	}
-}
-
-// TestDecompressionError tests that a decompressing a value that does not
-// decompress returns an error.
-func TestDecompressionError(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	rng := rand.New(rand.NewPCG(0, 1 /* fixed seed */))
-
-	// Create a buffer to represent a faux zstd compressed block. It's prefixed
-	// with a uvarint of the appropriate length, followed by garabge.
-	fauxCompressed := make([]byte, rng.IntN(10<<10 /* 10 KiB */))
-	compressedPayloadLen := len(fauxCompressed) - binary.MaxVarintLen64
-	n := binary.PutUvarint(fauxCompressed, uint64(compressedPayloadLen))
-	fauxCompressed = fauxCompressed[:n+compressedPayloadLen]
-	for i := range fauxCompressed[:n] {
-		fauxCompressed[i] = byte(rng.Uint32())
-	}
-
-	v, err := decompress(ZstdCompressionIndicator, fauxCompressed)
-	t.Log(err)
-	require.Error(t, err)
-	require.Nil(t, v)
-}
-
-// decompress decompresses an sstable block into memory manually allocated with
-// `cache.Alloc`.  NB: If Decompress returns (nil, nil), no decompression was
-// necessary and the caller may use `b` directly.
-func decompress(algo CompressionIndicator, b []byte) (*cache.Value, error) {
-	if algo == NoCompressionIndicator {
-		return nil, nil
-	}
-
-	// first obtain the decoded length.
-	decodedLen, err := DecompressedLen(algo, b)
-	if err != nil {
-		return nil, err
-	}
-	// Allocate sufficient space from the cache.
-	decoded := cache.Alloc(decodedLen)
-	decodedBuf := decoded.RawBuffer()
-	if err := DecompressInto(algo, b, decodedBuf); err != nil {
-		cache.Free(decoded)
-		return nil, err
-	}
-	return decoded, nil
-}
 
 func TestBufferRandomized(t *testing.T) {
 	seed := uint64(time.Now().UnixNano())
@@ -135,24 +52,5 @@ func TestBufferRandomized(t *testing.T) {
 			_, bh := b.CompressAndChecksum()
 			bh.Release()
 		})
-	}
-}
-
-func TestMinLZLargeBlock(t *testing.T) {
-	for _, delta := range []int{-1, 0, 1, 1 << rand.IntN(24)} {
-		b := make([]byte, minlz.MaxBlockSize+delta)
-		for i := range b {
-			b[i] = byte(i)
-		}
-		c := GetCompressor(MinLZCompression)
-		defer c.Close()
-		algo, compressed := c.Compress(nil, b)
-		require.Equal(t, MinLZCompressionIndicator, algo)
-		d := GetDecompressor(algo)
-		decompressed := make([]byte, len(b))
-		defer d.Close()
-
-		require.NoError(t, d.DecompressInto(decompressed, compressed))
-		require.Equal(t, b, decompressed)
 	}
 }

--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -1,166 +1,45 @@
 package block
 
-import (
-	"encoding/binary"
+import "github.com/cockroachdb/pebble/internal/compression"
 
-	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/golang/snappy"
-	"github.com/minio/minlz"
-)
-
-type Compressor interface {
-	Compress(dst, src []byte) (CompressionIndicator, []byte)
-
-	// Close must be called when the Compressor is no longer needed.
-	// After Close is called, the Compressor must not be used again.
-	Close()
+// Compressor is used to compress blocks. Typical usage:
+//
+//	c := GetCompressor(compression)
+//	.. = c.Compress(..)
+//	.. = c.Compress(..)
+//	c.Close()
+type Compressor struct {
+	algorithm  compression.Algorithm
+	compressor compression.Compressor
 }
 
-type noopCompressor struct{}
-type snappyCompressor struct{}
-type minlzCompressor struct{}
-
-var _ Compressor = noopCompressor{}
-var _ Compressor = snappyCompressor{}
-var _ Compressor = minlzCompressor{}
-
-func (noopCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte) {
-	dst = append(dst[:0], src...)
-	return NoCompressionIndicator, dst
-}
-func (noopCompressor) Close() {}
-
-func (snappyCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte) {
-	dst = dst[:cap(dst):cap(dst)]
-	return SnappyCompressionIndicator, snappy.Encode(dst, src)
-}
-
-func (snappyCompressor) Close() {}
-
-func (minlzCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte) {
-	// MinLZ cannot encode blocks greater than 8MB. Fall back to Snappy in those
-	// cases. Note that MinLZ can decode the Snappy compressed block.
-	if len(src) > minlz.MaxBlockSize {
-		_, result := (snappyCompressor{}).Compress(dst, src)
-		return MinLZCompressionIndicator, result
-	}
-
-	compressed, err := minlz.Encode(dst, src, minlz.LevelFastest)
-	if err != nil {
-		panic(errors.Wrap(err, "minlz compression"))
-	}
-	return MinLZCompressionIndicator, compressed
-}
-
-func (minlzCompressor) Close() {}
-
+// GetCompressor returns a Compressor that applies the given compression. Close
+// must be called when it is no longer needed.
 func GetCompressor(c Compression) Compressor {
-	switch c {
-	case NoCompression:
-		return noopCompressor{}
-	case SnappyCompression:
-		return snappyCompressor{}
-	case ZstdCompression:
-		return getZstdCompressor()
-	case MinLZCompression:
-		return minlzCompressor{}
-	default:
-		panic("Invalid compression type.")
+	algorithm := c.algorithm()
+	return Compressor{
+		algorithm:  algorithm,
+		compressor: compression.GetCompressor(algorithm),
 	}
 }
 
-type Decompressor interface {
-	// DecompressInto decompresses compressed into buf. The buf slice must have the
-	// exact size as the decompressed value. Callers may use DecompressedLen to
-	// determine the correct size.
-	DecompressInto(buf, compressed []byte) error
-
-	// DecompressedLen returns the length of the provided block once decompressed,
-	// allowing the caller to allocate a buffer exactly sized to the decompressed
-	// payload.
-	DecompressedLen(b []byte) (decompressedLen int, err error)
-
-	// Close must be called when the Decompressor is no longer needed.
-	// After Close is called, the Decompressor must not be used again.
-	Close()
+// Compress a block, appending the compressed data to dst[:0].
+//
+// In addition to the buffer, returns the algorithm that was used.
+func (c *Compressor) Compress(dst, src []byte) (CompressionIndicator, []byte) {
+	ci := compressionIndicatorFromAlgorithm(c.algorithm)
+	return ci, c.compressor.Compress(dst, src)
 }
 
-type noopDecompressor struct{}
-type snappyDecompressor struct{}
-type minlzDecompressor struct{}
-
-var _ Decompressor = noopDecompressor{}
-var _ Decompressor = snappyDecompressor{}
-var _ Decompressor = minlzDecompressor{}
-
-func (noopDecompressor) DecompressInto(dst, src []byte) error {
-	dst = dst[:len(src)]
-	copy(dst, src)
-	return nil
+// Close must be called when the Compressor is no longer needed.
+// After Close is called, the Compressor must not be used again.
+func (c *Compressor) Close() {
+	c.compressor.Close()
+	*c = Compressor{}
 }
 
-func (noopDecompressor) DecompressedLen(b []byte) (decompressedLen int, err error) {
-	return len(b), nil
-}
-
-func (noopDecompressor) Close() {}
-
-func (snappyDecompressor) DecompressInto(buf, compressed []byte) error {
-	result, err := snappy.Decode(buf, compressed)
-	if err != nil {
-		return err
-	}
-	if len(result) != len(buf) || (len(result) > 0 && &result[0] != &buf[0]) {
-		return base.CorruptionErrorf("pebble: decompressed into unexpected buffer: %p != %p",
-			errors.Safe(result), errors.Safe(buf))
-	}
-	return nil
-}
-
-func (snappyDecompressor) DecompressedLen(b []byte) (decompressedLen int, err error) {
-	return snappy.DecodedLen(b)
-}
-
-func (snappyDecompressor) Close() {}
-
-func (zstdDecompressor) DecompressedLen(b []byte) (decompressedLen int, err error) {
-	// This will also be used by zlib, bzip2 and lz4 to retrieve the decodedLen
-	// if we implement these algorithms in the future.
-	decodedLenU64, varIntLen := binary.Uvarint(b)
-	if varIntLen <= 0 {
-		return 0, base.CorruptionErrorf("pebble: compression block has invalid length")
-	}
-	return int(decodedLenU64), nil
-}
-
-func (minlzDecompressor) DecompressInto(buf, compressed []byte) error {
-	result, err := minlz.Decode(buf, compressed)
-	if len(result) != len(buf) || (len(result) > 0 && &result[0] != &buf[0]) {
-		return base.CorruptionErrorf("pebble/table: decompressed into unexpected buffer: %p != %p",
-			errors.Safe(result), errors.Safe(buf))
-	}
-	return err
-}
-
-func (minlzDecompressor) DecompressedLen(b []byte) (decompressedLen int, err error) {
-	l, err := minlz.DecodedLen(b)
-	return l, err
-}
-
-func (minlzDecompressor) Close() {}
+type Decompressor = compression.Decompressor
 
 func GetDecompressor(c CompressionIndicator) Decompressor {
-	switch c {
-	case NoCompressionIndicator:
-		return noopDecompressor{}
-	case SnappyCompressionIndicator:
-		return snappyDecompressor{}
-	case ZstdCompressionIndicator:
-		return getZstdDecompressor()
-	case MinLZCompressionIndicator:
-		return minlzDecompressor{}
-	default:
-		panic("Invalid compression type.")
-	}
+	return compression.GetDecompressor(c.algorithm())
 }

--- a/sstable/writer_fixture_test.go
+++ b/sstable/writer_fixture_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/compression"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -82,7 +83,7 @@ func TestFixtureOutput(t *testing.T) {
 		// <https://github.com/klauspost/compress/issues/109#issuecomment-498763233>.
 		// Since the fixture test requires bit-to-bit reproducibility, we cannot
 		// run the zstd test when the implementation is not based on facebook/zstd.
-		if !block.UseStandardZstdLib && fixture.Compression == block.ZstdCompression {
+		if !compression.UseStandardZstdLib && fixture.Compression == block.ZstdCompression {
 			continue
 		}
 		t.Run(fixture.Filename, func(t *testing.T) {


### PR DESCRIPTION
Move the compression code to a separate package. This package will
expose compression levels (useful for running experiments), while the
`sstable/block` options will remain higher level.
