### PR TITLE
compressionanalyzer: don't analyze Zstd levels 5 and 7

### DIFF
--- a/sstable/compressionanalyzer/buckets.go
+++ b/sstable/compressionanalyzer/buckets.go
@@ -101,8 +101,10 @@ var Settings = [...]compression.Setting{
 	compression.MinLZBalanced,
 	compression.ZstdLevel1,
 	compression.ZstdLevel3,
-	compression.ZstdLevel5,
-	compression.ZstdLevel7,
+	// Zstd levels 5+ are too slow (on the order of 15-20MB/s to compress) and
+	// don't usually offer a very large benefit in terms of size vs. level 3.
+	// compression.ZstdLevel5,
+	// compression.ZstdLevel7,
 }
 
 const numSettings = 7


### PR DESCRIPTION
From experiments so far, these levels are too slow (and with marginal
size benefit) so we will not be looking at using them, at least for
now. Remove them from the compression analyzer (which should speed it
up significantly).

For example (data from a TPCC backup):
```
        Snappy          ZSTD1          ZSTD3          ZSTD5          ZSTD7
CR      2.23 ± 6%       2.72 ± 10%     2.85 ± 9%      2.95 ± 9%      3.05 ± 10%
Comp    734MBps ± 27%   76MBps ± 25%   61MBps ± 26%   20MBps ± 16%   14MBps ± 16%
Decomp  1877MBps ± 30%  228MBps ± 27%  222MBps ± 23%  225MBps ± 22%  220MBps ± 19%
```