### PR TITLE
db: clean up table stats collection

### DIFF
--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -250,7 +250,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 				return errors.CombineErrors(err, readable.Close()).Error()
 			}
 			defer r.Close()
-			iter, err := newCombinedDeletionKeyspanIter(cmp, r, m, sstable.NoReadEnv)
+			iter, err := newCombinedDeletionKeyspanIter(context.Background(), cmp, r, m, sstable.NoReadEnv)
 			if err != nil {
 				return err.Error()
 			}


### PR DESCRIPTION
This commit cleans up some lingering branching on virtual sstables that was missed when we removed the concept of a virtual sstable reader in #4375. Additionally we take the opportunity to propagate a context throughout the table stats collection, remove an unused parameter and apply other small hygiene improvements.