### PR TITLE
metamophic: integrate value separation

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -109,12 +109,12 @@ func (cl compactionLevel) String() string {
 
 // compactionWritable is a objstorage.Writable wrapper that, on every write,
 // updates a metric in `versions` on bytes written by in-progress compactions so
-// far. It also increments a per-compaction `written` int.
+// far. It also increments a per-compaction `written` atomic int.
 type compactionWritable struct {
 	objstorage.Writable
 
 	versions *versionSet
-	written  *int64
+	written  *atomic.Int64
 }
 
 // Write is part of the objstorage.Writable interface.
@@ -123,7 +123,7 @@ func (c *compactionWritable) Write(p []byte) error {
 		return err
 	}
 
-	*c.written += int64(len(p))
+	c.written.Add(int64(len(p)))
 	c.versions.incrementCompactionBytes(int64(len(p)))
 	return nil
 }
@@ -259,7 +259,7 @@ type compaction struct {
 	// flushing contains the flushables (aka memtables) that are being flushed.
 	flushing flushableList
 	// bytesWritten contains the number of bytes that have been written to outputs.
-	bytesWritten int64
+	bytesWritten atomic.Int64
 
 	// The boundaries of the input data.
 	smallest InternalKey
@@ -1598,7 +1598,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 
 	d.clearCompactingState(c, err != nil)
 	delete(d.mu.compact.inProgress, c)
-	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.pickerMetrics, c.bytesWritten, err)
+	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.pickerMetrics, c.bytesWritten.Load(), err)
 
 	var flushed flushableList
 	if err == nil {
@@ -2536,8 +2536,8 @@ func (d *DB) compact1(c *compaction, errChannel chan error) (err error) {
 	// NB: clearing compacting state must occur before updating the read state;
 	// L0Sublevels initialization depends on it.
 	d.clearCompactingState(c, err != nil)
-	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.pickerMetrics, c.bytesWritten, err)
-	d.mu.versions.incrementCompactionBytes(-c.bytesWritten)
+	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.pickerMetrics, c.bytesWritten.Load(), err)
+	d.mu.versions.incrementCompactionBytes(-c.bytesWritten.Load())
 
 	info.TotalDuration = d.timeNow().Sub(c.beganAt)
 	d.opts.EventListener.CompactionEnd(info)

--- a/compaction.go
+++ b/compaction.go
@@ -302,6 +302,8 @@ type compaction struct {
 	pickerMetrics pickedCompactionMetrics
 
 	grantHandle CompactionGrantHandle
+
+	opts objstorage.CreateOptions
 }
 
 // inputLargestSeqNumAbsolute returns the maximum LargestSeqNumAbsolute of any
@@ -412,6 +414,7 @@ func newCompaction(
 	)
 	c.kind = pc.kind
 
+	preferSharedStorage := remote.ShouldCreateShared(opts.Experimental.CreateOnShared, c.outputLevel.level)
 	// In addition to the default compaction, we also check whether a tombstone density compaction can be optimized into
 	// a move compaction. However, we want to avoid performing a move compaction into the lowest level, since the goal
 	// there is to actually remove the tombstones.
@@ -438,10 +441,14 @@ func newCompaction(
 		// 1) The source file is a virtual sstable
 		// 2) The existing file `meta` is on non-remote storage
 		// 3) The output level prefers shared storage
-		mustCopy := !isRemote && remote.ShouldCreateShared(opts.Experimental.CreateOnShared, c.outputLevel.level)
+		//
+		// We also want to prevent ssts with blob references from being
+		// selected for copy compaction, as we currently lack a mechanism
+		// to propagate blob references along with the sstable.
+		mustCopy := !isRemote && preferSharedStorage && meta.BlobReferenceDepth == 0
 		if mustCopy {
-			// If the source is virtual, it's best to just rewrite the file as all
-			// conditions in the above comment are met.
+			// If the source is virtual, it's best to just rewrite the file as
+			// all conditions in the above comment are met.
 			if !meta.Virtual {
 				c.kind = compactionKindCopy
 			}
@@ -449,6 +456,15 @@ func newCompaction(
 			c.kind = compactionKindMove
 		}
 	}
+
+	c.opts = objstorage.CreateOptions{
+		PreferSharedStorage: preferSharedStorage,
+		WriteCategory:       getDiskWriteCategoryForCompaction(opts, c.kind),
+	}
+	if c.opts.PreferSharedStorage {
+		c.getValueSeparation = neverSeparateValues
+	}
+
 	return c
 }
 
