### PR TITLE
metamorphic: crossversion: debugging improvements

### DIFF
--- a/internal/metamorphic/meta_test.go
+++ b/internal/metamorphic/meta_test.go
@@ -76,7 +76,7 @@ func runTestMeta(t *testing.T, addtlOptions ...option) {
 		}
 		testRootDir, runSubdirs := runOnceFlags.ParseCompare()
 		if runOnceFlags.TryToReduce {
-			tryToReduceCompare(t, runOnceFlags.Dir, testRootDir, runSubdirs, runOnceFlags.ReduceAttempts)
+			tryToReduceCompare(t, runOnceFlags.Dir, testRootDir, runSubdirs, runOnceFlags.InitialStatePath, runOnceFlags.ReduceAttempts)
 			return
 		}
 		metamorphic.Compare(t, testRootDir, runOnceFlags.Seed, runSubdirs, onceOpts...)
@@ -90,7 +90,7 @@ func runTestMeta(t *testing.T, addtlOptions ...option) {
 			onceOpts = append(onceOpts, opt)
 		}
 		if runOnceFlags.TryToReduce {
-			tryToReduce(t, runOnceFlags.Dir, runOnceFlags.RunDir, runOnceFlags.ReduceAttempts)
+			tryToReduce(t, runOnceFlags.Dir, runOnceFlags.RunDir, runOnceFlags.InitialStatePath, runOnceFlags.ReduceAttempts)
 			return
 		}
 		metamorphic.RunOnce(t, runOnceFlags.RunDir, runOnceFlags.Seed,

--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -49,6 +49,9 @@ type CommonFlags struct {
 	// KeyFormatName is the name of the KeyFormat to use. Defaults to "testkeys".
 	// Acceptable values are "testkeys" and "cockroachkvs".
 	KeyFormatName string
+	// InitialStatePath is the path to a database data directory from a previous
+	// run. See the "initial-state" flag below.
+	InitialStatePath string
 }
 
 // KeyFormat returns the KeyFormat indicated by the flags KeyFormatName.
@@ -104,6 +107,10 @@ func initCommonFlags() *CommonFlags {
 
 	flag.StringVar(&c.KeyFormatName, "key-format", "testkeys",
 		"name of the key format to use")
+
+	flag.StringVar(&c.InitialStatePath, "initial-state", "",
+		`path to a database's data directory, used to prepopulate the test run's databases.
+		Must be used in conjunction with --previous-ops (unless --run or --compare is used).`)
 
 	return c
 }
@@ -161,9 +168,6 @@ type RunFlags struct {
 	// PreviousOps is the path to the ops file of a previous run. See the
 	// "previous-ops" flag below.
 	PreviousOps string
-	// InitialStatePath is the path to a database data directory from a previous
-	// run. See the "initial-state" flag below.
-	InitialStatePath string
 	// InitialStateDesc is a human-readable description of the initial database
 	// state. See "initial-state-desc" flag below.
 	InitialStateDesc string
@@ -201,10 +205,6 @@ with --run-dir or --compare`)
 	flag.StringVar(&r.PreviousOps, "previous-ops", "",
 		`path to an ops file, used to prepopulate the set of keys operations draw from." +
 		Must be used in conjunction with --initial-state`)
-
-	flag.StringVar(&r.InitialStatePath, "initial-state", "",
-		`path to a database's data directory, used to prepopulate the test run's databases.
-		Must be used in conjunction with --previous-ops.`)
 
 	flag.StringVar(&r.InitialStateDesc, "initial-state-desc", "",
 		`a human-readable description of the initial database state.
@@ -246,6 +246,9 @@ func (ro *RunOnceFlags) MakeRunOnceOptions() []metamorphic.RunOnceOption {
 	}
 	if ro.NumInstances > 1 {
 		onceOpts = append(onceOpts, metamorphic.MultiInstance(ro.NumInstances))
+	}
+	if ro.InitialStatePath != "" {
+		onceOpts = append(onceOpts, metamorphic.RunOnceInitialStatePath(ro.InitialStatePath))
 	}
 	return onceOpts
 }

--- a/internal/metamorphic/reduce_test.go
+++ b/internal/metamorphic/reduce_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -32,10 +33,12 @@ import (
 //
 // The test will save the smallest reproduction found and print out the relevant
 // information.
-func tryToReduce(t *testing.T, testStateDir string, runDir string, reduceAttempts int) {
+func tryToReduce(
+	t *testing.T, testStateDir string, runDir string, initialStatePath string, reduceAttempts int,
+) {
 	testRootDir := filepath.Dir(runDir)
 	runSubdir := filepath.Base(runDir)
-	r := makeReducer(t, testStateDir, testRootDir, []string{runSubdir}, reduceAttempts)
+	r := makeReducer(t, testStateDir, testRootDir, []string{runSubdir}, initialStatePath, reduceAttempts)
 	r.Run(t)
 }
 
@@ -52,9 +55,14 @@ func tryToReduce(t *testing.T, testStateDir string, runDir string, reduceAttempt
 // The test will save the smallest reproduction found and print out the relevant
 // information.
 func tryToReduceCompare(
-	t *testing.T, testStateDir string, testRootDir string, runSubdirs []string, reduceAttempts int,
+	t *testing.T,
+	testStateDir string,
+	testRootDir string,
+	runSubdirs []string,
+	initialStatePath string,
+	reduceAttempts int,
 ) {
-	r := makeReducer(t, testStateDir, testRootDir, runSubdirs, reduceAttempts)
+	r := makeReducer(t, testStateDir, testRootDir, runSubdirs, initialStatePath, reduceAttempts)
 	r.Run(t)
 }
 
@@ -62,9 +70,11 @@ func tryToReduceCompare(
 // tries to reduce the number of operations.
 type reducer struct {
 	// testRootDir is the directory of the test, which contains the "ops" file.
-	testRootDir    string
-	configs        []testConfig
-	reduceAttempts int
+	testRootDir string
+	configs     []testConfig
+	// initialStatePath stores the --initial-state value, if set.
+	initialStatePath string
+	reduceAttempts   int
 
 	ops []string
 
@@ -84,7 +94,12 @@ type testConfig struct {
 }
 
 func makeReducer(
-	t *testing.T, testStateDir string, testRootDir string, runSubdirs []string, reduceAttempts int,
+	t *testing.T,
+	testStateDir string,
+	testRootDir string,
+	runSubdirs []string,
+	initialStatePath string,
+	reduceAttempts int,
 ) *reducer {
 	// All run dirs should have the same parent path.
 	opsData, err := os.ReadFile(filepath.Join(testRootDir, "ops"))
@@ -105,11 +120,12 @@ func makeReducer(
 	t.Logf("Starting with %d operations", len(ops))
 
 	return &reducer{
-		testRootDir:    testRootDir,
-		configs:        tc,
-		ops:            ops,
-		reduceAttempts: reduceAttempts,
-		testStateDir:   testStateDir,
+		testRootDir:      testRootDir,
+		configs:          tc,
+		initialStatePath: initialStatePath,
+		ops:              ops,
+		reduceAttempts:   reduceAttempts,
+		testStateDir:     testStateDir,
 	}
 }
 
@@ -144,15 +160,16 @@ func (r *reducer) try(t *testing.T, ops []string) bool {
 		"--keep",
 	}
 
-	var runFlags []string
 	if len(runSubdirs) == 1 {
 		// RunOnce mode.
-		runFlags = []string{"--run-dir", filepath.Join(testRootDir, runSubdirs[0])}
+		args = append(args, "--run-dir", filepath.Join(testRootDir, runSubdirs[0]))
 	} else {
 		// Compare mode.
-		runFlags = []string{"--compare", filepath.Join(testRootDir, fmt.Sprintf("{%s}", strings.Join(runSubdirs, ",")))}
+		args = append(args, "--compare", filepath.Join(testRootDir, fmt.Sprintf("{%s}", strings.Join(runSubdirs, ","))))
 	}
-	args = append(args, runFlags...)
+	if r.initialStatePath != "" {
+		args = append(args, "--initial-state", r.initialStatePath)
+	}
 
 	var output bytes.Buffer
 	cmd := exec.CommandContext(context.Background(), os.Args[0], args...)
@@ -188,7 +205,7 @@ func (r *reducer) try(t *testing.T, ops []string) bool {
 		t.Logf("  Diagram: %s", diagramPath)
 	}
 
-	t.Logf(`  go test ./internal/metamorphic -tags invariants -run "%s$" -v %s %q`, t.Name(), runFlags[0], runFlags[1])
+	t.Logf("  go test ./internal/metamorphic -tags invariants %s", shellJoin(cmd.Args[1:]))
 	if r.lastSavedDir != "" {
 		require.NoError(t, os.RemoveAll(r.lastSavedDir))
 	}
@@ -237,4 +254,17 @@ func randomSubset(t *testing.T, ops []string, removeProbability float64) []strin
 		res = append(res, ops[i])
 	}
 	return res
+}
+
+func shellJoin(args []string) string {
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		// Quote if the word has bytes that the shell would interpret.
+		if strings.ContainsAny(a, " \t\n\"'\\$`*?[]{}<>|&;()") {
+			quoted[i] = strconv.Quote(a)
+		} else {
+			quoted[i] = a
+		}
+	}
+	return strings.Join(quoted, " ")
 }

--- a/metamorphic/history.go
+++ b/metamorphic/history.go
@@ -183,13 +183,7 @@ func CompareHistories(t TestingT, paths []string) (i int, diff string) {
 	for i := 1; i < len(paths); i++ {
 		lines := readHistory(t, paths[i])
 		lines = reorderHistory(lines)
-		diff := difflib.UnifiedDiff{
-			A:       base,
-			B:       lines,
-			Context: 5,
-		}
-		text, err := difflib.GetUnifiedDiffString(diff)
-		require.NoError(t, err)
+		text := lineByLineDiff(base, lines)
 		if text != "" {
 			return i, text
 		}

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -409,6 +409,7 @@ type runOnceOptions struct {
 	failRegexp          *regexp.Regexp
 	numInstances        int
 	keyFormat           KeyFormat
+	initialStatePath    string
 	customOptionParsers map[string]func(string) (CustomOption, bool)
 }
 
@@ -462,6 +463,12 @@ type MultiInstance int
 func (m MultiInstance) apply(ro *runAndCompareOptions) { ro.numInstances = int(m) }
 func (m MultiInstance) applyOnce(ro *runOnceOptions)   { ro.numInstances = int(m) }
 
+// RunOnceInitialStatePath is used to set an initial database state path for a
+// single run.
+type RunOnceInitialStatePath string
+
+func (i RunOnceInitialStatePath) applyOnce(ro *runOnceOptions) { ro.initialStatePath = string(i) }
+
 // RunOnce performs one run of the metamorphic tests. RunOnce expects the
 // directory named by `runDir` to already exist and contain an `OPTIONS` file
 // containing the test run's configuration. The history of the run is persisted
@@ -490,6 +497,10 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 	testOpts := defaultTestOptions(runOpts.keyFormat)
 	opts := testOpts.Opts
 	require.NoError(t, parseOptions(testOpts, string(optionsData), runOpts.customOptionParsers))
+
+	if runOpts.initialStatePath != "" {
+		testOpts.initialStatePath = runOpts.initialStatePath
+	}
 
 	ops, err := parse(opsData, parserOpts{
 		parseFormattedUserKey:       testOpts.KeyFormat.ParseFormattedKey,


### PR DESCRIPTION
#### metamorphic: support --initial-state with --run/compare

Allow supplying an initial state when trying to reproduce a failure.

#### metamorphic: support --initial-state with --try-to-reduce