### PR TITLE
compressionanalyzer: sample per byte instead of per block

### DIFF
--- a/sstable/compressionanalyzer/block_analyzer.go
+++ b/sstable/compressionanalyzer/block_analyzer.go
@@ -88,10 +88,10 @@ func (a *BlockAnalyzer) runExperiment(
 	}
 	decompressionTime := t2.Elapsed()
 
-	// CPU times are in microseconds.
-	pa.CompressionTime.Add(compressionTime.Seconds() * 1e6)
-	pa.DecompressionTime.Add(decompressionTime.Seconds() * 1e6)
-	pa.CompressionRatio.Add(float64(len(block)) / float64(len(compressed)))
+	// CPU times are in nanoseconds / byte.
+	pa.CompressionTime.Add(float64(compressionTime)/float64(len(block)), uint64(len(block)))
+	pa.DecompressionTime.Add(float64(decompressionTime)/float64(len(block)), uint64(len(block)))
+	pa.CompressionRatio.Add(float64(len(block))/float64(len(compressed)), uint64(len(block)))
 }
 
 func ensureLen(b []byte, n int) []byte {

--- a/sstable/compressionanalyzer/buckets_test.go
+++ b/sstable/compressionanalyzer/buckets_test.go
@@ -69,9 +69,10 @@ func exampleBuckets() Buckets {
 			b.UncompressedSize.Add(100 + float64(r.IntN(64*1024)))
 			for j := range b.Experiments {
 				e := &b.Experiments[j]
-				e.CompressionRatio.Add(float64(j+1) + 0.1*float64(r.IntN(10)))
-				e.CompressionTime.Add(float64((j+1)*10) + 0.1*float64(r.IntN(10)))
-				e.DecompressionTime.Add(float64((j+1)*100) + 0.1*float64(r.IntN(10)))
+				blockSize := uint64(50 + r.IntN(100))
+				e.CompressionRatio.Add(float64(j+1)+0.1*float64(r.IntN(10)), blockSize)
+				e.CompressionTime.Add(float64((j+1)*10)+0.1*float64(r.IntN(10)), blockSize)
+				e.DecompressionTime.Add(float64((j+1)*100)+0.1*float64(r.IntN(10)), blockSize)
 			}
 		}
 	}

--- a/sstable/compressionanalyzer/file_analyzer_test.go
+++ b/sstable/compressionanalyzer/file_analyzer_test.go
@@ -36,10 +36,10 @@ func TestFileAnalyzer(t *testing.T) {
 							// Snappy always has the same output in all configurations and on
 							// all platforms.
 							if Settings[l].Algorithm != compression.SnappyAlgorithm {
-								bucket.Experiments[l].CompressionRatio = Welford{}
+								bucket.Experiments[l].CompressionRatio = WeightedWelford{}
 							}
-							bucket.Experiments[l].CompressionTime = Welford{}
-							bucket.Experiments[l].DecompressionTime = Welford{}
+							bucket.Experiments[l].CompressionTime = WeightedWelford{}
+							bucket.Experiments[l].DecompressionTime = WeightedWelford{}
 						}
 					}
 				}

--- a/sstable/compressionanalyzer/testdata/buckets
+++ b/sstable/compressionanalyzer/testdata/buckets
@@ -53,54 +53,48 @@ compressibility
 
 example-buckets-string
 ----
