### PR TITLE
crl-release-25.1: crossversion: debugging improvements

### DIFF
--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -276,7 +276,7 @@ func runVersion(
 
 				if err := r.run(ctx, t, out); err != nil {
 					var dirs dirsToSave
-					dirs.add(rootDir, runID)
+					dirs.add(r.dir, runID)
 					if s.path != "" {
 						dirs.add(s.path, runID+"-initial-state")
 					}

--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -76,7 +76,7 @@ func runTestMeta(t *testing.T, addtlOptions ...option) {
 		}
 		testRootDir, runSubdirs := runOnceFlags.ParseCompare()
 		if runOnceFlags.TryToReduce {
-			tryToReduceCompare(t, runOnceFlags.Dir, testRootDir, runSubdirs, runOnceFlags.ReduceAttempts)
+			tryToReduceCompare(t, runOnceFlags.Dir, testRootDir, runSubdirs, runOnceFlags.InitialStatePath, runOnceFlags.ReduceAttempts)
 			return
 		}
 		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs,
@@ -91,7 +91,7 @@ func runTestMeta(t *testing.T, addtlOptions ...option) {
 			onceOpts = append(onceOpts, opt)
 		}
 		if runOnceFlags.TryToReduce {
-			tryToReduce(t, runOnceFlags.Dir, runOnceFlags.RunDir, runOnceFlags.ReduceAttempts)
+			tryToReduce(t, runOnceFlags.Dir, runOnceFlags.RunDir, runOnceFlags.InitialStatePath, runOnceFlags.ReduceAttempts)
 			return
 		}
 		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed,

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -48,6 +48,9 @@ type CommonFlags struct {
 	// KeyFormatName is the name of the KeyFormat to use. Defaults to "testkeys".
 	// Acceptable values are "testkeys" and "cockroachkvs".
 	KeyFormatName string
+	// InitialStatePath is the path to a database data directory from a previous
+	// run. See the "initial-state" flag below.
+	InitialStatePath string
 }
 
 // KeyFormat returns the KeyFormat indicated by the flags KeyFormatName.
@@ -103,6 +106,10 @@ func initCommonFlags() *CommonFlags {
 
 	flag.StringVar(&c.KeyFormatName, "key-format", "testkeys",
 		"name of the key format to use")
+
+	flag.StringVar(&c.InitialStatePath, "initial-state", "",
+		`path to a database's data directory, used to prepopulate the test run's databases.
+		Must be used in conjunction with --previous-ops (unless --run or --compare is used).`)
 
 	return c
 }
@@ -160,9 +167,6 @@ type RunFlags struct {
 	// PreviousOps is the path to the ops file of a previous run. See the
 	// "previous-ops" flag below.
 	PreviousOps string
-	// InitialStatePath is the path to a database data directory from a previous
-	// run. See the "initial-state" flag below.
-	InitialStatePath string
 	// InitialStateDesc is a human-readable description of the initial database
 	// state. See "initial-state-desc" flag below.
 	InitialStateDesc string
@@ -199,10 +203,6 @@ with --run-dir or --compare`)
 	flag.StringVar(&r.PreviousOps, "previous-ops", "",
 		`path to an ops file, used to prepopulate the set of keys operations draw from." +
 		Must be used in conjunction with --initial-state`)
-
-	flag.StringVar(&r.InitialStatePath, "initial-state", "",
-		`path to a database's data directory, used to prepopulate the test run's databases.
-		Must be used in conjunction with --previous-ops.`)
 
 	flag.StringVar(&r.InitialStateDesc, "initial-state-desc", "",
 		`a human-readable description of the initial database state.
@@ -243,6 +243,9 @@ func (ro *RunOnceFlags) MakeRunOnceOptions() []metamorphic.RunOnceOption {
 	}
 	if ro.NumInstances > 1 {
 		onceOpts = append(onceOpts, metamorphic.MultiInstance(ro.NumInstances))
+	}
+	if ro.InitialStatePath != "" {
+		onceOpts = append(onceOpts, metamorphic.RunOnceInitialStatePath(ro.InitialStatePath))
 	}
 	return onceOpts
 }

--- a/metamorphic/history.go
+++ b/metamorphic/history.go
@@ -183,13 +183,7 @@ func CompareHistories(t TestingT, paths []string) (i int, diff string) {
 	for i := 1; i < len(paths); i++ {
 		lines := readHistory(t, paths[i])
 		lines = reorderHistory(lines)
-		diff := difflib.UnifiedDiff{
-			A:       base,
-			B:       lines,
-			Context: 5,
-		}
-		text, err := difflib.GetUnifiedDiffString(diff)
-		require.NoError(t, err)
+		text := lineByLineDiff(base, lines)
 		if text != "" {
 			return i, text
 		}

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -409,6 +409,7 @@ type runOnceOptions struct {
 	failRegexp          *regexp.Regexp
 	numInstances        int
 	keyFormat           KeyFormat
+	initialStatePath    string
 	customOptionParsers map[string]func(string) (CustomOption, bool)
 }
 
@@ -462,6 +463,12 @@ type MultiInstance int
 func (m MultiInstance) apply(ro *runAndCompareOptions) { ro.numInstances = int(m) }
 func (m MultiInstance) applyOnce(ro *runOnceOptions)   { ro.numInstances = int(m) }
 
+// RunOnceInitialStatePath is used to set an initial database state path for a
+// single run.
+type RunOnceInitialStatePath string
+
+func (i RunOnceInitialStatePath) applyOnce(ro *runOnceOptions) { ro.initialStatePath = string(i) }
+
 // RunOnce performs one run of the metamorphic tests. RunOnce expects the
 // directory named by `runDir` to already exist and contain an `OPTIONS` file
 // containing the test run's configuration. The history of the run is persisted
@@ -492,6 +499,10 @@ func RunOnce(
 	testOpts := defaultTestOptions(kf)
 	opts := testOpts.Opts
 	require.NoError(t, parseOptions(testOpts, string(optionsData), runOpts.customOptionParsers))
+
+	if runOpts.initialStatePath != "" {
+		testOpts.initialStatePath = runOpts.initialStatePath
+	}
 
 	ops, err := parse(opsData, parserOpts{
 		parseFormattedUserKey:       testOpts.KeyFormat.ParseFormattedKey,


### PR DESCRIPTION
#### metamorphic: support --initial-state with --run/compare

Allow supplying an initial state when trying to reproduce a failure.

#### metamorphic: support --initial-state with --try-to-reduce


#### crossversion: only save the relevant run dir

We were saving the entire root dir which is huge; switch to saving
just the relevant run(s) (along with any initial states). Note that
the `rootDir -> r.dir` change was already made on master in #4282.