### PR TITLE
base: don't cache fetched LazyValue values

### DIFF
--- a/internal/base/lazy_value_test.go
+++ b/internal/base/lazy_value_test.go
@@ -68,7 +68,7 @@ func TestLazyValue(t *testing.T) {
 		require.Equal(t, []byte("foo"), getValue(fooLV3, callerOwned))
 		require.Equal(t, 1, numCalls)
 		require.Equal(t, []byte("foo"), getValue(fooLV3, callerOwned))
-		require.Equal(t, 1, numCalls)
+		require.Equal(t, 2, numCalls)
 		require.Equal(t, 3, fooLV3.Len())
 		attr, hasAttr := fooLV3.TryGetShortAttribute()
 		require.True(t, hasAttr)


### PR DESCRIPTION
Previously retrieving a value from a LazyValue would save the retrieved value on the ValueFetcher. Subsequent value retrievals would use this cached value, avoiding some overhead of re-extracting the value. The memory lifetime of cached values was very subtle and error prone.

With blob-file backed values, certain interleavings of iterator operations could result in a pebble.Iterator returning a LazyValue that already had its value retrieved and cached, but the memory backing the cached value had already been invalidated. See #4765.

This caching subtly relied on the pebble.Iterator not retrieving values as a part of its iteration. This commit removes teh caching altogether.

Fix #4765.