### PR TITLE
crl-release-25.1: metamorphic: more crossversion fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ stressmeta: override TESTS = TestMeta$$
 stressmeta: stress
 
 .PHONY: crossversion-meta
+crossversion-meta: LATEST_RELEASE := crl-release-24.3
 crossversion-meta:
-	$(eval LATEST_RELEASE := $(shell git fetch origin && git branch -r --list '*/crl-release-*' | grep -o 'crl-release-.*$$' | sort | tail -1))
 	git checkout ${LATEST_RELEASE}; \
 		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/${LATEST_RELEASE}.test'; \
 		git checkout -; \
@@ -72,7 +72,7 @@ crossversion-meta:
 
 .PHONY: stress-crossversion
 stress-crossversion:
-	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-23.1 crl-release-23.2 crl-release-24.1 crl-release-24.2 master
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-23.2 crl-release-24.1 crl-release-24.2 crl-release-24.3 crl-release-25.1
 
 .PHONY: gen-bazel
 gen-bazel:

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -601,6 +601,12 @@ func (p *parser) makeOp(methodName string, receiverID, targetID objID, pos token
 			receiverID, methodName, methodName, receiverID))
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			panic(errors.Newf("parsing %s.%s: %v", receiverID, methodName, r))
+		}
+	}()
+
 	op := info.constructor()
 	receiver, target, args := opArgs(op)
 

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -367,8 +367,14 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 			*t = p.parseUserKey(elem.pos, elem.lit)
 
 		case *UserKeySuffix:
-			elem.expectToken(p, token.STRING)
-			*t = p.parseUserKeySuffix(elem.pos, elem.lit)
+			if elem.tok == token.INT {
+				// Tolerate integers for backward compatibility (when loading ops from a
+				// previous version).
+				*t = UserKeySuffix(elem.lit)
+			} else {
+				elem.expectToken(p, token.STRING)
+				*t = p.parseUserKeySuffix(elem.pos, elem.lit)
+			}
 
 		case *[]byte:
 			elem.expectToken(p, token.STRING)

--- a/metamorphic/testdata/parser
+++ b/metamorphic/testdata/parser
@@ -16,22 +16,22 @@ metamorphic test internal error: 1:1: unknown op db1.bar
 parse
 db.Apply()
 ----
-metamorphic test internal error: 1:10: Apply: not enough arguments
+parsing db1.Apply: metamorphic test internal error: 1:10: Apply: not enough arguments
 
 parse
 db.Apply(hello)
 ----
-metamorphic test internal error: 1:10: unknown object type: "hello"
+parsing db1.Apply: metamorphic test internal error: 1:10: unknown object type: "hello"
 
 parse
 db.NewBatch()
 ----
-metamorphic test internal error: 1:1: assignment expected for db1.NewBatch
+parsing db1.NewBatch: metamorphic test internal error: 1:1: assignment expected for db1.NewBatch
 
 parse
 batch0 = db.Apply()
 ----
-metamorphic test internal error: 1:10: cannot use db1.Apply in assignment
+parsing db1.Apply: metamorphic test internal error: 1:10: cannot use db1.Apply in assignment
 
 parse
 batch0 = db.NewBatch()

--- a/open.go
+++ b/open.go
@@ -175,12 +175,6 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 					dirname)
 			}
 		}()
-	} else {
-		if opts.Experimental.CreateOnShared != remote.CreateOnSharedNone && formatVersion < FormatMinForSharedObjects {
-			return nil, errors.Newf(
-				"pebble: database %q configured with shared objects but written in too old format major version %d",
-				dirname, formatVersion)
-		}
 	}
 
 	// Find the currently active manifest, if there is one.


### PR DESCRIPTION
Informs #4729

#### Makefile: update crossversion targets


#### open: remove version check for shared objects

Remove a check that was too strict; even if the existing store version
is older, we will ratchet it up to `opts.FormatMajorVersion`, which
must support shared objects (checked by `opts.Validate()`).

#### metamorphic: show op name on parsing panics


#### metamorphic: tolerate integers for user key suffixes

This prevents a crossversion failure when parsing the NewIter op,
which switched from integers to strings in the filterMin/filterMax
arguments.