### PR TITLE
crl-release-25.1: options: fix missing case in WAL recovery dir check

### DIFF
--- a/open.go
+++ b/open.go
@@ -472,7 +472,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := opts.CheckCompatibility(previousOptions); err != nil {
+		if err := opts.CheckCompatibility(dirname, previousOptions); err != nil {
 			return nil, err
 		}
 	}

--- a/testdata/open_wal_failover
+++ b/testdata/open_wal_failover
@@ -58,8 +58,10 @@ grep-between path=(a,data/OPTIONS-000007) start=(\[WAL Failover\]) end=^$
 
 open path=(a,data)
 ----
-directory "secondary-wals" may contain relevant WALs
-  OPTIONS key: WAL Failover.secondary_dir
+directory "secondary-wals" may contain relevant WALs but is not in WALRecoveryDirs
+  WALFailover.Secondary changed from previous options
+  o.WALDir: ""
+  o.WALRecoveryDirs: 0
 
 # But opening the same directory while providing the secondary path as a WAL
 # recovery dir should succeed.


### PR DESCRIPTION
If the existing store did not have a `WALDir` set and the new options
have one, the store path itself must be either a failover secondary or
a recovery dir. This was not covered by the compatibility check (it
would have saved a lot of time debugging a crossversion failure).

We also make sure we check the previous WAL dir even if the `wal_dir=`
entry doesn't appear (as was the case in tests).