### PR TITLE
sstable: fix crash in copyFilter

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1265,7 +1265,7 @@ func (w *RawColumnWriter) addDataBlock(b, sep []byte, bhp block.HandleWithProper
 // copyFilter copies the specified filter to the table. It's specifically used
 // by the sstable copier that can copy parts of an sstable to a new sstable,
 // using CopySpan().
-func (w *RawColumnWriter) copyFilter(filter []byte, filterName string) error {
+func (w *RawColumnWriter) copyFilter(filter []byte) error {
 	w.filterBlock = copyFilterWriter{
 		origPolicyName: w.filterBlock.policyName(), origMetaName: w.filterBlock.metaName(), data: filter,
 	}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -99,14 +99,14 @@ func CopySpan(
 	// Set the filter block to be copied over if it exists. It will return false
 	// positives for keys in blocks of the original file that we don't copy, but
 	// filters can always have false positives, so this is fine.
-	if r.tableFilter != nil {
+	if r.tableFilter != nil && o.FilterPolicy != nil && o.FilterPolicy.Name() == props.FilterPolicyName {
 		filterBlock, err := r.readFilterBlock(ctx, block.NoReadEnv, rh, r.filterBH)
 		if err != nil {
 			return 0, errors.Wrap(err, "reading filter")
 		}
 		filterBytes := append([]byte{}, filterBlock.BlockData()...)
 		filterBlock.Release()
-		if err := w.copyFilter(filterBytes, props.FilterPolicyName); err != nil {
+		if err := w.copyFilter(filterBytes); err != nil {
 			return 0, errors.Wrap(err, "copying filter")
 		}
 	}

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -1962,7 +1962,7 @@ func (w *RawRowWriter) copyProperties(props Properties) {
 }
 
 // copyFilter implements RawWriter.
-func (w *RawRowWriter) copyFilter(filter []byte, filterName string) error {
+func (w *RawRowWriter) copyFilter(filter []byte) error {
 	w.filter = copyFilterWriter{
 		origPolicyName: w.filter.policyName(), origMetaName: w.filter.metaName(), data: filter,
 	}

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -374,7 +374,7 @@ type RawWriter interface {
 	// copyFilter copies the specified filter to the table. It's specifically used
 	// by the sstable copier that can copy parts of an sstable to a new sstable,
 	// using CopySpan().
-	copyFilter(filter []byte, filterName string) error
+	copyFilter(filter []byte) error
 
 	// copyProperties copies properties from the specified props, and resets others
 	// to prepare for copying data blocks from another sstable. It's specifically


### PR DESCRIPTION
I saw a `copyFilter` crash in a crossversion test - the
`WriterOptions` had no filter policy set. We fix the logic to verify
that the filter policy matches.