### PR TITLE
crl-release-25.2: db: create shared objects only once the format is new enough

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2565,7 +2565,7 @@ func (d *DB) runCopyCompaction(
 		return nil, compact.Stats{}, err
 	}
 	if !objMeta.IsExternal() {
-		if objMeta.IsRemote() || !remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, c.outputLevel.level) {
+		if objMeta.IsRemote() || !d.shouldCreateShared(c.outputLevel.level) {
 			panic("pebble: scheduled a copy compaction that is not actually moving files to shared storage")
 		}
 		// Note that based on logic in the compaction picker, we're guaranteed
@@ -2644,7 +2644,7 @@ func (d *DB) runCopyCompaction(
 		w, _, err := d.objProvider.Create(
 			ctx, base.FileTypeTable, newMeta.FileBacking.DiskFileNum,
 			objstorage.CreateOptions{
-				PreferSharedStorage: remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, c.outputLevel.level),
+				PreferSharedStorage: d.shouldCreateShared(c.outputLevel.level),
 			},
 		)
 		if err != nil {
@@ -3342,7 +3342,7 @@ func (d *DB) newCompactionOutputObj(
 
 	// Prefer shared storage if present.
 	createOpts := objstorage.CreateOptions{
-		PreferSharedStorage: remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, c.outputLevel.level),
+		PreferSharedStorage: d.shouldCreateShared(c.outputLevel.level),
 		WriteCategory:       writeCategory,
 	}
 	writable, objMeta, err := d.objProvider.Create(ctx, typ, diskFileNum, createOpts)

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
@@ -386,6 +387,13 @@ func (d *DB) TableFormat() sstable.TableFormat {
 		}
 	}
 	return f
+}
+
+// shouldCreateShared returns true if the database should use shared objects
+// when creating new objects on the given level.
+func (d *DB) shouldCreateShared(targetLevel int) bool {
+	return remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, targetLevel) &&
+		d.FormatMajorVersion() >= FormatMinForSharedObjects
 }
 
 // RatchetFormatMajorVersion ratchets the opened database's format major


### PR DESCRIPTION
We currently have a race when opening an older (pre-shared-storage)
store and having shared storage enabled in the object. We ratchet the
FMV to the appropriate one, but until that is done any
flushes/compactions can still create shared sstables. These sstables
will have an old format that is not supported with shared storage.

We modify the code paths that decide where to create objects to check
the FMV as well.