### PR TITLE
sstable: introduce ReadPropertiesBlock on reader

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -482,16 +482,11 @@ func (r *Reader) readMetaindex(
 	}
 
 	if bh, ok := meta[metaPropertiesName]; ok {
-		b, err = r.blockReader.Read(ctx, metaEnv, readHandle, bh, noInitBlockMetadataFn)
-		if err != nil {
-			return err
-		}
 		r.propertiesBH = bh
-		r.Properties, err = decodePropertiesBlock(r.tableFormat, b.BlockData(), deniedUserProperties)
+		r.Properties, err = r.readPropertiesBlockInternal(ctx, metaEnv.BufferPool, readHandle, deniedUserProperties)
 		if err != nil {
 			return err
 		}
-		b.Release()
 	} else {
 		return errors.New("did not read any value for the properties block in the meta index")
 	}
@@ -544,6 +539,48 @@ func decodePropertiesBlock(
 		}
 	}
 	return props, nil
+}
+
+var PropertiesBlockBufPools = sync.Pool{
+	New: func() any {
+		bp := new(block.BufferPool)
+		// New pools are initialized with a capacity of 2 to accommodate
+		// both the compressed properties block (1) and decompressed
+		// properties block (1).
+		bp.Init(2)
+		return bp
+	},
+}
+
+// ReadPropertiesBlock reads the properties block from the table.
+// We always read the properties block into a buffer pool instead
+// of the block cache.
+func (r *Reader) ReadPropertiesBlock(
+	ctx context.Context, bufferPool *block.BufferPool, deniedUserProperties map[string]struct{},
+) (Properties, error) {
+	return r.readPropertiesBlockInternal(ctx, bufferPool, noReadHandle, deniedUserProperties)
+}
+
+func (r *Reader) readPropertiesBlockInternal(
+	ctx context.Context,
+	bufferPool *block.BufferPool,
+	readHandle objstorage.ReadHandle,
+	deniedUserProperties map[string]struct{},
+) (Properties, error) {
+	if bufferPool == nil {
+		// We always use a buffer pool when reading the properties block as
+		// we don't want it in the block cache.
+		bufferPool = PropertiesBlockBufPools.Get().(*block.BufferPool)
+		defer PropertiesBlockBufPools.Put(bufferPool)
+		defer bufferPool.Release()
+	}
+	env := block.ReadEnv{BufferPool: bufferPool}
+	b, err := r.blockReader.Read(ctx, env, readHandle, r.propertiesBH, noInitBlockMetadataFn)
+	if err != nil {
+		return Properties{}, err
+	}
+	defer b.Release()
+	return decodePropertiesBlock(r.tableFormat, b.BlockData(), deniedUserProperties)
 }
 
 // Layout returns the layout (block organization) for an sstable.

--- a/tool/db.go
+++ b/tool/db.go
@@ -975,31 +975,38 @@ func (d *dbT) addProps(objProvider objstorage.Provider, m *manifest.TableMetadat
 		_ = f.Close()
 		return err
 	}
