### PR TITLE
crl-release-25.1: crossversion: pass all previous ops

### DIFF
--- a/internal/metamorphic/metaflags/meta_flags.go
+++ b/internal/metamorphic/metaflags/meta_flags.go
@@ -201,15 +201,16 @@ with --run-dir or --compare`)
 	// the `ops` file and one of the previous run's data directories.
 
 	flag.StringVar(&r.PreviousOps, "previous-ops", "",
-		`path to an ops file, used to prepopulate the set of keys operations draw from." +
-		Must be used in conjunction with --initial-state`)
+		`paths to the ops files for the previous runs that resulted in the initial state
+(separated by commas); used to prepopulate the set of keys operations draw from.
+Must be used in conjunction with --initial-state.`)
 
 	flag.StringVar(&r.InitialStateDesc, "initial-state-desc", "",
 		`a human-readable description of the initial database state.
-		If set this parameter is written to the OPTIONS to aid in
-		debugging. It's intended to describe the lineage of a
-		database's state, including sufficient information for
-		reproduction (eg, SHA, prng seed, etc).`)
+If set this parameter is written to the OPTIONS to aid in
+debugging. It's intended to describe the lineage of a
+database's state, including sufficient information for
+reproduction (eg, SHA, prng seed, etc).`)
 	return r
 }
 
@@ -304,7 +305,7 @@ func (r *RunFlags) MakeRunOptions() ([]metamorphic.RunOption, error) {
 		if r.InitialStatePath == "" {
 			return nil, errors.Newf("--previous-ops requires --initial-state")
 		}
-		opts = append(opts, metamorphic.ExtendPreviousRun(r.PreviousOps, r.InitialStatePath, r.InitialStateDesc))
+		opts = append(opts, metamorphic.ExtendPreviousRun(strings.Split(r.PreviousOps, ","), r.InitialStatePath, r.InitialStateDesc))
 	} else if r.InitialStatePath != "" {
 		return nil, errors.Newf("--initial-state requires --previous-ops")
 	}

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -77,7 +77,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *ingestOp:
 		return &t.dbID, nil, []interface{}{&t.batchIDs}
 	case *ingestAndExciseOp:
-		return &t.dbID, nil, []interface{}{&t.batchID, &t.exciseStart, &t.exciseEnd}
+		return &t.dbID, nil, []interface{}{&t.batchID, &t.exciseStart, &t.exciseEnd, ignoreExtraArgs{}}
 	case *ingestExternalFilesOp:
 		return &t.dbID, nil, []interface{}{&t.objs}
 	case *initOp:
@@ -133,6 +133,11 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	}
 	panic(fmt.Sprintf("unsupported op type: %T", op))
 }
+
+// ignoreExtraArgs is used as a stand-in for a variable length argument for
+// cases where we want to ignore additional arguments; used to support
+// mixed-version testing when a previous version had an extra argument.
+type ignoreExtraArgs struct{}
 
 var methods = map[string]*methodInfo{
 	"Apply":                     makeMethod(applyOp{}, dbTag, batchTag),
@@ -330,7 +335,7 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 	var varArg interface{}
 	if len(args) > 0 {
 		switch args[len(args)-1].(type) {
-		case *[]objID, *[]pebble.KeyRange, *[]pebble.CheckpointSpan, *[]pebble.DownloadSpan, *[]externalObjWithBounds:
+		case *[]objID, *[]pebble.KeyRange, *[]pebble.CheckpointSpan, *[]pebble.DownloadSpan, *[]externalObjWithBounds, ignoreExtraArgs:
 			varArg = args[len(args)-1]
 			args = args[:len(args)-1]
 		}
@@ -418,6 +423,7 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 			*t = p.parseDownloadSpans(list)
 		case *[]externalObjWithBounds:
 			*t = p.parseExternalObjsWithBounds(list)
+		case ignoreExtraArgs:
 		default:
 			// We already checked for these types when we set varArgs.
 			panic("unreachable")


### PR DESCRIPTION
#### metamorphic: tolerate extra arg for IngestAndExcise

Older versions had an extra bool arg; this mismatch is causing
failures in the (recently functional again) crossversion test.

Informs #4729

#### crossversion: pass all previous ops

We are passing the ops from the previous run. We need to pass ops from
all the runs that culminated in the initial state; this is necessary
for issuing correct SingleDel operations.

We change `--previous-ops` to take a list of files, separated by a
comma.