### PR TITLE
crl-release-24.1: metamorphic: fix shared and external directories

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -87,7 +87,10 @@ func runTestMeta(t *testing.T, multiInstance bool) {
 		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed, filepath.Join(runOnceFlags.RunDir, "history"), onceOpts...)
 
 	default:
-		opts := runFlags.MakeRunOptions()
+		opts, err := runFlags.MakeRunOptions()
+		if err != nil {
+			t.Fatal(err)
+		}
 		if multiInstance {
 			opts = append(opts, metamorphic.MultiInstance(2))
 		}

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/metamorphic"
@@ -164,10 +165,12 @@ with --run-dir or --compare`)
 	// the `ops` file and one of the previous run's data directories.
 
 	flag.StringVar(&r.PreviousOps, "previous-ops", "",
-		"path to an ops file, used to prepopulate the set of keys operations draw from")
+		`path to an ops file, used to prepopulate the set of keys operations draw from." +
+		Must be used in conjunction with --initial-state`)
 
 	flag.StringVar(&r.InitialStatePath, "initial-state", "",
-		"path to a database's data directory, used to prepopulate the test run's databases")
+		`path to a database's data directory, used to prepopulate the test run's databases.
+		Must be used in conjunction with --previous-ops.`)
 
 	flag.StringVar(&r.InitialStateDesc, "initial-state-desc", "",
 		`a human-readable description of the initial database state.
@@ -242,7 +245,7 @@ func (ro *RunOnceFlags) tryParseCompare() (testRootDir string, runSubdirs []stri
 }
 
 // MakeRunOptions constructs RunOptions based on the flags.
