### PR TITLE
crl-release-25.1: db: fix obsolete file metric underflows

### DIFF
--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/wal"
@@ -31,10 +32,9 @@ type DeleteCleaner = base.DeleteCleaner
 type ArchiveCleaner = base.ArchiveCleaner
 
 type cleanupManager struct {
-	opts            *Options
-	objProvider     objstorage.Provider
-	onTableDeleteFn func(fileSize uint64, isLocal bool)
-	deletePacer     *deletionPacer
+	opts        *Options
+	objProvider objstorage.Provider
+	deletePacer *deletionPacer
 
 	// jobsCh is used as the cleanup job queue.
 	jobsCh chan *cleanupJob
@@ -45,6 +45,7 @@ type cleanupManager struct {
 		sync.Mutex
 		// totalJobs is the total number of enqueued jobs (completed or in progress).
 		totalJobs              int
+		completedStats         obsoleteTableStats
 		completedJobs          int
 		completedJobsCond      sync.Cond
 		jobsQueueWarningIssued bool
@@ -74,22 +75,19 @@ type obsoleteFile struct {
 type cleanupJob struct {
 	jobID         JobID
 	obsoleteFiles []obsoleteFile
+	tableStats    obsoleteTableStats
 }
 
 // openCleanupManager creates a cleanupManager and starts its background goroutine.
 // The cleanupManager must be Close()d.
 func openCleanupManager(
-	opts *Options,
-	objProvider objstorage.Provider,
-	onTableDeleteFn func(fileSize uint64, isLocal bool),
-	getDeletePacerInfo func() deletionPacerInfo,
+	opts *Options, objProvider objstorage.Provider, getDeletePacerInfo func() deletionPacerInfo,
 ) *cleanupManager {
 	cm := &cleanupManager{
-		opts:            opts,
-		objProvider:     objProvider,
-		onTableDeleteFn: onTableDeleteFn,
-		deletePacer:     newDeletionPacer(crtime.NowMono(), int64(opts.TargetByteDeletionRate), getDeletePacerInfo),
-		jobsCh:          make(chan *cleanupJob, jobsQueueDepth),
+		opts:        opts,
+		objProvider: objProvider,
+		deletePacer: newDeletionPacer(crtime.NowMono(), int64(opts.TargetByteDeletionRate), getDeletePacerInfo),
+		jobsCh:      make(chan *cleanupJob, jobsQueueDepth),
 	}
 	cm.mu.completedJobsCond.L = &cm.mu.Mutex
 	cm.waitGroup.Add(1)
@@ -103,6 +101,14 @@ func openCleanupManager(
 	return cm
 }
 
+// CompletedStats returns the stats summarizing tables deleted. The returned
+// stats increase monotonically over the lifetime of the DB.
+func (cm *cleanupManager) CompletedStats() obsoleteTableStats {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.mu.completedStats
+}
+
 // Close stops the background goroutine, waiting until all queued jobs are completed.
 // Delete pacing is disabled for the remaining jobs.
 func (cm *cleanupManager) Close() {
@@ -111,10 +117,13 @@ func (cm *cleanupManager) Close() {
 }
 
 // EnqueueJob adds a cleanup job to the manager's queue.
-func (cm *cleanupManager) EnqueueJob(jobID JobID, obsoleteFiles []obsoleteFile) {
+func (cm *cleanupManager) EnqueueJob(
+	jobID JobID, obsoleteFiles []obsoleteFile, tableStats obsoleteTableStats,
+) {
 	job := &cleanupJob{
 		jobID:         jobID,
 		obsoleteFiles: obsoleteFiles,
+		tableStats:    tableStats,
 	}
 
 	// Report deleted bytes to the pacer, which can use this data to potentially
@@ -166,7 +175,6 @@ func (cm *cleanupManager) mainLoop() {
 			switch of.fileType {
 			case fileTypeTable:
 				cm.maybePace(&tb, of.fileType, of.nonLogFile.fileNum, of.nonLogFile.fileSize)
-				cm.onTableDeleteFn(of.nonLogFile.fileSize, of.nonLogFile.isLocal)
 				cm.deleteObsoleteObject(fileTypeTable, job.jobID, of.nonLogFile.fileNum)
 			case fileTypeLog:
 				cm.deleteObsoleteFile(of.logFile.FS, fileTypeLog, job.jobID, of.logFile.Path,
@@ -178,6 +186,7 @@ func (cm *cleanupManager) mainLoop() {
 			}
 		}
 		cm.mu.Lock()
+		cm.mu.completedStats.Add(job.tableStats)
 		cm.mu.completedJobs++
 		cm.mu.completedJobsCond.Broadcast()
 		cm.maybeLogLocked()
@@ -323,17 +332,6 @@ func (d *DB) getDeletionPacerInfo() deletionPacerInfo {
 	return pacerInfo
 }
 
-// onObsoleteTableDelete is called to update metrics when an sstable is deleted.
-func (d *DB) onObsoleteTableDelete(fileSize uint64, isLocal bool) {
-	d.mu.Lock()
-	d.mu.versions.metrics.Table.ObsoleteCount--
-	d.mu.versions.metrics.Table.ObsoleteSize -= fileSize
-	if isLocal {
-		d.mu.versions.metrics.Table.Local.ObsoleteSize -= fileSize
-	}
-	d.mu.Unlock()
-}
-
 // scanObsoleteFiles scans the filesystem for files that are no longer needed
 // and adds those to the internal lists of obsolete files. Note that the files
 // are not actually deleted by this method. A subsequent call to
@@ -440,7 +438,7 @@ func (d *DB) scanObsoleteFiles(list []string, flushableIngests []*ingestedFlusha
 //
 // d.mu must be held when calling this method.
 func (d *DB) disableFileDeletions() {
-	d.mu.disableFileDeletions++
+	d.mu.fileDeletions.disableCount++
 	d.mu.Unlock()
 	defer d.mu.Lock()
 	d.cleanupManager.Wait()
@@ -451,11 +449,11 @@ func (d *DB) disableFileDeletions() {
 //
 // d.mu must be held when calling this method.
 func (d *DB) enableFileDeletions() {
-	if d.mu.disableFileDeletions <= 0 {
+	if d.mu.fileDeletions.disableCount <= 0 {
 		panic("pebble: file deletion disablement invariant violated")
 	}
-	d.mu.disableFileDeletions--
-	if d.mu.disableFileDeletions > 0 {
+	d.mu.fileDeletions.disableCount--
+	if d.mu.fileDeletions.disableCount > 0 {
 		return
 	}
 	d.deleteObsoleteFiles(d.newJobIDLocked())
@@ -470,7 +468,7 @@ type fileInfo = base.FileInfo
 // Does nothing if file deletions are disabled (see disableFileDeletions). A
 // cleanup job will be scheduled when file deletions are re-enabled.
 func (d *DB) deleteObsoleteFiles(jobID JobID) {
-	if d.mu.disableFileDeletions > 0 {
+	if d.mu.fileDeletions.disableCount > 0 {
 		return
 	}
 	_, noRecycle := d.opts.Cleaner.(base.NeedsFileContents)
@@ -507,6 +505,14 @@ func (d *DB) deleteObsoleteFiles(jobID JobID) {
 
 	obsoleteOptions := d.mu.versions.obsoleteOptions
 	d.mu.versions.obsoleteOptions = nil
+
+	// Compute the stats for the tables being queued for deletion and add them
+	// to the running total. These stats will be used during DB.Metrics() to
+	// calculate the count and size of pending obsolete tables by diffing these
+	// stats and the stats reported by the cleanup manager.
+	tableStats := calculateObsoleteTableStats(obsoleteTables)
+	d.mu.fileDeletions.queuedStats.Add(tableStats)
+	d.mu.versions.updateObsoleteTableMetricsLocked()
 
 	// Release d.mu while preparing the cleanup job and possibly waiting.
 	// Note the unusual order: Unlock and then Lock.
@@ -561,7 +567,7 @@ func (d *DB) deleteObsoleteFiles(jobID JobID) {
 		}
 	}
 	if len(filesToDelete) > 0 {
-		d.cleanupManager.EnqueueJob(jobID, filesToDelete)
+		d.cleanupManager.EnqueueJob(jobID, filesToDelete, tableStats)
 	}
 	if d.opts.private.testingAlwaysWaitForCleanup {
 		d.cleanupManager.Wait()
@@ -578,6 +584,49 @@ func (d *DB) maybeScheduleObsoleteTableDeletionLocked() {
 	if len(d.mu.versions.obsoleteTables) > 0 {
 		d.deleteObsoleteFiles(d.newJobIDLocked())
 	}
+}
+
+func calculateObsoleteTableStats(objects []tableInfo) obsoleteTableStats {
+	var stats obsoleteTableStats
+	for _, o := range objects {
+		if o.isLocal {
+			stats.local.count++
+			stats.local.size += o.FileSize
+		}
+		stats.total.count++
+		stats.total.size += o.FileSize
+	}
+	return stats
+}
+
+type obsoleteTableStats struct {
+	local countAndSize
+	total countAndSize
+}
+
+func (s *obsoleteTableStats) Add(other obsoleteTableStats) {
+	s.local.Add(other.local)
+	s.total.Add(other.total)
+}
+
+func (s *obsoleteTableStats) Sub(other obsoleteTableStats) {
+	s.local.Sub(other.local)
+	s.total.Sub(other.total)
+}
+
+type countAndSize struct {
+	count uint64
+	size  uint64
+}
+
+func (c *countAndSize) Add(other countAndSize) {
+	c.count += other.count
+	c.size += other.size
+}
+
+func (c *countAndSize) Sub(other countAndSize) {
+	c.count = invariants.SafeSub(c.count, other.count)
+	c.size = invariants.SafeSub(c.size, other.size)
 }
 
 func merge(a, b []fileInfo) []fileInfo {

--- a/open.go
+++ b/open.go
@@ -385,7 +385,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 
 	d.mu.log.manager = walManager
 
-	d.cleanupManager = openCleanupManager(opts, d.objProvider, d.onObsoleteTableDelete, d.getDeletionPacerInfo)
+	d.cleanupManager = openCleanupManager(opts, d.objProvider, d.getDeletionPacerInfo)
 
 	if manifestExists && !opts.DisableConsistencyCheck {
 		curVersion := d.mu.versions.currentVersion()


### PR DESCRIPTION
Previously a race existed in the calculation of obsolete file metrics resulting in underflow. The values within versionSet.metrics were reset and recalculated to reflect the set of files in versionSet.obsoleteTables whenever new files were added to obsoleteFiles. Additionally, the cleanup manager invoked a callback to decrease versionSet.metrics whenever a table was deleted.

The recalculation of versionSet.metrics could reset the metrics to less than the sum of outstanding pending deletes. When the cleanup manager eventually deleted the pending tables, these metrics would underflow.

This commit fixes the bug by maintaining separate stats for all files that have been enqueued for the cleanup manager and all files that have been successfully deleted. The volume of outstanding, pending deletions is the difference between the two.

For now, there's an additional wart that the set of files that are sitting in versionSet.obsoleteTables are still separately tracked.

Informs cockroachdb#4811.