### PR TITLE
metamorphic: remove obj metadata created from previous ops

### DIFF
--- a/metamorphic/key_manager.go
+++ b/metamorphic/key_manager.go
@@ -935,6 +935,13 @@ func loadPrecedingKeys(ops []op, kg KeyGenerator, m *keyManager) {
 		// Update key tracking state.
 		m.update(op)
 	}
+	// We want to retain the keys that made it to the db and clear out everything
+	// else. All other objects would conflict with objects from the test itself.
+	for objID := range m.byObj {
+		if objID.tag() != dbTag {
+			delete(m.byObj, objID)
+		}
+	}
 }
 
 func insertSorted(cmp base.Compare, dst *[][]byte, k []byte) {


### PR DESCRIPTION
We partially "replay" previous ops. This populates the `objKeyMeta`
map for various objects from the previous run. These object IDs will
conflict with objects from a new run, so we have to clear them out. We
retain only the keys for the db itself, since that's all that carries
over from the previous run.

A symptom of this problem was
`metamorphic test internal error: external object empty`
This is because a batch that had just been created and was empty
already had an `objKeyMeta` that had bounds.