### PR TITLE
*: add BlobFileID

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2488,10 +2488,10 @@ func (d *DB) cleanupVersionEdit(ve *versionEdit) {
 		obsoleteFiles.AddBlob(ve.NewBlobFiles[i])
 		d.mu.versions.zombieBlobs.Add(objectInfo{
 			fileInfo: fileInfo{
-				FileNum:  ve.NewBlobFiles[i].FileNum,
+				FileNum:  base.DiskFileNum(ve.NewBlobFiles[i].FileID),
 				FileSize: ve.NewBlobFiles[i].Size,
 			},
-			isLocal: objstorage.IsLocalBlobFile(d.objProvider, ve.NewBlobFiles[i].FileNum),
+			isLocal: objstorage.IsLocalBlobFile(d.objProvider, base.DiskFileNum(ve.NewBlobFiles[i].FileID)),
 		})
 	}
 	for i := range ve.NewTables {

--- a/data_test.go
+++ b/data_test.go
@@ -927,7 +927,7 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 	// them to the final version edit.
 	valueSeparator := &defineDBValueSeparator{
 		pbr:   &preserveBlobReferences{},
-		metas: make(map[base.DiskFileNum]*manifest.BlobFileMetadata),
+		metas: make(map[base.BlobFileID]*manifest.BlobFileMetadata),
 	}
 
 	var mem *memTable
@@ -1173,8 +1173,8 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 			return nil, err
 		}
 		for f, stats := range fileStats {
-			valueSeparator.metas[f].Size = stats.FileLen
-			valueSeparator.metas[f].ValueSize = stats.UncompressedValueBytes
+			valueSeparator.metas[base.BlobFileID(f)].Size = stats.FileLen
+			valueSeparator.metas[base.BlobFileID(f)].ValueSize = stats.UncompressedValueBytes
 		}
 
 		ve.NewBlobFiles = slices.Collect(maps.Values(valueSeparator.metas))
@@ -1640,7 +1640,7 @@ func describeLSM(d *DB, verbose bool) string {
 	if blobFileMetas := d.mu.versions.blobFiles.Metadatas(); len(blobFileMetas) > 0 {
 		buf.WriteString("Blob files:\n")
 		for _, meta := range blobFileMetas {
-			fmt.Fprintf(&buf, "  %s: %d physical bytes, %d value bytes\n", meta.FileNum, meta.Size, meta.ValueSize)
+			fmt.Fprintf(&buf, "  %s: %d physical bytes, %d value bytes\n", meta.FileID, meta.Size, meta.ValueSize)
 		}
 	}
 	return buf.String()

--- a/event.go
+++ b/event.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/remote"
+	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 )
@@ -1234,8 +1235,9 @@ func (d *DB) reportCorruption(meta any, err error) error {
 	case *manifest.TableMetadata:
 		return d.reportFileCorruption(base.FileTypeTable, meta.TableBacking.DiskFileNum, meta.UserKeyBounds(), err)
 	case *manifest.BlobFileMetadata:
+		diskFileNum := blob.DiskFileNumTODO(meta.FileID)
 		// TODO(jackson): Add bounds for blob files.
-		return d.reportFileCorruption(base.FileTypeBlob, meta.FileNum, base.UserKeyBounds{}, err)
+		return d.reportFileCorruption(base.FileTypeBlob, diskFileNum, base.UserKeyBounds{}, err)
 	default:
 		panic(fmt.Sprintf("unknown metadata type: %T", meta))
 	}

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -44,6 +44,21 @@ func PhysicalTableFileNum(f DiskFileNum) TableNum {
 	return TableNum(f)
 }
 
+// BlobFileID is an internal identifier for a blob file.
+//
+// Initially there exists a physical blob file with a DiskFileNum that equals
+// the value of the BlobFileID. However, if the blob file is replaced, the
+// manifest.Version may re-map the BlobFileID to a new DiskFileNum.
+type BlobFileID uint64
+
+// String returns a string representation of the blob file ID.
+func (id BlobFileID) String() string { return fmt.Sprintf("%06d", id) }
+
+// SafeFormat implements redact.SafeFormatter.
+func (id BlobFileID) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%06d", redact.SafeUint(id))
+}
+
 // A DiskFileNum identifies a file or object with exists on disk.
 type DiskFileNum uint64
 

