### PR TITLE
crl-release-24.3: more fixes around shared objects and upgrade

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3076,7 +3076,8 @@ func (d *DB) newCompactionOutput(
 
 	// Prefer shared storage if present.
 	createOpts := objstorage.CreateOptions{
-		PreferSharedStorage: d.shouldCreateShared(c.outputLevel.level),
+		// The writerOpts table format was set earlier, the db could have upgraded in the meantime.
+		PreferSharedStorage: remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, c.outputLevel.level) && writerOpts.TableFormat >= FormatMinForSharedObjects.MaxTableFormat(),
 		WriteCategory:       writeCategory,
 	}
 	writable, objMeta, err := d.objProvider.Create(ctx, fileTypeTable, diskFileNum, createOpts)

--- a/compaction.go
+++ b/compaction.go
@@ -2353,8 +2353,8 @@ func (d *DB) runCopyCompaction(
 		return nil, compact.Stats{}, err
 	}
 	if !objMeta.IsExternal() {
-		if objMeta.IsRemote() || !d.shouldCreateShared(c.outputLevel.level) {
-			panic("pebble: scheduled a copy compaction that is not actually moving files to shared storage")
+		if objMeta.IsRemote() {
+			panic("pebble: scheduled a copy compaction of a shared file")
 		}
 		// Note that based on logic in the compaction picker, we're guaranteed
 		// inputMeta.Virtual is false.

--- a/table_cache.go
+++ b/table_cache.go
@@ -563,9 +563,6 @@ func (c *tableCacheShard) newPointIter(
 	}
 
 	if v.isShared && file.SyntheticSeqNum() != 0 {
-		if tableFormat < sstable.TableFormatPebblev4 {
-			return nil, errors.New("pebble: shared ingested sstable has a lower table format than expected")
-		}
 		// The table is shared and ingested.
 		hideObsoletePoints = true
 	}


### PR DESCRIPTION
#### compaction: relax copy compaction check

If we are racing with the db version being ratcheted, it is possible
that we plan to use shared storage when planning the compaction but
the old table format prevents us from doing so.

#### compaction: fix race in check for shared table format


#### db: remove format check for shared objects

This check is too strict: we could have a file that was ingested
through a non-shared ingestion (and which has no obsolete points)
which was then copied to shared storage.