### PR TITLE
manifest: clean up SortBySeqNum, SortBySmallest

### DIFF
--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -288,7 +288,7 @@ func TestL0Sublevels(t *testing.T) {
 					initialize = false
 				}
 			}
-			SortBySeqNum(fileMetas[0])
+			sortBySeqNum(fileMetas[0])
 			for i := 1; i < NumLevels; i++ {
 				SortBySmallest(fileMetas[i], base.DefaultComparer.Compare)
 			}
@@ -492,6 +492,13 @@ func TestL0Sublevels(t *testing.T) {
 			return builder.String()
 		}
 		return fmt.Sprintf("unrecognized command: %s", td.Cmd)
+	})
+}
+
+// sortBySeqNum sorts the specified files by increasing sequence number.
+func sortBySeqNum(files []*TableMetadata) {
+	slices.SortFunc(files, func(a, b *TableMetadata) int {
+		return a.cmpSeqNum(b)
 	})
 }
 

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -1001,10 +1001,6 @@ func (m *TableMetadata) cmpSeqNum(b *TableMetadata) int {
 	return stdcmp.Compare(m.TableNum, b.TableNum)
 }
 
-func (m *TableMetadata) lessSeqNum(b *TableMetadata) bool {
-	return m.cmpSeqNum(b) < 0
-}
-
 func (m *TableMetadata) cmpSmallestKey(b *TableMetadata, cmp Compare) int {
 	return base.InternalCompare(cmp, m.Smallest(), b.Smallest())
 }

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -10,7 +10,6 @@ import (
 	"iter"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -48,34 +47,12 @@ func KeyRange(ucmp Compare, iters ...iter.Seq[*TableMetadata]) (smallest, larges
 	return smallest, largest
 }
 
-type bySeqNum []*TableMetadata
-
-func (b bySeqNum) Len() int { return len(b) }
-func (b bySeqNum) Less(i, j int) bool {
-	return b[i].lessSeqNum(b[j])
-}
-func (b bySeqNum) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
-
-// SortBySeqNum sorts the specified files by increasing sequence number.
-func SortBySeqNum(files []*TableMetadata) {
-	sort.Sort(bySeqNum(files))
-}
-
-type bySmallest struct {
-	files []*TableMetadata
-	cmp   Compare
-}
-
-func (b bySmallest) Len() int { return len(b.files) }
-func (b bySmallest) Less(i, j int) bool {
-	return b.files[i].cmpSmallestKey(b.files[j], b.cmp) < 0
-}
-func (b bySmallest) Swap(i, j int) { b.files[i], b.files[j] = b.files[j], b.files[i] }
-
 // SortBySmallest sorts the specified files by smallest key using the supplied
 // comparison function to order user keys.
 func SortBySmallest(files []*TableMetadata, cmp Compare) {
-	sort.Sort(bySmallest{files, cmp})
+	slices.SortFunc(files, func(a, b *TableMetadata) int {
+		return a.cmpSmallestKey(b, cmp)
+	})
 }
 
 // NumLevels is the number of levels a Version contains.
@@ -773,7 +750,7 @@ func CheckOrdering(cmp Compare, format base.FormatKey, level Layer, files LevelI
 			// Validate that the sorting is sane.
 			if prev.LargestSeqNum == 0 && f.LargestSeqNum == prev.LargestSeqNum {
 				// Multiple files satisfying case 2 mentioned above.
-			} else if !prev.lessSeqNum(f) {
+			} else if prev.cmpSeqNum(f) >= 0 {
 				return base.CorruptionErrorf("L0 files %s and %s are not properly ordered: <#%d-#%d> vs <#%d-#%d>",
 					errors.Safe(prev.TableNum), errors.Safe(f.TableNum),
 					errors.Safe(prev.SmallestSeqNum), errors.Safe(prev.LargestSeqNum),


### PR DESCRIPTION
Update both SortBySeqNum and SortBySmallest to use slices.SortFunc instead of the more verbose, less-efficient sort.Interface. Additionally, unexport SortBySeqNum and move it into a test-only file because it is now only used by a unit test.