+
+	properties, err := r.ReadPropertiesBlock(context.TODO(), nil /* buffer pool */, opts.DeniedUserProperties)
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+
 	p.update(props{
 		Count:                      1,
 		SmallestSeqNum:             m.SmallestSeqNum,
 		LargestSeqNum:              m.LargestSeqNum,
-		DataSize:                   r.Properties.DataSize,
-		FilterSize:                 r.Properties.FilterSize,
-		IndexSize:                  r.Properties.IndexSize,
-		NumDataBlocks:              r.Properties.NumDataBlocks,
-		NumIndexBlocks:             1 + r.Properties.IndexPartitions,
-		NumDeletions:               r.Properties.NumDeletions,
-		NumSizedDeletions:          r.Properties.NumSizedDeletions,
-		NumEntries:                 r.Properties.NumEntries,
-		NumMergeOperands:           r.Properties.NumMergeOperands,
-		NumRangeDeletions:          r.Properties.NumRangeDeletions,
-		NumRangeKeySets:            r.Properties.NumRangeKeySets,
-		NumRangeKeyUnSets:          r.Properties.NumRangeKeyUnsets,
-		NumRangeKeyDeletes:         r.Properties.NumRangeKeyDels,
-		RawKeySize:                 r.Properties.RawKeySize,
-		RawPointTombstoneKeySize:   r.Properties.RawPointTombstoneKeySize,
-		RawPointTombstoneValueSize: r.Properties.RawPointTombstoneValueSize,
-		RawValueSize:               r.Properties.RawValueSize,
-		SnapshotPinnedKeySize:      r.Properties.SnapshotPinnedKeySize,
-		SnapshotPinnedValueSize:    r.Properties.SnapshotPinnedValueSize,
-		SnapshotPinnedKeys:         r.Properties.SnapshotPinnedKeys,
-		TopLevelIndexSize:          r.Properties.TopLevelIndexSize,
+		DataSize:                   properties.DataSize,
+		FilterSize:                 properties.FilterSize,
+		IndexSize:                  properties.IndexSize,
+		NumDataBlocks:              properties.NumDataBlocks,
+		NumIndexBlocks:             1 + properties.IndexPartitions,
+		NumDeletions:               properties.NumDeletions,
+		NumSizedDeletions:          properties.NumSizedDeletions,
+		NumEntries:                 properties.NumEntries,
+		NumMergeOperands:           properties.NumMergeOperands,
+		NumRangeDeletions:          properties.NumRangeDeletions,
+		NumRangeKeySets:            properties.NumRangeKeySets,
+		NumRangeKeyUnSets:          properties.NumRangeKeyUnsets,
+		NumRangeKeyDeletes:         properties.NumRangeKeyDels,
+		RawKeySize:                 properties.RawKeySize,
+		RawPointTombstoneKeySize:   properties.RawPointTombstoneKeySize,
+		RawPointTombstoneValueSize: properties.RawPointTombstoneValueSize,
+		RawValueSize:               properties.RawValueSize,
+		SnapshotPinnedKeySize:      properties.SnapshotPinnedKeySize,
+		SnapshotPinnedValueSize:    properties.SnapshotPinnedValueSize,
+		SnapshotPinnedKeys:         properties.SnapshotPinnedKeys,
+		TopLevelIndexSize:          properties.TopLevelIndexSize,
 	})
 	return r.Close()
 }

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/blob"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
 )
