### PR TITLE
crl-release-24.3: sstable: fix crash in copyFilter

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1199,10 +1199,7 @@ func (w *RawColumnWriter) addDataBlock(b, sep []byte, bhp block.HandleWithProper
 // copyFilter copies the specified filter to the table. It's specifically used
 // by the sstable copier that can copy parts of an sstable to a new sstable,
 // using CopySpan().
-func (w *RawColumnWriter) copyFilter(filter []byte, filterName string) error {
-	if w.filterBlock != nil && filterName != w.filterBlock.policyName() {
-		return errors.New("mismatched filters")
-	}
+func (w *RawColumnWriter) copyFilter(filter []byte) error {
 	w.filterBlock = copyFilterWriter{
 		origPolicyName: w.filterBlock.policyName(), origMetaName: w.filterBlock.metaName(), data: filter,
 	}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -98,14 +98,16 @@ func CopySpan(
 	// Set the filter block to be copied over if it exists. It will return false
 	// positives for keys in blocks of the original file that we don't copy, but
 	// filters can always have false positives, so this is fine.
-	if r.tableFilter != nil {
+	if r.tableFilter != nil && o.FilterPolicy != nil && o.FilterPolicy.Name() == r.Properties.FilterPolicyName {
 		filterBlock, err := r.readFilterBlock(ctx, noEnv, rh, r.filterBH)
 		if err != nil {
 			return 0, errors.Wrap(err, "reading filter")
 		}
 		filterBytes := append([]byte{}, filterBlock.BlockData()...)
 		filterBlock.Release()
-		w.copyFilter(filterBytes, r.Properties.FilterPolicyName)
+		if err := w.copyFilter(filterBytes); err != nil {
+			return 0, errors.Wrap(err, "copying filter")
+		}
 	}
 
 	// Copy all the props from the source file; we can't compute our own for many

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -2027,10 +2027,7 @@ func (w *RawRowWriter) copyProperties(props Properties) {
 }
 
 // copyFilter implements RawWriter.
-func (w *RawRowWriter) copyFilter(filter []byte, filterName string) error {
-	if w.filter != nil && filterName != w.filter.policyName() {
-		return errors.New("mismatched filters")
-	}
+func (w *RawRowWriter) copyFilter(filter []byte) error {
 	w.filter = copyFilterWriter{
 		origPolicyName: w.filter.policyName(), origMetaName: w.filter.metaName(), data: filter,
 	}

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -357,7 +357,7 @@ type RawWriter interface {
 	// copyFilter copies the specified filter to the table. It's specifically used
 	// by the sstable copier that can copy parts of an sstable to a new sstable,
 	// using CopySpan().
-	copyFilter(filter []byte, filterName string) error
+	copyFilter(filter []byte) error
 
 	// copyProperties copies properties from the specified props, and resets others
 	// to prepare for copying data blocks from another sstable. It's specifically


### PR DESCRIPTION
I saw a `copyFilter` crash in a crossversion test - the
`WriterOptions` had no filter policy set. We fix the logic to verify
that the filter policy matches.