### PR TITLE
block: introduce blockkinds

### DIFF
--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing.go
@@ -4,7 +4,10 @@
 
 package objiotracing
 
-import "github.com/cockroachdb/pebble/internal/base"
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/block/blockkind"
+)
 
 // OpType indicates the type of operation.
 type OpType uint8
@@ -33,18 +36,6 @@ const (
 	// TODO(radu): add ForUserFacing.
 )
 
-// BlockType indicates the type of data block relevant to an operation.
-type BlockType uint8
-
-// BlockType values.
-const (
-	UnknownBlock BlockType = iota
-	DataBlock
-	ValueBlock
-	FilterBlock
-	MetadataBlock
-)
-
 // Event is the on-disk format of a tracing event. It is exported here so that
 // trace processing tools can use it by importing this package.
 type Event struct {
@@ -54,7 +45,7 @@ type Event struct {
 	StartUnixNano int64
 	Op            OpType
 	Reason        Reason
-	BlockType     BlockType
+	BlockKind     blockkind.Kind
 	// LSM level plus one (with 0 indicating unknown level).
 	LevelPlusOne uint8
 	// Hardcoded padding so that struct layout doesn't depend on architecture.

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/sstable/block/blockkind"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -49,9 +50,9 @@ func (t *Tracer) WrapWritable(
 // traces created under that context).
 func WithReason(ctx context.Context, reason Reason) context.Context { return ctx }
 
-// WithBlockType creates a context that has an associated BlockType (which ends up in
+// WithBlockKind creates a context that has an associated BlockType (which ends up in
 // traces created under that context).
-func WithBlockType(ctx context.Context, blockType BlockType) context.Context { return ctx }
+func WithBlockKind(ctx context.Context, kind blockkind.Kind) context.Context { return ctx }
 
 // WithLevel creates a context that has an associated level (which ends up in
 // traces created under that context).

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_test.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
+	"github.com/cockroachdb/pebble/sstable/block/blockkind"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -128,6 +129,6 @@ func TestTracing(t *testing.T) {
 	events = collectEvents()
 	// Expect L6 data block reads.
 	require.Greater(t, num(func(e Event) bool {
-		return e.Op == objiotracing.ReadOp && e.BlockType == objiotracing.DataBlock && e.LevelPlusOne == 7
+		return e.Op == objiotracing.ReadOp && e.BlockKind == blockkind.SSTableData && e.LevelPlusOne == 7
 	}), 0)
 }

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/block/blockkind"
 )
 
 var (
@@ -460,14 +461,14 @@ func (r *FileReader) InitReadHandle(
 func (r *FileReader) ReadValueBlock(
 	ctx context.Context, env block.ReadEnv, rh objstorage.ReadHandle, h block.Handle,
 ) (block.BufferHandle, error) {
-	return r.r.Read(ctx, env, rh, h, initBlobValueBlockMetadata)
+	return r.r.Read(ctx, env, rh, h, blockkind.BlobValue, initBlobValueBlockMetadata)
 }
 
 // ReadIndexBlock reads the index block from the file.
 func (r *FileReader) ReadIndexBlock(
 	ctx context.Context, env block.ReadEnv, rh objstorage.ReadHandle,
 ) (block.BufferHandle, error) {
-	return r.r.Read(ctx, env, rh, r.footer.indexHandle, initIndexBlockMetadata)
+	return r.r.Read(ctx, env, rh, r.footer.indexHandle, blockkind.Metadata, initIndexBlockMetadata)
 }
 
 // IndexHandle returns the block handle for the file's index block.

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
-	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable/block"
 )
 
@@ -212,7 +211,6 @@ func (cr *cachedReader) GetUnsafeValue(
 	// If we already have a block loaded (eg, we're scanning retrieving multiple
 	// values), the current block might contain the value.
 	if !cr.currentValueBlock.loaded || cr.currentValueBlock.virtualID != vh.BlockID {
-		ctx = objiotracing.WithBlockType(ctx, objiotracing.ValueBlock)
 		if !cr.indexBlock.loaded {
 			// Read the index block.
 			var err error

--- a/sstable/block/blockkind/kind.go
+++ b/sstable/block/blockkind/kind.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package blockkind
+
+import "iter"
+
+// Kind identifies the type of block.
+type Kind uint8
+
+const (
+	Unknown Kind = iota
+	SSTableData
+	SSTableIndex
+	SSTableValue
+	BlobValue
+	Index
+	Filter
+	RangeDel
+	RangeKey
+	Metadata
+
+	NumKinds
+)
+
+var kindString = [...]string{
+	Unknown:      "unknown",
+	SSTableData:  "data",
+	SSTableValue: "sstval",
+	SSTableIndex: "index",
+	BlobValue:    "blobval",
+	Filter:       "filter",
+	RangeDel:     "rangedel",
+	RangeKey:     "rangekey",
+	Metadata:     "metadata",
+}
+
+func (k Kind) String() string {
+	return kindString[k]
+}
+
+// All returns all block kinds.
+func All() iter.Seq[Kind] {
+	return func(yield func(Kind) bool) {
+		for i := Kind(1); i < NumKinds; i++ {
+			if !yield(i) {
+				break
+			}
+		}
+	}
+}

--- a/sstable/compressionanalyzer/block_analyzer.go
+++ b/sstable/compressionanalyzer/block_analyzer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/pebble/internal/compression"
+	"github.com/cockroachdb/pebble/sstable/block"
 )
 
 // BlockAnalyzer is used to evaluate the performance and compressibility of different
@@ -48,7 +49,7 @@ func (a *BlockAnalyzer) Close() {
 
 // Block analyzes a block by measuring its compressibility and the performance
 // of various compression algorithms on it.
-func (a *BlockAnalyzer) Block(kind BlockKind, block []byte) {
+func (a *BlockAnalyzer) Block(kind block.Kind, block []byte) {
 	size := MakeBlockSize(len(block))
 	compressibility := MakeCompressibility(len(block), len(a.minLZFastest.Compress(a.buf1[:0], block)))
 	bucket := &a.b[kind][size][compressibility]

--- a/sstable/compressionanalyzer/buckets.go
+++ b/sstable/compressionanalyzer/buckets.go
@@ -12,34 +12,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/internal/compression"
+	"github.com/cockroachdb/pebble/sstable/block/blockkind"
 )
-
-// BlockKind breaks down the types of blocks into categories which might benefit
-// from individual compressions settings.
-type BlockKind uint8
-
-const (
-	DataBlock BlockKind = iota
-	SSTableValueBlock
-	BlobValueBlock
-	IndexBlock
-	// OtherBlock includes range del/key blocks, and other top-level metadata
-	// blocks.
-	OtherBlock
-	numBlockKinds
-)
-
-var blockKindString = [...]string{
-	DataBlock:         "data",
-	SSTableValueBlock: "sstval",
-	BlobValueBlock:    "blobval",
-	IndexBlock:        "index",
-	OtherBlock:        "other",
-}
-
-func (k BlockKind) String() string {
-	return blockKindString[k]
-}
 
 // BlockSize identifies a range of block sizes.
 type BlockSize uint8
@@ -134,7 +108,7 @@ var Settings = [...]compression.Setting{
 const numSettings = 7
 
 // Buckets holds the results of all experiments.
-type Buckets [numBlockKinds][numBlockSizes][numCompressibility]Bucket
+type Buckets [blockkind.NumKinds][numBlockSizes][numCompressibility]Bucket
 
 // Bucket aggregates results for blocks of the same kind, size range, and
 // compressibility.
@@ -161,7 +135,7 @@ func (b *Buckets) String(minSamples int) string {
 		fmt.Fprintf(tw, "\t%s", s.String())
 	}
 	fmt.Fprintf(tw, "\n")
-	for k := BlockKind(0); k < numBlockKinds; k++ {
+	for k := range blockkind.All() {
 		for sz := BlockSize(0); sz < numBlockSizes; sz++ {
 			for c := Compressibility(0); c < numCompressibility; c++ {
 				bucket := &b[k][sz][c]
@@ -223,7 +197,7 @@ func (b *Buckets) ToCSV(minSamples int) string {
 		fmt.Fprintf(&buf, ",%s Decomp±", s.String())
 	}
 	fmt.Fprintf(&buf, "\n")
-	for k := BlockKind(0); k < numBlockKinds; k++ {
+	for k := range blockkind.All() {
 		for sz := BlockSize(0); sz < numBlockSizes; sz++ {
 			for c := Compressibility(0); c < numCompressibility; c++ {
 				bucket := &b[k][sz][c]

--- a/sstable/compressionanalyzer/buckets_test.go
+++ b/sstable/compressionanalyzer/buckets_test.go
@@ -7,12 +7,14 @@ package compressionanalyzer
 import (
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/sstable/block/blockkind"
 )
 
 func TestBuckets(t *testing.T) {
@@ -60,8 +62,9 @@ func TestBuckets(t *testing.T) {
 func exampleBuckets() Buckets {
 	var buckets Buckets
 	r := rand.New(rand.NewPCG(0, 0))
+	kinds := slices.Collect(blockkind.All())
 	for n := 0; n < 10; n++ {
-		k := BlockKind(r.IntN(int(numBlockKinds)))
+		k := kinds[r.IntN(len(kinds))]
 		sz := BlockSize(r.IntN(int(numBlockSizes)))
 		c := Compressibility(r.IntN(int(numCompressibility)))
 		b := &buckets[k][sz][c]

--- a/sstable/compressionanalyzer/testdata/buckets
+++ b/sstable/compressionanalyzer/testdata/buckets
@@ -53,48 +53,48 @@ compressibility
 
 example-buckets-string
 ----
-Kind    Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       MinLZ2       ZSTD1        ZSTD3        ZSTD5        ZSTD7
-sstval  24-48KB     1.1-1.5  5        44.7KB ± 53%  CR      1.34 ± 17%   2.57 ± 9%    3.64 ± 6%    4.29 ± 3%    5.48 ± 5%    6.21 ± 4%    7.15 ± 1%
-                                                    Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-sstval  24-48KB     1.5-2.5  5        24.6KB ± 77%  CR      1.65 ± 10%   2.53 ± 13%   3.56 ± 4%    4.45 ± 6%    5.40 ± 6%    6.37 ± 3%    7.36 ± 4%
-                                                    Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-sstval  24-48KB     >2.5     6        34.3KB ± 71%  CR      1.34 ± 22%   2.48 ± 6%    3.35 ± 8%    4.38 ± 6%    5.34 ± 3%    6.58 ± 4%    7.41 ± 4%
-                                                    Comp    92MBps ± 2%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-index   48-128KB    >2.5     12       36.6KB ± 49%  CR      1.34 ± 23%   2.64 ± 11%   3.56 ± 7%    4.26 ± 5%    5.52 ± 5%    6.35 ± 4%    7.45 ± 4%
-                                                    Comp    92MBps ± 3%  47MBps ± 2%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-index   >128KB      <1.1     22       34.4KB ± 59%  CR      1.49 ± 22%   2.34 ± 11%   3.31 ± 7%    4.46 ± 6%    5.52 ± 6%    6.37 ± 4%    7.50 ± 4%
-                                                    Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-other   >128KB      >2.5     1        48.0KB ± 0%   CR      1.90 ± 0%    2.40 ± 0%    3.50 ± 0%    4.80 ± 0%    5.30 ± 0%    6.20 ± 0%    7.10 ± 0%
-                                                    Comp    87MBps ± 0%  47MBps ± 0%  31MBps ± 0%  24MBps ± 0%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+Kind      Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       MinLZ2       ZSTD1        ZSTD3        ZSTD5        ZSTD7
+sstval    24-48KB     1.1-1.5  5        44.7KB ± 53%  CR      1.34 ± 17%   2.57 ± 9%    3.64 ± 6%    4.29 ± 3%    5.48 ± 5%    6.21 ± 4%    7.15 ± 1%
+                                                      Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+sstval    24-48KB     >2.5     6        34.3KB ± 71%  CR      1.34 ± 22%   2.48 ± 6%    3.35 ± 8%    4.38 ± 6%    5.34 ± 3%    6.58 ± 4%    7.41 ± 4%
+                                                      Comp    92MBps ± 2%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+blobval   24-48KB     1.5-2.5  5        24.6KB ± 77%  CR      1.65 ± 10%   2.53 ± 13%   3.56 ± 4%    4.45 ± 6%    5.40 ± 6%    6.37 ± 3%    7.36 ± 4%
+                                                      Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+filter    >128KB      <1.1     22       34.4KB ± 59%  CR      1.49 ± 22%   2.34 ± 11%   3.31 ± 7%    4.46 ± 6%    5.52 ± 6%    6.37 ± 4%    7.50 ± 4%
+                                                      Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+rangedel  48-128KB    >2.5     12       36.6KB ± 49%  CR      1.34 ± 23%   2.64 ± 11%   3.56 ± 7%    4.26 ± 5%    5.52 ± 5%    6.35 ± 4%    7.45 ± 4%
+                                                      Comp    92MBps ± 3%  47MBps ± 2%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+rangekey  >128KB      >2.5     1        48.0KB ± 0%   CR      1.90 ± 0%    2.40 ± 0%    3.50 ± 0%    4.80 ± 0%    5.30 ± 0%    6.20 ± 0%    7.10 ± 0%
+                                                      Comp    87MBps ± 0%  47MBps ± 0%  31MBps ± 0%  24MBps ± 0%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
 
 example-buckets-string min-samples=5
 ----
-Kind    Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       MinLZ2       ZSTD1        ZSTD3        ZSTD5        ZSTD7
-sstval  24-48KB     1.1-1.5  5        44.7KB ± 53%  CR      1.34 ± 17%   2.57 ± 9%    3.64 ± 6%    4.29 ± 3%    5.48 ± 5%    6.21 ± 4%    7.15 ± 1%
-                                                    Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-sstval  24-48KB     1.5-2.5  5        24.6KB ± 77%  CR      1.65 ± 10%   2.53 ± 13%   3.56 ± 4%    4.45 ± 6%    5.40 ± 6%    6.37 ± 3%    7.36 ± 4%
-                                                    Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-sstval  24-48KB     >2.5     6        34.3KB ± 71%  CR      1.34 ± 22%   2.48 ± 6%    3.35 ± 8%    4.38 ± 6%    5.34 ± 3%    6.58 ± 4%    7.41 ± 4%
-                                                    Comp    92MBps ± 2%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-index   48-128KB    >2.5     12       36.6KB ± 49%  CR      1.34 ± 23%   2.64 ± 11%   3.56 ± 7%    4.26 ± 5%    5.52 ± 5%    6.35 ± 4%    7.45 ± 4%
-                                                    Comp    92MBps ± 3%  47MBps ± 2%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-index   >128KB      <1.1     22       34.4KB ± 59%  CR      1.49 ± 22%   2.34 ± 11%   3.31 ± 7%    4.46 ± 6%    5.52 ± 6%    6.37 ± 4%    7.50 ± 4%
-                                                    Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                    Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+Kind      Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       MinLZ2       ZSTD1        ZSTD3        ZSTD5        ZSTD7
+sstval    24-48KB     1.1-1.5  5        44.7KB ± 53%  CR      1.34 ± 17%   2.57 ± 9%    3.64 ± 6%    4.29 ± 3%    5.48 ± 5%    6.21 ± 4%    7.15 ± 1%
+                                                      Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+sstval    24-48KB     >2.5     6        34.3KB ± 71%  CR      1.34 ± 22%   2.48 ± 6%    3.35 ± 8%    4.38 ± 6%    5.34 ± 3%    6.58 ± 4%    7.41 ± 4%
+                                                      Comp    92MBps ± 2%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+blobval   24-48KB     1.5-2.5  5        24.6KB ± 77%  CR      1.65 ± 10%   2.53 ± 13%   3.56 ± 4%    4.45 ± 6%    5.40 ± 6%    6.37 ± 3%    7.36 ± 4%
+                                                      Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+filter    >128KB      <1.1     22       34.4KB ± 59%  CR      1.49 ± 22%   2.34 ± 11%   3.31 ± 7%    4.46 ± 6%    5.52 ± 6%    6.37 ± 4%    7.50 ± 4%
+                                                      Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+rangedel  48-128KB    >2.5     12       36.6KB ± 49%  CR      1.34 ± 23%   2.64 ± 11%   3.56 ± 7%    4.26 ± 5%    5.52 ± 5%    6.35 ± 4%    7.45 ± 4%
+                                                      Comp    92MBps ± 3%  47MBps ± 2%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
+                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
 
 example-buckets-csv min-samples=6
 ----
 Kind,Size Range,Test CR,Samples,Size,Size±,Snappy CR,Snappy CR±,Snappy Comp ns/b,Snappy Comp±,Snappy Decomp ns/b,Snappy Decomp±,MinLZ1 CR,MinLZ1 CR±,MinLZ1 Comp ns/b,MinLZ1 Comp±,MinLZ1 Decomp ns/b,MinLZ1 Decomp±,MinLZ2 CR,MinLZ2 CR±,MinLZ2 Comp ns/b,MinLZ2 Comp±,MinLZ2 Decomp ns/b,MinLZ2 Decomp±,ZSTD1 CR,ZSTD1 CR±,ZSTD1 Comp ns/b,ZSTD1 Comp±,ZSTD1 Decomp ns/b,ZSTD1 Decomp±,ZSTD3 CR,ZSTD3 CR±,ZSTD3 Comp ns/b,ZSTD3 Comp±,ZSTD3 Decomp ns/b,ZSTD3 Decomp±,ZSTD5 CR,ZSTD5 CR±,ZSTD5 Comp ns/b,ZSTD5 Comp±,ZSTD5 Decomp ns/b,ZSTD5 Decomp±,ZSTD7 CR,ZSTD7 CR±,ZSTD7 Comp ns/b,ZSTD7 Comp±,ZSTD7 Decomp ns/b,ZSTD7 Decomp±
 sstval,24-48KB,>2.5,6,35074,24930,1.337,0.289,10.348,0.191,100.419,0.268,2.483,0.157,20.422,0.270,200.394,0.223,3.347,0.276,30.423,0.254,300.431,0.084,4.384,0.251,40.392,0.226,400.273,0.278,5.341,0.182,50.513,0.218,500.538,0.152,6.583,0.274,60.574,0.173,600.736,0.254,7.408,0.300,70.489,0.264,700.386,0.291
-index,48-128KB,>2.5,12,37516,18543,1.336,0.308,10.419,0.275,100.429,0.305,2.635,0.282,20.423,0.351,200.391,0.336,3.559,0.248,30.453,0.319,300.496,0.267,4.262,0.210,40.597,0.290,400.442,0.233,5.525,0.250,50.441,0.295,500.490,0.281,6.353,0.226,60.591,0.281,600.367,0.240,7.450,0.301,70.278,0.145,700.416,0.313
-index,>128KB,<1.1,22,35247,20784,1.489,0.325,10.447,0.281,100.478,0.320,2.343,0.261,20.326,0.249,200.506,0.250,3.306,0.229,30.519,0.239,300.492,0.285,4.462,0.253,40.420,0.215,400.380,0.244,5.520,0.329,50.422,0.301,500.354,0.269,6.368,0.270,60.446,0.289,600.340,0.261,7.504,0.311,70.457,0.293,700.497,0.274
+filter,>128KB,<1.1,22,35247,20784,1.489,0.325,10.447,0.281,100.478,0.320,2.343,0.261,20.326,0.249,200.506,0.250,3.306,0.229,30.519,0.239,300.492,0.285,4.462,0.253,40.420,0.215,400.380,0.244,5.520,0.329,50.422,0.301,500.354,0.269,6.368,0.270,60.446,0.289,600.340,0.261,7.504,0.311,70.457,0.293,700.497,0.274
+rangedel,48-128KB,>2.5,12,37516,18543,1.336,0.308,10.419,0.275,100.429,0.305,2.635,0.282,20.423,0.351,200.391,0.336,3.559,0.248,30.453,0.319,300.496,0.267,4.262,0.210,40.597,0.290,400.442,0.233,5.525,0.250,50.441,0.295,500.490,0.281,6.353,0.226,60.591,0.281,600.367,0.240,7.450,0.301,70.278,0.145,700.416,0.313

--- a/sstable/compressionanalyzer/testdata/file_analyzer
+++ b/sstable/compressionanalyzer/testdata/file_analyzer
@@ -1,13 +1,13 @@
 sst
 ../testdata/hamlet-sst/000002.sst
 ----
-Kind   Size Range  Test CR  Samples  Size                 Snappy      MinLZ1      MinLZ2      ZSTD1       ZSTD3       ZSTD5       ZSTD7
-data   <24KB       1.5-2.5  14       1.9KB ± 25%  CR      1.93 ± 3%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
-                                                  Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-                                                  Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-index  <24KB       1.1-1.5  1        0.3KB ± 0%   CR      1.31 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
-                                                  Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-                                                  Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-other  <24KB       1.1-1.5  1        0.4KB ± 0%   CR      1.28 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
-                                                  Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-                                                  Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+Kind      Size Range  Test CR  Samples  Size                 Snappy      MinLZ1      MinLZ2      ZSTD1       ZSTD3       ZSTD5       ZSTD7
+data      <24KB       1.5-2.5  14       1.9KB ± 25%  CR      1.93 ± 3%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+index     <24KB       1.1-1.5  1        0.3KB ± 0%   CR      1.31 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+rangedel  <24KB       1.1-1.5  1        0.4KB ± 0%   CR      1.28 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/block/blockkind"
 	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
 	"github.com/cockroachdb/pebble/sstable/valblk"
@@ -269,7 +270,7 @@ func (l *Layout) Describe(
 				err = formatting.formatIndexBlock(tpNode, r, *b, h.BlockData())
 
 			case "properties":
-				h, err = r.blockReader.Read(ctx, block.NoReadEnv, noReadHandle, b.Handle, noInitBlockMetadataFn)
+				h, err = r.blockReader.Read(ctx, block.NoReadEnv, noReadHandle, b.Handle, blockkind.Metadata, noInitBlockMetadataFn)
 				if err != nil {
 					return err
 				}

--- a/sstable/valblk/reader.go
+++ b/sstable/valblk/reader.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
-	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"github.com/cockroachdb/pebble/sstable/block"
 )
 
@@ -58,7 +57,7 @@ func (bpwc blockProviderWhenClosed) ReadValueBlock(
 	// TODO(sumeer): consider fixing this. See
 	// https://github.com/cockroachdb/pebble/pull/3065#issue-1991175365 for an
 	// alternative.
-	ctx := objiotracing.WithBlockType(context.Background(), objiotracing.ValueBlock)
+	ctx := context.Background()
 	// TODO(jackson,sumeer): Consider whether to use a buffer pool in this case.
 	// The bpwc is not allowed to outlive the iterator tree, so it cannot
 	// outlive the buffer pool.


### PR DESCRIPTION
Introduce an enum of block kinds. This replaces two existing similar
enums - one in the compression analyzer and one in objiotracing.

This will allow integrating the compression analyzer in the read path,
and implementing a more complex `block.Compressor` which can take the
kind into account.

I used a separate package to avoid a circular dependency through objiotracing.