### PR TITLE
db: fix size of deduplicated external backings

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -916,6 +916,9 @@ func (m *TableMetadata) DebugString(format base.FormatKey, verbose bool) string 
 	}
 	if m.Size != 0 {
 		fmt.Fprintf(&b, " size:%d", m.Size)
+		if m.Virtual && m.FileBacking != nil {
+			fmt.Fprintf(&b, "(%d)", m.FileBacking.Size)
+		}
 	}
 	if len(m.BlobReferences) > 0 {
 		fmt.Fprint(&b, " blobrefs:[")

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -349,6 +349,6 @@ excise-dryrun b c
 ----
 would excise 1 files.
   del-table:     L6 000044
-  add-table:     L6 000053(000044):[a@1#0,SET-azzz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azzz@1#0,SET] size:238596 blobrefs:[(000006: 566234), (000008: 564260), (000010: 37624); depth:1]
-  add-table:     L6 000054(000044):[c@1#0,SET-czks@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-czks@1#0,SET] size:235737 blobrefs:[(000006: 559450), (000008: 557499), (000010: 37173); depth:1]
+  add-table:     L6 000053(000044):[a@1#0,SET-azzz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azzz@1#0,SET] size:238596(711466) blobrefs:[(000006: 566234), (000008: 564260), (000010: 37624); depth:1]
+  add-table:     L6 000054(000044):[c@1#0,SET-czks@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-czks@1#0,SET] size:235737(711466) blobrefs:[(000006: 559450), (000008: 557499), (000010: 37173); depth:1]
   add-backing:   000044

--- a/testdata/excise
+++ b/testdata/excise
@@ -33,8 +33,8 @@ excise-dryrun c k
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
   del-table:     L6 000004
-  add-table:     L6 000007(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] size:33
-  add-table:     L6 000008(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET] size:33
+  add-table:     L6 000007(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] size:33(654)
+  add-table:     L6 000008(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET] size:33(654)
   add-backing:   000004
 
 
@@ -43,8 +43,8 @@ excise-dryrun a e
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
   del-table:     L6 000004
-  add-table:     L0 000009(000006):[f#12,SET-f#12,SET] seqnums:[11-12] points:[f#12,SET-f#12,SET] size:45
-  add-table:     L6 000010(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET] size:33
+  add-table:     L0 000009(000006):[f#12,SET-f#12,SET] seqnums:[11-12] points:[f#12,SET-f#12,SET] size:45(696)
+  add-table:     L6 000010(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET] size:33(654)
   add-backing:   000006
   add-backing:   000004
 
@@ -53,8 +53,8 @@ excise-dryrun e z
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
   del-table:     L6 000004
-  add-table:     L0 000011(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET] size:45
-  add-table:     L6 000012(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] size:33
+  add-table:     L0 000011(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET] size:45(696)
+  add-table:     L6 000012(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] size:33(654)
   add-backing:   000006
   add-backing:   000004
 
@@ -63,9 +63,9 @@ excise-dryrun f l
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
   del-table:     L6 000004
-  add-table:     L0 000013(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET] size:45
-  add-table:     L6 000014(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] size:33
-  add-table:     L6 000015(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET] size:33
+  add-table:     L0 000013(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET] size:45(696)
+  add-table:     L6 000014(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] size:33(654)
+  add-table:     L6 000015(000004):[l#10,SET-l#10,SET] seqnums:[10-10] points:[l#10,SET-l#10,SET] size:33(654)
   add-backing:   000006
   add-backing:   000004
 
@@ -74,8 +74,8 @@ excise-dryrun f ll
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000006
   del-table:     L6 000004
-  add-table:     L0 000016(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET] size:45
-  add-table:     L6 000017(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] size:33
+  add-table:     L0 000016(000006):[d#11,SET-d#11,SET] seqnums:[11-12] points:[d#11,SET-d#11,SET] size:45(696)
+  add-table:     L6 000017(000004):[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] size:33(654)
   add-backing:   000006
   add-backing:   000004
 
@@ -163,15 +163,15 @@ excise-dryrun f g
 ----
 would excise 1 files, use ingest-and-excise to excise.
   del-table:     L0 000005
-  add-table:     L0 000006(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET] size:28
-  add-table:     L0 000007(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL] size:1
+  add-table:     L0 000006(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET] size:28(702)
+  add-table:     L0 000007(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL] size:1(702)
   add-backing:   000005
 
 excise-dryrun b c
 ----
 would excise 1 files, use ingest-and-excise to excise.
   del-table:     L0 000005
-  add-table:     L0 000008(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL] size:1
+  add-table:     L0 000008(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL] size:1(702)
   add-backing:   000005
 
 excise-dryrun i j
@@ -186,9 +186,9 @@ excise-dryrun c d
 would excise 2 files, use ingest-and-excise to excise.
   del-table:     L0 000005
   del-table:     L6 000004
-  add-table:     L0 000009(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET] size:28
-  add-table:     L0 000010(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL] size:1
-  add-table:     L6 000011(000004):[d#10,RANGEKEYSET-f#inf,RANGEKEYSET] seqnums:[10-10] ranges:[d#10,RANGEKEYSET-f#inf,RANGEKEYSET] size:1
+  add-table:     L0 000009(000005):[b#11,SET-b#11,SET] seqnums:[11-11] points:[b#11,SET-b#11,SET] size:28(702)
+  add-table:     L0 000010(000005):[g#11,RANGEDEL-i#inf,RANGEDEL] seqnums:[11-11] points:[g#11,RANGEDEL-i#inf,RANGEDEL] size:1(702)
+  add-table:     L6 000011(000004):[d#10,RANGEKEYSET-f#inf,RANGEKEYSET] seqnums:[10-10] ranges:[d#10,RANGEKEYSET-f#inf,RANGEKEYSET] size:1(760)
   add-backing:   000005
   add-backing:   000004
 

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -330,8 +330,8 @@ gi: (foo, .)
 lsm verbose
 ----
 L6:
-  000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1352
-  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:933
+  000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1352(1352)
+  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:933(933)
 
 download g h via-backing-file-download
 ----
@@ -341,8 +341,8 @@ ok
 lsm verbose
 ----
 L6:
-  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1015
-  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:930
+  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1015(1015)
+  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:930(930)
 
 reopen
 ----

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -675,43 +675,44 @@ j#0,SET = j
 ----
 
 # Test reuse of backings within a single ingestion. We should see only two
-# backings.
+# backings; their sizes should be the sum of the corresponding ingestions.
 ingest-external
-reuse1 bounds=(a,b)
-reuse2 bounds=(f,g)
-reuse2 bounds=(h,i)
-reuse1 bounds=(d,e)
-reuse1 bounds=(u,v)
-reuse2 bounds=(j,k)
+reuse1 bounds=(a,b) size=100
+reuse2 bounds=(f,g) size=200
+reuse2 bounds=(h,i) size=300
+reuse1 bounds=(d,e) size=400
+reuse1 bounds=(u,v) size=500
+reuse2 bounds=(j,k) size=600
 ----
 
-lsm
+lsm verbose
 ----
 L6:
-  000004(000004):[a#10,DELSIZED-b#inf,RANGEDEL]
-  000007(000004):[d#11,DELSIZED-e#inf,RANGEDEL]
-  000005(000005):[f#12,DELSIZED-g#inf,RANGEDEL]
-  000006(000005):[h#13,DELSIZED-i#inf,RANGEDEL]
-  000009(000005):[j#14,DELSIZED-k#inf,RANGEDEL]
-  000008(000004):[u#15,DELSIZED-v#inf,RANGEDEL]
+  000004(000004):[a#10,DELSIZED-b#inf,RANGEDEL] seqnums:[10-10] points:[a#10,DELSIZED-b#inf,RANGEDEL] size:100(1000)
+  000007(000004):[d#11,DELSIZED-e#inf,RANGEDEL] seqnums:[11-11] points:[d#11,DELSIZED-e#inf,RANGEDEL] size:400(1000)
+  000005(000005):[f#12,DELSIZED-g#inf,RANGEDEL] seqnums:[12-12] points:[f#12,DELSIZED-g#inf,RANGEDEL] size:200(1100)
+  000006(000005):[h#13,DELSIZED-i#inf,RANGEDEL] seqnums:[13-13] points:[h#13,DELSIZED-i#inf,RANGEDEL] size:300(1100)
+  000009(000005):[j#14,DELSIZED-k#inf,RANGEDEL] seqnums:[14-14] points:[j#14,DELSIZED-k#inf,RANGEDEL] size:600(1100)
+  000008(000004):[u#15,DELSIZED-v#inf,RANGEDEL] seqnums:[15-15] points:[u#15,DELSIZED-v#inf,RANGEDEL] size:500(1000)
 
 # Test reuse of backings across separate requests.
 ingest-external
-reuse1 bounds=(xu,xv) synthetic-prefix=x
-reuse2 bounds=(yj,yk) synthetic-prefix=y
+reuse1 bounds=(xu,xv) synthetic-prefix=x size=5000
+reuse2 bounds=(yj,yk) synthetic-prefix=y size=6000
 ----
 
-lsm
+# The sizes for the new tables should be capped to the backing size.
+lsm verbose
 ----
 L6:
-  000004(000004):[a#10,DELSIZED-b#inf,RANGEDEL]
-  000007(000004):[d#11,DELSIZED-e#inf,RANGEDEL]
-  000005(000005):[f#12,DELSIZED-g#inf,RANGEDEL]
-  000006(000005):[h#13,DELSIZED-i#inf,RANGEDEL]
-  000009(000005):[j#14,DELSIZED-k#inf,RANGEDEL]
-  000008(000004):[u#15,DELSIZED-v#inf,RANGEDEL]
-  000010(000004):[xu#16,DELSIZED-xv#inf,RANGEDEL]
-  000011(000005):[yj#17,DELSIZED-yk#inf,RANGEDEL]
+  000004(000004):[a#10,DELSIZED-b#inf,RANGEDEL] seqnums:[10-10] points:[a#10,DELSIZED-b#inf,RANGEDEL] size:100(1000)
+  000007(000004):[d#11,DELSIZED-e#inf,RANGEDEL] seqnums:[11-11] points:[d#11,DELSIZED-e#inf,RANGEDEL] size:400(1000)
+  000005(000005):[f#12,DELSIZED-g#inf,RANGEDEL] seqnums:[12-12] points:[f#12,DELSIZED-g#inf,RANGEDEL] size:200(1100)
+  000006(000005):[h#13,DELSIZED-i#inf,RANGEDEL] seqnums:[13-13] points:[h#13,DELSIZED-i#inf,RANGEDEL] size:300(1100)
+  000009(000005):[j#14,DELSIZED-k#inf,RANGEDEL] seqnums:[14-14] points:[j#14,DELSIZED-k#inf,RANGEDEL] size:600(1100)
+  000008(000004):[u#15,DELSIZED-v#inf,RANGEDEL] seqnums:[15-15] points:[u#15,DELSIZED-v#inf,RANGEDEL] size:500(1000)
+  000010(000004):[xu#16,DELSIZED-xv#inf,RANGEDEL] seqnums:[16-16] points:[xu#16,DELSIZED-xv#inf,RANGEDEL] size:1000(1000)
+  000011(000005):[yj#17,DELSIZED-yk#inf,RANGEDEL] seqnums:[17-17] points:[yj#17,DELSIZED-yk#inf,RANGEDEL] size:1100(1100)
 
 batch
 del-range a z
@@ -721,37 +722,37 @@ compact a z
 ----
 
 ingest-external
-reuse1 bounds=(a,b)
-reuse2 bounds=(f,g)
+reuse1 bounds=(a,b) size=100
+reuse2 bounds=(f,g) size=200
 ----
 
-lsm
+lsm verbose
 ----
 L6:
-  000014(000014):[a#19,DELSIZED-b#inf,RANGEDEL]
-  000015(000015):[f#20,DELSIZED-g#inf,RANGEDEL]
+  000014(000014):[a#19,DELSIZED-b#inf,RANGEDEL] seqnums:[19-19] points:[a#19,DELSIZED-b#inf,RANGEDEL] size:100(100)
+  000015(000015):[f#20,DELSIZED-g#inf,RANGEDEL] seqnums:[20-20] points:[f#20,DELSIZED-g#inf,RANGEDEL] size:200(200)
 
 # Multiple reuse of existing backings in one request.
 ingest-external
-reuse2 bounds=(h,i)
-reuse1 bounds=(d,e)
-reuse1 bounds=(u,v)
-reuse2 bounds=(j,k)
-reuse1 bounds=(xu,xv) synthetic-prefix=x
-reuse2 bounds=(yj,yk) synthetic-prefix=y
+reuse2 bounds=(h,i) size=300
+reuse1 bounds=(d,e) size=400
+reuse1 bounds=(u,v) size=500
+reuse2 bounds=(j,k) size=600
+reuse1 bounds=(xu,xv) synthetic-prefix=x size=700
+reuse2 bounds=(yj,yk) synthetic-prefix=y size=800
 ----
 
-lsm
+lsm verbose
 ----
 L6:
-  000014(000014):[a#19,DELSIZED-b#inf,RANGEDEL]
-  000017(000014):[d#21,DELSIZED-e#inf,RANGEDEL]
-  000015(000015):[f#20,DELSIZED-g#inf,RANGEDEL]
-  000016(000015):[h#22,DELSIZED-i#inf,RANGEDEL]
-  000019(000015):[j#23,DELSIZED-k#inf,RANGEDEL]
-  000018(000014):[u#24,DELSIZED-v#inf,RANGEDEL]
-  000020(000014):[xu#25,DELSIZED-xv#inf,RANGEDEL]
-  000021(000015):[yj#26,DELSIZED-yk#inf,RANGEDEL]
+  000014(000014):[a#19,DELSIZED-b#inf,RANGEDEL] seqnums:[19-19] points:[a#19,DELSIZED-b#inf,RANGEDEL] size:100(100)
+  000017(000014):[d#21,DELSIZED-e#inf,RANGEDEL] seqnums:[21-21] points:[d#21,DELSIZED-e#inf,RANGEDEL] size:100(100)
+  000015(000015):[f#20,DELSIZED-g#inf,RANGEDEL] seqnums:[20-20] points:[f#20,DELSIZED-g#inf,RANGEDEL] size:200(200)
+  000016(000015):[h#22,DELSIZED-i#inf,RANGEDEL] seqnums:[22-22] points:[h#22,DELSIZED-i#inf,RANGEDEL] size:200(200)
+  000019(000015):[j#23,DELSIZED-k#inf,RANGEDEL] seqnums:[23-23] points:[j#23,DELSIZED-k#inf,RANGEDEL] size:200(200)
+  000018(000014):[u#24,DELSIZED-v#inf,RANGEDEL] seqnums:[24-24] points:[u#24,DELSIZED-v#inf,RANGEDEL] size:100(100)
+  000020(000014):[xu#25,DELSIZED-xv#inf,RANGEDEL] seqnums:[25-25] points:[xu#25,DELSIZED-xv#inf,RANGEDEL] size:100(100)
+  000021(000015):[yj#26,DELSIZED-yk#inf,RANGEDEL] seqnums:[26-26] points:[yj#26,DELSIZED-yk#inf,RANGEDEL] size:200(200)
 
 # Test that reusing the same backing region with different prefix and suffix
 # works as expected. In particular, make sure the synthetic suffix doesn't

--- a/testdata/version_set
+++ b/testdata/version_set
@@ -42,7 +42,7 @@ applied:
 current version:
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
+    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300(2000)
 1 virtual backings, total size 2000:
   000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=300
 no zombie tables
@@ -60,8 +60,8 @@ applied:
 current version:
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
-    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
+    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300(2000)
+    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400(2000)
 1 virtual backings, total size 2000:
   000002:  size=2000  useCount=2  protectionCount=0  virtualizedSize=700
 no zombie tables
@@ -81,9 +81,9 @@ applied:
 current version:
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
+    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400(2000)
   L3:
-    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300
+    000003(000002):[e#1,SET-h#1,SET] seqnums:[0-0] points:[e#1,SET-h#1,SET] size:300(2000)
 1 virtual backings, total size 2000:
   000002:  size=2000  useCount=2  protectionCount=0  virtualizedSize=700
 no zombie tables
@@ -101,7 +101,7 @@ applied:
 current version:
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
+    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400(2000)
 1 virtual backings, total size 2000:
   000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=400
 no zombie tables
@@ -114,7 +114,7 @@ reopen
 current version:
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
-    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400
+    000004(000002):[i#1,SET-k#1,SET] seqnums:[0-0] points:[i#1,SET-k#1,SET] size:400(2000)
 1 virtual backings, total size 2000:
   000002:  size=2000  useCount=1  protectionCount=0  virtualizedSize=400
 no zombie tables
@@ -150,7 +150,7 @@ applied:
   add-backing:   000100
 current version:
   L1:
-    000005(000100):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:500
+    000005(000100):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:500(100000)
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 100000:
@@ -164,7 +164,7 @@ ref-version r1
 ----
 current version:
   L1:
-    000005(000100):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:500
+    000005(000100):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:500(100000)
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 100000:
@@ -218,8 +218,8 @@ applied:
   add-backing:   000101
 current version:
   L1:
-    000006(000101):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:600
-    000007(000101):[w#1,SET-x#1,SET] seqnums:[0-0] points:[w#1,SET-x#1,SET] size:700
+    000006(000101):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:600(101000)
+    000007(000101):[w#1,SET-x#1,SET] seqnums:[0-0] points:[w#1,SET-x#1,SET] size:700(101000)
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 101000:
@@ -233,8 +233,8 @@ protect-backing 101
 ----
 current version:
   L1:
-    000006(000101):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:600
-    000007(000101):[w#1,SET-x#1,SET] seqnums:[0-0] points:[w#1,SET-x#1,SET] size:700
+    000006(000101):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:600(101000)
+    000007(000101):[w#1,SET-x#1,SET] seqnums:[0-0] points:[w#1,SET-x#1,SET] size:700(101000)
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
 1 virtual backings, total size 101000:
@@ -307,7 +307,7 @@ applied:
   add-backing:   000102
 current version:
   L1:
-    000009(000102):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:900
+    000009(000102):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:900(102000)
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
   L3:
@@ -323,7 +323,7 @@ protect-backing 102
 ----
 current version:
   L1:
-    000009(000102):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:900
+    000009(000102):[u#1,SET-v#1,SET] seqnums:[0-0] points:[u#1,SET-v#1,SET] size:900(102000)
   L2:
     000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
   L3:


### PR DESCRIPTION
#### manifest: show backing size in TableMetadata.DebugString


#### db: fix size of deduplicated external backings

We allow external ingestions that have the same underlying remote
object, and we deduplicate the backings in this case. However, the
logic to set the backing size did not take deduplication into account.

We fix this by summing the `Size` of external files sharing a backing
within the same ingestion operation. When a backing is reused across
separate operations, we cap the virtual table size to the backing
size.