### PR TITLE
db: move TargetFileSize out of LevelOptions

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -103,7 +103,7 @@ func newPebbleDB(dir string) DB {
 		l.FilterType = pebble.TableFilter
 	}
 	opts.Levels[6].FilterPolicy = pebble.NoFilterPolicy
-	opts.FlushSplitBytes = opts.Levels[0].TargetFileSize
+	opts.FlushSplitBytes = opts.TargetFileSizes[0]
 
 	opts.EnsureDefaults()
 

--- a/cmd/pebble/replay_test.go
+++ b/cmd/pebble/replay_test.go
@@ -49,17 +49,19 @@ func TestParseOptionsStr(t *testing.T) {
 		},
 		{
 			c: replayConfig{optionsString: `[Options] [Level "0"] target_file_size=222`},
-			options: &pebble.Options{Levels: [manifest.NumLevels]pebble.LevelOptions{
-				0: {TargetFileSize: 222},
-			}},
+			options: &pebble.Options{
+				TargetFileSizes: [manifest.NumLevels]int64{0: 222},
+			},
 		},
 		{
 			c: replayConfig{optionsString: `[Options] lbase_max_bytes=10  max_open_files=20  [Level "0"] target_file_size=30 [Level "1"] index_block_size=40`},
 			options: &pebble.Options{
 				LBaseMaxBytes: 10,
 				MaxOpenFiles:  20,
+				TargetFileSizes: [manifest.NumLevels]int64{
+					0: 30,
+				},
 				Levels: [manifest.NumLevels]pebble.LevelOptions{
-					0: {TargetFileSize: 30},
 					1: {IndexBlockSize: 40},
 				},
 			},

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -467,25 +467,25 @@ func TestPickCompaction(t *testing.T) {
 				1: {
 					newFileMeta(
 						200,
-						expandedCompactionByteSizeLimit(opts, 1, math.MaxUint64)-1,
+						expandedCompactionByteSizeLimit(opts, 4<<20, math.MaxUint64)-1,
 						base.ParseInternalKey("i1.SET.201"),
 						base.ParseInternalKey("i2.SET.202"),
 					),
 					newFileMeta(
 						210,
-						expandedCompactionByteSizeLimit(opts, 1, math.MaxUint64)-1,
+						expandedCompactionByteSizeLimit(opts, 4<<20, math.MaxUint64)-1,
 						base.ParseInternalKey("j1.SET.211"),
 						base.ParseInternalKey("j2.SET.212"),
 					),
 					newFileMeta(
 						220,
-						expandedCompactionByteSizeLimit(opts, 1, math.MaxUint64)-1,
+						expandedCompactionByteSizeLimit(opts, 4<<20, math.MaxUint64)-1,
 						base.ParseInternalKey("k1.SET.221"),
 						base.ParseInternalKey("k2.SET.222"),
 					),
 					newFileMeta(
 						230,
-						expandedCompactionByteSizeLimit(opts, 1, math.MaxUint64)-1,
+						expandedCompactionByteSizeLimit(opts, 4<<20, math.MaxUint64)-1,
 						base.ParseInternalKey("l1.SET.231"),
 						base.ParseInternalKey("l2.SET.232"),
 					),
@@ -493,13 +493,13 @@ func TestPickCompaction(t *testing.T) {
 				2: {
 					newFileMeta(
 						300,
-						expandedCompactionByteSizeLimit(opts, 2, math.MaxUint64)-1,
+						expandedCompactionByteSizeLimit(opts, 8<<20, math.MaxUint64)-1,
 						base.ParseInternalKey("a0.SET.301"),
 						base.ParseInternalKey("l0.SET.302"),
 					),
 					newFileMeta(
 						310,
-						expandedCompactionByteSizeLimit(opts, 2, math.MaxUint64)-1,
+						expandedCompactionByteSizeLimit(opts, 8<<20, math.MaxUint64)-1,
 						base.ParseInternalKey("l2.SET.311"),
 						base.ParseInternalKey("z2.SET.312"),
 					),
@@ -2229,8 +2229,8 @@ func TestCompactionErrorCleanup(t *testing.T) {
 		},
 	}
 	opts.WithFSDefaults()
-	for i := range opts.Levels {
-		opts.Levels[i].TargetFileSize = 1
+	for i := range opts.TargetFileSizes {
+		opts.TargetFileSizes[i] = 1
 	}
 	opts.testingRandomized(t)
 	d, err := Open("", opts)
@@ -2932,8 +2932,8 @@ func TestCompactionErrorStats(t *testing.T) {
 		},
 	}
 	opts.WithFSDefaults()
-	for i := range opts.Levels {
-		opts.Levels[i].TargetFileSize = 1
+	for i := range opts.TargetFileSizes {
+		opts.TargetFileSizes[i] = 1
 	}
 	opts.testingRandomized(t)
 	d, err := Open("", opts)

--- a/data_test.go
+++ b/data_test.go
@@ -1779,13 +1779,13 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 				if err != nil {
 					return err
 				}
-				opts.Levels[i].TargetFileSize = size
+				opts.TargetFileSizes[i] = size
 			}
 			// Set the remaining file sizes. Normally, EnsureDefaults() would do that
 			// for us but it was already called and the target file sizes for all
 			// levels are now set to the defaults.
-			for i := len(cmdArg.Vals); i < len(opts.Levels); i++ {
-				opts.Levels[i].TargetFileSize = opts.Levels[i-1].TargetFileSize * 2
+			for i := len(cmdArg.Vals); i < len(opts.TargetFileSizes); i++ {
+				opts.TargetFileSizes[i] = opts.TargetFileSizes[i-1] * 2
 			}
 		case "value-separation":
 			if len(cmdArg.Vals) != 3 {

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -770,13 +770,8 @@ func RandomOptions(
 		opts.AllocatorSizeClasses = pebble.JemallocSizeClasses
 	}
 
-	var lopts pebble.LevelOptions
-	lopts.BlockRestartInterval = 1 + rng.IntN(64)  // 1 - 64
-	lopts.BlockSize = 1 << uint(rng.IntN(24))      // 1 - 16MB
-	lopts.BlockSizeThreshold = 50 + rng.IntN(50)   // 50 - 100
-	lopts.IndexBlockSize = 1 << uint(rng.IntN(24)) // 1 - 16MB
-	lopts.TargetFileSize = 1 << uint(rng.IntN(28)) // 1 - 256MB
-	if lopts.TargetFileSize < 1<<12 {
+	opts.TargetFileSizes[0] = 1 << uint(rng.IntN(28)) // 1 - 256MB
+	if opts.TargetFileSizes[0] < 1<<12 {
 		// We will generate a lot of files, which will slow down compactions.
 		// Increase L0StopWritesThreshold to reduce the number of write stalls
 		// that could cause operation timeouts.
@@ -784,7 +779,13 @@ func RandomOptions(
 	}
 	// The EstimatedSize of an empty table writer is 8 bytes. We want something a
 	// little bigger than that as the minimum target.
-	lopts.TargetFileSize = max(lopts.TargetFileSize, 12)
+	opts.TargetFileSizes[0] = max(opts.TargetFileSizes[0], 12)
+
+	var lopts pebble.LevelOptions
+	lopts.BlockRestartInterval = 1 + rng.IntN(64)  // 1 - 64
+	lopts.BlockSize = 1 << uint(rng.IntN(24))      // 1 - 16MB
+	lopts.BlockSizeThreshold = 50 + rng.IntN(50)   // 50 - 100
+	lopts.IndexBlockSize = 1 << uint(rng.IntN(24)) // 1 - 16MB
 
 	// We either use no bloom filter, the default filter, or a filter with
 	// randomized bits-per-key setting. We zero out the Filters map. It'll get

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -178,7 +178,7 @@ func TestMetrics(t *testing.T) {
 				MaxBlobReferenceDepth: 5,
 			}
 		}
-		opts.Levels[0] = LevelOptions{TargetFileSize: 50}
+		opts.TargetFileSizes[0] = 50
 
 		// Prevent foreground flushes and compactions from triggering asynchronous
 		// follow-up compactions. This avoids asynchronously-scheduled work from

--- a/options_test.go
+++ b/options_test.go
@@ -60,27 +60,28 @@ func testingRandomized(t testing.TB, o *Options) *Options {
 	return o
 }
 
-func TestLevelOptions(t *testing.T) {
+func TestTargetFileSize(t *testing.T) {
 	opts := DefaultOptions()
 
 	testCases := []struct {
 		level          int
+		baseLevel      int
 		targetFileSize int64
 	}{
-		{0, 2 << 20},
-		{1, (2 * 2) << 20},
-		{2, (4 * 2) << 20},
-		{3, (8 * 2) << 20},
-		{4, (16 * 2) << 20},
-		{5, (32 * 2) << 20},
-		{6, (64 * 2) << 20},
+		{level: 0, baseLevel: 1, targetFileSize: 2 << 20},
+		{level: 1, baseLevel: 1, targetFileSize: 2 * 2 << 20},
+		{level: 2, baseLevel: 1, targetFileSize: 4 * 2 << 20},
+		{level: 3, baseLevel: 1, targetFileSize: 8 * 2 << 20},
+		{level: 4, baseLevel: 1, targetFileSize: 16 * 2 << 20},
+		{level: 5, baseLevel: 1, targetFileSize: 32 * 2 << 20},
+		{level: 6, baseLevel: 1, targetFileSize: 64 * 2 << 20},
+
+		{level: 3, baseLevel: 3, targetFileSize: 2 * 2 << 20},
+		{level: 4, baseLevel: 3, targetFileSize: 4 * 2 << 20},
+		{level: 5, baseLevel: 3, targetFileSize: 8 * 2 << 20},
 	}
 	for _, c := range testCases {
-		l := opts.Levels[c.level]
-		if c.targetFileSize != l.TargetFileSize {
-			t.Fatalf("%d: expected target-file-size %d, but found %d",
-				c.level, c.targetFileSize, l.TargetFileSize)
-		}
+		require.Equal(t, c.targetFileSize, opts.TargetFileSize(c.level, c.baseLevel))
 	}
 }
 

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -262,10 +262,10 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		// Use a small target file size so that there is a single key per sstable.
 		d, err := Open("", &Options{
 			FS: vfs.NewMem(),
-			Levels: [manifest.NumLevels]LevelOptions{
-				0: {TargetFileSize: 100},
-				1: {TargetFileSize: 80},
-				2: {TargetFileSize: 1},
+			TargetFileSizes: [manifest.NumLevels]int64{
+				0: 100,
+				1: 80,
+				2: 1,
 			},
 			DebugCheck:         DebugCheckLevels,
 			FormatMajorVersion: formatVersion,
@@ -409,10 +409,10 @@ func TestRangeDelCompactionTruncation2(t *testing.T) {
 	// Use a small target file size so that there is a single key per sstable.
 	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
-		Levels: [manifest.NumLevels]LevelOptions{
-			0: {TargetFileSize: 200},
-			1: {TargetFileSize: 200},
-			2: {TargetFileSize: 1},
+		TargetFileSizes: [manifest.NumLevels]int64{
+			0: 200,
+			1: 200,
+			2: 1,
 		},
 		DebugCheck: DebugCheckLevels,
 	})
@@ -469,10 +469,10 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 	d, err := Open("tmp", &Options{
 		Cleaner: ArchiveCleaner{},
 		FS:      vfs.NewMem(),
-		Levels: [manifest.NumLevels]LevelOptions{
-			0: {TargetFileSize: 200},
-			1: {TargetFileSize: 200},
-			2: {TargetFileSize: 1},
+		TargetFileSizes: [manifest.NumLevels]int64{
+			0: 200,
+			1: 200,
+			2: 1,
 		},
 		DebugCheck: DebugCheckLevels,
 	})

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -277,8 +277,8 @@ func TestScanInternal(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				for i := range opts.Levels {
-					opts.Levels[i].TargetFileSize = int64(v)
+				for i := range opts.TargetFileSizes {
+					opts.TargetFileSizes[i] = int64(v)
 				}
 			case "bloom-bits-per-key":
 				v, err := strconv.Atoi(cmdArg.Vals[0])


### PR DESCRIPTION
`LevelOptions.TargetFileSize` is used in a way that is not consistent
with the rest of the level options. Whereas other level options apply
to the expected level (e.g. `Levels[1]` applies to `L1`), the target
file size applies to the level relative to Lbase. Specifically for
i > 0, `Levels[i].TargetFileSize` is the target file size of Lbase+i-1.

We move this field to its own separate array and add a convenience
`TargetFileSize()` method.

We don't change the options encoding.