### PR TITLE
db: expand blob file LevelMetrics

### DIFF
--- a/cmd/pebble/write_bench.go
+++ b/cmd/pebble/write_bench.go
@@ -297,7 +297,7 @@ func runWriteBenchmark(_ *cobra.Command, args []string) error {
 			l0Sublevels := m.Levels[0].Sublevels
 			nLevels := 0
 			for _, l := range m.Levels {
-				if l.BytesIn > 0 {
+				if l.TableBytesIn > 0 {
 					nLevels++
 				}
 			}

--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -617,8 +617,8 @@ func (y *ycsb) done(elapsed time.Duration) {
 		ycsbConfig.workload, ycsbConfig.values,
 		resultHist.TotalCount(),
 		float64(resultHist.TotalCount())/elapsed.Seconds(),
-		total.BytesRead,
-		total.BytesFlushed+total.BytesCompacted,
+		total.TableBytesRead,
+		total.TableBytesFlushed+total.TableBytesCompacted,
 		float64(readAmpSum)/float64(readAmpCount),
 		total.WriteAmp(),
 	)

--- a/compaction.go
+++ b/compaction.go
@@ -3242,7 +3242,11 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*versionEdit, error
 		TableBytesIn: startLevelBytes,
 		// TODO(jackson):  This BytesRead value does not include any blob files
 		// written. It either should, or we should add a separate metric.
-		TableBytesRead: c.outputLevel.files.TableSizeSum(),
+		TableBytesRead:   c.outputLevel.files.TableSizeSum(),
+		BlobBytesWritten: result.Stats.CumulativeBlobFileSize,
+	}
+	if c.flushing != nil {
+		outputMetrics.BlobBytesFlushed = result.Stats.CumulativeBlobFileSize
 	}
 	if len(c.extraLevels) > 0 {
 		outputMetrics.TableBytesIn += c.extraLevels[0].files.TableSizeSum()
@@ -3315,6 +3319,7 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*versionEdit, error
 			outputMetrics.TableBytesFlushed += fileMeta.Size
 		}
 		outputMetrics.EstimatedReferencesSize += fileMeta.EstimatedReferenceSize()
+		outputMetrics.BlobBytesReadEstimate += fileMeta.EstimatedReferenceSize()
 		outputMetrics.TablesSize += int64(fileMeta.Size)
 		outputMetrics.TablesCount++
 		outputMetrics.Additional.BytesWrittenDataBlocks += t.WriterMeta.Properties.DataSize

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1049,6 +1049,10 @@ func TestCompaction(t *testing.T) {
 			case "lsm":
 				return runLSMCmd(td, d)
 
+			case "metrics":
+				m := d.Metrics()
+				return m.StringForTests()
+
 			case "populate":
 				b := d.NewBatch()
 				runPopulateCmd(t, td, b)
@@ -1353,16 +1357,14 @@ func TestCompaction(t *testing.T) {
 		if !ok {
 			t.Fatalf("unknown test config: %s", filename)
 		}
-		t.Run(filename, func(t *testing.T) {
-			minVersion, maxVersion := tc.minVersion, tc.maxVersion
-			if minVersion == 0 {
-				minVersion = FormatMinSupported
-			}
-			if maxVersion == 0 {
-				maxVersion = internalFormatNewest
-			}
-			runTest(t, path, minVersion, maxVersion, tc.verbose)
-		})
+		minVersion, maxVersion := tc.minVersion, tc.maxVersion
+		if minVersion == 0 {
+			minVersion = FormatMinSupported
+		}
+		if maxVersion == 0 {
+			maxVersion = internalFormatNewest
+		}
+		runTest(t, path, minVersion, maxVersion, tc.verbose)
 	})
 }
 

