### PR TITLE
manifest: remove BlobReference.OriginalMetadata

### DIFF
--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -328,7 +328,7 @@ func (m *TableMetadata) VirtualMeta() *TableMetadata {
 func (m *TableMetadata) EstimatedReferenceSize() uint64 {
 	var size uint64
 	for i := range m.BlobReferences {
-		size += m.BlobReferences[i].EstimatedPhysicalSize()
+		size += m.BlobReferences[i].EstimatedPhysicalSize
 	}
 	return size
 }

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -233,7 +233,7 @@ L2:
 apply v8
   add-table:     L0 000004:[a#9,SET-z#9,DEL] seqnums:[9-9] points:[a#9,SET-z#9,DEL] blobrefs:[(B000003: 25935); depth:1]
 ----
-error during Accumulate: blob file B000003 referenced by L0.000004 not found
+pebble: blob file B000003 referenced by L0.000004 not found
 
 # Apply a version edit that introduces a new blob file and a corresponding table
 # that references its entirety.
@@ -258,7 +258,7 @@ Blob files:
 apply v8
   add-table:     L0 000005:[a#10,SET-a#10,SET] seqnums:[10-10] points:[a#10,SET-a#10,SET] blobrefs:[(B000003: 205); depth:1]
 ----
-error during Accumulate: blob file B000003 referenced by L0.000005 not found
+pebble: blob file B000003 referenced by L0.000005 not found
 
 # We can add new tables referencing the blob file if we delete an existing table
 # with a reference to the file.

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -984,13 +984,6 @@ type BulkVersionEdit struct {
 		//
 		// Deleted is keyed by blob file ID and points to the physical blob file.
 		Deleted map[base.BlobFileID]*PhysicalBlobFile
-		// DeletedReferences holds metadata of blob files referenced by tables
-		// deleted in the accumulated version edits. This is used during replay
-		// to populate the *BlobFileMetadata pointers of new blob references,
-		// making use of the invariant that new blob references must correspond
-		// to a file introduced in VersionEdit.AddedBlobFiles or a file
-		// referenced by a deleted sstable.
-		DeletedReferences map[base.BlobFileID]*PhysicalBlobFile
 	}
 
 	// AddedFileBacking is a map to support lookup so that we can populate the
@@ -1011,26 +1004,6 @@ type BulkVersionEdit struct {
 	// MarkedForCompactionCountDiff holds the aggregated count of files
 	// marked for compaction added or removed.
 	MarkedForCompactionCountDiff int
-}
-
-// getBlobFileMetadata returns the metadata for the specified blob file. When a
-// new sstable with a reference to a blob file is accumulated to the
-// BulkVersionEdit, it must be the case that either an already-accumulated
-// version edit added the blob file to the BlobFiles.Added map, or the blob file
-// was referenced by a file that was deleted (and the blob file was added to
-// BlobFiles.DeletedReferences).
-func (b *BulkVersionEdit) getBlobFileMetadata(fileID base.BlobFileID) *PhysicalBlobFile {
-	if b.BlobFiles.Added != nil {
-		if md, ok := b.BlobFiles.Added[fileID]; ok {
-			return md
-		}
-	}
-	if b.BlobFiles.DeletedReferences != nil {
-		if md, ok := b.BlobFiles.DeletedReferences[fileID]; ok {
-			return md
-		}
-	}
-	return nil
 }
 
 // Accumulate adds the file addition and deletions in the specified version
@@ -1106,17 +1079,6 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 			// Present in b.Added for the same level.
 			delete(b.AddedTables[df.Level], df.FileNum)
 		}
-		// If this deleted sstable had any references to blob files, record the
-		// referenced blob file to BlobFiles.DeletedReferences. If the
-		// references are carried forward to new files (eg, during a compaction
-		// that decides not to rewrite the blob file), then we'll have the
-		// *BlobFileMetadata available when we process the NewTableEntry.
-		for _, blobRef := range m.BlobReferences {
-			if b.BlobFiles.DeletedReferences == nil {
-				b.BlobFiles.DeletedReferences = make(map[base.BlobFileID]*PhysicalBlobFile)
-			}
-			b.BlobFiles.DeletedReferences[blobRef.FileID] = blobRef.OriginalMetadata
-		}
 	}
 
 	// Generate state for Added backing files. Note that these must be generated
@@ -1164,20 +1126,6 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 		}
 		if nf.Meta.MarkedForCompaction {
 			b.MarkedForCompactionCountDiff++
-		}
-
-		// If there are any new sstables with blob references without a pointer
-		// to the corresponding BlobFileMetadata, populate the pointer. This is
-		// the expected case during manifest replay.
-		for i := range nf.Meta.BlobReferences {
-			if nf.Meta.BlobReferences[i].OriginalMetadata != nil {
-				continue
-			}
-			nf.Meta.BlobReferences[i].OriginalMetadata = b.getBlobFileMetadata(nf.Meta.BlobReferences[i].FileID)
-			if nf.Meta.BlobReferences[i].OriginalMetadata == nil {
-				return errors.Errorf("blob file %s referenced by L%d.%s not found",
-					nf.Meta.BlobReferences[i].FileID, nf.Level, nf.Meta.TableNum)
-			}
 		}
 	}
 
