### PR TITLE
db: reformat Metrics.String and print value separation metrics

### DIFF
--- a/internal/whiteboard/table/examples_test.go
+++ b/internal/whiteboard/table/examples_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package table_test
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/pebble/internal/whiteboard"
+	"github.com/cockroachdb/pebble/internal/whiteboard/table"
+)
+
+func ExampleDefine() {
+	type Cat struct {
+		Name     string
+		Age      int
+		Cuteness int
+	}
+
+	tbl := table.Define(
+		table.String("name", 7, table.AlignLeft, func(c Cat) string { return c.Name }),
+		table.Div[Cat](),
+		table.Int("age", 4, table.AlignRight, func(c Cat) int { return c.Age }),
+		table.Div[Cat](),
+		table.Int("cuteness", 8, table.AlignRight, func(c Cat) int { return c.Cuteness }),
+	)
+
+	board := whiteboard.Make(8, tbl.CumulativeFieldWidth)
+	fmt.Println("Cool cats:")
+	table.RenderAll(tbl.RenderFunc(board.At(0, 0), table.RenderOptions{}), []Cat{
+		{Name: "Chicken", Age: 5, Cuteness: 10},
+		{Name: "Heart", Age: 4, Cuteness: 10},
+		{Name: "Mai", Age: 2, Cuteness: 10},
+		{Name: "Poi", Age: 15, Cuteness: 10},
+		{Name: "Pigeon", Age: 2, Cuteness: 10},
+		{Name: "Sugar", Age: 8, Cuteness: 10},
+		{Name: "Yaya", Age: 5, Cuteness: 10},
+		{Name: "Yuumi", Age: 5, Cuteness: 10},
+	})
+	fmt.Println(board.String())
+	// Output:
+	// Cool cats:
+	// name    |  age | cuteness
+	// --------+------+---------
+	// Chicken |    5 |       10
+	// Heart   |    4 |       10
+	// Mai     |    2 |       10
+	// Poi     |   15 |       10
+	// Pigeon  |    2 |       10
+	// Sugar   |    8 |       10
+	// Yaya    |    5 |       10
+	// Yuumi   |    5 |       10
+}
+
+func ExampleHorizontally() {
+	type Cat struct {
+		Name     string
+		Age      int
+		Cuteness int
+	}
+
+	tbl := table.Define(
+		table.String("name", 7, table.AlignRight, func(c Cat) string { return c.Name }),
+		table.Div[Cat](),
+		table.Int("age", 4, table.AlignRight, func(c Cat) int { return c.Age }),
+		table.Int("cuteness", 8, table.AlignRight, func(c Cat) int { return c.Cuteness }),
+	)
+
+	board := whiteboard.Make(8, tbl.CumulativeFieldWidth)
+	fmt.Println("Cool cats:")
+	opts := table.RenderOptions{Orientation: table.Horizontally}
+	table.RenderAll(tbl.RenderFunc(board.At(0, 0), opts), []Cat{
+		{Name: "Chicken", Age: 5, Cuteness: 10},
+		{Name: "Heart", Age: 4, Cuteness: 10},
+		{Name: "Mai", Age: 2, Cuteness: 10},
+		{Name: "Poi", Age: 15, Cuteness: 10},
+		{Name: "Pigeon", Age: 2, Cuteness: 10},
+		{Name: "Sugar", Age: 8, Cuteness: 10},
+		{Name: "Yaya", Age: 5, Cuteness: 10},
+		{Name: "Yuumi", Age: 5, Cuteness: 10},
+	})
+	fmt.Println(board.String())
+	// Output:
+	// Cool cats:
+	// name     |  Chicken   Heart     Mai     Poi  Pigeon   Sugar    Yaya   Yuumi
+	// ---------+-----------------------------------------------------------------
+	// age      |        5       4       2      15       2       8       5       5
+	// cuteness |       10      10      10      10      10      10      10      10
+}

--- a/internal/whiteboard/table/table.go
+++ b/internal/whiteboard/table/table.go
@@ -1,0 +1,356 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package table
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/pebble/internal/humanize"
+	"github.com/cockroachdb/pebble/internal/whiteboard"
+)
+
+// Define defines a new table layout with the given fields.
+func Define[T any](fields ...Field[T]) Definition[T] {
+	var verticalHeader strings.Builder
+	var verticalHeaderSep strings.Builder
+	defFields := make([]definitionField[T], len(fields))
+	maxFieldWidth := 0
+	for i := 0; i < len(fields); i++ {
+		maxFieldWidth = max(maxFieldWidth, fields[i].width())
+	}
+
+	for i := 0; i < len(fields); i++ {
+		w := fields[i].width()
+		h := fields[i].header(Vertically, maxFieldWidth)
+		if len(h) > w {
+			panic(fmt.Sprintf("header %q is too long for column %d", h, i))
+		}
+
+		defFields[i] = definitionField[T]{
+			f:   fields[i],
+			off: verticalHeaderSep.Len(),
+		}
+
+		// Create the vertical header strings.
+		if _, ok := fields[i].(divider[T]); ok {
+			verticalHeaderSep.WriteString("-+-")
+		} else {
+			verticalHeaderSep.WriteString(strings.Repeat("-", w))
+		}
+		padding := w - len(h)
+		verticalHeader.WriteString(fields[i].align().maybePadding(AlignRight, padding))
+		verticalHeader.WriteString(h)
+		verticalHeader.WriteString(fields[i].align().maybePadding(AlignLeft, padding))
+	}
+	return Definition[T]{
+		CumulativeFieldWidth: verticalHeaderSep.Len(),
+		MaxFieldWidth:        maxFieldWidth,
+		fields:               defFields,
+		verticalHeaderLine:   verticalHeader.String(),
+		verticalHeaderSep:    verticalHeaderSep.String(),
+	}
+}
+
+// A Definition defines the layout of a table.
+type Definition[T any] struct {
+	CumulativeFieldWidth int
+	MaxFieldWidth        int
+	fields               []definitionField[T]
+	verticalHeaderLine   string
+	verticalHeaderSep    string
+}
+
+type definitionField[T any] struct {
+	f   Field[T]
+	off int
+}
+
+// RenderAll renders all the rows of the table, calling fn for each row.
+func RenderAll[T any](fn func(r T) whiteboard.Cursor, rows []T) whiteboard.Cursor {
+	cur := whiteboard.Cursor{}
+	for _, r := range rows {
+		cur = fn(r)
+	}
+	return cur
+}
+
+// RenderOptions specifies the options for rendering a table.
+type RenderOptions struct {
+	Orientation Orientation
+}
+
+// RenderFunc returns a function that renders a single row of the table.
+func (d *Definition[T]) RenderFunc(
+	start whiteboard.Cursor, opts RenderOptions,
+) func(tuple T) whiteboard.Cursor {
+	cur := start
+
+	if opts.Orientation == Vertically {
+		cur.Offset(0, 0).WriteString(d.verticalHeaderLine)
+		cur.Offset(1, 0).WriteString(d.verticalHeaderSep)
+		r := 0
+		return func(tuple T) whiteboard.Cursor {
+			for c := range d.fields {
+				d.fields[c].f.renderValue(RenderContext[T]{
+					Definition:  d,
+					Orientation: Vertically,
+					TupleIndex:  r,
+					Pos:         cur.Offset(2+r, d.fields[c].off),
+				}, tuple)
+			}
+			r++
+			return cur.Offset(2+r, 0)
+		}
+	}
+
+	for i := 0; i < len(d.fields); i++ {
+		cur.Offset(i, 0).WriteString(d.fields[i].f.header(Horizontally, d.MaxFieldWidth))
+		if _, ok := d.fields[i].f.(divider[T]); ok {
+			cur.Offset(i, d.MaxFieldWidth).WriteString("-+-")
+		} else {
+			cur.Offset(i, d.MaxFieldWidth).WriteString(" | ")
+		}
+	}
+	tupleIndex := 0
+	c := d.MaxFieldWidth + 3
+	return func(tuple T) whiteboard.Cursor {
+		for r := 0; r < len(d.fields); r++ {
+			fieldOff := cur.Offset(r, c)
+			d.fields[r].f.renderValue(RenderContext[T]{
+				Definition:  d,
+				Orientation: Horizontally,
+				TupleIndex:  tupleIndex,
+				Pos:         fieldOff,
+			}, tuple)
+		}
+		tupleIndex++
+		c += d.MaxFieldWidth
+		return cur.Offset(len(d.fields), c)
+	}
+}
+
+// A RenderContext provides the context for rendering a table.
+type RenderContext[T any] struct {
+	Definition  *Definition[T]
+	Orientation Orientation
+	TupleIndex  int
+	Pos         whiteboard.Cursor
+}
+
+func (c *RenderContext[T]) PaddedPos(width int) whiteboard.Cursor {
+	if c.Orientation == Vertically {
+		return c.Pos
+	}
+	// Horizontally, we need to pad the width to the max field width.
+	return c.Pos.Offset(0, c.Definition.MaxFieldWidth-width)
+}
+
+// Div creates a divider field used to visually separate regions of the table.
+func Div[T any]() Field[T] {
+	return divider[T]{}
+}
+
+type divider[T any] struct{}
+
+var (
+	_ Field[any] = (*divider[any])(nil)
+
+	// TODO(jackson): The staticcheck tool doesn't recognize that these are used to
+	// satisfy the Field interface. Why not?
+	_ = divider[any].header
+	_ = divider[any].width
+	_ = divider[any].align
+	_ = divider[any].renderValue
+)
+
+func (d divider[T]) header(o Orientation, maxWidth int) string {
+	if o == Horizontally {
+		return strings.Repeat("-", maxWidth)
+	}
+	return " | "
+}
+func (d divider[T]) width() int   { return 3 }
+func (d divider[T]) align() Align { return AlignLeft }
+func (d divider[T]) renderValue(ctx RenderContext[T], tuple T) {
+	if ctx.Orientation == Horizontally {
+		ctx.Pos.RepeatByte(ctx.Definition.MaxFieldWidth, '-')
+	} else {
+		ctx.Pos.WriteString(" | ")
+	}
+}
+
+func Literal[T any](s string) Field[T] {
+	return literal[T](s)
+}
+
+type literal[T any] string
+
+var (
+	_ Field[any] = (*literal[any])(nil)
+
+	// TODO(jackson): The staticcheck tool doesn't recognize that these are used to
+	// satisfy the Field interface. Why not?
+	_ = literal[any].header
+	_ = literal[any].width
+	_ = literal[any].align
+	_ = literal[any].renderValue
+)
+
+func (l literal[T]) header(o Orientation, maxWidth int) string { return " " }
+func (l literal[T]) width() int                                { return len(l) }
+func (l literal[T]) align() Align                              { return AlignLeft }
+func (l literal[T]) renderValue(ctx RenderContext[T], tuple T) {
+	ctx.PaddedPos(len(l)).WriteString(string(l))
+}
+
+type Field[T any] interface {
+	header(o Orientation, maxWidth int) string
+	width() int
+	align() Align
+	renderValue(ctx RenderContext[T], tuple T)
+}
+
+const (
+	AlignLeft Align = iota
+	AlignRight
+)
+
+type Align uint8
+
+func (a Align) maybePadding(ifAlign Align, width int) string {
+	if a == ifAlign {
+		return strings.Repeat(" ", width)
+	}
+	return ""
+}
+
+const (
+	Vertically Orientation = iota
+	Horizontally
+)
+
+type Orientation uint8
+
+func String[T any](header string, width int, align Align, fn func(r T) string) Field[T] {
+	spec := widthStr(width, align) + "s"
+	return makeFuncField(header, width, align, func(ctx RenderContext[T], r T) {
+		ctx.PaddedPos(width).Printf(spec, fn(r))
+	})
+}
+
+func Int[T any](header string, width int, align Align, fn func(r T) int) Field[T] {
+	spec := widthStr(width, align) + "d"
+	return makeFuncField(header, width, align, func(ctx RenderContext[T], tuple T) {
+		ctx.PaddedPos(width).Printf(spec, fn(tuple))
+	})
+}
+
+func AutoIncrement[T any](header string, width int, align Align) Field[T] {
+	spec := widthStr(width, align) + "d"
+	return makeFuncField(header, width, align, func(ctx RenderContext[T], tuple T) {
+		ctx.PaddedPos(width).Printf(spec, ctx.TupleIndex)
+	})
+}
+
+func CountInt64[T any](header string, width int, align Align, fn func(r T) int64) Field[T] {
+	spec := widthStr(width, align) + "s"
+	return makeFuncField(header, width, align, func(ctx RenderContext[T], tuple T) {
+		ctx.PaddedPos(width).Printf(spec, humanize.Count.Int64(fn(tuple)))
+	})
+}
+
+func Count[T any](header string, width int, align Align, fn func(r T) uint64) Field[T] {
+	spec := widthStr(width, align) + "s"
+	return makeFuncField(header, width, align, func(ctx RenderContext[T], tuple T) {
+		ctx.PaddedPos(width).Printf(spec, humanize.Count.Uint64(fn(tuple)))
+	})
+}
+
+func BytesInt64[T any](header string, width int, align Align, fn func(r T) int64) Field[T] {
+	spec := widthStr(width, align) + "s"
+	return makeFuncField(header, width, align, func(ctx RenderContext[T], tuple T) {
+		ctx.PaddedPos(width).Printf(spec, humanize.Bytes.Int64(fn(tuple)))
+	})
+}
+
+func Bytes[T any](header string, width int, align Align, fn func(r T) uint64) Field[T] {
+	spec := widthStr(width, align) + "s"
+	return makeFuncField(header, width, align, func(ctx RenderContext[T], tuple T) {
+		ctx.PaddedPos(width).Printf(spec, humanize.Bytes.Uint64(fn(tuple)))
+	})
+}
+
+func Float[T any](header string, width int, align Align, fn func(r T) float64) Field[T] {
+	spec := widthStr(width, align) + "s"
+	return makeFuncField(header, width, align, func(ctx RenderContext[T], tuple T) {
+		ctx.PaddedPos(width).Printf(spec, humanizeFloat(fn(tuple), width))
+	})
+}
+
+func makeFuncField[T any](
+	header string, width int, align Align, fn func(ctx RenderContext[T], tuple T),
+) Field[T] {
+	return &funcField[T]{
+		headerValue: header,
+		widthValue:  width,
+		alignValue:  align,
+		fn:          fn,
+	}
+}
+
+type funcField[T any] struct {
+	headerValue string
+	widthValue  int
+	alignValue  Align
+	fn          func(ctx RenderContext[T], tuple T)
+}
+
+var (
+	_ Field[any] = (*funcField[any])(nil)
+
+	// TODO(jackson): The staticcheck tool doesn't recognize that these are used to
+	// satisfy the Field interface. Why not?
+	_ = (&funcField[any]{}).header
+	_ = (&funcField[any]{}).width
+	_ = (&funcField[any]{}).align
+	_ = (&funcField[any]{}).renderValue
+)
+
+func (c *funcField[T]) header(o Orientation, maxWidth int) string { return c.headerValue }
+func (c *funcField[T]) width() int                                { return c.widthValue }
+func (c *funcField[T]) align() Align                              { return c.alignValue }
+func (c *funcField[T]) renderValue(ctx RenderContext[T], tuple T) {
+	c.fn(ctx, tuple)
+}
+
+func widthStr(width int, align Align) string {
+	if align == AlignLeft {
+		return "%-" + strconv.Itoa(width)
+	}
+	return "%" + strconv.Itoa(width)
+}
+
+// humanizeFloat formats a float64 value as a string. It shows up to two
+// decimals, depending on the target length. NaN is shown as "-".
+func humanizeFloat(v float64, targetLength int) string {
+	if math.IsNaN(v) {
+		return "-"
+	}
+	// We treat 0 specially. Values near zero will show up as 0.00.
+	if v == 0 {
+		return "0"
+	}
+	res := fmt.Sprintf("%.2f", v)
+	if len(res) <= targetLength {
+		return res
+	}
+	if len(res) == targetLength+1 {
+		return fmt.Sprintf("%.1f", v)
+	}
+	return fmt.Sprintf("%.0f", v)
+}

