### PR TITLE
docs: add value separation annotation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,40 +40,10 @@
           </div>
         </div>
         <hr class="divider"/>
-        <div class="annotation" data-date="20200614">L0-sublevels and
-        flush-splits enabled</div>
-        <div class="annotation" data-date="20200604">Increased
-        LogWriter free blocks 4-&gt;16</div>
-        <div class="annotation" data-date="20200706">Began tracking
-        ycsb/E read-amp</div>
-        <div class="annotation" data-date="20201022">Level metadata
-        switched to use a B-Tree</div>
-        <div class="annotation" data-date="20201222">Enabled
-        read-triggered compactions</div>
-        <div class="annotation" data-date="20210113">Readahead
-        and preallocation bug fixed</div>
-        <div class="annotation" data-date="20210326">Removed excess
-        read samples for read-triggered compactions</div>
-        <div class="annotation" data-date="20210429">Switched to Ubuntu
-        20.04.2 LTS AMI</div>
-        <div class="annotation" data-date="20211018">Read compaction fixes</div>
-        <div class="annotation" data-date="20211109">Bumped benchmark
-          runtime to 90 minutes</div>
-        <div class="annotation" data-date="20220330">Data quality issue introduced (YCSB A only)</div>
-        <div class="annotation" data-date="20220526">Data quality issue fixed (YCSB A only)</div>
-        <div class="annotation" data-date="20220626">Began zeroing reused
-            iterator structs (#1822)</div>
-        <div class="annotation" data-date="20230215">Grandparent boundary
-            compaction splitting</div>
-        <div class="annotation" data-date="20230516">Infrastructure
-            change (#2578)</div>
-        <div class="annotation" data-date="20230607">ycsb/F sampling bug</div>
-        <div class="annotation" data-date="20230611">Switched to m6id.4xlarge
-            (from 5d.4xlarge)</div>
-        <div class="annotation" data-date="20240209">Changed AWS machine type
-            (<a href="https://github.com/cockroachdb/cockroach/pull/117852">#117852</a>).</div>
         <div class="annotation" data-date="20241015">Enabled columnar
           blocks</div>
+        <div class="annotation" data-date="20250509">Enabled value
+          separation (values=1024 variant)</div>
       </div>
       <div class="section rows">
         <div>


### PR DESCRIPTION
Add a annotation to the pebble nightly benchmarks indicating the date when value separation was enabled (only affecting the values=1024 variant currently). Also remove old annotations that are older than the 1-year of data we retain.