### PR TITLE
db: move KeyRange into base

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -40,55 +40,6 @@ func sstableKeyCompare(userCmp Compare, a, b InternalKey) int {
 	return 0
 }
 
-// KeyRange encodes a key range in user key space. A KeyRange's Start is
-// inclusive while its End is exclusive.
-//
-// KeyRange is equivalent to base.UserKeyBounds with exclusive end.
-type KeyRange struct {
-	Start, End []byte
-}
-
-// Valid returns true if the KeyRange is defined.
-func (k *KeyRange) Valid() bool {
-	return k.Start != nil && k.End != nil
-}
-
-// Contains returns whether the specified key exists in the KeyRange.
-func (k *KeyRange) Contains(cmp base.Compare, key InternalKey) bool {
-	v := cmp(key.UserKey, k.End)
-	return (v < 0 || (v == 0 && key.IsExclusiveSentinel())) && cmp(k.Start, key.UserKey) <= 0
-}
-
-// UserKeyBounds returns the KeyRange as UserKeyBounds. Also implements the internal `bounded` interface.
-func (k KeyRange) UserKeyBounds() base.UserKeyBounds {
-	return base.UserKeyBoundsEndExclusive(k.Start, k.End)
-}
-
-// OverlapsInternalKeyRange checks if the specified internal key range has an
-// overlap with the KeyRange. Note that we aren't checking for full containment
-// of smallest-largest within k, rather just that there's some intersection
-// between the two ranges.
-func (k *KeyRange) OverlapsInternalKeyRange(cmp base.Compare, smallest, largest InternalKey) bool {
-	ukb := k.UserKeyBounds()
-	b := base.UserKeyBoundsFromInternal(smallest, largest)
-	return ukb.Overlaps(cmp, &b)
-}
-
-// Overlaps checks if the specified file has an overlap with the KeyRange.
-// Note that we aren't checking for full containment of m within k, rather just
-// that there's some intersection between m and k's bounds.
-func (k *KeyRange) Overlaps(cmp base.Compare, m *tableMetadata) bool {
-	b := k.UserKeyBounds()
-	return m.Overlaps(cmp, &b)
-}
-
-// OverlapsKeyRange checks if this span overlaps with the provided KeyRange.
-// Note that we aren't checking for full containment of either span in the other,
-// just that there's a key x that is in both key ranges.
-func (k *KeyRange) OverlapsKeyRange(cmp Compare, span KeyRange) bool {
-	return cmp(k.Start, span.End) < 0 && cmp(k.End, span.Start) > 0
-}
-
 func ingestValidateKey(opts *Options, key *InternalKey) error {
 	if key.Kind() == InternalKeyKindInvalid {
 		return base.CorruptionErrorf("pebble: external sstable has corrupted key: %s",

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1506,6 +1506,7 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 func TestKeyRangeBasic(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
 	k1 := KeyRange{Start: []byte("b"), End: []byte("c")}
+	k1UserKeyBounds := k1.UserKeyBounds()
 
 	// Tests for Contains()
 	require.True(t, k1.Contains(cmp, base.MakeInternalKey([]byte("b"), 1, InternalKeyKindSet)))
@@ -1516,19 +1517,19 @@ func TestKeyRangeBasic(t *testing.T) {
 	m1 := &tableMetadata{}
 	m1.ExtendPointKeyBounds(cmp, base.MakeInternalKey([]byte("b"), 1, InternalKeyKindSet),
 		base.MakeInternalKey([]byte("c"), 1, InternalKeyKindSet))
-	require.True(t, k1.Overlaps(cmp, m1))
+	require.True(t, m1.Overlaps(cmp, &k1UserKeyBounds))
 	m2 := &tableMetadata{}
 	m2.ExtendPointKeyBounds(cmp, base.MakeInternalKey([]byte("c"), 1, InternalKeyKindSet),
 		base.MakeInternalKey([]byte("d"), 1, InternalKeyKindSet))
-	require.False(t, k1.Overlaps(cmp, m2))
+	require.False(t, m2.Overlaps(cmp, &k1UserKeyBounds))
 	m3 := &tableMetadata{}
 	m3.ExtendPointKeyBounds(cmp, base.MakeInternalKey([]byte("a"), 1, InternalKeyKindSet),
 		base.MakeExclusiveSentinelKey(InternalKeyKindRangeDelete, []byte("b")))
-	require.False(t, k1.Overlaps(cmp, m3))
+	require.False(t, m3.Overlaps(cmp, &k1UserKeyBounds))
 	m4 := &tableMetadata{}
 	m4.ExtendPointKeyBounds(cmp, base.MakeInternalKey([]byte("a"), 1, InternalKeyKindSet),
 		base.MakeInternalKey([]byte("b"), 1, InternalKeyKindSet))
-	require.True(t, k1.Overlaps(cmp, m4))
+	require.True(t, m4.Overlaps(cmp, &k1UserKeyBounds))
 }
 
 func BenchmarkIngestOverlappingMemtable(b *testing.B) {

--- a/internal.go
+++ b/internal.go
@@ -39,6 +39,9 @@ type InternalKeyTrailer = base.InternalKeyTrailer
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey
 
+// KeyRange exports the base.KeyRange type.
+type KeyRange = base.KeyRange
+
 // MakeInternalKey constructs an internal key from a specified user key,
 // sequence number and kind.
 func MakeInternalKey(userKey []byte, seqNum SeqNum, kind InternalKeyKind) InternalKey {

--- a/internal/base/key_bounds.go
+++ b/internal/base/key_bounds.go
@@ -10,6 +10,47 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
+// KeyRange encodes a key range in user key space. A KeyRange's Start is
+// inclusive while its End is exclusive.
+//
+// KeyRange is equivalent to UserKeyBounds with exclusive end.
+type KeyRange struct {
+	Start, End []byte
+}
+
+// Valid returns true if the KeyRange is defined.
+func (k *KeyRange) Valid() bool {
+	return k.Start != nil && k.End != nil
+}
+
+// Contains returns whether the specified key exists in the KeyRange.
+func (k *KeyRange) Contains(cmp Compare, key InternalKey) bool {
+	v := cmp(key.UserKey, k.End)
+	return (v < 0 || (v == 0 && key.IsExclusiveSentinel())) && cmp(k.Start, key.UserKey) <= 0
+}
+
+// UserKeyBounds returns the KeyRange as UserKeyBounds. Also implements the internal `bounded` interface.
+func (k KeyRange) UserKeyBounds() UserKeyBounds {
+	return UserKeyBoundsEndExclusive(k.Start, k.End)
+}
+
+// OverlapsInternalKeyRange checks if the specified internal key range has an
+// overlap with the KeyRange. Note that we aren't checking for full containment
+// of smallest-largest within k, rather just that there's some intersection
+// between the two ranges.
+func (k *KeyRange) OverlapsInternalKeyRange(cmp Compare, smallest, largest InternalKey) bool {
+	ukb := k.UserKeyBounds()
+	b := UserKeyBoundsFromInternal(smallest, largest)
+	return ukb.Overlaps(cmp, &b)
+}
+
+// OverlapsKeyRange checks if this span overlaps with the provided KeyRange.
+// Note that we aren't checking for full containment of either span in the other,
+// just that there's a key x that is in both key ranges.
+func (k *KeyRange) OverlapsKeyRange(cmp Compare, span KeyRange) bool {
+	return cmp(k.Start, span.End) < 0 && cmp(k.End, span.Start) > 0
+}
+
 // BoundaryKind indicates if a boundary is exclusive or inclusive.
 type BoundaryKind uint8
 


### PR DESCRIPTION
Move the KeyRange type into base, and re-export it in the pebble package. The ingest.go file is a bit unwieldy and I'd like to trim off the fluff.