--- a/internal/whiteboard/table/table_test.go
+++ b/internal/whiteboard/table/table_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package table
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/whiteboard"
+)
+
+func TestTable(t *testing.T) {
+	type Cat struct {
+		Name     string
+		Age      int
+		Cuteness int
+	}
+	cats := []Cat{
+		{Name: "Chicken", Age: 5, Cuteness: 10},
+		{Name: "Heart", Age: 4, Cuteness: 10},
+		{Name: "Mai", Age: 2, Cuteness: 10},
+		{Name: "Poi", Age: 15, Cuteness: 10},
+		{Name: "Pigeon", Age: 2, Cuteness: 10},
+		{Name: "Sugar", Age: 8, Cuteness: 10},
+		{Name: "Yaya", Age: 5, Cuteness: 10},
+		{Name: "Yuumi", Age: 5, Cuteness: 10},
+	}
+
+	wb := whiteboard.Make(1, 10)
+	datadriven.RunTest(t, "testdata/table", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "cats-autoincrement":
+			def := Define(
+				AutoIncrement[Cat]("idx", 3, AlignLeft),
+				Div[Cat](),
+				String("name", 7, AlignRight, func(c Cat) string { return c.Name }),
+			)
+			wb.Reset(def.CumulativeFieldWidth)
+			RenderAll(def.RenderFunc(wb.At(0, 0), RenderOptions{}), cats)
+			return wb.String()
+		case "cats-nodiv":
+			def := Define(
+				String("name", 7, AlignLeft, func(c Cat) string { return c.Name }),
+				Int("age", 4, AlignRight, func(c Cat) int { return c.Age }),
+				Int("cuteness", 8, AlignRight, func(c Cat) int { return c.Cuteness }),
+			)
+			wb.Reset(def.CumulativeFieldWidth)
+			RenderAll(def.RenderFunc(wb.At(0, 0), RenderOptions{}), cats)
+			return wb.String()
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}

--- a/internal/whiteboard/table/testdata/table
+++ b/internal/whiteboard/table/testdata/table
@@ -1,0 +1,25 @@
+cats-nodiv
+----
+name    agecuteness
+-------------------
+Chicken   5      10
+Heart     4      10
+Mai       2      10
+Poi      15      10
+Pigeon    2      10
+Sugar     8      10
+Yaya      5      10
+Yuumi     5      10
+
+cats-autoincrement
+----
+idx |    name
+----+--------
+0   | Chicken
+1   |   Heart
+2   |     Mai
+3   |     Poi
+4   |  Pigeon
+5   |   Sugar
+6   |    Yaya
+7   |   Yuumi

--- a/internal/whiteboard/testdata/ascii_board
+++ b/internal/whiteboard/testdata/ascii_board
@@ -1,0 +1,60 @@
+make w=8 h=8
+----
+
+write
+0  1  hello
+1  1  world
+----
+ hello
+ world
+
+write
+0 0 .
+1 6 !
+----
+.hello
+ world!
+
+write
+0 24 1234567890
+----
+.hello                  1234567890
+ world!
+
+write
+9 0 boop!
+----
+----
+.hello                  1234567890
+ world!
+
+
+
+
+
+
+
+boop!
+----
+----
+
+make w=1 h=1
+----
+
+write
+1 1 X
+0 2 O
+0 0 X
+2 2 O
+----
+X O
+ X
+  O
+
+write
+1 2 X
+1 0 O
+----
+X O
+OXX
+  O

--- a/internal/whiteboard/whiteboard.go
+++ b/internal/whiteboard/whiteboard.go
@@ -1,0 +1,190 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package whiteboard
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// ASCIIBoard is a simple ASCII-based board for rendering ASCII text diagrams.
+type ASCIIBoard struct {
+	buf   []byte
+	width int
+}
+
+// Make returns a new ASCIIBoard with the given initial width and height.
+func Make(w, h int) ASCIIBoard {
+	buf := make([]byte, 0, w*h)
+	return ASCIIBoard{buf: buf, width: w}
+}
+
+// At returns a position at the given coordinates.
+func (b *ASCIIBoard) At(r, c int) Cursor {
+	if r >= b.lines() {
+		b.buf = append(b.buf, bytes.Repeat([]byte{' '}, (r-b.lines()+1)*b.width)...)
+	}
+	return Cursor{b: b, r: r, c: c}
+}
+
+// NewLine appends a new line to the board and returns a position at the
+// beginning of the line.
+func (b *ASCIIBoard) NewLine() Cursor {
+	return b.At(b.lines(), 0)
+}
+
+// String returns the ASCIIBoard as a string.
+func (b *ASCIIBoard) String() string {
+	return b.Render("")
+}
+
+// Render returns the ASCIIBoard as a string, with every line prefixed by
+// indent.
+func (b *ASCIIBoard) Render(indent string) string {
+	var buf bytes.Buffer
+	for r := 0; r < b.lines(); r++ {
+		if r > 0 {
+			buf.WriteByte('\n')
+		}
+		buf.WriteString(indent)
+		buf.Write(bytes.TrimRight(b.row(r), " "))
+	}
+	return buf.String()
+}
+
+// Reset resets the board to the given width and clears the contents.
+func (b *ASCIIBoard) Reset(w int) {
+	b.buf = b.buf[:0]
+	b.width = w
+}
+
+func (b *ASCIIBoard) write(r, c int, s string) {
+	if c+len(s) > b.width {
+		b.growWidth(c + len(s))
+	}
+	row := b.row(r)
+	for i := 0; i < len(s); i++ {
+		row[c+i] = s[i]
+	}
+}
+
+func (b *ASCIIBoard) repeat(r, c int, n int, ch byte) {
+	if c+n > b.width {
+		b.growWidth(c + n)
+	}
+	row := b.row(r)
+	for i := 0; i < n; i++ {
+		row[c+i] = ch
+	}
+}
+
+func (b *ASCIIBoard) growWidth(w int) {
+	buf := bytes.Repeat([]byte{' '}, w*b.lines())
+	for i := 0; i < b.lines(); i++ {
+		copy(buf[i*w:(i+1)*w], b.buf[i*b.width:(i+1)*b.width])
+	}
+	b.buf = buf
+	b.width = w
+}
+
+func (b *ASCIIBoard) lines() int {
+	return len(b.buf) / b.width
+}
+
+func (b *ASCIIBoard) row(r int) []byte {
+	if sz := (r + 1) * b.width; sz > len(b.buf) {
+		b.buf = append(b.buf, bytes.Repeat([]byte{' '}, sz-len(b.buf))...)
+	}
+	return b.buf[r*b.width : (r+1)*b.width]
+}
+
+// Cursor is a position on an ASCIIBoard.
+type Cursor struct {
+	b    *ASCIIBoard
+	r, c int
+	// carriageReturnCol is the column to which newlines will return.  It is set
+	// by SetCarriageReturnPosition. It's used when writing text in a column,
+	// and newlines should return to the same column position.
+	carriageReturnCol int
+}
+
+// Offset returns a new cursor with the given offset from the current cursor.
+func (c Cursor) Offset(dr, dc int) Cursor {
+	c.r += dr
+	c.c += dc
+	return c
+}
+
+// SetCarriageReturnPosition returns a copy of the cursor, but with a carriage
+// return position set so that newlines written to the resulting Cursor will
+// return to the current column.
+func (c Cursor) SetCarriageReturnPosition() Cursor {
+	c.carriageReturnCol = c.c
+	return c
+}
+
+// Row returns the row of the current position.
+func (c Cursor) Row() int {
+	return c.r
+}
+
+// Column returns the column of the current position.
+func (c Cursor) Column() int {
+	return c.c
+}
+
+// SetRow returns a copy of the cursor, but with the row set to the given value.
+func (c Cursor) SetRow(row int) Cursor {
+	c.r = row
+	return c
+}
+
+// SetColumn returns a copy of the cursor, but with the column set to the given
+// value.
+func (c Cursor) SetColumn(col int) Cursor {
+	c.c = col
+	return c
+}
+
+// Printf writes the formatted string to cursor, returning a cursor where the
+// written text ends.
+func (c Cursor) Printf(format string, args ...interface{}) Cursor {
+	return c.WriteString(fmt.Sprintf(format, args...))
+}
+
+// WriteString writes the provided string starting at the cursor, returning a
+// cursor where the written text ends. Newlines in the string break to the next
+// row, with the column reset to the cursor's carriage return column.
+func (c Cursor) WriteString(s string) Cursor {
+	for len(s) > 0 {
+		i := strings.IndexByte(s, '\n')
+		if i >= 0 {
+			c.b.write(c.r, c.c, s[:i])
+			c = c.NewlineReturn()
+			s = s[i+1:]
+		} else {
+			c.b.write(c.r, c.c, s)
+			c.c += len(s)
+			break
+		}
+	}
+	return c
+}
+
+// RepeatByte writes the given byte n times starting at the cursor, returning a
+// cursor where the written bytes end.
+func (c Cursor) RepeatByte(n int, b byte) Cursor {
+	c.b.repeat(c.r, c.c, n, b)
+	return c.Offset(0, n)
+}
+
+// NewlineReturn returns a cursor at the next line, with the column set to the
+// cursor's carriage return column.
+func (c Cursor) NewlineReturn() Cursor {
+	c.r += 1
+	c.c = c.carriageReturnCol
+	return c
+}

--- a/internal/whiteboard/whiteboard_test.go
+++ b/internal/whiteboard/whiteboard_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package whiteboard
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/strparse"
+	"github.com/stretchr/testify/require"
+)
+
+func TestASCIIBoardDatadriven(t *testing.T) {
+	var board ASCIIBoard
+	datadriven.RunTest(t, "testdata/ascii_board", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "make":
+			var w, h int
+			td.ScanArgs(t, "w", &w)
+			td.ScanArgs(t, "h", &h)
+			board = Make(w, h)
+			return board.String()
+		case "write":
+			for _, line := range strings.Split(td.Input, "\n") {
+				p := strparse.MakeParser(" ", line)
+				r := p.Int()
+				c := p.Int()
+				board.At(r, c).WriteString(p.Remaining())
+			}
+			return board.String()
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}
+
+func TestASCIIBoard(t *testing.T) {
+	board := Make(10, 2)
+	board.At(0, 0).Printf("Hello\nworld!")
+	require.Equal(t, `Hello
+world!`, board.String())
+
+	board.Reset(10)
+	cur := board.At(1, 5).SetCarriageReturnPosition().Printf("a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n")
+	require.Equal(t, 11, cur.Row())
+	require.Equal(t, 5, cur.Column())
+	require.Equal(t, `
+     a
+     b
+     c
+     d
+     e
+     f
+     g
+     h
+     i
+     j`, board.String())
+}

--- a/metrics.go
+++ b/metrics.go
@@ -5,8 +5,8 @@
 package pebble
 
 import (
-	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/pebble/internal/base"
@@ -14,6 +14,8 @@ import (
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
+	"github.com/cockroachdb/pebble/internal/whiteboard"
+	"github.com/cockroachdb/pebble/internal/whiteboard/table"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedcache"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
@@ -21,6 +23,7 @@ import (
 	"github.com/cockroachdb/pebble/wal"
 	"github.com/cockroachdb/redact"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/constraints"
 )
 
 // CacheMetrics holds metrics for the block and file cache.
@@ -150,6 +153,7 @@ func (m *LevelMetrics) AggregateSize() int64 {
 
 // Add updates the counter metrics for the level.
 func (m *LevelMetrics) Add(u *LevelMetrics) {
+	m.Sublevels += u.Sublevels
 	m.TablesCount += u.TablesCount
 	m.TablesSize += u.TablesSize
 	m.VirtualTablesCount += u.VirtualTablesCount
@@ -559,7 +563,6 @@ func (m *Metrics) Total() LevelMetrics {
 	for level := 0; level < numLevels; level++ {
 		l := &m.Levels[level]
 		total.Add(l)
-		total.Sublevels += l.Sublevels
 	}
 	// Compute total bytes-in as the bytes written to the WAL + bytes ingested.
 	total.TableBytesIn = m.WAL.BytesWritten + total.TableBytesIngested
@@ -590,116 +593,135 @@ func (m *Metrics) RemoteTablesTotal() (count uint64, size uint64) {
 	return remoteCount, remoteSize
 }
 
-// String pretty-prints the metrics as below:
-//
-//	      |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |     multilevel
-//	level | tables  size val-bl vtables | score  uc    c |   in  | tables  size | tables  size | tables  size |  read |   r   w  |    top   in  read
-//	------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+------------------
-//	    0 |   101   102B     0B     101 | 1.10 2.10 0.30 |  104B |   112   104B |   113   106B |   221   217B |  107B |   1 2.09 |  104B  104B  104B
-//	    1 |   201   202B     0B     201 | 1.20 2.20 0.60 |  204B |   212   204B |   213   206B |   421   417B |  207B |   2 2.04 |  204B  204B  204B
-//	    2 |   301   302B     0B     301 | 1.30 2.30 0.90 |  304B |   312   304B |   313   306B |   621   617B |  307B |   3 2.03 |  304B  304B  304B
-//	    3 |   401   402B     0B     401 | 1.40 2.40 1.20 |  404B |   412   404B |   413   406B |   821   817B |  407B |   4 2.02 |  404B  404B  404B
-//	    4 |   501   502B     0B     501 | 1.50 2.50 1.50 |  504B |   512   504B |   513   506B |  1.0K  1017B |  507B |   5 2.02 |  504B  504B  504B
-//	    5 |   601   602B     0B     601 | 1.60 2.60 1.80 |  604B |   612   604B |   613   606B |  1.2K  1.2KB |  607B |   6 2.01 |  604B  604B  604B
-//	    6 |   701   702B     0B     701 |    - 2.70 2.10 |  704B |   712   704B |   713   706B |  1.4K  1.4KB |  707B |   7 2.01 |  704B  704B  704B
-//	total |  2.8K  2.7KB     0B    2.8K |    -    -    - | 2.8KB |  2.9K  2.8KB |  2.9K  2.8KB |  5.7K  8.4KB | 2.8KB |  28 3.00 | 2.8KB 2.8KB 2.8KB
-//	------------------------------------------------------------------------------------------------------------------------------------------------
-//	WAL: 22 files (24B)  in: 25B  written: 26B (4% overhead)
-//	Flushes: 8
-//	Compactions: 5  estimated debt: 6B  in progress: 2 (7B)
-//	             default: 27  delete: 28  elision: 29  move: 30  read: 31  tombstone-density: 16  rewrite: 32  copy: 33  multi-level: 34
-//	MemTables: 12 (11B)  zombie: 14 (13B)
-//	Zombie tables: 16 (15B, local: 30B)
-//	Backing tables: 1 (2.0MB)
-//	Virtual tables: 2807 (2.8KB)
-//	Local tables size: 28B
-//	Compression types:
-//	Table stats: 31
-//	Block cache: 2 entries (1B)  hit rate: 42.9%
-//	Table cache: 18 entries (17B)  hit rate: 48.7%
-//	Range key sets: 123  Tombstones: 456  Total missized tombstones encountered: 789
-//	Snapshots: 4  earliest seq num: 1024
-//	Table iters: 21
-//	Filter utility: 47.4%
-//	Ingestions: 27  as flushable: 36 (34B in 35 tables)
-//	Cgo memory usage: 15KB  block cache: 9.0KB (data: 4.0KB, maps: 2.0KB, entries: 3.0KB)  memtables: 5.0KB
-func (m *Metrics) String() string {
-	return redact.StringWithoutMarkers(m)
-}
-
-var _ redact.SafeFormatter = &Metrics{}
+// Assert that Metrics implements redact.SafeFormatter.
+var _ redact.SafeFormatter = (*Metrics)(nil)
 
 // SafeFormat implements redact.SafeFormatter.
 func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
-	// NB: Pebble does not make any assumptions as to which Go primitive types
-	// have been registered as safe with redact.RegisterSafeType and does not
-	// register any types itself. Some of the calls to `redact.Safe`, etc are
-	// superfluous in the context of CockroachDB, which registers all the Go
-	// numeric types as safe.
+	w.SafeString(redact.SafeString(m.String()))
+}
 
-	multiExists := m.Compact.MultiLevelCount > 0
-	appendIfMulti := func(line redact.SafeString) {
-		if multiExists {
-			w.SafeString(line)
-		}
-	}
-	newline := func() {
-		w.SafeString("\n")
-	}
+var (
+	levelMetricsTableTopHeader = `LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp`
+	levelMetricsTable          = table.Define(
+		table.AutoIncrement[*LevelMetrics]("level", 5, table.AlignRight),
+		table.Div[*LevelMetrics](),
+		table.Bytes("aggsize", 7, table.AlignRight, func(m *LevelMetrics) uint64 { return uint64(m.TablesSize) + m.EstimatedReferencesSize }),
+		table.Div[*LevelMetrics](),
+		table.CountInt64("tables", 6, table.AlignRight, func(m *LevelMetrics) int64 { return m.TablesCount }),
+		table.Literal[*LevelMetrics](" "),
+		table.BytesInt64("size", 5, table.AlignRight, func(m *LevelMetrics) int64 { return m.TablesSize }),
+		table.Div[*LevelMetrics](),
+		table.Count("count", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.VirtualTablesCount }),
+		table.Literal[*LevelMetrics](" "),
+		table.Count("size", 5, table.AlignRight, func(m *LevelMetrics) uint64 { return m.VirtualTablesSize }),
+		table.Div[*LevelMetrics](),
+		table.Bytes("refsz", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.EstimatedReferencesSize }),
+		table.Literal[*LevelMetrics](" "),
+		table.Bytes("valblk", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.Additional.ValueBlocksSize }),
+		table.Div[*LevelMetrics](),
+		table.Bytes("in", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.TableBytesIn }),
+		table.Div[*LevelMetrics](),
+		table.Count("tables", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.TablesIngested }),
+		table.Literal[*LevelMetrics](" "),
+		table.Bytes("size", 5, table.AlignRight, func(m *LevelMetrics) uint64 { return m.TableBytesIngested }),
+		table.Div[*LevelMetrics](),
+		table.Int("r", 3, table.AlignRight, func(m *LevelMetrics) int { return int(m.Sublevels) }),
+		table.Literal[*LevelMetrics](" "),
+		table.Float("w", 5, table.AlignRight, func(m *LevelMetrics) float64 { return m.WriteAmp() }),
+	)
+	levelMetricsTableBottomDivider       = strings.Repeat("-", levelMetricsTable.CumulativeFieldWidth)
+	levelCompactionMetricsTableTopHeader = `COMPACTIONS               |     moved    |     multilevel    |     read     |       written     `
+	compactionLevelMetricsTable          = table.Define(
+		table.AutoIncrement[*LevelMetrics]("level", 5, table.AlignRight),
+		table.Div[*LevelMetrics](),
+		table.Float("score", 5, table.AlignRight, func(m *LevelMetrics) float64 { return m.Score }),
+		table.Literal[*LevelMetrics](" "),
+		table.Float("ff", 5, table.AlignRight, func(m *LevelMetrics) float64 { return m.FillFactor }),
+		table.Literal[*LevelMetrics](" "),
+		table.Float("cff", 5, table.AlignRight, func(m *LevelMetrics) float64 { return m.CompensatedFillFactor }),
+		table.Div[*LevelMetrics](),
+		table.Count("tables", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.TablesMoved }),
+		table.Literal[*LevelMetrics](" "),
+		table.Bytes("size", 5, table.AlignRight, func(m *LevelMetrics) uint64 { return m.TableBytesMoved }),
+		table.Div[*LevelMetrics](),
+		table.Bytes("top", 5, table.AlignRight, func(m *LevelMetrics) uint64 { return m.MultiLevel.TableBytesInTop }),
+		table.Literal[*LevelMetrics](" "),
+		table.Bytes("in", 5, table.AlignRight, func(m *LevelMetrics) uint64 { return m.MultiLevel.TableBytesIn }),
+		table.Literal[*LevelMetrics](" "),
+		table.Bytes("read", 5, table.AlignRight, func(m *LevelMetrics) uint64 { return m.MultiLevel.TableBytesRead }),
+		table.Div[*LevelMetrics](),
+		table.Bytes("tables", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.TableBytesRead }),
+		table.Literal[*LevelMetrics](" "),
+		table.Bytes("blob", 5, table.AlignRight, func(m *LevelMetrics) uint64 { return m.BlobBytesReadEstimate }),
+		table.Div[*LevelMetrics](),
+		table.Count("tables", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.TablesFlushed + m.TablesCompacted }),
+		table.Literal[*LevelMetrics](" "),
+		table.Bytes("sstsz", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.TableBytesFlushed + m.TableBytesCompacted }),
+		table.Literal[*LevelMetrics](" "),
+		table.Bytes("blobsz", 6, table.AlignRight, func(m *LevelMetrics) uint64 { return m.BlobBytesFlushed + m.BlobBytesCompacted }),
+	)
+	compactionKindTable = table.Define(
+		table.String("kind", 9, table.AlignRight, func(p pair[string, int64]) string { return p.k }),
+		table.CountInt64("count", 9, table.AlignRight, func(p pair[string, int64]) int64 { return p.v }),
+	)
+)
 