-func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
+func (r *RunFlags) MakeRunOptions() ([]metamorphic.RunOption, error) {
 	opts := []metamorphic.RunOption{
 		metamorphic.Seed(r.Seed),
 		metamorphic.OpCount(r.Ops.Static),
@@ -262,7 +265,12 @@ func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
 		opts = append(opts, metamorphic.RuntimeTrace(r.TraceFile))
 	}
 	if r.PreviousOps != "" {
+		if r.InitialStatePath == "" {
+			return nil, errors.Newf("--previous-ops requires --initial-state")
+		}
 		opts = append(opts, metamorphic.ExtendPreviousRun(r.PreviousOps, r.InitialStatePath, r.InitialStateDesc))
+	} else if r.InitialStatePath != "" {
+		return nil, errors.Newf("--initial-state requires --previous-ops")
 	}
 	if r.NumInstances > 1 {
 		opts = append(opts, metamorphic.MultiInstance(r.NumInstances))
@@ -282,5 +290,5 @@ func (r *RunFlags) MakeRunOptions() []metamorphic.RunOption {
 	if r.InnerBinary != "" {
 		opts = append(opts, metamorphic.InnerBinary(r.InnerBinary))
 	}
-	return opts
+	return opts, nil
 }

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -233,7 +233,8 @@ func openExternalObj(
 	rangeDelIter keyspan.FragmentIterator,
 	rangeKeyIter keyspan.FragmentIterator,
 ) {
-	objReader, objSize, err := t.externalStorage.ReadObject(context.Background(), externalObjName(externalObjID))
+	objMeta := t.getExternalObj(externalObjID)
+	objReader, objSize, err := t.externalStorage.ReadObject(context.Background(), objMeta.objName)
 	panicIfErr(err)
 	opts := sstable.ReaderOptions{
 		Comparer: t.opts.Comparer,

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -238,7 +238,7 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 		cmd := exec.Command(binary, args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			t.Fatalf(`
+			t.Fatalf(`error running %v
 ===== SEED =====
 %d
 ===== ERR =====
@@ -252,6 +252,7 @@ func RunAndCompare(t *testing.T, rootDir string, rOpts ...RunOption) {
 ===== HISTORY =====
 %s
 To reduce:  go test ./internal/metamorphic -tags invariants -run '%s$' --run-dir %s --try-to-reduce -v`,
+				cmd.String(),
 				runOpts.seed,
 				err,
 				out,
@@ -513,13 +514,13 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 		testOpts.Threads = runOpts.maxThreads
 	}
 
-	dir := opts.FS.PathJoin(runDir, "data")
+	dataDir := opts.FS.PathJoin(runDir, "data")
 	// Set up the initial database state if configured to start from a non-empty
 	// database. By default tests start from an empty database, but split
 	// version testing may configure a previous metamorphic tests's database
 	// state as the initial state.
 	if testOpts.initialStatePath != "" {
-		require.NoError(t, setupInitialState(dir, testOpts))
+		require.NoError(t, setupInitialState(dataDir, testOpts))
 	}
 
 	if testOpts.Opts.WALFailover != nil {
@@ -551,7 +552,7 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	defer h.Close()
 
 	m := newTest(ops)
-	require.NoError(t, m.init(h, dir, testOpts, runOpts.numInstances, runOpts.opTimeout))
+	require.NoError(t, m.init(h, dataDir, testOpts, runOpts.numInstances, runOpts.opTimeout))
 
 	if err := Execute(m); err != nil {
 		fmt.Fprintf(os.Stderr, "Seed: %d\n", seed)

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -530,19 +530,13 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 			testOpts.Opts.WALFailover = nil
 		} else {
 			testOpts.Opts.WALFailover.Secondary.FS = opts.FS
-			testOpts.Opts.WALFailover.Secondary.Dirname = opts.FS.PathJoin(
-				runDir, testOpts.Opts.WALFailover.Secondary.Dirname)
 		}
 	}
 
-	if opts.WALDir != "" {
-		if runOpts.numInstances > 1 {
-			// TODO(bilal): Allow opts to diverge on a per-instance basis, and use
-			// that to set unique WAL dirs for all instances in multi-instance mode.
-			opts.WALDir = ""
-		} else {
-			opts.WALDir = opts.FS.PathJoin(runDir, opts.WALDir)
-		}
+	if runOpts.numInstances > 1 {
+		// TODO(bilal): Allow opts to diverge on a per-instance basis, and use
+		// that to set unique WAL dirs for all instances in multi-instance mode.
+		opts.WALDir = ""
 	}
 
 	historyFile, err := os.Create(historyPath)

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -7,10 +7,11 @@ package metamorphic
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"path"
 	"path/filepath"
 	"slices"
@@ -1038,7 +1039,7 @@ func (o *ingestExternalFilesOp) run(t *Test, h historyRecorder) {
 			meta := t.getExternalObj(obj.externalObjID)
 			external[i] = pebble.ExternalFile{
 				Locator:           "external",
-				ObjName:           externalObjName(obj.externalObjID),
+				ObjName:           meta.objName,
 				Size:              meta.sstMeta.Size,
 				StartKey:          obj.bounds.Start,
 				EndKey:            obj.bounds.End,
@@ -1178,8 +1179,8 @@ func (o *newIterOp) run(t *Test, h historyRecorder) {
 	// Trash the bounds to ensure that Pebble doesn't rely on the stability of
 	// the user-provided bounds.
 	if opts != nil {
-		rand.Read(opts.LowerBound[:])
-		rand.Read(opts.UpperBound[:])
+		cryptorand.Read(opts.LowerBound[:])
+		cryptorand.Read(opts.UpperBound[:])
 	}
 	h.Recordf("%s // %v", o, i.Error())
 }
@@ -1296,8 +1297,8 @@ func (o *iterSetBoundsOp) run(t *Test, h historyRecorder) {
 
 	// Trash the bounds to ensure that Pebble doesn't rely on the stability of
 	// the user-provided bounds.
-	rand.Read(lower[:])
-	rand.Read(upper[:])
+	cryptorand.Read(lower[:])
+	cryptorand.Read(upper[:])
 
 	h.Recordf("%s // %v", o, i.Error())
 }
@@ -1339,8 +1340,8 @@ func (o *iterSetOptionsOp) run(t *Test, h historyRecorder) {
 
 	// Trash the bounds to ensure that Pebble doesn't rely on the stability of
 	// the user-provided bounds.
-	rand.Read(opts.LowerBound[:])
-	rand.Read(opts.UpperBound[:])
+	cryptorand.Read(opts.LowerBound[:])
+	cryptorand.Read(opts.UpperBound[:])
 
 	h.Recordf("%s // %v", o, i.Error())
 }
@@ -1816,18 +1817,20 @@ type newExternalObjOp struct {
 	externalObjID objID
 }
 
-func externalObjName(externalObjID objID) string {
-	if externalObjID.tag() != externalObjTag {
-		panic(fmt.Sprintf("invalid externalObjID %s", externalObjID))
-	}
-	return fmt.Sprintf("external-for-ingest-%d.sst", externalObjID.slot())
-}
-
 func (o *newExternalObjOp) run(t *Test, h historyRecorder) {
 	b := t.getBatch(o.batchID)
 	t.clearObj(o.batchID)
 
-	writeCloser, err := t.externalStorage.CreateObject(externalObjName(o.externalObjID))
+	if o.externalObjID.tag() != externalObjTag {
+		panic(fmt.Sprintf("invalid externalObjID %s", o.externalObjID))
+	}
+	// We add a unique number to the object name to avoid collisions with existing
+	// external objects (when using an initial starting state).
+	//
+	// Note that the number is not based on the seed, in case we run using the
+	// same seed that was used in a previous run with the same store.
+	objName := fmt.Sprintf("external-for-ingest-%d-%d.sst", o.externalObjID.slot(), rand.Uint64())
+	writeCloser, err := t.externalStorage.CreateObject(objName)
 	if err != nil {
 		panic(err)
 	}
@@ -1853,6 +1856,7 @@ func (o *newExternalObjOp) run(t *Test, h historyRecorder) {
 		panic("external object has range keys")
 	}
 	t.setExternalObj(o.externalObjID, externalObjMeta{
+		objName: objName,
 		sstMeta: sstMeta,
 	})
 	h.Recordf("%s", o)

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -106,14 +106,12 @@ func parseOptions(
 				return true
 			case "TestOptions.shared_storage_enabled":
 				opts.sharedStorageEnabled = true
-				opts.sharedStorageFS = remote.NewInMem()
 				if opts.Opts.Experimental.CreateOnShared == remote.CreateOnSharedNone {
 					opts.Opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 				}
 				return true
 			case "TestOptions.external_storage_enabled":
 				opts.externalStorageEnabled = true
-				opts.externalStorageFS = remote.NewInMem()
 				return true
 			case "TestOptions.secondary_cache_enabled":
 				opts.secondaryCacheEnabled = true
@@ -183,7 +181,6 @@ func parseOptions(
 	if opts.Opts.WALFailover != nil {
 		opts.Opts.WALFailover.Secondary.FS = opts.Opts.FS
 	}
-	opts.InitRemoteStorageFactory()
 	opts.Opts.EnsureDefaults()
 	return err
 }
@@ -359,10 +356,8 @@ type TestOptions struct {
 	asyncApplyToDB bool
 	// Enable the use of shared storage.
 	sharedStorageEnabled bool
-	sharedStorageFS      remote.Storage
 	// Enable the use of shared storage for external file ingestion.
 	externalStorageEnabled bool
-	externalStorageFS      remote.Storage
 	// Enables the use of shared replication in TestOptions.
 	useSharedReplicate bool
 	// Enables the use of external replication in TestOptions.
@@ -390,20 +385,6 @@ type TestOptions struct {
 	// excises. However !useExcise && !useSharedReplicate can be used to guarantee
 	// lack of excises.
 	useExcise bool
-}
-
-// InitRemoteStorageFactory initializes Opts.Experimental.RemoteStorage.
-func (testOpts *TestOptions) InitRemoteStorageFactory() {
-	if testOpts.sharedStorageEnabled || testOpts.externalStorageEnabled {
-		m := make(map[remote.Locator]remote.Storage)
-		if testOpts.sharedStorageEnabled {
-			m[""] = testOpts.sharedStorageFS
-		}
-		if testOpts.externalStorageEnabled {
-			m["external"] = testOpts.externalStorageFS
-		}
-		testOpts.Opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(m)
-	}
 }
 
 // CustomOption defines a custom option that configures the behavior of an
@@ -781,7 +762,6 @@ func RandomOptions(
 		if testOpts.Opts.FormatMajorVersion < pebble.FormatMinForSharedObjects {
 			testOpts.Opts.FormatMajorVersion = pebble.FormatMinForSharedObjects
 		}
-		testOpts.sharedStorageFS = remote.NewInMem()
 		// If shared storage is enabled, pick between writing all files on shared
 		// vs. lower levels only, 50% of the time.
 		testOpts.Opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
@@ -804,7 +784,6 @@ func RandomOptions(
 		if testOpts.Opts.FormatMajorVersion < pebble.FormatSyntheticPrefixSuffix {
 			testOpts.Opts.FormatMajorVersion = pebble.FormatSyntheticPrefixSuffix
 		}
-		testOpts.externalStorageFS = remote.NewInMem()
 	}
 
 	testOpts.seedEFOS = rng.Uint64()
@@ -816,7 +795,6 @@ func RandomOptions(
 			testOpts.Opts.FormatMajorVersion = pebble.FormatVirtualSSTables
 		}
 	}
-	testOpts.InitRemoteStorageFactory()
 	testOpts.Opts.EnsureDefaults()
 	return testOpts
 }

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -456,7 +456,7 @@ func standardOptions() []*TestOptions {
 `,
 		10: `
 [Options]
-  wal_dir=data/wal
+  wal_dir={store_path}/wal
 `,
 		11: `
 [Level "0"]
@@ -626,7 +626,7 @@ func RandomOptions(
 	opts.MemTableSize = 2 << (10 + uint(rng.Intn(16))) // 2KB - 256MB
 	opts.MemTableStopWritesThreshold = 2 + rng.Intn(5) // 2 - 5
 	if rng.Intn(2) == 0 {
-		opts.WALDir = "data/wal"
+		opts.WALDir = pebble.MakeStoreRelativePath(opts.FS, "wal")
 	}
 
 	// Half the time enable WAL failover.
@@ -645,7 +645,7 @@ func RandomOptions(
 		healthyThreshold := expRandDuration(rng, 3*referenceDur, time.Second)
 		healthyInterval := scaleDuration(healthyThreshold, 1.0, 10.0) // Between 1-10x the healthy threshold
 		opts.WALFailover = &pebble.WALFailoverOptions{
-			Secondary: wal.Dir{FS: vfs.Default, Dirname: "data/wal_secondary"},
+			Secondary: wal.Dir{FS: vfs.Default, Dirname: pebble.MakeStoreRelativePath(vfs.Default, "wal_secondary")},
 			FailoverOptions: wal.FailoverOptions{
 				PrimaryDirProbeInterval:      scaleDuration(healthyThreshold, 0.10, 0.50), // Between 10-50% of the healthy threshold
 				HealthyProbeLatencyThreshold: healthyThreshold,

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -5,12 +5,10 @@
 package metamorphic
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -107,12 +105,6 @@ func (t *Test) init(
 	if numInstances < 1 {
 		numInstances = 1
 	}
-	if t.testOpts.externalStorageEnabled {
-		t.externalStorage = t.testOpts.externalStorageFS
-	} else {
-		t.externalStorage = remote.NewInMem()
-	}
-
 	t.opsWaitOn, t.opsDone = computeSynchronizationPoints(t.ops)
 
 	defer t.opts.Cache.Unref()
@@ -189,7 +181,8 @@ func (t *Test) init(
 			dir = path.Join(t.dir, fmt.Sprintf("db%d", i+1))
 		}
 		err = t.withRetries(func() error {
-			db, err = pebble.Open(dir, t.opts)
+			o := t.finalizeOptions(dir)
+			db, err = pebble.Open(dir, &o)
 			return err
 		})
 		if err != nil {
@@ -243,6 +236,42 @@ func (t *Test) init(
 	}
 
 	return nil
+}
+
+// finalizeOptions returns the options that need to be passed to pebble.Open().
+//
+// It initializes t.externalStorage and creates the compaction scheduler and
+// remote storage factory.
+func (t *Test) finalizeOptions(dataDir string) pebble.Options {
+	o := *t.opts
+
+	// Set up external/shared storage.
+	externalDir := o.FS.PathJoin(dataDir, "external")
+	if err := o.FS.MkdirAll(externalDir, 0755); err != nil {
+		panic(fmt.Sprintf("failed to create directory %q: %s", externalDir, err))
+	}
+	// Even if externalStorageEnabled is false, the test uses externalStorage to
+	// emulate external ingestion.
+	t.externalStorage = remote.NewLocalFS(externalDir, o.FS)
+
+	m := make(map[remote.Locator]remote.Storage)
+	// If we are starting from an initial state (initialStatePath != ""), the
+	// existing store might use shared or external storage, so we set them up
+	// unconditionally.
+	if t.testOpts.sharedStorageEnabled || t.testOpts.initialStatePath != "" {
+		sharedDir := o.FS.PathJoin(dataDir, "shared")
+		if err := o.FS.MkdirAll(sharedDir, 0755); err != nil {
+			panic(fmt.Sprintf("failed to create directory %q: %s", sharedDir, err))
+		}
+		m[""] = remote.NewLocalFS(sharedDir, o.FS)
+	}
+	if t.testOpts.externalStorageEnabled || t.testOpts.initialStatePath != "" {
+		m["external"] = t.externalStorage
+	}
+	if len(m) > 0 {
+		o.Experimental.RemoteStorage = remote.MakeSimpleFactory(m)
+	}
+	return o
 }
 
 func (t *Test) withRetries(fn func() error) error {
@@ -307,7 +336,8 @@ func (t *Test) restartDB(dbID objID) error {
 		if len(t.dbs) > 1 {
 			dir = path.Join(dir, fmt.Sprintf("db%d", dbID.slot()))
 		}
-		t.dbs[dbID.slot()-1], err = pebble.Open(dir, t.opts)
+		o := t.finalizeOptions(dir)
+		t.dbs[dbID.slot()-1], err = pebble.Open(dir, &o)
 		if err != nil {
 			return err
 		}
@@ -324,49 +354,6 @@ func (t *Test) saveInMemoryDataInternal() error {
 			return err
 		}
 		if _, err := vfs.Clone(rootFS, vfs.Default, t.dir, t.dir); err != nil {
-			return err
-		}
-	}
-	if t.testOpts.sharedStorageEnabled {
-		if err := copyRemoteStorage(t.testOpts.sharedStorageFS, filepath.Join(t.dir, "shared")); err != nil {
-			return err
-		}
-	}
-	if t.testOpts.externalStorageEnabled {
-		if err := copyRemoteStorage(t.testOpts.externalStorageFS, filepath.Join(t.dir, "external")); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func copyRemoteStorage(fs remote.Storage, outputDir string) error {
-	if err := vfs.Default.MkdirAll(outputDir, 0755); err != nil {
-		return err
-	}
-	objs, err := fs.List("", "")
-	if err != nil {
-		return err
-	}
-	for i := range objs {
-		reader, readSize, err := fs.ReadObject(context.TODO(), objs[i])
-		if err != nil {
-			return err
-		}
-		buf := make([]byte, readSize)
-		if err := reader.ReadAt(context.TODO(), buf, 0); err != nil {
-			return err
-		}
-		outputPath := vfs.Default.PathJoin(outputDir, objs[i])
-		outputFile, err := vfs.Default.Create(outputPath)
-		if err != nil {
-			return err
-		}
-		if _, err := outputFile.Write(buf); err != nil {
-			outputFile.Close()
-			return err
-		}
-		if err := outputFile.Close(); err != nil {
 			return err
 		}
 	}

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -9,12 +9,15 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -120,6 +123,7 @@ func (t *Test) init(
 		}
 		t.saveInMemoryData()
 		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, string(debug.Stack()))
 		os.Exit(1)
 	}
 
@@ -175,31 +179,40 @@ func (t *Test) init(
 
 	t.dbs = make([]*pebble.DB, numInstances)
 	for i := range t.dbs {
-		var db *pebble.DB
-		var err error
 		if len(t.dbs) > 1 {
 			dir = path.Join(t.dir, fmt.Sprintf("db%d", i+1))
 		}
-		err = t.withRetries(func() error {
-			o := t.finalizeOptions(dir)
-			db, err = pebble.Open(dir, &o)
+		var db *pebble.DB
+		err := t.withRetries(func() error {
+			opts := t.finalizeOptions(dir)
+			// If shared storage is enabled, we want to set up the CreatorID. We could
+			// call db.SetCreatorID() after Open() but this is fragile in the case
+			// where we are using an existing store (via --initial-state) which did
+			// not use shared storage. In that case, flushes or compactions issued
+			// during Open() can fail to create shared objects (leading to background
+			// errors which fail the metamorphic test).
+			if t.testOpts.sharedStorageEnabled {
+				providerSettings := opts.MakeObjStorageProviderSettings(dir)
+				objProvider, err := objstorageprovider.Open(providerSettings)
+				if err != nil {
+					return errors.Wrapf(err, "opening objstorage provider")
+				}
+				err = objProvider.SetCreatorID(objstorage.CreatorID(i + 1))
+				err = errors.CombineErrors(err, objProvider.Close())
+				if err != nil {
+					return errors.Wrapf(err, "setting creator ID")
+				}
+			}
+			var err error
+			db, err = pebble.Open(dir, &opts)
 			return err
 		})
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "opening store")
 		}
+
 		t.dbs[i] = db
 		h.log.Printf("// db%d.Open() %v", i+1, err)
-
-		if t.testOpts.sharedStorageEnabled {
-			err = t.withRetries(func() error {
-				return db.SetCreatorID(uint64(i + 1))
-			})
-			if err != nil {
-				return err
-			}
-			h.log.Printf("// db%d.SetCreatorID() %v", i+1, err)
-		}
 	}
 
 	var err error

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -72,6 +72,7 @@ type Test struct {
 
 type externalObjMeta struct {
 	sstMeta *sstable.WriterMetadata
+	objName string
 }
 
 func newTest(ops []op) *Test {

--- a/open.go
+++ b/open.go
@@ -288,21 +288,8 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 
 	jobID := d.newJobIDLocked()
 
-	providerSettings := objstorageprovider.Settings{
-		Logger:              opts.Logger,
-		FS:                  opts.FS,
-		FSDirName:           dirname,
-		FSDirInitialListing: ls,
-		FSCleaner:           opts.Cleaner,
-		NoSyncOnClose:       opts.NoSyncOnClose,
-		BytesPerSync:        opts.BytesPerSync,
-	}
-	providerSettings.Local.ReadaheadConfig = opts.Local.ReadaheadConfig
-	providerSettings.Remote.StorageFactory = opts.Experimental.RemoteStorage
-	providerSettings.Remote.CreateOnShared = opts.Experimental.CreateOnShared
-	providerSettings.Remote.CreateOnSharedLocator = opts.Experimental.CreateOnSharedLocator
-	providerSettings.Remote.CacheSizeBytes = opts.Experimental.SecondaryCacheSizeBytes
-
+	providerSettings := opts.MakeObjStorageProviderSettings(dirname)
+	providerSettings.FSDirInitialListing = ls
 	d.objProvider, err = objstorageprovider.Open(providerSettings)
 	if err != nil {
 		return nil, err

--- a/open.go
+++ b/open.go
@@ -352,12 +352,17 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	}
 	if opts.WALFailover != nil {
 		walOpts.Secondary = opts.WALFailover.Secondary
+		walOpts.Secondary.Dirname = resolveStorePath(dirname, walOpts.Secondary.Dirname)
 		walOpts.FailoverOptions = opts.WALFailover.FailoverOptions
 		walOpts.FailoverWriteAndSyncLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 			Buckets: FsyncLatencyBuckets,
 		})
 	}
-	walDirs := append(walOpts.Dirs(), opts.WALRecoveryDirs...)
+	walDirs := walOpts.Dirs()
+	for _, dir := range opts.WALRecoveryDirs {
+		dir.Dirname = resolveStorePath(dirname, dir.Dirname)
+		walDirs = append(walDirs, dir)
+	}
 	wals, err := wal.Scan(walDirs...)
 	if err != nil {
 		return nil, err
@@ -617,9 +622,9 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 func prepareAndOpenDirs(
 	dirname string, opts *Options,
 ) (walDirname string, dataDir vfs.File, err error) {
-	walDirname = opts.WALDir
-	if opts.WALDir == "" {
-		walDirname = dirname
+	walDirname = dirname
+	if opts.WALDir != "" {
+		walDirname = resolveStorePath(dirname, opts.WALDir)
 	}
 
 	// Create directories if needed.
@@ -638,7 +643,7 @@ func prepareAndOpenDirs(
 		}
 		if opts.WALFailover != nil {
 			secondary := opts.WALFailover.Secondary
-			f, err := mkdirAllAndSyncParents(secondary.FS, secondary.Dirname)
+			f, err := mkdirAllAndSyncParents(secondary.FS, resolveStorePath(dirname, secondary.Dirname))
 			if err != nil {
 				return "", nil, err
 			}

--- a/open_test.go
+++ b/open_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -359,6 +360,7 @@ func TestNewDBFilenames(t *testing.T) {
 func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 	opts := testingRandomized(t, &Options{FS: fs})
 
+	useStoreRelativeWALPath := rand.Intn(2) == 0
 	for _, startFromEmpty := range []bool{false, true} {
 		for _, walDirname := range []string{"", "wal"} {
 			for _, length := range []int{-1, 0, 1, 1000, 10000, 100000} {
@@ -370,7 +372,11 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 				if walDirname == "" {
 					opts.WALDir = ""
 				} else {
-					opts.WALDir = fs.PathJoin(dirname, walDirname)
+					if useStoreRelativeWALPath {
+						opts.WALDir = MakeStoreRelativePath(fs, walDirname)
+					} else {
+						opts.WALDir = fs.PathJoin(dirname, walDirname)
+					}
 				}
 
 				got, xxx := []byte(nil), ""

--- a/options.go
+++ b/options.go
@@ -2025,3 +2025,22 @@ func resolveDefaultCompression(c Compression) Compression {
 	}
 	return c
 }
+
+// MakeObjStorageProviderSettings creates the object storage provider settings.
+// Note that FSDirInitialListing is not initialized.
+func (o *Options) MakeObjStorageProviderSettings(dirname string) objstorageprovider.Settings {
+	s := objstorageprovider.Settings{
+		Logger:        o.Logger,
+		FS:            o.FS,
+		FSDirName:     dirname,
+		FSCleaner:     o.Cleaner,
+		NoSyncOnClose: o.NoSyncOnClose,
+		BytesPerSync:  o.BytesPerSync,
+	}
+	s.Local.ReadaheadConfig = o.Local.ReadaheadConfig
+	s.Remote.StorageFactory = o.Experimental.RemoteStorage
+	s.Remote.CreateOnShared = o.Experimental.CreateOnShared
+	s.Remote.CreateOnSharedLocator = o.Experimental.CreateOnSharedLocator
+	s.Remote.CacheSizeBytes = o.Experimental.SecondaryCacheSizeBytes
+	return s
+}

--- a/options.go
+++ b/options.go
@@ -1880,12 +1880,13 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 // opened without supplying a Options.WALRecoveryDir entry for a directory that
 // may contain WALs required to recover a consistent database state.
 type ErrMissingWALRecoveryDir struct {
-	Dir string
+	Dir       string
+	ExtraInfo string
 }
 
 // Error implements error.
 func (e ErrMissingWALRecoveryDir) Error() string {
-	return fmt.Sprintf("directory %q may contain relevant WALs", e.Dir)
+	return fmt.Sprintf("directory %q may contain relevant WALs%s", e.Dir, e.ExtraInfo)
 }
 
 // CheckCompatibility verifies the options are compatible with the previous options
@@ -1921,7 +1922,18 @@ func (o *Options) CheckCompatibility(previousOptions string) error {
 						return nil
 					}
 				}
-				return ErrMissingWALRecoveryDir{Dir: value}
+				var buf bytes.Buffer
+				fmt.Fprintf(&buf, "\n  OPTIONS key: %s\n", section+"."+key)
+				if o.WALDir != "" {
+					fmt.Fprintf(&buf, "  o.WALDir: %s\n", o.WALDir)
+				}
+				if o.WALFailover != nil {
+					fmt.Fprintf(&buf, "  o.WALFailover.Secondary.Dirname: %s\n", o.WALFailover.Secondary.Dirname)
+				}
+				for _, d := range o.WALRecoveryDirs {
+					fmt.Fprintf(&buf, "  WALRecoveryDir: %s\n", d)
+				}
+				return ErrMissingWALRecoveryDir{Dir: value, ExtraInfo: buf.String()}
 			}
 		}
 		return nil
@@ -2043,4 +2055,27 @@ func (o *Options) MakeObjStorageProviderSettings(dirname string) objstorageprovi
 	s.Remote.CreateOnSharedLocator = o.Experimental.CreateOnSharedLocator
 	s.Remote.CacheSizeBytes = o.Experimental.SecondaryCacheSizeBytes
 	return s
+}
+
+const storePathIdentifier = "{store_path}"
+
+// MakeStoreRelativePath takes a path that is relative to the store directory
+// and creates a path that can be used for Options.WALDir and wal.Dir.Dirname.
+//
+// This is used in metamorphic tests, so that the test run directory can be
+// copied or moved.
+func MakeStoreRelativePath(fs vfs.FS, relativePath string) string {
+	if relativePath == "" {
+		return storePathIdentifier
+	}
+	return fs.PathJoin(storePathIdentifier, relativePath)
+}
+
+// resolveStorePath is the inverse of MakeStoreRelativePath(). It replaces any
+// storePathIdentifier prefix with the store dir.
+func resolveStorePath(storeDir, path string) string {
+	if remainder, ok := strings.CutPrefix(path, storePathIdentifier); ok {
+		return storeDir + remainder
+	}
+	return path
 }

--- a/options.go
+++ b/options.go
@@ -1912,6 +1912,8 @@ func (o *Options) CheckCompatibility(previousOptions string) error {
 			}
 		case "Options.wal_dir", "WAL Failover.secondary_dir":
 			switch {
+			case value == "":
+				return nil
 			case o.WALDir == value:
 				return nil
 			case o.WALFailover != nil && o.WALFailover.Secondary.Dirname == value:

--- a/testdata/open_wal_failover
+++ b/testdata/open_wal_failover
@@ -59,6 +59,7 @@ grep-between path=(a,data/OPTIONS-000006) start=(\[WAL Failover\]) end=^$
 open path=(a,data)
 ----
 directory "secondary-wals" may contain relevant WALs
+  OPTIONS key: WAL Failover.secondary_dir
 
 # But opening the same directory while providing the secondary path as a WAL
 # recovery dir should succeed.


### PR DESCRIPTION
Backport of #4777
Informs #4732

#### metamorphic: use FS-based remote storage

The metamorphic test uses in-mem remote storage, which doesn't work
when starting with an initial state (as in the crossversion tests).

Note that there is code to save the remote storage contents to disk
when the store is in-memory, but they are not read back when used as
initial state.

This commit changes to using FS-based remote storage in `shared`
and `external` subdirs inside the data dir. Note that the store itself
can still be in-memory; the data gets saved automatically with the
store.

We improve the FS-based Storage implementation to sync data and list
objects. We can now allow simulating crashes in the metamorphic test
when shared storage is enabled.

#### metamorphic: support CreateOnShared on existing store

If the metamorphic test has `CreateOnShared` set to something other
than "none" and we start with an initial store which did not have
remote storage configured, there can be background errors right after
opening the store, before we get a chance to call `SetCreatorID()`.
The metamorphic test fails on these background errors.

To fix this, we always open with `CreateOnSharedNone` first, and if
necessary reopen after setting the creator ID.

#### metamorphic: add random number to external object names

External object names can collide with existing objects when starting
with an initial state. This change adds a random unique number to the
filenames.

#### db: support store-relative paths for WAL dirs

Relative WAL paths (including the actual WAL, the failover path, and
the recovery paths) are (unfortunately) interpreted as relative to the
current working directory.

The cross-version metamorphic test copies a store from a previous run
as the initial state for a new test. The options will fail the
compatibility check since the path changes.

This change adds support for using a special `{store_path}` prefix
inside the path. Any such prefix is replaced with the store directory.

We also improve the missing WAL recovery dir error to show what
directories are actually configured.

#### metamorphic: use store-relative paths


#### metamorphic: fix code around WAL recovery directories


#### metamorphic: sanity check initial-state and previous-ops flags

Error out if `--initial-state` is used without `--previous-ops`.

#### crossversion: pass --previous-ops flag

Lack of this flag is the root cause for the crossversion tests not
actually testing across versions (instead, each run was separate).

#### metamorphic: fix shared and external directories

When multiple stores are used, the shared and external directories
were set up inside the data dir of each store, which is not correct.
This commit fixes the paths.