-Kind     Size Range  Test CR  Samples  Size                  Snappy        MinLZ1        MinLZ2        ZSTD1         ZSTD3         ZSTD5         ZSTD7
-data     48-128KB    <1.1     19       24.8KB ± 55%  CR      1.4 ± 22%     2.6 ± 11%     3.4 ± 7%      4.5 ± 6%      5.5 ± 6%      6.4 ± 4%      7.4 ± 4%
-                                                     Comp    10.4us ± 2%   20.4us ± 1%   30.4us ± 0%   40.5us ± 0%   50.5us ± 0%   60.5us ± 0%   70.5us ± 0%
-                                                     Decomp  100.4us ± 0%  200.5us ± 0%  300.4us ± 0%  400.5us ± 0%  500.5us ± 0%  600.5us ± 0%  700.4us ± 0%
-sstval   24-48KB     1.5-2.5  5        44.8KB ± 40%  CR      1.5 ± 5%      2.4 ± 11%     3.6 ± 7%      4.4 ± 6%      5.6 ± 2%      6.4 ± 4%      7.4 ± 4%
-                                                     Comp    10.4us ± 4%   20.4us ± 1%   30.3us ± 0%   40.4us ± 0%   50.4us ± 0%   60.6us ± 0%   70.3us ± 0%
-                                                     Decomp  100.3us ± 0%  200.5us ± 0%  300.5us ± 0%  400.4us ± 0%  500.4us ± 0%  600.2us ± 0%  700.3us ± 0%
-sstval   24-48KB     >2.5     6        32.5KB ± 57%  CR      1.4 ± 22%     2.4 ± 10%     3.2 ± 6%      4.4 ± 6%      5.5 ± 5%      6.4 ± 3%      7.7 ± 2%
-                                                     Comp    10.6us ± 3%   20.5us ± 1%   30.2us ± 0%   40.6us ± 0%   50.5us ± 0%   60.4us ± 0%   70.5us ± 0%
-                                                     Decomp  100.4us ± 0%  200.4us ± 0%  300.3us ± 0%  400.4us ± 0%  500.2us ± 0%  600.3us ± 0%  700.5us ± 0%
-sstval   >128KB      >2.5     4        34.7KB ± 69%  CR      1.4 ± 10%     2.4 ± 9%      3.5 ± 3%      4.5 ± 6%      5.2 ± 2%      6.2 ± 1%      7.3 ± 2%
-                                                     Comp    10.6us ± 3%   20.6us ± 1%   30.2us ± 0%   40.8us ± 0%   50.2us ± 0%   60.4us ± 0%   70.3us ± 0%
-                                                     Decomp  100.4us ± 0%  200.3us ± 0%  300.3us ± 0%  400.6us ± 0%  500.4us ± 0%  600.5us ± 0%  700.5us ± 0%
-blobval  <24KB       <1.1     2        3.9KB ± 32%   CR      1.5 ± 37%     2.3 ± 12%     3.7 ± 7%      4.3 ± 1%      5.5 ± 1%      6.5 ± 5%      7.7 ± 0%
-                                                     Comp    10.6us ± 0%   20.4us ± 1%   30.7us ± 0%   40.3us ± 0%   50.3us ± 0%   60.7us ± 0%   70.7us ± 0%
-                                                     Decomp  100.7us ± 0%  200.0us ± 0%  300.4us ± 0%  400.2us ± 0%  500.7us ± 0%  600.4us ± 0%  700.1us ± 0%
-blobval  48-128KB    1.5-2.5  1        27.1KB ± 0%   CR      1.7 ± 0%      2.8 ± 0%      3.3 ± 0%      4.7 ± 0%      5.9 ± 0%      6.4 ± 0%      7.8 ± 0%
-                                                     Comp    10.5us ± 0%   20.0us ± 0%   30.5us ± 0%   40.5us ± 0%   50.3us ± 0%   60.3us ± 0%   70.2us ± 0%
-                                                     Decomp  100.4us ± 0%  200.0us ± 0%  300.7us ± 0%  400.2us ± 0%  500.9us ± 0%  600.2us ± 0%  700.6us ± 0%
-other    <24KB       1.1-1.5  8        21.1KB ± 61%  CR      1.5 ± 20%     2.5 ± 14%     3.6 ± 5%      4.5 ± 8%      5.4 ± 4%      6.2 ± 5%      7.4 ± 3%
-                                                     Comp    10.6us ± 3%   20.4us ± 1%   30.3us ± 0%   40.3us ± 0%   50.5us ± 0%   60.5us ± 0%   70.6us ± 0%
-                                                     Decomp  100.3us ± 0%  200.2us ± 0%  300.6us ± 0%  400.4us ± 0%  500.4us ± 0%  600.5us ± 0%  700.4us ± 0%
-other    48-128KB    1.1-1.5  5        37.7KB ± 66%  CR      1.4 ± 18%     2.6 ± 11%     3.4 ± 8%      4.5 ± 8%      5.4 ± 4%      6.6 ± 5%      7.7 ± 4%
-                                                     Comp    10.5us ± 3%   20.6us ± 1%   30.5us ± 0%   40.5us ± 0%   50.3us ± 0%   60.4us ± 0%   70.4us ± 0%
-                                                     Decomp  100.3us ± 0%  200.4us ± 0%  300.5us ± 0%  400.6us ± 0%  500.4us ± 0%  600.3us ± 0%  700.3us ± 0%
+Kind    Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       MinLZ2       ZSTD1        ZSTD3        ZSTD5        ZSTD7
+sstval  24-48KB     1.1-1.5  5        44.7KB ± 53%  CR      1.34 ± 17%   2.57 ± 9%    3.64 ± 6%    4.29 ± 3%    5.48 ± 5%    6.21 ± 4%    7.15 ± 1%
+                                                    Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+sstval  24-48KB     1.5-2.5  5        24.6KB ± 77%  CR      1.65 ± 10%   2.53 ± 13%   3.56 ± 4%    4.45 ± 6%    5.40 ± 6%    6.37 ± 3%    7.36 ± 4%
+                                                    Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+sstval  24-48KB     >2.5     6        34.3KB ± 71%  CR      1.34 ± 22%   2.48 ± 6%    3.35 ± 8%    4.38 ± 6%    5.34 ± 3%    6.58 ± 4%    7.41 ± 4%
+                                                    Comp    92MBps ± 2%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+index   48-128KB    >2.5     12       36.6KB ± 49%  CR      1.34 ± 23%   2.64 ± 11%   3.56 ± 7%    4.26 ± 5%    5.52 ± 5%    6.35 ± 4%    7.45 ± 4%
+                                                    Comp    92MBps ± 3%  47MBps ± 2%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+index   >128KB      <1.1     22       34.4KB ± 59%  CR      1.49 ± 22%   2.34 ± 11%   3.31 ± 7%    4.46 ± 6%    5.52 ± 6%    6.37 ± 4%    7.50 ± 4%
+                                                    Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+other   >128KB      >2.5     1        48.0KB ± 0%   CR      1.90 ± 0%    2.40 ± 0%    3.50 ± 0%    4.80 ± 0%    5.30 ± 0%    6.20 ± 0%    7.10 ± 0%
+                                                    Comp    87MBps ± 0%  47MBps ± 0%  31MBps ± 0%  24MBps ± 0%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
 
 example-buckets-string min-samples=5
 ----