-	w.SafeString("      |                             |                |       |   ingested   |     moved    |    written   |       |    amp")
-	appendIfMulti("   |     multilevel")
-	newline()
-	w.SafeString("level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w")
-	appendIfMulti("  |    top   in  read")
-	newline()
-	w.SafeString("------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------")
-	appendIfMulti("-+------------------")
-	newline()
+type pair[k, v any] struct {
+	k k
+	v v
+}
 
-	// formatRow prints out a row of the table.
-	formatRow := func(m *LevelMetrics) {
-		score := m.Score
-		if score == 0 {
-			// Format a zero level score as a dash.
-			score = math.NaN()
-		}
-		w.Printf("| %5s %6s %6s %7s | %4s %4s %4s | %5s | %5s %6s | %5s %6s | %5s %6s | %5s | %3d %4s",
-			humanize.Count.Int64(m.TablesCount),
-			humanize.Bytes.Int64(m.TablesSize),
-			humanize.Bytes.Uint64(m.Additional.ValueBlocksSize),
-			humanize.Count.Uint64(m.VirtualTablesCount),
-			humanizeFloat(score, 4),
-			humanizeFloat(m.FillFactor, 4),
-			humanizeFloat(m.CompensatedFillFactor, 4),
-			humanize.Bytes.Uint64(m.TableBytesIn),
-			humanize.Count.Uint64(m.TablesIngested),
-			humanize.Bytes.Uint64(m.TableBytesIngested),
-			humanize.Count.Uint64(m.TablesMoved),
-			humanize.Bytes.Uint64(m.TableBytesMoved),
-			humanize.Count.Uint64(m.TablesFlushed+m.TablesCompacted),
-			humanize.Bytes.Uint64(m.TableBytesFlushed+m.TableBytesCompacted),
-			humanize.Bytes.Uint64(m.TableBytesRead),
-			redact.Safe(m.Sublevels),
-			humanizeFloat(m.WriteAmp(), 4),
-		)
-
-		if multiExists {
-			w.Printf(" | %5s %5s %5s",
-				humanize.Bytes.Uint64(m.MultiLevel.TableBytesInTop),
-				humanize.Bytes.Uint64(m.MultiLevel.TableBytesIn),
-				humanize.Bytes.Uint64(m.MultiLevel.TableBytesRead))
-		}
-		newline()
-	}
-
+// String pretty-prints the metrics as below:
+//
+//	LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+//	level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+//	------+---------+--------------+--------------+---------------+--------+--------------+----------
+//	    0 |    216B |    101  102B |    101   103 |   114B   114B |   104B |    112  104B |   1  1.52
+//	    1 |    416B |    201  202B |    201   203 |   214B   214B |   204B |    212  204B |   2  1.51
+//	    2 |    616B |    301  302B |    301   303 |   314B   314B |   304B |    312  304B |   3  1.51
+//	    3 |    816B |    401  402B |    401   403 |   414B   414B |   404B |    412  404B |   4  1.51
+//	    4 |   1016B |    501  502B |    501   503 |   514B   514B |   504B |    512  504B |   5  1.50
+//	    5 |   1.2KB |    601  602B |    601   603 |   614B   614B |   604B |    612  604B |   6  1.50
+//	    6 |   1.4KB |    701  702B |    701   703 |   714B   714B |   704B |    712  704B |   7  1.50
+//	total |   5.6KB |   2.8K 2.7KB |   2.8K  2.8K |  2.8KB  2.8KB |  2.8KB |   2.9K 2.8KB |  28  1.99
+//	-------------------------------------------------------------------------------------------------
+//	COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+//	level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+//	------+-------------------+--------------+-------------------+--------------+---------------------
+//	    0 |  1.10  2.10  0.30 |    113  106B |  104B  104B  104B |   107B  117B |    221   217B   231B
+//	    1 |  1.20  2.20  0.60 |    213  206B |  204B  204B  204B |   207B  217B |    421   417B   431B
+//	    2 |  1.30  2.30  0.90 |    313  306B |  304B  304B  304B |   307B  317B |    621   617B   631B
+//	    3 |  1.40  2.40  1.20 |    413  406B |  404B  404B  404B |   407B  417B |    821   817B   831B
+//	    4 |  1.50  2.50  1.50 |    513  506B |  504B  504B  504B |   507B  517B |   1.0K  1017B  1.0KB
+//	    5 |  1.60  2.60  1.80 |    613  606B |  604B  604B  604B |   607B  617B |   1.2K  1.2KB  1.2KB
+//	    6 |     0  2.70  2.10 |    713  706B |  704B  704B  704B |   707B  717B |   1.4K  1.4KB  1.4KB
+//	total |     -     -     - |   2.9K 2.8KB | 2.8KB 2.8KB 2.8KB |  2.8KB 2.9KB |   5.7K  8.4KB  5.7KB
+//	--------------------------------------------------------------------------------------------------
+//	kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+//	count     |        27       28       29       30       31       16       32       33       34
+//	--------------------------------------------------------------------------------------------------
+//	COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+//	wals                      block cache           stats 31 pending          15KB tot        6B estimated debt
+//	  22 files (24B)            2 entries (1B)      backing: 2.0MB (1)      block cache       2 in-progress (7B)
+//	  25B  written: 26B         42.9% hit rate      zombie:  15B (16)         9.0KB tot       3 cancelled (3.0KB)
+//	  (4.0% overhead)         file cache                     30B local        4.0KB data      5 failed
+//	memtables                   18 entries (17B)                              2.0KB maps      2 problem spans !
+//	  flushes: 8                48.7% hit rate      BLOB FILES                3.0KB ents
+//	  live:    12 (11B)       bloom filter          live:   0 (0B)          memtables         GARBAGE
+//	  zombie:  14 (13B)         47.4% util          zombie: 0 (0B)            5.0KB tot       1.0KB point dels
+//	ingestions                sstable iters         values                                    2.0KB range dels
+//	  total: 27                 21 open               0B total              KEYS
+//	  as flushable: 36 (34B)  snapshots               0B referenced         range keys        COMPRESSION
+//	                            4 open                0% referenced           123 sets          minlz:  32
+//	                                                                        tombstones          snappy: 33
+//	                                                                          456 total         zstd:   34
+//	                                                                          789 missized !    none:   35
+func (m *Metrics) String() string {
+	wb := whiteboard.Make(92, levelMetricsTable.CumulativeFieldWidth)
 	var total LevelMetrics
-	for level := 0; level < numLevels; level++ {
-		l := &m.Levels[level]
-		w.Printf("%5d ", redact.Safe(level))
-		formatRow(l)
-		total.Add(l)
-		total.Sublevels += l.Sublevels
+	for l := 0; l < numLevels; l++ {
+		total.Add(&m.Levels[l])
 	}
 	// Compute total bytes-in as the bytes written to the WAL + bytes ingested.
 	total.TableBytesIn = m.WAL.BytesWritten + total.TableBytesIngested
@@ -710,163 +732,187 @@ func (m *Metrics) SafeFormat(w redact.SafePrinter, _ rune) {
 	total.Score = math.NaN()
 	total.FillFactor = math.NaN()
 	total.CompensatedFillFactor = math.NaN()
-	w.SafeString("total ")
-	formatRow(&total)
 
-	w.SafeString("----------------------------------------------------------------------------------------------------------------------------")
-	appendIfMulti("--------------------")
-	newline()
-	w.Printf("WAL: %d files (%s)  in: %s  written: %s (%.0f%% overhead)",
-		redact.Safe(m.WAL.Files),
-		humanize.Bytes.Uint64(m.WAL.Size),
-		humanize.Bytes.Uint64(m.WAL.BytesIn),
-		humanize.Bytes.Uint64(m.WAL.BytesWritten),
-		redact.Safe(percent(int64(m.WAL.BytesWritten)-int64(m.WAL.BytesIn), int64(m.WAL.BytesIn))))
-	failoverStats := m.WAL.Failover
-	failoverStats.FailoverWriteAndSyncLatency = nil
-	if failoverStats == (wal.FailoverStats{}) {
-		w.Printf("\n")
-	} else {
-		w.Printf(" failover: (switches: %d, primary: %s, secondary: %s)\n", m.WAL.Failover.DirSwitchCount,
-			m.WAL.Failover.PrimaryWriteDuration.String(), m.WAL.Failover.SecondaryWriteDuration.String())
+	// LSM level metrics.
+	cur := wb.At(0, 0)
+	cur = cur.WriteString(levelMetricsTableTopHeader).NewlineReturn()
+	renderLevelMetrics := levelMetricsTable.RenderFunc(cur, table.RenderOptions{})
+	for l := 0; l < numLevels; l++ {
+		renderLevelMetrics(&m.Levels[l])
 	}
+	cur = renderLevelMetrics(&total)
+	cur.Offset(-1, 0).WriteString("total")
+	cur = cur.WriteString(levelMetricsTableBottomDivider).NewlineReturn()
 
-	w.Printf("Flushes: %d\n", redact.Safe(m.Flush.Count))
+	// Compaction level metrics.
+	cur = cur.WriteString(levelCompactionMetricsTableTopHeader).NewlineReturn()
+	renderCompactionLevelMetrics := compactionLevelMetricsTable.RenderFunc(cur, table.RenderOptions{})
+	for l := 0; l < numLevels; l++ {
+		renderCompactionLevelMetrics(&m.Levels[l])
+	}
+	cur = renderCompactionLevelMetrics(&total)
+	cur.Offset(-1, 0).WriteString("total")
 
-	w.Printf("Compactions: %d  estimated debt: %s  in progress: %d (%s)  canceled: %d (%s)  failed: %d  problem spans: %d\n",
-		redact.Safe(m.Compact.Count),
-		humanize.Bytes.Uint64(m.Compact.EstimatedDebt),
-		redact.Safe(m.Compact.NumInProgress),
-		humanize.Bytes.Int64(m.Compact.InProgressBytes),
-		redact.Safe(m.Compact.CancelledCount),
-		humanize.Bytes.Int64(m.Compact.CancelledBytes),
-		redact.Safe(m.Compact.FailedCount),
-		redact.Safe(m.Compact.NumProblemSpans),
-	)
+	kindTableCur := cur.NewlineReturn()
+	renderCompactionKind := compactionKindTable.RenderFunc(kindTableCur, table.RenderOptions{Orientation: table.Horizontally})
+	renderCompactionKind(pair[string, int64]{k: "default", v: m.Compact.DefaultCount})
+	renderCompactionKind(pair[string, int64]{k: "delete", v: m.Compact.DeleteOnlyCount})
+	renderCompactionKind(pair[string, int64]{k: "elision", v: m.Compact.ElisionOnlyCount})
+	renderCompactionKind(pair[string, int64]{k: "move", v: m.Compact.MoveCount})
+	renderCompactionKind(pair[string, int64]{k: "read", v: m.Compact.ReadCount})
+	renderCompactionKind(pair[string, int64]{k: "tomb", v: m.Compact.TombstoneDensityCount})
+	renderCompactionKind(pair[string, int64]{k: "rewrite", v: m.Compact.RewriteCount})
+	renderCompactionKind(pair[string, int64]{k: "copy", v: m.Compact.CopyCount})
+	cur = renderCompactionKind(pair[string, int64]{k: "multi", v: m.Compact.MultiLevelCount})
+	dividerLen := max(compactionLevelMetricsTable.CumulativeFieldWidth, cur.Column())
+	kindTableCur.Offset(-1, 0).RepeatByte(dividerLen, '-')
+	cur = cur.SetColumn(0).RepeatByte(dividerLen, '-').NewlineReturn()
 
-	w.Printf("             default: %d  delete: %d  elision: %d  move: %d  read: %d  tombstone-density: %d  rewrite: %d  copy: %d  multi-level: %d\n",
-		redact.Safe(m.Compact.DefaultCount),
-		redact.Safe(m.Compact.DeleteOnlyCount),
-		redact.Safe(m.Compact.ElisionOnlyCount),
-		redact.Safe(m.Compact.MoveCount),
-		redact.Safe(m.Compact.ReadCount),
-		redact.Safe(m.Compact.TombstoneDensityCount),
-		redact.Safe(m.Compact.RewriteCount),
-		redact.Safe(m.Compact.CopyCount),
-		redact.Safe(m.Compact.MultiLevelCount),
-	)
+	func(cur whiteboard.Cursor) {
+		cur.SetCarriageReturnPosition().WriteString("COMMIT PIPELINE\n").
+			WriteString("wals\n").
+			Printf("  %s files (%s)\n",
+				humanize.Count.Int64(m.WAL.Files),
+				humanize.Bytes.Uint64(m.WAL.Size)).
+			Printf("  %s  written: %s\n",
+				humanize.Bytes.Uint64(m.WAL.BytesIn),
+				humanize.Bytes.Uint64(m.WAL.BytesWritten)).
+			Printf("  (%.1f%% overhead)\n",
+				percent(int64(m.WAL.BytesWritten)-int64(m.WAL.BytesIn), int64(m.WAL.BytesIn))).
+			WriteString("memtables\n").
+			Printf("  flushes: %s\n", humanize.Count.Int64(m.Flush.Count)).
+			Printf("  live:    %s (%s)\n",
+				humanize.Count.Int64(m.MemTable.Count),
+				humanize.Bytes.Uint64(m.MemTable.Size)).
+			Printf("  zombie:  %s (%s)\n",
+				humanize.Count.Int64(m.MemTable.ZombieCount),
+				humanize.Bytes.Uint64(m.MemTable.ZombieSize)).
+			WriteString("ingestions\n").
+			Printf("  total: %s\n", humanize.Count.Uint64(m.Ingest.Count)).
+			Printf("  as flushable: %s (%s)\n",
+				humanize.Count.Uint64(m.Flush.AsIngestCount),
+				humanize.Bytes.Uint64(m.Flush.AsIngestBytes))
+	}(cur)
+	func(cur whiteboard.Cursor) {
+		cur.Offset(0, 26).SetCarriageReturnPosition().WriteString("ITERATORS\n").
+			WriteString("block cache\n").
+			Printf("  %s entries (%s)\n",
+				humanize.Count.Int64(m.BlockCache.Count),
+				humanize.Bytes.Int64(m.BlockCache.Size)).
+			Printf("  %.1f%% hit rate\n", hitRate(m.BlockCache.Hits, m.BlockCache.Misses)).
+			WriteString("file cache\n").
+			Printf("  %s entries (%s)\n",
+				humanize.Count.Int64(m.FileCache.Count),
+				humanize.Bytes.Int64(m.FileCache.Size)).
+			Printf("  %.1f%% hit rate\n", hitRate(m.FileCache.Hits, m.FileCache.Misses)).
+			WriteString("bloom filter\n").
+			Printf("  %.1f%% util\n", hitRate(m.Filter.Hits, m.Filter.Misses)).
+			WriteString("sstable iters\n").
+			Printf("  %s open\n", humanize.Count.Int64(m.TableIters)).
+			WriteString("snapshots\n").
+			Printf("  %s open\n", humanize.Count.Uint64(uint64(m.Snapshots.Count)))
+	}(cur)
+	func(cur whiteboard.Cursor) {
+		cur = cur.Offset(0, 48).SetCarriageReturnPosition().WriteString("TABLES\n").
+			Printf("stats")
+		if !m.Table.InitialStatsCollectionComplete {
+			cur = cur.WriteString(" initial load\n in progress")
+		} else if m.Table.PendingStatsCollectionCount == 0 {
+			cur = cur.WriteString(" all loaded")
+		} else {
+			cur = cur.Printf(" %s pending", humanize.Count.Int64(m.Table.PendingStatsCollectionCount))
+		}
+		cur = cur.Printf("\nbacking: %s (%d)\n",
+			humanize.Bytes.Uint64(m.Table.BackingTableSize), m.Table.BackingTableCount).
+			Printf("zombie:  %s (%d)\n",
+				humanize.Bytes.Uint64(m.Table.ZombieSize), m.Table.ZombieCount).
+			Printf("         %s local\n", humanize.Bytes.Uint64(m.Table.Local.ZombieSize))
+		cur.Printf("\nBLOB FILES\n").
+			Printf("live:   %s (%s)\n",
+				humanize.Count.Uint64(m.BlobFiles.LiveCount),
+				humanize.Bytes.Uint64(m.BlobFiles.LiveSize)).
+			Printf("zombie: %s (%s)\n",
+				humanize.Count.Uint64(m.BlobFiles.ZombieCount),
+				humanize.Bytes.Uint64(m.BlobFiles.ZombieSize)).
+			WriteString("values\n").
+			Printf("  %s total\n", humanize.Bytes.Uint64(m.BlobFiles.ValueSize)).
+			Printf("  %s referenced\n", humanize.Bytes.Uint64(m.BlobFiles.ReferencedValueSize)).
+			Printf("  %.0f%% referenced\n", percent(m.BlobFiles.ReferencedValueSize, m.BlobFiles.ValueSize))
+	}(cur)
+	func(cur whiteboard.Cursor) {
+		var inUseTotal uint64
+		for i := range m.manualMemory {
+			inUseTotal += m.manualMemory[i].InUseBytes
+		}
+		inUse := func(purpose manual.Purpose) uint64 {
+			return m.manualMemory[purpose].InUseBytes
+		}
+		cur = cur.Offset(0, 72).SetCarriageReturnPosition().WriteString("CGO MEMORY\n").
+			Printf("  %s tot\n", humanize.Bytes.Uint64(inUseTotal)).
+			Printf("block cache\n").
+			Printf("  %s tot\n", humanize.Bytes.Uint64(inUse(manual.BlockCacheData)+inUse(manual.BlockCacheMap)+inUse(manual.BlockCacheEntry))).
+			Printf("  %s data\n", humanize.Bytes.Uint64(inUse(manual.BlockCacheData))).
+			Printf("  %s maps\n", humanize.Bytes.Uint64(inUse(manual.BlockCacheMap))).
+			Printf("  %s ents\n", humanize.Bytes.Uint64(inUse(manual.BlockCacheEntry))).
+			Printf("memtables\n").
+			Printf("  %s tot\n", humanize.Bytes.Uint64(inUse(manual.MemTable))).
+			WriteString("\nKEYS\n").
+			WriteString("range keys\n").
+			Printf("  %s sets\n", humanize.Count.Uint64(m.Keys.RangeKeySetsCount)).
+			WriteString("tombstones\n").
+			Printf("  %s total\n", humanize.Count.Uint64(m.Keys.TombstoneCount))
+		if m.Keys.MissizedTombstonesCount > 0 {
+			cur.Printf("  %d missized !\n", m.Keys.MissizedTombstonesCount)
+		}
+	}(cur)
+	func(cur whiteboard.Cursor) {
+		cur = cur.Offset(0, 90).SetCarriageReturnPosition().WriteString("COMPACTIONS\n").
+			Printf("%s estimated debt\n", humanize.Bytes.Uint64(m.Compact.EstimatedDebt)).
+			Printf("%s in-progress (%s)\n",
+				humanize.Count.Int64(m.Compact.NumInProgress),
+				humanize.Bytes.Int64(m.Compact.InProgressBytes)).
+			Printf("%s cancelled (%s)\n",
+				humanize.Count.Int64(m.Compact.CancelledCount),
+				humanize.Bytes.Int64(m.Compact.CancelledBytes)).
+			Printf("%d failed\n", m.Compact.FailedCount).
+			Printf("%d problem spans%s\n", m.Compact.NumProblemSpans, ifNonZero(m.Compact.NumProblemSpans, " !"))
 
-	w.Printf("MemTables: %d (%s)  zombie: %d (%s)\n",
-		redact.Safe(m.MemTable.Count),
-		humanize.Bytes.Uint64(m.MemTable.Size),
-		redact.Safe(m.MemTable.ZombieCount),
-		humanize.Bytes.Uint64(m.MemTable.ZombieSize))
+		if m.Table.Garbage.PointDeletionsBytesEstimate > 0 || m.Table.Garbage.RangeDeletionsBytesEstimate > 0 {
+			cur = cur.WriteString("\nGARBAGE\n").
+				Printf("%s point dels\n", humanize.Bytes.Uint64(m.Table.Garbage.PointDeletionsBytesEstimate)).
+				Printf("%s range dels\n", humanize.Bytes.Uint64(m.Table.Garbage.RangeDeletionsBytesEstimate))
+		}
 
-	w.Printf("Zombie tables: %d (%s, local: %s)\n",
-		redact.Safe(m.Table.ZombieCount),
-		humanize.Bytes.Uint64(m.Table.ZombieSize),
-		humanize.Bytes.Uint64(m.Table.Local.ZombieSize))
+		maybePrintCompression := func(pos whiteboard.Cursor, name string, value int64) whiteboard.Cursor {
+			if value > 0 {
+				pos = pos.Printf("  %s %s\n", name, humanize.Count.Int64(value))
+			}
+			return pos
+		}
+		cur = cur.WriteString("\nCOMPRESSION\n")
+		cur = maybePrintCompression(cur, "minlz: ", m.Table.CompressedCountMinLZ)
+		cur = maybePrintCompression(cur, "snappy:", m.Table.CompressedCountSnappy)
+		cur = maybePrintCompression(cur, "zstd:  ", m.Table.CompressedCountZstd)
+		cur = maybePrintCompression(cur, "none:  ", m.Table.CompressedCountNone)
+		cur = maybePrintCompression(cur, "???:   ", m.Table.CompressedCountUnknown)
+		_ = cur
+	}(cur)
 
-	w.Printf("Backing tables: %d (%s)\n",
-		redact.Safe(m.Table.BackingTableCount),
-		humanize.Bytes.Uint64(m.Table.BackingTableSize))
-	w.Printf("Virtual tables: %d (%s)\n",
-		redact.Safe(m.NumVirtual()),
-		humanize.Bytes.Uint64(m.VirtualSize()))
-	w.Printf("Local tables size: %s\n", humanize.Bytes.Uint64(m.Table.Local.LiveSize))
-	w.SafeString("Compression types:")
-	if count := m.Table.CompressedCountSnappy; count > 0 {
-		w.Printf(" snappy: %d", redact.Safe(count))
-	}
-	if count := m.Table.CompressedCountZstd; count > 0 {
-		w.Printf(" zstd: %d", redact.Safe(count))
-	}
-	if count := m.Table.CompressedCountMinLZ; count > 0 {
-		w.Printf(" minlz: %d", redact.Safe(count))
-	}
-	if count := m.Table.CompressedCountNone; count > 0 {
-		w.Printf(" none: %d", redact.Safe(count))
-	}
-	if count := m.Table.CompressedCountUnknown; count > 0 {
-		w.Printf(" unknown: %d", redact.Safe(count))
-	}
-	w.Printf("\n")
-	if m.Table.Garbage.PointDeletionsBytesEstimate > 0 || m.Table.Garbage.RangeDeletionsBytesEstimate > 0 {
-		w.Printf("Garbage: point-deletions %s range-deletions %s\n",
-			humanize.Bytes.Uint64(m.Table.Garbage.PointDeletionsBytesEstimate),
-			humanize.Bytes.Uint64(m.Table.Garbage.RangeDeletionsBytesEstimate))
-	}
-	w.Printf("Table stats: ")
-	if !m.Table.InitialStatsCollectionComplete {
-		w.Printf("initial load in progress")
-	} else if m.Table.PendingStatsCollectionCount == 0 {
-		w.Printf("all loaded")
-	} else {
-		w.Printf("%s", humanize.Count.Int64(m.Table.PendingStatsCollectionCount))
-	}
-	w.Printf("\n")
+	return wb.String()
+}
 
-	formatCacheMetrics := func(m *CacheMetrics, name redact.SafeString) {
-		w.Printf("%s: %s entries (%s)  hit rate: %.1f%%\n",
-			name,
-			humanize.Count.Int64(m.Count),
-			humanize.Bytes.Int64(m.Size),
-			redact.Safe(hitRate(m.Hits, m.Misses)))
+func ifNonZero[T constraints.Integer](v T, s string) string {
+	if v > 0 {
+		return s
 	}
-	formatCacheMetrics(&m.BlockCache, "Block cache")
-	formatCacheMetrics(&m.FileCache, "Table cache")
-
-	formatSharedCacheMetrics := func(w redact.SafePrinter, m *SecondaryCacheMetrics, name redact.SafeString) {
-		w.Printf("%s: %s entries (%s)  hit rate: %.1f%%\n",
-			name,
-			humanize.Count.Int64(m.Count),
-			humanize.Bytes.Int64(m.Size),
-			redact.Safe(hitRate(m.ReadsWithFullHit, m.ReadsWithPartialHit+m.ReadsWithNoHit)))
-	}
-	if m.SecondaryCacheMetrics.Size > 0 || m.SecondaryCacheMetrics.ReadsWithFullHit > 0 {
-		formatSharedCacheMetrics(w, &m.SecondaryCacheMetrics, "Secondary cache")
-	}
-
-	w.Printf("Range key sets: %s  Tombstones: %s  Total missized tombstones encountered: %s\n",
-		humanize.Count.Uint64(m.Keys.RangeKeySetsCount),
-		humanize.Count.Uint64(m.Keys.TombstoneCount),
-		humanize.Count.Uint64(m.Keys.MissizedTombstonesCount),
-	)
-
-	w.Printf("Snapshots: %d  earliest seq num: %d\n",
-		redact.Safe(m.Snapshots.Count),
-		redact.Safe(m.Snapshots.EarliestSeqNum))
-
-	w.Printf("Table iters: %d\n", redact.Safe(m.TableIters))
-	w.Printf("Filter utility: %.1f%%\n", redact.Safe(hitRate(m.Filter.Hits, m.Filter.Misses)))
-	w.Printf("Ingestions: %d  as flushable: %d (%s in %d tables)\n",
-		redact.Safe(m.Ingest.Count),
-		redact.Safe(m.Flush.AsIngestCount),
-		humanize.Bytes.Uint64(m.Flush.AsIngestBytes),
-		redact.Safe(m.Flush.AsIngestTableCount))
-
-	var inUseTotal uint64
-	for i := range m.manualMemory {
-		inUseTotal += m.manualMemory[i].InUseBytes
-	}
-	inUse := func(purpose manual.Purpose) uint64 {
-		return m.manualMemory[purpose].InUseBytes
-	}
-	w.Printf("Cgo memory usage: %s  block cache: %s (data: %s, maps: %s, entries: %s)  memtables: %s\n",
-		humanize.Bytes.Uint64(inUseTotal),
-		humanize.Bytes.Uint64(inUse(manual.BlockCacheData)+inUse(manual.BlockCacheMap)+inUse(manual.BlockCacheEntry)),
-		humanize.Bytes.Uint64(inUse(manual.BlockCacheData)),
-		humanize.Bytes.Uint64(inUse(manual.BlockCacheMap)),
-		humanize.Bytes.Uint64(inUse(manual.BlockCacheEntry)),
-		humanize.Bytes.Uint64(inUse(manual.MemTable)),
-	)
+	return ""
 }
 
 func hitRate(hits, misses int64) float64 {
 	return percent(hits, hits+misses)
 }
 
-func percent(numerator, denominator int64) float64 {
+func percent[T constraints.Integer](numerator, denominator T) float64 {
 	if denominator == 0 {
 		return 0
 	}
@@ -905,24 +951,4 @@ func (m *Metrics) updateLevelMetrics(updates levelMetricsDelta) {
 			m.Levels[i].Add(u)
 		}
 	}
-}
-
-// humanizeFloat formats a float64 value as a string. It shows up to two
-// decimals, depending on the target length. NaN is shown as "-".
-func humanizeFloat(v float64, targetLength int) redact.SafeString {
-	if math.IsNaN(v) {
-		return "-"
-	}
-	// We treat 0 specially. Values near zero will show up as 0.00.
-	if v == 0 {
-		return "0"
-	}
-	res := fmt.Sprintf("%.2f", v)
-	if len(res) <= targetLength {
-		return redact.SafeString(res)
-	}
-	if len(res) == targetLength+1 {
-		return redact.SafeString(fmt.Sprintf("%.1f", v))
-	}
-	return redact.SafeString(fmt.Sprintf("%.0f", v))
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -91,6 +91,12 @@ func exampleMetrics() Metrics {
 	m.Table.Local.ZombieSize = 30
 	m.Table.PendingStatsCollectionCount = 31
 	m.Table.InitialStatsCollectionComplete = true
+	m.Table.Garbage.PointDeletionsBytesEstimate = 1024
+	m.Table.Garbage.RangeDeletionsBytesEstimate = 2048
+	m.Table.CompressedCountMinLZ = 32
+	m.Table.CompressedCountSnappy = 33
+	m.Table.CompressedCountZstd = 34
+	m.Table.CompressedCountNone = 35
 
 	for i := range m.Levels {
 		l := &m.Levels[i]
@@ -116,6 +122,10 @@ func exampleMetrics() Metrics {
 		l.TablesFlushed = base + 11
 		l.TablesIngested = base + 12
 		l.TablesMoved = base + 13
+		l.Additional.ValueBlocksSize = base + 14
+		l.BlobBytesCompacted = base + 15
+		l.BlobBytesFlushed = base + 16
+		l.BlobBytesReadEstimate = base + 17
 		l.MultiLevel.TableBytesInTop = base + 4
 		l.MultiLevel.TableBytesIn = base + 4
 		l.MultiLevel.TableBytesRead = base + 4

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -116,37 +116,48 @@ z: (zoo, .)
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |     multilevel
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  |    top   in  read
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+------------------
-    0 |     0     0B     0B       0 |    -    0    0 |   41B |     0     0B |     0     0B |     1   784B |    0B |   0 24.0 |    0B    0B    0B
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   784B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   784B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   784B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    6 |     1   834B     0B       0 |    - 0.00 0.00 |  784B |     0     0B |     0     0B |     1   834B | 1.6KB |   1 1.21 |    0B    0B    0B
-total |     1   834B     0B       0 |    -    -    - |   41B |     0     0B |     3  2.3KB |     2  1.6KB | 1.6KB |   1 48.1 |    0B    0B    0B
-------------------------------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 30B  written: 41B (37% overhead)
-Flushes: 1
-Compactions: 4  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 2
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 834B
-Compression types: snappy: 1
-Table stats: all loaded
-Block cache: 4 entries (1.6KB)  hit rate: 70.3%
-Table cache: 2 entries (792B)  hit rate: 82.2%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 24.00
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |    946B |      1  834B |      0     0 |   112B     0B |   784B |      0    0B |   1  1.21
+total |    946B |      1  834B |      0     0 |   112B     0B |    41B |      0    0B |   1 48.07
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B  100B |      1   784B   200B
+    1 |     0     0     0 |      1  784B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      1  784B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      1  784B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  1.6KB  112B |      1   834B   112B
+total |     -     -     - |      3 2.3KB |    0B    0B    0B |  1.6KB  212B |      2  1.6KB   312B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        3        0        0        0        0        2
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              4 entries (1.6KB)   backing: 0B (0)         block cache       0 in-progress (0B)
+  30B  written: 41B         70.3% hit rate      zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (36.7% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   2 entries (792B)                              0B maps         0 problem spans
+  flushes: 1                82.2% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   1 (112B)        memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 1
+ingestions                sstable iters         values
+  total: 0                  0 open                19B total             KEYS
+  as flushable: 0 (0B)    snapshots               19B referenced        range keys
+                            0 open                100% referenced         0 sets
+                                                                        tombstones
+                                                                          0 total
 
 # Set the minimum size for a separated value to 5.
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -231,37 +231,48 @@ remove: ext/0
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |    - 0.40 0.40 |   97B |     1   750B |     0     0B |     3  2.2KB |    0B |   2 23.1
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   750B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   750B | 1.5KB |   1 0.50
-total |     3  2.2KB     0B       0 |    -    -    - |  847B |     1   750B |     0     0B |     4  3.7KB | 1.5KB |   3 4.53
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 48B  written: 97B (102% overhead)
-Flushes: 3
-Compactions: 1  estimated debt: 2.2KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 2.2KB
-Compression types: snappy: 3
-Table stats: initial load in progress
-Block cache: 2 entries (784B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 50.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 1  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |    97B |      1  750B |   2 23.10
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |    750B |      1  750B |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.50
+total |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |   847B |      1  750B |   3  4.53
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.40  0.40 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.2KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  1.5KB    0B |      1   750B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.5KB    0B |      4  3.7KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats initial load        0B tot          2.2KB estimated debt
+  1 files (0B)              2 entries (784B)     in progress            block cache       0 in-progress (0B)
+  48B  written: 97B         0.0% hit rate       backing: 0B (0)           0B tot          0 cancelled (0B)
+  (102.1% overhead)       file cache            zombie:  0B (0)           0B data         0 failed
+memtables                   0 entries (0B)               0B local         0B maps         0 problem spans
+  flushes: 3                50.0% hit rate                                0B ents
+  live:    1 (256KB)      bloom filter          BLOB FILES              memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           live:   0 (0B)            0B tot            snappy: 3
+ingestions                sstable iters         zombie: 0 (0B)
+  total: 1                  0 open              values                  KEYS
+  as flushable: 0 (0B)    snapshots               0B total              range keys
+                            0 open                0B referenced           0 sets
+                                                  0% referenced         tombstones
+                                                                          0 total
 
 # Set up a scenario where the table to be ingested overlaps with the memtable.
 # The table is ingested as a flushable. The flush metrics refect the flushed
@@ -336,37 +347,48 @@ sync: db/MANIFEST-000023
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     4  2.9KB     0B       0 |    - 0.80 0.80 |  132B |     2  1.5KB |     0     0B |     4  2.9KB |    0B |   4 22.6
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     1   750B |     0     0B |     1   750B | 1.5KB |   1 0.50
-total |     6  4.4KB     0B       0 |    -    -    - | 2.3KB |     3  2.2KB |     0     0B |     5  6.0KB | 1.5KB |   5 2.57
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 82B  written: 132B (61% overhead)
-Flushes: 6
-Compactions: 1  estimated debt: 4.4KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (512KB)  zombie: 1 (512KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 4.4KB
-Compression types: snappy: 6
-Table stats: initial load in progress
-Block cache: 6 entries (2.3KB)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 50.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 2  as flushable: 1 (1.5KB in 2 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   2.9KB |      4 2.9KB |      0     0 |     0B     0B |   132B |      2 1.5KB |   4 22.64
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      1  750B |   1  0.50
+total |   4.4KB |      6 4.4KB |      0     0 |     0B     0B |  2.3KB |      3 2.2KB |   5  2.57
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.80  0.80 |      0    0B |    0B    0B    0B |     0B    0B |      4  2.9KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  1.5KB    0B |      1   750B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.5KB    0B |      5  6.0KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats initial load        0B tot          4.4KB estimated debt
+  1 files (0B)              6 entries (2.3KB)    in progress            block cache       0 in-progress (0B)
+  82B  written: 132B        0.0% hit rate       backing: 0B (0)           0B tot          0 cancelled (0B)
+  (61.0% overhead)        file cache            zombie:  0B (0)           0B data         0 failed
+memtables                   0 entries (0B)               0B local         0B maps         0 problem spans
+  flushes: 6                50.0% hit rate                                0B ents
+  live:    1 (512KB)      bloom filter          BLOB FILES              memtables         COMPRESSION
+  zombie:  1 (512KB)        0.0% util           live:   0 (0B)            0B tot            snappy: 6
+ingestions                sstable iters         zombie: 0 (0B)
+  total: 2                  0 open              values                  KEYS
+  as flushable: 1 (1.5KB) snapshots               0B total              range keys
+                            0 open                0B referenced           0 sets
+                                                  0% referenced         tombstones
+                                                                          0 total
 
 sstables
 ----

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -31,37 +31,48 @@ L6:
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     1   569B     0B       0 |    - 0.00 0.00 |    0B |     1   569B |     0     0B |     0     0B |    0B |   1    0
-total |     1   569B     0B       0 |    -    -    - |  569B |     1   569B |     0     0B |     0   569B |    0B |   1 1.00
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
-Flushes: 0
-Compactions: 0  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 0 (0B)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 569B
-Compression types: snappy: 1
-Table stats: all loaded
-Block cache: 3 entries (1.1KB)  hit rate: 15.4%
-Table cache: 1 entries (480B)  hit rate: 50.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 1  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |    569B |      1  569B |      0     0 |     0B     0B |     0B |      1  569B |   1     0
+total |    569B |      1  569B |      0     0 |     0B     0B |   569B |      1  569B |   1  1.00
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      0   569B     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         0        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              3 entries (1.1KB)   backing: 0B (0)         block cache       0 in-progress (0B)
+  0B  written: 0B           15.4% hit rate      zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (0.0% overhead)         file cache                     0B local         0B data         0 failed
+memtables                   1 entries (480B)                              0B maps         0 problem spans
+  flushes: 0                50.0% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  0 (0B)           0.0% util           zombie: 0 (0B)            0B tot            snappy: 1
+ingestions                sstable iters         values
+  total: 1                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 total
 
 
 iter

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -1,36 +1,48 @@
 example
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |     multilevel
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  |    top   in  read
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+------------------
-    0 |   101   102B     0B     101 | 1.10 2.10 0.30 |  104B |   112   104B |   113   106B |   221   217B |  107B |   1 2.09 |  104B  104B  104B
-    1 |   201   202B     0B     201 | 1.20 2.20 0.60 |  204B |   212   204B |   213   206B |   421   417B |  207B |   2 2.04 |  204B  204B  204B
-    2 |   301   302B     0B     301 | 1.30 2.30 0.90 |  304B |   312   304B |   313   306B |   621   617B |  307B |   3 2.03 |  304B  304B  304B
-    3 |   401   402B     0B     401 | 1.40 2.40 1.20 |  404B |   412   404B |   413   406B |   821   817B |  407B |   4 2.02 |  404B  404B  404B
-    4 |   501   502B     0B     501 | 1.50 2.50 1.50 |  504B |   512   504B |   513   506B |  1.0K  1017B |  507B |   5 2.02 |  504B  504B  504B
-    5 |   601   602B     0B     601 | 1.60 2.60 1.80 |  604B |   612   604B |   613   606B |  1.2K  1.2KB |  607B |   6 2.01 |  604B  604B  604B
-    6 |   701   702B     0B     701 |    - 2.70 2.10 |  704B |   712   704B |   713   706B |  1.4K  1.4KB |  707B |   7 2.01 |  704B  704B  704B
-total |  2.8K  2.7KB     0B    2.8K |    -    -    - | 2.8KB |  2.9K  2.8KB |  2.9K  2.8KB |  5.7K  8.4KB | 2.8KB |  28 3.00 | 2.8KB 2.8KB 2.8KB
-------------------------------------------------------------------------------------------------------------------------------------------------
-WAL: 22 files (24B)  in: 25B  written: 26B (4% overhead)
-Flushes: 8
-Compactions: 5  estimated debt: 6B  in progress: 2 (7B)  canceled: 3 (3.0KB)  failed: 5  problem spans: 2
-             default: 27  delete: 28  elision: 29  move: 30  read: 31  tombstone-density: 16  rewrite: 32  copy: 33  multi-level: 34
-MemTables: 12 (11B)  zombie: 14 (13B)
-Zombie tables: 16 (15B, local: 30B)
-Backing tables: 1 (2.0MB)
-Virtual tables: 2807 (2.8KB)
-Local tables size: 28B
-Compression types:
-Table stats: 31
-Block cache: 2 entries (1B)  hit rate: 42.9%
-Table cache: 18 entries (17B)  hit rate: 48.7%
-Range key sets: 123  Tombstones: 456  Total missized tombstones encountered: 789
-Snapshots: 4  earliest seq num: 1024
-Table iters: 21
-Filter utility: 47.4%
-Ingestions: 27  as flushable: 36 (34B in 35 tables)
-Cgo memory usage: 15KB  block cache: 9.0KB (data: 4.0KB, maps: 2.0KB, entries: 3.0KB)  memtables: 5.0KB
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |    216B |    101  102B |    101   103 |   114B   114B |   104B |    112  104B |   1  4.31
+    1 |    416B |    201  202B |    201   203 |   214B   214B |   204B |    212  204B |   2  4.16
+    2 |    616B |    301  302B |    301   303 |   314B   314B |   304B |    312  304B |   3  4.11
+    3 |    816B |    401  402B |    401   403 |   414B   414B |   404B |    412  404B |   4  4.08
+    4 |   1016B |    501  502B |    501   503 |   514B   514B |   504B |    512  504B |   5  4.06
+    5 |   1.2KB |    601  602B |    601   603 |   614B   614B |   604B |    612  604B |   6  4.05
+    6 |   1.4KB |    701  702B |    701   703 |   714B   714B |   704B |    712  704B |   7  4.05
+total |   5.6KB |   2.8K 2.7KB |   2.8K  2.8K |  2.8KB  2.8KB |  2.8KB |   2.9K 2.8KB |  28  5.04
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |  1.10  2.10  0.30 |    113  106B |  104B  104B  104B |   107B  117B |    221   217B   231B
+    1 |  1.20  2.20  0.60 |    213  206B |  204B  204B  204B |   207B  217B |    421   417B   431B
+    2 |  1.30  2.30  0.90 |    313  306B |  304B  304B  304B |   307B  317B |    621   617B   631B
+    3 |  1.40  2.40  1.20 |    413  406B |  404B  404B  404B |   407B  417B |    821   817B   831B
+    4 |  1.50  2.50  1.50 |    513  506B |  504B  504B  504B |   507B  517B |   1.0K  1017B  1.0KB
+    5 |  1.60  2.60  1.80 |    613  606B |  604B  604B  604B |   607B  617B |   1.2K  1.2KB  1.2KB
+    6 |     0  2.70  2.10 |    713  706B |  704B  704B  704B |   707B  717B |   1.4K  1.4KB  1.4KB
+total |     -     -     - |   2.9K 2.8KB | 2.8KB 2.8KB 2.8KB |  2.8KB 2.9KB |   5.7K  8.4KB  5.7KB
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |        27       28       29       30       31       16       32       33       34
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats 31 pending          15KB tot        6B estimated debt
+  22 files (24B)            2 entries (1B)      backing: 2.0MB (1)      block cache       2 in-progress (7B)
+  25B  written: 26B         42.9% hit rate      zombie:  15B (16)         9.0KB tot       3 cancelled (3.0KB)
+  (4.0% overhead)         file cache                     30B local        4.0KB data      5 failed
+memtables                   18 entries (17B)                              2.0KB maps      2 problem spans !
+  flushes: 8                48.7% hit rate      BLOB FILES                3.0KB ents
+  live:    12 (11B)       bloom filter          live:   0 (0B)          memtables         GARBAGE
+  zombie:  14 (13B)         47.4% util          zombie: 0 (0B)            5.0KB tot       1.0KB point dels
+ingestions                sstable iters         values                                    2.0KB range dels
+  total: 27                 21 open               0B total              KEYS
+  as flushable: 36 (34B)  snapshots               0B referenced         range keys        COMPRESSION
+                            4 open                0% referenced           123 sets          minlz:  32
+                                                                        tombstones          snappy: 33
+                                                                          456 total         zstd:   34
+                                                                          789 missized !    none:   35
 
 init
 ----
@@ -54,38 +66,48 @@ iter-new b category=b
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   755B     0B       0 |    - 0.25 0.25 |   28B |     0     0B |     0     0B |     1   755B |    0B |   1 27.0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-total |     1   755B     0B       0 |    -    -    - |   28B |     0     0B |     0     0B |     1   783B |    0B |   1 28.0
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 17B  written: 28B (65% overhead)
-Flushes: 1
-Compactions: 0  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 755B
-Compression types: snappy: 1
-Table stats: all loaded
-Block cache: 2 entries (795B)  hit rate: 0.0%
-Table cache: 1 entries (480B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 1
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |    755B |      1  755B |      0     0 |     0B     0B |    28B |      0    0B |   1 26.96
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+total |    755B |      1  755B |      0     0 |     0B     0B |    28B |      0    0B |   1 27.96
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      1   755B     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      1   783B     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         0        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              2 entries (795B)    backing: 0B (0)         block cache       0 in-progress (0B)
+  17B  written: 28B         0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (64.7% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   1 entries (480B)                              0B maps         0 problem spans
+  flushes: 1                0.0% hit rate       BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 1
+ingestions                sstable iters         values
+  total: 0                  1 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -119,38 +141,48 @@ L6:
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.6
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
-total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.3
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
-Flushes: 2
-Compactions: 1  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 2 (512KB)
-Zombie tables: 2 (1.5KB, local: 1.5KB)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 1.5KB
-Compression types: snappy: 2
-Table stats: all loaded
-Block cache: 2 entries (795B)  hit rate: 33.3%
-Table cache: 2 entries (960B)  hit rate: 66.7%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 2
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 23.59
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  1.00
+total |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.28
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.5KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  1.5KB    0B |      2  1.5KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.5KB    0B |      4  3.0KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              2 entries (795B)    backing: 0B (0)         block cache       0 in-progress (0B)
+  34B  written: 64B         33.3% hit rate      zombie:  1.5KB (2)        0B tot          0 cancelled (0B)
+  (88.2% overhead)        file cache                     1.5KB local      0B data         0 failed
+memtables                   2 entries (960B)                              0B maps         0 problem spans
+  flushes: 2                66.7% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  2 (512KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 2
+ingestions                sstable iters         values
+  total: 0                  2 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -167,38 +199,48 @@ iter-close a
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.6
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
-total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.3
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
-Flushes: 2
-Compactions: 1  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 2 (512KB)
-Zombie tables: 2 (1.5KB, local: 1.5KB)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 1.5KB
-Compression types: snappy: 2
-Table stats: all loaded
-Block cache: 2 entries (795B)  hit rate: 33.3%
-Table cache: 2 entries (960B)  hit rate: 66.7%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 2
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 23.59
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  1.00
+total |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.28
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.5KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  1.5KB    0B |      2  1.5KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.5KB    0B |      4  3.0KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              2 entries (795B)    backing: 0B (0)         block cache       0 in-progress (0B)
+  34B  written: 64B         33.3% hit rate      zombie:  1.5KB (2)        0B tot          0 cancelled (0B)
+  (88.2% overhead)        file cache                     1.5KB local      0B data         0 failed
+memtables                   2 entries (960B)                              0B maps         0 problem spans
+  flushes: 2                66.7% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  2 (512KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 2
+ingestions                sstable iters         values
+  total: 0                  2 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -212,38 +254,48 @@ iter-close c
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.6
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
-total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.3
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
-Flushes: 2
-Compactions: 1  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 2 (512KB)
-Zombie tables: 1 (755B, local: 755B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 1.5KB
-Compression types: snappy: 2
-Table stats: all loaded
-Block cache: 2 entries (795B)  hit rate: 33.3%
-Table cache: 1 entries (480B)  hit rate: 66.7%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 1
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 23.59
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  1.00
+total |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.28
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.5KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  1.5KB    0B |      2  1.5KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.5KB    0B |      4  3.0KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              2 entries (795B)    backing: 0B (0)         block cache       0 in-progress (0B)
+  34B  written: 64B         33.3% hit rate      zombie:  755B (1)         0B tot          0 cancelled (0B)
+  (88.2% overhead)        file cache                     755B local       0B data         0 failed
+memtables                   1 entries (480B)                              0B maps         0 problem spans
+  flushes: 2                66.7% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  2 (512KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 2
+ingestions                sstable iters         values
+  total: 0                  1 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -260,38 +312,48 @@ iter-close b
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.6
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
-total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.3
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
-Flushes: 2
-Compactions: 1  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 1.5KB
-Compression types: snappy: 2
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 33.3%
-Table cache: 0 entries (0B)  hit rate: 66.7%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 23.59
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  1.00
+total |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.28
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.5KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  1.5KB    0B |      2  1.5KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.5KB    0B |      4  3.0KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  34B  written: 64B         33.3% hit rate      zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (88.2% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 2                66.7% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 2
+ingestions                sstable iters         values
+  total: 0                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -339,38 +401,48 @@ L6:
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     7  5.3KB     0B       0 |    - 0.25 0.25 |  165B |     0     0B |     0     0B |     9  6.8KB |    0B |   1 50.0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.00
-total |     9  6.8KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    11  8.4KB | 1.5KB |   2 60.2
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
-Flushes: 3
-Compactions: 1  estimated debt: 7.4KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 6.8KB
-Compression types: snappy: 9
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 33.3%
-Table cache: 0 entries (0B)  hit rate: 66.7%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   5.9KB |      7 5.3KB |      0     0 |   644B     0B |   165B |      0    0B |   1 49.96
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  1.00
+total |   7.4KB |      9 6.8KB |      0     0 |   644B     0B |   165B |      0    0B |   2 60.15
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.25  0.25 |      0    0B |    0B    0B    0B |     0B  644B |      9  6.8KB  1.3KB
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  1.5KB    0B |      2  1.5KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.5KB  644B |     11  8.4KB  1.3KB
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          7.4KB estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  116B  written: 165B       33.3% hit rate      zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (42.2% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 3                66.7% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   7 (644B)        memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 9
+ingestions                sstable iters         values
+  total: 0                  0 open                21B total             KEYS
+  as flushable: 0 (0B)    snapshots               21B referenced        range keys
+                            0 open                100% referenced         0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -403,38 +475,48 @@ L6:
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |  165B |     0     0B |     0     0B |     9  6.8KB |    0B |   0 50.0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     9  6.8KB     0B       0 |    - 0.00 0.00 | 6.8KB |     0     0B |     0     0B |     9  6.8KB | 6.8KB |   1 1.00
-total |     9  6.8KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    18   14KB | 6.8KB |   1 93.1
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
-Flushes: 3
-Compactions: 2  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 6.8KB
-Compression types: snappy: 9
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 10.0%
-Table cache: 0 entries (0B)  hit rate: 55.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 49.96
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   7.4KB |      9 6.8KB |      0     0 |   644B     0B |  6.8KB |      0    0B |   1  1.00
+total |   7.4KB |      9 6.8KB |      0     0 |   644B     0B |   165B |      0    0B |   1 93.07
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B  644B |      9  6.8KB  1.3KB
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  6.8KB  644B |      9  6.8KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  6.8KB 1.3KB |     18   14KB  1.3KB
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         2        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  116B  written: 165B       10.0% hit rate      zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (42.2% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 3                55.0% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   7 (644B)        memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 9
+ingestions                sstable iters         values
+  total: 0                  0 open                21B total             KEYS
+  as flushable: 0 (0B)    snapshots               21B referenced        range keys
+                            0 open                100% referenced         0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -518,38 +600,48 @@ L6:
 # iterator.
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     6  4.4KB     0B       0 |    - 0.50 0.50 |  211B |     3  2.2KB |     0     0B |    12  9.0KB |    0B |   2 49.8
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     9  6.8KB     0B       0 |    - 0.00 0.00 | 6.8KB |     0     0B |     0     0B |     9  6.8KB | 6.8KB |   1 1.00
-total |    15   11KB     0B       0 |    -    -    - | 2.4KB |     3  2.2KB |     0     0B |    21   18KB | 6.8KB |   3 8.02
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 176B  written: 211B (20% overhead)
-Flushes: 8
-Compactions: 2  estimated debt: 12KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 11KB
-Compression types: snappy: 15
-Table stats: all loaded
-Block cache: 6 entries (2.3KB)  hit rate: 7.3%
-Table cache: 0 entries (0B)  hit rate: 55.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 2  as flushable: 2 (2.2KB in 3 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   4.4KB |      6 4.4KB |      0     0 |     0B     0B |   211B |      3 2.2KB |   2 49.81
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   7.4KB |      9 6.8KB |      0     0 |   644B     0B |  6.8KB |      0    0B |   1  1.00
+total |    12KB |     15  11KB |      0     0 |   644B     0B |  2.4KB |      3 2.2KB |   3  8.02
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.50  0.50 |      0    0B |    0B    0B    0B |     0B  644B |     12  9.0KB  1.3KB
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  6.8KB  644B |      9  6.8KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  6.8KB 1.3KB |     21   18KB  1.3KB
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         2        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          12KB estimated debt
+  1 files (0B)              6 entries (2.3KB)   backing: 0B (0)         block cache       0 in-progress (0B)
+  176B  written: 211B       7.3% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (19.9% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 8                55.0% hit rate      BLOB FILES                0B ents
+  live:    1 (1.0MB)      bloom filter          live:   7 (644B)        memtables         COMPRESSION
+  zombie:  1 (1.0MB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 15
+ingestions                sstable iters         values
+  total: 2                  0 open                21B total             KEYS
+  as flushable: 2 (2.2KB) snapshots               21B referenced        range keys
+                            0 open                100% referenced         0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -595,38 +687,48 @@ L6:
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |    13  9.6KB     0B       0 |    - 0.50 0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 57.0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     9  6.8KB     0B       0 |    - 0.00 0.00 | 6.8KB |     0     0B |     0     0B |     9  6.8KB | 6.8KB |   1 1.00
-total |    22   16KB     0B       0 |    -    -    - | 2.5KB |     3  2.2KB |     0     0B |    28   23KB | 6.8KB |   3 9.91
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
-Flushes: 9
-Compactions: 2  estimated debt: 17KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 16KB
-Compression types: snappy: 22
-Table stats: all loaded
-Block cache: 6 entries (2.3KB)  hit rate: 7.3%
-Table cache: 0 entries (0B)  hit rate: 55.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 2  as flushable: 2 (2.2KB in 3 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   9.6KB |     13 9.6KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 57.02
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   7.4KB |      9 6.8KB |      0     0 |   644B     0B |  6.8KB |      0    0B |   1  1.00
+total |    17KB |     22  16KB |      0     0 |   644B     0B |  2.5KB |      3 2.2KB |   3  9.91
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.50  0.50 |      0    0B |    0B    0B    0B |     0B  644B |     19   14KB  1.3KB
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  6.8KB  644B |      9  6.8KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  6.8KB 1.3KB |     28   23KB  1.3KB
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         2        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          17KB estimated debt
+  1 files (0B)              6 entries (2.3KB)   backing: 0B (0)         block cache       0 in-progress (0B)
+  223B  written: 277B       7.3% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (24.2% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 9                55.0% hit rate      BLOB FILES                0B ents
+  live:    1 (1.0MB)      bloom filter          live:   7 (644B)        memtables         COMPRESSION
+  zombie:  1 (1.0MB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 22
+ingestions                sstable iters         values
+  total: 2                  0 open                21B total             KEYS
+  as flushable: 2 (2.2KB) snapshots               21B referenced        range keys
+                            0 open                100% referenced         0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -684,38 +786,48 @@ virtual-size
 
 metrics zero-cache-hits-misses
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |    11  8.1KB     0B       0 |    - 0.50 0.50 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   2 57.0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |    10  7.5KB     0B       0 |    - 0.00 0.00 | 6.8KB |     1   758B |     0     0B |     9  6.8KB | 6.8KB |   1 1.00
-total |    21   16KB     0B       0 |    -    -    - | 3.2KB |     4  3.0KB |     0     0B |    28   24KB | 6.8KB |   3 7.87
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
-Flushes: 9
-Compactions: 2  estimated debt: 16KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 16KB
-Compression types: snappy: 21
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 3  as flushable: 2 (2.2KB in 3 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   8.1KB |     11 8.1KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 57.02
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   8.2KB |     10 7.5KB |      0     0 |   644B     0B |  6.8KB |      1  758B |   1  1.00
+total |    16KB |     21  16KB |      0     0 |   644B     0B |  3.2KB |      4 3.0KB |   3  7.87
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.50  0.50 |      0    0B |    0B    0B    0B |     0B  644B |     19   14KB  1.3KB
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  6.8KB  644B |      9  6.8KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  6.8KB 1.3KB |     28   24KB  1.3KB
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         2        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          16KB estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  223B  written: 277B       0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (24.2% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 9                0.0% hit rate       BLOB FILES                0B ents
+  live:    1 (1.0MB)      bloom filter          live:   7 (644B)        memtables         COMPRESSION
+  zombie:  1 (1.0MB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 21
+ingestions                sstable iters         values
+  total: 3                  0 open                21B total             KEYS
+  as flushable: 2 (2.2KB) snapshots               21B referenced        range keys
+                            0 open                100% referenced         0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -809,38 +921,48 @@ virtual-size
 
 metrics zero-cache-hits-misses
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |  277B |     3  2.2KB |     0     0B |    19   14KB |    0B |   0 57.0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |    18   13KB     0B       0 |    - 0.00 0.00 |  14KB |     2  1.5KB |     0     0B |    16   12KB |  14KB |   1 0.84
-total |    18   13KB     0B       0 |    -    -    - | 4.0KB |     5  3.7KB |     0     0B |    35   30KB |  14KB |   1 7.91
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
-Flushes: 9
-Compactions: 3  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 3  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 13KB
-Compression types: snappy: 18
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 4  as flushable: 2 (2.2KB in 3 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |   277B |      3 2.2KB |   0 57.02
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |    14KB |     18  13KB |      0     0 |   644B     0B |   14KB |      2 1.5KB |   1  0.84
+total |    14KB |     18  13KB |      0     0 |   644B     0B |  4.0KB |      5 3.7KB |   1  7.91
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B  644B |     19   14KB  1.3KB
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |   14KB  644B |     16   12KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   14KB 1.3KB |     35   30KB  1.3KB
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         3        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  223B  written: 277B       0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (24.2% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 9                0.0% hit rate       BLOB FILES                0B ents
+  live:    1 (1.0MB)      bloom filter          live:   7 (644B)        memtables         COMPRESSION
+  zombie:  1 (1.0MB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 18
+ingestions                sstable iters         values
+  total: 4                  0 open                21B total             KEYS
+  as flushable: 2 (2.2KB) snapshots               21B referenced        range keys
+                            0 open                100% referenced         0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:2235 BlockBytesInCache:457 BlockReadDuration:150ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
@@ -867,38 +989,48 @@ L0.0:
 # One local table.
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     3  2.2KB     0B       0 |    - 0.25 0.25 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 59.6
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-total |     3  2.2KB     0B       0 |    -    -    - |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 60.6
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
-Flushes: 1
-Compactions: 0  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 2.2KB
-Compression types: snappy: 3
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |    38B |      0    0B |   1 59.61
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+total |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |    38B |      0    0B |   1 60.61
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.2KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      3  2.2KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         0        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  27B  written: 38B         0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (40.7% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 1                0.0% hit rate       BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 3
+ingestions                sstable iters         values
+  total: 0                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
 
 compact a-z
@@ -911,38 +1043,48 @@ L6:
 # Table becomes shared, so local table size becomes 0.
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   0 59.6
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.00
-total |     3  2.2KB     0B       0 |    -    -    - |   38B |     0     0B |     0     0B |     6  4.5KB | 2.2KB |   1  120
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
-Flushes: 1
-Compactions: 1  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 0B
-Compression types: snappy: 3
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 50.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |    38B |      0    0B |   0 59.61
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.2KB |      0    0B |   1  1.00
+total |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |    38B |      0    0B |   1 120.4
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.2KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  2.2KB    0B |      3  2.2KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |      6  4.5KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  27B  written: 38B         0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (40.7% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 1                50.0% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 3
+ingestions                sstable iters         values
+  total: 0                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
 
 build ext1.sst
@@ -971,38 +1113,48 @@ L6:
 # Ingest is also shared table, so local table size stays 0.
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   758B     0B       0 |    - 0.25 0.25 |   38B |     1   758B |     0     0B |     3  2.2KB |    0B |   1 59.6
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.00
-total |     4  3.0KB     0B       0 |    -    -    - |  796B |     1   758B |     0     0B |     6  5.2KB | 2.2KB |   2 6.70
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
-Flushes: 1
-Compactions: 1  estimated debt: 3.0KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 0B
-Compression types: snappy: 4
-Table stats: all loaded
-Block cache: 2 entries (787B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 50.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 1  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |    758B |      1  758B |      0     0 |     0B     0B |    38B |      1  758B |   1 59.61
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.2KB |      0    0B |   1  1.00
+total |   3.0KB |      4 3.0KB |      0     0 |     0B     0B |   796B |      1  758B |   2  6.70
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.2KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  2.2KB    0B |      3  2.2KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |      6  5.2KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          3.0KB estimated debt
+  1 files (0B)              2 entries (787B)    backing: 0B (0)         block cache       0 in-progress (0B)
+  27B  written: 38B         0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (40.7% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 1                50.0% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 4
+ingestions                sstable iters         values
+  total: 1                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
 
 batch
@@ -1023,38 +1175,48 @@ L6:
 # Local table size increases due to flush.
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |    - 0.50 0.50 |   74B |     1   758B |     0     0B |     4  2.9KB |    0B |   2 40.8
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.00
-total |     5  3.7KB     0B       0 |    -    -    - |  832B |     1   758B |     0     0B |     7  6.0KB | 2.2KB |   3 7.36
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 44B  written: 74B (68% overhead)
-Flushes: 2
-Compactions: 1  estimated debt: 3.7KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 755B
-Compression types: snappy: 5
-Table stats: all loaded
-Block cache: 2 entries (787B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 50.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 1  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |    74B |      1  758B |   2 40.81
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.2KB |      0    0B |   1  1.00
+total |   3.7KB |      5 3.7KB |      0     0 |     0B     0B |   832B |      1  758B |   3  7.36
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |      4  2.9KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  2.2KB    0B |      3  2.2KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |      7  6.0KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          3.7KB estimated debt
+  1 files (0B)              2 entries (787B)    backing: 0B (0)         block cache       0 in-progress (0B)
+  44B  written: 74B         0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (68.2% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 2                50.0% hit rate      BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 5
+ingestions                sstable iters         values
+  total: 1                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
 
 # Reopen DB, to ensure stats are consistent. Also, reopened DB is not
@@ -1064,38 +1226,48 @@ init reopen
 
 metrics zero-cache-hits-misses
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |    - 0.50 0.50 |    0B |     0     0B |     0     0B |     0     0B |    0B |   2    0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 |    0B |     0     0B |     0     0B |     0     0B |    0B |   1    0
-total |     5  3.7KB     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     0     0B |    0B |   3    0
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
-Flushes: 1
-Compactions: 0  estimated debt: 3.7KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (512KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 755B
-Compression types: snappy: 5
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |     0B |      0    0B |   2     0
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+total |   3.7KB |      5 3.7KB |      0     0 |     0B     0B |     0B |      0    0B |   3     0
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         0        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          3.7KB estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  0B  written: 0B           0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (0.0% overhead)         file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 1                0.0% hit rate       BLOB FILES                0B ents
+  live:    1 (512KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 5
+ingestions                sstable iters         values
+  total: 0                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
 
 compact a-z
@@ -1108,38 +1280,48 @@ L6:
 # All tables are local after compaction.
 metrics zero-cache-hits-misses
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   758B | 2.2KB |   1 0.50
-total |     3  2.2KB     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     1   758B | 2.2KB |   1    0
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
-Flushes: 1
-Compactions: 1  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (512KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 758B
-Compression types: snappy: 3
-Table stats: all loaded
-Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.50
+total |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      0    0B |    0B    0B    0B |  2.2KB    0B |      1   758B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |      1   758B     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         1        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          0B estimated debt
+  1 files (0B)              0 entries (0B)      backing: 0B (0)         block cache       0 in-progress (0B)
+  0B  written: 0B           0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (0.0% overhead)         file cache                     0B local         0B data         0 failed
+memtables                   0 entries (0B)                                0B maps         0 problem spans
+  flushes: 1                0.0% hit rate       BLOB FILES                0B ents
+  live:    1 (512KB)      bloom filter          live:   0 (0B)          memtables         COMPRESSION
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot            snappy: 3
+ingestions                sstable iters         values
+  total: 0                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys
+                            0 open                0% referenced           0 sets
+                                                                        tombstones
+                                                                          0 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:342 BlockBytesInCache:0 BlockReadDuration:30ms}
 
 init
@@ -1190,39 +1372,48 @@ L6:
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |    - 0.25 0.25 |  106B |     0     0B |     0     0B |     5  3.7KB |    0B |   1 35.9
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 |    0B |     0     0B |     3  2.2KB |     0     0B |    0B |   1    0
-total |     5  3.7KB     0B       0 |    -    -    - |  106B |     0     0B |     3  2.2KB |     5  3.8KB |    0B |   2 36.9
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 57B  written: 106B (86% overhead)
-Flushes: 3
-Compactions: 3  estimated debt: 3.7KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 0  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 3.7KB
-Compression types: snappy: 5
-Garbage: point-deletions 502B range-deletions 1.5KB
-Table stats: all loaded
-Block cache: 2 entries (774B)  hit rate: 0.0%
-Table cache: 2 entries (960B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 3  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |   106B |      0    0B |   1 35.92
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+total |   3.7KB |      5 3.7KB |      0     0 |     0B     0B |   106B |      0    0B |   2 36.92
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      5  3.7KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      3 2.2KB |    0B    0B    0B |     0B    0B |      0     0B     0B
+total |     -     -     - |      3 2.2KB |    0B    0B    0B |     0B    0B |      5  3.8KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         0        0        0        3        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          3.7KB estimated debt
+  1 files (0B)              2 entries (774B)    backing: 0B (0)         block cache       0 in-progress (0B)
+  57B  written: 106B        0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (86.0% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   2 entries (960B)                              0B maps         0 problem spans
+  flushes: 3                0.0% hit rate       BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         GARBAGE
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot          502B point dels
+ingestions                sstable iters         values                                    1.5KB range dels
+  total: 0                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys        COMPRESSION
+                            0 open                0% referenced           0 sets            snappy: 5
+                                                                        tombstones
+                                                                          3 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
 
 problem-spans
@@ -1232,37 +1423,46 @@ L6 [u, v]
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     2  1.5KB     0B       0 |    - 0.25 0.25 |  106B |     0     0B |     0     0B |     5  3.7KB |    0B |   1 35.9
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 |    0B |     0     0B |     3  2.2KB |     0     0B |    0B |   1    0
-total |     5  3.7KB     0B       0 |    -    -    - |  106B |     0     0B |     3  2.2KB |     5  3.8KB |    0B |   2 36.9
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 57B  written: 106B (86% overhead)
-Flushes: 3
-Compactions: 3  estimated debt: 3.7KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 2
-             default: 0  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 1 (256KB)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 3.7KB
-Compression types: snappy: 5
-Garbage: point-deletions 502B range-deletions 1.5KB
-Table stats: all loaded
-Block cache: 2 entries (774B)  hit rate: 0.0%
-Table cache: 2 entries (960B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 3  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
-Iter category stats:
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |   1.5KB |      2 1.5KB |      0     0 |     0B     0B |   106B |      0    0B |   1 35.92
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |   2.2KB |      3 2.2KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+total |   3.7KB |      5 3.7KB |      0     0 |     0B     0B |   106B |      0    0B |   2 36.92
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      5  3.7KB     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0  0.00  0.00 |      3 2.2KB |    0B    0B    0B |     0B    0B |      0     0B     0B
+total |     -     -     - |      3 2.2KB |    0B    0B    0B |     0B    0B |      5  3.8KB     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         0        0        0        3        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats all loaded          0B tot          3.7KB estimated debt
+  1 files (0B)              2 entries (774B)    backing: 0B (0)         block cache       0 in-progress (0B)
+  57B  written: 106B        0.0% hit rate       zombie:  0B (0)           0B tot          0 cancelled (0B)
+  (86.0% overhead)        file cache                     0B local         0B data         0 failed
+memtables                   2 entries (960B)                              0B maps         2 problem spans !
+  flushes: 3                0.0% hit rate       BLOB FILES                0B ents
+  live:    1 (256KB)      bloom filter          live:   0 (0B)          memtables         GARBAGE
+  zombie:  1 (256KB)        0.0% util           zombie: 0 (0B)            0B tot          502B point dels
+ingestions                sstable iters         values                                    1.5KB range dels
+  total: 0                  0 open                0B total              KEYS
+  as flushable: 0 (0B)    snapshots               0B referenced         range keys        COMPRESSION
+                            0 open                0% referenced           0 sets            snappy: 5
+                                                                        tombstones
+                                                                          3 totalIter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}

--- a/tool/db.go
+++ b/tool/db.go
@@ -528,6 +528,8 @@ func (d *dbT) runGet(cmd *cobra.Command, args []string) {
 	}
 }
 
+var renderMetrics func(*pebble.Metrics) string = (*pebble.Metrics).String
+
 func (d *dbT) runLSM(cmd *cobra.Command, args []string) {
 	stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 	db, err := d.openDB(args[0])
@@ -537,7 +539,7 @@ func (d *dbT) runLSM(cmd *cobra.Command, args []string) {
 	}
 	defer d.closeDB(stderr, db)
 
-	fmt.Fprintf(stdout, "%s", db.Metrics())
+	fmt.Fprintf(stdout, "%s", renderMetrics(db.Metrics()))
 	if d.lsmURL {
 		fmt.Fprintf(stdout, "\nLSM viewer: %s\n", db.LSMViewURL())
 	}

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -10,74 +10,92 @@ error opening database at "non-existent": pebble: database "non-existent" does n
 db lsm
 ../testdata/db-stage-4
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   709B     0B       0 |    - 0.50 0.50 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-total |     1   709B     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 0 files (0B)  in: 0B  written: 0B (0% overhead)
-Flushes: 0
-Compactions: 0  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 0 (0B)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 709B
-Compression types: unknown: 1
-Table stats: <redacted>
-Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: <redacted>
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |    709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+total |    709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         0        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats initial load        0B tot          0B estimated debt
+  0 files (0B)              0 entries (0B)       in progress            block cache       0 in-progress (0B)
+  0B  written: 0B           0.0% hit rate       backing: 0B (0)           0B tot          0 cancelled (0B)
+  (0.0% overhead)         file cache            zombie:  0B (0)           0B data         0 failed
+memtables                   0 entries (0B)               0B local         0B maps         0 problem spans
+  flushes: 0                0.0% hit rate                                 0B ents
+  live:    1 (256KB)      bloom filter          BLOB FILES              memtables         COMPRESSION
+  zombie:  0 (0B)           0.0% util           live:   0 (0B)            0B tot            ???:    1
+ingestions                sstable iters         zombie: 0 (0B)
+  total: 0                  0 open              values                  KEYS
+  as flushable: 0 (0B)    snapshots               0B total              range keys
+                            0 open                0B referenced           0 sets
+                                                  0% referenced         tombstones
+                                                                          0 total
 
 db lsm --url
 ../testdata/db-stage-4
 ----
-----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     1   709B     0B       0 |    - 0.50 0.50 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-total |     1   709B     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-----------------------------------------------------------------------------------------------------------------------------
-WAL: 0 files (0B)  in: 0B  written: 0B (0% overhead)
-Flushes: 0
-Compactions: 0  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 0  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0
-MemTables: 1 (256KB)  zombie: 0 (0B)
-Zombie tables: 0 (0B, local: 0B)
-Backing tables: 0 (0B)
-Virtual tables: 0 (0B)
-Local tables size: 709B
-Compression types: unknown: 1
-Table stats: <redacted>
-Block cache: 0 entries (0B)  hit rate: 0.0%
-Table cache: 0 entries (0B)  hit rate: 0.0%
-Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
-Snapshots: 0  earliest seq num: 0
-Table iters: 0
-Filter utility: 0.0%
-Ingestions: 0  as flushable: 0 (0B in 0 tables)
-Cgo memory usage: <redacted>
-
+LSM   |                        |    virtual   |   value sep   |        |   ingested   |    amp
+level | aggsize | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+------+---------+--------------+--------------+---------------+--------+--------------+----------
+    0 |    709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    1 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    2 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    3 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    4 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    5 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+    6 |      0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+total |    709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+-------------------------------------------------------------------------------------------------
+COMPACTIONS               |     moved    |     multilevel    |     read     |       written
+level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
+------+-------------------+--------------+-------------------+--------------+---------------------
+    0 |     0  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    1 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     0     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
+--------------------------------------------------------------------------------------------------
+kind      |   default   delete  elision     move     read     tomb  rewrite     copy    multi
+count     |         0        0        0        0        0        0        0        0        0
+--------------------------------------------------------------------------------------------------
+COMMIT PIPELINE           ITERATORS             TABLES                  CGO MEMORY        COMPACTIONS
+wals                      block cache           stats initial load        0B tot          0B estimated debt
+  0 files (0B)              0 entries (0B)       in progress            block cache       0 in-progress (0B)
+  0B  written: 0B           0.0% hit rate       backing: 0B (0)           0B tot          0 cancelled (0B)
+  (0.0% overhead)         file cache            zombie:  0B (0)           0B data         0 failed
+memtables                   0 entries (0B)               0B local         0B maps         0 problem spans
+  flushes: 0                0.0% hit rate                                 0B ents
+  live:    1 (256KB)      bloom filter          BLOB FILES              memtables         COMPRESSION
+  zombie:  0 (0B)           0.0% util           live:   0 (0B)            0B tot            ???:    1
+ingestions                sstable iters         zombie: 0 (0B)
+  total: 0                  0 open              values                  KEYS
+  as flushable: 0 (0B)    snapshots               0B total              range keys
+                            0 open                0B referenced           0 sets
+                                                  0% referenced         tombstones
+                                                                          0 total
 LSM viewer: https://raduberinde.github.io/lsmview/decode.html#eJyE0EFLw0AQBeC7v2J4uU5lN42W7lHsrTe9SSgTOi2hm13NRqGV_HdJCaUWMXvaxzfMwPuG1y_1Ce5t_G6CNAqHtbk3YHRSeR1ZKvVwKMBI9UnhFmbJSI14r6nbHPQIZxhe2v0lW8ZWO6nPJ2CGVziqpM1swc-rNc1oF2Nm5_yyeh0XO1qY5dMQ9CN8NsmRzWlGdjj8HuvQpf820JWN8ZTZ_KI3wyFSK2GvtB1qKPuy59sm7HUPf3g-4fMJLyb8YcIff3vJOOjx3HclLRi7GFH2dz8BAAD__2dulBM=
-----
-----


### PR DESCRIPTION
Reformat the string outputted by Metrics.String to add more organization, and
add the value separation related metrics to the string's output.

Informs https://github.com/cockroachdb/pebble/issues/4581.