### PR TITLE
metamorphic: fix shared and external directories, fix testing of multiple instances

### DIFF
--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -2134,6 +2134,10 @@ func (r *replicateOp) run(t *Test, h historyRecorder) {
 	// Shared replication only works if shared storage is enabled and value
 	// separation is disabled.
 	useSharedIngest := t.testOpts.useSharedReplicate && t.testOpts.sharedStorageEnabled &&
+		// TODO(radu): allow shared ingest with value separation. We automatically
+		// disable value separation when the output is on shared storage, so it
+		// should work. We curently get a crash in ScanInternal in this combination
+		// which we need to root cause.
 		!t.testOpts.Opts.Experimental.ValueSeparationPolicy().Enabled
 	useExternalIngest := t.testOpts.useExternalReplicate && t.testOpts.externalStorageEnabled
 

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -66,6 +66,10 @@ func parseOptions(
 			return pebble.KeySchema{}, errors.Newf("unknown key schema %q", name)
 		},
 		SkipUnknown: func(name, value string) bool {
+			if strings.EqualFold(value, "false") {
+				// TODO(radu): audit all settings and use ParseBool wherever necessary.
+				panic(fmt.Sprintf("%s: boolean options can only be set to true", name))
+			}
 			switch name {
 			case "TestOptions":
 				return true
@@ -628,7 +632,6 @@ func standardOptions(kf KeyFormat) []*TestOptions {
 [TestOptions]
   shared_storage_enabled=true
   external_storage_enabled=true
-  secondary_cache_enabled=false
 `, pebble.FormatSyntheticPrefixSuffix),
 		29: `
 [TestOptions]

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -11,6 +11,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -109,24 +110,11 @@ func TestOptionsRoundtrip(t *testing.T) {
 
 		// In some options, the closure obscures the underlying value. Check
 		// that the return values are equal.
-		require.Equal(t, o.Opts.Experimental.EnableValueBlocks == nil, parsed.Opts.Experimental.EnableValueBlocks == nil)
-		if o.Opts.Experimental.EnableValueBlocks != nil {
-			require.Equal(t, o.Opts.Experimental.EnableValueBlocks(), parsed.Opts.Experimental.EnableValueBlocks())
-		}
-		require.Equal(t, o.Opts.Experimental.DisableIngestAsFlushable == nil, parsed.Opts.Experimental.DisableIngestAsFlushable == nil)
-		if o.Opts.Experimental.DisableIngestAsFlushable != nil {
-			require.Equal(t, o.Opts.Experimental.DisableIngestAsFlushable(), parsed.Opts.Experimental.DisableIngestAsFlushable())
-		}
-		if o.Opts.Experimental.IngestSplit != nil && o.Opts.Experimental.IngestSplit() {
-			require.Equal(t, o.Opts.Experimental.IngestSplit(), parsed.Opts.Experimental.IngestSplit())
-		}
-
-		require.Equal(t, o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency == nil,
-			parsed.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency == nil)
-		if o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency != nil {
-			require.InDelta(t, o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency(),
-				parsed.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency(), 1e-5)
-		}
+		expectEqualFn(t, o.Opts.Experimental.EnableValueBlocks, parsed.Opts.Experimental.EnableValueBlocks)
+		expectEqualFn(t, o.Opts.Experimental.DisableIngestAsFlushable, parsed.Opts.Experimental.DisableIngestAsFlushable)
+		expectEqualFn(t, o.Opts.Experimental.IngestSplit, parsed.Opts.Experimental.IngestSplit)
+		expectEqualFn(t, o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency, parsed.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency)
+		expectEqualFn(t, o.Opts.Experimental.ValueSeparationPolicy, parsed.Opts.Experimental.ValueSeparationPolicy)
 
 		expBaseline, expUpper := o.Opts.CompactionConcurrencyRange()
 		parsedBaseline, parsedUpper := parsed.Opts.CompactionConcurrencyRange()
@@ -165,6 +153,23 @@ func TestOptionsRoundtrip(t *testing.T) {
 			o := RandomOptions(rng, TestkeysKeyFormat, nil)
 			checkOptions(t, o)
 		})
+	}
+}
+
+// expectEqualFn verifies that both expected and actual are nil, or they are
+// both non-nil and return equal values.
+func expectEqualFn[T any](t *testing.T, expected func() T, actual func() T) {
+	t.Helper()
+	if expected == nil {
+		require.Nil(t, actual)
+	} else {
+		require.NotNil(t, actual)
+		var zeroT T
+		if reflect.TypeOf(zeroT) == reflect.TypeOf(float64(0)) {
+			require.InDelta(t, expected(), actual(), 1e-5)
+		} else {
+			require.Equal(t, expected(), actual())
+		}
 	}
 }
 

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -188,7 +188,7 @@ func (t *Test) init(
 		}
 		var db *pebble.DB
 		err := t.withRetries(func() error {
-			opts := t.finalizeOptions(dir)
+			opts := t.finalizeOptions()
 			// If shared storage is enabled, we want to set up the CreatorID. We could
 			// call db.SetCreatorID() after Open() but this is fragile in the case
 			// where we are using an existing store (via --initial-state) which did
@@ -196,6 +196,9 @@ func (t *Test) init(
 			// during Open() can fail to create shared objects (leading to background
 			// errors which fail the metamorphic test).
 			if t.testOpts.sharedStorageEnabled {
+				if err := t.opts.FS.MkdirAll(dir, 0755); err != nil {
+					return err
+				}
 				providerSettings := opts.MakeObjStorageProviderSettings(dir)
 				objProvider, err := objstorageprovider.Open(providerSettings)
 				if err != nil {
@@ -259,14 +262,15 @@ func (t *Test) init(
 //
 // It initializes t.externalStorage and creates the compaction scheduler and
 // remote storage factory.
-func (t *Test) finalizeOptions(dataDir string) pebble.Options {
+func (t *Test) finalizeOptions() pebble.Options {
 	o := *t.opts
 	// Give each DB its own CompactionScheduler.
 	o.Experimental.CompactionScheduler =
 		pebble.NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 
-	// Set up external/shared storage.
-	externalDir := o.FS.PathJoin(dataDir, "external")
+	// Set up external/shared storage. These directories are created inside the
+	// test's data dir and can be shared among multiple dbs.
+	externalDir := o.FS.PathJoin(t.dir, "external")
 	if err := o.FS.MkdirAll(externalDir, 0755); err != nil {
 		panic(fmt.Sprintf("failed to create directory %q: %s", externalDir, err))
 	}
@@ -279,7 +283,7 @@ func (t *Test) finalizeOptions(dataDir string) pebble.Options {
 	// existing store might use shared or external storage, so we set them up
 	// unconditionally.
 	if t.testOpts.sharedStorageEnabled || t.testOpts.initialStatePath != "" {
-		sharedDir := o.FS.PathJoin(dataDir, "shared")
+		sharedDir := o.FS.PathJoin(t.dir, "shared")
 		if err := o.FS.MkdirAll(sharedDir, 0755); err != nil {
 			panic(fmt.Sprintf("failed to create directory %q: %s", sharedDir, err))
 		}
@@ -361,7 +365,7 @@ func (t *Test) restartDB(dbID objID) error {
 		if len(t.dbs) > 1 {
 			dir = path.Join(dir, fmt.Sprintf("db%d", dbID.slot()))
 		}
-		o := t.finalizeOptions(dir)
+		o := t.finalizeOptions()
 		t.dbs[dbID.slot()-1], err = pebble.Open(dir, &o)
 		if err != nil {
 			return err

--- a/options.go
+++ b/options.go
@@ -2126,7 +2126,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 		if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 			return nil
 		}
-		return errors.Errorf("pebble: unknown section: %q", errors.Safe(section))
+		return errors.Errorf("pebble: unknown section %q or key %q", errors.Safe(section), errors.Safe(key))
 	}
 	err := parseOptions(s, parseOptionsFuncs{
 		visitKeyValue: visitKeyValue,


### PR DESCRIPTION
#### metamorphic: check for false values when parsing options

The test parsing code assumes that the presence of a flag means that
it is turned on. One of the standard options uses `=false` which is
actually interpreted as true.

This commit adds an assertion and fixes the problematic option.

#### metamorphic: tweak secondary cache settings

We don't use the secondary cache at all, so remove it from the
standard settings and reduce the probability of it being turned on
when randomizing options.

#### metamorphic: sometimes turn off value separation in randomizeOptions

We also remove support for `disable_value_separation` as we can just
set the Pebble setting directly.

#### metamorphic: fix shared and external directories

When multiple stores are used, the shared and external directories
were set up inside the data dir of each store, which is not correct.
This commit fixes the paths.