### PR TITLE
go.mod: revert to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,4 +53,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24
+go 1.23


### PR DESCRIPTION
There is no benefit to requiring 1.24 right now, and it blocks Pebble
bumps until CRDB is switched over.

We should only bump it back up after CRDB was switched over and
everything is stable (and we want to use some go1.24 feature).