### PR TITLE
tool: print normal value in blob mode print

### DIFF
--- a/tool/find.go
+++ b/tool/find.go
@@ -495,6 +495,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			var blobContext sstable.TableBlobContext
 			switch ConvertToBlobRefMode(f.blobMode) {
 			case BlobRefModePrint:
+				f.fmtValue.mustSet("[%s]")
 				blobContext = sstable.DebugHandlesBlobContext
 			case BlobRefModeLoad:
 				provider := debugReaderProvider{

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -365,6 +365,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 		var blobContext sstable.TableBlobContext
 		switch blobMode {
 		case BlobRefModePrint:
+			s.fmtValue.mustSet("[%s]")
 			blobContext = sstable.DebugHandlesBlobContext
 		case BlobRefModeLoad:
 			blobRefs, err := findAndReadManifests(stderr, s.opts.FS, blobDir)

--- a/tool/testdata/find
+++ b/tool/testdata/find
@@ -153,10 +153,10 @@ crdb:aaa
 --blob-mode=print
 ----
 000002.log
-    aaa\x00#10,SET [7975756d69]
+    aaa\x00#10,SET [yuumi]
 000005.sst [aaa\x00#10,SET-ddd\x00#13,SET]
     (flushed to L0)
-    aaa\x00#10,SET [2866302c626c6b302c6964302c6c656e3529]
+    aaa\x00#10,SET [(f0,blk0,id0,len5)]
 
 find
 testdata/find-db-val-sep
@@ -164,10 +164,10 @@ crdb:ddd
 --blob-mode=print
 ----
 000002.log
-    ddd\x00#13,SET [36]
+    ddd\x00#13,SET [6]
 000005.sst [aaa\x00#10,SET-ddd\x00#13,SET]
     (flushed to L0)
-    ddd\x00#13,SET [36]
+    ddd\x00#13,SET [6]
 
 find
 testdata/find-db-val-sep

--- a/tool/testdata/sstable_scan
+++ b/tool/testdata/sstable_scan
@@ -427,17 +427,17 @@ sstable scan
 --blob-mode=print
 ----
 find-db-val-sep/000005.sst
-aaa\x00#10,SET [2866302c626c6b302c6964302c6c656e3529]
-bbb\x00#11,SET [2866302c626c6b302c6964312c6c656e3329]
-ccc\x00#12,SET [2866302c626c6b302c6964322c6c656e313029]
-ddd\x00#13,SET [36]
+aaa\x00#10,SET [(f0,blk0,id0,len5)]
+bbb\x00#11,SET [(f0,blk0,id1,len3)]
+ccc\x00#12,SET [(f0,blk0,id2,len10)]
+ddd\x00#13,SET [6]
 
 sstable scan
 --filter=armed
 --blob-mode=print
 ../sstable/testdata/h.sst
 ----
-h.sst: armed#0,SET [32]
+h.sst: armed#0,SET [2]
 
 sstable scan
 ./testdata/find-db-val-sep/000005.sst


### PR DESCRIPTION
This ensures that we don't print encoded values by default.