### PR TITLE
internal/manifest: genericize btree

### DIFF
--- a/internal/manifest/annotator.go
+++ b/internal/manifest/annotator.go
@@ -79,7 +79,7 @@ type annotation struct {
 	valid atomic.Bool
 }
 
-func (a *Annotator[T]) findExistingAnnotation(n *node) *annotation {
+func (a *Annotator[T]) findExistingAnnotation(n *node[*TableMetadata]) *annotation {
 	n.annotMu.RLock()
 	defer n.annotMu.RUnlock()
 	for i := range n.annot {
@@ -92,7 +92,7 @@ func (a *Annotator[T]) findExistingAnnotation(n *node) *annotation {
 
 // findAnnotation finds this Annotator's annotation on a node, creating
 // one if it doesn't already exist.
-func (a *Annotator[T]) findAnnotation(n *node) *annotation {
+func (a *Annotator[T]) findAnnotation(n *node[*TableMetadata]) *annotation {
 	if a := a.findExistingAnnotation(n); a != nil {
 		return a
 	}
@@ -111,7 +111,7 @@ func (a *Annotator[T]) findAnnotation(n *node) *annotation {
 // nodeAnnotation computes this annotator's annotation of this node across all
 // files in the node's subtree. The second return value indicates whether the
 // annotation is stable and thus cacheable.
-func (a *Annotator[T]) nodeAnnotation(n *node) (t *T, cacheOK bool) {
+func (a *Annotator[T]) nodeAnnotation(n *node[*TableMetadata]) (t *T, cacheOK bool) {
 	annot := a.findAnnotation(n)
 	// If the annotation is already marked as valid, we can return it without
 	// recomputing anything.
@@ -153,7 +153,7 @@ func (a *Annotator[T]) nodeAnnotation(n *node) (t *T, cacheOK bool) {
 // files in the node's subtree which overlap with the range defined by bounds.
 // The computed annotation is accumulated into a.scratch.
 func (a *Annotator[T]) accumulateRangeAnnotation(
-	n *node,
+	n *node[*TableMetadata],
 	cmp base.Compare,
 	bounds base.UserKeyBounds,
 	// fullyWithinLowerBound and fullyWithinUpperBound indicate whether this
@@ -237,7 +237,7 @@ func (a *Annotator[T]) accumulateRangeAnnotation(
 
 // InvalidateAnnotation removes any existing cached annotations from this
 // annotator from a node's subtree.
-func (a *Annotator[T]) invalidateNodeAnnotation(n *node) {
+func (a *Annotator[T]) invalidateNodeAnnotation(n *node[*TableMetadata]) {
 	annot := a.findAnnotation(n)
 	annot.valid.Store(false)
 	if !n.leaf {

--- a/internal/manifest/annotator.go
+++ b/internal/manifest/annotator.go
@@ -280,14 +280,16 @@ func (a *Annotator[T]) MultiLevelAnnotation(lms []LevelMetadata) *T {
 // [lowerBound, upperBound). A pointer to the Annotator is used as the key for
 // pre-calculated values, so the same Annotator must be used to avoid duplicate
 // computation.
-func (a *Annotator[T]) LevelRangeAnnotation(lm LevelMetadata, bounds base.UserKeyBounds) *T {
+func (a *Annotator[T]) LevelRangeAnnotation(
+	cmp base.Compare, lm LevelMetadata, bounds base.UserKeyBounds,
+) *T {
 	if lm.Empty() {
 		return a.Aggregator.Zero(nil)
 	}
 
 	var dst *T
 	dst = a.Aggregator.Zero(dst)
-	dst = a.accumulateRangeAnnotation(lm.tree.root, lm.tree.cmp, bounds, false, false, dst)
+	dst = a.accumulateRangeAnnotation(lm.tree.root, cmp, bounds, false, false, dst)
 	return dst
 }
 

--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -88,7 +88,7 @@ func randomBounds(rng *rand.Rand, count int) base.UserKeyBounds {
 
 func requireMatchOverlaps(t *testing.T, v *Version, bounds base.UserKeyBounds) {
 	overlaps := v.Overlaps(6, bounds)
-	numFiles := *NumFilesAnnotator.LevelRangeAnnotation(v.Levels[6], bounds)
+	numFiles := *NumFilesAnnotator.LevelRangeAnnotation(v.cmp.Compare, v.Levels[6], bounds)
 	require.EqualValues(t, overlaps.length, numFiles)
 }
 
@@ -150,7 +150,7 @@ func BenchmarkNumFilesRangeAnnotation(b *testing.B) {
 			toDelete := rng.IntN(count)
 			v.Levels[6].tree.Delete(files[toDelete], ignoreObsoleteFiles{})
 
-			NumFilesAnnotator.LevelRangeAnnotation(v.Levels[6], b)
+			NumFilesAnnotator.LevelRangeAnnotation(v.cmp.Compare, v.Levels[6], b)
 
 			v.Levels[6].tree.Insert(files[toDelete])
 		}

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -14,7 +14,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -690,7 +689,6 @@ func (n *node[M]) verifyInvariants() {
 // goroutines, but Read operations are.
 type btree[M fileMetadata] struct {
 	root *node[M]
-	cmp  base.Compare
 	bcmp btreeCmp[M]
 }
 

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -321,7 +321,7 @@ func newL0Sublevels(
 	// Construct a parallel slice of sublevel B-Trees.
 	// TODO(jackson): Consolidate and only use the B-Trees.
 	for _, sublevelFiles := range s.levelFiles {
-		ls := makeLevelSlice(cmp, btreeCmpSmallestKey(cmp), sublevelFiles)
+		ls := makeLevelSlice(btreeCmpSmallestKey(cmp), sublevelFiles)
 		s.Levels = append(s.Levels, ls)
 	}
 
@@ -635,7 +635,7 @@ func (s *l0Sublevels) addL0Files(
 	// Construct a parallel slice of sublevel B-Trees.
 	// TODO(jackson): Consolidate and only use the B-Trees.
 	for _, sublevel := range updatedSublevels {
-		ls := makeLevelSlice(newVal.cmp, btreeCmpSmallestKey(newVal.cmp), newVal.levelFiles[sublevel])
+		ls := makeLevelSlice(btreeCmpSmallestKey(newVal.cmp), newVal.levelFiles[sublevel])
 		if sublevel == len(newVal.Levels) {
 			newVal.Levels = append(newVal.Levels, ls)
 		} else {

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -83,7 +83,7 @@ L0.0:
 apply v2
   add-table: L0 000001:[a#1,SET-c#2,SET] seqnums:[1-2]
 ----
-pebble: files 000001 and 000001 collided on sort keys
+pebble: files 000001:[a#1,SET-c#2,SET] and 000001:[a#1,SET-c#2,SET] collided on sort keys
 
 apply empty
   add-table: L0 000001:[a#1,SET-c#2,SET] seqnums:[1-2]

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1334,7 +1334,7 @@ func NewVersionForTesting(
 		// order to test consistency checking, etc. Once we've constructed the
 		// initial B-Tree, we swap out the btreeCmp for the correct one.
 		// TODO(jackson): Adjust or remove the tests and remove this.
-		v.Levels[l].tree = makeBTree(comparer.Compare, btreeCmpSpecificOrder(files[l]), files[l])
+		v.Levels[l].tree = makeBTree(btreeCmpSpecificOrder(files[l]), files[l])
 		v.Levels[l].level = l
 		if l == 0 {
 			v.Levels[l].tree.bcmp = btreeCmpSeqNum

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -1758,7 +1758,7 @@ func (v *Version) Overlaps(level int, bounds base.UserKeyBounds) LevelSlice {
 
 			if !restart {
 				// Construct a B-Tree containing only the matching items.
-				var tr btree
+				var tr btree[*TableMetadata]
 				tr.bcmp = v.Levels[level].tree.bcmp
 				for i, meta := 0, l0Iter.First(); meta != nil; i, meta = i+1, l0Iter.Next() {
 					if selectedIndices[i] {
@@ -1768,7 +1768,7 @@ func (v *Version) Overlaps(level int, bounds base.UserKeyBounds) LevelSlice {
 						}
 					}
 				}
-				slice = newLevelSlice(tr.Iter())
+				slice = newLevelSlice(tableMetadataIter(&tr))
 				// TODO(jackson): Avoid the oddity of constructing and
 				// immediately releasing a B-Tree. Make LevelSlice an
 				// interface?

--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -270,12 +270,12 @@ MANIFEST-invalid
   last-seq-num:  20
   added:         L6 000002:0<#1-#4>[#0,DEL-#0,DEL]
 EOF
-pebble: files 000002 and 000001 collided on sort keys
+pebble: files 000002:[#0,DEL-#0,DEL] and 000001:[#0,DEL-#0,DEL] collided on sort keys
 
 manifest check
 ./testdata/MANIFEST-invalid
 ----
-MANIFEST-invalid: offset: 65 err: pebble: files 000002 and 000001 collided on sort keys
+MANIFEST-invalid: offset: 65 err: pebble: files 000002:[#0,DEL-#0,DEL] and 000001:[#0,DEL-#0,DEL] collided on sort keys
 Version state before failed Apply
 --- L0 ---
 --- L1 ---


### PR DESCRIPTION
Convert the B-Tree used for organizing and reference counting TableMetadata
into a generic collection. This is in preparation for storing blob file
metadata in a B-Tree for copy-on-write reference counting. The iterator type is
left specialized to *TableMetadata because we will not need arbitrary iteration
over the blob file B-Tree.

We can consider eventually using an alternative B-Tree implementation, like the
one in the btreemap package, but we would need to introduce support for
copy-on-write reference counting. The existing table metadata B-Tree
implementation supports the reference counting semantics we need.