### PR TITLE
crl-release-25.2: sstable: fix invariants panic due to zero virtual table size

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -344,7 +344,7 @@ func ingestLoad1(
 
 	meta = &tableMetadata{}
 	meta.FileNum = fileNum
-	meta.Size = uint64(readable.Size())
+	meta.Size = max(uint64(readable.Size()), 1)
 	meta.CreationTime = time.Now().Unix()
 	meta.InitPhysicalBacking()
 
@@ -764,13 +764,14 @@ func (d *DB) ingestAttachRemote(jobID JobID, lr ingestLoadResult) error {
 		// We have to attach the remote object (and assign it a DiskFileNum). For
 		// simplicity, we use the same number for both the FileNum and the
 		// DiskFileNum (even though this is a virtual sstable).
+		size := max(lr.external[i].external.Size, 1)
 		meta.InitProviderBacking(base.DiskFileNum(meta.FileNum), lr.external[i].external.Size)
 
 		// Set the underlying FileBacking's size to the same size as the virtualized
 		// view of the sstable. This ensures that we don't over-prioritize this
 		// sstable for compaction just yet, as we do not have a clear sense of
 		// what parts of this sstable are referenced by other nodes.
-		meta.FileBacking.Size = lr.external[i].external.Size
+		meta.FileBacking.Size = size
 		newFileBackings[key] = meta.FileBacking
 
 		remoteObjs = append(remoteObjs, objstorage.RemoteObjectToAttach{
@@ -804,7 +805,7 @@ func (d *DB) ingestAttachRemote(jobID JobID, lr ingestLoadResult) error {
 			if err != nil {
 				return err
 			}
-			lr.shared[i].FileBacking.Size = uint64(size)
+			lr.shared[i].FileBacking.Size = max(uint64(size), 1)
 		}
 	}
 

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -249,6 +249,47 @@ func writeProperties(loaded map[uintptr]struct{}, v reflect.Value, buf *bytes.Bu
 	}
 }
 
+func (p *Properties) GetScaledProperties(backingSize, size uint64) CommonProperties {
+	// Make sure the sizes are sane, just in case.
+	size = max(size, 1)
+	backingSize = max(backingSize, size)
+
+	scale := func(a uint64) uint64 {
+		return (a*size + backingSize - 1) / backingSize
+	}
+	// It's important that no non-zero fields (like NumDeletions, NumRangeKeySets)
+	// become zero (or vice-versa).
+	if invariants.Enabled && (scale(1) != 1 || scale(0) != 0) {
+		panic("bad scale()")
+	}
+
+	var props CommonProperties
+	props.RawKeySize = scale(p.RawKeySize)
+	props.RawValueSize = scale(p.RawValueSize)
+	props.NumEntries = scale(p.NumEntries)
+	props.NumDataBlocks = scale(p.NumDataBlocks)
+	props.NumTombstoneDenseBlocks = scale(p.NumTombstoneDenseBlocks)
+
+	props.NumRangeDeletions = scale(p.NumRangeDeletions)
+	props.NumSizedDeletions = scale(p.NumSizedDeletions)
+	// We cannot directly scale NumDeletions, because it is supposed to be the sum
+	// of various types of deletions. See #4670.
+	numOtherDeletions := scale(invariants.SafeSub(p.NumDeletions, p.NumRangeDeletions) + p.NumSizedDeletions)
+	props.NumDeletions = numOtherDeletions + props.NumRangeDeletions + props.NumSizedDeletions
+
+	props.NumRangeKeyDels = scale(p.NumRangeKeyDels)
+	props.NumRangeKeySets = scale(p.NumRangeKeySets)
+
+	props.ValueBlocksSize = scale(p.ValueBlocksSize)
+
+	props.RawPointTombstoneKeySize = scale(p.RawPointTombstoneKeySize)
+	props.RawPointTombstoneValueSize = scale(p.RawPointTombstoneValueSize)
+
+	props.CompressionName = p.CompressionName
+
+	return props
+}
+
 func (p *Properties) String() string {
 	var buf bytes.Buffer
 	v := reflect.ValueOf(*p)

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -127,6 +127,27 @@ func TestPropertiesSave(t *testing.T) {
 	}
 }
 
+func TestScalePropertiesBadSizes(t *testing.T) {
+	// Verify that GetScaledProperties works even if the given sizes are not
+	// valid.
+	p := Properties{
+		CommonProperties: CommonProperties{
+			NumDeletions:  0,
+			NumEntries:    1,
+			NumDataBlocks: 10,
+		},
+	}
+	scaled := p.GetScaledProperties(100, 0)
+	require.Equal(t, uint64(0), scaled.NumDeletions)
+	require.Equal(t, uint64(1), scaled.NumEntries)
+	require.Equal(t, uint64(1), scaled.NumDataBlocks)
+
+	scaled = p.GetScaledProperties(100, 1000)
+	require.Equal(t, uint64(0), scaled.NumDeletions)
+	require.Equal(t, uint64(1), scaled.NumEntries)
+	require.Equal(t, uint64(10), scaled.NumDataBlocks)
+}
+
 func BenchmarkPropertiesLoad(b *testing.B) {
 	var w rowblk.Writer
 	w.RestartInterval = propertiesBlockRestartInterval


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/146240