### PR TITLE
block: add FastestCompression profile

### DIFF
--- a/options.go
+++ b/options.go
@@ -51,7 +51,8 @@ var (
 	ZstdCompression    = block.ZstdCompression
 	// MinLZCompression is only supported with table formats v6+. Older formats
 	// fall back to snappy.
-	MinLZCompression = block.MinLZCompression
+	MinLZCompression   = block.MinLZCompression
+	FastestCompression = block.FastestCompression
 )
 
 // FilterType exports the base.FilterType type.

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -5,6 +5,7 @@
 package block
 
 import (
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -50,7 +51,17 @@ var (
 	MinLZCompression  = simpleCompressionProfile("MinLZ", compression.MinLZFastest)
 
 	DefaultCompression = SnappyCompression
+	FastestCompression = simpleCompressionProfile("Fastest", fastestAlgorithm())
 )
+
+var fastestAlgorithm = func() compression.Setting {
+	if runtime.GOARCH == "arm64" {
+		// MinLZ is generally faster and better than Snappy except for arm64: Snappy
+		// has an arm64 assembly implementation and MinLZ does not.
+		return compression.Snappy
+	}
+	return compression.MinLZFastest
+}
 
 // simpleCompressionProfile returns a CompressionProfile that uses the same
 // compression setting for all blocks and which uses the uncompressed block if


### PR DESCRIPTION
Add a profile that automatically selects between Snappy and MinLZ
depending on the platform. This will replace the similar code in CRDB
(which is causing CI failures because of different cluster setting
defaults for different platforms).