### PR TITLE
tool: analyze-data: support remote storage

### DIFF
--- a/objstorage/objstorageprovider/vfs_readable.go
+++ b/objstorage/objstorageprovider/vfs_readable.go
@@ -200,6 +200,14 @@ func (rh *vfsReadHandle) RecordCacheHit(_ context.Context, offset, size int64) {
 	rh.rs.recordCacheHit(offset, size)
 }
 
+// NewFileReadable returns a new objstorage.Readable that reads from the given
+// file. It should not be used directly, except in tools or tests.
+func NewFileReadable(
+	file vfs.File, fs vfs.FS, readaheadConfig *ReadaheadConfig, filename string,
+) (objstorage.Readable, error) {
+	return newFileReadable(file, fs, readaheadConfig, filename)
+}
+
 // TestingCheckMaxReadahead returns true if the ReadHandle has switched to
 // OS-level read-ahead.
 func TestingCheckMaxReadahead(rh objstorage.ReadHandle) bool {

--- a/sstable/compressionanalyzer/file_analyzer.go
+++ b/sstable/compressionanalyzer/file_analyzer.go
@@ -48,10 +48,12 @@ func (fa *FileAnalyzer) Close() {
 	*fa = FileAnalyzer{}
 }
 
-// SSTable analyzes the blocks in an sstable file.
+// SSTable analyzes the blocks in an sstable file and closes the readable (even
+// in error cases).
 func (fa *FileAnalyzer) SSTable(ctx context.Context, readable objstorage.Readable) error {
 	r, err := sstable.NewReader(ctx, readable, fa.sstReadOpts)
 	if err != nil {
+		_ = readable.Close()
 		return err
 	}
 	defer func() { _ = r.Close() }()

--- a/sstable/compressionanalyzer/file_analyzer_test.go
+++ b/sstable/compressionanalyzer/file_analyzer_test.go
@@ -22,7 +22,15 @@ func TestFileAnalyzer(t *testing.T) {
 			fa := NewFileAnalyzer(nil, sstable.ReaderOptions{})
 			defer fa.Close()
 			for _, path := range crstrings.Lines(td.Input) {
-				if err := fa.SSTable(context.Background(), vfs.Default, path); err != nil {
+				file, err := vfs.Default.Open(path)
+				if err != nil {
+					td.Fatalf(t, "%v", err)
+				}
+				readable, err := sstable.NewSimpleReadable(file)
+				if err != nil {
+					td.Fatalf(t, "%v", err)
+				}
+				if err := fa.SSTable(context.Background(), readable); err != nil {
 					td.Fatalf(t, "%v", err)
 				}
 			}

--- a/tool/db.go
+++ b/tool/db.go
@@ -55,6 +55,7 @@ type dbT struct {
 	openErrEnhancer func(error) error
 	openOptions     []OpenOption
 	exciseSpanFn    DBExciseSpanFn
+	remoteStorageFn DBRemoteStorageFn
 
 	// Flags.
 	comparerName string

--- a/tool/db.go
+++ b/tool/db.go
@@ -88,6 +88,7 @@ func newDB(
 	openErrEnhancer func(error) error,
 	openOptions []OpenOption,
 	exciseSpanFn DBExciseSpanFn,
+	remoteStorageFn DBRemoteStorageFn,
 ) *dbT {
 	d := &dbT{
 		opts:            opts,
@@ -96,6 +97,7 @@ func newDB(
 		openErrEnhancer: openErrEnhancer,
 		openOptions:     openOptions,
 		exciseSpanFn:    exciseSpanFn,
+		remoteStorageFn: remoteStorageFn,
 	}
 	d.fmtKey.mustSet("quoted")
 	d.fmtValue.mustSet("[%x]")

--- a/tool/db_analyze_data_test.go
+++ b/tool/db_analyze_data_test.go
@@ -51,7 +51,7 @@ func TestFileSetSampling(t *testing.T) {
 		dbStorage := newVFSStorage(fsWrapper{memFS}, "")
 		fs, err := makeFileSet(dbStorage, rng)
 		require.NoError(t, err)
-		file, _ := fs.Sample()
+		file := fs.Sample()
 		if file != largeFileName {
 			smallFileChosen++
 		}

--- a/tool/db_analyze_data_test.go
+++ b/tool/db_analyze_data_test.go
@@ -48,7 +48,8 @@ func TestFileSetSampling(t *testing.T) {
 	rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 	smallFileChosen := 0
 	for i := 0; i < iterations; i++ {
-		fs, err := makeFileSet(fsWrapper{memFS}, "", rng)
+		dbStorage := newVFSStorage(fsWrapper{memFS}, "")
+		fs, err := makeFileSet(dbStorage, rng)
 		require.NoError(t, err)
 		file, _ := fs.Sample()
 		if file != largeFileName {

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -183,7 +183,7 @@ func New(opts ...Option) *T {
 		opt(t)
 	}
 
-	t.db = newDB(&t.opts, t.comparers, t.mergers, t.openErrEnhancer, t.openOptions, t.exciseSpanFn)
+	t.db = newDB(&t.opts, t.comparers, t.mergers, t.openErrEnhancer, t.openOptions, t.exciseSpanFn, t.remoteStorageFn)
 	t.find = newFind(&t.opts, t.comparers, t.defaultComparer, t.mergers)
 	t.lsm = newLSM(&t.opts, t.comparers)
 	t.manifest = newManifest(&t.opts, t.comparers)

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -45,6 +45,7 @@ type T struct {
 	openErrEnhancer func(error) error
 	openOptions     []OpenOption
 	exciseSpanFn    DBExciseSpanFn
+	remoteStorageFn DBRemoteStorageFn
 }
 
 // A Option configures the Pebble introspection tool.
@@ -145,6 +146,18 @@ type DBExciseSpanFn func() (pebble.KeyRange, error)
 func WithDBExciseSpanFn(fn DBExciseSpanFn) Option {
 	return func(t *T) {
 		t.exciseSpanFn = fn
+	}
+}
+
+// DBRemoteStorageFn is used for certain commands which support cloud URIs (like
+// gs://foo/bar).
+type DBRemoteStorageFn func(uri string) (remote.Storage, error)
+
+// WithDBRemoteStorageFn specifies a function that returns the excise span for the
+// `db excise` command.
+func WithDBRemoteStorageFn(fn DBRemoteStorageFn) Option {
+	return func(t *T) {
+		t.remoteStorageFn = fn
 	}
 }
 


### PR DESCRIPTION
#### tool: improvements to analyze-data

We use a "real" `objstorage.ReadHandle` and set it up for readahead.

#### tool: analyze-data: separate vfs-specific code behind interface


#### tool: analyze-data: support remote storage

We add support for analyzing ssts from cloud storage (backups). A tool
option is used to register a function that can take a URI and return a
`remote.Storage` implementation.

With remote storage, retrieving the size of each file one by one takes
too long when there are many files, so we don't do that upfront. Most
of the refactoring is to support tracking progress by file count only
in case of remote storage.