### PR TITLE
db: fix 32-bit overflow

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -41,15 +41,14 @@ func (o *Options) testingRandomized(t testing.TB) *Options {
 	}
 	// Enable value separation if using a format major version that supports it.
 	if o.FormatMajorVersion >= FormatValueSeparation && o.Experimental.ValueSeparationPolicy == nil && rand.Int64N(4) > 0 {
-		o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
-			return ValueSeparationPolicy{
-				Enabled:               true,
-				MinimumSize:           1 << rand.IntN(10), // [1, 512]
-				MaxBlobReferenceDepth: rand.IntN(10) + 1,  // [1, 10)
-				// Constrain the rewrite minimum age to [0, 15m).
-				RewriteMinimumAge: time.Duration(rand.IntN(int(15 * time.Minute))).Truncate(time.Second),
-			}
+		policy := ValueSeparationPolicy{
+			Enabled:               true,
+			MinimumSize:           1 << rand.IntN(10), // [1, 512]
+			MaxBlobReferenceDepth: rand.IntN(10) + 1,  // [1, 10)
+			// Constrain the rewrite minimum age to [0, 15s).
+			RewriteMinimumAge: time.Duration(rand.IntN(15)) * time.Second,
 		}
+		o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy { return policy }
 	}
 	o.EnsureDefaults()
 	return o


### PR DESCRIPTION
Fix a 32-bit overflow introduced in 23da05e. Additionally, keep the value separation policy constant throughout the filetime of a Options configured with testingRandomized(). Previously every invocation of the ValueSeparationPolicy func would generate new random values.

Fix #4930.
Fix #4931.