### PR TITLE
db: ensure deletesized keys don't get separated, fix zero size blob ref vals

### DIFF
--- a/excise.go
+++ b/excise.go
@@ -445,9 +445,12 @@ func determineExcisedTableSize(
 func determineExcisedTableBlobReferences(
 	originalBlobReferences manifest.BlobReferences, originalSize uint64, excisedTable *tableMetadata,
 ) {
+	if len(originalBlobReferences) == 0 {
+		return
+	}
 	newBlobReferences := make(manifest.BlobReferences, len(originalBlobReferences))
 	for i, bf := range originalBlobReferences {
-		bf.ValueSize = bf.ValueSize * excisedTable.Size / originalSize
+		bf.ValueSize = max(bf.ValueSize*excisedTable.Size/originalSize, 1)
 		newBlobReferences[i] = bf
 	}
 	excisedTable.BlobReferences = newBlobReferences

--- a/testdata/value_separation_policy
+++ b/testdata/value_separation_policy
@@ -26,9 +26,20 @@ foo#209,SET:poiandyaya
 RawWriter.AddWithBlobHandle("baz#202,SET", "(f0,blk0[0:5])", 0, false)
 RawWriter.AddWithBlobHandle("foo#209,SET", "(f0,blk0[5:15])", 0, false)
 
+# Ensure that merge and deletesized keys do not get separated if they meet the
+# minimum size.
+add
+gaa#210,MERGE:chickenpigeon
+gaa#209,DELSIZED:varint(16)
+gac#211,SET:yuumiisthebest
+----
+RawWriter.Add("gaa#210,MERGE", "chickenpigeon", false)
+RawWriter.Add("gaa#209,DELSIZED", "varint(16)", false)
+RawWriter.AddWithBlobHandle("gac#211,SET", "(f0,blk0[15:29])", 0, false)
+
 estimated-sizes
 ----
-file: 70, references: 70
+file: 84, references: 84
 
 close-output
 ----
@@ -36,10 +47,10 @@ close-output
 # close: 000001.sst
 # sync-data: 000002.blob
 # close: 000002.blob
-Blob file created: 000002 size:[61 (61B)] vals:[15 (15B)]
-{BlockCount: 1, ValueCount: 2, BlockLenLongest: 15, UncompressedValueBytes: 15, FileLen: 61}
+Blob file created: 000002 size:[75 (75B)] vals:[29 (29B)]
+{BlockCount: 1, ValueCount: 3, BlockLenLongest: 29, UncompressedValueBytes: 29, FileLen: 75}
 blobrefs:[
- 0: 000002 15
+ 0: 000002 29
 ]
 
 add

--- a/value_separation.go
+++ b/value_separation.go
@@ -213,13 +213,13 @@ func (vs *writeNewBlobFiles) Add(
 	if len(v) < vs.minimumSize {
 		return tw.Add(kv.K, v, forceObsolete)
 	}
-	// Merge keys are never separated.
-	if kv.K.Kind() == base.InternalKeyKindMerge {
+	// Merge and deletesized keys are never separated.
+	switch kv.K.Kind() {
+	case base.InternalKeyKindMerge, base.InternalKeyKindDeleteSized:
 		return tw.Add(kv.K, v, forceObsolete)
 	}
 
 	// This KV met all the criteria and its value will be separated.
-
 	// If there's a configured short attribute extractor, extract the value's
 	// short attribute.
 	var shortAttr base.ShortAttribute


### PR DESCRIPTION
### db: ensure deletesized do not get separated
This patch ensures that keys of the `DeleteSized` kind
do not get value-separated as such values are not worth
externalizing and sometimes used by compaction.

---

### db: ensure blob references have proper value size
When scaling blob references' `ValueSize` during excise, we need to ensure 
that we round up to the nearest integer. Otherwise, a low `ValueSize` we want to
scale could easily be rounded to `0`.