### PR TITLE
fix: update the magic number constant in StringForTests() for consistent testing

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -872,9 +872,15 @@ func percent(numerator, denominator int64) float64 {
 func (m *Metrics) StringForTests() string {
 	mCopy := *m
 	if math.MaxInt == math.MaxInt32 {
-		// This is the difference in Sizeof(sstable.Reader{})) between 64 and 32 bit
-		// platforms.
-		const tableCacheSizeAdjustment = 212
+		// README: This is the difference in Sizeof(sstable.Reader{})) + Sizeof(blob.FileReader{})
+		// between 64 and 32 bit platforms. See Metrics() in file_cache.go for more details.
+		// This magic number must be updated if the sstable.Reader or blob.FileReader struct changes.
+		// On 64-bit platforms, the size of the sstable.Reader struct is 616 bytes.
+		// On 32-bit platforms, the size of the sstable.Reader struct is 496 bytes.
+		// On 64-bit platforms, the size of the blob.FileReader struct is 88 bytes.
+		// On 32-bit platforms, the size of the blob.FileReader struct is 56 bytes.
+		// The difference is 616 - 496 + 88 - 56 = 152 bytes.
+		const tableCacheSizeAdjustment = 152
 		mCopy.FileCache.Size += mCopy.FileCache.Count * tableCacheSizeAdjustment
 	}
 	// Don't show cgo memory statistics as they can vary based on architecture,

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -352,6 +352,8 @@ func (f *fileFooter) encode(b []byte) {
 }
 
 // FileReader reads a blob file.
+// If you update this struct, make sure you also update the magic number in
+// StringForTests() in metrics.go.
 type FileReader struct {
 	r      block.Reader
 	footer fileFooter

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -42,6 +42,8 @@ const (
 )
 
 // Reader is a table reader.
+// If you update this struct, make sure you also update the magic number in
+// StringForTests() in metrics.go.
 type Reader struct {
 	blockReader block.Reader
 


### PR DESCRIPTION
Update  the magic number constant in StringForTests() to match the changes to `sstable.Reader` and `blob.FileReader` structs and add comments for future reference.

Fixes: #4677