### PR TITLE
db: close blob file readable if unable to open blob reader

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -600,6 +600,7 @@ func TestAutomaticFlush(t *testing.T) {
 					}
 					r, err := sstable.NewReader(context.Background(), f, opts.MakeReaderOptions())
 					if err != nil {
+						err = errors.CombineErrors(err, f.Close())
 						return errors.WithStack(err)
 					}
 					defer r.Close()

--- a/data_test.go
+++ b/data_test.go
@@ -1345,7 +1345,7 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	}
 	r, err := sstable.NewReader(context.Background(), readable, readerOpts)
 	if err != nil {
-		return err.Error()
+		return errors.CombineErrors(err, readable.Close()).Error()
 	}
 	defer r.Close()
 
@@ -1385,7 +1385,7 @@ func runLayoutCmd(t *testing.T, td *datadriven.TestData, d *DB) string {
 	}
 	r, err := sstable.NewReader(context.Background(), readable, d.opts.MakeReaderOptions())
 	if err != nil {
-		return err.Error()
+		return errors.CombineErrors(err, readable.Close()).Error()
 	}
 	defer r.Close()
 	l, err := r.Layout()

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -307,7 +307,7 @@ func openExternalTables(
 		}
 		r, err := sstable.NewReader(ctx, readable, readerOpts)
 		if err != nil {
-			return readers, err
+			return readers, errors.CombineErrors(err, readable.Close())
 		}
 		if r.Attributes.Has(sstable.AttributeBlobValues) {
 			return readers, errors.Newf("pebble: NewExternalIter does not support blob references")

--- a/file_cache.go
+++ b/file_cache.go
@@ -221,7 +221,9 @@ func (h *fileCacheHandle) openFile(
 			ReaderOptions: o.ReaderOptions,
 		})
 		if err != nil {
-			return nil, objMeta, err
+			// If opening the blob file reader fails, we're responsible for
+			// closing the objstorage.Readable.
+			return nil, objMeta, errors.CombineErrors(err, f.Close())
 		}
 		return r, objMeta, nil
 	default:

--- a/file_cache.go
+++ b/file_cache.go
@@ -213,7 +213,9 @@ func (h *fileCacheHandle) openFile(
 	case base.FileTypeTable:
 		r, err := sstable.NewReader(ctx, f, o)
 		if err != nil {
-			return nil, objMeta, err
+			// If opening the sstable reader fails, we're responsible for
+			// closing the objstorage.Readable.
+			return nil, objMeta, errors.CombineErrors(err, f.Close())
 		}
 		return r, objMeta, nil
 	case base.FileTypeBlob:

--- a/ingest.go
+++ b/ingest.go
@@ -266,7 +266,7 @@ func ingestLoad1(
 	}
 	r, err := sstable.NewReader(ctx, readable, o)
 	if err != nil {
-		return nil, keyspan.Span{}, err
+		return nil, keyspan.Span{}, errors.CombineErrors(err, readable.Close())
 	}
 	defer func() { _ = r.Close() }()
 

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -243,7 +243,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 				readerOpts.CacheOpts = sstableinternal.CacheOptions{FileNum: base.DiskFileNum(tableNum - 1)}
 				r, err := sstable.NewReader(context.Background(), readable, readerOpts)
 				if err != nil {
-					return err.Error()
+					return errors.CombineErrors(err, readable.Close()).Error()
 				}
 				readers = append(readers, r)
 			}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -300,7 +300,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 		},
 	})
 	if err != nil {
-		return err.Error()
+		return errors.CombineErrors(err, readable.Close()).Error()
 	}
 	lt.readers = append(lt.readers, r)
 	m := &tableMetadata{TableNum: tableNum}
@@ -566,7 +566,7 @@ func buildLevelIterTables(
 		}
 		readers[i], err = sstable.NewReader(context.Background(), readable, opts)
 		if err != nil {
-			b.Fatal(err)
+			b.Fatal(errors.CombineErrors(err, readable.Close()))
 		}
 	}
 

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -268,7 +268,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 					}
 					r, err := sstable.NewReader(context.Background(), readable, opts.MakeReaderOptions())
 					if err != nil {
-						return err.Error()
+						return errors.CombineErrors(err, readable.Close()).Error()
 					}
 					readers[m.TableNum] = r
 				}
