### PR TITLE
crl-release-25.1: sstable: fix invariants panic due to zero virtual table size

### DIFF
--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -247,6 +247,47 @@ func writeProperties(loaded map[uintptr]struct{}, v reflect.Value, buf *bytes.Bu
 	}
 }
 
+func (p *Properties) GetScaledProperties(backingSize, size uint64) CommonProperties {
+	// Make sure the sizes are sane, just in case.
+	size = max(size, 1)
+	backingSize = max(backingSize, size)
+
+	scale := func(a uint64) uint64 {
+		return (a*size + backingSize - 1) / backingSize
+	}
+	// It's important that no non-zero fields (like NumDeletions, NumRangeKeySets)
+	// become zero (or vice-versa).
+	if invariants.Enabled && (scale(1) != 1 || scale(0) != 0) {
+		panic("bad scale()")
+	}
+
+	var props CommonProperties
+	props.RawKeySize = scale(p.RawKeySize)
+	props.RawValueSize = scale(p.RawValueSize)
+	props.NumEntries = scale(p.NumEntries)
+	props.NumDataBlocks = scale(p.NumDataBlocks)
+	props.NumTombstoneDenseBlocks = scale(p.NumTombstoneDenseBlocks)
+
+	props.NumRangeDeletions = scale(p.NumRangeDeletions)
+	props.NumSizedDeletions = scale(p.NumSizedDeletions)
+	// We cannot directly scale NumDeletions, because it is supposed to be the sum
+	// of various types of deletions. See #4670.
+	numOtherDeletions := scale(invariants.SafeSub(p.NumDeletions, p.NumRangeDeletions) + p.NumSizedDeletions)
+	props.NumDeletions = numOtherDeletions + props.NumRangeDeletions + props.NumSizedDeletions
+
+	props.NumRangeKeyDels = scale(p.NumRangeKeyDels)
+	props.NumRangeKeySets = scale(p.NumRangeKeySets)
+
+	props.ValueBlocksSize = scale(p.ValueBlocksSize)
+
+	props.RawPointTombstoneKeySize = scale(p.RawPointTombstoneKeySize)
+	props.RawPointTombstoneValueSize = scale(p.RawPointTombstoneValueSize)
+
+	props.CompressionName = p.CompressionName
+
+	return props
+}
+
 func (p *Properties) String() string {
 	var buf bytes.Buffer
 	v := reflect.ValueOf(*p)

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -127,6 +127,27 @@ func TestPropertiesSave(t *testing.T) {
 	}
 }
 
+func TestScalePropertiesBadSizes(t *testing.T) {
+	// Verify that GetScaledProperties works even if the given sizes are not
+	// valid.
+	p := Properties{
+		CommonProperties: CommonProperties{
+			NumDeletions:  0,
+			NumEntries:    1,
+			NumDataBlocks: 10,
+		},
+	}
+	scaled := p.GetScaledProperties(100, 0)
+	require.Equal(t, uint64(0), scaled.NumDeletions)
+	require.Equal(t, uint64(1), scaled.NumEntries)
+	require.Equal(t, uint64(1), scaled.NumDataBlocks)
+
+	scaled = p.GetScaledProperties(100, 1000)
+	require.Equal(t, uint64(0), scaled.NumDeletions)
+	require.Equal(t, uint64(1), scaled.NumEntries)
+	require.Equal(t, uint64(10), scaled.NumDataBlocks)
+}
+
 func BenchmarkPropertiesLoad(b *testing.B) {
 	var w rowblk.Writer
 	w.RestartInterval = propertiesBlockRestartInterval

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -8,7 +8,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -63,43 +62,10 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 		isSharedIngested: p.IsSharedIngested,
 	}
 	v := VirtualReader{
-		vState: vState,
-		reader: reader,
+		vState:     vState,
+		reader:     reader,
+		Properties: reader.Properties.GetScaledProperties(p.BackingSize, p.Size),
 	}