-Kind    Size Range  Test CR  Samples  Size                  Snappy        MinLZ1        MinLZ2        ZSTD1         ZSTD3         ZSTD5         ZSTD7
-data    48-128KB    <1.1     19       24.8KB ± 55%  CR      1.4 ± 22%     2.6 ± 11%     3.4 ± 7%      4.5 ± 6%      5.5 ± 6%      6.4 ± 4%      7.4 ± 4%
-                                                    Comp    10.4us ± 2%   20.4us ± 1%   30.4us ± 0%   40.5us ± 0%   50.5us ± 0%   60.5us ± 0%   70.5us ± 0%
-                                                    Decomp  100.4us ± 0%  200.5us ± 0%  300.4us ± 0%  400.5us ± 0%  500.5us ± 0%  600.5us ± 0%  700.4us ± 0%
-sstval  24-48KB     1.5-2.5  5        44.8KB ± 40%  CR      1.5 ± 5%      2.4 ± 11%     3.6 ± 7%      4.4 ± 6%      5.6 ± 2%      6.4 ± 4%      7.4 ± 4%
-                                                    Comp    10.4us ± 4%   20.4us ± 1%   30.3us ± 0%   40.4us ± 0%   50.4us ± 0%   60.6us ± 0%   70.3us ± 0%
-                                                    Decomp  100.3us ± 0%  200.5us ± 0%  300.5us ± 0%  400.4us ± 0%  500.4us ± 0%  600.2us ± 0%  700.3us ± 0%
-sstval  24-48KB     >2.5     6        32.5KB ± 57%  CR      1.4 ± 22%     2.4 ± 10%     3.2 ± 6%      4.4 ± 6%      5.5 ± 5%      6.4 ± 3%      7.7 ± 2%
-                                                    Comp    10.6us ± 3%   20.5us ± 1%   30.2us ± 0%   40.6us ± 0%   50.5us ± 0%   60.4us ± 0%   70.5us ± 0%
-                                                    Decomp  100.4us ± 0%  200.4us ± 0%  300.3us ± 0%  400.4us ± 0%  500.2us ± 0%  600.3us ± 0%  700.5us ± 0%
-other   <24KB       1.1-1.5  8        21.1KB ± 61%  CR      1.5 ± 20%     2.5 ± 14%     3.6 ± 5%      4.5 ± 8%      5.4 ± 4%      6.2 ± 5%      7.4 ± 3%
-                                                    Comp    10.6us ± 3%   20.4us ± 1%   30.3us ± 0%   40.3us ± 0%   50.5us ± 0%   60.5us ± 0%   70.6us ± 0%
-                                                    Decomp  100.3us ± 0%  200.2us ± 0%  300.6us ± 0%  400.4us ± 0%  500.4us ± 0%  600.5us ± 0%  700.4us ± 0%
-other   48-128KB    1.1-1.5  5        37.7KB ± 66%  CR      1.4 ± 18%     2.6 ± 11%     3.4 ± 8%      4.5 ± 8%      5.4 ± 4%      6.6 ± 5%      7.7 ± 4%
-                                                    Comp    10.5us ± 3%   20.6us ± 1%   30.5us ± 0%   40.5us ± 0%   50.3us ± 0%   60.4us ± 0%   70.4us ± 0%
-                                                    Decomp  100.3us ± 0%  200.4us ± 0%  300.5us ± 0%  400.6us ± 0%  500.4us ± 0%  600.3us ± 0%  700.3us ± 0%
+Kind    Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       MinLZ2       ZSTD1        ZSTD3        ZSTD5        ZSTD7
+sstval  24-48KB     1.1-1.5  5        44.7KB ± 53%  CR      1.34 ± 17%   2.57 ± 9%    3.64 ± 6%    4.29 ± 3%    5.48 ± 5%    6.21 ± 4%    7.15 ± 1%
+                                                    Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+sstval  24-48KB     1.5-2.5  5        24.6KB ± 77%  CR      1.65 ± 10%   2.53 ± 13%   3.56 ± 4%    4.45 ± 6%    5.40 ± 6%    6.37 ± 3%    7.36 ± 4%
+                                                    Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+sstval  24-48KB     >2.5     6        34.3KB ± 71%  CR      1.34 ± 22%   2.48 ± 6%    3.35 ± 8%    4.38 ± 6%    5.34 ± 3%    6.58 ± 4%    7.41 ± 4%
+                                                    Comp    92MBps ± 2%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+index   48-128KB    >2.5     12       36.6KB ± 49%  CR      1.34 ± 23%   2.64 ± 11%   3.56 ± 7%    4.26 ± 5%    5.52 ± 5%    6.35 ± 4%    7.45 ± 4%
+                                                    Comp    92MBps ± 3%  47MBps ± 2%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+index   >128KB      <1.1     22       34.4KB ± 59%  CR      1.49 ± 22%   2.34 ± 11%   3.31 ± 7%    4.46 ± 6%    5.52 ± 6%    6.37 ± 4%    7.50 ± 4%
+                                                    Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
 
 example-buckets-csv min-samples=6
 ----
