### PR TITLE
crl-release-25.2: scripts: run-crossversion-meta: use artifacts subdir

### DIFF
--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -37,6 +37,7 @@ if [[ -z "${STRESS}" ]]; then
       -test.run 'TestMetaCrossVersion$' \
       -seed ${SEED:-0} \
       -factor ${FACTOR:-10} \
+      -artifacts ./artifacts \
       $(echo $VERSIONS)
 else
     stress -p 1 go test ./internal/metamorphic/crossversion \
@@ -45,6 +46,7 @@ else
       -test.run 'TestMetaCrossVersion$' \
       -seed ${SEED:-0} \
       -factor ${FACTOR:-10} \
+      -artifacts ./artifacts \
       $(echo $VERSIONS)
 fi
 

--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -17,8 +17,13 @@ do
     # {XX.X}.
     version=`cut -d- -f3 <<< "$branch"`
 
+    toolchain=
+    if [ "$version" == "24.1" ]; then
+      toolchain=go1.22.12
+    fi
+
     echo "Building $version ($sha)"
-    go test -c -o "$TEMPDIR/meta.$version.test" ./internal/metamorphic
+    GOTOOLCHAIN="$toolchain" go test -c -o "$TEMPDIR/meta.$version.test" ./internal/metamorphic
     VERSIONS="$VERSIONS -version $version,$sha,$TEMPDIR/meta.$version.test"
 done
 


### PR DESCRIPTION
#### metamorphic: user-friendly diff output

The diff output in a meta test failure is huge; once the histories
diverge, it's expected that a fraction of remaining operations will
differ.

This change shows only the first chunk of differences; it also
switches to showing diffs line-by-line instead of using unified diff
which groups differences into chunks.

Sample output:
```
===== DIFF =====
_meta/250604-110807.3903755035503/{standard-000,standard-025}
iter11.Prev("sziamgyg@5") // [valid,"vlqfkriwzhr",<no point>,["vlqfkriwzhr","yydpkltsctb")=>{"@11"="g","@9"="wbcwhbfszyji"}*] <nil> #802
db1.Set("yujhfwdgxzzk@9", "hgptsktbwcnkw") // <nil> #803
snap8.Get("cemsyb") // [""] pebble: not found #804
iter11.Last() // [true,"vlqfkriwzhr",<no point>,["vlqfkriwzhr","yydpkltsctb")=>{"@11"="g","@9"="wbcwhbfszyji"}] <nil> #805
db1.Set("bhxdce@12", "kpwvjwmvcjwxjtj") // <nil> #806
iter10.SetBounds("", "odueuzsefsqf@12") // <nil> #807
iter10.SeekLT("odueuzsefsqf@12", "") // [true,"nsgx@3","gdkyjtqkatm",<no range>] <nil> #808
snap9 = db1.NewSnapshot("bnbadmt", "kybn", "lnrdbtk", "pklhwdj", "rvhbyjcl", "ukvtn", "vlqfkriwzhr", "yshz") #809

-snap9.Get("rvhbyjcl@10") // ["thiwmgnem"] <nil> #810
+snap9.Get("rvhbyjcl@10") // ["thiwngnem"] <nil> #810

iter11.SetBounds("ppfgkaakurwg@6", "qjpjfqfggpj@2") // <nil> #811
iter11.SeekGE("ppfgkaakurwg@6", "") // [true,"ppfgkaakurwg@6",<no point>,["ppfgkaakurwg@6","qjpjfqfggpj@2")=>{"@11"="g","@1"="rh"}*] <nil> #812
iter11.Next("") // [false] <nil> #813
iter10.Prev("") // [true,"nsgx@4","khicwpgiqbgzhsdm",<no range>] <nil> #814
snap9.Get("iojegwnjm") // [""] pebble: not found #815
iter11.SeekGE("qwjzbcz@6", "") // [false] <nil> #816
iter10.Last() // [true,"nsgx@3","gdkyjtqkatm",<no range>] <nil> #817
```

#### metamorphic: crossversion debugging improvements

 - We now save the initial state directory too, which is necessary for
   reproduction.
 - We reformat test logs to make them more readable, especially when
   the paths are long.

#### metamorphic: show only the last part of the history

We now show the path to the history file and show only the last 30
lines of it.

#### scripts: run-crossversion-meta: use go 1.22 to build 24.1 test

`crl-release-24.1` does not build with go 1.23+ because of an older
version of the `swiss` package.

#### scripts: run-crossversion-meta: use artifacts subdir

Currently crossversion artifacts go directly inside the crossversion
directory. They end up being gitignored (because they contain .test)
but they are hard to clean up and can't easily be configured to be
ignored by IDEs.

We now put everything in an `artifacts` subdir (already gitignored).