-
-	// Scales the given value by the (Size / BackingSize) ratio, rounding up.
-	scale := func(a uint64) uint64 {
-		return (a*p.Size + p.BackingSize - 1) / p.BackingSize
-	}
-	// It's important that no non-zero fields (like NumDeletions, NumRangeKeySets)
-	// become zero (or vice-versa).
-	if invariants.Enabled && (scale(1) != 1 || scale(0) != 0) {
-		panic("bad scale()")
-	}
-
-	physical := &reader.Properties
-	virtual := &v.Properties
-
-	virtual.RawKeySize = scale(physical.RawKeySize)
-	virtual.RawValueSize = scale(physical.RawValueSize)
-	virtual.NumEntries = scale(physical.NumEntries)
-	virtual.NumDataBlocks = scale(physical.NumDataBlocks)
-	virtual.NumTombstoneDenseBlocks = scale(physical.NumTombstoneDenseBlocks)
-
-	virtual.NumRangeDeletions = scale(physical.NumRangeDeletions)
-	virtual.NumSizedDeletions = scale(physical.NumSizedDeletions)
-	// We cannot directly scale NumDeletions, because it is supposed to be the sum
-	// of various types of deletions. See #4670.
-	numOtherDeletions := scale(invariants.SafeSub(physical.NumDeletions, physical.NumRangeDeletions) + physical.NumSizedDeletions)
-	virtual.NumDeletions = numOtherDeletions + virtual.NumRangeDeletions + virtual.NumSizedDeletions
-
-	virtual.NumRangeKeyDels = scale(physical.NumRangeKeyDels)
-	virtual.NumRangeKeySets = scale(physical.NumRangeKeySets)
-
-	virtual.ValueBlocksSize = scale(physical.ValueBlocksSize)
-
-	virtual.RawPointTombstoneKeySize = scale(physical.RawPointTombstoneKeySize)
-	virtual.RawPointTombstoneValueSize = scale(physical.RawPointTombstoneValueSize)
 
 	return v
 }

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -22,6 +22,7 @@ props:
   rocksdb.raw.key.size: 3
   rocksdb.raw.value.size: 1
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
 
 # Repeat the above with (Pebble,v5).
 
@@ -47,6 +48,7 @@ props:
   rocksdb.raw.key.size: 4
   rocksdb.raw.value.size: 1
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
 
 
 # Test 2: Similar to test 1 but force two level iterators.
@@ -68,6 +70,7 @@ props:
   rocksdb.raw.key.size: 2
   rocksdb.raw.value.size: 1
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
 
 # Test the constrain bounds function. It performs some subtle shrinking and
 # expanding of bounds. The current virtual sstable bounds are [b,c].
@@ -142,6 +145,7 @@ props:
   rocksdb.raw.key.size: 5
   rocksdb.raw.value.size: 1
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
 
 # Test the constrain bounds function. It performs some subtle shrinking and
 # expanding of bounds. The current virtual sstable bounds are [b,c].
@@ -224,6 +228,7 @@ props:
   rocksdb.num.range-deletions: 1
   pebble.num.range-key-sets: 1
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
 
 # Repeat the above with (Pebble,v5).
 
@@ -255,6 +260,7 @@ props:
   rocksdb.num.range-deletions: 1
   pebble.num.range-key-sets: 1
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
 
 build table-format=(Pebble,v4)
 a.SET.1:a
@@ -278,6 +284,7 @@ props:
   rocksdb.raw.key.size: 10
   rocksdb.raw.value.size: 2
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
 
 # Repeat the above with (Pebble,v5).
 
@@ -303,6 +310,7 @@ props:
   rocksdb.raw.key.size: 10
   rocksdb.raw.value.size: 2
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
 
 build
 a.DEL.1:
@@ -327,3 +335,4 @@ props:
   rocksdb.deleted.keys: 3
   rocksdb.num.range-deletions: 1
   rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -663,7 +663,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 2 (1.2KB)
 Virtual tables: 2 (102B)
 Local tables size: 6.7KB
-Compression types: snappy: 9 unknown: 2
+Compression types: snappy: 11
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -656,6 +656,7 @@ rocksdb.raw.value.size: 1
 pebble.raw.point-tombstone.key.size: 1
 rocksdb.deleted.keys: 1
 rocksdb.num.data.blocks: 1
+rocksdb.compression: Snappy
 
 properties file=8
 ----
@@ -665,6 +666,7 @@ rocksdb.raw.value.size: 1
 pebble.raw.point-tombstone.key.size: 1
 rocksdb.deleted.keys: 1
 rocksdb.num.data.blocks: 1
+rocksdb.compression: Snappy
 
 wait-pending-table-stats
 000007
@@ -771,6 +773,7 @@ rocksdb.raw.key.size: 2
 rocksdb.raw.value.size: 1
 pebble.num.range-key-sets: 1
 rocksdb.num.data.blocks: 1
+rocksdb.compression: Snappy
 
 properties file=13
 ----
@@ -779,6 +782,7 @@ rocksdb.raw.key.size: 2
 rocksdb.raw.value.size: 1
 pebble.num.range-key-sets: 1
 rocksdb.num.data.blocks: 1
+rocksdb.compression: Snappy
 
 wait-pending-table-stats
 000012
@@ -879,6 +883,7 @@ rocksdb.raw.value.size: 1
 rocksdb.deleted.keys: 1
 rocksdb.num.range-deletions: 1
 rocksdb.num.data.blocks: 1
+rocksdb.compression: Snappy
 
 properties file=21
 ----
@@ -888,6 +893,7 @@ rocksdb.raw.value.size: 1
 rocksdb.deleted.keys: 1
 rocksdb.num.range-deletions: 1
 rocksdb.num.data.blocks: 1
+rocksdb.compression: Snappy
 
 wait-pending-table-stats
 000020


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/146240