### PR TITLE
scripts: metamorphic and crossversion debugging improvements

### DIFF
--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -18,8 +18,10 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,7 +31,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/randvar"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
-	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -304,14 +305,8 @@ To reduce:  go test ./internal/metamorphic -tags invariants -run '%s$' --run-dir
 			t.Run(names[i], func(t *testing.T) {
 				lines := readHistory(t, getHistoryPath(names[i]))
 				lines = reorderHistory(lines)
-				diff := difflib.UnifiedDiff{
-					A:       base,
-					B:       lines,
-					Context: 5,
-				}
-				text, err := difflib.GetUnifiedDiffString(diff)
-				require.NoError(t, err)
-				if text != "" {
+				diff := lineByLineDiff(base, lines)
+				if diff != "" {
 					// NB: We force an exit rather than using t.Fatal because the latter
 					// will run another instance of the test if -count is specified, while
 					// we're happy to exit on the first failure.
@@ -333,7 +328,7 @@ To reduce:  go test ./internal/metamorphic -tags invariants -run '%s$' --run-dir
 To reduce:  go test ./internal/metamorphic -tags invariants -run '%s$' --compare "%s/{%s,%s}" --try-to-reduce -v
 `,
 						runOpts.seed,
-						metaDir, names[0], names[i], text,
+						metaDir, names[0], names[i], diff,
 						names[0], optionsStrA,
 						names[i], optionsStrB,
 						opsPath,
@@ -701,4 +696,44 @@ func readFile(path string) string {
 	}
 
 	return string(history)
+}
+
+// lineByLineDiff performs a line-by-line diff of two histories and returns the
+// first chunk of differences.
+//
+// This is preferable to unified diffs (which groups differences into sections)
+// because it's easier to see the difference in each particular operation.
+//
+// Returns "" if the two slices are equal (modulo any trailing empty lines).
+func lineByLineDiff(a, b []string) string {
+	// Make the two slices the same length.
+	for len(a) < len(b) {
+		a = append(a, "")
+	}
+	for len(b) < len(a) {
+		b = append(b, "")
+	}
+	if slices.Equal(a, b) {
+		return ""
+	}
+	firstDiff := 0
+	for ; a[firstDiff] == b[firstDiff]; firstDiff++ {
+	}
+	start := max(0, firstDiff-8)
+	end := min(firstDiff+8, len(a))
+	var buf strings.Builder
+	extraLine := false
+	for i := start; i < end; i++ {
+		if a[i] == b[i] {
+			if extraLine {
+				fmt.Fprintf(&buf, "\n")
+				extraLine = false
+			}
+			fmt.Fprintf(&buf, "%s\n", strings.TrimSuffix(a[i], "\n"))
+		} else {
+			fmt.Fprintf(&buf, "\n-%s\n+%s\n", strings.TrimSuffix(a[i], "\n"), strings.TrimSuffix(b[i], "\n"))
+			extraLine = true
+		}
+	}
+	return buf.String()
 }

--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -37,6 +37,7 @@ if [[ -z "${STRESS}" ]]; then
       -test.run 'TestMetaCrossVersion$' \
       -seed ${SEED:-0} \
       -factor ${FACTOR:-10} \
+      -artifacts ./artifacts \
       $(echo $VERSIONS)
 else
     stress -p 1 go test ./internal/metamorphic/crossversion \
@@ -45,6 +46,7 @@ else
       -test.run 'TestMetaCrossVersion$' \
       -seed ${SEED:-0} \
       -factor ${FACTOR:-10} \
+      -artifacts ./artifacts \
       $(echo $VERSIONS)
 fi
 

--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -17,8 +17,13 @@ do
     # {XX.X}.
     version=`cut -d- -f3 <<< "$branch"`
 
+    toolchain=
+    if [ "$version" == "24.1" ]; then
+      toolchain=go1.22.12
+    fi
+
     echo "Building $version ($sha)"
-    go test -c -o "$TEMPDIR/meta.$version.test" ./internal/metamorphic
+    GOTOOLCHAIN="$toolchain" go test -c -o "$TEMPDIR/meta.$version.test" ./internal/metamorphic
     VERSIONS="$VERSIONS -version $version,$sha,$TEMPDIR/meta.$version.test"
 done
 


### PR DESCRIPTION
#### metamorphic: user-friendly diff output

The diff output in a meta test failure is huge; once the histories
diverge, it's expected that a fraction of remaining operations will
differ.

This change shows only the first chunk of differences; it also
switches to showing diffs line-by-line instead of using unified diff
which groups differences into chunks.

Sample output:
```
===== DIFF =====
_meta/250604-110807.3903755035503/{standard-000,standard-025}
iter11.Prev("sziamgyg@5") // [valid,"vlqfkriwzhr",<no point>,["vlqfkriwzhr","yydpkltsctb")=>{"@11"="g","@9"="wbcwhbfszyji"}*] <nil> #802
db1.Set("yujhfwdgxzzk@9", "hgptsktbwcnkw") // <nil> #803
snap8.Get("cemsyb") // [""] pebble: not found #804
iter11.Last() // [true,"vlqfkriwzhr",<no point>,["vlqfkriwzhr","yydpkltsctb")=>{"@11"="g","@9"="wbcwhbfszyji"}] <nil> #805
db1.Set("bhxdce@12", "kpwvjwmvcjwxjtj") // <nil> #806
iter10.SetBounds("", "odueuzsefsqf@12") // <nil> #807
iter10.SeekLT("odueuzsefsqf@12", "") // [true,"nsgx@3","gdkyjtqkatm",<no range>] <nil> #808
snap9 = db1.NewSnapshot("bnbadmt", "kybn", "lnrdbtk", "pklhwdj", "rvhbyjcl", "ukvtn", "vlqfkriwzhr", "yshz") #809

-snap9.Get("rvhbyjcl@10") // ["thiwmgnem"] <nil> #810
+snap9.Get("rvhbyjcl@10") // ["thiwngnem"] <nil> #810

iter11.SetBounds("ppfgkaakurwg@6", "qjpjfqfggpj@2") // <nil> #811
iter11.SeekGE("ppfgkaakurwg@6", "") // [true,"ppfgkaakurwg@6",<no point>,["ppfgkaakurwg@6","qjpjfqfggpj@2")=>{"@11"="g","@1"="rh"}*] <nil> #812
iter11.Next("") // [false] <nil> #813
iter10.Prev("") // [true,"nsgx@4","khicwpgiqbgzhsdm",<no range>] <nil> #814
snap9.Get("iojegwnjm") // [""] pebble: not found #815
iter11.SeekGE("qwjzbcz@6", "") // [false] <nil> #816
iter10.Last() // [true,"nsgx@3","gdkyjtqkatm",<no range>] <nil> #817
```

#### metamorphic: crossversion debugging improvements

 - We now save the initial state directory too, which is necessary for
   reproduction.
 - We reformat test logs to make them more readable, especially when
   the paths are long.

#### metamorphic: show only the last part of the history

We now show the path to the history file and show only the last 30
lines of it.

#### scripts: run-crossversion-meta: use go 1.22 to build 24.1 test

`crl-release-24.1` does not build with go 1.23+ because of an older
version of the `swiss` package.

#### scripts: run-crossversion-meta: use artifacts subdir

Currently crossversion artifacts go directly inside the crossversion
directory. They end up being gitignored (because they contain .test)
but they are hard to clean up and can't easily be configured to be
ignored by IDEs.

We now put everything in an `artifacts` subdir (already gitignored).