### PR TITLE
github: use go 1.23 for the 25.2 nightlies

### DIFF
--- a/.github/workflows/nightlies-25.2.yaml
+++ b/.github/workflows/nightlies-25.2.yaml
@@ -33,6 +33,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
+      go_version: 1.23
 
   s390x:
     needs: resolve-sha
@@ -40,6 +41,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
+      go_version: 1.23
 
   stress:
     needs: resolve-sha
@@ -47,6 +49,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
+      go_version: 1.23
 
   instrumented:
     needs: resolve-sha
@@ -54,3 +57,4 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
+      go_version: 1.23


### PR DESCRIPTION
The nightly 25.2 crossversion tests fail because 25.1 or older cannot be built with 1.24.