### PR TITLE
crl-release-24.3: db: don't require quotes around level number in options section

### DIFF
--- a/options.go
+++ b/options.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1969,15 +1970,11 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			return err
 
 		case strings.HasPrefix(section, "Level "):
-			var index int
-			if n, err := fmt.Sscanf(section, `Level "%d"`, &index); err != nil {
-				return err
-			} else if n != 1 {
-				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section, value) {
-					return nil
-				}
+			m := regexp.MustCompile(`Level\s*"?(\d+)"?\s*$`).FindStringSubmatch(section)
+			if m == nil {
 				return errors.Errorf("pebble: unknown section: %q", errors.Safe(section))
 			}
+			index, _ := strconv.Atoi(m[1])
 
 			if len(o.Levels) <= index {
 				newLevels := make([]LevelOptions, index+1)

--- a/options_test.go
+++ b/options_test.go
@@ -319,6 +319,36 @@ func TestOptionsParse(t *testing.T) {
 	}
 }
 
+func TestOptionsParseLevelNoQuotes(t *testing.T) {
+	withQuotes := `
+[Options]
+[Level "1"]
+  block_restart_interval=8
+  block_size=10
+[Level "6"]
+  block_restart_interval=8
+  block_size=10
+`
+	withoutQuotes := `
+[Options]
+[Level 1]
+  block_restart_interval=8
+  block_size=10
+[Level 6]
+  block_restart_interval=8
+  block_size=10
+`
+	o1 := &Options{}
+	require.NoError(t, o1.Parse(withQuotes, nil))
+	o1.EnsureDefaults()
+
+	o2 := &Options{}
+	require.NoError(t, o2.Parse(withoutQuotes, nil))
+	o2.EnsureDefaults()
+
+	require.Equal(t, o1.String(), o2.String())
+}
+
 func TestOptionsParseComparerOverwrite(t *testing.T) {
 	// Test that an unrecognized comparer in the OPTIONS file does not nil out
 	// the Comparer field.


### PR DESCRIPTION
Backport of #4731.

The current format requires per-level sections to look like
`[Level "1"]`. The quotes can be a pain to escape, especially when
this is passed through the `--store` command line.

This change makes the parsing more tolerant to allow but not require
quotes, so that `[Level 1]` also works.