### PR TITLE
block: support different setting for value blocks

### DIFF
--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -72,6 +72,9 @@ var (
 // Compressor is an interface for compressing data. An instance is associated
 // with a specific Setting.
 type Compressor interface {
+	// Algorithm returns the algorithm used by this Compressor.
+	Algorithm() Algorithm
+
 	// Compress a block, appending the compressed data to dst[:0].
 	Compress(dst, src []byte) []byte
 

--- a/internal/compression/minlz.go
+++ b/internal/compression/minlz.go
@@ -16,6 +16,8 @@ type minlzCompressor struct {
 
 var _ Compressor = (*minlzCompressor)(nil)
 
+func (c *minlzCompressor) Algorithm() Algorithm { return MinLZ }
+
 func (c *minlzCompressor) Compress(dst, src []byte) []byte {
 	// MinLZ cannot encode blocks greater than 8MB. Fall back to Snappy in those
 	// cases. Note that MinLZ can decode the Snappy compressed block.

--- a/internal/compression/noop.go
+++ b/internal/compression/noop.go
@@ -8,6 +8,7 @@ type noopCompressor struct{}
 
 var _ Compressor = noopCompressor{}
 
+func (noopCompressor) Algorithm() Algorithm { return NoCompression }
 func (noopCompressor) Compress(dst, src []byte) []byte {
 	return append(dst[:0], src...)
 }

--- a/internal/compression/snappy.go
+++ b/internal/compression/snappy.go
@@ -14,6 +14,8 @@ type snappyCompressor struct{}
 
 var _ Compressor = snappyCompressor{}
 
+func (snappyCompressor) Algorithm() Algorithm { return SnappyAlgorithm }
+
 func (snappyCompressor) Compress(dst, src []byte) []byte {
 	dst = dst[:cap(dst):cap(dst)]
 	return snappy.Encode(dst, src)

--- a/internal/compression/zstd_cgo.go
+++ b/internal/compression/zstd_cgo.go
@@ -39,6 +39,8 @@ var zstdCompressorPool = sync.Pool{
 // relies on CGo.
 const UseStandardZstdLib = true
 
+func (z *zstdCompressor) Algorithm() Algorithm { return Zstd }
+
 func (z *zstdCompressor) Compress(compressedBuf []byte, b []byte) []byte {
 	if len(compressedBuf) < binary.MaxVarintLen64 {
 		compressedBuf = append(compressedBuf, make([]byte, binary.MaxVarintLen64-len(compressedBuf))...)

--- a/internal/compression/zstd_nocgo.go
+++ b/internal/compression/zstd_nocgo.go
@@ -34,6 +34,8 @@ func getZstdCompressor(level int) *zstdCompressor {
 // relies on CGo.
 const UseStandardZstdLib = false
 
+func (z *zstdCompressor) Algorithm() Algorithm { return Zstd }
+
 func (z *zstdCompressor) Compress(compressedBuf, b []byte) []byte {
 	if len(compressedBuf) < binary.MaxVarintLen64 {
 		compressedBuf = append(compressedBuf, make([]byte, binary.MaxVarintLen64-len(compressedBuf))...)

--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -48,10 +48,8 @@ func (c *Compressor) Close() {
 //
 // In addition to the buffer, returns the algorithm that was used.
 func (c *Compressor) Compress(dst, src []byte, kind Kind) (CompressionIndicator, []byte) {
-	setting := c.profile.DataBlocks
 	compressor := c.dataBlocksCompressor
 	if kind != blockkind.SSTableData && kind != blockkind.SSTableValue && kind != blockkind.BlobValue {
-		setting = c.profile.OtherBlocks
 		compressor = c.otherBlocksCompressor
 	}
 	out := compressor.Compress(dst, src)
@@ -62,11 +60,12 @@ func (c *Compressor) Compress(dst, src []byte, kind Kind) (CompressionIndicator,
 	//   after * 100
 	//   -----------  >  100 - MinReductionPercent
 	//      before
-	if setting.Algorithm != compression.NoCompression &&
+	algorithm := compressor.Algorithm()
+	if algorithm != compression.NoCompression &&
 		int64(len(out))*100 > int64(len(src))*int64(100-c.profile.MinReductionPercent) {
 		return NoCompressionIndicator, append(out[:0], src...)
 	}
-	return compressionIndicatorFromAlgorithm(setting.Algorithm), out
+	return compressionIndicatorFromAlgorithm(algorithm), out
 }
 
 // NoopCompressor is a Compressor that does not compress data. It does not have

--- a/sstable/block/compressor_test.go
+++ b/sstable/block/compressor_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package block
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/compression"
+	"github.com/cockroachdb/pebble/sstable/block/blockkind"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressor(t *testing.T) {
+	settings := []compression.Setting{
+		compression.None,
+		compression.Snappy,
+		compression.MinLZFastest,
+		compression.ZstdLevel3,
+	}
+
+	src := make([]byte, 1024)
+	dst := make([]byte, 0, 1024)
+	for runs := 0; runs < 100; runs++ {
+		profile := &CompressionProfile{
+			DataBlocks:          settings[rand.IntN(len(settings))],
+			ValueBlocks:         settings[rand.IntN(len(settings))],
+			OtherBlocks:         settings[rand.IntN(len(settings))],
+			MinReductionPercent: 0,
+		}
+
+		compressor := MakeCompressor(profile)
+		ci, _ := compressor.Compress(dst, src, blockkind.SSTableData)
+		require.Equal(t, compressionIndicatorFromAlgorithm(profile.DataBlocks.Algorithm), ci)
+
+		ci, _ = compressor.Compress(dst, src, blockkind.SSTableValue)
+		require.Equal(t, compressionIndicatorFromAlgorithm(profile.ValueBlocks.Algorithm), ci)
+
+		ci, _ = compressor.Compress(dst, src, blockkind.BlobValue)
+		require.Equal(t, compressionIndicatorFromAlgorithm(profile.ValueBlocks.Algorithm), ci)
+
+		ci, _ = compressor.Compress(dst, src, blockkind.Index)
+		require.Equal(t, compressionIndicatorFromAlgorithm(profile.OtherBlocks.Algorithm), ci)
+
+		ci, _ = compressor.Compress(dst, src, blockkind.Metadata)
+		require.Equal(t, compressionIndicatorFromAlgorithm(profile.OtherBlocks.Algorithm), ci)
+
+		compressor.Close()
+	}
+}

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/compression"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/colblk"
@@ -355,12 +354,9 @@ func (o WriterOptions) ensureDefaults() WriterOptions {
 }
 
 func tableFormatSupportsCompressionProfile(tf TableFormat, profile *block.CompressionProfile) bool {
-	if tf < TableFormatPebblev6 {
-		// MinLZ is only supported in TableFormatPebblev6 and higher.
-		if profile.DataBlocks.Algorithm == compression.MinLZ ||
-			profile.OtherBlocks.Algorithm == compression.MinLZ {
-			return false
-		}
+	// MinLZ is only supported in TableFormatPebblev6 and higher.
+	if tf < TableFormatPebblev6 && profile.UsesMinLZ() {
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
#### compression: add Compressor.Algorithm() convenience method


#### block: support different setting for value blocks

A possible "balanced" setting could be to use Zstd1 for value blocks
and MinLZ for everything else.