### PR TITLE
block: push down MinLZ->Snappy fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/guptarohit/asciigraph v0.5.5
 	github.com/klauspost/compress v1.17.11
 	github.com/kr/pretty v0.3.1
-	github.com/minio/minlz v1.0.0
+	github.com/minio/minlz v1.0.1-0.20250507153514-87eb42fe8882
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGw
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/minio/minlz v1.0.0 h1:Kj7aJZ1//LlTP1DM8Jm7lNKvvJS2m74gyyXXn3+uJWQ=
-github.com/minio/minlz v1.0.0/go.mod h1:qT0aEB35q79LLornSzeDH75LBf3aH1MV+jB5w9Wasec=
+github.com/minio/minlz v1.0.1-0.20250507153514-87eb42fe8882 h1:0lgqHvJWHLGW5TuObJrfyEi6+ASTKDBWikGvPqy9Yiw=
+github.com/minio/minlz v1.0.1-0.20250507153514-87eb42fe8882/go.mod h1:qT0aEB35q79LLornSzeDH75LBf3aH1MV+jB5w9Wasec=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -39,9 +39,11 @@ func (snappyCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte)
 func (snappyCompressor) Close() {}
 
 func (minlzCompressor) Compress(dst, src []byte) (CompressionIndicator, []byte) {
-	// MinLZ cannot encode blocks greater than 8MB. Fall back to Snappy in those cases.
+	// MinLZ cannot encode blocks greater than 8MB. Fall back to Snappy in those
+	// cases. Note that MinLZ can decode the Snappy compressed block.
 	if len(src) > minlz.MaxBlockSize {
-		return (snappyCompressor{}).Compress(dst, src)
+		_, result := (snappyCompressor{}).Compress(dst, src)
+		return MinLZCompressionIndicator, result
 	}
 
 	compressed, err := minlz.Encode(dst, src, minlz.LevelFastest)


### PR DESCRIPTION
#### block: push down MinLZ->Snappy fallback

MinLZ has an 8MB block limit. We fall back to Snappy for the unlikely
case of larger blocks. The MinLZ compressor `Compress()` call can
return `SnappyCompressionIndicator`, which is unintuitive.

This commit hides this unfortunate detail inside the MinLZ
implementation. The decompression relies on the fact that the MinLZ
library can detect when it is used to decode a Snappy block. The
MinLZ compressor now always returns `MinLZCompressionIndicator`.