--- a/internal/base/lazy_value_test.go
+++ b/internal/base/lazy_value_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 type valueFetcherFunc func(
-	handle []byte, blobFileNum DiskFileNum, valLen uint32, buf []byte) (val []byte, callerOwned bool, err error)
+	handle []byte, blobFileID BlobFileID, valLen uint32, buf []byte) (val []byte, callerOwned bool, err error)
 
 func (v valueFetcherFunc) Fetch(
-	ctx context.Context, handle []byte, blobFileNum DiskFileNum, valLen uint32, buf []byte,
+	ctx context.Context, handle []byte, blobFileID BlobFileID, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
-	return v(handle, blobFileNum, valLen, buf)
+	return v(handle, blobFileID, valLen, buf)
 }
 
 func TestLazyValue(t *testing.T) {
@@ -54,15 +54,15 @@ func TestLazyValue(t *testing.T) {
 			ValueOrHandle: []byte("foo-handle"),
 			Fetcher: &LazyFetcher{
 				Fetcher: valueFetcherFunc(
-					func(handle []byte, blobFileNum DiskFileNum, valLen uint32, buf []byte) ([]byte, bool, error) {
+					func(handle []byte, blobFileID BlobFileID, valLen uint32, buf []byte) ([]byte, bool, error) {
 						numCalls++
 						require.Equal(t, []byte("foo-handle"), handle)
 						require.Equal(t, uint32(3), valLen)
-						require.Equal(t, DiskFileNum(90), blobFileNum)
+						require.Equal(t, BlobFileID(90), blobFileID)
 						return fooBytes1, callerOwned, nil
 					}),
-				Attribute:   AttributeAndLen{ValueLen: 3, ShortAttribute: 7},
-				BlobFileNum: 90,
+				Attribute:  AttributeAndLen{ValueLen: 3, ShortAttribute: 7},
+				BlobFileID: 90,
 			},
 		}
 		require.Equal(t, []byte("foo"), getValue(fooLV3, callerOwned))

--- a/internal/base/value.go
+++ b/internal/base/value.go
@@ -31,7 +31,7 @@ func MakeInPlaceValue(val []byte) InternalValue {
 // to a value stored externally in a blob file.
 func (v *InternalValue) IsBlobValueHandle() bool {
 	f := v.lazyValue.Fetcher
-	return f != nil && f.BlobFileNum > 0
+	return f != nil && f.BlobFileID > 0
 }
 
 // IsInPlaceValue returns true iff the value was stored in-place and does not

--- a/internal/compact/iterator_test.go
+++ b/internal/compact/iterator_test.go
@@ -218,7 +218,7 @@ func TestCompactionIter(t *testing.T) {
 						if kv.V.IsBlobValueHandle() {
 							lv := kv.V.LazyValue()
 							value = []byte(fmt.Sprintf("<blobref(%s, encodedHandle=%x, valLen=%d)>",
-								lv.Fetcher.BlobFileNum, lv.ValueOrHandle, lv.Fetcher.Attribute.ValueLen))
+								lv.Fetcher.BlobFileID, lv.ValueOrHandle, lv.Fetcher.Attribute.ValueLen))
 						} else {
 							var err error
 							value, _, err = kv.Value(nil)
@@ -297,10 +297,10 @@ type mockBlobValueFetcher struct{}
 var _ base.ValueFetcher = mockBlobValueFetcher{}
 
 func (mockBlobValueFetcher) Fetch(
-	ctx context.Context, handle []byte, fileNum base.DiskFileNum, valLen uint32, buf []byte,
+	ctx context.Context, handle []byte, blobFileID base.BlobFileID, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
 	s := fmt.Sprintf("<fetched value from blobref(%s, encodedHandle=%x, valLen=%d)>",
-		fileNum, handle, valLen)
+		blobFileID, handle, valLen)
 	return []byte(s), false, nil
 }
 
@@ -324,8 +324,8 @@ func decodeBlobReference(t testing.TB, ref string) base.InternalValue {
 	return base.MakeLazyValue(base.LazyValue{
 		ValueOrHandle: encodeRemainingHandle(uint32(blockNum), uint32(off)),
 		Fetcher: &base.LazyFetcher{
-			Fetcher:     mockBlobValueFetcher{},
-			BlobFileNum: base.DiskFileNum(fileNum),
+			Fetcher:    mockBlobValueFetcher{},
+			BlobFileID: base.BlobFileID(fileNum),
 			Attribute: base.AttributeAndLen{
 				ValueLen: uint32(valLen),
 			},

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -164,7 +164,7 @@ func (assertNoObsoleteFiles) AddBacking(fb *TableBacking) {
 
 // AddBlob appends the provided BlobFileMetadata to the list of obsolete files.
 func (assertNoObsoleteFiles) AddBlob(bm *BlobFileMetadata) {
-	panic(errors.AssertionFailedf("blob file %s dereferenced to zero during tree mutation", bm.FileNum))
+	panic(errors.AssertionFailedf("blob file %s dereferenced to zero during tree mutation", bm.FileID))
 }
 
 // ignoreObsoleteFiles is an ObsoleteFilesSet implementation that ignores

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -117,10 +117,10 @@ type TableInfo struct {
 
 // GetBlobReferenceFiles returns the list of blob file numbers referenced by
 // the table.
-func (t *TableInfo) GetBlobReferenceFiles() []base.DiskFileNum {
-	files := make([]base.DiskFileNum, 0, len(t.blobReferences))
+func (t *TableInfo) GetBlobReferenceFiles() []base.BlobFileID {
+	files := make([]base.BlobFileID, 0, len(t.blobReferences))
 	for _, blob := range t.blobReferences {
-		files = append(files, blob.FileNum)
+		files = append(files, blob.FileID)
 	}
 	return files
 }
@@ -438,7 +438,7 @@ func (m *TableMetadata) Ref() {
 			// set it explicitly when constructing the TableMetadata (during
 			// compactions, flushes).
 			if blobRef.Metadata == nil {
-				panic(errors.AssertionFailedf("%s reference to blob %s has no metadata", m.TableNum, blobRef.FileNum))
+				panic(errors.AssertionFailedf("%s reference to blob %s has no metadata", m.TableNum, blobRef.FileID))
 			}
 			blobRef.Metadata.ref()
 		}
@@ -938,7 +938,7 @@ func (m *TableMetadata) DebugString(format base.FormatKey, verbose bool) string 
 			if i > 0 {
 				fmt.Fprint(&b, ", ")
 			}
-			fmt.Fprintf(&b, "(%s: %d)", r.FileNum, r.ValueSize)
+			fmt.Fprintf(&b, "(%s: %d)", r.FileID, r.ValueSize)
 		}
 		fmt.Fprintf(&b, "; depth:%d]", m.BlobReferenceDepth)
 	}
@@ -1022,7 +1022,7 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 				}
 				p.Expect("(")
 				var ref BlobReference
-				ref.FileNum = base.DiskFileNum(p.FileNum())
+				ref.FileID = base.BlobFileID(p.Uint64())
 				p.Expect(":")
 				ref.ValueSize = p.Uint64()
 				m.BlobReferences = append(m.BlobReferences, ref)

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -847,9 +847,9 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 						// referenced by the sstable are present.
 						if refs, ok := blobRefMap[fileNum]; ok {
 							for _, bf := range refs {
-								if _, ok := r.workload.blobFiles[base.FileNum(bf.FileNum)]; !ok {
+								if _, ok := r.workload.blobFiles[base.FileNum(bf.FileID)]; !ok {
 									return errors.Newf("blob file %s not found for sstable %s",
-										bf.FileNum, fileNum)
+										bf.FileID, fileNum)
 								}
 							}
 						}

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -154,10 +154,10 @@ func (w *FileWriter) AddValue(v []byte) Handle {
 	w.stats.UncompressedValueBytes += uint64(len(v))
 	w.valuesEncoder.AddValue(v)
 	return Handle{
-		FileNum:  w.fileNum,
-		ValueLen: uint32(len(v)),
-		BlockID:  BlockID(w.stats.BlockCount),
-		ValueID:  BlockValueID(valuesInBlock),
+		BlobFileID: base.BlobFileID(w.fileNum),
+		ValueLen:   uint32(len(v)),
+		BlockID:    BlockID(w.stats.BlockCount),
+		ValueID:    BlockValueID(valuesInBlock),
 	}
 }
 

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -132,7 +132,7 @@ func TestValueFetcher(t *testing.T) {
 			}.Encode(handleBuf[:])
 			encodedHandleSuffix := handleBuf[:n]
 
-			val, _, err := fetcher.Fetch(ctx, encodedHandleSuffix, base.DiskFileNum(blobFileNum), valLen, nil)
+			val, _, err := fetcher.Fetch(ctx, encodedHandleSuffix, base.BlobFileID(blobFileNum), valLen, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -152,7 +152,7 @@ func writeValueFetcherState(w *bytes.Buffer, f *ValueFetcher) {
 			fmt.Fprintln(w, "  empty")
 			continue
 		}
-		fmt.Fprintf(w, "  %s (blk%d)\n", cr.fileNum, cr.currentValueBlock.physicalIndex)
+		fmt.Fprintf(w, "  %s (blk%d)\n", cr.diskFileNum, cr.currentValueBlock.physicalIndex)
 	}
 	fmt.Fprintf(w, "}\n")
 }

--- a/sstable/blob/handle.go
+++ b/sstable/blob/handle.go
@@ -32,8 +32,8 @@ type BlockID uint32
 
 // Handle describes the location of a value stored within a blob file.
 type Handle struct {
-	FileNum  base.DiskFileNum
-	ValueLen uint32
+	BlobFileID base.BlobFileID
+	ValueLen   uint32
 	// BlockID identifies the block within the blob file containing the value.
 	BlockID BlockID
 	// ValueID identifies the value within the block identified by BlockID.
@@ -47,7 +47,7 @@ func (h Handle) String() string {
 
 // SafeFormat implements redact.SafeFormatter.
 func (h Handle) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("(%s,blk%d,id%d,len%d)", h.FileNum, h.BlockID, h.ValueID, h.ValueLen)
+	w.Printf("(%s,blk%d,id%d,len%d)", h.BlobFileID, h.BlockID, h.ValueID, h.ValueLen)
 }
 
 // TODO(jackson): Consider encoding the handle's data using columnar block

--- a/sstable/valblk/reader.go
+++ b/sstable/valblk/reader.go
@@ -190,7 +190,7 @@ func newValueBlockFetcher(
 
 // Fetch implements base.ValueFetcher.
 func (f *valueBlockFetcher) Fetch(
-	ctx context.Context, handle []byte, blobFileNum base.DiskFileNum, valLen uint32, buf []byte,
+	ctx context.Context, handle []byte, _ base.BlobFileID, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
 	if !f.closed {
 		val, err := f.getValueInternal(handle, valLen)

--- a/sstable/values.go
+++ b/sstable/values.go
@@ -53,15 +53,15 @@ func LoadValBlobContext(
 	}
 }
 
-// BlobReferences provides a mapping from an index to a file number for a
+// BlobReferences provides a mapping from an index to a blob file ID for a
 // sstable's blob references. In practice, this is implemented by
 // manifest.BlobReferences.
 type BlobReferences interface {
-	// FileNumByID returns the FileNum for the identified BlobReference.
-	FileNumByID(i blob.ReferenceID) base.DiskFileNum
-	// IDByFileNum returns the reference ID for the given FileNum. If the file
-	// number is not found, the second return value is false.
-	IDByFileNum(fileNum base.DiskFileNum) (blob.ReferenceID, bool)
+	// BlobFileIDByID returns the BlobFileID for the identified BlobReference.
+	BlobFileIDByID(i blob.ReferenceID) base.BlobFileID
+	// IDByBlobFileID returns the reference ID for the given BlobFileID. If the
+	// blob file ID is not found, the second return value is false.
+	IDByBlobFileID(fileID base.BlobFileID) (blob.ReferenceID, bool)
 }
 
 // TableBlobContext configures how values that reference external blob files
@@ -155,7 +155,7 @@ func (i *defaultInternalValueConstructor) GetInternalValueForPrefixAndValueHandl
 			ValueLen:       preface.ValueLen,
 			ShortAttribute: vp.ShortAttribute(),
 		},
-		BlobFileNum: i.blobContext.References.FileNumByID(preface.ReferenceID),
+		BlobFileID: i.blobContext.References.BlobFileIDByID(preface.ReferenceID),
 	}
 	return base.MakeLazyValue(base.LazyValue{
 		ValueOrHandle: remainder,

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -107,7 +107,7 @@ Print the records in the sstables. The sstables are scanned in command line
 order which means the records will be printed in that order. Raw range
 tombstones are displayed interleaved with point records.
 
-When --blob-mode=load is specified, the path to a directory containing a 
+When --blob-mode=load is specified, the path to a directory containing a
 manifest and blob file must be provided as the last argument.
 `,
 		Args: cobra.MinimumNArgs(1),
@@ -625,7 +625,7 @@ func findAndReadManifests(
 	if len(manifests) == 0 {
 		return nil, errors.New("no MANIFEST files found in the given path")
 	}
-	blobMetas := make(map[base.DiskFileNum]struct{})
+	blobMetas := make(map[base.BlobFileID]struct{})
 	for _, fl := range manifests {
 		func() {
 			mf, err := fs.Open(fl.path)
@@ -650,8 +650,8 @@ func findAndReadManifests(
 					break
 				}
 				for _, bf := range ve.NewBlobFiles {
-					if _, ok := blobMetas[bf.FileNum]; !ok {
-						blobMetas[bf.FileNum] = struct{}{}
+					if _, ok := blobMetas[bf.FileID]; !ok {
+						blobMetas[bf.FileID] = struct{}{}
 					}
 				}
 			}
@@ -662,7 +662,7 @@ func findAndReadManifests(
 	i := 0
 	for fn := range blobMetas {
 		blobRefs[i] = manifest.BlobReference{
-			FileNum: fn,
+			FileID: base.BlobFileID(fn),
 		}
 		i++
 	}

--- a/version_set.go
+++ b/version_set.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/record"
+	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
 )
@@ -905,21 +906,21 @@ func getZombieBlobFilesAndComputeLocalMetrics(
 	ve *versionEdit, provider objstorage.Provider,
 ) (zombieBlobFiles []objectInfo, localLiveDelta fileMetricDelta) {
 	for _, b := range ve.NewBlobFiles {
-		if objstorage.IsLocalBlobFile(provider, b.FileNum) {
+		if objstorage.IsLocalBlobFile(provider, base.DiskFileNum(b.FileID)) {
 			localLiveDelta.count++
 			localLiveDelta.size += int64(b.Size)
 		}
 	}
 	zombieBlobFiles = make([]objectInfo, 0, len(ve.DeletedBlobFiles))
-	for _, b := range ve.DeletedBlobFiles {
-		isLocal := objstorage.IsLocalBlobFile(provider, b.FileNum)
+	for dfn, b := range ve.DeletedBlobFiles {
+		isLocal := objstorage.IsLocalBlobFile(provider, dfn)
 		if isLocal {
 			localLiveDelta.count--
 			localLiveDelta.size -= int64(b.Size)
 		}
 		zombieBlobFiles = append(zombieBlobFiles, objectInfo{
 			fileInfo: fileInfo{
-				FileNum:  b.FileNum,
+				FileNum:  dfn,
 				FileSize: b.Size,
 			},
 			isLocal: isLocal,
@@ -1139,7 +1140,10 @@ func (vs *versionSet) addLiveFileNums(m map[base.DiskFileNum]struct{}) {
 			for f := range lm.All() {
 				m[f.TableBacking.DiskFileNum] = struct{}{}
 				for _, ref := range f.BlobReferences {
-					m[ref.FileNum] = struct{}{}
+					// TODO(jackson): Once we support blob file replacement, we
+					// need to look up the new blob file's number here.
+					diskFileNum := blob.DiskFileNumTODO(ref.FileID)
+					m[diskFileNum] = struct{}{}
 				}
 			}
 		}
@@ -1179,7 +1183,7 @@ func (vs *versionSet) addObsoleteLocked(obsolete manifest.ObsoleteFiles) {
 
 	newlyObsoleteBlobFiles := make([]objectInfo, len(obsolete.BlobFiles))
 	for i, bf := range obsolete.BlobFiles {
-		newlyObsoleteBlobFiles[i] = vs.zombieBlobs.Extract(bf.FileNum)
+		newlyObsoleteBlobFiles[i] = vs.zombieBlobs.Extract(base.DiskFileNum(bf.FileID))
 	}
 	vs.obsoleteBlobs = mergeObjectInfos(vs.obsoleteBlobs, newlyObsoleteBlobFiles)
 	vs.updateObsoleteObjectMetricsLocked()


### PR DESCRIPTION
Add a BlobFileID type for identifying blob files. When we introduce rewriting and replacing blob files, a BlobReference's file identifier may not translate directly to a file on disk, so we should not use DiskFileNum.

Informs #112.