-Kind,Size Range,Test CR,Samples,Size,Size±,Snappy CR,Snappy CR±,Snappy Comp us,Snappy Comp±,Snappy Decomp us,Snappy Decomp±,MinLZ1 CR,MinLZ1 CR±,MinLZ1 Comp us,MinLZ1 Comp±,MinLZ1 Decomp us,MinLZ1 Decomp±,MinLZ2 CR,MinLZ2 CR±,MinLZ2 Comp us,MinLZ2 Comp±,MinLZ2 Decomp us,MinLZ2 Decomp±,ZSTD1 CR,ZSTD1 CR±,ZSTD1 Comp us,ZSTD1 Comp±,ZSTD1 Decomp us,ZSTD1 Decomp±,ZSTD3 CR,ZSTD3 CR±,ZSTD3 Comp us,ZSTD3 Comp±,ZSTD3 Decomp us,ZSTD3 Decomp±,ZSTD5 CR,ZSTD5 CR±,ZSTD5 Comp us,ZSTD5 Comp±,ZSTD5 Decomp us,ZSTD5 Decomp±,ZSTD7 CR,ZSTD7 CR±,ZSTD7 Comp us,ZSTD7 Comp±,ZSTD7 Decomp us,ZSTD7 Decomp±
-data,48-128KB,<1.1,19,25432,14059,1.4,0.3,10.4,0.3,100.4,0.3,2.6,0.3,20.4,0.3,200.5,0.2,3.4,0.3,30.4,0.3,300.4,0.3,4.5,0.3,40.5,0.3,400.5,0.3,5.5,0.3,50.5,0.2,500.5,0.3,6.4,0.3,60.5,0.2,600.5,0.3,7.4,0.3,70.5,0.3,700.4,0.3
-sstval,24-48KB,>2.5,6,33277,19214,1.4,0.3,10.6,0.4,100.4,0.2,2.4,0.2,20.5,0.3,200.4,0.3,3.2,0.2,30.2,0.3,300.3,0.3,4.4,0.3,40.6,0.3,400.4,0.2,5.5,0.3,50.5,0.3,500.2,0.2,6.4,0.2,60.4,0.2,600.3,0.3,7.7,0.2,70.5,0.2,700.5,0.2
-other,<24KB,1.1-1.5,8,21600,13217,1.5,0.3,10.6,0.3,100.3,0.3,2.5,0.4,20.4,0.2,200.2,0.3,3.6,0.2,30.3,0.2,300.6,0.2,4.5,0.4,40.3,0.2,400.4,0.2,5.4,0.2,50.5,0.3,500.4,0.4,6.2,0.3,60.5,0.3,600.5,0.3,7.4,0.3,70.6,0.1,700.4,0.3
+Kind,Size Range,Test CR,Samples,Size,Size±,Snappy CR,Snappy CR±,Snappy Comp ns/b,Snappy Comp±,Snappy Decomp ns/b,Snappy Decomp±,MinLZ1 CR,MinLZ1 CR±,MinLZ1 Comp ns/b,MinLZ1 Comp±,MinLZ1 Decomp ns/b,MinLZ1 Decomp±,MinLZ2 CR,MinLZ2 CR±,MinLZ2 Comp ns/b,MinLZ2 Comp±,MinLZ2 Decomp ns/b,MinLZ2 Decomp±,ZSTD1 CR,ZSTD1 CR±,ZSTD1 Comp ns/b,ZSTD1 Comp±,ZSTD1 Decomp ns/b,ZSTD1 Decomp±,ZSTD3 CR,ZSTD3 CR±,ZSTD3 Comp ns/b,ZSTD3 Comp±,ZSTD3 Decomp ns/b,ZSTD3 Decomp±,ZSTD5 CR,ZSTD5 CR±,ZSTD5 Comp ns/b,ZSTD5 Comp±,ZSTD5 Decomp ns/b,ZSTD5 Decomp±,ZSTD7 CR,ZSTD7 CR±,ZSTD7 Comp ns/b,ZSTD7 Comp±,ZSTD7 Decomp ns/b,ZSTD7 Decomp±
+sstval,24-48KB,>2.5,6,35074,24930,1.337,0.289,10.348,0.191,100.419,0.268,2.483,0.157,20.422,0.270,200.394,0.223,3.347,0.276,30.423,0.254,300.431,0.084,4.384,0.251,40.392,0.226,400.273,0.278,5.341,0.182,50.513,0.218,500.538,0.152,6.583,0.274,60.574,0.173,600.736,0.254,7.408,0.300,70.489,0.264,700.386,0.291
+index,48-128KB,>2.5,12,37516,18543,1.336,0.308,10.419,0.275,100.429,0.305,2.635,0.282,20.423,0.351,200.391,0.336,3.559,0.248,30.453,0.319,300.496,0.267,4.262,0.210,40.597,0.290,400.442,0.233,5.525,0.250,50.441,0.295,500.490,0.281,6.353,0.226,60.591,0.281,600.367,0.240,7.450,0.301,70.278,0.145,700.416,0.313
+index,>128KB,<1.1,22,35247,20784,1.489,0.325,10.447,0.281,100.478,0.320,2.343,0.261,20.326,0.249,200.506,0.250,3.306,0.229,30.519,0.239,300.492,0.285,4.462,0.253,40.420,0.215,400.380,0.244,5.520,0.329,50.422,0.301,500.354,0.269,6.368,0.270,60.446,0.289,600.340,0.261,7.504,0.311,70.457,0.293,700.497,0.274

