### PR TITLE
replay: support blob files 

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -111,6 +111,18 @@ type TableInfo struct {
 	SmallestSeqNum base.SeqNum
 	// LargestSeqNum is the largest sequence number in the table.
 	LargestSeqNum base.SeqNum
+	// blobReferences is the list of blob files referenced by the table.
+	blobReferences BlobReferences
+}
+
+// GetBlobReferenceFiles returns the list of blob file numbers referenced by
+// the table.
+func (t *TableInfo) GetBlobReferenceFiles() []base.DiskFileNum {
+	files := make([]base.DiskFileNum, 0, len(t.blobReferences))
+	for _, blob := range t.blobReferences {
+		files = append(files, blob.FileNum)
+	}
+	return files
 }
 
 // TableStats contains statistics on a table used for compaction heuristics,
@@ -1189,6 +1201,7 @@ func (m *TableMetadata) TableInfo() TableInfo {
 		Largest:        m.Largest(),
 		SmallestSeqNum: m.SmallestSeqNum,
 		LargestSeqNum:  m.LargestSeqNum,
+		blobReferences: m.BlobReferences,
 	}
 }
 

--- a/replay/testdata/corpus/findWorkloadFiles
+++ b/replay/testdata/corpus/findWorkloadFiles
@@ -36,6 +36,7 @@ find-workload-files capture
 ----
 manifests
 sstables
+blob files
 error
   no manifests found
 
@@ -74,4 +75,5 @@ manifests
 sstables
   000001
   000004
+blob files
 error