@@ -396,7 +396,7 @@ func buildMergingIterTables(
 		opts.CacheOpts.FileNum = base.DiskFileNum(i)
 		readers[i], err = sstable.NewReader(context.Background(), readable, opts)
 		if err != nil {
-			b.Fatal(err)
+			b.Fatal(errors.CombineErrors(err, readable.Close()))
 		}
 	}
 	return readers, keys, func() {
@@ -662,7 +662,7 @@ func buildLevelsForMergingIterSeqSeek(
 			fileCount++
 			r, err := sstable.NewReader(context.Background(), readable, opts)
 			if err != nil {
-				b.Fatal(err)
+				b.Fatal(errors.CombineErrors(err, readable.Close()))
 			}
 			readers[i] = append(readers[i], r)
 		}

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -265,7 +266,9 @@ func openExternalObj(
 		objstorageprovider.NewRemoteReadable(objReader, objSize),
 		opts,
 	)
-	panicIfErr(err)
+	if err != nil {
+		panic(errors.CombineErrors(err, objReader.Close()))
+	}
 
 	start := bounds.Start
 	end := bounds.End

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/sstable"
@@ -214,7 +215,7 @@ func TestBlockPropertiesParse(t *testing.T) {
 			}
 			r, err := sstable.NewReader(context.Background(), readable, opts.Opts.MakeReaderOptions())
 			if err != nil {
-				return err
+				return errors.CombineErrors(err, readable.Close())
 			}
 			_, ok := r.Properties.UserProperties[opts.Opts.BlockPropertyCollectors[0]().Name()]
 			foundTableBlockProperty = foundTableBlockProperty || ok

--- a/objstorage/objstorageprovider/vfs_readable.go
+++ b/objstorage/objstorageprovider/vfs_readable.go
@@ -54,7 +54,7 @@ func newFileReadable(
 		stack := debug.Stack()
 		invariants.SetFinalizer(r, func(obj interface{}) {
 			if obj.(*fileReadable).file != nil {
-				fmt.Fprintf(os.Stderr, "Readable was not closed\n%s", stack)
+				fmt.Fprintf(os.Stderr, "Readable %s was not closed\n%s", filename, stack)
 				os.Exit(1)
 			}
 		})

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -994,7 +994,7 @@ func loadFlushedSSTableKeys(
 			}
 			r, err := sstable.NewReader(context.Background(), readable, readOpts)
 			if err != nil {
-				return err
+				return errors.CombineErrors(err, readable.Close())
 			}
 			defer func() { _ = r.Close() }()
 

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -375,6 +375,9 @@ func (o FileReaderOptions) ensureDefaults() FileReaderOptions {
 }
 
 // NewFileReader opens a blob file for reading.
+//
+// In error cases, the objstorage.Readable is still open. The caller remains
+// responsible for closing it if necessary.
 func NewFileReader(
 	ctx context.Context, r objstorage.Readable, ro FileReaderOptions,
 ) (*FileReader, error) {

--- a/sstable/compressionanalyzer/file_analyzer.go
+++ b/sstable/compressionanalyzer/file_analyzer.go
@@ -7,6 +7,7 @@ package compressionanalyzer
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -60,7 +61,7 @@ func (fa *FileAnalyzer) SSTable(ctx context.Context, fs vfs.FS, path string) err
 	}
 	r, err := sstable.NewReader(ctx, readable, fa.sstReadOpts)
 	if err != nil {
-		return err
+		return errors.CombineErrors(err, readable.Close())
 	}
 	defer func() { _ = r.Close() }()
 	layout, err := r.Layout()

--- a/sstable/copier_test.go
+++ b/sstable/copier_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
@@ -100,7 +101,7 @@ func TestCopySpan(t *testing.T) {
 			r, err := NewReader(context.TODO(), readable, rOpts)
 			defer r.Close()
 			if err != nil {
-				return err.Error()
+				return errors.CombineErrors(err, readable.Close()).Error()
 			}
 			iter, err := r.NewIter(block.NoTransforms, start, end, AssertNoBlobHandles)
 			if err != nil {
@@ -151,7 +152,7 @@ func TestCopySpan(t *testing.T) {
 			}
 			r, err := NewReader(context.TODO(), readable, rOpts)
 			if err != nil {
-				return err.Error()
+				return errors.CombineErrors(err, readable.Close()).Error()
 			}
 			defer r.Close()
 			wOpts := WriterOptions{
@@ -187,7 +188,7 @@ func TestCopySpan(t *testing.T) {
 				KeySchemas: KeySchemas{keySchema.Name: &keySchema},
 			})
 			if err != nil {
-				return err.Error()
+				return errors.CombineErrors(err, readable.Close()).Error()
 			}
 			defer r.Close()
 			l, err := r.Layout()

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -163,7 +163,7 @@ func runBuildRawCmd(
 		KeySchemas: KeySchemas{opts.KeySchema.Name: opts.KeySchema},
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.CombineErrors(err, f1.Close())
 	}
 	return meta, r, nil
 }

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -2559,7 +2559,11 @@ func newReader(r ReadableFile, o ReaderOptions) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewReader(context.Background(), readable, o)
+	reader, err := NewReader(context.Background(), readable, o)
+	if err != nil {
+		return nil, errors.CombineErrors(err, readable.Close())
+	}
+	return reader, nil
 }
 
 // TestReaderReportsCorruption tests that the reader reports corruption when

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -31,7 +31,7 @@ func ReadAll(
 ) (points []base.InternalKV, rangeDels, rangeKeys []keyspan.Span, err error) {
 	reader, err := NewReader(context.Background(), r, ro)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.CombineErrors(err, r.Close())
 	}
 	defer func() { _ = reader.Close() }()
 	pointIter, err := reader.NewIter(NoTransforms, nil /* lower */, nil /* upper */, AssertNoBlobHandles)

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
@@ -246,7 +247,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 				KeySchemas: sstable.KeySchemas{keySchema.Name: &keySchema},
 			})
 			if err != nil {
-				return err.Error()
+				return errors.CombineErrors(err, readable.Close()).Error()
 			}
 			defer r.Close()
 			iter, err := newCombinedDeletionKeyspanIter(cmp, r, m, sstable.NoReadEnv)