@@ -1297,6 +1245,22 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 			}
 			f.AllowedSeeks.Store(allowedSeeks)
 			f.InitAllowedSeeks = allowedSeeks
+
+			// Validate that all referenced blob files exist.
+			for i, ref := range f.BlobReferences {
+				phys, ok := v.BlobFiles.LookupPhysical(ref.FileID)
+				if !ok {
+					return nil, errors.AssertionFailedf("pebble: blob file %s referenced by L%d.%s not found",
+						ref.FileID, level, f.TableNum)
+				}
+				// NB: It's possible that the reference already has an estimated
+				// physical size if the table was moved.
+				if ref.EstimatedPhysicalSize == 0 {
+					// We must call MakeBlobReference so that we compute the
+					// reference's physical estimated size.
+					f.BlobReferences[i] = MakeBlobReference(ref.FileID, ref.ValueSize, phys)
+				}
+			}
 
 			err := lm.insert(f)
 			if err != nil {

--- a/testdata/version_set
+++ b/testdata/version_set
@@ -615,16 +615,43 @@ no obsolete tables
 no zombie blob files
 no obsolete blob files
 
+# Compact the referencing sstable, removing half its referenced value size.
+
+apply
+  del-table: L4 000017
+  add-table: L5 000018:[f#20,SET-g#20,SET] seqnums:[0-0] points:[f#20,SET-g#20,SET] size:1500 blobrefs:[(B000016: 5000); depth:1]
+----
+applied:
+  last-seq-num:  99
+  del-table:     L4 000017
+  add-table:     L5 000018:[f#20,SET-g#20,SET]
+current version:
+  L2:
+    000001:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:100
+  L3:
+    000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
+    000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
+  L5:
+    000018:[f#20,SET-g#20,SET] seqnums:[0-0] points:[f#20,SET-g#20,SET] size:1800 blobrefs:[(B000016: 5000); depth:1]
+  Blob files:
+    B000016 physical:{000016 size:[10000 (9.8KB)] vals:[10000 (9.8KB)]}
+no virtual backings
+zombie tables: 000017
+no obsolete tables
+no zombie blob files
+no obsolete blob files
+
+
 # Apply the blob file replacement. Because we ref'd the previous version, the
 # previous physical blob file should be considered a zombie.
 
 apply
   del-blob-file: B000016 000016
-  add-blob-file: B000016 physical:{000018 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
+  add-blob-file: B000016 physical:{000019 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
 ----
 applied:
   last-seq-num:  99
-  add-blob-file: B000016 physical:{000018 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
+  add-blob-file: B000016 physical:{000019 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
   del-blob-file: B000016 000016
 current version:
   L2:
@@ -632,12 +659,12 @@ current version:
   L3:
     000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
     000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
-  L4:
-    000017:[f#20,SET-g#20,SET] seqnums:[0-0] points:[f#20,SET-g#20,SET] size:1700 blobrefs:[(B000016: 10000); depth:1]
+  L5:
+    000018:[f#20,SET-g#20,SET] seqnums:[0-0] points:[f#20,SET-g#20,SET] size:1800 blobrefs:[(B000016: 5000); depth:1]
   Blob files:
-    B000016 physical:{000018 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
+    B000016 physical:{000019 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
 no virtual backings
-no zombie tables
+zombie tables: 000017
 no obsolete tables
 zombie blob files: 000016
 no obsolete blob files
@@ -654,13 +681,13 @@ current version:
   L3:
     000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
     000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
-  L4:
-    000017:[f#20,SET-g#20,SET] seqnums:[0-0] points:[f#20,SET-g#20,SET] size:1700 blobrefs:[(B000016: 10000); depth:1]
+  L5:
+    000018:[f#20,SET-g#20,SET] seqnums:[0-0] points:[f#20,SET-g#20,SET] size:1800 blobrefs:[(B000016: 5000); depth:1]
   Blob files:
-    B000016 physical:{000018 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
+    B000016 physical:{000019 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
 no virtual backings
 no zombie tables
-no obsolete tables
+obsolete tables: 000017
 no zombie blob files
 obsolete blob files: 000016
 
@@ -674,10 +701,10 @@ current version:
   L3:
     000008:[a#1,SET-c#1,SET] seqnums:[0-0] points:[a#1,SET-c#1,SET] size:800
     000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] size:1000
-  L4:
-    000017:[f#20,SET-g#20,SET] seqnums:[0-0] points:[f#20,SET-g#20,SET] size:1700 blobrefs:[(B000016: 10000); depth:1]
+  L5:
+    000018:[f#20,SET-g#20,SET] seqnums:[0-0] points:[f#20,SET-g#20,SET] size:1800 blobrefs:[(B000016: 5000); depth:1]
   Blob files:
-    B000016 physical:{000018 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
+    B000016 physical:{000019 size:[5000 (4.9KB)] vals:[5000 (4.9KB)]}
 no virtual backings
 no zombie tables
 no obsolete tables

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -110,10 +110,6 @@ func TestVersionSet(t *testing.T) {
 				if !nf.Meta.Virtual {
 					createFile(nf.Meta.TableBacking.DiskFileNum)
 				}
-				for i := range nf.Meta.BlobReferences {
-					fileNum := blobFileIDMappings[nf.Meta.BlobReferences[i].FileID]
-					nf.Meta.BlobReferences[i].OriginalMetadata = physicalBlobs[fileNum]
-				}
 			}
 
 			for de := range ve.DeletedTables {
@@ -208,10 +204,6 @@ func TestVersionSet(t *testing.T) {
 			for _, l := range v.Levels {
 				for f := range l.All() {
 					tableMetas[f.TableNum] = f
-					for _, b := range f.BlobReferences {
-						physicalBlobs[b.OriginalMetadata.FileNum] = b.OriginalMetadata
-						blobFileIDMappings[b.FileID] = b.OriginalMetadata.FileNum
-					}
 					dedupBacking(f.TableBacking)
 				}
 			}


### PR DESCRIPTION
Previously a TableMetadata's BlobReferences maintained a pointer to the original PhysicalBlobFile that existed when the reference was created. This was confusing state and only existed for the purpose of calculating the estimated physical size of the referenced values.

This commit replaces the *PhysicalBlobFile pointer with a EstimatedPhysicalSize field that's calculated once upfront. Some of the version edit accumulation and application logic is also simplified, removing the need to track referenced *PhysicalBlobFiles.

Informs #112.