### PR TITLE
metamorphic: sanity check initial-state and previous-ops flags, pass --previous-ops flag

### DIFF
--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -174,6 +174,9 @@ func runCrossVersion(
 		// version's metamorphic runs used the same seed, so all of the
 		// resulting histories should be identical.
 		histories := subrunResults.historyPaths()
+		if len(histories) == 0 {
+			t.Fatal("no subrun histories")
+		}
 		if h, diff := metamorphic.CompareHistories(t, histories); h > 0 {
 			fatalf(t, &fatalOnce, []string{subrunResults[0].runDir, subrunResults[h].runDir},
 				"Metamorphic test divergence between %q and %q:\nDiff:\n%s",
@@ -280,9 +283,10 @@ func runVersion(
 				if streamOutput {
 					out = io.MultiWriter(out, os.Stderr)
 				}
-				t.Logf("  Running test with version %s with initial state %s.",
-					vers.SHA, s)
-				if err := r.run(ctx, out); err != nil {
+				t.Logf("  Running test with version %s with initial state %s (dir=%s initial=%s).",
+					vers.SHA, s, r.dir, s.path)
+
+				if err := r.run(ctx, t, out); err != nil {
 					fatalf(t, fatalOnce, []string{r.dir},
 						"Metamorphic test failed: %s\nOutput:%s\n", err, buf.String())
 				}
@@ -356,7 +360,7 @@ type metamorphicTestRun struct {
 	testBinaryPath string
 }
 
-func (r *metamorphicTestRun) run(ctx context.Context, output io.Writer) error {
+func (r *metamorphicTestRun) run(ctx context.Context, t *testing.T, output io.Writer) error {
 	args := []string{
 		"-test.run", "TestMeta$",
 		"-seed", strconv.FormatUint(r.seed, 10),
@@ -387,8 +391,9 @@ func (r *metamorphicTestRun) run(ctx context.Context, output io.Writer) error {
 	cmd.Stdout = output
 
 	// Print the command itself before executing it.
+	fmt.Println(output, cmd)
 	if testing.Verbose() {
-		fmt.Fprintln(output, cmd)
+		t.Logf("running: %s", cmd.String())
 	}
 
 	return cmd.Run()

--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -218,8 +218,9 @@ type subrunResult struct {
 }
 
 type initialState struct {
-	desc string
-	path string
+	desc    string
+	path    string
+	opsPath string
 }
 
 func (s initialState) String() string {
@@ -288,7 +289,7 @@ func runVersion(
 
 				if err := r.run(ctx, t, out); err != nil {
 					fatalf(t, fatalOnce, []string{r.dir},
-						"Metamorphic test failed: %s\nOutput:%s\n", err, buf.String())
+						"Metamorphic test failed: %s. Output:\n%s\n", err, buf.String())
 				}
 
 				// dir is a directory containing the ops file and subdirectories for
@@ -313,8 +314,9 @@ func runVersion(
 						runDir:      dir,
 						historyPath: filepath.Join(dir, subrunDir, "history"),
 						initialState: initialState{
-							path: filepath.Join(dir, subrunDir),
-							desc: fmt.Sprintf("sha=%s-seed=%d-opts=%s(%s)", vers.SHA, seed, subrunDir, s.String()),
+							desc:    fmt.Sprintf("sha=%s-seed=%d-opts=%s(%s)", vers.SHA, seed, subrunDir, s.String()),
+							path:    filepath.Join(dir, subrunDir),
+							opsPath: filepath.Join(dir, "ops"),
 						},
 					})
 				}
@@ -381,9 +383,9 @@ func (r *metamorphicTestRun) run(ctx context.Context, t *testing.T, output io.Wr
 		args = append(args, "-test.v")
 	}
 	if r.initialState.path != "" {
-		args = append(args,
-			"--initial-state", r.initialState.path,
-			"--initial-state-desc", r.initialState.desc)
+		args = append(args, "--initial-state-desc", r.initialState.desc)
+		args = append(args, "--initial-state", r.initialState.path)
+		args = append(args, "--previous-ops", r.initialState.opsPath)
 	}
 	cmd := exec.CommandContext(ctx, r.testBinaryPath, args...)
 	cmd.Dir = r.dir

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -97,7 +97,10 @@ func runTestMeta(t *testing.T, addtlOptions ...option) {
 			filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
 
 	default:
-		opts := runFlags.MakeRunOptions()
+		opts, err := runFlags.MakeRunOptions()
+		if err != nil {
+			t.Fatal(err)
+		}
 		for _, opt := range addtlOptions {
 			opts = append(opts, opt)
 		}

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/metamorphic"
@@ -198,10 +199,12 @@ with --run-dir or --compare`)
 	// the `ops` file and one of the previous run's data directories.
 
 	flag.StringVar(&r.PreviousOps, "previous-ops", "",
-		"path to an ops file, used to prepopulate the set of keys operations draw from")
+		`path to an ops file, used to prepopulate the set of keys operations draw from." +
+		Must be used in conjunction with --initial-state`)
 
 	flag.StringVar(&r.InitialStatePath, "initial-state", "",
-		"path to a database's data directory, used to prepopulate the test run's databases")
+		`path to a database's data directory, used to prepopulate the test run's databases.
+		Must be used in conjunction with --previous-ops.`)
 
 	flag.StringVar(&r.InitialStateDesc, "initial-state-desc", "",
 		`a human-readable description of the initial database state.
@@ -277,7 +280,7 @@ func (ro *RunOnceFlags) tryParseCompare() (testRootDir string, runSubdirs []stri
 }
 
 // MakeRunOptions constructs RunOptions based on the flags.
-func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
+func (r *RunFlags) MakeRunOptions() ([]metamorphic.RunOption, error) {
 	opts := []metamorphic.RunOption{
 		metamorphic.Seed(r.Seed),
 		metamorphic.OpCount(r.Ops.Static),
@@ -298,7 +301,12 @@ func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
 		opts = append(opts, metamorphic.RuntimeTrace(r.TraceFile))
 	}
 	if r.PreviousOps != "" {
+		if r.InitialStatePath == "" {
+			return nil, errors.Newf("--previous-ops requires --initial-state")
+		}
 		opts = append(opts, metamorphic.ExtendPreviousRun(r.PreviousOps, r.InitialStatePath, r.InitialStateDesc))
+	} else if r.InitialStatePath != "" {
+		return nil, errors.Newf("--initial-state requires --previous-ops")
 	}
 	if r.NumInstances > 1 {
 		opts = append(opts, metamorphic.MultiInstance(r.NumInstances))
@@ -318,5 +326,5 @@ func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
 	if r.InnerBinary != "" {
 		opts = append(opts, metamorphic.InnerBinary(r.InnerBinary))
 	}
-	return opts
+	return opts, nil
 }


### PR DESCRIPTION
This requires https://github.com/cockroachdb/pebble/pull/4760 and https://github.com/cockroachdb/pebble/pull/4755 (and those need to be backported).

Informs #4732

#### metamorphic: sanity check initial-state and previous-ops flags

Error out if `--initial-state` is used without `--previous-ops`.

#### crossversion: pass --previous-ops flag

Lack of this flag is the root cause for the crossversion tests not
actually testing across versions (instead, each run was separate).
