### PR TITLE
crl-release-25.2: options: fix missing case in WAL recovery dir check

### DIFF
--- a/open.go
+++ b/open.go
@@ -474,7 +474,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := opts.CheckCompatibility(previousOptions); err != nil {
+		if err := opts.CheckCompatibility(dirname, previousOptions); err != nil {
 			return nil, err
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -2026,7 +2026,7 @@ type ErrMissingWALRecoveryDir struct {
 
 // Error implements error.
 func (e ErrMissingWALRecoveryDir) Error() string {
-	return fmt.Sprintf("directory %q may contain relevant WALs%s", e.Dir, e.ExtraInfo)
+	return fmt.Sprintf("directory %q may contain relevant WALs but is not in WALRecoveryDirs%s", e.Dir, e.ExtraInfo)
 }
 
 // CheckCompatibility verifies the options are compatible with the previous options
@@ -2035,7 +2035,9 @@ func (e ErrMissingWALRecoveryDir) Error() string {
 //
 // This function only looks at specific keys and does not error out if the
 // options are newer and contain unknown keys.
-func (o *Options) CheckCompatibility(previousOptions string) error {
+func (o *Options) CheckCompatibility(storeDir string, previousOptions string) error {
+	previousWALDir := ""
+
 	visitKeyValue := func(i, j int, section, key, value string) error {
 		switch section + "." + key {
 		case "Options.comparer":
@@ -2050,37 +2052,65 @@ func (o *Options) CheckCompatibility(previousOptions string) error {
 				return errors.Errorf("pebble: merger name from file %q != merger name from options %q",
 					errors.Safe(value), errors.Safe(o.Merger.Name))
 			}
-		case "Options.wal_dir", "WAL Failover.secondary_dir":
-			switch {
-			case value == "":
-				return nil
-			case o.WALDir == value:
-				return nil
-			case o.WALFailover != nil && o.WALFailover.Secondary.Dirname == value:
-				return nil
-			default:
-				for _, d := range o.WALRecoveryDirs {
-					if d.Dirname == value {
-						return nil
-					}
-				}
-				var buf bytes.Buffer
-				fmt.Fprintf(&buf, "\n  OPTIONS key: %s\n", section+"."+key)
-				if o.WALDir != "" {
-					fmt.Fprintf(&buf, "  o.WALDir: %s\n", o.WALDir)
-				}
-				if o.WALFailover != nil {
-					fmt.Fprintf(&buf, "  o.WALFailover.Secondary.Dirname: %s\n", o.WALFailover.Secondary.Dirname)
-				}
-				for _, d := range o.WALRecoveryDirs {
-					fmt.Fprintf(&buf, "  WALRecoveryDir: %s\n", d)
-				}
-				return ErrMissingWALRecoveryDir{Dir: value, ExtraInfo: buf.String()}
+		case "Options.wal_dir":
+			previousWALDir = value
+		case "WAL Failover.secondary_dir":
+			previousWALSecondaryDir := value
+			if err := o.checkWALDir(storeDir, previousWALSecondaryDir, "WALFailover.Secondary changed from previous options"); err != nil {
+				return err
 			}
 		}
 		return nil
 	}
-	return parseOptions(previousOptions, parseOptionsFuncs{visitKeyValue: visitKeyValue})
+	if err := parseOptions(previousOptions, parseOptionsFuncs{visitKeyValue: visitKeyValue}); err != nil {
+		return err
+	}
+	if err := o.checkWALDir(storeDir, previousWALDir, "WALDir changed from previous options"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkWALDir verifies that walDir is among o.WALDir, o.WALFailover.Secondary,
+// or o.WALRecoveryDirs. An empty "walDir" maps to the storeDir.
+func (o *Options) checkWALDir(storeDir, walDir, errContext string) error {
+	walPath := resolveStorePath(storeDir, walDir)
+	if walDir == "" {
+		walPath = storeDir
+	}
+
+	if o.WALDir == "" {
+		if walPath == storeDir {
+			return nil
+		}
+	} else {
+		if walPath == resolveStorePath(storeDir, o.WALDir) {
+			return nil
+		}
+	}
+
+	if o.WALFailover != nil && walPath == resolveStorePath(storeDir, o.WALFailover.Secondary.Dirname) {
+		return nil
+	}
+
+	for _, d := range o.WALRecoveryDirs {
+		// TODO(radu): should we also check that d.FS is the same as walDir's FS?
+		if walPath == resolveStorePath(storeDir, d.Dirname) {
+			return nil
+		}
+	}
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "\n  %s\n", errContext)
+	fmt.Fprintf(&buf, "  o.WALDir: %q\n", o.WALDir)
+	if o.WALFailover != nil {
+		fmt.Fprintf(&buf, "  o.WALFailover.Secondary.Dirname: %q\n", o.WALFailover.Secondary.Dirname)
+	}
+	fmt.Fprintf(&buf, "  o.WALRecoveryDirs: %d", len(o.WALRecoveryDirs))
+	for _, d := range o.WALRecoveryDirs {
+		fmt.Fprintf(&buf, "\n    %q", d.Dirname)
+	}
+	return ErrMissingWALRecoveryDir{Dir: walPath, ExtraInfo: buf.String()}
 }
 
 // Validate verifies that the options are mutually consistent. For example,

--- a/options_test.go
+++ b/options_test.go
@@ -139,18 +139,19 @@ func TestDefaultOptionsString(t *testing.T) {
 }
 
 func TestOptionsCheckCompatibility(t *testing.T) {
+	storeDir := "/mnt/foo"
 	opts := DefaultOptions()
 	s := opts.String()
-	require.NoError(t, opts.CheckCompatibility(s))
-	require.Regexp(t, `invalid key=value syntax`, opts.CheckCompatibility("foo\n"))
+	require.NoError(t, opts.CheckCompatibility(storeDir, s))
+	require.Regexp(t, `invalid key=value syntax`, opts.CheckCompatibility(storeDir, "foo\n"))
 
 	tmp := *opts
 	tmp.Comparer = &Comparer{Name: "foo"}
-	require.Regexp(t, `comparer name from file.*!=.*`, tmp.CheckCompatibility(s))
+	require.Regexp(t, `comparer name from file.*!=.*`, tmp.CheckCompatibility(storeDir, s))
 
 	tmp = *opts
 	tmp.Merger = &Merger{Name: "foo"}
-	require.Regexp(t, `merger name from file.*!=.*`, tmp.CheckCompatibility(s))
+	require.Regexp(t, `merger name from file.*!=.*`, tmp.CheckCompatibility(storeDir, s))
 
 	// RocksDB uses a similar (INI-style) syntax for the OPTIONS file, but
 	// different section names and keys.
@@ -161,14 +162,14 @@ func TestOptionsCheckCompatibility(t *testing.T) {
 `
 	tmp = *opts
 	tmp.Comparer = &Comparer{Name: "foo"}
-	require.Regexp(t, `comparer name from file.*!=.*`, tmp.CheckCompatibility(s))
+	require.Regexp(t, `comparer name from file.*!=.*`, tmp.CheckCompatibility(storeDir, s))
 
 	tmp.Comparer = &Comparer{Name: "rocksdb-comparer"}
 	tmp.Merger = &Merger{Name: "foo"}
-	require.Regexp(t, `merger name from file.*!=.*`, tmp.CheckCompatibility(s))
+	require.Regexp(t, `merger name from file.*!=.*`, tmp.CheckCompatibility(storeDir, s))
 
 	tmp.Merger = &Merger{Name: "rocksdb-merger"}
-	require.NoError(t, tmp.CheckCompatibility(s))
+	require.NoError(t, tmp.CheckCompatibility(storeDir, s))
 
 	// RocksDB allows the merge operator to be unspecified, in which case it
 	// shows up as "nullptr".
@@ -177,12 +178,12 @@ func TestOptionsCheckCompatibility(t *testing.T) {
   merge_operator=nullptr
 `
 	tmp = *opts
-	require.NoError(t, tmp.CheckCompatibility(s))
+	require.NoError(t, tmp.CheckCompatibility(storeDir, s))
 
 	// Check that an OPTIONS file that configured an explicit WALDir that will
 	// no longer be used errors if it's not also present in WALRecoveryDirs.
 	//require.Equal(t, ErrMissingWALRecoveryDir{Dir: "external-wal-dir"},
-	err := DefaultOptions().CheckCompatibility(`
+	err := DefaultOptions().CheckCompatibility(storeDir, `
 [Options]
   wal_dir=external-wal-dir
 `)
@@ -193,21 +194,46 @@ func TestOptionsCheckCompatibility(t *testing.T) {
 	// But not if it's configured as a WALRecoveryDir or current WALDir.
 	opts = &Options{WALRecoveryDirs: []wal.Dir{{Dirname: "external-wal-dir"}}}
 	opts.EnsureDefaults()
-	require.NoError(t, opts.CheckCompatibility(`
+	require.NoError(t, opts.CheckCompatibility(storeDir, `
 [Options]
   wal_dir=external-wal-dir
 `))
 	opts = &Options{WALDir: "external-wal-dir"}
 	opts.EnsureDefaults()
-	require.NoError(t, opts.CheckCompatibility(`
+	require.NoError(t, opts.CheckCompatibility(storeDir, `
 [Options]
   wal_dir=external-wal-dir
 `))
 
+	// Check that an OPTIONS file that was configured without an explicit WALDir
+	// errors out if the store path is not in WALRecoveryDirs.
+	opts = &Options{WALDir: "external-wal-dir"}
+	opts.EnsureDefaults()
+	err = opts.CheckCompatibility(storeDir, `
+[Options]
+  wal_dir=
+`)
+	require.True(t, errors.As(err, &missingWALRecoveryDirErr))
+	require.Equal(t, storeDir, missingWALRecoveryDirErr.Dir)
+
+	// Should be the same as above.
+	err = opts.CheckCompatibility(storeDir, ``)
+	require.True(t, errors.As(err, &missingWALRecoveryDirErr))
+	require.Equal(t, storeDir, missingWALRecoveryDirErr.Dir)
+
+	opts.WALRecoveryDirs = []wal.Dir{{Dirname: storePathIdentifier}}
+	require.NoError(t, DefaultOptions().CheckCompatibility(storeDir, `
+[Options]
+  wal_dir=
+`))
+
+	// Should be the same as above.
+	require.NoError(t, DefaultOptions().CheckCompatibility(storeDir, ``))
+
 	// Check that an OPTIONS file that configured a secondary failover WAL dir
 	// that will no longer be used errors if it's not also present in
 	// WALRecoveryDirs.
-	err = DefaultOptions().CheckCompatibility(`
+	err = DefaultOptions().CheckCompatibility(storeDir, `
 [Options]
 
 [WAL Failover]
@@ -220,7 +246,7 @@ func TestOptionsCheckCompatibility(t *testing.T) {
 	// secondary dir.
 	opts = &Options{WALRecoveryDirs: []wal.Dir{{Dirname: "failover-wal-dir"}}}
 	opts.EnsureDefaults()
-	require.NoError(t, opts.CheckCompatibility(`
+	require.NoError(t, opts.CheckCompatibility(storeDir, `
 [Options]
 
 [WAL Failover]
@@ -228,7 +254,7 @@ func TestOptionsCheckCompatibility(t *testing.T) {
 `))
 	opts = &Options{WALFailover: &WALFailoverOptions{Secondary: wal.Dir{Dirname: "failover-wal-dir"}}}
 	opts.EnsureDefaults()
-	require.NoError(t, opts.CheckCompatibility(`
+	require.NoError(t, opts.CheckCompatibility(storeDir, `
 [Options]
 
 [WAL Failover]

--- a/testdata/open_wal_failover
+++ b/testdata/open_wal_failover
@@ -58,8 +58,10 @@ grep-between path=(a,data/OPTIONS-000007) start=(\[WAL Failover\]) end=^$
 
 open path=(a,data)
 ----
-directory "secondary-wals" may contain relevant WALs
-  OPTIONS key: WAL Failover.secondary_dir
+directory "secondary-wals" may contain relevant WALs but is not in WALRecoveryDirs
+  WALFailover.Secondary changed from previous options
+  o.WALDir: ""
+  o.WALRecoveryDirs: 0
 
 # But opening the same directory while providing the secondary path as a WAL
 # recovery dir should succeed.


### PR DESCRIPTION
If the existing store did not have a `WALDir` set and the new options
have one, the store path itself must be either a failover secondary or
a recovery dir. This was not covered by the compatibility check (it
would have saved a lot of time debugging a crossversion failure).

We also make sure we check the previous WAL dir even if the `wal_dir=`
entry doesn't appear (as was the case in tests).