### PR TITLE
sstable: lazy load the index block in single- and two- level iterator

### DIFF
--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -68,13 +68,18 @@ func TestIteratorErrorOnInit(t *testing.T) {
 			require.Error(t, iter.Error())
 			iter.Close()
 		} else {
-			_, err := newRowBlockTwoLevelIterator(context.Background(), r, IterOptions{
+			iter, err := newRowBlockTwoLevelIterator(context.Background(), r, IterOptions{
 				Transforms:           NoTransforms,
 				FilterBlockSizeLimit: NeverUseFilterBlock,
 				Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &pool}},
 				ReaderProvider:       MakeTrivialReaderProvider(r),
 			})
-			require.Error(t, err)
+			// Two-level iterators use lazy loading - creation succeeds but first access fails
+			require.NoError(t, err)
+			// Error should surface when trying to use the iterator
+			_ = iter.First()
+			require.Error(t, iter.Error())
+			iter.Close()
 		}
 	}
 }

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -78,6 +78,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) loadSecondLevelIndexBlock(dir int8) loa
 		i.secondLevel.err = err
 		return loadBlockFailed
 	}
+	i.secondLevel.indexLoaded = true
 	return loadBlockOK
 }
 

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -32,6 +32,9 @@ type twoLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIterat
 	// false - any filtering happens at the top level.
 	useFilterBlock         bool
 	lastBloomFilterMatched bool
+
+	// Lazy loading flag for top-level index block
+	topLevelIndexLoaded bool
 }
 
 var _ Iterator = (*twoLevelIteratorRowBlocks)(nil)
@@ -45,6 +48,14 @@ func (i *twoLevelIterator[I, PI, D, PD]) loadSecondLevelIndexBlock(dir int8) loa
 	// the index fails.
 	PD(&i.secondLevel.data).Invalidate()
 	PI(&i.secondLevel.index).Invalidate()
+
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return loadBlockFailed
+		}
+	}
+
 	if !PI(&i.topLevelIndex).Valid() {
 		return loadBlockFailed
 	}
@@ -182,14 +193,9 @@ func newColumnBlockTwoLevelIterator(
 			objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
 	i.secondLevel.data.InitOnce(r.keySchema, r.Comparer, &i.secondLevel.internalValueConstructor)
-	topLevelIndexH, err := r.readTopLevelIndexBlock(ctx, i.secondLevel.readEnv.Block, i.secondLevel.indexFilterRH)
-	if err == nil {
-		err = i.topLevelIndex.InitHandle(r.Comparer, topLevelIndexH, opts.Transforms)
-	}
-	if err != nil {
-		_ = i.Close()
-		return nil, err
-	}
+
+	// Use lazy loading by default - top-level index will be loaded on first access
+	i.topLevelIndexLoaded = false
 	return i, nil
 }
 
@@ -236,14 +242,8 @@ func newRowBlockTwoLevelIterator(
 		i.secondLevel.data.SetHasValuePrefix(true)
 	}
 
-	topLevelIndexH, err := r.readTopLevelIndexBlock(ctx, i.secondLevel.readEnv.Block, i.secondLevel.indexFilterRH)
-	if err == nil {
-		err = i.topLevelIndex.InitHandle(r.Comparer, topLevelIndexH, opts.Transforms)
-	}
-	if err != nil {
-		_ = i.Close()
-		return nil, err
-	}
+	// Use lazy loading by default - top-level index will be loaded on first access
+	i.topLevelIndexLoaded = false
 	return i, nil
 }
 
@@ -284,6 +284,13 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekGE(
 		err == nil {
 		// Already exhausted, so return nil.
 		return nil
+	}
+
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return nil
+		}
 	}
 
 	// SeekGE performs various step-instead-of-seeking optimizations: eg enabled
