### PR TITLE
sstable: add `RawKeySize` and `RawValueSize` to TableStats

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -216,7 +216,7 @@ func TestIngestLoadRand(t *testing.T) {
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{
 				TableFormat: version.MaxTableFormat(),
 			})
-			var count uint64
+			var count, rawKeySize uint64
 			for i := range keys {
 				if i > 0 && base.InternalCompare(cmp, keys[i-1], keys[i]) == 0 {
 					// Duplicate key, ignore.
@@ -224,7 +224,9 @@ func TestIngestLoadRand(t *testing.T) {
 				}
 				require.NoError(t, w.Add(keys[i], nil, false /* forceObsolete */))
 				count++
+				rawKeySize += uint64(keys[i].Size())
 			}
+			expected[i].Stats.RawKeySize = rawKeySize
 			expected[i].Stats.NumEntries = count
 			require.NoError(t, w.Close())
 

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -1197,6 +1197,8 @@ type TableStats struct {
 	// This statistic is used to determine eligibility for a tombstone density
 	// compaction.
 	TombstoneDenseBlocksRatio float64
+	RawKeySize                uint64
+	RawValueSize              uint64
 }
 
 // CompactionState is the compaction state of a file.

--- a/internal/manifest/table_metadata_test.go
+++ b/internal/manifest/table_metadata_test.go
@@ -148,7 +148,7 @@ func TestTableMetadataSize(t *testing.T) {
 	}
 	structSize := unsafe.Sizeof(TableMetadata{})
 
-	const tableMetadataSize = 304
+	const tableMetadataSize = 320
 	if structSize != tableMetadataSize {
 		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableMetadataSize)


### PR DESCRIPTION
Add these properties to table stats so we don't need to load the properties block when calculating table stats.

Closes: #4792