### PR TITLE
sstable: include all filter blocks in Reader.Layout

### DIFF
--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -714,6 +714,8 @@ func forEachIndexEntry(
 	return indexIter.Close()
 }
 
+// decodeMetaindex decodes a row-based meta index block. The returned map owns
+// all its memory and can outlive the provided data slice.
 func decodeMetaindex(
 	data []byte,
 ) (meta map[string]block.Handle, vbih valblk.IndexHandle, err error) {
@@ -723,9 +725,11 @@ func decodeMetaindex(
 	}
 	defer func() { err = firstError(err, i.Close()) }()
 
+	var keysAlloc bytealloc.A
 	meta = map[string]block.Handle{}
 	for valid := i.First(); valid; valid = i.Next() {
 		value := i.Value()
+		var bh block.Handle
 		if bytes.Equal(i.Key().UserKey, []byte(metaValueIndexName)) {
 			var n int
 			vbih, n, err = valblk.DecodeIndexHandle(i.Value())
@@ -735,27 +739,36 @@ func decodeMetaindex(
 			if n == 0 || n != len(value) {
 				return nil, vbih, base.CorruptionErrorf("pebble/table: invalid table (bad value blocks index handle)")
 			}
+			bh = vbih.Handle
 		} else {
-			bh, n := block.DecodeHandle(value)
+			var n int
+			bh, n = block.DecodeHandle(value)
 			if n == 0 || n != len(value) {
 				return nil, vbih, base.CorruptionErrorf("pebble/table: invalid table (bad block handle)")
 			}
-			meta[string(i.Key().UserKey)] = bh
 		}
+		var key []byte
+		keysAlloc, key = keysAlloc.Copy(i.Key().UserKey)
+		keyStr := unsafe.String(unsafe.SliceData(key), len(key))
+		meta[keyStr] = bh
 	}
 	return meta, vbih, nil
 }
 
+// decodeColumnarMetaIndex decodes a columnar meta index block. The returned map
+// owns all its memory and can outlive the provided data slice.
 func decodeColumnarMetaIndex(
 	data []byte,
 ) (meta map[string]block.Handle, vbih valblk.IndexHandle, err error) {
 	var decoder colblk.KeyValueBlockDecoder
 	decoder.Init(data)
+	var keysAlloc bytealloc.A
 	meta = map[string]block.Handle{}
 	for i := 0; i < decoder.BlockDecoder().Rows(); i++ {
 		key := decoder.KeyAt(i)
 		value := decoder.ValueAt(i)
 
+		var bh block.Handle
 		if bytes.Equal(key, []byte(metaValueIndexName)) {
 			var n int
 			vbih, n, err = valblk.DecodeIndexHandle(value)
@@ -765,13 +778,18 @@ func decodeColumnarMetaIndex(
 			if n == 0 || n != len(value) {
 				return nil, vbih, base.CorruptionErrorf("pebble/table: invalid table (bad value blocks index handle)")
 			}
+			bh = vbih.Handle
 		} else {
-			bh, n := block.DecodeHandle(value)
+			var n int
+			bh, n = block.DecodeHandle(value)
 			if n == 0 || n != len(value) {
 				return nil, vbih, base.CorruptionErrorf("pebble/table: invalid table (bad block handle)")
 			}
-			meta[string(key)] = bh
 		}
+		var keyCopy []byte
+		keysAlloc, keyCopy = keysAlloc.Copy(key)
+		keyStr := unsafe.String(unsafe.SliceData(keyCopy), len(keyCopy))
+		meta[keyStr] = bh
 	}
 	return meta, vbih, nil
 }

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -261,8 +261,27 @@ func ParseWriterOptions[StringOrStringer any](o *WriterOptions, args ...StringOr
 			o.IndexBlockSize, err = strconv.Atoi(value)
 
 		case "filter":
-			o.FilterPolicy = bloom.FilterPolicy(10)
-
+			fields := strings.FieldsFunc(value, func(r rune) bool {
+				return r == '(' || r == ')'
+			})
+			if len(fields) == 0 {
+				o.FilterPolicy = bloom.FilterPolicy(10)
+				continue
+			} else if len(fields) != 2 {
+				return errors.Errorf("expected filter policy name and parameters, got %q", value)
+			}
+			switch fields[0] {
+			case "bloom":
+				bits, err := strconv.Atoi(fields[1])
+				if err != nil {
+					return errors.Wrapf(err, "parsing bloom filter bits")
+				}
+				o.FilterPolicy = bloom.FilterPolicy(bits)
+			case "none":
+				o.FilterPolicy = nil
+			default:
+				return errors.Errorf("unknown filter policy: %q", value)
+			}
 		case "comparer":
 			o.Comparer, err = comparerFromCmdArg(value)
 

--- a/sstable/testdata/copy_span
+++ b/sstable/testdata/copy_span
@@ -230,3 +230,70 @@ iter test34
 a#0,SET: foo
 b#0,SET: bar
 c#0,SET: baz
+
+# Create a table with a filter.
+build bloom-sst table-format=Pebble,v6 filter=bloom(10)
+a.SET.5:foo
+b.SET.3:bar
+c.SET.4:baz
+d.SET.5:foobar
+e.SET.5:foo
+f.SET.5:foo
+g.SET.5:foo
+h.SET.5:foo
+i.SET.5:foo
+j.SET.5:foo
+----
+
+describe bloom-sst
+----
+sstable
+ ├── data  offset: 0  length: 81
+ ├── data  offset: 86  length: 81
+ ├── data  offset: 172  length: 81
+ ├── data  offset: 258  length: 73
+ ├── data  offset: 336  length: 81
+ ├── data  offset: 422  length: 81
+ ├── data  offset: 508  length: 81
+ ├── data  offset: 594  length: 81
+ ├── data  offset: 680  length: 81
+ ├── data  offset: 766  length: 81
+ ├── index  offset: 852  length: 36
+ ├── index  offset: 893  length: 37
+ ├── index  offset: 935  length: 37
+ ├── index  offset: 977  length: 38
+ ├── index  offset: 1020  length: 38
+ ├── index  offset: 1063  length: 38
+ ├── index  offset: 1106  length: 38
+ ├── index  offset: 1149  length: 38
+ ├── index  offset: 1192  length: 38
+ ├── index  offset: 1235  length: 38
+ ├── top-index  offset: 1278  length: 83
+ ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 1366  length: 69
+ ├── properties  offset: 1440  length: 583
+ ├── meta-index  offset: 2028  length: 88
+ └── footer  offset: 2121  length: 57
+
+props bloom-sst
+----
+rocksdb.num.entries: 10
+rocksdb.raw.key.size: 90
+rocksdb.raw.value.size: 33
+rocksdb.deleted.keys: 0
+rocksdb.num.range-deletions: 0
+rocksdb.num.data.blocks: 10
+rocksdb.compression: Snappy
+rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; 
+rocksdb.comparator: pebble.internal.testkeys
+rocksdb.data.size: 852
+rocksdb.filter.policy: rocksdb.BuiltinBloomFilter
+rocksdb.filter.size: 69
+rocksdb.index.partitions: 10
+rocksdb.index.size: 459
+rocksdb.block.based.table.index.type: 2
+pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
+rocksdb.merge.operator: pebble.concatenate
+rocksdb.merge.operands: 0
+rocksdb.property.collectors: [obsolete-key]
+rocksdb.top-level.index.size: 83
+obsolete-key: hex:00


### PR DESCRIPTION
Previously, (*sstable.Reader).Layout only included 1 filter block and only if it matched the reader's configuration. This commit updates the Layout method to collect the block handles of all filter blocks contained within the metaindex block.