### PR TITLE
crl-release-25.1: metamorphic and crossversion debugging improvements

### DIFF
--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -160,7 +160,7 @@ func runCrossVersion(
 		versionSeeds[i] = prng.Uint64()
 	}
 
-	rootDir := filepath.Join(tempDir, strconv.FormatInt(seed, 10))
+	rootDir := filepath.Join(tempDir, fmt.Sprint(seed))
 	if err := os.MkdirAll(rootDir, os.ModePerm); err != nil {
 		return err
 	}
@@ -179,7 +179,6 @@ func runCrossVersion(
 	// next is fixed by `factor`.
 	initialStates := []initialState{{}}
 	for i := range versions {
-		t.Logf("Running tests with version %s with %d initial state(s).", versions[i].SHA, len(initialStates))
 		histories, nextInitialStates, err := runVersion(ctx, t, &fatalOnce, rootDir, versions[i], versionSeeds[i], initialStates)
 		if err != nil {
 			return err
@@ -192,8 +191,19 @@ func runCrossVersion(
 			t.Fatal("no subrun histories")
 		}
 		if h, diff := metamorphic.CompareHistories(t, histories); h > 0 {
-			fatalf(t, &fatalOnce, rootDir, "Metamorphic test divergence between %q and %q:\nDiff:\n%s",
-				nextInitialStates[0].desc, nextInitialStates[h].desc, diff)
+			var dirs dirsToSave
+			dirs.add(rootDir, fmt.Sprint(seed))
+			fatalf(t, &fatalOnce, dirs,
+				"Divergence when using different initial states.\n"+
+					"  initial state 1: %s (%s)\n"+
+					"  initial state 2: %s (%s)\n"+
+					"Diff:\n"+
+					"%s",
+				nextInitialStates[0].desc,
+				nextInitialStates[0].path,
+				nextInitialStates[h].desc,
+				nextInitialStates[h].path,
+				diff)
 		}
 
 		// Prune the set of initial states we collected for this version, using
@@ -229,6 +239,12 @@ func runVersion(
 	// The outer 'execution-<label>' subtest will block until all of the
 	// individual subtests have completed.
 	t.Run(fmt.Sprintf("execution-%s", vers.Label), func(t *testing.T) {
+		if len(initialStates) == 1 && initialStates[0].path == "" {
+			t.Logf("Will run the metamorphic test to generate first set of initial states.")
+		} else {
+			t.Logf("Will run the metamorphic test %d times, each time with a different initial state.", len(initialStates))
+		}
+		t.Logf("  Version: %s (%s)", vers.Label, vers.SHA)
 		for j, s := range initialStates {
 			j, s := j, s // re-bind loop vars to scope
 
@@ -240,7 +256,11 @@ func runVersion(
 				initialState:   s,
 				testBinaryPath: vers.TestBinaryPath,
 			}
-			t.Run(s.desc, func(t *testing.T) {
+			desc := s.desc
+			if s.desc == "" {
+				desc = "no-initial-state"
+			}
+			t.Run(desc, func(t *testing.T) {
 				t.Parallel()
 				require.NoError(t, os.MkdirAll(r.dir, os.ModePerm))
 
@@ -249,11 +269,18 @@ func runVersion(
 				if streamOutput {
 					out = io.MultiWriter(out, os.Stderr)
 				}
-				t.Logf("  Running test with version %s with initial state %s (dir=%s initial=%s).",
-					vers.SHA, s, r.dir, s.path)
+				t.Logf("Running metamorphic test binary.")
+				t.Logf("  Version: %s (%s)", vers.Label, vers.SHA)
+				t.Logf("  Test state dir: %s", r.dir)
+				t.Logf("  Initial state: %s (%s)", s.desc, s.path)
 
 				if err := r.run(ctx, t, out); err != nil {
-					fatalf(t, fatalOnce, rootDir, "Metamorphic test failed: %s. Output:\n%s\n", err, buf.String())
+					var dirs dirsToSave
+					dirs.add(rootDir, runID)
+					if s.path != "" {
+						dirs.add(s.path, runID+"-initial-state")
+					}
+					fatalf(t, fatalOnce, dirs, "Metamorphic test failed: %s. Output:\n%s\n", err, buf.String())
 				}
 
 				// dir is a directory containing the ops file and subdirectories for
@@ -288,23 +315,50 @@ func runVersion(
 	return histories, nextInitialStates, err
 }
 
-func fatalf(t testing.TB, fatalOnce *sync.Once, dir string, msg string, args ...interface{}) {
-	fatalOnce.Do(func() {
-		if artifactsDir == "" {
-			var err error
-			artifactsDir, err = os.Getwd()
-			require.NoError(t, err)
+type dirToSave struct {
+	path string
+	// name of the directory to create in the artifacts dir.
+	name string
+}
+type dirsToSave struct {
+	dirs []dirToSave
+}
+
+// add appends a directory to the list of directories to save on test failure.
+// The path is copied to the artifacts subdir with the given name.
+func (d *dirsToSave) add(path string, name string) {
+	d.dirs = append(d.dirs, dirToSave{path: path, name: name})
+}
+
+func saveDirs(t testing.TB, d dirsToSave) {
+	if len(d.dirs) == 0 {
+		return
+	}
+	outDir := artifactsDir
+	if outDir == "" {
+		var err error
+		outDir, err = os.Getwd()
+		if err != nil {
+			t.Errorf("failed to determine current working directory: %s", err)
+			return
 		}
-		// When run with test parallelism, other subtests may still be running
-		// within subdirectories of `dir`. We copy instead of rename so that those
-		// substests don't also fail when we remove their files out from under them.
-		// Those additional failures would confuse the test output.
-		dst := filepath.Join(artifactsDir, filepath.Base(dir))
-		t.Logf("Copying test dir %q to %q.", dir, dst)
-		_, err := vfs.Clone(vfs.Default, vfs.Default, dir, dst, vfs.CloneTryLink)
+	}
+	t.Logf("Saving artifacts:")
+	for _, dir := range d.dirs {
+		dst := filepath.Join(outDir, dir.name)
+		t.Logf("  %s", dir.name)
+		t.Logf("    src: %s", dir.path)
+		t.Logf("    dst: %s", dst)
+		_, err := vfs.Clone(vfs.Default, vfs.Default, dir.path, dst, vfs.CloneTryLink)
 		if err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func fatalf(t testing.TB, fatalOnce *sync.Once, dirs dirsToSave, msg string, args ...interface{}) {
+	fatalOnce.Do(func() {
+		saveDirs(t, dirs)
 		t.Fatalf(msg, args...)
 	})
 }
@@ -318,40 +372,48 @@ type metamorphicTestRun struct {
 }
 
 func (r *metamorphicTestRun) run(ctx context.Context, t *testing.T, output io.Writer) error {
-	args := []string{
-		"-test.run", "TestMeta$",
-		"-seed", strconv.FormatUint(r.seed, 10),
-		"-keep",
-		// Use an op-count distribution that includes a low lower bound, so that
-		// some intermediary versions do very little work besides opening the
-		// database. This helps exercise state from version n that survives to
-		// versions ≥ n+2.
-		"-ops", "uniform:1-10000",
-		// Explicitly specify the location of the _meta directory. In Cockroach
-		// CI when built using bazel, the subprocesses may be given a different
-		// current working directory than the one provided below. To ensure we
-		// can find this run's artifacts, explicitly pass the intended dir.
-		"-dir", filepath.Join(r.dir, "_meta"),
+	var args []string
+
+	// We also build a readable string of the command that will be run.
+	var prettyCmdLin strings.Builder
+	prettyCmdLin.WriteString(r.dir)
+
+	add := func(a ...string) {
+		args = append(args, a...)
+		prettyCmdLin.WriteString(" \\\n  ")
+		prettyCmdLin.WriteString(strings.Join(a, " "))
 	}
-	// Propagate the verbose flag, if necessary.
+
+	add("-test.run", "TestMeta$")
 	if testing.Verbose() {
-		args = append(args, "-test.v")
+		add("-test.v")
 	}
+	add("-seed", strconv.FormatUint(r.seed, 10))
+	add("-keep")
+
+	// Use an op-count distribution that includes a low lower bound, so that
+	// some intermediary versions do very little work besides opening the
+	// database. This helps exercise state from version n that survives to
+	// versions ≥ n+2.
+	add("-ops", "uniform:1-10000")
+
+	// Explicitly specify the location of the _meta directory. In Cockroach
+	// CI when built using bazel, the subprocesses may be given a different
+	// current working directory than the one provided below. To ensure we
+	// can find this run's artifacts, explicitly pass the intended dir.
+	add("-dir", filepath.Join(r.dir, "_meta"))
+
 	if r.initialState.path != "" {
-		args = append(args, "--initial-state-desc", r.initialState.desc)
-		args = append(args, "--initial-state", r.initialState.path)
-		args = append(args, "--previous-ops", r.initialState.opsPath)
+		add("--initial-state-desc", r.initialState.desc)
+		add("--initial-state", r.initialState.path)
+		add("--previous-ops", r.initialState.opsPath)
 	}
 	cmd := exec.CommandContext(ctx, r.testBinaryPath, args...)
 	cmd.Dir = r.dir
 	cmd.Stderr = output
 	cmd.Stdout = output
 
-	// Print the command itself before executing it.
-	fmt.Println(output, cmd)
-	if testing.Verbose() {
-		t.Logf("running: %s", cmd.String())
-	}
+	t.Logf("running:\n%s", prettyCmdLin.String())
 
 	return cmd.Run()
 }

--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -37,6 +37,7 @@ if [[ -z "${STRESS}" ]]; then
       -test.run 'TestMetaCrossVersion$' \
       -seed ${SEED:-0} \
       -factor ${FACTOR:-10} \
+      -artifacts ./artifacts \
       $(echo $VERSIONS)
 else
     stress -p 1 go test ./internal/metamorphic/crossversion \
@@ -45,6 +46,7 @@ else
       -test.run 'TestMetaCrossVersion$' \
       -seed ${SEED:-0} \
       -factor ${FACTOR:-10} \
+      -artifacts ./artifacts \
       $(echo $VERSIONS)
 fi
 

--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -17,8 +17,13 @@ do
     # {XX.X}.
     version=`cut -d- -f3 <<< "$branch"`
 
+    toolchain=
+    if [ "$version" == "24.1" ]; then
+      toolchain=go1.22.12
+    fi
+
     echo "Building $version ($sha)"
-    go test -c -o "$TEMPDIR/meta.$version.test" ./internal/metamorphic
+    GOTOOLCHAIN="$toolchain" go test -c -o "$TEMPDIR/meta.$version.test" ./internal/metamorphic
     VERSIONS="$VERSIONS -version $version,$sha,$TEMPDIR/meta.$version.test"
 done
 


### PR DESCRIPTION
#### metamorphic: user-friendly diff output

The diff output in a meta test failure is huge; once the histories
diverge, it's expected that a fraction of remaining operations will
differ.

This change shows only the first chunk of differences; it also
switches to showing diffs line-by-line instead of using unified diff
which groups differences into chunks.

Sample output:
```
===== DIFF =====
_meta/250604-110807.3903755035503/{standard-000,standard-025}
iter11.Prev("sziamgyg@5") // [valid,"vlqfkriwzhr",<no point>,["vlqfkriwzhr","yydpkltsctb")=>{"@11"="g","@9"="wbcwhbfszyji"}*] <nil> #802
db1.Set("yujhfwdgxzzk@9", "hgptsktbwcnkw") // <nil> #803
snap8.Get("cemsyb") // [""] pebble: not found #804
iter11.Last() // [true,"vlqfkriwzhr",<no point>,["vlqfkriwzhr","yydpkltsctb")=>{"@11"="g","@9"="wbcwhbfszyji"}] <nil> #805
db1.Set("bhxdce@12", "kpwvjwmvcjwxjtj") // <nil> #806
iter10.SetBounds("", "odueuzsefsqf@12") // <nil> #807
iter10.SeekLT("odueuzsefsqf@12", "") // [true,"nsgx@3","gdkyjtqkatm",<no range>] <nil> #808
snap9 = db1.NewSnapshot("bnbadmt", "kybn", "lnrdbtk", "pklhwdj", "rvhbyjcl", "ukvtn", "vlqfkriwzhr", "yshz") #809

-snap9.Get("rvhbyjcl@10") // ["thiwmgnem"] <nil> #810
+snap9.Get("rvhbyjcl@10") // ["thiwngnem"] <nil> #810

iter11.SetBounds("ppfgkaakurwg@6", "qjpjfqfggpj@2") // <nil> #811
iter11.SeekGE("ppfgkaakurwg@6", "") // [true,"ppfgkaakurwg@6",<no point>,["ppfgkaakurwg@6","qjpjfqfggpj@2")=>{"@11"="g","@1"="rh"}*] <nil> #812
iter11.Next("") // [false] <nil> #813
iter10.Prev("") // [true,"nsgx@4","khicwpgiqbgzhsdm",<no range>] <nil> #814
snap9.Get("iojegwnjm") // [""] pebble: not found #815
iter11.SeekGE("qwjzbcz@6", "") // [false] <nil> #816
iter10.Last() // [true,"nsgx@3","gdkyjtqkatm",<no range>] <nil> #817
```

#### metamorphic: crossversion debugging improvements

 - We now save the initial state directory too, which is necessary for
   reproduction.
 - We reformat test logs to make them more readable, especially when
   the paths are long.

#### metamoprhic: show only the last part of the history

We now show the path to the history file and show only the last 30
lines of it.

#### scripts: run-crossversion-meta: use go 1.22 to build 24.1 test

`crl-release-24.1` does not build with go 1.23+ because of an older
version of the `swiss` package.