### PR TITLE
blob,manifest: lookup physical blob file in Version

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3215,7 +3215,7 @@ func (d *DB) compactAndWrite(
 			categoryCompaction,
 		),
 	}
-	c.valueFetcher.Init(d.fileCache, blockReadEnv)
+	c.valueFetcher.Init(&c.version.BlobFiles, d.fileCache, blockReadEnv)
 	iiopts := internalIterOpts{
 		compaction:       true,
 		readEnv:          sstable.ReadEnv{Block: blockReadEnv},

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -592,7 +592,7 @@ func TestAutomaticFlush(t *testing.T) {
 					continue
 				}
 				err := func() error {
-					fetcher, blobContext := sstable.LoadValBlobContext(d.fileCache, &meta.BlobReferences)
+					fetcher, blobContext := sstable.LoadValBlobContext(&v.BlobFiles, d.fileCache, &meta.BlobReferences)
 					defer fetcher.Close()
 
 					f, err := provider.OpenForReading(context.Background(), base.FileTypeTable, meta.TableBacking.DiskFileNum, objstorage.OpenOptions{})

--- a/level_checker.go
+++ b/level_checker.go
@@ -549,7 +549,7 @@ func (d *DB) CheckLevels(stats *CheckLevelsStats) error {
 			// TODO(jackson): Add categorized stats.
 		},
 	}
-	checkConfig.blobValueFetcher.Init(d.fileCache, checkConfig.readEnv)
+	checkConfig.blobValueFetcher.Init(&readState.current.BlobFiles, d.fileCache, checkConfig.readEnv)
 	defer func() { _ = checkConfig.blobValueFetcher.Close() }()
 	return checkLevelsInternal(checkConfig)
 }

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -211,7 +211,7 @@ func TestLoadFlushedSSTableKeys(t *testing.T) {
 				return err.Error()
 			}
 			defer closeFunc()
