### PR TITLE
manifest: rework blob file reference counting

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -354,13 +354,12 @@ func (d *DB) Checkpoint(
 	// When we write the MANIFEST of the checkpoint, we'll include a final
 	// VersionEdit that removes these blob files so that the checkpointed
 	// manifest is consistent.
-	var excludedBlobFiles map[base.DiskFileNum]*manifest.BlobFileMetadata
+	var excludedBlobFiles map[base.BlobFileID]*manifest.PhysicalBlobFile
 	if len(includedBlobFiles) < len(versionBlobFiles) {
-		excludedBlobFiles = make(map[base.DiskFileNum]*manifest.BlobFileMetadata, len(versionBlobFiles)-len(includedBlobFiles))
-		for _, blobFile := range versionBlobFiles {
-			if _, ok := includedBlobFiles[blobFile.FileID]; !ok {
-				diskFileNum := blob.DiskFileNumTODO(blobFile.FileID)
-				excludedBlobFiles[diskFileNum] = blobFile
+		excludedBlobFiles = make(map[base.BlobFileID]*manifest.PhysicalBlobFile, len(versionBlobFiles)-len(includedBlobFiles))
+		for _, meta := range versionBlobFiles {
+			if _, ok := includedBlobFiles[meta.FileID]; !ok {
+				excludedBlobFiles[meta.FileID] = meta.Physical
 			}
 		}
 	}
@@ -471,7 +470,7 @@ func (d *DB) writeCheckpointManifest(
 	manifestSize int64,
 	excludedTables map[manifest.DeletedTableEntry]*manifest.TableMetadata,
 	removeBackingTables []base.DiskFileNum,
-	excludedBlobFiles map[base.DiskFileNum]*manifest.BlobFileMetadata,
+	excludedBlobFiles map[base.BlobFileID]*manifest.PhysicalBlobFile,
 ) error {
 	// Copy the MANIFEST, and create a pointer to it. We copy rather
 	// than link because additional version edits added to the

--- a/compaction.go
+++ b/compaction.go
@@ -2478,7 +2478,7 @@ func (d *DB) handleCompactFailure(c *compaction, err error) {
 func (d *DB) cleanupVersionEdit(ve *manifest.VersionEdit) {
 	obsoleteFiles := manifest.ObsoleteFiles{
 		TableBackings: make([]*manifest.TableBacking, 0, len(ve.NewTables)),
-		BlobFiles:     make([]*manifest.BlobFileMetadata, 0, len(ve.NewBlobFiles)),
+		BlobFiles:     make([]*manifest.PhysicalBlobFile, 0, len(ve.NewBlobFiles)),
 	}
 	deletedTables := make(map[base.TableNum]struct{})
 	for key := range ve.DeletedTables {
@@ -2488,10 +2488,10 @@ func (d *DB) cleanupVersionEdit(ve *manifest.VersionEdit) {
 		obsoleteFiles.AddBlob(ve.NewBlobFiles[i])
 		d.mu.versions.zombieBlobs.Add(objectInfo{
 			fileInfo: fileInfo{
-				FileNum:  base.DiskFileNum(ve.NewBlobFiles[i].FileID),
+				FileNum:  ve.NewBlobFiles[i].FileNum,
 				FileSize: ve.NewBlobFiles[i].Size,
 			},
-			isLocal: objstorage.IsLocalBlobFile(d.objProvider, base.DiskFileNum(ve.NewBlobFiles[i].FileID)),
+			isLocal: objstorage.IsLocalBlobFile(d.objProvider, ve.NewBlobFiles[i].FileNum),
 		})
 	}
 	for i := range ve.NewTables {
@@ -3105,7 +3105,7 @@ func (d *DB) runCompaction(
 		// Delete any created tables or blob files.
 		obsoleteFiles := manifest.ObsoleteFiles{
 			TableBackings: make([]*manifest.TableBacking, 0, len(result.Tables)),
-			BlobFiles:     make([]*manifest.BlobFileMetadata, 0, len(result.Blobs)),
+			BlobFiles:     make([]*manifest.PhysicalBlobFile, 0, len(result.Blobs)),
 		}
 		d.mu.Lock()
 		for i := range result.Tables {
@@ -3291,7 +3291,7 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*manifest.VersionEd
 		}
 	}
 	// Add any newly constructed blob files to the version edit.
-	ve.NewBlobFiles = make([]*manifest.BlobFileMetadata, len(result.Blobs))
+	ve.NewBlobFiles = make([]*manifest.PhysicalBlobFile, len(result.Blobs))
 	for i := range result.Blobs {
 		ve.NewBlobFiles[i] = result.Blobs[i].Metadata
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -927,7 +927,7 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 	// them to the final version edit.
 	valueSeparator := &defineDBValueSeparator{
 		pbr:   &preserveBlobReferences{},
-		metas: make(map[base.BlobFileID]*manifest.BlobFileMetadata),
+		metas: make(map[base.BlobFileID]*manifest.PhysicalBlobFile),
 	}
 
 	var mem *memTable
@@ -1640,7 +1640,8 @@ func describeLSM(d *DB, verbose bool) string {
 	if blobFileMetas := d.mu.versions.blobFiles.Metadatas(); len(blobFileMetas) > 0 {
 		buf.WriteString("Blob files:\n")
 		for _, meta := range blobFileMetas {
-			fmt.Fprintf(&buf, "  %s: %d physical bytes, %d value bytes\n", meta.FileID, meta.Size, meta.ValueSize)
+			fmt.Fprintf(&buf, "  %s: [%s] %d physical bytes, %d value bytes\n",
+				meta.FileID, meta.Physical.FileNum, meta.Physical.Size, meta.Physical.ValueSize)
 		}
 	}
 	return buf.String()

--- a/event.go
+++ b/event.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/remote"
-	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 )
@@ -1234,10 +1233,9 @@ func (d *DB) reportCorruption(meta any, err error) error {
 	switch meta := meta.(type) {
 	case *manifest.TableMetadata:
 		return d.reportFileCorruption(base.FileTypeTable, meta.TableBacking.DiskFileNum, meta.UserKeyBounds(), err)
-	case *manifest.BlobFileMetadata:
-		diskFileNum := blob.DiskFileNumTODO(meta.FileID)
+	case *manifest.PhysicalBlobFile:
 		// TODO(jackson): Add bounds for blob files.
-		return d.reportFileCorruption(base.FileTypeBlob, diskFileNum, base.UserKeyBounds{}, err)
+		return d.reportFileCorruption(base.FileTypeBlob, meta.FileNum, base.UserKeyBounds{}, err)
 	default:
 		panic(fmt.Sprintf("unknown metadata type: %T", meta))
 	}

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -60,7 +60,7 @@ type OutputBlob struct {
 	// ObjMeta is metadata for the object backing the blob file.
 	ObjMeta objstorage.ObjectMetadata
 	// Metadata is metadata for the blob file.
-	Metadata *manifest.BlobFileMetadata
+	Metadata *manifest.PhysicalBlobFile
 }
 
 // Stats describes stats collected during the compaction.
@@ -140,7 +140,7 @@ type ValueSeparationMetadata struct {
 	// The below fields are only populated if a new blob file was created.
 	BlobFileStats    blob.FileWriterStats
 	BlobFileObject   objstorage.ObjectMetadata
-	BlobFileMetadata *manifest.BlobFileMetadata
+	BlobFileMetadata *manifest.PhysicalBlobFile
 }
 
 // Runner is a helper for running the "data" part of a compaction (where we use

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -20,9 +20,12 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// A BlobReference describes a sstable's reference to a blob value file.
+// A BlobReference describes a sstable's reference to a blob value file. A
+// BlobReference is immutable.
 type BlobReference struct {
-	// FileID identifies the referenced blob file.
+	// FileID identifies the referenced blob file. FileID is stable. If a blob
+	// file is rewritten and a blob reference is preserved during a compaction,
+	// the new sstable's BlobReference will preserve the same FileID.
 	FileID base.BlobFileID
 	// ValueSize is the sum of the lengths of the uncompressed values within the
 	// blob file for which there exists a reference in the sstable. Note that if
@@ -32,12 +35,21 @@ type BlobReference struct {
 	// INVARIANT: ValueSize <= Metadata.ValueSize
 	ValueSize uint64
 
-	// Metadata is the metadata for the blob file. It is non-nil for blob
-	// references contained within active Versions. It is expected to initially
-	// be nil when decoding a version edit as a part of manfiest replay. When
-	// the version edit is accumulated into a bulk version edit, the metadata
-	// is populated.
-	Metadata *BlobFileMetadata
+	// OriginalMetadata is the metadata for the original physical blob file. It
+	// is non-nil for blob references contained within active Versions. It is
+	// expected to initially be nil when decoding a version edit as a part of
+	// manfiest replay. When the version edit is accumulated into a bulk version
+	// edit, the metadata is populated.
+	//
+	// The OriginalMetadata describes the physical blob file that existed when
+	// the reference was originally created. The original physical blob file may
+	// no longer exist. The BlobReference.FileID should be translated using a
+	// Version's BlobFileSet.
+	//
+	// TODO(jackson): We should either remove the OriginalMetadata from the
+	// BlobReference or use it to infer when a blob file has definitely NOT been
+	// replaced and a lookup in Version.BlobFileSet is unnecessary.
+	OriginalMetadata *PhysicalBlobFile
 }
 
 // EstimatedPhysicalSize returns an estimate of the physical size of the blob
@@ -46,29 +58,70 @@ type BlobReference struct {
 // ValueSize of the blob file.
 func (br *BlobReference) EstimatedPhysicalSize() uint64 {
 	if invariants.Enabled {
-		if br.ValueSize > br.Metadata.ValueSize {
+		if br.ValueSize > br.OriginalMetadata.ValueSize {
 			panic(errors.AssertionFailedf("pebble: blob reference value size %d is greater than the blob file's value size %d",
-				br.ValueSize, br.Metadata.ValueSize))
+				br.ValueSize, br.OriginalMetadata.ValueSize))
 		}
 		if br.ValueSize == 0 {
 			panic(errors.AssertionFailedf("pebble: blob reference value size %d is zero", br.ValueSize))
 		}
-		if br.Metadata.ValueSize == 0 {
-			panic(errors.AssertionFailedf("pebble: blob file value size %d is zero", br.Metadata.ValueSize))
+		if br.OriginalMetadata.ValueSize == 0 {
+			panic(errors.AssertionFailedf("pebble: blob file value size %d is zero", br.OriginalMetadata.ValueSize))
 		}
 	}
 	//                         br.ValueSize
-	//   Reference size =  --------------------   ×  br.Metadata.Size
-	//                     br.Metadata.ValueSize
+	//   Reference size =  -----------------------------  ×  br.OriginalMetadata.Size
+	//                     br.OriginalMetadata.ValueSize
 	//
 	// We perform the multiplication first to avoid floating point arithmetic.
-	return (br.ValueSize * br.Metadata.Size) / br.Metadata.ValueSize
+	return (br.ValueSize * br.OriginalMetadata.Size) / br.OriginalMetadata.ValueSize
 }
 
-// BlobFileMetadata is metadata describing a blob value file.
+// BlobFileMetadata encapsulates a blob file ID used to identify a particular
+// blob file, and a reference-counted physical blob file. Different Versions may
+// contain different BlobFileMetadata with the same FileID, but if so they
+// necessarily point to different PhysicalBlobFiles.
+//
+// See the BlobFileSet documentation for more details.
 type BlobFileMetadata struct {
-	// FileID is an ID that uniquely identifies the blob file.
+	// FileID is a stable identifier for referencing a blob file containing
+	// values. It is the same domain as the BlobReference.FileID. Blob
+	// references use the FileID to look up the physical blob file containing
+	// referenced values.
 	FileID base.BlobFileID
+	// Physical is the metadata for the physical blob file.
+	//
+	// If the blob file has been replaced, Physical.FileNum ≠ FileID. Physical
+	// is always non-nil.
+	Physical *PhysicalBlobFile
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (m BlobFileMetadata) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%s -> %s", m.FileID, m.Physical)
+}
+
+// String implements fmt.Stringer.
+func (m BlobFileMetadata) String() string {
+	return redact.StringWithoutMarkers(m)
+}
+
+// Ref increments the reference count for the physical blob file.
+func (m BlobFileMetadata) Ref() {
+	m.Physical.ref()
+}
+
+// Unref decrements the reference count for the physical blob file. If the
+// reference count reaches zero, the blob file is added to the provided obsolete
+// files set.
+func (m BlobFileMetadata) Unref(of ObsoleteFilesSet) {
+	m.Physical.unref(of)
+}
+
+// PhysicalBlobFile is metadata describing a physical blob value file.
+type PhysicalBlobFile struct {
+	// FileNum is an ID that uniquely identifies the blob file.
+	FileNum base.DiskFileNum
 	// Size is the size of the file, in bytes.
 	Size uint64
 	// ValueSize is the sum of the length of the uncompressed values stored in
@@ -90,39 +143,64 @@ type BlobFileMetadata struct {
 }
 
 // SafeFormat implements redact.SafeFormatter.
-func (m *BlobFileMetadata) SafeFormat(w redact.SafePrinter, _ rune) {
+func (m *PhysicalBlobFile) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("%s size:[%d (%s)] vals:[%d (%s)]",
-		m.FileID, redact.Safe(m.Size), humanize.Bytes.Uint64(m.Size),
+		m.FileNum, redact.Safe(m.Size), humanize.Bytes.Uint64(m.Size),
 		redact.Safe(m.ValueSize), humanize.Bytes.Uint64(m.ValueSize))
 }
 
 // String implements fmt.Stringer.
-func (m *BlobFileMetadata) String() string {
+func (m *PhysicalBlobFile) String() string {
 	return redact.StringWithoutMarkers(m)
 }
 
 // ref increments the reference count for the blob file.
-func (m *BlobFileMetadata) ref() {
+func (m *PhysicalBlobFile) ref() {
 	m.refs.Add(+1)
 }
 
-// unref decrements the reference count for the blob file. It returns the
-// resulting reference count.
-func (m *BlobFileMetadata) unref() int32 {
+// unref decrements the reference count for the blob file. If the reference
+// count reaches zero, the blob file is added to the provided obsolete files
+// set.
+func (m *PhysicalBlobFile) unref(of ObsoleteFilesSet) {
 	refs := m.refs.Add(-1)
 	if refs < 0 {
-		panic(errors.AssertionFailedf("pebble: refs for blob file %d equal to %d", m.FileID, refs))
+		panic(errors.AssertionFailedf("pebble: refs for blob file %s equal to %d", m.FileNum, refs))
+	} else if refs == 0 {
+		of.AddBlob(m)
 	}
-	return refs
 }
 
 // ParseBlobFileMetadataDebug parses a BlobFileMetadata from its string
 // representation. This function is intended for use in tests. It's the inverse
 // of BlobFileMetadata.String().
+func ParseBlobFileMetadataDebug(s string) (_ BlobFileMetadata, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.CombineErrors(err, errFromPanic(r))
+		}
+	}()
+
+	// Input format:
+	//  000102 -> 000000: size:[206536 (201KiB)], vals:[393256 (384KiB)]
+	p := strparse.MakeParser(debugParserSeparators, s)
+	fileID := base.BlobFileID(p.Int())
+	p.Expect("-")
+	p.Expect(">")
+	physical, err := parsePhysicalBlobFileDebug(&p)
+	if err != nil {
+		return BlobFileMetadata{}, err
+	}
+	return BlobFileMetadata{FileID: fileID, Physical: physical}, nil
+}
+
+// ParsePhysicalBlobFileDebug parses a PhysicalBlobFile from its string
+// representation. This function is intended for use in tests. It's the inverse
+// of PhysicalBlobFile.String().
 //
-// In production code paths, the BlobFileMetadata is serialized in a binary
+// In production code paths, the PhysicalBlobFile is serialized in a binary
 // format within a version edit under the tag tagNewBlobFile.
-func ParseBlobFileMetadataDebug(s string) (_ *BlobFileMetadata, err error) {
+func ParsePhysicalBlobFileDebug(s string) (_ *PhysicalBlobFile, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = errors.CombineErrors(err, errFromPanic(r))
@@ -131,9 +209,13 @@ func ParseBlobFileMetadataDebug(s string) (_ *BlobFileMetadata, err error) {
 
 	// Input format:
 	//  000000: size:[206536 (201KiB)], vals:[393256 (384KiB)]
-	m := &BlobFileMetadata{}
 	p := strparse.MakeParser(debugParserSeparators, s)
-	m.FileID = base.BlobFileID(p.FileNum())
+	return parsePhysicalBlobFileDebug(&p)
+}
+
+func parsePhysicalBlobFileDebug(p *strparse.Parser) (*PhysicalBlobFile, error) {
+	m := &PhysicalBlobFile{}
+	m.FileNum = p.DiskFileNum()
 
 	maybeSkipParens := func() {
 		if p.Peek() != "(" {
@@ -226,6 +308,56 @@ func (br *BlobReferences) IDByBlobFileID(fileID base.BlobFileID) (blob.Reference
 	return blob.ReferenceID(len(*br)), false
 }
 
+// BlobFileSet contains a set of blob files that are referenced by a version.
+// It's used to maintain reference counts on blob files still in-use by some
+// referenced version.
+//
+// It's backed by a copy-on-write B-Tree of BlobFileMetadata keyed by FileID. A
+// version edit that adds or deletes m blob files updates m⋅log(n) nodes in the
+// B-Tree.
+//
+// Initially a BlobFileMetadata has a FileID that matches the DiskFileNum of the
+// backing physical blob file. However a blob file may be replaced without
+// replacing the referencing TableMetadatas, which is recorded in the
+// BlobFileSet by replacing the old BlobFileMetadata with a different
+// PhysicalBlobFile.
+type BlobFileSet struct {
+	tree btree[BlobFileMetadata]
+}
+
+// MakeBlobFileSet creates a BlobFileSet from the given blob files.
+func MakeBlobFileSet(entries []BlobFileMetadata) BlobFileSet {
+	return BlobFileSet{tree: makeBTree(btreeCmpBlobFileID, entries)}
+}
+
+// clone returns a copy-on-write clone of the blob file set.
+func (s *BlobFileSet) clone() BlobFileSet {
+	return BlobFileSet{tree: s.tree.Clone()}
+}
+
+// insert inserts a blob file into the set.
+func (s *BlobFileSet) insert(entry BlobFileMetadata) error {
+	return s.tree.Insert(entry)
+}
+
+// remove removes a blob file from the set.
+func (s *BlobFileSet) remove(entry BlobFileMetadata) {
+	// Removing an entry from the B-Tree may decrement file reference counts.
+	// However, the BlobFileSet is copy-on-write. We only mutate the BlobFileSet
+	// while constructing a new version edit. The current Version (to which the
+	// edit will be applied) should maintain a reference. So a call to remove()
+	// should never result in a file's reference count dropping to zero, and we
+	// pass assertNoObsoleteFiles{} to assert such.
+	s.tree.Delete(entry, assertNoObsoleteFiles{})
+}
+
+// release releases the blob file's references. It's called when unreferencing a
+// Version.
+func (s *BlobFileSet) release(of ObsoleteFilesSet) {
+	s.tree.Release(of)
+	s.tree = btree[BlobFileMetadata]{}
+}
+
 // AggregateBlobFileStats records cumulative stats across blob files.
 type AggregateBlobFileStats struct {
 	// Count is the number of blob files in the set.
@@ -257,15 +389,16 @@ func (s AggregateBlobFileStats) String() string {
 // the latest Version. CurrentBlobFileSet is not thread-safe. In practice its
 // use is protected by the versionSet logLock.
 type CurrentBlobFileSet struct {
-	// files is a map of blob file numbers to a *currentBlobFile, recording
-	// metadata about the blob file's active references in the latest Version.
+	// files is a map of blob file IDs to *currentBlobFiles, recording metadata
+	// about the blob file's active references in the latest Version.
 	files map[base.BlobFileID]*currentBlobFile
 	// stats records cumulative stats across all blob files in the set.
 	stats AggregateBlobFileStats
 }
 
 type currentBlobFile struct {
-	metadata *BlobFileMetadata
+	// metadata is a copy of the current BlobFileMetadata in the latest Version.
+	metadata BlobFileMetadata
 	// references holds pointers to TableMetadatas that exist in the latest
 	// version and reference this blob file. When the length of references falls
 	// to zero, the blob file is either a zombie file (if BlobFileMetadata.refs
@@ -292,25 +425,25 @@ func (s *CurrentBlobFileSet) Init(bve *BulkVersionEdit) {
 	if bve == nil {
 		return
 	}
-	for _, m := range bve.BlobFiles.Added {
-		s.files[base.BlobFileID(m.FileID)] = &currentBlobFile{
-			metadata:   m,
+	for blobFileID, pbf := range bve.BlobFiles.Added {
+		s.files[blobFileID] = &currentBlobFile{
+			metadata:   BlobFileMetadata{FileID: blobFileID, Physical: pbf},
 			references: make(map[*TableMetadata]struct{}),
 		}
 		s.stats.Count++
-		s.stats.PhysicalSize += m.Size
-		s.stats.ValueSize += m.ValueSize
+		s.stats.PhysicalSize += pbf.Size
+		s.stats.ValueSize += pbf.ValueSize
 	}
 	// Record references to blob files from extant tables. Any referenced blob
 	// files should already exist in s.files.
-	for _, levelFiles := range bve.AddedTables {
-		for _, m := range levelFiles {
-			for _, ref := range m.BlobReferences {
+	for _, levelTables := range bve.AddedTables {
+		for _, table := range levelTables {
+			for _, ref := range table.BlobReferences {
 				cbf, ok := s.files[ref.FileID]
 				if !ok {
 					panic(errors.AssertionFailedf("pebble: referenced blob file %d not found", ref.FileID))
 				}
-				cbf.references[m] = struct{}{}
+				cbf.references[table] = struct{}{}
 				cbf.referencedValueSize += ref.ValueSize
 				s.stats.ReferencedValueSize += ref.ValueSize
 				s.stats.ReferencesCount++
@@ -326,12 +459,12 @@ func (s *CurrentBlobFileSet) Stats() AggregateBlobFileStats {
 
 // Metadatas returns a slice of all blob file metadata in the set, sorted by
 // file number for determinism.
-func (s *CurrentBlobFileSet) Metadatas() []*BlobFileMetadata {
-	m := make([]*BlobFileMetadata, 0, len(s.files))
+func (s *CurrentBlobFileSet) Metadatas() []BlobFileMetadata {
+	m := make([]BlobFileMetadata, 0, len(s.files))
 	for _, cbf := range s.files {
 		m = append(m, cbf.metadata)
 	}
-	slices.SortFunc(m, func(a, b *BlobFileMetadata) int {
+	slices.SortFunc(m, func(a, b BlobFileMetadata) int {
 		return stdcmp.Compare(a.FileID, b.FileID)
 	})
 	return m
@@ -344,12 +477,13 @@ func (s *CurrentBlobFileSet) Metadatas() []*BlobFileMetadata {
 func (s *CurrentBlobFileSet) ApplyAndUpdateVersionEdit(ve *VersionEdit) error {
 	// Insert new blob files into the set.
 	for _, nf := range ve.NewBlobFiles {
-		if _, ok := s.files[base.BlobFileID(nf.FileID)]; ok {
-			return errors.AssertionFailedf("pebble: new blob file %d already exists", nf.FileID)
+		if _, ok := s.files[base.BlobFileID(nf.FileNum)]; ok {
+			return errors.AssertionFailedf("pebble: new blob file %d already exists", nf.FileNum)
 		}
+		blobFileID := base.BlobFileID(nf.FileNum)
 		cbf := &currentBlobFile{references: make(map[*TableMetadata]struct{})}
-		cbf.metadata = nf
-		s.files[base.BlobFileID(nf.FileID)] = cbf
+		cbf.metadata = BlobFileMetadata{FileID: blobFileID, Physical: nf}
+		s.files[blobFileID] = cbf
 		s.stats.Count++
 		s.stats.PhysicalSize += nf.Size
 		s.stats.ValueSize += nf.ValueSize
@@ -385,7 +519,7 @@ func (s *CurrentBlobFileSet) ApplyAndUpdateVersionEdit(ve *VersionEdit) error {
 			}
 			if invariants.Enabled {
 				if ref.ValueSize > cbf.referencedValueSize {
-					return errors.AssertionFailedf("pebble: referenced value size %d for blob file %d is greater than the referenced value size %d",
+					return errors.AssertionFailedf("pebble: referenced value size %d for blob file %s is greater than the referenced value size %d",
 						ref.ValueSize, cbf.metadata.FileID, cbf.referencedValueSize)
 				}
 				if _, ok := cbf.references[meta]; !ok {
@@ -417,16 +551,13 @@ func (s *CurrentBlobFileSet) ApplyAndUpdateVersionEdit(ve *VersionEdit) error {
 						cbf.referencedValueSize, cbf.metadata.FileID)
 				}
 				if ve.DeletedBlobFiles == nil {
-					ve.DeletedBlobFiles = make(map[base.DiskFileNum]*BlobFileMetadata)
+					ve.DeletedBlobFiles = make(map[base.BlobFileID]*PhysicalBlobFile)
 				}
-				// TODO(jackson): Once we support blob file replacement, the
-				// backing file num might be different.
-				diskFileNum := blob.DiskFileNumTODO(cbf.metadata.FileID)
 
-				ve.DeletedBlobFiles[diskFileNum] = cbf.metadata
+				ve.DeletedBlobFiles[cbf.metadata.FileID] = cbf.metadata.Physical
 				s.stats.Count--
-				s.stats.PhysicalSize -= cbf.metadata.Size
-				s.stats.ValueSize -= cbf.metadata.ValueSize
+				s.stats.PhysicalSize -= cbf.metadata.Physical.Size
+				s.stats.ValueSize -= cbf.metadata.Physical.ValueSize
 				delete(s.files, cbf.metadata.FileID)
 			}
 		}

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -7,6 +7,7 @@ package manifest
 import (
 	stdcmp "cmp"
 	"fmt"
+	"iter"
 	"slices"
 	"sync/atomic"
 
@@ -328,6 +329,11 @@ type BlobFileSet struct {
 // MakeBlobFileSet creates a BlobFileSet from the given blob files.
 func MakeBlobFileSet(entries []BlobFileMetadata) BlobFileSet {
 	return BlobFileSet{tree: makeBTree(btreeCmpBlobFileID, entries)}
+}
+
+// All returns an iterator over all the blob files in the set.
+func (s *BlobFileSet) All() iter.Seq[BlobFileMetadata] {
+	return s.tree.All()
 }
 
 // clone returns a copy-on-write clone of the blob file set.

--- a/internal/manifest/blob_metadata_test.go
+++ b/internal/manifest/blob_metadata_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlobFileMetadata_ParseRoundTrip(t *testing.T) {
+func TestPhysicalBlobFile_ParseRoundTrip(t *testing.T) {
 	testCases := []struct {
 		name   string
 		input  string
@@ -33,6 +33,41 @@ func TestBlobFileMetadata_ParseRoundTrip(t *testing.T) {
 			name:   "humanized sizes are optional",
 			input:  "000001 size:[903530] vals:[39531]",
 			output: "000001 size:[903530 (882KB)] vals:[39531 (39KB)]",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := ParsePhysicalBlobFileDebug(tc.input)
+			require.NoError(t, err)
+			got := m.String()
+			want := tc.input
+			if tc.output != "" {
+				want = tc.output
+			}
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+func TestBlobFileMetadata_ParseRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name:  "verbatim",
+			input: "000002 -> 000001 size:[903530 (882KB)] vals:[39531 (39KB)]",
+		},
+		{
+			name:   "whitespace is insignificant",
+			input:  "000002          -> 000001   size  : [ 903530 (882KB )] vals: [ 39531 ( 39KB ) ]",
+			output: "000002 -> 000001 size:[903530 (882KB)] vals:[39531 (39KB)]",
+		},
+		{
+			name:   "humanized sizes are optional",
+			input:  "000002 -> 000001 size:[903530] vals:[39531]",
+			output: "000002 -> 000001 size:[903530 (882KB)] vals:[39531 (39KB)]",
 		},
 	}
 	for _, tc := range testCases {

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -37,6 +37,12 @@ func btreeCmpSmallestKey(cmp Compare) btreeCmp[*TableMetadata] {
 	}
 }
 
+// btreeCmpBlobFileID is a comparator function that compares two BlobFileIDEntry
+// items by their file ID. It's used for the blob file set's B-Tree.
+func btreeCmpBlobFileID(a, b BlobFileMetadata) int {
+	return stdcmp.Compare(a.FileID, b.FileID)
+}
+
 // btreeCmpSpecificOrder is used in tests to construct a B-Tree with a specific
 // ordering of TableMetadata within the tree. It's typically used to test
 // consistency checking code that needs to construct a malformed B-Tree.
@@ -160,7 +166,7 @@ type ObsoleteFilesSet interface {
 	AddBacking(*TableBacking)
 	// AddBlob appends the provided BlobFileMetadata to the list of obsolete
 	// files.
-	AddBlob(*BlobFileMetadata)
+	AddBlob(*PhysicalBlobFile)
 }
 
 // assertNoObsoleteFiles is an obsoleteFiles implementation that panics if its
@@ -180,8 +186,8 @@ func (assertNoObsoleteFiles) AddBacking(fb *TableBacking) {
 }
 
 // AddBlob appends the provided BlobFileMetadata to the list of obsolete files.
-func (assertNoObsoleteFiles) AddBlob(bm *BlobFileMetadata) {
-	panic(errors.AssertionFailedf("blob file %s dereferenced to zero during tree mutation", bm.FileID))
+func (assertNoObsoleteFiles) AddBlob(bm *PhysicalBlobFile) {
+	panic(errors.AssertionFailedf("blob file %s dereferenced to zero during tree mutation", bm.FileNum))
 }
 
 // ignoreObsoleteFiles is an ObsoleteFilesSet implementation that ignores
@@ -196,7 +202,7 @@ var _ ObsoleteFilesSet = ignoreObsoleteFiles{}
 func (ignoreObsoleteFiles) AddBacking(fb *TableBacking) {}
 
 // AddBlob appends the provided BlobFileMetadata to the list of obsolete files.
-func (ignoreObsoleteFiles) AddBlob(bm *BlobFileMetadata) {}
+func (ignoreObsoleteFiles) AddBlob(bm *PhysicalBlobFile) {}
 
 // incRef acquires a reference to the node.
 func (n *node[M]) incRef() {

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	stdcmp "cmp"
 	"fmt"
+	"iter"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -771,6 +772,20 @@ func (t *btree[M]) Insert(item M) error {
 		t.root.verifyInvariants()
 	}
 	return err
+}
+
+// All returns an iterator over all the items in the tree.
+func (t *btree[M]) All() iter.Seq[M] {
+	iter := iterator[M]{r: t.root, pos: -1, cmp: t.bcmp}
+	iter.first()
+	return func(yield func(M) bool) {
+		for iter.valid() {
+			if !yield(iter.cur()) {
+				return
+			}
+			iter.next()
+		}
+	}
 }
 
 // tableMetadataIter returns a new iterator over a B-Tree of *TableMetadata. It

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -462,7 +462,8 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 	t.Logf("Starting equality checks on %d trees", len(trees))
 	want := rang(0, cloneTestSize-1)
 	for i, tree := range trees {
-		if got := all(tree); !reflect.DeepEqual(strReprs(got), strReprs(want)) {
+		got := slices.Collect(tree.All())
+		if !reflect.DeepEqual(strReprs(got), strReprs(want)) {
 			t.Errorf("tree %v mismatch", i)
 		}
 	}
@@ -489,7 +490,8 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 		} else {
 			wantpart = want
 		}
-		if got := all(tree); !reflect.DeepEqual(strReprs(got), strReprs(wantpart)) {
+		got := slices.Collect(tree.All())
+		if !reflect.DeepEqual(strReprs(got), strReprs(wantpart)) {
 			t.Errorf("tree %v mismatch, want %#v got %#v", i, strReprs(wantpart), strReprs(got))
 		}
 	}
@@ -664,17 +666,6 @@ func strReprs(items []*TableMetadata) []string {
 		s[i] = items[i].String()
 	}
 	return s
-}
-
-// all extracts all items from a tree in order as a slice.
-func all(tr *btree[*TableMetadata]) (out []*TableMetadata) {
-	it := tableMetadataIter(tr)
-	it.first()
-	for it.valid() {
-		out = append(out, it.cur())
-		it.next()
-	}
-	return out
 }
 
 func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -160,7 +160,9 @@ func keyWithMemo(i int, memo map[int]InternalKey) InternalKey {
 	return s
 }
 
-func checkIterRelative(t *testing.T, it *iterator, start, end int, keyMemo map[int]InternalKey) {
+func checkIterRelative(
+	t *testing.T, it *iterator[*TableMetadata], start, end int, keyMemo map[int]InternalKey,
+) {
 	t.Helper()
 	i := start
 	for ; it.valid(); it.next() {
@@ -176,7 +178,9 @@ func checkIterRelative(t *testing.T, it *iterator, start, end int, keyMemo map[i
 	}
 }
 
-func checkIter(t *testing.T, it iterator, start, end int, keyMemo map[int]InternalKey) {
+func checkIter(
+	t *testing.T, it iterator[*TableMetadata], start, end int, keyMemo map[int]InternalKey,
+) {
 	t.Helper()
 	i := start
 	for it.first(); it.valid(); it.next() {
@@ -501,11 +505,11 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 
 // TestIterStack tests the interface of the iterStack type.
 func TestIterStack(t *testing.T) {
-	f := func(i int) iterFrame {
-		return iterFrame{pos: int16(i)}
+	f := func(i int) iterFrame[*TableMetadata] {
+		return iterFrame[*TableMetadata]{pos: int16(i)}
 	}
-	var is iterStack
-	for i := 1; i <= 2*len(iterStackArr{}); i++ {
+	var is iterStack[*TableMetadata]
+	for i := 1; i <= 2*len(iterStackArr[*TableMetadata]{}); i++ {
 		var j int
 		for j = 0; j < i; j++ {
 			is.push(f(j))

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -208,7 +208,7 @@ func NewLevelSliceSpecificOrder(files []*TableMetadata) LevelSlice {
 }
 
 // newLevelSlice constructs a new LevelSlice backed by iter.
-func newLevelSlice(iter iterator) LevelSlice {
+func newLevelSlice(iter iterator[*TableMetadata]) LevelSlice {
 	s := LevelSlice{iter: iter}
 	if iter.r != nil {
 		s.length = iter.r.subtreeCount
@@ -221,7 +221,9 @@ func newLevelSlice(iter iterator) LevelSlice {
 // by the provided start and end bounds. The provided startBound and endBound
 // iterators must be iterators over the same B-Tree. Both start and end bounds
 // are inclusive.
-func newBoundedLevelSlice(iter iterator, startBound, endBound *iterator) LevelSlice {
+func newBoundedLevelSlice(
+	iter iterator[*TableMetadata], startBound, endBound *iterator[*TableMetadata],
+) LevelSlice {
 	s := LevelSlice{
 		iter:  iter,
 		start: startBound,
@@ -253,13 +255,13 @@ func newBoundedLevelSlice(iter iterator, startBound, endBound *iterator) LevelSl
 // LevelSlices should be constructed through one of the existing constructors,
 // not manually initialized.
 type LevelSlice struct {
-	iter   iterator
+	iter   iterator[*TableMetadata]
 	length int
 	// start and end form the inclusive bounds of a slice of files within a
 	// level of the LSM. They may be nil if the entire B-Tree backing iter is
 	// accessible.
-	start *iterator
-	end   *iterator
+	start *iterator[*TableMetadata]
+	end   *iterator[*TableMetadata]
 }
 
 func (ls LevelSlice) verifyInvariants() {
@@ -430,11 +432,11 @@ const (
 // LevelIterator iterates over a set of files' metadata. Its zero value is an
 // empty iterator.
 type LevelIterator struct {
-	iter iterator
+	iter iterator[*TableMetadata]
 	// If set, start is an inclusive lower bound on the iterator.
-	start *iterator
+	start *iterator[*TableMetadata]
 	// If set, end is an inclusive upper bound on the iterator.
-	end    *iterator
+	end    *iterator[*TableMetadata]
 	filter KeyType
 }
 
@@ -508,7 +510,7 @@ func (i *LevelIterator) Filter(keyType KeyType) LevelIterator {
 	return l
 }
 
-func emptyWithBounds(i iterator, start, end *iterator) bool {
+func emptyWithBounds(i iterator[*TableMetadata], start, end *iterator[*TableMetadata]) bool {
 	// If i.r is nil, the iterator was constructed from an empty btree.
 	// If the end bound is before the start bound, the bounds represent an
 	// empty slice of the B-Tree.

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -64,8 +64,8 @@ func MakeLevelMetadata(cmp Compare, level int, files []*TableMetadata) LevelMeta
 	return lm
 }
 
-func makeBTree(bcmp btreeCmp[*TableMetadata], files []*TableMetadata) btree[*TableMetadata] {
-	t := btree[*TableMetadata]{bcmp: bcmp}
+func makeBTree[M fileMetadata](bcmp btreeCmp[M], files []M) btree[M] {
+	t := btree[M]{bcmp: bcmp}
 	for _, f := range files {
 		if err := t.Insert(f); err != nil {
 			panic(err)

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/strparse"
 	"github.com/cockroachdb/pebble/sstable"
 )
@@ -1296,5 +1297,14 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 			}
 		}
 	}
+
+	// In invariants builds, sometimes check invariants across all blob files
+	// and their references.
+	if invariants.Sometimes(20) {
+		if err := v.validateBlobFileInvariants(); err != nil {
+			return nil, err
+		}
+	}
+
 	return v, nil
 }

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -14,7 +14,7 @@ compact a-b
 L6:
   000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:785 blobrefs:[(000006: 2); depth:1]
 Blob files:
-  000006: 92 physical bytes, 2 value bytes
+  000006: [000006] 92 physical bytes, 2 value bytes
 
 batch
 set c 3
@@ -27,8 +27,8 @@ L6:
   000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:785 blobrefs:[(000006: 2); depth:1]
   000008:[c#12,SET-d#13,SET] seqnums:[12-13] points:[c#12,SET-d#13,SET] size:785 blobrefs:[(000009: 2); depth:1]
 Blob files:
-  000006: 92 physical bytes, 2 value bytes
-  000009: 92 physical bytes, 2 value bytes
+  000006: [000006] 92 physical bytes, 2 value bytes
+  000009: [000009] 92 physical bytes, 2 value bytes
 
 batch
 set b 5
@@ -40,9 +40,9 @@ compact a-d
 L6:
   000013:[a#0,SET-d#0,SET] seqnums:[0-0] points:[a#0,SET-d#0,SET] size:812 blobrefs:[(000006: 1), (000012: 2), (000009: 1); depth:2]
 Blob files:
-  000006: 92 physical bytes, 2 value bytes
-  000009: 92 physical bytes, 2 value bytes
-  000012: 92 physical bytes, 2 value bytes
+  000006: [000006] 92 physical bytes, 2 value bytes
+  000009: [000009] 92 physical bytes, 2 value bytes
+  000012: [000012] 92 physical bytes, 2 value bytes
 
 batch
 del-range a e
@@ -80,10 +80,10 @@ L0.0:
 L6:
   000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:814 blobrefs:[(100002: 3), (100003: 3), (100004: 3); depth:3]
 Blob files:
-  000007: 100 physical bytes, 10 value bytes
-  100002: 92 physical bytes, 3 value bytes
-  100003: 92 physical bytes, 3 value bytes
-  100004: 92 physical bytes, 3 value bytes
+  000007: [000007] 100 physical bytes, 10 value bytes
+  100002: [100002] 92 physical bytes, 3 value bytes
+  100003: [100003] 92 physical bytes, 3 value bytes
+  100004: [100004] 92 physical bytes, 3 value bytes
 
 # Compacting these two sstables should result in writing the values to a new
 # blob file and the removal of the no longer referenced blob files.
@@ -93,7 +93,7 @@ compact a-z
 L6:
   000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:834 blobrefs:[(000009: 19); depth:1]
 Blob files:
-  000009: 112 physical bytes, 19 value bytes
+  000009: [000009] 112 physical bytes, 19 value bytes
 
 # Ensure we can read the separated values by iterating over the database.
 
@@ -185,7 +185,7 @@ L0.1:
 L0.0:
   000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:768
 Blob files:
-  000008: 100 physical bytes, 10 value bytes
+  000008: [000008] 100 physical bytes, 10 value bytes
 
 get
 a
@@ -221,7 +221,7 @@ L0.0:
   000005:[a#10,SET-d#13,SET] seqnums:[10-13] points:[a#10,SET-d#13,SET] size:798
   000006:[m#14,SET-m#14,SET] seqnums:[14-14] points:[m#14,SET-m#14,SET] size:781 blobrefs:[(000007: 5); depth:1]
 Blob files:
-  000007: 94 physical bytes, 5 value bytes
+  000007: [000007] 94 physical bytes, 5 value bytes
 
 # Construct an initial state with two overlapping files in L0, both with blob
 # references. Because these files overlap and are in separate sublevels, a
@@ -248,10 +248,10 @@ compact a-z
 L1:
   000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:838 blobrefs:[(100002: 3), (100001: 1), (100003: 3), (100004: 3); depth:4]
 Blob files:
-  100001: 90 physical bytes, 1 value bytes
-  100002: 92 physical bytes, 3 value bytes
-  100003: 92 physical bytes, 3 value bytes
-  100004: 92 physical bytes, 3 value bytes
+  100001: [100001] 90 physical bytes, 1 value bytes
+  100002: [100002] 92 physical bytes, 3 value bytes
+  100003: [100003] 92 physical bytes, 3 value bytes
+  100004: [100004] 92 physical bytes, 3 value bytes
 
 # Construct an initial state with two non-overlapping files in L0, both with
 # blob references. Because these files do NOT overlap and are in the same
@@ -278,10 +278,10 @@ compact a-z
 L1:
   000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:832 blobrefs:[(100001: 1), (100002: 3), (100003: 3), (100004: 3); depth:3]
 Blob files:
-  100001: 90 physical bytes, 1 value bytes
-  100002: 92 physical bytes, 3 value bytes
-  100003: 92 physical bytes, 3 value bytes
-  100004: 92 physical bytes, 3 value bytes
+  100001: [100001] 90 physical bytes, 1 value bytes
+  100002: [100002] 92 physical bytes, 3 value bytes
+  100003: [100003] 92 physical bytes, 3 value bytes
+  100004: [100004] 92 physical bytes, 3 value bytes
 
 define value-separation=(true,5,5) l0-compaction-threshold=1
 ----
@@ -320,25 +320,25 @@ L0.0:
   000039:[xwmd@1#436223,SET-zhar@1#461926,SET] seqnums:[436223-461926] points:[xwmd@1#436223,SET-zhar@1#461926,SET] size:390252 blobrefs:[(000040: 1645056); depth:1]
   000041:[zhas@1#461927,SET-zzzz@1#475263,SET] seqnums:[461927-475263] points:[zhas@1#461927,SET-zzzz@1#475263,SET] size:206528 blobrefs:[(000042: 853568); depth:1]
 Blob files:
-  000006: 1704578 physical bytes, 1642240 value bytes
-  000008: 1704776 physical bytes, 1642432 value bytes
-  000010: 1705238 physical bytes, 1642880 value bytes
-  000012: 1704776 physical bytes, 1642432 value bytes
-  000014: 1702730 physical bytes, 1640448 value bytes
-  000016: 1704644 physical bytes, 1642304 value bytes
-  000018: 1707970 physical bytes, 1645504 value bytes
-  000020: 1702994 physical bytes, 1640704 value bytes
-  000022: 1705172 physical bytes, 1642816 value bytes
-  000024: 1703918 physical bytes, 1641600 value bytes
-  000026: 1703390 physical bytes, 1641088 value bytes
-  000028: 1704182 physical bytes, 1641856 value bytes
-  000030: 1702796 physical bytes, 1640512 value bytes
-  000032: 1703720 physical bytes, 1641408 value bytes
-  000034: 1706584 physical bytes, 1644160 value bytes
-  000036: 1703720 physical bytes, 1641408 value bytes
-  000038: 1706254 physical bytes, 1643840 value bytes
-  000040: 1707508 physical bytes, 1645056 value bytes
-  000042: 886008 physical bytes, 853568 value bytes
+  000006: [000006] 1704578 physical bytes, 1642240 value bytes
+  000008: [000008] 1704776 physical bytes, 1642432 value bytes
+  000010: [000010] 1705238 physical bytes, 1642880 value bytes
+  000012: [000012] 1704776 physical bytes, 1642432 value bytes
+  000014: [000014] 1702730 physical bytes, 1640448 value bytes
+  000016: [000016] 1704644 physical bytes, 1642304 value bytes
+  000018: [000018] 1707970 physical bytes, 1645504 value bytes
+  000020: [000020] 1702994 physical bytes, 1640704 value bytes
+  000022: [000022] 1705172 physical bytes, 1642816 value bytes
+  000024: [000024] 1703918 physical bytes, 1641600 value bytes
+  000026: [000026] 1703390 physical bytes, 1641088 value bytes
+  000028: [000028] 1704182 physical bytes, 1641856 value bytes
+  000030: [000030] 1702796 physical bytes, 1640512 value bytes
+  000032: [000032] 1703720 physical bytes, 1641408 value bytes
+  000034: [000034] 1706584 physical bytes, 1644160 value bytes
+  000036: [000036] 1703720 physical bytes, 1641408 value bytes
+  000038: [000038] 1706254 physical bytes, 1643840 value bytes
+  000040: [000040] 1707508 physical bytes, 1645056 value bytes
+  000042: [000042] 886008 physical bytes, 853568 value bytes
 
 # Schedule automatic compactions. These compactions should write data to L6. The
 # resulting sstables will reference multiple blob files but maintain a blob
@@ -358,25 +358,25 @@ L6:
   000051:[uweo@1#0,SET-xvqm@1#0,SET] seqnums:[0-0] points:[uweo@1#0,SET-xvqm@1#0,SET] size:709725 blobrefs:[(000034: 237440), (000036: 1641408), (000038: 1606400); depth:1]
   000052:[xvqn@1#0,SET-zzzz@1#0,SET] seqnums:[0-0] points:[xvqn@1#0,SET-zzzz@1#0,SET] size:516069 blobrefs:[(000038: 37440), (000040: 1645056), (000042: 853568); depth:1]
 Blob files:
-  000006: 1704578 physical bytes, 1642240 value bytes
-  000008: 1704776 physical bytes, 1642432 value bytes
-  000010: 1705238 physical bytes, 1642880 value bytes
-  000012: 1704776 physical bytes, 1642432 value bytes
-  000014: 1702730 physical bytes, 1640448 value bytes
-  000016: 1704644 physical bytes, 1642304 value bytes
-  000018: 1707970 physical bytes, 1645504 value bytes
-  000020: 1702994 physical bytes, 1640704 value bytes
-  000022: 1705172 physical bytes, 1642816 value bytes
-  000024: 1703918 physical bytes, 1641600 value bytes
-  000026: 1703390 physical bytes, 1641088 value bytes
-  000028: 1704182 physical bytes, 1641856 value bytes
-  000030: 1702796 physical bytes, 1640512 value bytes
-  000032: 1703720 physical bytes, 1641408 value bytes
-  000034: 1706584 physical bytes, 1644160 value bytes
-  000036: 1703720 physical bytes, 1641408 value bytes
-  000038: 1706254 physical bytes, 1643840 value bytes
-  000040: 1707508 physical bytes, 1645056 value bytes
-  000042: 886008 physical bytes, 853568 value bytes
+  000006: [000006] 1704578 physical bytes, 1642240 value bytes
+  000008: [000008] 1704776 physical bytes, 1642432 value bytes
+  000010: [000010] 1705238 physical bytes, 1642880 value bytes
+  000012: [000012] 1704776 physical bytes, 1642432 value bytes
+  000014: [000014] 1702730 physical bytes, 1640448 value bytes
+  000016: [000016] 1704644 physical bytes, 1642304 value bytes
+  000018: [000018] 1707970 physical bytes, 1645504 value bytes
+  000020: [000020] 1702994 physical bytes, 1640704 value bytes
+  000022: [000022] 1705172 physical bytes, 1642816 value bytes
+  000024: [000024] 1703918 physical bytes, 1641600 value bytes
+  000026: [000026] 1703390 physical bytes, 1641088 value bytes
+  000028: [000028] 1704182 physical bytes, 1641856 value bytes
+  000030: [000030] 1702796 physical bytes, 1640512 value bytes
+  000032: [000032] 1703720 physical bytes, 1641408 value bytes
+  000034: [000034] 1706584 physical bytes, 1644160 value bytes
+  000036: [000036] 1703720 physical bytes, 1641408 value bytes
+  000038: [000038] 1706254 physical bytes, 1643840 value bytes
+  000040: [000040] 1707508 physical bytes, 1645056 value bytes
+  000042: [000042] 886008 physical bytes, 853568 value bytes
 
 
 excise-dryrun b c

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -16,7 +16,7 @@ L5:
 L6:
   000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:876 blobrefs:[(000921: 6); depth:1]
 Blob files:
-  000921: 106 physical bytes, 16 value bytes
+  000921: [000921] 106 physical bytes, 16 value bytes
 
 combined-iter
 first
@@ -76,8 +76,8 @@ L5:
 L6:
   000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:885 blobrefs:[(000039: 11), (000921: 13); depth:2]
 Blob files:
-  000039: 117 physical bytes, 25 value bytes
-  000921: 125 physical bytes, 33 value bytes
+  000039: [000039] 117 physical bytes, 25 value bytes
+  000921: [000921] 125 physical bytes, 33 value bytes
 
 # The iterator stats should indicate that only the first value from each file
 # should trigger a read of the blob file. Once loaded, subsequent reads of the
@@ -139,7 +139,7 @@ L6
 L6:
   000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:956 blobrefs:[(000009: 96); depth:1]
 Blob files:
-  000009: 322 physical bytes, 96 value bytes
+  000009: [000009] 322 physical bytes, 96 value bytes
 
 combined-iter
 first
@@ -212,7 +212,7 @@ L6
 L6:
   000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:1029 blobrefs:[(000009: 7); depth:1]
 Blob files:
-  000009: 96 physical bytes, 7 value bytes
+  000009: [000009] 96 physical bytes, 7 value bytes
 
 combined-iter
 seek-lt c

--- a/value_separation_test.go
+++ b/value_separation_test.go
@@ -80,11 +80,11 @@ func TestValueSeparationPolicy(t *testing.T) {
 				case "preserve-blob-references":
 					pbr := &preserveBlobReferences{}
 					lines := crstrings.Lines(d.Input)
-					pbr.inputBlobMetadatas = make([]*manifest.BlobFileMetadata, 0, len(lines))
+					pbr.inputBlobMetadatas = make([]*manifest.PhysicalBlobFile, 0, len(lines))
 					for _, line := range lines {
-						bfm, err := manifest.ParseBlobFileMetadataDebug(line)
+						bfm, err := manifest.ParsePhysicalBlobFileDebug(line)
 						require.NoError(t, err)
-						fn = max(fn, base.DiskFileNum(bfm.FileID))
+						fn = max(fn, base.DiskFileNum(bfm.FileNum))
 						pbr.inputBlobMetadatas = append(pbr.inputBlobMetadatas, bfm)
 					}
 					vs = pbr
@@ -180,7 +180,7 @@ func (w *loggingRawWriter) AddWithBlobHandle(
 // references from values.
 type defineDBValueSeparator struct {
 	bv    blobtest.Values
-	metas map[base.BlobFileID]*manifest.BlobFileMetadata
+	metas map[base.BlobFileID]*manifest.PhysicalBlobFile
 	pbr   *preserveBlobReferences
 	kv    base.InternalKV
 }
@@ -223,8 +223,8 @@ func (vs *defineDBValueSeparator) Add(
 	fileID := lv.Fetcher.BlobFileID
 	meta, ok := vs.metas[fileID]
 	if !ok {
-		meta = &manifest.BlobFileMetadata{
-			FileID:       fileID,
+		meta = &manifest.PhysicalBlobFile{
+			FileNum:      base.DiskFileNum(fileID),
 			CreationTime: uint64(time.Now().Unix()),
 		}
 		vs.metas[fileID] = meta

--- a/version_set.go
+++ b/version_set.go
@@ -898,22 +898,22 @@ func getZombieBlobFilesAndComputeLocalMetrics(
 	ve *manifest.VersionEdit, provider objstorage.Provider,
 ) (zombieBlobFiles []objectInfo, localLiveDelta fileMetricDelta) {
 	for _, b := range ve.NewBlobFiles {
-		if objstorage.IsLocalBlobFile(provider, base.DiskFileNum(b.FileID)) {
+		if objstorage.IsLocalBlobFile(provider, b.FileNum) {
 			localLiveDelta.count++
 			localLiveDelta.size += int64(b.Size)
 		}
 	}
 	zombieBlobFiles = make([]objectInfo, 0, len(ve.DeletedBlobFiles))
-	for dfn, b := range ve.DeletedBlobFiles {
-		isLocal := objstorage.IsLocalBlobFile(provider, dfn)
+	for _, physical := range ve.DeletedBlobFiles {
+		isLocal := objstorage.IsLocalBlobFile(provider, physical.FileNum)
 		if isLocal {
 			localLiveDelta.count--
-			localLiveDelta.size -= int64(b.Size)
+			localLiveDelta.size -= int64(physical.Size)
 		}
 		zombieBlobFiles = append(zombieBlobFiles, objectInfo{
 			fileInfo: fileInfo{
-				FileNum:  dfn,
-				FileSize: b.Size,
+				FileNum:  physical.FileNum,
+				FileSize: physical.Size,
 			},
 			isLocal: isLocal,
 		})
@@ -1036,8 +1036,13 @@ func (vs *versionSet) createManifest(
 		MinUnflushedLogNum:   minUnflushedLogNum,
 		NextFileNum:          nextFileNum,
 		CreatedBackingTables: virtualBackings,
-		NewBlobFiles:         vs.blobFiles.Metadatas(),
 	}
+	blobFileMetadatas := vs.blobFiles.Metadatas()
+	snapshot.NewBlobFiles = make([]*manifest.PhysicalBlobFile, len(blobFileMetadatas))
+	for i, m := range blobFileMetadatas {
+		snapshot.NewBlobFiles[i] = m.Physical
+	}
+
 	// Add all extant sstables in the current version.
 	for level, levelMetadata := range vs.currentVersion().Levels {
 		for meta := range levelMetadata.All() {
@@ -1176,7 +1181,7 @@ func (vs *versionSet) addObsoleteLocked(obsolete manifest.ObsoleteFiles) {
 
 	newlyObsoleteBlobFiles := make([]obsoleteFile, len(obsolete.BlobFiles))
 	for i, bf := range obsolete.BlobFiles {
-		newlyObsoleteBlobFiles[i] = vs.zombieBlobs.Extract(base.DiskFileNum(bf.FileID)).
+		newlyObsoleteBlobFiles[i] = vs.zombieBlobs.Extract(bf.FileNum).
 			asObsoleteFile(vs.fs, base.FileTypeBlob, vs.dirname)
 	}
 	vs.obsoleteBlobs = mergeObsoleteFiles(vs.obsoleteBlobs, newlyObsoleteBlobFiles)

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -67,7 +67,7 @@ func TestVersionSet(t *testing.T) {
 
 	tableMetas := make(map[base.TableNum]*manifest.TableMetadata)
 	backings := make(map[base.DiskFileNum]*manifest.TableBacking)
-	blobMetas := make(map[base.BlobFileID]*manifest.BlobFileMetadata)
+	blobMetas := make(map[base.BlobFileID]*manifest.PhysicalBlobFile)
 	// When we parse VersionEdits, we get a new TableBacking each time. We need to
 	// deduplicate them, since they hold a ref count.
 	dedupBacking := func(b *manifest.TableBacking) *manifest.TableBacking {
@@ -98,7 +98,7 @@ func TestVersionSet(t *testing.T) {
 				td.Fatalf(t, "%v", err)
 			}
 			for _, bm := range ve.NewBlobFiles {
-				blobMetas[base.BlobFileID(bm.FileID)] = bm
+				blobMetas[base.BlobFileID(bm.FileNum)] = bm
 			}
 			for _, nf := range ve.NewTables {
 				// Set a size that depends on FileNum.
@@ -109,7 +109,7 @@ func TestVersionSet(t *testing.T) {
 					createFile(nf.Meta.TableBacking.DiskFileNum)
 				}
 				for i := range nf.Meta.BlobReferences {
-					nf.Meta.BlobReferences[i].Metadata = blobMetas[nf.Meta.BlobReferences[i].FileID]
+					nf.Meta.BlobReferences[i].OriginalMetadata = blobMetas[nf.Meta.BlobReferences[i].FileID]
 				}
 			}
 
@@ -199,13 +199,13 @@ func TestVersionSet(t *testing.T) {
 			// Repopulate the maps.
 			tableMetas = make(map[base.TableNum]*manifest.TableMetadata)
 			backings = make(map[base.DiskFileNum]*manifest.TableBacking)
-			blobMetas = make(map[base.BlobFileID]*manifest.BlobFileMetadata)
+			blobMetas = make(map[base.BlobFileID]*manifest.PhysicalBlobFile)
 			v := vs.currentVersion()
 			for _, l := range v.Levels {
 				for f := range l.All() {
 					tableMetas[f.TableNum] = f
 					for _, b := range f.BlobReferences {
-						blobMetas[b.FileID] = b.Metadata
+						blobMetas[b.FileID] = b.OriginalMetadata
 					}
 					dedupBacking(f.TableBacking)
 				}


### PR DESCRIPTION
Rework the reference counting of in-use blob files to decouple the reference counts from the TableMetadatas' blob references. With the introduction of blob file rewrites and replacement, the physical blob file and the logical blob file's references have distinct lifetimes. A physical blob file that has been replaced will need to be removed once all Versions that predate the replacement have been unreferenced.

This commit renames the struct previously known as BlobFileMetadata to PhysicalBlobFile, describing metadata particular to a physical file backing a logical blob file. A new BlobFileMetadata struct is introduced that holds a BlobFileID and a pointer to the PhysicalBlobFile.

This commit additionally adapts the physical blob file referencing to occur through a separate B-Tree of BlobFileMetadata structs. Similar to TableMetadata, references to blob files are maintained by copy-on-write B-Tree nodes which themselves are reference counted. A PhysicalBlobFile's reference count is incremented when a new B-Tree node references a containing BlobFileMetadata, and it's decremented when the B-Tree node's reference count falls to zero. This indirection ensures that a mutation to the set of blob files only performs log(n) work. Since addition and removal of blob files within a version is now modeled directly (as opposed to indirectly via TableMetadata BlobReferences), a blob file may be removed or replaced within the set before all referencing TableMetadata are removed.

Informs #4802.