@@ -167,11 +168,21 @@ func (s *sstableT) newReader(f vfs.File, cacheHandle *cache.Handle) (*sstable.Re
 
 func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	bp := sstable.PropertiesBlockBufPools.Get().(*block.BufferPool)
+	defer sstable.PropertiesBlockBufPools.Put(bp)
 	s.foreachSstable(stderr, args, func(path string, r *sstable.Reader) {
 		fmt.Fprintf(stdout, "%s\n", path)
+
+		defer bp.Release()
+		props, err := r.ReadPropertiesBlock(context.Background(), bp, nil)
+		if err != nil {
+			fmt.Fprintf(stderr, "%s\n", err)
+			return
+		}
+
 		// Update the internal formatter if this comparator has one specified.
-		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
-		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
+		s.fmtKey.setForComparer(props.ComparerName, s.comparers)
+		s.fmtValue.setForComparer(props.ComparerName, s.comparers)
 
 		iter, err := r.NewIter(sstable.NoTransforms, nil, nil, sstable.AssertNoBlobHandles)
 		if err != nil {
@@ -220,12 +231,22 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 
 func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
 	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	bp := sstable.PropertiesBlockBufPools.Get().(*block.BufferPool)
+	defer sstable.PropertiesBlockBufPools.Put(bp)
 	s.foreachSstable(stderr, args, func(path string, r *sstable.Reader) {
+		// If the file is empty, print a message and return.
 		fmt.Fprintf(stdout, "%s\n", path)
 
+		defer bp.Release()
+		props, err := r.ReadPropertiesBlock(context.Background(), bp, nil)
+		if err != nil {
+			fmt.Fprintf(stderr, "%s\n", err)
+			return
+		}
+
 		// Update the internal formatter if this comparator has one specified.
-		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
-		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
+		s.fmtKey.setForComparer(props.ComparerName, s.comparers)
+		s.fmtValue.setForComparer(props.ComparerName, s.comparers)
 
 		l, err := r.Layout()
 		if err != nil {
@@ -247,11 +268,23 @@ func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
 
 func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
 	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
+	bp := sstable.PropertiesBlockBufPools.Get().(*block.BufferPool)
+	defer sstable.PropertiesBlockBufPools.Put(bp)
 	s.foreachSstable(stderr, args, func(path string, r *sstable.Reader) {
+		defer bp.Release()
 		fmt.Fprintf(stdout, "%s\n", path)
 
+		// Load properties.
+		opts := s.opts.MakeReaderOptions()
+		props, err := r.ReadPropertiesBlock(context.Background(), bp, opts.DeniedUserProperties)
+
+		if err != nil {
+			fmt.Fprintf(stderr, "%s\n", err)
+			return
+		}
+
 		if s.verbose {
-			fmt.Fprintf(stdout, "%s", r.Properties.String())
+			fmt.Fprintf(stdout, "%s", props.String())
 			return
 		}
 
@@ -279,47 +312,47 @@ func (s *sstableT) runProperties(cmd *cobra.Command, args []string) {
 		}
 		fmt.Fprintf(tw, "size\t\n")
 		fmt.Fprintf(tw, "  file\t%s\n", humanize.Bytes.Int64(stat.Size()))
-		fmt.Fprintf(tw, "  data\t%s\n", humanize.Bytes.Uint64(r.Properties.DataSize))
-		fmt.Fprintf(tw, "    blocks\t%d\n", r.Properties.NumDataBlocks)
-		fmt.Fprintf(tw, "  index\t%s\n", humanize.Bytes.Uint64(r.Properties.IndexSize))
-		fmt.Fprintf(tw, "    blocks\t%d\n", 1+r.Properties.IndexPartitions)
-		fmt.Fprintf(tw, "    top-level\t%s\n", humanize.Bytes.Uint64(r.Properties.TopLevelIndexSize))
-		fmt.Fprintf(tw, "  filter\t%s\n", humanize.Bytes.Uint64(r.Properties.FilterSize))
-		fmt.Fprintf(tw, "  raw-key\t%s\n", humanize.Bytes.Uint64(r.Properties.RawKeySize))
-		fmt.Fprintf(tw, "  raw-value\t%s\n", humanize.Bytes.Uint64(r.Properties.RawValueSize))
-		fmt.Fprintf(tw, "  pinned-key\t%d\n", r.Properties.SnapshotPinnedKeySize)
-		fmt.Fprintf(tw, "  pinned-val\t%d\n", r.Properties.SnapshotPinnedValueSize)
-		fmt.Fprintf(tw, "  point-del-key-size\t%d\n", r.Properties.RawPointTombstoneKeySize)
-		fmt.Fprintf(tw, "  point-del-value-size\t%d\n", r.Properties.RawPointTombstoneValueSize)
-		fmt.Fprintf(tw, "records\t%d\n", r.Properties.NumEntries)
-		fmt.Fprintf(tw, "  set\t%d\n", r.Properties.NumEntries-
-			(r.Properties.NumDeletions+r.Properties.NumMergeOperands))
-		fmt.Fprintf(tw, "  delete\t%d\n", r.Properties.NumPointDeletions())
-		fmt.Fprintf(tw, "  delete-sized\t%d\n", r.Properties.NumSizedDeletions)
-		fmt.Fprintf(tw, "  range-delete\t%d\n", r.Properties.NumRangeDeletions)
-		fmt.Fprintf(tw, "  range-key-set\t%d\n", r.Properties.NumRangeKeySets)
-		fmt.Fprintf(tw, "  range-key-unset\t%d\n", r.Properties.NumRangeKeyUnsets)
-		fmt.Fprintf(tw, "  range-key-delete\t%d\n", r.Properties.NumRangeKeyDels)
-		fmt.Fprintf(tw, "  merge\t%d\n", r.Properties.NumMergeOperands)
-		fmt.Fprintf(tw, "  pinned\t%d\n", r.Properties.SnapshotPinnedKeys)
+		fmt.Fprintf(tw, "  data\t%s\n", humanize.Bytes.Uint64(props.DataSize))
+		fmt.Fprintf(tw, "    blocks\t%d\n", props.NumDataBlocks)
+		fmt.Fprintf(tw, "  index\t%s\n", humanize.Bytes.Uint64(props.IndexSize))
+		fmt.Fprintf(tw, "    blocks\t%d\n", 1+props.IndexPartitions)
+		fmt.Fprintf(tw, "    top-level\t%s\n", humanize.Bytes.Uint64(props.TopLevelIndexSize))
+		fmt.Fprintf(tw, "  filter\t%s\n", humanize.Bytes.Uint64(props.FilterSize))
+		fmt.Fprintf(tw, "  raw-key\t%s\n", humanize.Bytes.Uint64(props.RawKeySize))
+		fmt.Fprintf(tw, "  raw-value\t%s\n", humanize.Bytes.Uint64(props.RawValueSize))
+		fmt.Fprintf(tw, "  pinned-key\t%d\n", props.SnapshotPinnedKeySize)
+		fmt.Fprintf(tw, "  pinned-val\t%d\n", props.SnapshotPinnedValueSize)
+		fmt.Fprintf(tw, "  point-del-key-size\t%d\n", props.RawPointTombstoneKeySize)
+		fmt.Fprintf(tw, "  point-del-value-size\t%d\n", props.RawPointTombstoneValueSize)
+		fmt.Fprintf(tw, "records\t%d\n", props.NumEntries)
+		fmt.Fprintf(tw, "  set\t%d\n", props.NumEntries-
+			(props.NumDeletions+props.NumMergeOperands))
+		fmt.Fprintf(tw, "  delete\t%d\n", props.NumPointDeletions())
+		fmt.Fprintf(tw, "  delete-sized\t%d\n", props.NumSizedDeletions)
+		fmt.Fprintf(tw, "  range-delete\t%d\n", props.NumRangeDeletions)
+		fmt.Fprintf(tw, "  range-key-set\t%d\n", props.NumRangeKeySets)
+		fmt.Fprintf(tw, "  range-key-unset\t%d\n", props.NumRangeKeyUnsets)
+		fmt.Fprintf(tw, "  range-key-delete\t%d\n", props.NumRangeKeyDels)
+		fmt.Fprintf(tw, "  merge\t%d\n", props.NumMergeOperands)
+		fmt.Fprintf(tw, "  pinned\t%d\n", props.SnapshotPinnedKeys)
 		fmt.Fprintf(tw, "index\t\n")
 		fmt.Fprintf(tw, "  key\t")
 		fmt.Fprintf(tw, "  value\t")
-		fmt.Fprintf(tw, "comparer\t%s\n", r.Properties.ComparerName)
-		fmt.Fprintf(tw, "key-schema\t%s\n", formatNull(r.Properties.KeySchemaName))
-		fmt.Fprintf(tw, "merger\t%s\n", formatNull(r.Properties.MergerName))
-		fmt.Fprintf(tw, "filter\t%s\n", formatNull(r.Properties.FilterPolicyName))
-		fmt.Fprintf(tw, "compression\t%s\n", r.Properties.CompressionName)
-		fmt.Fprintf(tw, "  options\t%s\n", r.Properties.CompressionOptions)
+		fmt.Fprintf(tw, "comparer\t%s\n", props.ComparerName)
+		fmt.Fprintf(tw, "key-schema\t%s\n", formatNull(props.KeySchemaName))
+		fmt.Fprintf(tw, "merger\t%s\n", formatNull(props.MergerName))
+		fmt.Fprintf(tw, "filter\t%s\n", formatNull(props.FilterPolicyName))
+		fmt.Fprintf(tw, "compression\t%s\n", props.CompressionName)
+		fmt.Fprintf(tw, "  options\t%s\n", props.CompressionOptions)
 		fmt.Fprintf(tw, "user properties\t\n")
-		fmt.Fprintf(tw, "  collectors\t%s\n", r.Properties.PropertyCollectorNames)
-		keys := make([]string, 0, len(r.Properties.UserProperties))
-		for key := range r.Properties.UserProperties {
+		fmt.Fprintf(tw, "  collectors\t%s\n", props.PropertyCollectorNames)
+		keys := make([]string, 0, len(props.UserProperties))
+		for key := range props.UserProperties {
 			keys = append(keys, key)
 		}
 		slices.Sort(keys)
 		for _, key := range keys {
-			fmt.Fprintf(tw, "  %s\t%s\n", key, r.Properties.UserProperties[key])
+			fmt.Fprintf(tw, "  %s\t%s\n", key, props.UserProperties[key])
 		}
 		_ = tw.Flush()
 	})
@@ -340,10 +373,20 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		blobDir = args[len(args)-1]
 		args = args[:len(args)-1]
 	}
+
+	bp := sstable.PropertiesBlockBufPools.Get().(*block.BufferPool)
+	defer sstable.PropertiesBlockBufPools.Put(bp)
 	s.foreachSstable(stderr, args, func(path string, r *sstable.Reader) {
+		defer bp.Release()
+		props, err := r.ReadPropertiesBlock(context.Background(), bp, nil)
+		if err != nil {
+			fmt.Fprintf(stderr, "%s\n", err)
+			return
+		}
+
 		// Update the internal formatter if this comparator has one specified.
-		s.fmtKey.setForComparer(r.Properties.ComparerName, s.comparers)
-		s.fmtValue.setForComparer(r.Properties.ComparerName, s.comparers)
+		s.fmtKey.setForComparer(props.ComparerName, s.comparers)
+		s.fmtValue.setForComparer(props.ComparerName, s.comparers)
 
 		// In filter-mode, we prefix ever line that is output with the sstable
 		// filename.


### PR DESCRIPTION
### sstable: introduce ReadPropertiesBlock on reader

Introduces ReadPropertiesBlock on the reader struct to prep for loading
properties on demand from various callers. For now we continue to populate
`Properties` on reader creation.

### tools: load properties on demand

tools: load properties on demand
To support the goal of removing the props struct from the reader, this commit
loads properties on demand when running the following commands instead of
reading from the in-memory struct:
- runCheck
- runProperties (sstable + db level)
- runLayout
- runScan

Part of: #4383