-			err = loadFlushedSSTableKeys(b, opts.FS, "", diskFileNums, nil /* blobRefMap */, provider,
+			err = loadFlushedSSTableKeys(b, opts.FS, "", diskFileNums, nil /* blobRefMap */, nil /* blobFileMap */, provider,
 				readerOpts, &flushBufs)
 			if err != nil {
 				b.Close()

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -39,18 +39,20 @@ type ValueReader interface {
 	ReadIndexBlock(context.Context, block.ReadEnv, objstorage.ReadHandle) (block.BufferHandle, error)
 }
 
+// A FileMapping defines the mapping between blob file IDs and disk file numbers.
+// It's implemented by *manifest.BlobFileSet.
+type FileMapping interface {
+	// Lookup returns the disk file number for the given blob file ID. It
+	// returns false for the second return value if the blob file ID is not
+	// present in the mapping.
+	Lookup(base.BlobFileID) (base.DiskFileNum, bool)
+}
+
 // A ReaderProvider is an interface that can be used to retrieve a ValueReader
 // for a given file number.
 type ReaderProvider interface {
 	// GetValueReader returns a ValueReader for the given file number.
 	GetValueReader(ctx context.Context, fileNum base.DiskFileNum) (r ValueReader, closeFunc func(), err error)
-}
-
-// DiskFileNumTODO is a temporary function to convert a BlobFileID to a
-// DiskFileNum. It should be removed once the manifest.Version contains a
-// mapping.
-func DiskFileNumTODO(blobFileID base.BlobFileID) base.DiskFileNum {
-	return base.DiskFileNum(blobFileID)
 }
 
 // A ValueFetcher retrieves values stored out-of-band in separate blob files.
@@ -63,6 +65,7 @@ func DiskFileNumTODO(blobFileID base.BlobFileID) base.DiskFileNum {
 // When finished with a ValueFetcher, one must call Close to release all cached
 // readers and block buffers.
 type ValueFetcher struct {
+	fileMapping    FileMapping
 	readerProvider ReaderProvider
 	env            block.ReadEnv
 	fetchCount     int
@@ -76,7 +79,8 @@ type ValueFetcher struct {
 var _ base.ValueFetcher = (*ValueFetcher)(nil)
 
 // Init initializes the ValueFetcher.
-func (r *ValueFetcher) Init(rp ReaderProvider, env block.ReadEnv) {
+func (r *ValueFetcher) Init(fm FileMapping, rp ReaderProvider, env block.ReadEnv) {
+	r.fileMapping = fm
 	r.readerProvider = rp
 	r.env = env
 	if r.readerProvider == nil {
@@ -129,7 +133,10 @@ func (r *ValueFetcher) retrieve(ctx context.Context, vh Handle) (val []byte, err
 				return nil, err
 			}
 		}
-		diskFileNum := DiskFileNumTODO(vh.BlobFileID)
+		diskFileNum, ok := r.fileMapping.Lookup(vh.BlobFileID)
+		if !ok {
+			return nil, errors.AssertionFailedf("blob file %s not found", vh.BlobFileID)
+		}
 		if cr.r, cr.closeFunc, err = r.readerProvider.GetValueReader(ctx, diskFileNum); err != nil {
 			return nil, err
 		}

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -25,6 +25,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// identityFileMapping is an implementation of FileMapping that casts a
+// BlobFileID to a DiskFileNum.
+type identityFileMapping struct{}
+
+// Assert that (identityFileMapping) implements FileMapping.
+var _ FileMapping = identityFileMapping{}
+
+func (identityFileMapping) Lookup(blobFileID base.BlobFileID) (base.DiskFileNum, bool) {
+	return base.DiskFileNum(blobFileID), true
+}
+
 type mockReaderProvider struct {
 	w       *bytes.Buffer
 	readers map[base.DiskFileNum]*FileReader
@@ -107,7 +118,7 @@ func TestValueFetcher(t *testing.T) {
 			var name string
 			td.ScanArgs(t, "name", &name)
 			fetchers[name] = &ValueFetcher{}
-			fetchers[name].Init(rp, block.ReadEnv{})
+			fetchers[name].Init(identityFileMapping{}, rp, block.ReadEnv{})
 			return ""
 		case "fetch":
 			var (
@@ -192,7 +203,7 @@ func TestValueFetcherRetrieveRandomized(t *testing.T) {
 
 	t.Run("sequential", func(t *testing.T) {
 		var fetcher ValueFetcher
-		fetcher.Init(rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
 		defer fetcher.Close()
 		for i := 0; i < len(handles); i++ {
 			val, err := fetcher.retrieve(ctx, handles[i])
@@ -202,7 +213,7 @@ func TestValueFetcherRetrieveRandomized(t *testing.T) {
 	})
 	t.Run("random", func(t *testing.T) {
 		var fetcher ValueFetcher
-		fetcher.Init(rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
 		defer fetcher.Close()
 		for _, i := range rng.Perm(len(handles)) {
 			val, err := fetcher.retrieve(ctx, handles[i])
@@ -264,7 +275,7 @@ func benchmarkValueFetcherRetrieve(b *testing.B, valueSize int, cacheSize int64)
 		rp := makeMockReaderProvider(b, obj, cacheSize, handles)
 		defer rp.Close()
 		var fetcher ValueFetcher
-		fetcher.Init(rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
 		defer fetcher.Close()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -284,7 +295,7 @@ func benchmarkValueFetcherRetrieve(b *testing.B, valueSize int, cacheSize int64)
 			indices[i] = testutils.RandIntInRange(rng, 0, len(handles))
 		}
 		var fetcher ValueFetcher
-		fetcher.Init(rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
 		defer fetcher.Close()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -322,7 +333,7 @@ func makeMockReaderProvider(
 	// blocks.
 	if cacheSize > 0 {
 		var fetcher ValueFetcher
-		fetcher.Init(rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
 		defer fetcher.Close()
 		for i, h := range handles {
 			if i > 0 && handles[i-1].BlockID == h.BlockID {

--- a/sstable/values.go
+++ b/sstable/values.go
@@ -43,10 +43,10 @@ var DebugHandlesBlobContext = TableBlobContext{
 // sstable iterator to fetch the value stored in a blob file. It is the
 // caller's responsibility to close the ValueFetcher returned.
 func LoadValBlobContext(
-	rp blob.ReaderProvider, blobRefs BlobReferences,
+	fm blob.FileMapping, rp blob.ReaderProvider, blobRefs BlobReferences,
 ) (*blob.ValueFetcher, TableBlobContext) {
 	vf := &blob.ValueFetcher{}
-	vf.Init(rp, block.ReadEnv{})
+	vf.Init(fm, rp, block.ReadEnv{})
 	return vf, TableBlobContext{
 		ValueFetcher: vf,
 		References:   blobRefs,

--- a/testdata/value_separation_policy
+++ b/testdata/value_separation_policy
@@ -104,9 +104,9 @@ blobrefs:[]
 # input sstables. The compaction should only observe references to these files.
 
 init preserve-blob-references
-000001 size:[903530] vals:[39531]
-000002 size:[82530] vals:[72111]
-000003 size:[192542] vals:[85225]
+B000001 physical:{000001 size:[903530] vals:[39531]}
+B000002 physical:{000002 size:[82530] vals:[72111]}
+B000003 physical:{000003 size:[192542] vals:[85225]}
 ----
 
 add

--- a/version_set.go
+++ b/version_set.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/record"
-	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
 )
@@ -1132,13 +1131,10 @@ func (vs *versionSet) addLiveFileNums(m map[base.DiskFileNum]struct{}) {
 		for _, lm := range v.Levels {
 			for f := range lm.All() {
 				m[f.TableBacking.DiskFileNum] = struct{}{}
-				for _, ref := range f.BlobReferences {
-					// TODO(jackson): Once we support blob file replacement, we
-					// need to look up the new blob file's number here.
-					diskFileNum := blob.DiskFileNumTODO(ref.FileID)
-					m[diskFileNum] = struct{}{}
-				}
 			}
+		}
+		for bf := range v.BlobFiles.All() {
+			m[bf.Physical.FileNum] = struct{}{}
 		}
 		if v == current {
 			break


### PR DESCRIPTION
Configure blob.ValueFetcher to take a func to translate a base.BlobFileID to the base.DiskFileNum of the backing blob file. Add a (*BlobFileSet).Lookup function with the same signature, and configure the various users of ValueFetcher to propagate their Version's BlobFileSet's Lookup func.

Informs #4802.