--- a/tool/db.go
+++ b/tool/db.go
@@ -1011,8 +1011,7 @@ func (d *dbT) addProps(objProvider objstorage.Provider, m *manifest.TableMetadat
 	}
 	r, err := sstable.NewReader(ctx, f, opts)
 	if err != nil {
-		_ = f.Close()
-		return err
+		return errors.CombineErrors(err, f.Close())
 	}
 	p.update(props{
 		Count:                      1,

--- a/tool/find.go
+++ b/tool/find.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -476,6 +477,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			}
 			r, err := sstable.NewReader(context.Background(), readable, opts)
 			if err != nil {
+				err = errors.CombineErrors(err, readable.Close())
 				f.errors = append(f.errors, fmt.Sprintf("Unable to decode sstable %s, %s", fl.path, err.Error()))
 				// Ensure the error only gets printed once.
 				err = nil

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -162,7 +162,11 @@ func (s *sstableT) newReader(f vfs.File, cacheHandle *cache.Handle) (*sstable.Re
 	o.Comparers = s.comparers
 	o.Mergers = s.mergers
 	o.CacheOpts = sstableinternal.CacheOptions{CacheHandle: cacheHandle}
-	return sstable.NewReader(context.Background(), readable, o)
+	reader, err := sstable.NewReader(context.Background(), readable, o)
+	if err != nil {
+		return nil, errors.CombineErrors(err, readable.Close())
+	}
+	return reader, nil
 }
 
 func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Previously, if an error was encountered while opening a blob file reader, the objstorage Readable created by the file cache was leaked and never closed.

Fix #4745.