--- a/db.go
+++ b/db.go
@@ -2096,7 +2096,7 @@ func (d *DB) Metrics() *Metrics {
 	for i, n := 0, len(d.mu.mem.queue)-1; i < n; i++ {
 		metrics.WAL.Size += d.mu.mem.queue[i].logSize
 	}
-	metrics.WAL.BytesWritten = metrics.Levels[0].BytesIn + metrics.WAL.Size
+	metrics.WAL.BytesWritten = metrics.Levels[0].TableBytesIn + metrics.WAL.Size
 	metrics.WAL.Failover = walStats.Failover
 
 	if p := d.mu.versions.picker; p != nil {

--- a/file_cache.go
+++ b/file_cache.go
@@ -661,6 +661,9 @@ func (h *fileCacheHandle) newPointIter(
 	}
 	var blobReferences sstable.BlobReferences
 	if r.Attributes.Has(sstable.AttributeBlobValues) {
+		if len(file.BlobReferences) == 0 {
+			return nil, errors.AssertionFailedf("pebble: sstable %s has blob values but no blob references", file.FileNum)
+		}
 		blobReferences = &file.BlobReferences
 	}
 	if internalOpts.compaction {

--- a/ingest.go
+++ b/ingest.go
@@ -2029,7 +2029,7 @@ func (d *DB) ingestApply(
 			levelMetrics.TablesCount++
 			levelMetrics.TablesSize += int64(m.Size)
 			levelMetrics.EstimatedReferencesSize += m.EstimatedReferenceSize()
-			levelMetrics.BytesIngested += m.Size
+			levelMetrics.TableBytesIngested += m.Size
 			levelMetrics.TablesIngested++
 		}
 		// replacedFiles maps files excised due to exciseSpan (or splitFiles returned

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -106,19 +106,19 @@ func exampleMetrics() Metrics {
 		}
 		l.FillFactor = 2.0 + float64(i+1)*0.1
 		l.CompensatedFillFactor = 3.0 * +float64(i+1) * 0.1
-		l.BytesIn = base + 4
-		l.BytesIngested = base + 4
-		l.BytesMoved = base + 6
-		l.BytesRead = base + 7
-		l.BytesCompacted = base + 8
-		l.BytesFlushed = base + 9
+		l.TableBytesIn = base + 4
+		l.TableBytesIngested = base + 4
+		l.TableBytesMoved = base + 6
+		l.TableBytesRead = base + 7
+		l.TableBytesCompacted = base + 8
+		l.TableBytesFlushed = base + 9
 		l.TablesCompacted = base + 10
 		l.TablesFlushed = base + 11
 		l.TablesIngested = base + 12
 		l.TablesMoved = base + 13
-		l.MultiLevel.BytesInTop = base + 4
-		l.MultiLevel.BytesIn = base + 4
-		l.MultiLevel.BytesRead = base + 4
+		l.MultiLevel.TableBytesInTop = base + 4
+		l.MultiLevel.TableBytesIn = base + 4
+		l.MultiLevel.TableBytesRead = base + 4
 	}
 	for i := range m.manualMemory {
 		m.manualMemory[i].InUseBytes = uint64((i + 1) * 1024)

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -523,7 +523,7 @@ func (r *Runner) Wait() (Metrics, error) {
 	total := pm.Total()
 	var ingestBytesWeighted uint64
 	for l := 0; l < len(pm.Levels); l++ {
-		ingestBytesWeighted += pm.Levels[l].BytesIngested * uint64(len(pm.Levels)-l-1)
+		ingestBytesWeighted += pm.Levels[l].TableBytesIngested * uint64(len(pm.Levels)-l-1)
 	}
 
 	m := Metrics{
@@ -560,7 +560,7 @@ func (r *Runner) Wait() (Metrics, error) {
 	m.CompactionCounts.Rewrite = pm.Compact.RewriteCount
 	m.CompactionCounts.Copy = pm.Compact.CopyCount
 	m.CompactionCounts.MultiLevel = pm.Compact.MultiLevelCount
-	m.Ingest.BytesIntoL0 = pm.Levels[0].BytesIngested
+	m.Ingest.BytesIntoL0 = pm.Levels[0].TableBytesIngested
 	m.Ingest.BytesWeightedByLevel = ingestBytesWeighted
 	return m, err
 }

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -114,6 +114,40 @@ f: (foo, .)
 k: (k, .)
 z: (zoo, .)
 
+metrics
+----
+      |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |     multilevel
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  |    top   in  read
+------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+------------------
+    0 |     0     0B     0B       0 |    -    0    0 |   41B |     0     0B |     0     0B |     1   765B |    0B |   0 7.77 |    0B    0B    0B
+    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   765B |     0     0B |    0B |   0    0 |    0B    0B    0B
+    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B    0B    0B
+    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   765B |     0     0B |    0B |   0    0 |    0B    0B    0B
+    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B    0B    0B
+    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   765B |     0     0B |    0B |   0    0 |    0B    0B    0B
+    6 |     1   815B     0B       0 |    - 0.00 0.00 |  765B |     0     0B |     0     0B |     1   815B | 1.5KB |   1 0.97 |    0B    0B    0B
+total |     1   815B     0B       0 |    -    -    - |   41B |     0     0B |     3  2.2KB |     2  1.6KB | 1.5KB |   1 9.27 |    0B    0B    0B
+------------------------------------------------------------------------------------------------------------------------------------------------
+WAL: 1 files (0B)  in: 30B  written: 41B (37% overhead)
+Flushes: 1
+Compactions: 4  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
+             default: 1  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 2
+MemTables: 1 (256KB)  zombie: 1 (256KB)
+Zombie tables: 0 (0B, local: 0B)
+Backing tables: 0 (0B)
+Virtual tables: 0 (0B)
+Local tables size: 815B
+Compression types: snappy: 1
+Table stats: all loaded
+Block cache: 4 entries (1.5KB)  hit rate: 70.3%
+Table cache: 2 entries (1.1KB)  hit rate: 82.2%
+Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
+Snapshots: 0  earliest seq num: 0
+Table iters: 0
+Filter utility: 0.0%
+Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
+
 # Set the minimum size for a separated value to 5.
 
 define value-separation=(true, 5, 3)


### PR DESCRIPTION
Clarify the LevelMetrics fields related to byte quantities as bytes of
sstables by prefixing them with 'Table'.

Add totals about blob files to LevelMetrics and use them to correct the write
amplification calculation in the presence of value separation.