### PR TITLE
crl-release-24.3: db: bump maximum {Range,Point}DeletionsBytesEstimate

### DIFF
--- a/table_stats.go
+++ b/table_stats.go
@@ -652,8 +652,8 @@ var lastSanityCheckStatsLog atomic.Int64 // time of last log as time.Duration si
 
 func sanityCheckStats(meta *fileMetadata, logger Logger, info string) {
 	// Values for PointDeletionsBytesEstimate and RangeDeletionsBytesEstimate that
-	// exceed this value are most likely indicative of a bug.
-	const maxDeletionBytesEstimate = 16 << 30 // 16 GiB
+	// exceed this value are likely indicative of a bug (eg, underflow).
+	const maxDeletionBytesEstimate = 1 << 50 // 1 PiB
 
 	if meta.Stats.PointDeletionsBytesEstimate > maxDeletionBytesEstimate ||
 		meta.Stats.RangeDeletionsBytesEstimate > maxDeletionBytesEstimate {


### PR DESCRIPTION
Bump the maximum RangeDeletionsBytesEstimate or RangeDeletionsBytesEstimate value that logs an assertion error. During a table or database drop, a single L0 sstable can contain range deletions that delete the entirety of the database. Bump this threshold to a PiB so that we can at least detect outrageous values, like those possible from an underflow.

Informs cockroachdb/cockroach#146521.
Informs cockroachdb/cockroach#146269.
Informs cockroachdb/cockroach#146505.
Informs cockroachdb/cockroach#146348.
Informs cockroachdb/cockroach#146504.
Informs cockroachdb/cockroach#146503.