### PR TITLE
metamorphic: update error blacklist

### DIFF
--- a/internal/metamorphic/reduce_test.go
+++ b/internal/metamorphic/reduce_test.go
@@ -163,6 +163,7 @@ func (r *reducer) try(t *testing.T, ops []string) bool {
 	// removed important ops.
 	if err == nil ||
 		strings.Contains(output.String(), "metamorphic test internal error") ||
+		strings.Contains(output.String(), "element has outstanding references") ||
 		strings.Contains(output.String(), "leaked iterators") ||
 		strings.Contains(output.String(), "leaked snapshots") ||
 		strings.Contains(output.String(), "test timed out") {


### PR DESCRIPTION
We see this error when we close the DB without closing all iterators
first (perhaps only if value separation is enabled?). This error
indicates that we did not reproduce the original problem when
reducing.