@@ -578,7 +594,6 @@ func newFlush(
 	}
 	c.startLevel = &c.inputs[0]
 	c.outputLevel = &c.inputs[1]
-
 	if len(flushing) > 0 {
 		if _, ok := flushing[0].flushable.(*ingestedFlushable); ok {
 			if len(flushing) != 1 {
@@ -587,6 +602,14 @@ func newFlush(
 			c.kind = compactionKindIngestedFlushable
 			return c, nil
 		}
+	}
+
+	c.opts = objstorage.CreateOptions{
+		PreferSharedStorage: remote.ShouldCreateShared(opts.Experimental.CreateOnShared, c.outputLevel.level),
+		WriteCategory:       getDiskWriteCategoryForCompaction(opts, c.kind),
+	}
+	if c.opts.PreferSharedStorage {
+		c.getValueSeparation = neverSeparateValues
 	}
 
 	// Make sure there's no ingestedFlushable after the first flushable in the
@@ -3394,20 +3417,8 @@ func (d *DB) newCompactionOutputObj(
 	c *compaction, typ base.FileType,
 ) (objstorage.Writable, objstorage.ObjectMetadata, error) {
 	diskFileNum := d.mu.versions.getNextDiskFileNum()
-
-	var writeCategory vfs.DiskWriteCategory
-	if d.opts.EnableSQLRowSpillMetrics {
-		// In the scenario that the Pebble engine is used for SQL row spills the
-		// data written to the memtable will correspond to spills to disk and
-		// should be categorized as such.
-		writeCategory = "sql-row-spill"
-	} else if c.kind == compactionKindFlush {
-		writeCategory = "pebble-memtable-flush"
-	} else {
-		writeCategory = "pebble-compaction"
-	}
-
 	ctx := context.TODO()
+
 	if objiotracing.Enabled {
 		ctx = objiotracing.WithLevel(ctx, c.outputLevel.level)
 		if c.kind == compactionKindFlush {
@@ -3417,12 +3428,7 @@ func (d *DB) newCompactionOutputObj(
 		}
 	}
 
-	// Prefer shared storage if present.
-	createOpts := objstorage.CreateOptions{
-		PreferSharedStorage: remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, c.outputLevel.level),
-		WriteCategory:       writeCategory,
-	}
-	writable, objMeta, err := d.objProvider.Create(ctx, typ, diskFileNum, createOpts)
+	writable, objMeta, err := d.objProvider.Create(ctx, typ, diskFileNum, c.opts)
 	if err != nil {
 		return nil, objstorage.ObjectMetadata{}, err
 	}
@@ -3456,5 +3462,18 @@ func validateVersionEdit(
 	for _, m := range ve.DeletedTables {
 		validateKey(m, m.Smallest().UserKey)
 		validateKey(m, m.Largest().UserKey)
+	}
+}
+
+func getDiskWriteCategoryForCompaction(opts *Options, kind compactionKind) vfs.DiskWriteCategory {
+	if opts.EnableSQLRowSpillMetrics {
+		// In the scenario that the Pebble engine is used for SQL row spills the
+		// data written to the memtable will correspond to spills to disk and
+		// should be categorized as such.
+		return "sql-row-spill"
+	} else if kind == compactionKindFlush {
+		return "pebble-memtable-flush"
+	} else {
+		return "pebble-compaction"
 	}
 }

--- a/compaction.go
+++ b/compaction.go
@@ -2599,6 +2599,11 @@ func (d *DB) runCopyCompaction(
 	if c.cancel.Load() {
 		return nil, compact.Stats{}, ErrCancelledCompaction
 	}
+	if inputMeta.BlobReferenceDepth > 0 || len(inputMeta.BlobReferences) > 0 {
+		return nil, compact.Stats{},
+			base.AssertionFailedf("copy compaction for %d with non-zero blob reference "+
+				"depth %d or references %v", inputMeta.TableNum, inputMeta.BlobReferenceDepth)
+	}
 	ve = &versionEdit{
 		DeletedTables: map[manifest.DeletedTableEntry]*tableMetadata{
 			{Level: c.startLevel.level, FileNum: inputMeta.TableNum}: inputMeta,
@@ -3298,6 +3303,13 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*versionEdit, error
 	ve.NewTables = make([]newTableEntry, len(result.Tables))
 	for i := range result.Tables {
 		t := &result.Tables[i]
+
+		if t.WriterMeta.Properties.NumValuesInBlobFiles > 0 {
+			if len(t.BlobReferences) == 0 {
+				return nil, base.AssertionFailedf("num values in blob files %d but no blob references",
+					t.WriterMeta.Properties.NumValuesInBlobFiles)
+			}
+		}
 
 		fileMeta := &tableMetadata{
 			TableNum:           base.PhysicalTableFileNum(t.ObjMeta.DiskFileNum),

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -2127,8 +2127,10 @@ func (r *replicateOp) runExternalReplicate(
 }
 
 func (r *replicateOp) run(t *Test, h historyRecorder) {
-	// Shared replication only works if shared storage is enabled.
-	useSharedIngest := t.testOpts.useSharedReplicate && t.testOpts.sharedStorageEnabled
+	// Shared replication only works if shared storage is enabled and value
+	// separation is disabled.
+	useSharedIngest := t.testOpts.useSharedReplicate && t.testOpts.sharedStorageEnabled &&
+		!t.testOpts.Opts.Experimental.ValueSeparationPolicy().Enabled
 	useExternalIngest := t.testOpts.useExternalReplicate && t.testOpts.externalStorageEnabled
 
 	source := t.getDB(r.source)

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -82,6 +82,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"Experimental.RemoteStorage:",
 		"Experimental.SingleDeleteInvariantViolationCallback:",
 		"Experimental.EnableDeleteOnlyCompactionExcises:",
+		"Experimental.ValueSeparationPolicy:",
 		"Levels[0].Compression:",
 		"Levels[1].Compression:",
 		"Levels[2].Compression:",


### PR DESCRIPTION
### db: update compaction's bytesWritten atomically
Due to value separation, a compaction can be writing to
blob files and sstables in parallel. This means that a race
condition can occur in which updates to our per-compaction
`written` accumulator might be lost. This patch fixes this
behavior by using the `atomic.Int64` type to synchronize our
`written` accumulator.

---

### db: prohibit blob references in shared sstables
This patch prohibits the creation of shared sstables with blob references and
prevents sstables with blob references from going through a
copy compaction.
If a compaction is configured to output to shared storage, it will run
with the `neverSeparateValues` `compact.ValueSeparation` implementation.

Fixes: https://github.com/cockroachdb/pebble/issues/4693

---

### sstable/blob: ensure no mutation after returning writer to pool

Previously, it was possible for a race condition to occur between
blob file writers because the logic to close a file writer made it
possible (in the defer) to mutate a writer after putting it back in
the writer pool. This patch ensures that this is no longer possible
by removing said defer logic.

---

### metamophic: integrate value separation
This patch enables value separation within the metamorphic
test.

Fixes: https://github.com/cockroachdb/pebble/issues/4566