### PR TITLE
db: improve file cache panic

### DIFF
--- a/file_cache.go
+++ b/file_cache.go
@@ -274,6 +274,11 @@ func (h *fileCacheHandle) findOrCreateBlob(
 
 // Evict the given file from the file cache and the block cache.
 func (h *fileCacheHandle) Evict(fileNum base.DiskFileNum, fileType base.FileType) {
+	defer func() {
+		if p := recover(); p != nil {
+			panic(fmt.Sprintf("pebble: evicting in-use file %s(%s): %v", fileNum, fileType, p))
+		}
+	}()
 	h.fileCache.c.Evict(fileCacheKey{handle: h, fileNum: fileNum, fileType: fileType})
 	h.blockCacheHandle.EvictFile(fileNum)
 }

--- a/internal/metamorphic/reduce_test.go
+++ b/internal/metamorphic/reduce_test.go
@@ -163,7 +163,7 @@ func (r *reducer) try(t *testing.T, ops []string) bool {
 	// removed important ops.
 	if err == nil ||
 		strings.Contains(output.String(), "metamorphic test internal error") ||
-		strings.Contains(output.String(), "element has outstanding references") ||
+		strings.Contains(output.String(), "evicting in-use file") ||
 		strings.Contains(output.String(), "leaked iterators") ||
 		strings.Contains(output.String(), "leaked snapshots") ||
 		strings.Contains(output.String(), "test timed out") {


### PR DESCRIPTION
Improve the panic message when we try to evict a file that is still in
use.