### PR TITLE
sstable/blob: expand BenchmarkValueFetcherRetrieve

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -120,10 +120,12 @@ func New(size int64) *Cache {
 	if m > 4 && int(size)/m < minimumShardSize {
 		m = 4
 	}
-	return newCache(size, m)
+	return NewWithShards(size, m)
 }
 
-func newCache(size int64, shards int) *Cache {
+// NewWithShards creates a new cache with the specified size and number of
+// shards.
+func NewWithShards(size int64, shards int) *Cache {
 	c := &Cache{
 		maxSize: size,
 		shards:  make([]shard, shards),

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -25,7 +25,7 @@ func TestCache(t *testing.T) {
 	f, err := os.Open("testdata/cache")
 	require.NoError(t, err)
 
-	cache := newCache(200, 1)
+	cache := NewWithShards(200, 1)
 	defer cache.Unref()
 	h := cache.NewHandle()
 	defer h.Close()
@@ -70,7 +70,7 @@ func setTestValue(c *Handle, fileNum base.DiskFileNum, offset uint64, s string, 
 }
 
 func TestCacheDelete(t *testing.T) {
-	cache := newCache(100, 1)
+	cache := NewWithShards(100, 1)
 	defer cache.Unref()
 	h := cache.NewHandle()
 	defer h.Close()
@@ -101,7 +101,7 @@ func TestCacheDelete(t *testing.T) {
 }
 
 func TestEvictFile(t *testing.T) {
-	cache := newCache(100, 1)
+	cache := NewWithShards(100, 1)
 	defer cache.Unref()
 	h := cache.NewHandle()
 	defer h.Close()
@@ -131,7 +131,7 @@ func TestEvictFile(t *testing.T) {
 func TestEvictAll(t *testing.T) {
 	// Verify that it is okay to evict all of the data from a cache. Previously
 	// this would trigger a nil-pointer dereference.
-	cache := newCache(100, 1)
+	cache := NewWithShards(100, 1)
 	defer cache.Unref()
 	h := cache.NewHandle()
 	defer h.Close()
@@ -141,7 +141,7 @@ func TestEvictAll(t *testing.T) {
 }
 
 func TestMultipleDBs(t *testing.T) {
-	cache := newCache(100, 1)
+	cache := NewWithShards(100, 1)
 	defer cache.Unref()
 	h1 := cache.NewHandle()
 	defer h1.Close()
@@ -177,7 +177,7 @@ func TestZeroSize(t *testing.T) {
 }
 
 func TestReserve(t *testing.T) {
-	cache := newCache(4, 2)
+	cache := NewWithShards(4, 2)
 	defer cache.Unref()
 	h1 := cache.NewHandle()
 	defer h1.Close()
@@ -207,7 +207,7 @@ func TestReserve(t *testing.T) {
 }
 
 func TestReserveDoubleRelease(t *testing.T) {
-	cache := newCache(100, 1)
+	cache := NewWithShards(100, 1)
 	defer cache.Unref()
 
 	r := cache.Reserve(10)
@@ -229,7 +229,7 @@ func TestReserveDoubleRelease(t *testing.T) {
 }
 
 func TestCacheStressSetExisting(t *testing.T) {
-	cache := newCache(1, 1)
+	cache := NewWithShards(1, 1)
 	defer cache.Unref()
 	h := cache.NewHandle()
 	defer h.Close()
@@ -252,7 +252,7 @@ func BenchmarkCacheGet(b *testing.B) {
 	const size = 100000
 
 	n := runtime.GOMAXPROCS(0)
-	cache := newCache(size*int64(n), n)
+	cache := NewWithShards(size*int64(n), n)
 	defer cache.Unref()
 	h := cache.NewHandle()
 	defer h.Close()

--- a/internal/cache/clockpro_test.go
+++ b/internal/cache/clockpro_test.go
@@ -15,7 +15,7 @@ func TestReserveColdTarget(t *testing.T) {
 	// then we unnecessarily remove nodes from the
 	// cache.
 
-	cache := newCache(100, 1)
+	cache := NewWithShards(100, 1)
 	defer cache.Unref()
 	h := make([]*Handle, 50)
 	for i := range h {


### PR DESCRIPTION
Expand the BenchmarkValueFetcherRetrieve microbenchmark to benchmark against multiple file sizes and with and without cache hits.