### PR TITLE
db: add logic for blob file rewriting

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -1,0 +1,232 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"container/heap"
+	"context"
+	"slices"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/blob"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/colblk"
+)
+
+// blockHeap is a min-heap of blob reference liveness encodings, ordered by
+// blockID. We use this to help us determine the overall liveness of values in
+// each blob block by combining the blob reference liveness encodings of all
+// referencing sstables for a particular blockID.
+type blockHeap []*sstable.BlobRefLivenessEncoding
+
+// Len implements sort.Interface.
+func (h blockHeap) Len() int { return len(h) }
+
+// Less implements sort.Interface.
+func (h blockHeap) Less(i, j int) bool { return h[i].BlockID < h[j].BlockID }
+
+// Swap implements sort.Interface.
+func (h blockHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+// Push implements heap.Interface.
+func (h *blockHeap) Push(x any) {
+	blobEnc := x.(*sstable.BlobRefLivenessEncoding)
+	*h = append(*h, blobEnc)
+}
+
+// Pop implements heap.Interface.
+func (h *blockHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	*h = old[0 : n-1]
+	return item
+}
+
+// accumulatedBlockData holds the accumulated liveness data for blockID.
+type accumulatedBlockData struct {
+	blockID      blob.BlockID
+	valuesSize   int
+	liveValueIDs []int
+}
+
+// blobFileMapping implements blob.FileMapping to always map to the input blob
+// file.
+type blobFileMapping struct {
+	fileNum base.DiskFileNum
+}
+
+// Assert that (*blobFileMapping) implements blob.FileMapping.
+var _ blob.FileMapping = (*blobFileMapping)(nil)
+
+func (m *blobFileMapping) Lookup(fileID base.BlobFileID) (base.DiskFileNum, bool) {
+	return m.fileNum, true
+}
+
+// blobFileRewriter is responsible for rewriting blob files by combining and
+// processing blob reference liveness encodings from multiple SSTables. It
+// maintains state for writing to an output blob file.
+type blobFileRewriter struct {
+	fc       *fileCacheHandle
+	env      block.ReadEnv
+	sstables []*manifest.TableMetadata
+
+	inputBlob    manifest.BlobFileMetadata
+	valueFetcher blob.ValueFetcher
+	fileMapping  blobFileMapping
+	blkHeap      blockHeap
+
+	// Current blob writer state.
+	writer *blob.FileWriter
+}
+
+func newBlobFileRewriter(
+	fc *fileCacheHandle,
+	env block.ReadEnv,
+	writer *blob.FileWriter,
+	sstables []*manifest.TableMetadata,
+	inputBlob manifest.BlobFileMetadata,
+) *blobFileRewriter {
+	return &blobFileRewriter{
+		fc:          fc,
+		env:         env,
+		writer:      writer,
+		sstables:    sstables,
+		inputBlob:   inputBlob,
+		fileMapping: blobFileMapping{fileNum: inputBlob.Physical.FileNum},
+		blkHeap:     blockHeap{},
+	}
+}
+
+// generateHeap populates rw.blkHeap with the blob reference liveness encodings
+// for each referencing sstable, rw.sstables.
+func (rw *blobFileRewriter) generateHeap() error {
+	ctx := context.TODO()
+	heap.Init(&rw.blkHeap)
+
+	var decoder colblk.ReferenceLivenessBlockDecoder
+	// For each sstable that references the input blob file, push its
+	// sstable.BlobLivenessEncoding on to the heap.
+	for _, sst := range rw.sstables {
+		// Validate that the sstable contains a reference to the input blob
+		// file.
+		refID, ok := sst.BlobReferences.IDByBlobFileID(rw.inputBlob.FileID)
+		if !ok {
+			return errors.AssertionFailedf("table %s doesn't contain a reference to blob file %s",
+				sst.TableNum, rw.inputBlob.FileID)
+		}
+		err := rw.fc.withReader(ctx, rw.env, sst, func(r *sstable.Reader, _ sstable.ReadEnv) error {
+			h, err := r.ReadBlobRefIndexBlock(ctx, rw.env)
+			if err != nil {
+				return errors.CombineErrors(err, r.Close())
+			}
+			decoder.Init(h.BlockData())
+			bitmapEncodings := slices.Clone(decoder.LivenessAtReference(int(refID)))
+			h.Release()
+			// TODO(annie): We should instead maintain 1 heap item per sstable
+			// instead of 1 heap item per sstable block ref to reduce the heap
+			// comparisons to O(sstables).
+			for _, enc := range sstable.DecodeBlobRefLivenessEncoding(bitmapEncodings) {
+				heap.Push(&rw.blkHeap, &enc)
+			}
+			return r.Close()
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyBlockValues copies the live values from the given block to the output
+// blob file, flushing the current block before if necessary. If a flush is
+// performed, it returns true to signal the callee that we have started on a
+// new block.
+func (rw *blobFileRewriter) copyBlockValues(
+	ctx context.Context, toWrite *accumulatedBlockData, currentBlockSize int,
+) (bool, error) {
+	shouldFlush := rw.writer.ShouldFlush(currentBlockSize, currentBlockSize+toWrite.valuesSize)
+	if shouldFlush {
+		rw.writer.ForceFlush()
+	}
+	slices.Sort(toWrite.liveValueIDs)
+	for _, valueID := range toWrite.liveValueIDs {
+		value, _, err := rw.valueFetcher.Fetch(ctx, rw.inputBlob.FileID, toWrite.blockID, blob.BlockValueID(valueID))
+		if err != nil {
+			return shouldFlush, err
+		}
+		rw.writer.AddValue(value)
+	}
+	return shouldFlush, nil
+}
+
+func (rw *blobFileRewriter) Rewrite() error {
+	ctx := context.TODO()
+
+	rw.valueFetcher.Init(&rw.fileMapping, rw.fc, rw.env)
+	defer func() { _ = rw.valueFetcher.Close() }()
+
+	err := rw.generateHeap()
+	if err != nil {
+		return err
+	}
+
+	// Begin constructing our output blob file. We maintain a map of blockID
+	// to accumulated liveness data across all referencing sstables.
+	var lastAccEncoding *accumulatedBlockData
+	blockSize := 0
+	for rw.blkHeap.Len() > 0 {
+		currBlock := heap.Pop(&rw.blkHeap).(*sstable.BlobRefLivenessEncoding)
+
+		// Initialize the last accumulated block if nil.
+		if lastAccEncoding == nil {
+			lastAccEncoding = &accumulatedBlockData{
+				blockID:      currBlock.BlockID,
+				valuesSize:   currBlock.ValuesSize,
+				liveValueIDs: slices.Collect(sstable.IterSetBitsInRunLengthBitmap(currBlock.Bitmap)),
+			}
+		}
+		// If we are encountering a new block, write the last accumulated block to
+		// the blob file.
+		if lastAccEncoding.blockID != currBlock.BlockID {
+			// Add virtual block mappings for all blocks between the last block
+			// we encountered and the current block.
+			for blockID := lastAccEncoding.blockID; blockID < currBlock.BlockID; blockID++ {
+				rw.writer.BeginNewVirtualBlock(blockID)
+			}
+			// Write the last accumulated block's values to the blob file.
+			if flushed, err := rw.copyBlockValues(ctx, lastAccEncoding, blockSize); err != nil {
+				return err
+			} else if flushed {
+				blockSize = 0
+			} else {
+				blockSize += lastAccEncoding.valuesSize
+			}
+		}
+
+		// Update the accumulated encoding for this block.
+		lastAccEncoding.valuesSize += currBlock.ValuesSize
+		lastAccEncoding.liveValueIDs = slices.AppendSeq(lastAccEncoding.liveValueIDs,
+			sstable.IterSetBitsInRunLengthBitmap(currBlock.Bitmap))
+	}
+
+	// Copy the last accumulated block.
+	rw.writer.BeginNewVirtualBlock(lastAccEncoding.blockID)
+	if _, err := rw.copyBlockValues(ctx, lastAccEncoding, blockSize); err != nil {
+		return err
+	}
+
+	_, err = rw.writer.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -1,0 +1,213 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/blobtest"
+	"github.com/cockroachdb/pebble/internal/compact"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/blob"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlobRewrite(t *testing.T) {
+	var (
+		bv  blobtest.Values
+		vs  compact.ValueSeparation
+		tw  sstable.RawWriter
+		fn  base.DiskFileNum
+		buf bytes.Buffer
+		// Set up a logging FS to capture the filesystem operations throughout
+		// the test. When testing a value separation policy that writes new blob
+		// files, this demonstrates the creation of new blob files and that
+		// they're created lazily, the first time a value is actually separated.
+		fs = vfs.WithLogging(vfs.NewMem(), func(format string, args ...interface{}) {
+			fmt.Fprint(&buf, "# ")
+			fmt.Fprintf(&buf, format, args...)
+			fmt.Fprintln(&buf)
+		})
+	)
+	ctx := context.Background()
+	objStore, err := objstorageprovider.Open(objstorageprovider.Settings{
+		FS: fs,
+	})
+	require.NoError(t, err)
+
+	initRawWriter := func() {
+		if tw != nil {
+			require.NoError(t, tw.Close())
+		}
+		fn++
+		w, _, err := objStore.Create(ctx, base.FileTypeTable, fn, objstorage.CreateOptions{})
+		require.NoError(t, err)
+		tw = sstable.NewRawWriter(w, sstable.WriterOptions{
+			TableFormat: sstable.TableFormatMax,
+		})
+		tw = &loggingRawWriter{w: &buf, RawWriter: tw}
+	}
+
+	datadriven.RunTest(t, "testdata/blob_rewrite",
+		func(t *testing.T, d *datadriven.TestData) string {
+			buf.Reset()
+			switch d.Cmd {
+			case "init":
+				if tw != nil {
+					require.NoError(t, tw.Close())
+				}
+				bv = blobtest.Values{}
+				switch x := d.CmdArgs[0].String(); x {
+				case "preserve-blob-references":
+					pbr := &preserveBlobReferences{}
+					lines := crstrings.Lines(d.Input)
+					pbr.inputBlobPhysicalFiles = make(map[base.BlobFileID]*manifest.PhysicalBlobFile, len(lines))
+					for _, line := range lines {
+						bfm, err := manifest.ParseBlobFileMetadataDebug(line)
+						require.NoError(t, err)
+						fn = max(fn, bfm.Physical.FileNum)
+						pbr.inputBlobPhysicalFiles[bfm.FileID] = bfm.Physical
+					}
+					vs = pbr
+				case "write-new-blob-files":
+					newSep := &writeNewBlobFiles{
+						comparer: testkeys.Comparer,
+						newBlobObject: func() (objstorage.Writable, objstorage.ObjectMetadata, error) {
+							fn++
+							return objStore.Create(ctx, base.FileTypeBlob, fn, objstorage.CreateOptions{})
+						},
+					}
+					d.MaybeScanArgs(t, "minimum-size", &newSep.minimumSize)
+					vs = newSep
+				default:
+					t.Fatalf("unknown value separation policy: %s", x)
+				}
+				return buf.String()
+			case "add":
+				if tw == nil {
+					initRawWriter()
+				}
+				var ikv base.InternalKV
+				for _, line := range crstrings.Lines(d.Input) {
+					parts := strings.SplitN(line, ":", 2)
+					ik := base.ParseInternalKey(parts[0])
+					ikv.K = ik
+					if strings.HasPrefix(parts[1], "blob") {
+						ikv.V, err = bv.ParseInternalValue(parts[1])
+						require.NoError(t, err)
+					} else {
+						ikv.V = base.MakeInPlaceValue([]byte(parts[1]))
+					}
+					require.NoError(t, vs.Add(tw, &ikv, false /* forceObsolete */))
+				}
+				return buf.String()
+			case "close-output":
+				if tw != nil {
+					require.NoError(t, tw.Close())
+					tw = nil
+				}
+
+				meta, err := vs.FinishOutput()
+				require.NoError(t, err)
+				if meta.BlobFileObject.DiskFileNum == 0 {
+					fmt.Fprintln(&buf, "no blob file created")
+				} else {
+					fmt.Fprintf(&buf, "Blob file created: %s\n", meta.BlobFileMetadata)
+					fmt.Fprintln(&buf, meta.BlobFileStats)
+				}
+				if len(meta.BlobReferences) == 0 {
+					fmt.Fprintln(&buf, "blobrefs:[]")
+				} else {
+					fmt.Fprintln(&buf, "blobrefs:[")
+					for i, ref := range meta.BlobReferences {
+						fmt.Fprintf(&buf, " %d: %s %d\n", i, ref.FileID, ref.ValueSize)
+					}
+					fmt.Fprintln(&buf, "]")
+				}
+				return buf.String()
+			case "rewrite-blob":
+				// rewrite-blob <target-blob-file> <sstable1> <sstable2> ...
+				if len(d.CmdArgs) < 2 {
+					t.Fatalf("rewrite-blob requires at least a target blob file and one SSTable")
+				}
+				targetBlobFileStr := d.CmdArgs[0].String()
+				targetBlobFileNum, err := strconv.ParseUint(targetBlobFileStr, 10, 64)
+				if err != nil {
+					t.Fatalf("invalid blob file number %s: %v", targetBlobFileStr, err)
+				}
+				var sstableFileNums []base.DiskFileNum
+				for i := 1; i < len(d.CmdArgs); i++ {
+					sstFileNumStr := d.CmdArgs[i].String()
+					sstFileNum, err := strconv.ParseUint(sstFileNumStr, 10, 64)
+					if err != nil {
+						t.Fatalf("invalid SSTable file number %s: %v", sstFileNumStr, err)
+					}
+					sstableFileNums = append(sstableFileNums, base.DiskFileNum(sstFileNum))
+				}
+
+				fileCache := NewFileCache(1, 100)
+				mockFC := fileCache.newHandle(
+					nil,
+					objStore,
+					&base.LoggerWithNoopTracer{Logger: base.DefaultLogger},
+					sstable.ReaderOptions{},
+					func(any, error) error { return nil },
+				)
+				var sstables []*manifest.TableMetadata
+				for _, sstFileNum := range sstableFileNums {
+					sst := &manifest.TableMetadata{
+						TableBacking: &manifest.TableBacking{
+							DiskFileNum: sstFileNum,
+						},
+						BlobReferences: []manifest.BlobReference{{FileID: base.BlobFileID(targetBlobFileNum)}},
+					}
+					sstables = append(sstables, sst)
+				}
+
+				inputBlob := manifest.BlobFileMetadata{
+					FileID: base.BlobFileID(targetBlobFileNum),
+					Physical: &manifest.PhysicalBlobFile{
+						FileNum:      base.DiskFileNum(targetBlobFileNum),
+						CreationTime: uint64(time.Now().Unix()),
+					},
+				}
+				fn++
+				outputWritable, _, err := objStore.Create(ctx, base.FileTypeBlob, fn, objstorage.CreateOptions{})
+				require.NoError(t, err)
+
+				blobWriter := blob.NewFileWriter(fn, outputWritable, blob.FileWriterOptions{})
+				rewriter := newBlobFileRewriter(mockFC, block.ReadEnv{}, blobWriter, sstables, inputBlob)
+				err = rewriter.Rewrite()
+				if err != nil {
+					fmt.Fprintf(&buf, "rewrite error: %v\n", err)
+				} else {
+					fmt.Fprintf(&buf, "Successfully rewrote blob file %s to %s\n",
+						targetBlobFileStr, fn.String())
+					fmt.Fprintf(&buf, "Input SSTables: %v\n", sstableFileNums)
+					fmt.Fprintf(&buf, "SSTables with blob references: %d\n", len(sstables))
+				}
+
+				return buf.String()
+			default:
+				t.Fatalf("unknown command: %s", d.Cmd)
+			}
+			panic("unreachable")
+		})
+}

--- a/internal/base/lazy_value_test.go
+++ b/internal/base/lazy_value_test.go
@@ -16,7 +16,7 @@ import (
 type valueFetcherFunc func(
 	handle []byte, blobFileID BlobFileID, valLen uint32, buf []byte) (val []byte, callerOwned bool, err error)
 
-func (v valueFetcherFunc) Fetch(
+func (v valueFetcherFunc) FetchHandle(
 	ctx context.Context, handle []byte, blobFileID BlobFileID, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
 	return v(handle, blobFileID, valLen, buf)

--- a/internal/blobtest/handles.go
+++ b/internal/blobtest/handles.go
@@ -243,7 +243,7 @@ func (bv *Values) WriteFiles(
 		prevID := -1
 		for i, handle := range handles {
 			if i > 0 && handles[i-1].BlockID != handle.BlockID {
-				writer.FlushForTesting()
+				writer.ForceFlush()
 				prevID = -1
 			}
 			// The user of a blobtest.Values may specify a value ID for a handle. If

--- a/internal/blobtest/handles.go
+++ b/internal/blobtest/handles.go
@@ -34,8 +34,8 @@ type Values struct {
 	trackedHandles map[blob.Handle]string
 }
 
-// Fetch returns the value corresponding to the given handle.
-func (bv *Values) Fetch(
+// FetchHandle returns the value corresponding to the given handle.
+func (bv *Values) FetchHandle(
 	ctx context.Context, handleSuffix []byte, blobFileID base.BlobFileID, valLen uint32, _ []byte,
 ) (val []byte, callerOwned bool, err error) {
 	if bv.trackedHandles == nil {

--- a/internal/compact/iterator_test.go
+++ b/internal/compact/iterator_test.go
@@ -296,7 +296,7 @@ type mockBlobValueFetcher struct{}
 
 var _ base.ValueFetcher = mockBlobValueFetcher{}
 
-func (mockBlobValueFetcher) Fetch(
+func (mockBlobValueFetcher) FetchHandle(
 	ctx context.Context, handle []byte, blobFileID base.BlobFileID, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
 	s := fmt.Sprintf("<fetched value from blobref(%s, encodedHandle=%x, valLen=%d)>",

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -195,17 +195,25 @@ func (w *FileWriter) EstimatedSize() uint64 {
 	return sz
 }
 
-// FlushForTesting flushes the current block to the write queue. Writers should
-// generally not call FlushForTesting, and instead let the heuristics configured
+// ForceFlush flushes the current block to the write queue. Writers should
+// generally not call ForceFlush, and instead let the heuristics configured
 // through FileWriterOptions handle flushing.
 //
-// It's exposed so that tests can force flushes to construct blob files with
-// arbitrary structures.
-func (w *FileWriter) FlushForTesting() {
+// For blob file rewriting, ForceFlush needs to be called to ensure that there
+// is a 1:1 remapping of virtual blocks to physical blocks.
+//
+// Otherwise, it's exposed so that tests can force flushes to construct blob
+// files with arbitrary structures.
+func (w *FileWriter) ForceFlush() {
 	if w.valuesEncoder.Count() == 0 {
 		return
 	}
 	w.flush()
+}
+
+// ShouldFlush returns true if the current block should be flushed.
+func (w *FileWriter) ShouldFlush(sizeBefore, sizeAfter int) bool {
+	return w.flushGov.ShouldFlush(sizeBefore, sizeAfter)
 }
 
 // flush flushes the current block to the write queue.

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -143,7 +143,7 @@ func TestValueFetcher(t *testing.T) {
 			}.Encode(handleBuf[:])
 			encodedHandleSuffix := handleBuf[:n]
 
-			val, _, err := fetcher.Fetch(ctx, encodedHandleSuffix, base.BlobFileID(blobFileNum), valLen, nil)
+			val, _, err := fetcher.FetchHandle(ctx, encodedHandleSuffix, base.BlobFileID(blobFileNum), valLen, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -369,7 +369,7 @@ func (l *Layout) Describe(
 				// We have already read the value-index to construct the list of
 				// value-blocks, so no need to do it again.
 			case "blob-reference-index":
-				h, err = r.blockReader.Read(ctx, block.NoReadEnv, noReadHandle, b.Handle, blockkind.BlobReferenceValueLivenessIndex, noInitBlockMetadataFn)
+				h, err = r.readBlobRefIndexBlock(ctx, block.NoReadEnv, noReadHandle)
 				if err != nil {
 					return err
 				}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -422,6 +422,18 @@ func (r *Reader) readValueBlock(
 	return r.blockReader.Read(ctx, env, readHandle, bh, blockkind.SSTableValue, noInitBlockMetadataFn)
 }
 
+func (r *Reader) ReadBlobRefIndexBlock(
+	ctx context.Context, env block.ReadEnv,
+) (block.BufferHandle, error) {
+	return r.readBlobRefIndexBlock(ctx, env, noReadHandle)
+}
+
+func (r *Reader) readBlobRefIndexBlock(
+	ctx context.Context, env block.ReadEnv, readHandle objstorage.ReadHandle,
+) (block.BufferHandle, error) {
+	return r.blockReader.Read(ctx, env, readHandle, r.blobRefIndexBH, blockkind.BlobReferenceValueLivenessIndex, noInitBlockMetadataFn)
+}
+
 // metaBufferPools is a sync pool of BufferPools used exclusively when opening a
 // table and loading its meta blocks.
 var metaBufferPools = sync.Pool{

--- a/sstable/runlength_bitmap.go
+++ b/sstable/runlength_bitmap.go
@@ -156,9 +156,9 @@ func (bb *BitmapRunLengthEncoder) Size() int {
 	}
 }
 
-// iterSetBitsInRunLengthBitmap returns an iterator over the indices of set bits
+// IterSetBitsInRunLengthBitmap returns an iterator over the indices of set bits
 // within the provided run-length encoded bitmap.
-func iterSetBitsInRunLengthBitmap(bitmap []byte) iter.Seq[int] {
+func IterSetBitsInRunLengthBitmap(bitmap []byte) iter.Seq[int] {
 	return func(yield func(int) bool) {
 		// i is the index of the current byte in the bitmap.
 		i := 0

--- a/sstable/runlength_bitmap_test.go
+++ b/sstable/runlength_bitmap_test.go
@@ -43,7 +43,7 @@ func TestRunLengthBitmap(t *testing.T) {
 			// Validate that decoding the bitmap and re-encoding it yields the
 			// same encoding.
 			enc.Init()
-			for i := range iterSetBitsInRunLengthBitmap(encodedBuf) {
+			for i := range IterSetBitsInRunLengthBitmap(encodedBuf) {
 				enc.Set(i)
 			}
 			roundtripBuf = enc.FinishAndAppend(roundtripBuf[:0])
@@ -87,7 +87,7 @@ func TestRunLengthBitmap_Randomized(t *testing.T) {
 		encoded := enc.FinishAndAppend(nil)
 		enc = BitmapRunLengthEncoder{}
 		enc.Init()
-		for i := range iterSetBitsInRunLengthBitmap(encoded) {
+		for i := range IterSetBitsInRunLengthBitmap(encoded) {
 			enc.Set(i)
 		}
 		reencoded := enc.FinishAndAppend(nil)

--- a/sstable/valblk/reader.go
+++ b/sstable/valblk/reader.go
@@ -187,8 +187,8 @@ func newValueBlockFetcher(
 	}
 }
 
-// Fetch implements base.ValueFetcher.
-func (f *valueBlockFetcher) Fetch(
+// FetchHandle implements base.ValueFetcher.
+func (f *valueBlockFetcher) FetchHandle(
 	ctx context.Context, handle []byte, _ base.BlobFileID, valLen uint32, buf []byte,
 ) (val []byte, callerOwned bool, err error) {
 	if !f.closed {

--- a/testdata/blob_rewrite
+++ b/testdata/blob_rewrite
@@ -1,0 +1,80 @@
+init write-new-blob-files minimum-size=5
+----
+
+add
+bar#201,SET:poi
+bax#202,SET:blob{value=yaya}
+----
+# create: 000001.sst
+RawWriter.Add("bar#201,SET", "poi", false)
+RawWriter.Add("bax#202,SET", "yaya", false)
+
+add
+baz#202,SET:blob{value=yuumi}
+foo#209,SET:poiandyaya
+----
+# create: 000002.blob
+RawWriter.AddWithBlobHandle("baz#202,SET", "(f0,blk0,id0,len5)", 0, false)
+RawWriter.AddWithBlobHandle("foo#209,SET", "(f0,blk0,id1,len10)", 0, false)
+
+close-output
+----
+# sync-data: 000001.sst
+# close: 000001.sst
+# sync-data: 000002.blob
+# close: 000002.blob
+Blob file created: 000002 size:[105 (105B)] vals:[15 (15B)]
+{BlockCount: 1, ValueCount: 2, UncompressedValueBytes: 15, FileLen: 105}
+blobrefs:[
+ 0: B000002 15
+]
+
+init preserve-blob-references
+B000002 physical:{000002 size:[82530] vals:[72111]}
+----
+
+add
+a#9,SET:blob{fileNum=000002 value=darcy}
+a#5,SET:blob{fileNum=000002 value=tani}
+b#2,DEL:
+c#9,SET:paddy
+----
+# create: 000003.sst
+RawWriter.AddWithBlobHandle("a#9,SET", "(f0,blk0,id0,len5)", 5, false)
+RawWriter.AddWithBlobHandle("a#5,SET", "(f0,blk0,id1,len4)", 4, false)
+RawWriter.Add("b#2,DEL", "", false)
+RawWriter.Add("c#9,SET", "paddy", false)
+
+close-output
+----
+# sync-data: 000003.sst
+# close: 000003.sst
+no blob file created
+blobrefs:[
+ 0: B000002 9
+]
+
+rewrite-blob 000002 000001 000003
+----
+# create: 000004.blob
+# open: 000001.sst (options: *vfs.randomReadsOption)
+# read-at(813, 61): 000001.sst
+# read-at(736, 77): 000001.sst
+# read-at(209, 527): 000001.sst
+# read-at(184, 25): 000001.sst
+# close: 000001.sst
+# open: 000003.sst (options: *vfs.randomReadsOption)
+# read-at(828, 61): 000003.sst
+# read-at(751, 77): 000003.sst
+# read-at(193, 558): 000003.sst
+# read-at(168, 25): 000003.sst
+# close: 000003.sst
+# open: 000002.blob (options: *vfs.randomReadsOption)
+# read-at(67, 38): 000002.blob
+# read-at(37, 30): 000002.blob
+# read-at(0, 37): 000002.blob
+# sync-data: 000004.blob
+# close: 000004.blob
+Successfully rewrote blob file 000002 to 000004
+Input SSTables: [000001 000003]
+SSTables with blob references: 2


### PR DESCRIPTION
This patch adds logic for rewriting a blob file, given referencing sstables, by `OR`ing together all referencing sstables' bitmaps to avoid writing never-referenced values.