### PR TITLE
db: remove iteratorRangeKeyState.init

### DIFF
--- a/db.go
+++ b/db.go
@@ -1209,7 +1209,6 @@ func finishInitializingIter(ctx context.Context, buf *iterAlloc) *Iterator {
 			}
 			if dbi.rangeKey == nil {
 				dbi.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
-				dbi.rangeKey.init(dbi.comparer.Compare, dbi.comparer.Split, &dbi.opts)
 				dbi.constructRangeKeyIter()
 			} else {
 				dbi.rangeKey.iterConfig.SetBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
@@ -1392,7 +1391,6 @@ func finishInitializingInternalIter(
 	// For internal iterators, we skip the lazy combined iteration optimization
 	// entirely, and create the range key iterator stack directly.
 	i.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
-	i.rangeKey.init(i.comparer.Compare, i.comparer.Split, &i.opts.IterOptions)
 	if err := i.constructRangeKeyIter(); err != nil {
 		return nil, err
 	}

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -271,7 +271,6 @@ func finishInitializingExternal(ctx context.Context, it *Iterator) error {
 			}
 			if len(rangeKeyIters) > 0 {
 				it.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
-				it.rangeKey.init(it.comparer.Compare, it.comparer.Split, &it.opts)
 				it.rangeKey.rangeKeyIter = it.rangeKey.iterConfig.Init(
 					&it.comparer,
 					base.SeqNumMax,

--- a/iterator.go
+++ b/iterator.go
@@ -336,9 +336,6 @@ func (i *Iterator) equal(a, b []byte) bool {
 
 // iteratorRangeKeyState holds an iterator's range key iteration state.
 type iteratorRangeKeyState struct {
-	opts  *IterOptions
-	cmp   base.Compare
-	split base.Split
 	// rangeKeyIter holds the range key iterator stack that iterates over the
 	// merged spans across the entirety of the LSM.
 	rangeKeyIter keyspan.FragmentIterator
@@ -415,12 +412,6 @@ func (b *rangeKeyBuffers) PrepareForReuse() {
 		b.buf = b.buf[:0]
 	}
 	b.internal.PrepareForReuse()
-}
-
-func (i *iteratorRangeKeyState) init(cmp base.Compare, split base.Split, opts *IterOptions) {
-	i.cmp = cmp
-	i.split = split
-	i.opts = opts
 }
 
 var iterRangeKeyStateAllocPool = sync.Pool{

--- a/range_keys.go
+++ b/range_keys.go
@@ -558,7 +558,6 @@ func (i *lazyCombinedIter) initCombinedIteration(
 	// the range key iterator stack. It must not exist, otherwise we'd already
 	// be performing combined iteration.
 	i.parent.rangeKey = iterRangeKeyStateAllocPool.Get().(*iteratorRangeKeyState)
-	i.parent.rangeKey.init(i.parent.comparer.Compare, i.parent.comparer.Split, &i.parent.opts)
 	i.parent.constructRangeKeyIter()
 
 	// Initialize the Iterator's interleaving iterator.


### PR DESCRIPTION
Remove unused fields on the iteratorRangeKeyState struct and the init method that initializes them.