--- a/replay/testdata/corpus/simple_val_sep
+++ b/replay/testdata/corpus/simple_val_sep
@@ -1,0 +1,108 @@
+open-val-sep
+----
+
+list-files build
+----
+build:
+  000002.log
+  LOCK
+  MANIFEST-000001
+  OPTIONS-000003
+  marker.format-version.000009.022
+  marker.manifest.000001.MANIFEST-000001
+
+commit
+set a a
+set b byaya
+set c cyuumi
+set d d
+----
+
+flush
+----
+
+commit
+set e elephant
+set f f
+set g g
+----
+
+flush
+----
+
+commit
+set h h
+----
+
+
+flush
+----
+
+list-files build
+----
+build:
+  000005.sst
+  000006.blob
+  000007.log
+  000008.sst
+  000009.blob
+  000011.log
+  000012.sst
+  LOCK
+  MANIFEST-000010
+  MANIFEST-000013
+  OPTIONS-000003
+  marker.format-version.000009.022
+  marker.manifest.000003.MANIFEST-000013
+
+start
+----
+started
+
+list-files simple_val_sep
+----
+simple_val_sep:
+  checkpoint
+
+list-files simple_val_sep/checkpoint
+----
+simple_val_sep/checkpoint:
+  000005.sst
+  000006.blob
+  000008.sst
+  000009.blob
+  000011.log
+  000012.sst
+  MANIFEST-000013
+  OPTIONS-000003
+  marker.format-version.000001.022
+  marker.manifest.000001.MANIFEST-000013
+
+commit
+set i icecream
+set j j
+----
+
+flush
+----
+
+stop
+----
+stopped
+
+list-files simple_val_sep
+----
+simple_val_sep:
+  000015.sst
+  000016.blob
+  MANIFEST-000013
+  checkpoint
+
+stat simple_val_sep/MANIFEST-000013 simple_val_sep/000015.sst simple_val_sep/000016.blob
+----
+simple_val_sep/MANIFEST-000013:
+  size: 247
+simple_val_sep/000015.sst:
+  size: 790
+simple_val_sep/000016.blob:
+  size: 64

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -1,0 +1,132 @@
+corpus simple_val_sep
+----
+
+tree
+----
+          /
+            build/
+     826      000005.sst
+      67      000006.blob
+     795      000008.sst
+      64      000009.blob
+      92      000011.log
+     742      000012.sst
+      63      000014.log
+     790      000015.sst
+      64      000016.blob
+       0      LOCK
+     150      MANIFEST-000010
+     247      MANIFEST-000013
+    1687      OPTIONS-000003
+       0      marker.format-version.000009.022
+       0      marker.manifest.000003.MANIFEST-000013
+            simple_val_sep/
+     790      000015.sst
+      64      000016.blob
+     247      MANIFEST-000013
+              checkpoint/
+     826        000005.sst
+      67        000006.blob
+     795        000008.sst
+      64        000009.blob
+      64        000011.log
+     742        000012.sst
+     185        MANIFEST-000013
+    1687        OPTIONS-000003
+       0        marker.format-version.000001.022
+       0        marker.manifest.000001.MANIFEST-000013
+
+replay simple_val_sep unpaced
+----
+
+cat build/OPTIONS-000003
+----
+----
+[Version]
+  pebble_version=0.1
+
+[Options]
+  bytes_per_sync=524288
+  cache_size=8388608
+  cleaner=replay.WorkloadCollector("delete")
+  compaction_debt_concurrency=1073741824
+  compaction_garbage_fraction_for_max_concurrency=0.40
+  comparer=pebble.internal.testkeys
+  disable_wal=false
+  enable_columnar_blocks=true
+  flush_delay_delete_range=0s
+  flush_delay_range_key=0s
+  flush_split_bytes=4194304
+  format_major_version=22
+  key_schema=DefaultKeySchema(pebble.internal.testkeys,16)
+  l0_compaction_concurrency=10
+  l0_compaction_file_threshold=500
+  l0_compaction_threshold=4
+  l0_stop_writes_threshold=12
+  lbase_max_bytes=67108864
+  concurrent_compactions=1
+  max_concurrent_compactions=1
+  max_concurrent_downloads=1
+  max_manifest_file_size=96
+  max_open_files=1000
+  mem_table_size=4194304
+  mem_table_stop_writes_threshold=2
+  min_deletion_rate=0
+  free_space_threshold_bytes=17179869184
+  free_space_timeframe=10s
+  obsolete_bytes_max_ratio=0.200000
+  obsolete_bytes_timeframe=5m0s
+  merger=pebble.concatenate
+  multilevel_compaction_heuristic=wamp(0.00, false)
+  read_compaction_rate=16000
+  read_sampling_multiplier=16
+  num_deletions_threshold=100
+  deletion_size_ratio_threshold=0.500000
+  tombstone_dense_compaction_threshold=0.100000
+  strict_wal_tail=true
+  table_cache_shards=2
+  validate_on_ingest=false
+  wal_dir=
+  wal_bytes_per_sync=0
+  secondary_cache_size_bytes=0
+  create_on_shared=0
+
+[Value Separation]
+  enabled=true
+  minimum_size=3
+  max_blob_reference_depth=5
+
+[Level "0"]
+  block_restart_interval=16
+  block_size=4096
+  block_size_threshold=90
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=2097152
+----
+----
+
+wait
+----
+replayed 29B in writes
+
+# NB: The file sizes are non-deterministic after replay (because compactions are
+# nondeterministic). We don't `tree` here as a result.
+
+scan-keys
+----
+a: a
+b: byaya
+c: cyuumi
+d: d
+e: elephant
+f: f
+g: g
+h: h
+i: icecream
+j: j
+
+close
+----

--- a/replay/workload_capture_test.go
+++ b/replay/workload_capture_test.go
@@ -156,7 +156,7 @@ func TestWorkloadCollector(t *testing.T) {
 				// Wait until all pending sstables have been copied, then list
 				// the files in the destination directory.
 				c.mu.Lock()
-				for c.mu.tablesEnqueued != c.mu.tablesCopied {
+				for c.mu.filesEnqueued != c.mu.filesCopied {
 					c.mu.copyCond.Wait()
 				}
 				c.mu.Unlock()


### PR DESCRIPTION
This patch ensures that `replay` is able to monitor & replay flushes with
value separation enabled.

Fixes: https://github.com/cockroachdb/pebble/issues/4459