### PR TITLE
crl-release-24.1: sstable: fix invariants panic due to zero virtual table size

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -275,7 +275,7 @@ func ingestLoad1(
 
 	meta := &fileMetadata{}
 	meta.FileNum = fileNum
-	meta.Size = uint64(readable.Size())
+	meta.Size = max(uint64(readable.Size()), 1)
 	meta.CreationTime = time.Now().Unix()
 	meta.InitPhysicalBacking()
 
@@ -656,13 +656,14 @@ func (d *DB) ingestAttachRemote(jobID JobID, lr ingestLoadResult) error {
 		// We have to attach the remote object (and assign it a DiskFileNum). For
 		// simplicity, we use the same number for both the FileNum and the
 		// DiskFileNum (even though this is a virtual sstable).
+		size := max(lr.external[i].external.Size, 1)
 		meta.InitProviderBacking(base.DiskFileNum(meta.FileNum), lr.external[i].external.Size)
 
 		// Set the underlying FileBacking's size to the same size as the virtualized
 		// view of the sstable. This ensures that we don't over-prioritize this
 		// sstable for compaction just yet, as we do not have a clear sense of
 		// what parts of this sstable are referenced by other nodes.
-		meta.FileBacking.Size = lr.external[i].external.Size
+		meta.FileBacking.Size = size
 		newFileBackings[key] = meta.FileBacking
 
 		remoteObjs = append(remoteObjs, objstorage.RemoteObjectToAttach{
@@ -696,7 +697,7 @@ func (d *DB) ingestAttachRemote(jobID JobID, lr ingestLoadResult) error {
 			if err != nil {
 				return err
 			}
-			lr.shared[i].FileBacking.Size = uint64(size)
+			lr.shared[i].FileBacking.Size = max(uint64(size), 1)
 		}
 	}
 

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -123,6 +123,27 @@ func TestPropertiesSave(t *testing.T) {
 	}
 }
 
+func TestScalePropertiesBadSizes(t *testing.T) {
+	// Verify that GetScaledProperties works even if the given sizes are not
+	// valid.
+	p := Properties{
+		CommonProperties: CommonProperties{
+			NumDeletions:    0,
+			NumEntries:      1,
+			ValueBlocksSize: 10,
+		},
+	}
+	scaled := p.GetScaledProperties(100, 0)
+	require.Equal(t, uint64(0), scaled.NumDeletions)
+	require.Equal(t, uint64(1), scaled.NumEntries)
+	require.Equal(t, uint64(1), scaled.ValueBlocksSize)
+
+	scaled = p.GetScaledProperties(100, 1000)
+	require.Equal(t, uint64(0), scaled.NumDeletions)
+	require.Equal(t, uint64(1), scaled.NumEntries)
+	require.Equal(t, uint64(10), scaled.ValueBlocksSize)
+}
+
 func BenchmarkPropertiesLoad(b *testing.B) {
 	var w rawBlockWriter
 	w.restartInterval = propertiesBlockRestartInterval

--- a/sstable/reader_virtual.go
+++ b/sstable/reader_virtual.go
@@ -8,7 +8,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/rangekey"
 )
@@ -61,41 +60,10 @@ func MakeVirtualReader(reader *Reader, p VirtualReaderParams) VirtualReader {
 		isSharedIngested: p.IsSharedIngested,
 	}
 	v := VirtualReader{
-		vState: vState,
-		reader: reader,
+		vState:     vState,
+		reader:     reader,
+		Properties: reader.Properties.GetScaledProperties(p.BackingSize, p.Size),
 	}
-
-	// Scales the given value by the (Size / BackingSize) ratio, rounding up.
-	scale := func(a uint64) uint64 {
-		return (a*p.Size + p.BackingSize - 1) / p.BackingSize
-	}
-	// It's important that no non-zero fields (like NumDeletions, NumRangeKeySets)
-	// become zero (or vice-versa).
-	if invariants.Enabled && (scale(1) != 1 || scale(0) != 0) {
-		panic("bad scale()")
-	}
-
-	physical := &reader.Properties
-	virtual := &v.Properties
-
-	virtual.RawKeySize = scale(physical.RawKeySize)
-	virtual.RawValueSize = scale(physical.RawValueSize)
-	virtual.NumEntries = scale(physical.NumEntries)
-
-	virtual.NumRangeDeletions = scale(physical.NumRangeDeletions)
-	virtual.NumSizedDeletions = scale(physical.NumSizedDeletions)
-	// We cannot directly scale NumDeletions, because it is supposed to be the sum
-	// of various types of deletions. See #4670.
-	numOtherDeletions := scale(invariants.SafeSub(physical.NumDeletions, physical.NumRangeDeletions) + physical.NumSizedDeletions)
-	virtual.NumDeletions = numOtherDeletions + virtual.NumRangeDeletions + virtual.NumSizedDeletions
-
-	virtual.NumRangeKeyDels = scale(physical.NumRangeKeyDels)
-	virtual.NumRangeKeySets = scale(physical.NumRangeKeySets)
-
-	virtual.ValueBlocksSize = scale(physical.ValueBlocksSize)
-
-	virtual.RawPointTombstoneKeySize = scale(physical.RawPointTombstoneKeySize)
-	virtual.RawPointTombstoneValueSize = scale(physical.RawPointTombstoneValueSize)
 
 	return v
 }

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -21,6 +21,7 @@ props:
   rocksdb.num.entries: 1
   rocksdb.raw.key.size: 3
   rocksdb.raw.value.size: 1
+  rocksdb.compression: Snappy
 
 # Test 2: Similar to test 1 but force two level iterators.
 build block-size=1 index-block-size=1
@@ -40,6 +41,7 @@ props:
   rocksdb.num.entries: 1
   rocksdb.raw.key.size: 2
   rocksdb.raw.value.size: 1
+  rocksdb.compression: Snappy
 
 # Test the constrain bounds function. It performs some subtle shrinking and
 # expanding of bounds. The current virtual sstable bounds are [b,c].
@@ -121,6 +123,7 @@ props:
   rocksdb.deleted.keys: 1
   rocksdb.num.range-deletions: 1
   pebble.num.range-key-sets: 1
+  rocksdb.compression: Snappy
 
 build
 a.SET.1:a
@@ -143,6 +146,7 @@ props:
   rocksdb.num.entries: 1
   rocksdb.raw.key.size: 10
   rocksdb.raw.value.size: 2
+  rocksdb.compression: Snappy
 
 build
 a.DEL.1:
@@ -167,3 +171,4 @@ props:
   pebble.num.deletions.sized: 1
   rocksdb.deleted.keys: 3
   rocksdb.num.range-deletions: 1
+  rocksdb.compression: Snappy

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -647,7 +647,7 @@ Zombie tables: 0 (0B, local: 0B)
 Backing tables: 2 (1.2KB)
 Virtual tables: 2 (102B)
 Local tables size: 6.8KB
-Compression types: snappy: 9 unknown: 2
+Compression types: snappy: 11
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
 Table cache: 0 entries (0B)  hit rate: 0.0%

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -655,6 +655,7 @@ rocksdb.raw.key.size: 3
 rocksdb.raw.value.size: 1
 pebble.raw.point-tombstone.key.size: 1
 rocksdb.deleted.keys: 1
+rocksdb.compression: Snappy
 
 properties file=8
 ----
@@ -663,6 +664,7 @@ rocksdb.raw.key.size: 3
 rocksdb.raw.value.size: 1
 pebble.raw.point-tombstone.key.size: 1
 rocksdb.deleted.keys: 1
+rocksdb.compression: Snappy
 
 wait-pending-table-stats
 000007
@@ -768,6 +770,7 @@ rocksdb.num.entries: 1
 rocksdb.raw.key.size: 2
 rocksdb.raw.value.size: 1
 pebble.num.range-key-sets: 1
+rocksdb.compression: Snappy
 
 properties file=13
 ----
@@ -775,6 +778,7 @@ rocksdb.num.entries: 1
 rocksdb.raw.key.size: 2
 rocksdb.raw.value.size: 1
 pebble.num.range-key-sets: 1
+rocksdb.compression: Snappy
 
 wait-pending-table-stats
 000012
@@ -874,6 +878,7 @@ rocksdb.raw.key.size: 1
 rocksdb.raw.value.size: 1
 rocksdb.deleted.keys: 1
 rocksdb.num.range-deletions: 1
+rocksdb.compression: Snappy
 
 properties file=21
 ----
@@ -882,6 +887,7 @@ rocksdb.raw.key.size: 1
 rocksdb.raw.value.size: 1
 rocksdb.deleted.keys: 1
 rocksdb.num.range-deletions: 1
+rocksdb.compression: Snappy
 
 wait-pending-table-stats
 000020


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/146240