### PR TITLE
crl-release-25.2: db: fix obsolete file metric underflows

### DIFF
--- a/db.go
+++ b/db.go
@@ -452,10 +452,16 @@ type DB struct {
 			noOngoingFlushStartTime crtime.Mono
 		}
 
-		// Non-zero when file cleaning is disabled. The disabled count acts as a
-		// reference count to prohibit file cleaning. See
-		// DB.{disable,Enable}FileDeletions().
-		disableFileDeletions int
+		fileDeletions struct {
+			// Non-zero when file cleaning is disabled. The disabled count acts
+			// as a reference count to prohibit file cleaning. See
+			// DB.{disable,Enable}FileDeletions().
+			disableCount int
+			// queuedStats holds cumulative stats for files that have been
+			// queued for deletion by the cleanup manager. These stats are
+			// monotonically increasing for the *DB's lifetime.
+			queuedStats obsoleteObjectStats
+		}
 
 		snapshots struct {
 			// The list of active snapshots.
@@ -1995,6 +2001,7 @@ func (d *DB) AsyncFlush() (<-chan struct{}, error) {
 func (d *DB) Metrics() *Metrics {
 	metrics := &Metrics{}
 	walStats := d.mu.log.manager.Stats()
+	completedCleanupStats := d.cleanupManager.CompletedStats()
 
 	d.mu.Lock()
 	vers := d.mu.versions.currentVersion()
@@ -2058,6 +2065,25 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Table.ZombieSize = d.mu.versions.zombieTables.TotalSize()
 	metrics.Table.Local.ZombieSize = d.mu.versions.zombieTables.LocalSize()
 	metrics.private.optionsFileSize = d.optionsFileSize
+
+	// The obsolete blob/table metrics have a subtle calculation:Add commentMore actions
+	//
+	// (A) The vs.metrics.Table.[Local.]ObsoleteSize fields reflect the set of
+	// files currently sitting in vs.obsoleteTables but not yet enqueued to the
+	// cleanup manager.
+	//
+	// (B) The d.mu.fileDeletions.queuedStats field holds the set of files that
+	// have been queued for deletion by the cleanup manager.
+	//
+	// (C) The cleanup manager also maintains cumulative stats for the set of
+	// files that have been deleted.
+	//
+	// The value of currently pending obsolete files is (A) + (B) - (C).
+	pendingObsoleteFileStats := d.mu.fileDeletions.queuedStats
+	pendingObsoleteFileStats.Sub(completedCleanupStats)
+	metrics.Table.Local.ObsoleteSize += pendingObsoleteFileStats.tablesLocal.size
+	metrics.Table.ObsoleteCount += int64(pendingObsoleteFileStats.tablesAll.count)
+	metrics.Table.ObsoleteSize += pendingObsoleteFileStats.tablesAll.size
 
 	// TODO(jackson): Consider making these metrics optional.
 	metrics.Keys.RangeKeySetsCount = *rangeKeySetsAnnotator.MultiLevelAnnotation(vers.RangeKeyLevels[:])

--- a/open.go
+++ b/open.go
@@ -385,7 +385,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 
 	d.mu.log.manager = walManager
 
-	d.cleanupManager = openCleanupManager(opts, d.objProvider, d.onObsoleteTableDelete, d.getDeletionPacerInfo)
+	d.cleanupManager = openCleanupManager(opts, d.objProvider, d.getDeletionPacerInfo)
 
 	if manifestExists && !opts.DisableConsistencyCheck {
 		curVersion := d.mu.versions.currentVersion()


### PR DESCRIPTION
Previously a race existed in the calculation of obsolete file metrics resulting in underflow. The values within versionSet.metrics were reset and recalculated to reflect the set of files in versionSet.obsoleteTables whenever new files were added to obsoleteFiles. Additionally, the cleanup manager invoked a callback to decrease versionSet.metrics whenever a table was deleted.

The recalculation of versionSet.metrics could reset the metrics to less than the sum of outstanding pending deletes. When the cleanup manager eventually deleted the pending tables, these metrics would underflow.

This commit fixes the bug by maintaining separate stats for all files that have been enqueued for the cleanup manager and all files that have been successfully deleted. The volume of outstanding, pending deletions is the difference between the two.

For now, there's an additional wart that the set of files that are sitting in versionSet.obsoleteTables are still separately tracked.

Informs #4811.