### PR TITLE
crl-release-25.2: metamorphic: show op name on parsing panics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ crossversion-meta:
 
 .PHONY: stress-crossversion
 stress-crossversion:
-	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-23.2 crl-release-24.1 crl-release-24.3 crl-release-25.1 master
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-24.1 crl-release-24.2 crl-release-24.3 crl-release-25.1 crl-release-25.2
 
 .PHONY: test-s390x-qemu
 test-s390x-qemu: TAGS += slowbuild

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -601,6 +601,12 @@ func (p *parser) makeOp(methodName string, receiverID, targetID objID, pos token
 			receiverID, methodName, methodName, receiverID))
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			panic(errors.Newf("parsing %s.%s: %v", receiverID, methodName, r))
+		}
+	}()
+
 	op := info.constructor()
 	receiver, target, args := opArgs(op)
 

--- a/metamorphic/testdata/parser
+++ b/metamorphic/testdata/parser
@@ -16,22 +16,22 @@ metamorphic test internal error: 1:1: unknown op db1.bar
 parse
 db.Apply()
 ----
-metamorphic test internal error: 1:10: Apply: not enough arguments
+parsing db1.Apply: metamorphic test internal error: 1:10: Apply: not enough arguments
 
 parse
 db.Apply(hello)
 ----
-metamorphic test internal error: 1:10: unknown object type: "hello"
+parsing db1.Apply: metamorphic test internal error: 1:10: unknown object type: "hello"
 
 parse
 db.NewBatch()
 ----
-metamorphic test internal error: 1:1: assignment expected for db1.NewBatch
+parsing db1.NewBatch: metamorphic test internal error: 1:1: assignment expected for db1.NewBatch
 
 parse
 batch0 = db.Apply()
 ----
-metamorphic test internal error: 1:10: cannot use db1.Apply in assignment
+parsing db1.Apply: metamorphic test internal error: 1:10: cannot use db1.Apply in assignment
 
 parse
 batch0 = db.NewBatch()

--- a/open.go
+++ b/open.go
@@ -180,12 +180,6 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 					dirname)
 			}
 		}()
-	} else {
-		if opts.Experimental.CreateOnShared != remote.CreateOnSharedNone && formatVersion < FormatMinForSharedObjects {
-			return nil, errors.Newf(
-				"pebble: database %q configured with shared objects but written in too old format major version %d",
-				dirname, formatVersion)
-		}
 	}
 
 	// Find the currently active manifest, if there is one.


### PR DESCRIPTION
#### Makefile: update crossversion targets


#### open: remove version check for shared objects

Remove a check that was too strict; even if the existing store version
is older, we will ratchet it up to `opts.FormatMajorVersion`, which
must support shared objects (checked by `opts.Validate()`).

#### metamorphic: show op name on parsing panics