### PR TITLE
db: skip TestCompactionCorruption on slow builds

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2994,8 +2994,8 @@ func TestCompactionErrorStats(t *testing.T) {
 }
 
 func TestCompactionCorruption(t *testing.T) {
-	if buildtags.Race {
-		t.Skip("disabled in race mode to avoid timeouts")
+	if buildtags.SlowBuild {
+		t.Skip("disabled in slow builds")
 	}
 	mem := vfs.NewMem()
 	var numFinishedCompactions atomic.Int32


### PR DESCRIPTION
We added a skip in race mode but that doesn't include other slow
builds (like address sanitizer builds). Switch to checking for
`buildtags.SlowBuild`.