### PR TITLE
block: clean up compression buffers

### DIFF
--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -116,7 +116,7 @@ type FileWriter struct {
 
 type compressedBlock struct {
 	pb  block.PhysicalBlock
-	bh  *block.BufHandle
+	bh  *block.TempBuffer
 	off uint64
 }
 

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -282,7 +282,7 @@ func (w *FileWriter) Close() (FileWriterStats, error) {
 	{
 		indexBlock := w.indexEncoder.Finish()
 		var compressedBuf []byte
-		pb := block.CompressAndChecksum(&compressedBuf, indexBlock, block.NoCompression, &w.checksummer)
+		pb := block.CompressAndChecksum(&compressedBuf, indexBlock, block.NoopCompressor, &w.checksummer)
 		if _, w.err = pb.WriteTo(w.w); w.err != nil {
 			err = w.err
 			if w.w != nil {

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -144,6 +144,10 @@ type Checksummer struct {
 	blockTypeBuf [1]byte
 }
 
+func (c *Checksummer) Init(typ ChecksumType) {
+	c.Type = typ
+}
+
 // Checksum computes a checksum over the provided block and block type.
 func (c *Checksummer) Checksum(block []byte, blockType byte) (checksum uint32) {
 	// Calculate the checksum.

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -260,14 +260,6 @@ func (b *PhysicalBlock) WriteTo(w objstorage.Writable) (n int, err error) {
 // the compressed payload is discarded and the original, uncompressed block data
 // is used to avoid unnecessary decompression overhead at read time.
 func CompressAndChecksum(
-	dst *[]byte, blockData []byte, c Compression, checksummer *Checksummer,
-) PhysicalBlock {
-	compressor := GetCompressor(c)
-	defer compressor.Close()
-	return CompressAndChecksumWithCompressor(dst, blockData, compressor, checksummer)
-}
-
-func CompressAndChecksumWithCompressor(
 	dst *[]byte, blockData []byte, compressor Compressor, checksummer *Checksummer,
 ) PhysicalBlock {
 	buf := (*dst)[:0]
@@ -296,7 +288,7 @@ func CompressAndChecksumToTempBuffer(
 ) (PhysicalBlock, *TempBuffer) {
 	// Grab a buffer to use as the destination for compression.
 	compressedBuf := NewTempBuffer()
-	pb := CompressAndChecksumWithCompressor(&compressedBuf.b, blockData, compressor, checksummer)
+	pb := CompressAndChecksum(&compressedBuf.b, blockData, compressor, checksummer)
 	return pb, compressedBuf
 }
 

--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -38,6 +38,13 @@ func (c *Compressor) Close() {
 	*c = Compressor{}
 }
 
+// NoopCompressor is a Compressor that does not compress data. It does not have
+// any state and can be used in parallel.
+var NoopCompressor = Compressor{
+	algorithm:  compression.NoCompression,
+	compressor: compression.GetCompressor(compression.None),
+}
+
 type Decompressor = compression.Decompressor
 
 func GetDecompressor(c CompressionIndicator) Decompressor {

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -720,7 +720,7 @@ func (w *RawColumnWriter) enqueueDataBlock(
 	// Serialize the data block, compress it and send it to the write queue.
 	cb := compressedBlockPool.Get().(*compressedBlock)
 	cb.blockBuf.checksummer.Type = w.opts.Checksum
-	cb.physical = block.CompressAndChecksumWithCompressor(
+	cb.physical = block.CompressAndChecksum(
 		&cb.blockBuf.dataBuf,
 		serializedBlock,
 		w.compressor,
@@ -1247,7 +1247,7 @@ func (w *RawColumnWriter) addDataBlock(b, sep []byte, bhp block.HandleWithProper
 	// Serialize the data block, compress it and send it to the write queue.
 	cb := compressedBlockPool.Get().(*compressedBlock)
 	cb.blockBuf.checksummer.Type = w.opts.Checksum
-	cb.physical = block.CompressAndChecksumWithCompressor(
+	cb.physical = block.CompressAndChecksum(
 		&cb.blockBuf.dataBuf,
 		b,
 		w.compressor,

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -758,7 +758,7 @@ func decodeColumnarMetaIndex(
 }
 
 // layoutWriter writes the structure of an sstable to durable storage. It
-// accepts serialized blocks, writes them to storage and returns a block handle
+// accepts serialized blocks, writes them to storage, and returns a block handle
 // describing the offset and length of the block.
 type layoutWriter struct {
 	writable objstorage.Writable
@@ -842,7 +842,7 @@ func (w *layoutWriter) WriteIndexBlock(b []byte) (block.Handle, error) {
 	return h, err
 }
 
-// WriteFilterBlock finishes the provided filter, constructs a trailer and
+// WriteFilterBlock finishes the provided filter, constructs a trailer, and
 // writes the block and trailer to the writer. It automatically adds the filter
 // block to the file's meta index when the writer is finished.
 func (w *layoutWriter) WriteFilterBlock(f filterWriter) (bh block.Handle, err error) {

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -916,7 +916,10 @@ func (w *layoutWriter) WriteValueIndexBlock(
 func (w *layoutWriter) writeBlock(
 	b []byte, compression block.Compression, buf *blockBuf,
 ) (block.Handle, error) {
-	pb := block.CompressAndChecksum(&buf.dataBuf, b, compression, &buf.checksummer)
+	// TODO(radu): store a compressor in the layoutWriter.
+	compressor := block.GetCompressor(compression)
+	defer compressor.Close()
+	pb := block.CompressAndChecksum(&buf.dataBuf, b, compressor, &buf.checksummer)
 	h, err := w.writePrecompressedBlock(pb)
 	return h, err
 }

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -170,6 +170,8 @@ func rewriteDataBlocksInParallel(
 			// We'll assume all blocks are _roughly_ equal so round-robin static partition
 			// of each worker doing every ith block is probably enough.
 			err := func() error {
+				compressor := block.GetCompressor(opts.Compression)
+				defer compressor.Close()
 				for i := worker; i < len(input); i += concurrency {
 					bh := input[i]
 					var err error
@@ -190,7 +192,7 @@ func rewriteDataBlocksInParallel(
 						return err
 					}
 					compressedBuf = compressedBuf[:cap(compressedBuf)]
-					finished := block.CompressAndChecksum(&compressedBuf, outputBlock, opts.Compression, &checksummer)
+					finished := block.CompressAndChecksum(&compressedBuf, outputBlock, compressor, &checksummer)
 					output[i].physical = finished.CloneWithByteAlloc(&blockAlloc)
 				}
 				return nil

--- a/sstable/valblk/writer.go
+++ b/sstable/valblk/writer.go
@@ -30,7 +30,7 @@ type Writer struct {
 
 type bufferedValueBlock struct {
 	block     block.PhysicalBlock
-	bufHandle *block.BufHandle
+	bufHandle *block.TempBuffer
 	handle    block.Handle
 }
 


### PR DESCRIPTION
#### block: rename BufHandle to TempBuffer, use single pool

Using two separate temp buffer pools for compressed and uncompressed
data seems unnecessary and likely leads to more memory usage. Switch
to a single temp buffer pool (which simplifies the code) and rename
`BufHandle` to `TempBuffer`.

#### block: remove Buffer

The `block.Buffer` type does very little and is barely used. Use
`TempBuffer` directly instead.

#### block: remove CompressAndChecksum variant without compressor

We now require a compressor for `CompressAndChecksum`.