### PR TITLE
crl-release-25.1: scripts: run-crossversion-meta fix aliasing of test binaries

### DIFF
--- a/scripts/run-crossversion-meta.sh
+++ b/scripts/run-crossversion-meta.sh
@@ -15,7 +15,11 @@ do
     # If the branch name has a "-<suffix>", pull off the suffix. With the
     # crl-release-{XX.X} release branch naming scheme, this will extract the
     # {XX.X}.
-    version=`cut -d- -f3 <<< "$branch"`
+    version="$branch"
+    if [[ $branch == crl-release-* || $branch == origin/crl-release-* ]]; then
+      # Extract the xy.z version name from crl-release-xy.z.
+      version=`cut -d- -f3 <<< "$branch"`
+    fi
 
     toolchain=
     if [ "$version" == "24.1" ]; then
@@ -23,8 +27,8 @@ do
     fi
 
     echo "Building $version ($sha)"
-    GOTOOLCHAIN="$toolchain" go test -c -o "$TEMPDIR/meta.$version.test" ./internal/metamorphic
-    VERSIONS="$VERSIONS -version $version,$sha,$TEMPDIR/meta.$version.test"
+    GOTOOLCHAIN="$toolchain" go test -c -o "$TEMPDIR/meta.$version.$sha.test" ./internal/metamorphic
+    VERSIONS="$VERSIONS -version $version,$sha,$TEMPDIR/meta.$version.$sha.test"
 done
 
 # Return to whence we came.


### PR DESCRIPTION
We add the SHA to the binary name to avoid collisions and only extract
the version when it's an crl-release branch.