### PR TITLE
manifest: fix bug in accumulating blob file deletions

### DIFF
--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -306,3 +306,37 @@ new version edit
 ----
 L2:
   000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+
+# Create a state with two blob files.
+
+apply v10 name=v11
+  add-blob-file: B000003 physical:{000003 size:[20535 (20KB)] vals:[25935 (25KB)]}
+  add-blob-file: B000004 physical:{000004 size:[20535 (20KB)] vals:[25935 (25KB)]}
+  add-table:     L0 000005:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(B000003: 25935); depth:1]
+  add-table:     L0 000006:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(B000004: 25935); depth:1]
+----
+L0.1:
+  000006:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(B000004: 25935); depth:1]
+L0.0:
+  000005:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(B000003: 25935); depth:1]
+L1:
+  000001:[a#2,SET-e#2,SET] seqnums:[0-0] points:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]
+Blob files:
+  B000003 physical:{000003 size:[20535 (20KB)] vals:[25935 (25KB)]}
+  B000004 physical:{000004 size:[20535 (20KB)] vals:[25935 (25KB)]}
+
+# Remove both table+blob file pairs but in separate version edits.
+
+apply v11
+  del-table:     L0 000005
+  del-blob-file: B000003
+new version edit
+  del-table:     L0 000006
+  del-blob-file: B000004
+----
+L1:
+  000001:[a#2,SET-e#2,SET] seqnums:[0-0] points:[a#2,SET-e#2,SET]
+L2:
+  000002:[c#1,SET-f#1,SET] seqnums:[0-0] points:[c#1,SET-f#1,SET]

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -101,7 +101,8 @@ func NewVersionForTesting(
 	comparer *base.Comparer, l0Organizer *L0Organizer, files [7][]*TableMetadata,
 ) *Version {
 	v := &Version{
-		cmp: comparer,
+		cmp:       comparer,
+		BlobFiles: MakeBlobFileSet(nil),
 	}
 	for l := range files {
 		// NB: We specifically insert `files` into the B-Tree in the order

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1030,8 +1030,10 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 		b.BlobFiles.Added[nbf.FileID] = nbf.Physical
 	}
 
-	b.BlobFiles.Deleted = make(map[base.BlobFileID]*PhysicalBlobFile, len(ve.DeletedBlobFiles))
 	for blobFileID, physicalBlobFile := range ve.DeletedBlobFiles {
+		if b.BlobFiles.Deleted == nil {
+			b.BlobFiles.Deleted = make(map[base.BlobFileID]*PhysicalBlobFile)
+		}
 		// If the blob file was added in a prior, accumulated version edit we
 		// can resolve the deletion by removing it from the added files map.
 		// Otherwise the blob file deleted was added prior to this bulk edit,


### PR DESCRIPTION
Previously when accumulating multiple version edits in a BulkVersionEdit, later calls to Accumulate would wipe blob file deletions that had already been accumulated.