### PR TITLE
pebble: use ReadPropertiesBlock when accessing reader props

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1349,11 +1349,15 @@ func runSSTablePropertiesCmd(t *testing.T, td *datadriven.TestData, d *DB) strin
 	}
 	defer r.Close()
 
-	props := r.Properties.String()
+	loadedProps, err := r.ReadPropertiesBlock(context.Background(), nil /* buffer pool */)
+	if err != nil {
+		return err.Error()
+	}
+	props := loadedProps.String()
 	env := sstable.ReadEnv{}
 	if m != nil && m.Virtual {
 		env.Virtual = m.VirtualParams
-		scaledProps := r.Properties.GetScaledProperties(m.TableBacking.Size, m.Size)
+		scaledProps := loadedProps.GetScaledProperties(m.TableBacking.Size, m.Size)
 		props = scaledProps.String()
 	}
 	if len(td.Input) == 0 {

--- a/db.go
+++ b/db.go
@@ -1789,6 +1789,8 @@ func (d *DB) Close() error {
 		err = firstError(err, errors.Errorf("non-zero zombie blob count: %d", zblobs))
 	}
 
+	err = firstError(err, d.fileCache.Close())
+
 	err = firstError(err, d.objProvider.Close())
 
 	// If the options include a closer to 'close' the filesystem, close it.
@@ -1800,8 +1802,6 @@ func (d *DB) Close() error {
 	if v := d.mu.snapshots.count(); v > 0 {
 		err = firstError(err, errors.Errorf("leaked snapshots: %d open snapshots on DB %p", v, d))
 	}
-
-	err = firstError(err, d.fileCache.Close())
 
 	return err
 }

--- a/file_cache.go
+++ b/file_cache.go
@@ -946,7 +946,11 @@ func (h *fileCacheHandle) getTableProperties(file *tableMetadata) (*sstable.Prop
 	defer v.Unref()
 
 	r := v.Value().mustSSTableReader()
-	return &r.Properties, nil
+	props, err := r.ReadPropertiesBlock(context.TODO(), nil /* buffer pool */)
+	if err != nil {
+		return nil, err
+	}
+	return &props, nil
 }
 
 type fileCacheValue struct {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -65,7 +65,6 @@ type Reader struct {
 	metaindexBH  block.Handle
 	footerBH     block.Handle
 
-	Properties     Properties
 	tableFormat    TableFormat
 	Attributes     Attributes
 	UserProperties map[string]string
@@ -958,7 +957,6 @@ func NewReader(ctx context.Context, f objstorage.Readable, o ReaderOptions) (*Re
 		r.err = err
 		return nil, err
 	}
-	r.Properties = props
 	r.UserProperties = props.UserProperties
 
 	// Set which attributes are in use based on property values.

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -140,7 +140,7 @@ Local tables size: 834B
 Compression types: snappy: 1
 Table stats: all loaded
 Block cache: 4 entries (1.6KB)  hit rate: 70.3%
-Table cache: 2 entries (1.1KB)  hit rate: 82.2%
+Table cache: 2 entries (792B)  hit rate: 82.2%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -209,6 +209,7 @@ open: ext/0
 read-at(689, 61): ext/0
 read-at(639, 50): ext/0
 read-at(122, 517): ext/0
+read-at(122, 517): ext/0
 read-at(81, 41): ext/0
 read-at(0, 81): ext/0
 close: ext/0
@@ -273,12 +274,14 @@ open: ext/a
 read-at(689, 61): ext/a
 read-at(639, 50): ext/a
 read-at(122, 517): ext/a
+read-at(122, 517): ext/a
 read-at(81, 41): ext/a
 read-at(0, 81): ext/a
 close: ext/a
 open: ext/b
 read-at(689, 61): ext/b
 read-at(639, 50): ext/b
+read-at(122, 517): ext/b
 read-at(122, 517): ext/b
 read-at(81, 41): ext/b
 read-at(0, 81): ext/b

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -54,8 +54,8 @@ Virtual tables: 0 (0B)
 Local tables size: 569B
 Compression types: snappy: 1
 Table stats: all loaded
-Block cache: 3 entries (1.1KB)  hit rate: 18.2%
-Table cache: 1 entries (840B)  hit rate: 50.0%
+Block cache: 3 entries (1.1KB)  hit rate: 15.4%
+Table cache: 1 entries (480B)  hit rate: 50.0%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -78,7 +78,7 @@ Local tables size: 755B
 Compression types: snappy: 1
 Table stats: all loaded
 Block cache: 2 entries (795B)  hit rate: 0.0%
-Table cache: 1 entries (840B)  hit rate: 0.0%
+Table cache: 1 entries (480B)  hit rate: 0.0%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -143,7 +143,7 @@ Local tables size: 1.5KB
 Compression types: snappy: 2
 Table stats: all loaded
 Block cache: 2 entries (795B)  hit rate: 33.3%
-Table cache: 2 entries (1.6KB)  hit rate: 66.7%
+Table cache: 2 entries (960B)  hit rate: 66.7%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
@@ -191,7 +191,7 @@ Local tables size: 1.5KB
 Compression types: snappy: 2
 Table stats: all loaded
 Block cache: 2 entries (795B)  hit rate: 33.3%
-Table cache: 2 entries (1.6KB)  hit rate: 66.7%
+Table cache: 2 entries (960B)  hit rate: 66.7%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 2
@@ -236,7 +236,7 @@ Local tables size: 1.5KB
 Compression types: snappy: 2
 Table stats: all loaded
 Block cache: 2 entries (795B)  hit rate: 33.3%
-Table cache: 1 entries (840B)  hit rate: 66.7%
+Table cache: 1 entries (480B)  hit rate: 66.7%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 1
@@ -541,7 +541,7 @@ Virtual tables: 0 (0B)
 Local tables size: 11KB
 Compression types: snappy: 15
 Table stats: all loaded
-Block cache: 6 entries (2.3KB)  hit rate: 7.7%
+Block cache: 6 entries (2.3KB)  hit rate: 7.3%
 Table cache: 0 entries (0B)  hit rate: 55.0%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
@@ -618,7 +618,7 @@ Virtual tables: 0 (0B)
 Local tables size: 16KB
 Compression types: snappy: 22
 Table stats: all loaded
-Block cache: 6 entries (2.3KB)  hit rate: 7.7%
+Block cache: 6 entries (2.3KB)  hit rate: 7.3%
 Table cache: 0 entries (0B)  hit rate: 55.0%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
@@ -1215,7 +1215,7 @@ Compression types: snappy: 5
 Garbage: point-deletions 502B range-deletions 1.5KB
 Table stats: all loaded
 Block cache: 2 entries (774B)  hit rate: 0.0%
-Table cache: 2 entries (1.6KB)  hit rate: 0.0%
+Table cache: 2 entries (960B)  hit rate: 0.0%
 Range key sets: 0  Tombstones: 3  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 0
@@ -1257,7 +1257,7 @@ Compression types: snappy: 5
 Garbage: point-deletions 502B range-deletions 1.5KB
 Table stats: all loaded
 Block cache: 2 entries (774B)  hit rate: 0.0%
-Table cache: 2 entries (1.6KB)  hit rate: 0.0%
+Table cache: 2 entries (960B)  hit rate: 0.0%
 Range key sets: 0  Tombstones: 3  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 0


### PR DESCRIPTION
### pebble: close file cache before closing the objstorage provider

It seems that during close, the file cache may attempt to access structures
managed by the objstroage provider during the eviction process, such as sending
to channels used for tracing events. We should close the file cache before the
obj storage provider.

----------------------------------

### pebble: use ReadPropertiesBlock when accessing reader props

Remove remaining reads of `Properites` on the reader struct. This commit also
removes the Properties field from the reader.

Closes: https://github.com/cockroachdb/pebble/issues/4383


----------
Previous: https://github.com/cockroachdb/pebble/pull/4773