--- a/sstable/compressionanalyzer/testdata/file_analyzer
+++ b/sstable/compressionanalyzer/testdata/file_analyzer
@@ -2,12 +2,12 @@ sst
 ../testdata/hamlet-sst/000002.sst
 ----
 Kind   Size Range  Test CR  Samples  Size                 Snappy      MinLZ1      MinLZ2      ZSTD1       ZSTD3       ZSTD5       ZSTD7
-data   <24KB       1.5-2.5  14       1.9KB ± 25%  CR      1.9 ± 5%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%
-                                                  Comp    0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%
-                                                  Decomp  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%
-index  <24KB       1.1-1.5  1        0.3KB ± 0%   CR      1.3 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%
-                                                  Comp    0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%
-                                                  Decomp  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%
-other  <24KB       1.1-1.5  1        0.4KB ± 0%   CR      1.3 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%    0.0 ± 0%
-                                                  Comp    0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%
-                                                  Decomp  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%  0.0us ± 0%
+data   <24KB       1.5-2.5  14       1.9KB ± 25%  CR      1.93 ± 3%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                  Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                  Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+index  <24KB       1.1-1.5  1        0.3KB ± 0%   CR      1.31 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                  Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                  Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+other  <24KB       1.1-1.5  1        0.4KB ± 0%   CR      1.28 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                  Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                  Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%

