### PR TITLE
manifest: rename FileBacking to TableBacking

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -194,7 +194,7 @@ func (d *DB) Checkpoint(
 	optionsFileNum := d.optionsFileNum
 
 	virtualBackingFiles := make(map[base.DiskFileNum]struct{})
-	d.mu.versions.virtualBackings.ForEach(func(backing *fileBacking) {
+	d.mu.versions.virtualBackings.ForEach(func(backing *manifest.TableBacking) {
 		virtualBackingFiles[backing.DiskFileNum] = struct{}{}
 	})
 	versionBlobFiles := d.mu.versions.blobFiles.Metadatas()
@@ -267,7 +267,7 @@ func (d *DB) Checkpoint(
 	var excludedTables map[manifest.DeletedTableEntry]*tableMetadata
 	var includedBlobFiles map[base.DiskFileNum]struct{}
 	var remoteFiles []base.DiskFileNum
-	// Set of FileBacking.DiskFileNum which will be required by virtual sstables
+	// Set of TableBacking.DiskFileNum which will be required by virtual sstables
 	// in the checkpoint.
 	requiredVirtualBackingFiles := make(map[base.DiskFileNum]struct{})
 
@@ -322,14 +322,14 @@ func (d *DB) Checkpoint(
 				}
 			}
 
-			fileBacking := f.FileBacking
+			tableBacking := f.TableBacking
 			if f.Virtual {
-				if _, ok := requiredVirtualBackingFiles[fileBacking.DiskFileNum]; ok {
+				if _, ok := requiredVirtualBackingFiles[tableBacking.DiskFileNum]; ok {
 					continue
 				}
-				requiredVirtualBackingFiles[fileBacking.DiskFileNum] = struct{}{}
+				requiredVirtualBackingFiles[tableBacking.DiskFileNum] = struct{}{}
 			}
-			ckErr = copyFile(base.FileTypeTable, fileBacking.DiskFileNum)
+			ckErr = copyFile(base.FileTypeTable, tableBacking.DiskFileNum)
 			if ckErr != nil {
 				return ckErr
 			}

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -143,8 +143,8 @@ func testCheckpointImpl(t *testing.T, ddFile string, createOnShared bool) {
 			return memLog.String()
 
 		case "print-backing":
-			// prints contents of the file backing map in the version. Used to
-			// test whether the checkpoint removed the filebackings correctly.
+			// Print the virtual backings in the version. Used to test whether the
+			// checkpoint removed the backings correctly.
 			if len(td.CmdArgs) != 1 {
 				return "print-backing <db>"
 			}

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1208,11 +1208,11 @@ func responsibleForGarbageBytes(
 	if !m.Virtual {
 		return 0
 	}
-	useCount, virtualizedSize := virtualBackings.Usage(m.FileBacking.DiskFileNum)
+	useCount, virtualizedSize := virtualBackings.Usage(m.TableBacking.DiskFileNum)
 	// Since virtualizedSize is the sum of the estimated size of all virtual
 	// ssts, we allow for the possibility that virtualizedSize could exceed
-	// m.FileBacking.Size.
-	totalGarbage := int64(m.FileBacking.Size) - int64(virtualizedSize)
+	// m.TableBacking.Size.
+	totalGarbage := int64(m.TableBacking.Size) - int64(virtualizedSize)
 	if totalGarbage <= 0 {
 		return 0
 	}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -589,7 +589,7 @@ func TestAutomaticFlush(t *testing.T) {
 				if meta.Virtual {
 					continue
 				}
-				f, err := provider.OpenForReading(context.Background(), base.FileTypeTable, meta.FileBacking.DiskFileNum, objstorage.OpenOptions{})
+				f, err := provider.OpenForReading(context.Background(), base.FileTypeTable, meta.TableBacking.DiskFileNum, objstorage.OpenOptions{})
 				if err != nil {
 					return "", "", errors.WithStack(err)
 				}
@@ -3166,7 +3166,7 @@ func hasExternalFiles(d *DB) bool {
 		iter := v.Levels[level].Iter()
 		for m := iter.First(); m != nil; m = iter.Next() {
 			if m.Virtual {
-				meta, err := d.objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)
+				meta, err := d.objProvider.Lookup(base.FileTypeTable, m.TableBacking.DiskFileNum)
 				if err != nil {
 					panic(err)
 				}

--- a/data_test.go
+++ b/data_test.go
@@ -1322,7 +1322,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 
 	backingFileNum := base.DiskFileNum(file)
 	if m != nil {
-		backingFileNum = m.FileBacking.DiskFileNum
+		backingFileNum = m.TableBacking.DiskFileNum
 	}
 	fileName := base.MakeFilename(base.FileTypeTable, backingFileNum)
 	f, err := d.opts.FS.Open(fileName)
@@ -1351,7 +1351,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	env := sstable.ReadEnv{}
 	if m != nil && m.Virtual {
 		env.Virtual = m.VirtualParams
-		scaledProps := r.Properties.GetScaledProperties(m.FileBacking.Size, m.Size)
+		scaledProps := r.Properties.GetScaledProperties(m.TableBacking.Size, m.Size)
 		props = scaledProps.String()
 	}
 	if len(td.Input) == 0 {

--- a/db.go
+++ b/db.go
@@ -2332,14 +2332,14 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 					return nil, err
 				}
 				if m.Virtual {
-					commonProps := p.GetScaledProperties(m.FileBacking.Size, m.Size)
+					commonProps := p.GetScaledProperties(m.TableBacking.Size, m.Size)
 					p = &sstable.Properties{CommonProperties: commonProps}
 				}
 				destTables[j].Properties = p
 			}
 			destTables[j].Virtual = m.Virtual
-			destTables[j].BackingSSTNum = m.FileBacking.DiskFileNum
-			objMeta, err := d.objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)
+			destTables[j].BackingSSTNum = m.TableBacking.DiskFileNum
+			objMeta, err := d.objProvider.Lookup(base.FileTypeTable, m.TableBacking.DiskFileNum)
 			if err != nil {
 				return nil, err
 			}
@@ -3037,7 +3037,7 @@ func (d *DB) checkVirtualBounds(m *tableMetadata) {
 		return
 	}
 
-	objMeta, err := d.objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)
+	objMeta, err := d.objProvider.Lookup(base.FileTypeTable, m.TableBacking.DiskFileNum)
 	if err != nil {
 		panic(err)
 	}

--- a/download.go
+++ b/download.go
@@ -251,7 +251,7 @@ func (d *DB) newDownloadSpanTask(vers *version, sp DownloadSpan) (_ *downloadSpa
 	for _, ls := range vers.AllLevelsAndSublevels() {
 		iter := ls.Iter()
 		if f := iter.SeekGE(d.cmp, sp.StartKey); f != nil &&
-			objstorage.IsExternalTable(d.objProvider, f.FileBacking.DiskFileNum) &&
+			objstorage.IsExternalTable(d.objProvider, f.TableBacking.DiskFileNum) &&
 			d.cmp(f.Smallest().UserKey, bounds.Start) < 0 {
 			bounds.Start = f.Smallest().UserKey
 		}
@@ -403,7 +403,7 @@ func firstExternalFileInLevelIter(
 		f = it.Next()
 	}
 	for ; f != nil && endBound.IsUpperBoundFor(cmp, f.Smallest().UserKey); f = it.Next() {
-		if f.Virtual && objstorage.IsExternalTable(objProvider, f.FileBacking.DiskFileNum) {
+		if f.Virtual && objstorage.IsExternalTable(objProvider, f.TableBacking.DiskFileNum) {
 			return f
 		}
 	}

--- a/download_test.go
+++ b/download_test.go
@@ -182,7 +182,7 @@ func TestDownloadTask(t *testing.T) {
 				} else {
 					fmt.Fprintf(&buf, "downloading %s\n", f.TableNum)
 					f.Virtual = false
-					f.FileBacking.DiskFileNum = base.DiskFileNum(f.TableNum)
+					f.TableBacking.DiskFileNum = base.DiskFileNum(f.TableNum)
 					ch <- nil
 				}
 				return ch, true

--- a/event.go
+++ b/event.go
@@ -1232,7 +1232,7 @@ func (r *lowDiskSpaceReporter) findThreshold(
 func (d *DB) reportCorruption(meta any, err error) error {
 	switch meta := meta.(type) {
 	case *manifest.TableMetadata:
-		return d.reportFileCorruption(base.FileTypeTable, meta.FileBacking.DiskFileNum, meta.UserKeyBounds(), err)
+		return d.reportFileCorruption(base.FileTypeTable, meta.TableBacking.DiskFileNum, meta.UserKeyBounds(), err)
 	case *manifest.BlobFileMetadata:
 		// TODO(jackson): Add bounds for blob files.
 		return d.reportFileCorruption(base.FileTypeBlob, meta.FileNum, base.UserKeyBounds{}, err)

--- a/excise.go
+++ b/excise.go
@@ -92,7 +92,7 @@ func (d *DB) exciseTable(
 	}
 
 	looseBounds := boundsPolicy == looseExciseBounds ||
-		(boundsPolicy == tightExciseBoundsIfLocal && !objstorage.IsLocalTable(d.objProvider, m.FileBacking.DiskFileNum))
+		(boundsPolicy == tightExciseBoundsIfLocal && !objstorage.IsLocalTable(d.objProvider, m.TableBacking.DiskFileNum))
 
 	if exciseBounds.End.Kind == base.Inclusive {
 		// Loose bounds are not allowed with end-inclusive bounds. This can only
@@ -156,7 +156,7 @@ func (d *DB) exciseTable(
 		}
 
 		if leftTable.HasRangeKeys || leftTable.HasPointKeys {
-			leftTable.AttachVirtualBacking(m.FileBacking)
+			leftTable.AttachVirtualBacking(m.TableBacking)
 			if err := determineExcisedTableSize(d.fileCache, m, leftTable); err != nil {
 				return nil, nil, err
 			}
@@ -193,7 +193,7 @@ func (d *DB) exciseTable(
 			return nil, nil, err
 		}
 		if rightTable.HasRangeKeys || rightTable.HasPointKeys {
-			rightTable.AttachVirtualBacking(m.FileBacking)
+			rightTable.AttachVirtualBacking(m.TableBacking)
 			if err := determineExcisedTableSize(d.fileCache, m, rightTable); err != nil {
 				return nil, nil, err
 			}
@@ -475,7 +475,7 @@ func applyExciseToVersionEdit(
 		// to the manifest; we don't need to create another file backing. Note that
 		// there must be only one CreatedBackingTables entry per backing sstable.
 		// This is indicated by the VersionEdit.CreatedBackingTables invariant.
-		ve.CreatedBackingTables = append(ve.CreatedBackingTables, originalTable.FileBacking)
+		ve.CreatedBackingTables = append(ve.CreatedBackingTables, originalTable.TableBacking)
 	}
 	originalLen := len(ve.NewTables)
 	if leftTable != nil {

--- a/excise_test.go
+++ b/excise_test.go
@@ -288,7 +288,7 @@ func TestExcise(t *testing.T) {
 			}
 			return fmt.Sprintf("would excise %d files, use ingest-and-excise to excise.\n%s", len(ve.DeletedTables), ve.DebugString(base.DefaultFormatter))
 		case "confirm-backing":
-			// Confirms that the files have the same FileBacking.
+			// Confirms that the files have the same TableBacking.
 			fileNums := make(map[base.FileNum]struct{})
 			for i := range td.CmdArgs {
 				fNum, err := strconv.Atoi(td.CmdArgs[i].Key)
@@ -300,15 +300,15 @@ func TestExcise(t *testing.T) {
 			d.mu.Lock()
 			defer d.mu.Unlock()
 			currVersion := d.mu.versions.currentVersion()
-			var ptr *manifest.FileBacking
+			var ptr *manifest.TableBacking
 			for _, level := range currVersion.Levels {
 				for f := range level.All() {
 					if _, ok := fileNums[f.TableNum]; ok {
 						if ptr == nil {
-							ptr = f.FileBacking
+							ptr = f.TableBacking
 							continue
 						}
-						if f.FileBacking != ptr {
+						if f.TableBacking != ptr {
 							d.mu.Unlock()
 							return "file backings are not the same"
 						}

--- a/file_cache.go
+++ b/file_cache.go
@@ -237,7 +237,7 @@ func (h *fileCacheHandle) findOrCreateTable(
 ) (genericcache.ValueRef[fileCacheKey, fileCacheValue], error) {
 	key := fileCacheKey{
 		handle:   h,
-		fileNum:  meta.FileBacking.DiskFileNum,
+		fileNum:  meta.TableBacking.DiskFileNum,
 		fileType: base.FileTypeTable,
 	}
 	valRef, err := h.fileCache.c.FindOrCreate(ctx, key)

--- a/flushable_test.go
+++ b/flushable_test.go
@@ -78,7 +78,7 @@ func TestIngestedSSTFlushableAPI(t *testing.T) {
 		// The file cache requires the *fileMetadata to have a positive
 		// reference count. Fake a reference before we try to load the file.
 		for _, f := range meta {
-			f.FileBacking.Ref()
+			f.TableBacking.Ref()
 		}
 
 		// Verify the sstables do not overlap.

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -138,9 +138,9 @@ func mut(n **node) *node {
 
 // ObsoleteFilesSet accumulates files that now have zero references.
 type ObsoleteFilesSet interface {
-	// AddBacking appends the provided FileBacking to the list of obsolete
+	// AddBacking appends the provided TableBacking to the list of obsolete
 	// files.
-	AddBacking(*FileBacking)
+	AddBacking(*TableBacking)
 	// AddBlob appends the provided BlobFileMetadata to the list of obsolete
 	// files.
 	AddBlob(*BlobFileMetadata)
@@ -157,8 +157,8 @@ type assertNoObsoleteFiles struct{}
 // Assert that assertNoObsoleteFiles implements ObsoleteFilesSet.
 var _ ObsoleteFilesSet = assertNoObsoleteFiles{}
 
-// AddBacking appends the provided FileBacking to the list of obsolete files.
-func (assertNoObsoleteFiles) AddBacking(fb *FileBacking) {
+// AddBacking appends the provided TableBacking to the list of obsolete files.
+func (assertNoObsoleteFiles) AddBacking(fb *TableBacking) {
 	panic(errors.AssertionFailedf("file backing %s dereferenced to zero during tree mutation", fb.DiskFileNum))
 }
 
@@ -175,8 +175,8 @@ type ignoreObsoleteFiles struct{}
 // Assert that ignoreObsoleteFiles implements ObsoleteFilesSet.
 var _ ObsoleteFilesSet = ignoreObsoleteFiles{}
 
-// AddBacking appends the provided FileBacking to the list of obsolete files.
-func (ignoreObsoleteFiles) AddBacking(fb *FileBacking) {}
+// AddBacking appends the provided TableBacking to the list of obsolete files.
+func (ignoreObsoleteFiles) AddBacking(fb *TableBacking) {}
 
 // AddBlob appends the provided BlobFileMetadata to the list of obsolete files.
 func (ignoreObsoleteFiles) AddBlob(bm *BlobFileMetadata) {}

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -232,7 +232,7 @@ func TestBTree(t *testing.T) {
 	for i := 0; i < count; i++ {
 		var obsolete ObsoleteFiles
 		tr.Delete(items[i], &obsolete)
-		if len(obsolete.FileBackings) == 0 {
+		if len(obsolete.TableBackings) == 0 {
 			t.Fatalf("expected item %d to be obsolete", i)
 		}
 		tr.Verify(t)
@@ -256,7 +256,7 @@ func TestBTree(t *testing.T) {
 	for i := 1; i <= count; i++ {
 		var obsolete ObsoleteFiles
 		tr.Delete(items[count-i], &obsolete)
-		if len(obsolete.FileBackings) == 0 {
+		if len(obsolete.TableBackings) == 0 {
 			t.Fatalf("expected item %d to be obsolete", i)
 		}
 		tr.Verify(t)
@@ -494,8 +494,8 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 	for i := range trees {
 		trees[i].Release(&obsoleteFiles)
 	}
-	if len(obsoleteFiles.FileBackings) != len(p) {
-		t.Errorf("got %d obsolete trees, expected %d", len(obsoleteFiles.FileBackings), len(p))
+	if len(obsoleteFiles.TableBackings) != len(p) {
+		t.Errorf("got %d obsolete trees, expected %d", len(obsoleteFiles.TableBackings), len(p))
 	}
 }
 

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -45,9 +45,9 @@ func checkRoundTrip(e0 VersionEdit) error {
 }
 
 // Version edits with virtual sstables will not be the same after a round trip
-// as the Decode function will not set the FileBacking for a virtual sstable.
+// as the Decode function will not set the TableBacking for a virtual sstable.
 // We test round trip + bve accumulation here, after which the virtual sstable
-// FileBacking should be set.
+// TableBacking should be set.
 func TestVERoundTripAndAccumulate(t *testing.T) {
 	cmp := base.DefaultComparer.Compare
 	m1 := (&TableMetadata{
@@ -82,7 +82,7 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 		base.MakeInternalKey([]byte("a"), 0, base.InternalKeyKindSet),
 		base.MakeInternalKey([]byte("c"), 0, base.InternalKeyKindSet),
 	)
-	m2.AttachVirtualBacking(m1.FileBacking)
+	m2.AttachVirtualBacking(m1.TableBacking)
 
 	ve1 := VersionEdit{
 		ComparerName:         "11",
@@ -90,13 +90,13 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 		ObsoletePrevLogNum:   33,
 		NextFileNum:          44,
 		LastSeqNum:           55,
-		CreatedBackingTables: []*FileBacking{m1.FileBacking},
+		CreatedBackingTables: []*TableBacking{m1.TableBacking},
 		NewTables: []NewTableEntry{
 			{
 				Level: 4,
 				Meta:  m2,
 				// Only set for the test.
-				BackingFileNum: m2.FileBacking.DiskFileNum,
+				BackingFileNum: m2.TableBacking.DiskFileNum,
 			},
 		},
 	}
@@ -109,7 +109,7 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 	if err = ve2.Decode(buf); err != nil {
 		t.Error(err)
 	}
-	// Perform accumulation to set the FileBacking on the files in the Decoded
+	// Perform accumulation to set the TableBacking on the files in the Decoded
 	// version edit.
 	var bve BulkVersionEdit
 	require.NoError(t, bve.Accumulate(&ve2))
@@ -223,7 +223,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 			NextFileNum:          44,
 			LastSeqNum:           55,
 			RemovedBackingTables: []base.DiskFileNum{10, 11},
-			CreatedBackingTables: []*FileBacking{m5.FileBacking, m6.FileBacking},
+			CreatedBackingTables: []*TableBacking{m5.TableBacking, m6.TableBacking},
 			DeletedTables: map[DeletedTableEntry]*TableMetadata{
 				{
 					Level:   3,

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -794,8 +794,8 @@ func TestIterAllocs(t *testing.T) {
 			var tables []*TableMetadata
 			for i := 0; i < n; i++ {
 				tables = append(tables, &TableMetadata{
-					TableNum:    base.FileNum(i),
-					FileBacking: &FileBacking{},
+					TableNum:     base.FileNum(i),
+					TableBacking: &TableBacking{},
 				})
 			}
 			return NewLevelSliceSeqSorted(tables)
@@ -817,8 +817,8 @@ func TestIterAllocs(t *testing.T) {
 			var tables []*TableMetadata
 			for i := 0; i < n; i++ {
 				tables = append(tables, &TableMetadata{
-					TableNum:    base.FileNum(i),
-					FileBacking: &FileBacking{},
+					TableNum:     base.FileNum(i),
+					TableBacking: &TableBacking{},
 				})
 			}
 			return MakeLevelMetadata(base.DefaultComparer.Compare, 0, tables)

--- a/internal/manifest/virtual_backings_test.go
+++ b/internal/manifest/virtual_backings_test.go
@@ -28,7 +28,7 @@ func TestVirtualBackings(t *testing.T) {
 
 		switch d.Cmd {
 		case "add":
-			bv.AddAndRef(&FileBacking{
+			bv.AddAndRef(&TableBacking{
 				DiskFileNum: n,
 				Size:        size,
 			})
@@ -38,17 +38,17 @@ func TestVirtualBackings(t *testing.T) {
 
 		case "add-table":
 			m := &TableMetadata{
-				FileBacking: &FileBacking{DiskFileNum: n},
-				Size:        size,
-				Virtual:     true,
+				TableBacking: &TableBacking{DiskFileNum: n},
+				Size:         size,
+				Virtual:      true,
 			}
 			bv.AddTable(m)
 
 		case "remove-table":
 			m := &TableMetadata{
-				FileBacking: &FileBacking{DiskFileNum: n},
-				Size:        size,
-				Virtual:     true,
+				TableBacking: &TableBacking{DiskFileNum: n},
+				Size:         size,
+				Virtual:      true,
 			}
 			bv.RemoveTable(m)
 

--- a/lsm_view.go
+++ b/lsm_view.go
@@ -145,7 +145,7 @@ func (b *lsmViewBuilder) Build(
 			if !f.Virtual {
 				t.Label = fmt.Sprintf("%d", f.TableNum)
 			} else {
-				t.Label = fmt.Sprintf("%d (%d)", f.TableNum, f.FileBacking.DiskFileNum)
+				t.Label = fmt.Sprintf("%d (%d)", f.TableNum, f.TableBacking.DiskFileNum)
 			}
 
 			t.Size = f.Size
@@ -168,7 +168,7 @@ func (b *lsmViewBuilder) tableDetails(
 	outf("%s: %s - %s", m.TableNum, m.Smallest().Pretty(b.fmtKey), m.Largest().Pretty(b.fmtKey))
 	outf("size: %s", humanize.Bytes.Uint64(m.Size))
 	if m.Virtual {
-		meta, err := objProvider.Lookup(base.FileTypeTable, m.FileBacking.DiskFileNum)
+		meta, err := objProvider.Lookup(base.FileTypeTable, m.TableBacking.DiskFileNum)
 		var backingInfo string
 		switch {
 		case err != nil:
@@ -178,7 +178,7 @@ func (b *lsmViewBuilder) tableDetails(
 		case meta.IsExternal():
 			backingInfo = "external; "
 		}
-		outf("virtual; backed by %s (%ssize: %s)", m.FileBacking.DiskFileNum, backingInfo, humanize.Bytes.Uint64(m.FileBacking.Size))
+		outf("virtual; backed by %s (%ssize: %s)", m.TableBacking.DiskFileNum, backingInfo, humanize.Bytes.Uint64(m.TableBacking.Size))
 	}
 	outf("seqnums: %d - %d", m.SmallestSeqNum, m.LargestSeqNum)
 	if m.SyntheticPrefixAndSuffix.HasPrefix() {

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -371,7 +371,7 @@ func (d *DB) scanObsoleteFiles(list []string, flushableIngests []*ingestedFlusha
 	// file scan to avoid double-deleting these files.
 	for _, f := range flushableIngests {
 		for _, file := range f.files {
-			liveFileNums[file.FileBacking.DiskFileNum] = struct{}{}
+			liveFileNums[file.TableBacking.DiskFileNum] = struct{}{}
 		}
 	}
 

--- a/open.go
+++ b/open.go
@@ -421,14 +421,14 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		return true
 	})
 	d.mu.annotators.remoteSize = d.makeFileSizeAnnotator(func(f *manifest.TableMetadata) bool {
-		meta, err := d.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
+		meta, err := d.objProvider.Lookup(base.FileTypeTable, f.TableBacking.DiskFileNum)
 		if err != nil {
 			return false
 		}
 		return meta.IsRemote()
 	})
 	d.mu.annotators.externalSize = d.makeFileSizeAnnotator(func(f *manifest.TableMetadata) bool {
-		meta, err := d.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
+		meta, err := d.objProvider.Lookup(base.FileTypeTable, f.TableBacking.DiskFileNum)
 		if err != nil {
 			return false
 		}
@@ -1271,7 +1271,7 @@ func checkConsistency(v *manifest.Version, objProvider objstorage.Provider) erro
 	dedup := make(map[base.DiskFileNum]struct{})
 	for level, files := range v.Levels {
 		for f := range files.All() {
-			backingState := f.FileBacking
+			backingState := f.TableBacking
 			if _, ok := dedup[backingState.DiskFileNum]; ok {
 				continue
 			}

--- a/open_test.go
+++ b/open_test.go
@@ -1484,7 +1484,7 @@ func TestCheckConsistency(t *testing.T) {
 					if err != nil {
 						return err.Error()
 					}
-					path := base.MakeFilepath(mem, dir, base.FileTypeTable, m.FileBacking.DiskFileNum)
+					path := base.MakeFilepath(mem, dir, base.FileTypeTable, m.TableBacking.DiskFileNum)
 					_ = mem.Remove(path)
 					f, err := mem.Create(path, vfs.WriteCategoryUnspecified)
 					if err != nil {

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -788,7 +788,7 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 				}
 				var newFiles []base.DiskFileNum
 				for _, nf := range ve.NewTables {
-					newFiles = append(newFiles, nf.Meta.FileBacking.DiskFileNum)
+					newFiles = append(newFiles, nf.Meta.TableBacking.DiskFileNum)
 					if s.kind == ingestStepKind && (nf.Meta.SmallestSeqNum != nf.Meta.LargestSeqNum || nf.Level != 0) {
 						s.kind = flushStepKind
 					}

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -711,7 +711,7 @@ func scanInternalImpl(
 
 				var objMeta objstorage.ObjectMetadata
 				var err error
-				objMeta, err = provider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
+				objMeta, err = provider.Lookup(base.FileTypeTable, f.TableBacking.DiskFileNum)
 				if err != nil {
 					return err
 				}
@@ -939,7 +939,7 @@ func (i *scanInternalIterator) constructPointIter(
 		if level == skipStart {
 			nonRemoteFiles := make([]*manifest.TableMetadata, 0)
 			for f := levIter.First(); f != nil; f = levIter.Next() {
-				meta, err := i.db.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
+				meta, err := i.db.objProvider.Lookup(base.FileTypeTable, f.TableBacking.DiskFileNum)
 				if err != nil {
 					return err
 				}
@@ -1051,7 +1051,7 @@ func (i *scanInternalIterator) constructRangeKeyIter() error {
 		if level == skipStart {
 			nonRemoteFiles := make([]*manifest.TableMetadata, 0)
 			for f := levIter.First(); f != nil; f = levIter.Next() {
-				meta, err := i.db.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
+				meta, err := i.db.objProvider.Lookup(base.FileTypeTable, f.TableBacking.DiskFileNum)
 				if err != nil {
 					return err
 				}

--- a/table_stats.go
+++ b/table_stats.go
@@ -249,10 +249,10 @@ func (d *DB) scanReadStateTableStats(
 			// matches. This is because checkConsistency skips over remote files.
 			//
 			// SharedForeign and External files are skipped as their sizes are allowed
-			// to have a mismatch; the size stored in the FileBacking is just the part
+			// to have a mismatch; the size stored in the TableBacking is just the part
 			// of the file that is referenced by this Pebble instance, not the size of
 			// the whole object.
-			objMeta, err := d.objProvider.Lookup(base.FileTypeTable, f.FileBacking.DiskFileNum)
+			objMeta, err := d.objProvider.Lookup(base.FileTypeTable, f.TableBacking.DiskFileNum)
 			if err != nil {
 				// Set `moreRemain` so we'll try again.
 				moreRemain = true
@@ -263,9 +263,9 @@ func (d *DB) scanReadStateTableStats(
 			shouldCheckSize := objMeta.IsRemote() &&
 				!d.objProvider.IsSharedForeign(objMeta) &&
 				!objMeta.IsExternal()
-			if _, ok := sizesChecked[f.FileBacking.DiskFileNum]; !ok && shouldCheckSize {
+			if _, ok := sizesChecked[f.TableBacking.DiskFileNum]; !ok && shouldCheckSize {
 				size, err := d.objProvider.Size(objMeta)
-				fileSize := f.FileBacking.Size
+				fileSize := f.TableBacking.Size
 				if err != nil {
 					moreRemain = true
 					d.opts.EventListener.BackgroundError(err)
@@ -280,7 +280,7 @@ func (d *DB) scanReadStateTableStats(
 					d.opts.Logger.Fatalf("%s", err)
 				}
 
-				sizesChecked[f.FileBacking.DiskFileNum] = struct{}{}
+				sizesChecked[f.TableBacking.DiskFileNum] = struct{}{}
 			}
 
 			stats, newHints, err := d.loadTableStats(
@@ -312,7 +312,7 @@ func (d *DB) loadTableStats(
 		context.TODO(), block.NoReadEnv, meta, func(r *sstable.Reader, env sstable.ReadEnv) (err error) {
 			props := r.Properties.CommonProperties
 			if meta.Virtual {
-				props = r.Properties.GetScaledProperties(meta.FileBacking.Size, meta.Size)
+				props = r.Properties.GetScaledProperties(meta.TableBacking.Size, meta.Size)
 			}
 			stats.NumEntries = props.NumEntries
 			stats.NumDeletions = props.NumDeletions

--- a/tool/db.go
+++ b/tool/db.go
@@ -960,7 +960,7 @@ func (p *props) update(o props) {
 
 func (d *dbT) addProps(objProvider objstorage.Provider, m *manifest.TableMetadata, p *props) error {
 	ctx := context.Background()
-	f, err := objProvider.OpenForReading(ctx, base.FileTypeTable, m.FileBacking.DiskFileNum, objstorage.OpenOptions{})
+	f, err := objProvider.OpenForReading(ctx, base.FileTypeTable, m.TableBacking.DiskFileNum, objstorage.OpenOptions{})
 	if err != nil {
 		return err
 	}
@@ -968,7 +968,7 @@ func (d *dbT) addProps(objProvider objstorage.Provider, m *manifest.TableMetadat
 	opts.Mergers = d.mergers
 	opts.Comparers = d.comparers
 	opts.ReaderOptions.CacheOpts = sstableinternal.CacheOptions{
-		FileNum: m.FileBacking.DiskFileNum,
+		FileNum: m.TableBacking.DiskFileNum,
 	}
 	r, err := sstable.NewReader(ctx, f, opts)
 	if err != nil {

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -277,7 +277,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 	l.state.Files = make(map[base.FileNum]lsmTableMetadata)
 	var currentFiles [manifest.NumLevels][]*manifest.TableMetadata
 
-	backings := make(map[base.DiskFileNum]*manifest.FileBacking)
+	backings := make(map[base.DiskFileNum]*manifest.TableBacking)
 
 	for _, ve := range edits {
 		for _, i := range ve.CreatedBackingTables {

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -117,7 +117,7 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 					largest := f.Largest()
 					formatKeyRange(stdout, m.fmtKey, &smallest, &largest)
 					if f.Virtual {
-						fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
+						fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.TableBacking.DiskFileNum)
 					}
 					fmt.Fprintf(stdout, "\n")
 				}
@@ -135,7 +135,7 @@ func (m *manifestT) printLevels(cmp base.Compare, stdout io.Writer, v *manifest.
 			largest := f.Largest()
 			formatKeyRange(stdout, m.fmtKey, &smallest, &largest)
 			if f.Virtual {
-				fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.FileBacking.DiskFileNum)
+				fmt.Fprintf(stdout, "(virtual:backingNum=%s)", f.TableBacking.DiskFileNum)
 			}
 			fmt.Fprintf(stdout, "\n")
 		}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -66,11 +66,11 @@ func TestVersionSet(t *testing.T) {
 	vs.logSeqNum.Store(100)
 
 	tableMetas := make(map[base.FileNum]*manifest.TableMetadata)
-	backings := make(map[base.DiskFileNum]*manifest.FileBacking)
+	backings := make(map[base.DiskFileNum]*manifest.TableBacking)
 	blobMetas := make(map[base.DiskFileNum]*manifest.BlobFileMetadata)
-	// When we parse VersionEdits, we get a new FileBacking each time. We need to
+	// When we parse VersionEdits, we get a new TableBacking each time. We need to
 	// deduplicate them, since they hold a ref count.
-	dedupBacking := func(b *manifest.FileBacking) *manifest.FileBacking {
+	dedupBacking := func(b *manifest.TableBacking) *manifest.TableBacking {
 		if existing, ok := backings[b.DiskFileNum]; ok {
 			return existing
 		}
@@ -103,10 +103,10 @@ func TestVersionSet(t *testing.T) {
 			for _, nf := range ve.NewTables {
 				// Set a size that depends on FileNum.
 				nf.Meta.Size = uint64(nf.Meta.TableNum) * 100
-				nf.Meta.FileBacking = dedupBacking(nf.Meta.FileBacking)
+				nf.Meta.TableBacking = dedupBacking(nf.Meta.TableBacking)
 				tableMetas[nf.Meta.TableNum] = nf.Meta
 				if !nf.Meta.Virtual {
-					createFile(nf.Meta.FileBacking.DiskFileNum)
+					createFile(nf.Meta.TableBacking.DiskFileNum)
 				}
 				for i := range nf.Meta.BlobReferences {
 					nf.Meta.BlobReferences[i].Metadata = blobMetas[nf.Meta.BlobReferences[i].FileNum]
@@ -198,7 +198,7 @@ func TestVersionSet(t *testing.T) {
 
 			// Repopulate the maps.
 			tableMetas = make(map[base.FileNum]*manifest.TableMetadata)
-			backings = make(map[base.DiskFileNum]*manifest.FileBacking)
+			backings = make(map[base.DiskFileNum]*manifest.TableBacking)
 			blobMetas = make(map[base.DiskFileNum]*manifest.BlobFileMetadata)
 			v := vs.currentVersion()
 			for _, l := range v.Levels {
@@ -207,7 +207,7 @@ func TestVersionSet(t *testing.T) {
 					for _, b := range f.BlobReferences {
 						blobMetas[b.FileNum] = b.Metadata
 					}
-					dedupBacking(f.FileBacking)
+					dedupBacking(f.TableBacking)
 				}
 			}
 


### PR DESCRIPTION
We also remove the unnecessary alias.