### PR TITLE
db: add fallback behavior if ShortAttributeExtractor errors

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/redact"
 )
 
 var errEmptyTable = errors.New("pebble: empty table")
@@ -3254,9 +3255,10 @@ func (d *DB) compactAndWrite(
 		},
 		MissizedDeleteCallback: func(userKey []byte, elidedSize, expectedSize uint64) {
 			d.opts.EventListener.PossibleAPIMisuse(PossibleAPIMisuseInfo{
-				Kind:      MissizedDelete,
-				UserKey:   slices.Clone(userKey),
-				ExtraInfo: fmt.Sprintf("elidedSize=%d,expectedSize=%d", elidedSize, expectedSize),
+				Kind:    MissizedDelete,
+				UserKey: slices.Clone(userKey),
+				ExtraInfo: redact.Sprintf("elidedSize=%d,expectedSize=%d",
+					redact.SafeUint(elidedSize), redact.SafeUint(expectedSize)),
 			})
 		},
 	}

--- a/event.go
+++ b/event.go
@@ -646,12 +646,14 @@ type PossibleAPIMisuseInfo struct {
 	// UserKey is set for the following kinds:
 	//  - IneffectualSingleDelete,
 	//  - NondeterministicSingleDelete,
-	//  - MissizedDelete.
+	//  - MissizedDelete,
+	//  - InvalidValue.
 	UserKey []byte
 
 	// ExtraInfo is set for the following kinds:
 	//  - MissizedDelete: contains "elidedSize=<size>,expectedSize=<size>"
-	ExtraInfo string
+	//  - InvalidValue: contains "callback=<callbackName>,value=<value>,err=<err>"
+	ExtraInfo redact.RedactableString
 }
 
 func (i PossibleAPIMisuseInfo) String() string {
@@ -664,7 +666,9 @@ func (i PossibleAPIMisuseInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	case IneffectualSingleDelete, NondeterministicSingleDelete:
 		w.Printf("possible API misuse: %s (key=%q)", redact.Safe(i.Kind), i.UserKey)
 	case MissizedDelete:
-		w.Printf("possible API misuse: %s (key=%q, %s)", redact.Safe(i.Kind), i.UserKey, redact.Safe(i.ExtraInfo))
+		w.Printf("possible API misuse: %s (key=%q, %s)", redact.Safe(i.Kind), i.UserKey, i.ExtraInfo)
+	case InvalidValue:
+		w.Printf("possible API misuse: %s (key=%q, %s)", redact.Safe(i.Kind), i.UserKey, i.ExtraInfo)
 	default:
 		if invariants.Enabled {
 			panic("invalid API misuse event")
@@ -759,6 +763,12 @@ const (
 	// not accurately record the size of the value it deleted. This can lead to
 	// incorrect behavior in compactions.
 	MissizedDelete
+
+	// InvalidValue is emitted when a user-implemented callback (such as
+	// ShortAttributeExtractor) returns an error for a committed value. This
+	// suggests that either the callback is not implemented for all possible
+	// values or a malformed value was committed to the DB.
+	InvalidValue
 )
 
 func (k APIMisuseKind) String() string {
@@ -769,6 +779,8 @@ func (k APIMisuseKind) String() string {
 		return "nondeterministic SINGLEDEL"
 	case MissizedDelete:
 		return "missized DELSIZED"
+	case InvalidValue:
+		return "invalid value"
 	default:
 		return "unknown"
 	}

--- a/testdata/value_separation_policy
+++ b/testdata/value_separation_policy
@@ -155,3 +155,27 @@ no blob file created
 blobrefs:[
  0: B000003 5
 ]
+
+# Test handling of a short attribute extractor that errors when we attempt to
+# extract the short attribute. We should fall back to writing the value inplace
+# within the output sstable.
+
+init write-new-blob-files minimum-size=2 short-attr-extractor=error
+----
+
+add
+bar#201,SET:poi
+bax#202,SET:blob{value=yaya}
+----
+# create: 000007.sst
+# invalid value for key "bar", value: "poi": short attribute extractor error
+RawWriter.Add("bar#201,SET", "poi", false)
+# invalid value for key "bax", value: "yaya": short attribute extractor error
+RawWriter.Add("bax#202,SET", "yaya", false)
+
+close-output
+----
+# sync-data: 000007.sst
+# close: 000007.sst
+no blob file created
+blobrefs:[]


### PR DESCRIPTION
When separating a value, we call a user-provided 'ShortAttributeExtractor' to extract a few bits of data from the value. These bits, known as the 'short attribute', are stored in-place with the sstable key for fast retrieval.

Previously, if the user-provided ShortAttributeExtractor errored, the calling flush or compaction would abort and bubble the error up. If this was during a flush, the engine was unable to make progress, repeatedly attempting to flush a key that cannot be flushed.

This commit updates the logic to fallback to storing a value in-place if the short attribute extractor is unable to parse a value. The error is still surfaced through the PossibleAPIMisuse event.