### PR TITLE
db: move latest version state into a shared struct

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -197,10 +197,10 @@ func (d *DB) Checkpoint(
 	optionsFileNum := d.optionsFileNum
 
 	virtualBackingFiles := make(map[base.DiskFileNum]struct{})
-	d.mu.versions.virtualBackings.ForEach(func(backing *manifest.TableBacking) {
+	d.mu.versions.latest.virtualBackings.ForEach(func(backing *manifest.TableBacking) {
 		virtualBackingFiles[backing.DiskFileNum] = struct{}{}
 	})
-	versionBlobFiles := d.mu.versions.blobFiles.Metadatas()
+	versionBlobFiles := d.mu.versions.latest.blobFiles.Metadatas()
 
 	// Acquire the logs while holding mutexes to ensure we don't race with a
 	// flush that might mark a log that's relevant to `current` as obsolete

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -151,7 +151,7 @@ func testCheckpointImpl(t *testing.T, ddFile string, createOnShared bool) {
 			d := dbs[td.CmdArgs[0].String()]
 			d.mu.Lock()
 			d.mu.versions.logLock()
-			fileNums := d.mu.versions.virtualBackings.DiskFileNums()
+			fileNums := d.mu.versions.latest.virtualBackings.DiskFileNums()
 			d.mu.versions.logUnlock()
 			d.mu.Unlock()
 

--- a/compaction.go
+++ b/compaction.go
@@ -1178,7 +1178,7 @@ func (d *DB) addInProgressCompaction(c *compaction) {
 		if isIntraL0 {
 			l0Inputs = append(l0Inputs, c.outputLevel.files)
 		}
-		if err := d.mu.versions.l0Organizer.UpdateStateForStartedCompaction(l0Inputs, isBase); err != nil {
+		if err := d.mu.versions.latest.l0Organizer.UpdateStateForStartedCompaction(l0Inputs, isBase); err != nil {
 			d.opts.Logger.Fatalf("could not update state for compaction: %s", err)
 		}
 	}
@@ -1235,7 +1235,7 @@ func (d *DB) clearCompactingState(c *compaction, rollback bool) {
 		// may be able to pick a better compaction (though when this compaction
 		// succeeded we've also cleared the cache in UpdateVersionLocked).
 		defer d.mu.versions.logUnlockAndInvalidatePickedCompactionCache()
-		d.mu.versions.l0Organizer.InitCompactingFileInfo(l0InProgress)
+		d.mu.versions.latest.l0Organizer.InitCompactingFileInfo(l0InProgress)
 	}()
 }
 
@@ -1592,7 +1592,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 		}
 	}
 
-	c, err := newFlush(d.opts, d.mu.versions.currentVersion(), d.mu.versions.l0Organizer,
+	c, err := newFlush(d.opts, d.mu.versions.currentVersion(), d.mu.versions.latest.l0Organizer,
 		d.mu.versions.picker.getBaseLevel(), d.mu.mem.queue[:n], d.timeNow(), d.TableFormat(), d.determineCompactionValueSeparation)
 	if err != nil {
 		return 0, err
@@ -2060,7 +2060,7 @@ func (d *DB) tryScheduleDownloadCompactions(env compactionEnv, maxConcurrentDown
 			break
 		}
 		download := d.mu.compact.downloads[i]
-		switch d.tryLaunchDownloadCompaction(download, vers, d.mu.versions.l0Organizer, env, maxConcurrentDownloads) {
+		switch d.tryLaunchDownloadCompaction(download, vers, d.mu.versions.latest.l0Organizer, env, maxConcurrentDownloads) {
 		case launchedCompaction:
 			started = true
 			continue
@@ -2079,7 +2079,8 @@ func (d *DB) pickManualCompaction(env compactionEnv) (pc *pickedCompaction) {
 	v := d.mu.versions.currentVersion()
 	for len(d.mu.compact.manual) > 0 {
 		manual := d.mu.compact.manual[0]
-		pc, retryLater := newPickedManualCompaction(v, d.mu.versions.l0Organizer, d.opts, env, d.mu.versions.picker.getBaseLevel(), manual)
+		pc, retryLater := newPickedManualCompaction(v, d.mu.versions.latest.l0Organizer,
+			d.opts, env, d.mu.versions.picker.getBaseLevel(), manual)
 		if pc != nil {
 			return pc
 		}

--- a/data_test.go
+++ b/data_test.go
@@ -943,7 +943,7 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 			flushable: mem,
 			flushed:   make(chan struct{}),
 		}}
-		c, err := newFlush(d.opts, d.mu.versions.currentVersion(), d.mu.versions.l0Organizer,
+		c, err := newFlush(d.opts, d.mu.versions.currentVersion(), d.mu.versions.latest.l0Organizer,
 			d.mu.versions.picker.getBaseLevel(), toFlush, time.Now(), d.TableFormat(), d.determineCompactionValueSeparation)
 		if err != nil {
 			return err
@@ -1641,7 +1641,7 @@ func describeLSM(d *DB, verbose bool) string {
 	} else {
 		buf.WriteString(d.mu.versions.currentVersion().String())
 	}
-	if blobFileMetas := d.mu.versions.blobFiles.Metadatas(); len(blobFileMetas) > 0 {
+	if blobFileMetas := d.mu.versions.latest.blobFiles.Metadatas(); len(blobFileMetas) > 0 {
 		buf.WriteString("Blob files:\n")
 		for _, meta := range blobFileMetas {
 			fmt.Fprintf(&buf, "  %s: [%s] %d physical bytes, %d value bytes\n",

--- a/db.go
+++ b/db.go
@@ -2017,7 +2017,7 @@ func (d *DB) splitManualCompaction(
 	if level == 0 {
 		endLevel = baseLevel
 	}
-	keyRanges := curr.CalculateInuseKeyRanges(d.mu.versions.l0Organizer, level, endLevel, start, end)
+	keyRanges := curr.CalculateInuseKeyRanges(d.mu.versions.latest.l0Organizer, level, endLevel, start, end)
 	for _, keyRange := range keyRanges {
 		splitCompactions = append(splitCompactions, &manualCompaction{
 			level: level,
@@ -2165,10 +2165,10 @@ func (d *DB) Metrics() *Metrics {
 
 	d.mu.versions.logLock()
 	metrics.private.manifestFileSize = uint64(d.mu.versions.manifest.Size())
-	backingCount, backingTotalSize := d.mu.versions.virtualBackings.Stats()
+	backingCount, backingTotalSize := d.mu.versions.latest.virtualBackings.Stats()
 	metrics.Table.BackingTableCount = uint64(backingCount)
 	metrics.Table.BackingTableSize = backingTotalSize
-	blobStats := d.mu.versions.blobFiles.Stats()
+	blobStats := d.mu.versions.latest.blobFiles.Stats()
 	d.mu.versions.logUnlock()
 	metrics.BlobFiles.LiveCount = blobStats.Count
 	metrics.BlobFiles.LiveSize = blobStats.PhysicalSize
@@ -2656,7 +2656,7 @@ func (d *DB) maybeInduceWriteStall(b *Batch) {
 			}
 			continue
 		}
-		l0ReadAmp := d.mu.versions.l0Organizer.ReadAmplification()
+		l0ReadAmp := d.mu.versions.latest.l0Organizer.ReadAmplification()
 		if l0ReadAmp >= d.opts.L0StopWritesThreshold {
 			// There are too many level-0 files, so we wait.
 			if !stalled {

--- a/ingest.go
+++ b/ingest.go
@@ -802,10 +802,10 @@ func (d *DB) findExistingBackingsForExternalObjects(metas []ingestExternalMeta) 
 		// exists in a previous version. In that case, that object could be removed
 		// at any time so we cannot reuse it.
 		for _, n := range diskFileNums {
-			if backing, ok := d.mu.versions.virtualBackings.Get(n); ok {
+			if backing, ok := d.mu.versions.latest.virtualBackings.Get(n); ok {
 				// Protect this backing from being removed from the latest version. We
 				// will unprotect in ingestUnprotectExternalBackings.
-				d.mu.versions.virtualBackings.Protect(n)
+				d.mu.versions.latest.virtualBackings.Protect(n)
 				metas[i].usedExistingBacking = true
 				metas[i].AttachVirtualBacking(backing)
 
@@ -830,7 +830,7 @@ func (d *DB) ingestUnprotectExternalBackings(lr ingestLoadResult) {
 			// If the backing is not use anywhere else and the ingest failed (or the
 			// ingested tables were already compacted away), this call will cause in
 			// the next version update to remove the backing.
-			d.mu.versions.virtualBackings.Unprotect(meta.TableBacking.DiskFileNum)
+			d.mu.versions.latest.virtualBackings.Unprotect(meta.TableBacking.DiskFileNum)
 		}
 	}
 }

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -3116,6 +3116,6 @@ func runBenchmarkManySSTablesInUseKeyRanges(b *testing.B, d *DB, count int) {
 	smallest := []byte("0")
 	largest := []byte("z")
 	for i := 0; i < b.N; i++ {
-		_ = v.CalculateInuseKeyRanges(d.mu.versions.l0Organizer, 0, numLevels-1, smallest, largest)
+		_ = v.CalculateInuseKeyRanges(d.mu.versions.latest.l0Organizer, 0, numLevels-1, smallest, largest)
 	}
 }

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -160,11 +160,11 @@ func TestVersionSet(t *testing.T) {
 
 		case "protect-backing":
 			n, _ := strconv.Atoi(td.CmdArgs[0].String())
-			vs.virtualBackings.Protect(base.DiskFileNum(n))
+			vs.latest.virtualBackings.Protect(base.DiskFileNum(n))
 
 		case "unprotect-backing":
 			n, _ := strconv.Atoi(td.CmdArgs[0].String())
-			vs.virtualBackings.Unprotect(base.DiskFileNum(n))
+			vs.latest.virtualBackings.Unprotect(base.DiskFileNum(n))
 
 		case "ref-version":
 			name := td.CmdArgs[0].String()
@@ -218,7 +218,7 @@ func TestVersionSet(t *testing.T) {
 				fmt.Fprintf(&buf, "  %s\n", l)
 			}
 		}
-		buf.WriteString(vs.virtualBackings.String())
+		buf.WriteString(vs.latest.virtualBackings.String())
 		printObjectBreakdown := func(kind string, zombies zombieObjects, obsolete []obsoleteFile) {
 			if zombies.Count() == 0 {
 				buf.WriteString(fmt.Sprintf("no zombie %s\n", kind))


### PR DESCRIPTION
Consolidate the various fields that hold mutable state describing the latest version. Consolidating helps highlight the distinction that this state is expected to be mutated, unlike an immutable manifest.Version.

Additonally, this prepares for passing additional mutable state into the compaction picker so that the compaction picker is capable of picking blob file rewrite compactions.