### PR TITLE
pebble: clarify some multilevel compaction areas

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -420,11 +420,15 @@ func newCompaction(
 	if pc.startLevel.l0SublevelInfo != nil {
 		c.startLevel.l0SublevelInfo = pc.startLevel.l0SublevelInfo
 	}
-	c.outputLevel = &c.inputs[1]
 
-	if len(pc.extraLevels) > 0 {
-		c.extraLevels = pc.extraLevels
-		c.outputLevel = &c.inputs[len(c.inputs)-1]
+	c.outputLevel = &c.inputs[len(c.inputs)-1]
+
+	if len(pc.inputs) > 2 {
+		// TODO(xinhaoz): Look into removing extraLevels on the compaction struct.
+		c.extraLevels = make([]*compactionLevel, 0, len(pc.inputs)-2)
+		for i := 1; i < len(pc.inputs)-1; i++ {
+			c.extraLevels = append(c.extraLevels, &c.inputs[i])
+		}
 	}
 	// Compute the set of outputLevel+1 files that overlap this compaction (these
 	// are the grandparent sstables).

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1152,7 +1152,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 			}
 
 			if initMultiLevel {
-				extraLevel := pc.extraLevels[0].level
+				extraLevel := pc.inputs[1].level
 				fmt.Fprintf(&buf, "init-multi-level(%d,%d,%d)\n", pc.startLevel.level, extraLevel,
 					pc.outputLevel.level)
 				fmt.Fprintf(&buf, "Original WriteAmp %.2f; ML WriteAmp %.2f\n", origPC.predictedWriteAmp(), pc.predictedWriteAmp())


### PR DESCRIPTION
This commit adds some comments to some of the existing ML compaction code. It
also removes the `extraLevels` fields from the pickedCompaction struct, since we
can read `inputs` directly.

Closes: https://github.com/cockroachdb/pebble/issues/4511