--- a/sstable/compressionanalyzer/welford.go
+++ b/sstable/compressionanalyzer/welford.go
@@ -29,36 +29,62 @@ func (w *Welford) Count() int64 {
 }
 
 // Mean returns the current running mean.
-// If no values have been added, returns NaN.
+// If no values have been added, returns 0.
 func (w *Welford) Mean() float64 {
-	if w.count == 0 {
-		return math.NaN()
-	}
 	return w.mean
 }
 
-// Variance returns the population variance (M2/n). Returns NaN if no values.
-func (w *Welford) Variance() float64 {
-	if w.count == 0 {
-		return math.NaN()
-	}
-	return w.m2 / float64(w.count)
-}
-
-// SampleVariance returns the sample variance (M2/(n-1)). Returns NaN if fewer than 2 values.
+// SampleVariance returns the sample variance (M2/(n-1)). Returns 0 if fewer than 2 values.
 func (w *Welford) SampleVariance() float64 {
 	if w.count < 2 {
-		return math.NaN()
+		return 0
 	}
 	return w.m2 / float64(w.count-1)
-}
-
-// StandardDeviation returns the population standard deviation.
-func (w *Welford) StandardDeviation() float64 {
-	return math.Sqrt(w.Variance())
 }
 
 // SampleStandardDeviation returns the sample standard deviation.
 func (w *Welford) SampleStandardDeviation() float64 {
 	return math.Sqrt(w.SampleVariance())
+}
+
+// WeightedWelford maintains running statistics for mean and variance using
+// an extension of Welford's algorithm which allows for weighted samples; see
+// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Weighted_incremental_algorithm
+type WeightedWelford struct {
+	wSum  float64
+	w2Sum float64
+	mean  float64
+	s     float64
+}
+
+// Add incorporates a new data point x with the given frequency into the running
+// statistics.
+func (ww *WeightedWelford) Add(x float64, frequency uint64) {
+	w := float64(frequency)
+	ww.wSum += w
+	ww.w2Sum += w * w
+	delta := x - ww.mean
+	ww.mean += delta * (w / ww.wSum)
+	delta2 := x - ww.mean
+	ww.s += w * delta * delta2
+}
+
+// Mean returns the current running mean.
+// If no values have been added, returns 0.
+func (ww *WeightedWelford) Mean() float64 {
+	return ww.mean
+}
+
+// SampleVariance returns the sample variance (M2/(n-1)). Returns 0 if the sum
+// of added frequencies is less than 2.
+func (ww *WeightedWelford) SampleVariance() float64 {
+	if ww.wSum < 2 {
+		return 0
+	}
+	return ww.s / (ww.wSum - 1)
+}
+
+// SampleStandardDeviation returns the sample standard deviation.
+func (ww *WeightedWelford) SampleStandardDeviation() float64 {
+	return math.Sqrt(ww.SampleVariance())
 }


### PR DESCRIPTION
We record compression ratio and block compression/decompression time
per block. This is ok when blocks are about the same size but are less
useful when there is larger variance (as in >128KB buckets).

We want the compression ratio to be the ratio between the total
decompressed size and the total compressed size, not the average
compression ratio among blocks. Similarly, we want to measure
performance in terms of CPU time per byte.

We switch to using frequency-weighted sampling (where frequency is the
size of the block) and we now show compression/decompression
performance in MB/s. Note that the standard deviation for the latter
is derived from the CPU time per second metric, it doesn't apply
directly to the MB/s figure.