@@ -464,6 +471,13 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 	// than the index block containing the sought key, resulting in a wasteful
 	// block load.
 
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return nil
+		}
+	}
+
 	var dontSeekWithinSingleLevelIter bool
 	if PI(&i.topLevelIndex).IsDataInvalidated() || !PI(&i.topLevelIndex).Valid() || PI(&i.secondLevel.index).IsDataInvalidated() || err != nil ||
 		(i.secondLevel.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || PI(&i.topLevelIndex).SeparatorLT(key) {
@@ -623,6 +637,13 @@ func (i *twoLevelIterator[I, PI, D, PD]) virtualLastSeekLE() *base.InternalKV {
 func (i *twoLevelIterator[I, PI, D, PD]) SeekLT(
 	key []byte, flags base.SeekLTFlags,
 ) *base.InternalKV {
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return nil
+		}
+	}
+
 	if i.secondLevel.readEnv.Virtual != nil {
 		// Might have to fix upper bound since virtual sstable bounds are not
 		// known to callers of SeekLT.
@@ -704,6 +725,12 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekLT(
 // to ensure that key is greater than or equal to the lower bound (e.g. via a
 // call to SeekGE(lower)).
 func (i *twoLevelIterator[I, PI, D, PD]) First() *base.InternalKV {
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return nil
+		}
+	}
 	// If we have a lower bound, use SeekGE. Note that in general this is not
 	// supported usage, except when the lower bound is there because the table is
 	// virtual.
@@ -749,6 +776,13 @@ func (i *twoLevelIterator[I, PI, D, PD]) First() *base.InternalKV {
 // to ensure that key is less than the upper bound (e.g. via a call to
 // SeekLT(upper))
 func (i *twoLevelIterator[I, PI, D, PD]) Last() *base.InternalKV {
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return nil
+		}
+	}
+
 	if i.secondLevel.readEnv.Virtual != nil {
 		if i.secondLevel.endKeyInclusive {
 			return i.virtualLast()
@@ -796,6 +830,12 @@ func (i *twoLevelIterator[I, PI, D, PD]) Last() *base.InternalKV {
 // Note: twoLevelCompactionIterator.Next mirrors the implementation of
 // twoLevelIterator.Next due to performance. Keep the two in sync.
 func (i *twoLevelIterator[I, PI, D, PD]) Next() *base.InternalKV {
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return nil
+		}
+	}
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.secondLevel.boundsCmp = 0
 	if i.secondLevel.err != nil {
@@ -813,6 +853,13 @@ func (i *twoLevelIterator[I, PI, D, PD]) Next() *base.InternalKV {
 func (i *twoLevelIterator[I, PI, D, PD]) NextPrefix(succKey []byte) *base.InternalKV {
 	if i.secondLevel.exhaustedBounds == +1 {
 		panic("Next called even though exhausted upper bound")
+	}
+
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return nil
+		}
 	}
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.secondLevel.boundsCmp = 0
@@ -861,6 +908,12 @@ func (i *twoLevelIterator[I, PI, D, PD]) NextPrefix(succKey []byte) *base.Intern
 // Prev implements internalIterator.Prev, as documented in the pebble
 // package.
 func (i *twoLevelIterator[I, PI, D, PD]) Prev() *base.InternalKV {
+	if !i.topLevelIndexLoaded {
+		if err := i.ensureTopLevelIndexLoaded(); err != nil {
+			i.secondLevel.err = err
+			return nil
+		}
+	}
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.secondLevel.boundsCmp = 0
 	if i.secondLevel.err != nil {
@@ -1020,8 +1073,27 @@ func (i *twoLevelIterator[I, PI, D, PD]) Close() error {
 	err = firstError(err, PI(&i.topLevelIndex).Close())
 	i.useFilterBlock = false
 	i.lastBloomFilterMatched = false
+	i.topLevelIndexLoaded = false
 	if pool != nil {
 		pool.Put(i)
 	}
 	return err
+}
+
+func (i *twoLevelIterator[I, PI, D, PD]) ensureTopLevelIndexLoaded() error {
+	if i.topLevelIndexLoaded {
+		return nil
+	}
+
+	topLevelIndexH, err := i.secondLevel.reader.readTopLevelIndexBlock(i.secondLevel.ctx,
+		i.secondLevel.readEnv.Block, i.secondLevel.indexFilterRH)
+	if err == nil {
+		err = PI(&i.topLevelIndex).InitHandle(i.secondLevel.reader.Comparer,
+			topLevelIndexH, i.secondLevel.transforms)
+	}
+	if err != nil {
+		return err
+	}
+	i.topLevelIndexLoaded = true
+	return nil
 }

--- a/sstable/reader_iter_two_lvl_benchmark_test.go
+++ b/sstable/reader_iter_two_lvl_benchmark_test.go
@@ -1,0 +1,268 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTwoLevelBenchmarkData creates test data designed for two-level indexes
+func setupTwoLevelBenchmarkData(b *testing.B, blockSize int) (*Reader, [][]byte) {
+	// Generate a large dataset to ensure two-level index creation
+	// Using smaller block size to force more blocks and two-level index
+	numKeys := 50000
+	keys := make([][]byte, numKeys)
+
+	// Generate keys that will create a two-level index
+	ks := testkeys.Alpha(5) // Use larger alphabet to support more keys
+	for i := 0; i < numKeys; i++ {
+		key := testkeys.Key(ks, int64(i))
+		keys[i] = []byte(key)
+	}
+
+	// Create SSTable with small block size to force two-level index
+	mem := vfs.NewMem()
+	f, err := mem.Create("bench", vfs.WriteCategoryUnspecified)
+	require.NoError(b, err)
+
+	w := NewWriter(objstorageprovider.NewFileWritable(f), WriterOptions{
+		BlockSize:      blockSize, // Small block size
+		IndexBlockSize: 1024,      // Small index block size to force two-level
+		Comparer:       testkeys.Comparer,
+		MergerName:     "nullptr",
+		TableFormat:    TableFormatPebblev3,
+	})
+
+	// Write keys to create two-level index
+	for i, key := range keys {
+		value := fmt.Sprintf("value-%d", i)
+		require.NoError(b, w.Set(key, []byte(value)))
+	}
+
+	require.NoError(b, w.Close())
+
+	// Re-open the file for reading
+	f, err = mem.Open("bench")
+	require.NoError(b, err)
+
+	// Create reader
+	r, err := newReader(f, ReaderOptions{
+		Comparer: testkeys.Comparer,
+	})
+	require.NoError(b, err)
+
+	// Verify we actually created a two-level index
+	if !r.Attributes.Has(AttributeTwoLevelIndex) {
+		b.Fatalf("Test data did not create two-level index (keys: %d, blockSize: %d)", numKeys, blockSize)
+	}
+
+	return r, keys
+}
+
+// BenchmarkTwoLevelIteratorConstruction measures just the construction time
+// How to: go test -bench=BenchmarkTwoLevelIteratorConstruction -run=^$ -count=10 ./sstable
+func BenchmarkTwoLevelIteratorConstruction(b *testing.B) {
+	b.Run("rowblk", func(b *testing.B) {
+		reader, _ := setupTwoLevelBenchmarkData(b, 1024)
+		defer reader.Close()
+
+		opts := IterOptions{}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var iter Iterator
+			var err error
+
+			iter, err = newRowBlockTwoLevelIterator(context.Background(), reader, opts)
+
+			require.NoError(b, err)
+
+			// Close immediately to measure just construction
+			iter.Close()
+		}
+	})
+}
+
+// BenchmarkTwoLevelIteratorFirst measures construction + first access
+// How to: go test -bench=BenchmarkTwoLevelIteratorFirst -run=^$ -count=10 ./sstable
+func BenchmarkTwoLevelIteratorFirst(b *testing.B) {
+	b.Run("rowblk", func(b *testing.B) {
+		reader, _ := setupTwoLevelBenchmarkData(b, 1024)
+		defer reader.Close()
+
+		opts := IterOptions{}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var iter Iterator
+			var err error
+
+			iter, err = newRowBlockTwoLevelIterator(context.Background(), reader, opts)
+
+			require.NoError(b, err)
+
+			// First access
+			kv := iter.First()
+			if kv == nil {
+				b.Fatal("Expected non-nil key-value from First()")
+			}
+
+			iter.Close()
+		}
+	})
+}
+
+// BenchmarkTwoLevelIteratorSeekGE measures construction + SeekGE performance
+// How to: go test -bench=BenchmarkTwoLevelIteratorSeekGE -run=^$ -count=10 ./sstable
+func BenchmarkTwoLevelIteratorSeekGE(b *testing.B) {
+	b.Run("rowblk", func(b *testing.B) {
+		reader, keys := setupTwoLevelBenchmarkData(b, 1024)
+		defer reader.Close()
+
+		opts := IterOptions{}
+		seekKey := keys[len(keys)/2]
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var iter Iterator
+			var err error
+			iter, err = newRowBlockTwoLevelIterator(context.Background(), reader, opts)
+			require.NoError(b, err)
+
+			// First SeekGE call
+			kv := iter.SeekGE(seekKey, base.SeekGEFlagsNone)
+			if kv == nil {
+				b.Fatal("Expected non-nil key-value from SeekGE")
+			}
+
+			iter.Close()
+		}
+	})
+}
+
+// setupBloomFilterData creates test data with bloom filter
+func setupBloomFilterData(b *testing.B) (*Reader, []string) {
+	mem := vfs.NewMem()
+	f, err := mem.Create("bench", vfs.WriteCategoryUnspecified)
+	require.NoError(b, err)
+
+	w := NewWriter(objstorageprovider.NewFileWritable(f), WriterOptions{
+		BlockSize:      512, // Smaller block size to force two-level index
+		IndexBlockSize: 512, // Smaller index block size to force two-level index
+		Comparer:       testkeys.Comparer,
+		MergerName:     "nullptr",
+		FilterPolicy:   bloom.FilterPolicy(10), // Enable bloom filter
+		TableFormat:    TableFormatPebblev3,
+	})
+
+	// Generate enough keys to force two-level index creation
+	ks := testkeys.Alpha(5) // Use 5-character alphabet for more keys
+	var keys []string
+
+	// Generate many more keys to ensure two-level index
+	for i := range int64(10000) {
+		// Use decreasing timestamps since testkeys.Comparer sorts them in reverse
+		timestamp := int64(10000 - i)
+		key := testkeys.KeyAt(ks, i%ks.Count(), timestamp)
+		keys = append(keys, string(key))
+		require.NoError(b, w.Set(key, []byte("value")))
+	}
+
+	require.NoError(b, w.Close())
+
+	// Read the file back
+	f, err = mem.Open("bench")
+	require.NoError(b, err)
+
+	readable, err := NewSimpleReadable(f)
+	require.NoError(b, err)
+
+	reader, err := NewReader(context.Background(), readable, ReaderOptions{
+		Comparer: testkeys.Comparer,
+	})
+	require.NoError(b, err)
+
+	// Verify we actually created a two-level index
+	if !reader.Attributes.Has(AttributeTwoLevelIndex) {
+		b.Fatalf("Bloom filter test data did not create two-level index")
+	}
+
+	return reader, keys
+}
+
+// BenchmarkTwoLevelIteratorSeekPrefixGE_NoHit measures construction + SeekPrefixGE with bloom filter miss
+// How to: go test -bench=BenchmarkTwoLevelIteratorSeekPrefixGE_NoHit -run=^$ -count=10 ./sstable
+func BenchmarkTwoLevelIteratorSeekPrefixGE_NoHit(b *testing.B) {
+	b.Run("rowblk", func(b *testing.B) {
+		reader, _ := setupBloomFilterData(b)
+		defer reader.Close()
+
+		opts := IterOptions{}
+		// Use a prefix that doesn't exist to trigger bloom filter miss
+		prefix := []byte("nonexistent")
+		seekKey := []byte("nonexistent@1")
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var iter Iterator
+			var err error
+			iter, err = newRowBlockTwoLevelIterator(context.Background(), reader, opts)
+			require.NoError(b, err)
+
+			// First SeekPrefixGE call - should be rejected by bloom filter
+			kv := iter.SeekPrefixGE(prefix, seekKey, base.SeekGEFlagsNone)
+			// Expect nil due to bloom filter rejection
+			if kv != nil {
+				b.Fatal("Expected nil key-value from SeekPrefixGE with non-existent prefix")
+			}
+
+			iter.Close()
+		}
+	})
+}
+
+// BenchmarkTwoLevelIteratorSeekPrefixGE_Hit measures construction + SeekPrefixGE with bloom filter hit
+// How to: go test -bench=BenchmarkTwoLevelIteratorSeekPrefixGE_Hit -run=^$ -count=10 ./sstable
+func BenchmarkTwoLevelIteratorSeekPrefixGE_Hit(b *testing.B) {
+	b.Run("rowblk", func(b *testing.B) {
+		reader, keys := setupBloomFilterData(b)
+		defer reader.Close()
+
+		opts := IterOptions{}
+		// Use the first key from our generated keys to ensure it exists
+		fullKey := []byte(keys[0])
+		// Extract prefix using the comparer's Split method
+		splitIndex := testkeys.Comparer.Split(fullKey)
+		prefix := fullKey[:splitIndex]
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var iter Iterator
+			var err error
+			iter, err = newRowBlockTwoLevelIterator(context.Background(), reader, opts)
+			require.NoError(b, err)
+
+			// First SeekPrefixGE call - should pass bloom filter and find data
+			kv := iter.SeekPrefixGE(prefix, fullKey, base.SeekGEFlagsNone)
+			if kv == nil {
+				b.Fatalf("Expected non-nil key-value from SeekPrefixGE, prefix=%s, key=%s", string(prefix), string(fullKey))
+			}
+
+			iter.Close()
+		}
+	})
+}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -261,16 +261,16 @@ open: db/000007.sst (options: *vfs.randomReadsOption)
 read-at(700, 61): db/000007.sst
 read-at(649, 51): db/000007.sst
 read-at(132, 517): db/000007.sst
-read-at(91, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
+read-at(91, 41): db/000005.sst
 read-at(0, 91): db/000005.sst
-read-at(91, 41): db/000007.sst
 open: db/000007.sst (options: *vfs.sequentialReadsOption)
+read-at(91, 41): db/000007.sst
 read-at(0, 91): db/000007.sst
 create: db/000010.sst
 close: db/000005.sst
-read-at(95, 41): db/000009.sst
 open: db/000009.sst (options: *vfs.sequentialReadsOption)
+read-at(95, 41): db/000009.sst
 read-at(0, 95): db/000009.sst
 close: db/000007.sst
 close: db/000009.sst

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -82,13 +82,13 @@ open: db/000007.sst (options: *vfs.randomReadsOption)
 read-at(501, 61): db/000007.sst
 read-at(472, 37): db/000007.sst
 read-at(53, 419): db/000007.sst
-read-at(52, 27): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
+read-at(52, 27): db/000005.sst
 read-at(0, 52): db/000005.sst
 create: db/000008.sst
 close: db/000005.sst
-read-at(26, 27): db/000007.sst
 open: db/000007.sst (options: *vfs.sequentialReadsOption)
+read-at(26, 27): db/000007.sst
 read-at(0, 26): db/000007.sst
 close: db/000007.sst
 sync-data: db/000008.sst

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -145,11 +145,11 @@ open: db/000008.sst (options: *vfs.randomReadsOption)
 read-at(686, 61): db/000008.sst
 read-at(636, 50): db/000008.sst
 read-at(119, 517): db/000008.sst
-read-at(78, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
+read-at(78, 41): db/000005.sst
 read-at(0, 78): db/000005.sst
-read-at(78, 41): db/000008.sst
 open: db/000008.sst (options: *vfs.sequentialReadsOption)
+read-at(78, 41): db/000008.sst
 read-at(0, 78): db/000008.sst
 close: db/000008.sst
 close: db/000005.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -651,17 +651,17 @@ allowFlush
 get with-fs-logging
 small-00001
 ----
-read-at(158, 41): 000004.sst
 read-at(199, 74): 000004.sst
+read-at(158, 41): 000004.sst
 read-at(0, 158): 000004.sst
 small-00001:val-00001
 
-# When the key doesn't pass the bloom filter, we should see only two block
-# reads.
+# When the key doesn't pass the bloom filter, we should see only one block
+# read due to lazy loading optimization - bloom filter is checked first,
+# and if it rejects the key, we can avoid loading the index block entirely.
 get with-fs-logging
 small-00001-does-not-exist
 ----
-read-at(158, 41): 000004.sst
 read-at(199, 74): 000004.sst
 small-00001-does-not-exist: pebble: not found
 


### PR DESCRIPTION
This commit implements the index block lazy loading in single-level iterator as default behavior. The index block loading is now deferred until first access. At the same time, it leads to semantic changes as the file reading ordering changes because of this.

Here is a quick overview of the change.

Before (eager loading)
1. Iterator Construction:
    1.1 the constructor calls readTopLevelIndexBlock()
    1.2 readTopLevelIndexBlock() calls readIndexBlock()
    1.3 readIndexBlock(() calls blockReader.Read()
    1.4 blockReader.Read() calls objstorage ReadHandle ReadAt()
    1.5 ReadAt() loads the index block
    1.6 construction completes

2. First Positioning (e.g., First(), SeekGE(), SeekPrefixGE()):
    2.1 the positioning function uses the already-loaded index via PI(&i.index)
    2.2 file opened for data read
    2.3 ReadAt() loads the data block

After (lazy loading)
1. Iterator Construction:
    1.1 the constructor sets indexLoaded = false to defer loading
    1.2 construction completes (no I/O)

2. First Positioning (e.g., First(), SeekGE(), SeekPrefixGE()):
    2.1 the positioning function calls the new indexIter() wrapper
    2.2 indexIter() calls ensureIndexLoaded()
    2.3 ensureIndexLoaded() calls ReadAt()
    2.4 ReadAt() loads the index block
    2.5 uses the newly-loaded index for positioning
    2.6 ReadAt() loads the data block

As seen above, the I/O operation is now deferred. While the overall behavior is transparent to users, the internal semantic is different now. And the data-driven tests have to change accordingly. See the order of events change in file: checkpoint, cleaner, and event_listener.

What's interesting (optimized) is the change observed in flushable_ingest, which demonstrate the I/O saving thanks to the optimization.
```
-# When the key doesn't pass the bloom filter, we should see only two block
-# reads.
+# When the key doesn't pass the bloom filter, we should see only one block
+# read due to lazy loading optimization - bloom filter is checked first,
+# and if it rejects the key, we can avoid loading the index block entirely.
 get with-fs-logging
 small-00001-does-not-exist
 ----
-read-at(158, 41): 000004.sst
 read-at(199, 74): 000004.sst
```

Next is a comparison between eager loading and lazy loading. We should collect metrics on how often SeekPrefixGE() saved I/O; how often an iterator is created but not used; or how much the deferred operations improve memory usage if they are not available today (TODO).

Benchmark will be moved to a separate PR.
~~While one may argue the amortized cost is similar in the long run, lazy load could also help with perceived performance potentially. In other words, the average might be same in theory, but the common case is indeed optimized.~~


implements #3248 