### PR TITLE
db: clean up compaction, pickedCompaction structs

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -385,7 +385,7 @@ func newCompaction(
 ) *compaction {
 	c := &compaction{
 		kind:               compactionKindDefault,
-		cmp:                pc.cmp,
+		cmp:                opts.Comparer.Compare,
 		equal:              opts.Comparer.Equal,
 		comparer:           opts.Comparer,
 		formatKey:          opts.Comparer.FormatKey,

--- a/compaction.go
+++ b/compaction.go
@@ -268,12 +268,6 @@ type compaction struct {
 	delElision      compact.TombstoneElision
 	rangeKeyElision compact.TombstoneElision
 
-	// allowedZeroSeqNum is true if seqnums can be zeroed if there are no
-	// snapshots requiring them to be kept. This determination is made by
-	// looking for an sstable which overlaps the bounds of the compaction at a
-	// lower level in the LSM during runCompaction.
-	allowedZeroSeqNum bool
-
 	// deleteOnly contains information specific to compactions with kind
 	// compactionKindDeleteOnly. A delete-only compaction is a special
 	// compaction that does not merge or write sstables. Instead, it only
@@ -3237,14 +3231,13 @@ func (d *DB) compactAndWrite(
 	if err != nil {
 		return compact.Result{Err: err}
 	}
-	c.allowedZeroSeqNum = c.allowZeroSeqNum()
 	cfg := compact.IterConfig{
 		Comparer:         c.comparer,
 		Merge:            d.merge,
 		TombstoneElision: c.delElision,
 		RangeKeyElision:  c.rangeKeyElision,
 		Snapshots:        snapshots,
-		AllowZeroSeqNum:  c.allowedZeroSeqNum,
+		AllowZeroSeqNum:  c.allowZeroSeqNum(),
 		IneffectualSingleDeleteCallback: func(userKey []byte) {
 			d.opts.EventListener.PossibleAPIMisuse(PossibleAPIMisuseInfo{
 				Kind:    IneffectualSingleDelete,

--- a/compaction.go
+++ b/compaction.go
@@ -202,8 +202,6 @@ type compaction struct {
 	comparer *base.Comparer
 	logger   Logger
 	version  *manifest.Version
-	stats    base.InternalIteratorStats
-	beganAt  time.Time
 	// versionEditApplied is set to true when a compaction has completed and the
 	// resulting version has been installed (if successful), but the compaction
 	// goroutine is still cleaning up (eg, deleting obsolete files).
@@ -254,9 +252,6 @@ type compaction struct {
 	// single output table with the tables in the grandparent level.
 	maxOverlapBytes uint64
 
-	// bytesWritten contains the number of bytes that have been written to outputs.
-	bytesWritten atomic.Int64
-
 	// The boundaries of the input data.
 	bounds base.UserKeyBounds
 
@@ -305,14 +300,33 @@ type compaction struct {
 		l0Limits [][]byte
 	}
 
-	metrics levelMetricsDelta
-
-	pickerMetrics pickedCompactionMetrics
+	// metrics encapsulates various metrics collected during a compaction.
+	metrics compactionMetrics
 
 	grantHandle CompactionGrantHandle
 
 	tableFormat   sstable.TableFormat
 	objCreateOpts objstorage.CreateOptions
+}
+
+// compactionMetrics contians metrics surrounding a compaction.
+type compactionMetrics struct {
+	// beganAt is the time when the compaction began.
+	beganAt time.Time
+	// bytesWritten contains the number of bytes that have been written to
+	// outputs. It's updated whenever the compaction outputs'
+	// objstorage.Writables receive new writes. See newCompactionOutputObj.
+	bytesWritten atomic.Int64
+	// internalIterStats contains statistics from the internal iterators used by
+	// the compaction.
+	//
+	// TODO(jackson): Use these to power the compaction BytesRead metric.
+	internalIterStats base.InternalIteratorStats
+	// perLevel contains metrics for each level involved in the compaction.
+	perLevel levelMetricsDelta
+	// picker contains metrics from the compaction picker when the compaction
+	// was picked.
+	picker pickedCompactionMetrics
 }
 
 // inputLargestSeqNumAbsolute returns the maximum LargestSeqNumAbsolute of any
@@ -360,11 +374,11 @@ func (c *compaction) makeInfo(jobID JobID) CompactionInfo {
 		info.Output.Level = numLevels - 1
 	}
 
-	for i, score := range c.pickerMetrics.scores {
+	for i, score := range c.metrics.picker.scores {
 		info.Input[i].Score = score
 	}
-	info.SingleLevelOverlappingRatio = c.pickerMetrics.singleLevelOverlappingRatio
-	info.MultiLevelOverlappingRatio = c.pickerMetrics.multiLevelOverlappingRatio
+	info.SingleLevelOverlappingRatio = c.metrics.picker.singleLevelOverlappingRatio
+	info.MultiLevelOverlappingRatio = c.metrics.picker.multiLevelOverlappingRatio
 	if len(info.Input) > 2 {
 		info.Annotations = append(info.Annotations, "multilevel")
 	}
@@ -393,13 +407,15 @@ func newCompaction(
 		bounds:             pc.bounds,
 		logger:             opts.Logger,
 		version:            pc.version,
-		beganAt:            beganAt,
 		getValueSeparation: getValueSeparation,
 		maxOutputFileSize:  pc.maxOutputFileSize,
 		maxOverlapBytes:    pc.maxOverlapBytes,
-		pickerMetrics:      pc.pickerMetrics,
-		grantHandle:        grantHandle,
-		tableFormat:        tableFormat,
+		metrics: compactionMetrics{
+			beganAt: beganAt,
+			picker:  pc.pickerMetrics,
+		},
+		grantHandle: grantHandle,
+		tableFormat: tableFormat,
 	}
 	// Acquire a reference to the version to ensure that files and in-memory
 	// version state necessary for reading files remain available. Ignoring
@@ -542,9 +558,11 @@ func newDeleteOnlyCompaction(
 		comparer:    opts.Comparer,
 		logger:      opts.Logger,
 		version:     cur,
-		beganAt:     beganAt,
 		inputs:      inputs,
 		grantHandle: noopGrantHandle{},
+		metrics: compactionMetrics{
+			beganAt: beganAt,
+		},
 	}
 	c.deleteOnly.hints = hints
 	c.deleteOnly.exciseEnabled = exciseEnabled
@@ -664,13 +682,15 @@ func newFlush(
 		comparer:           opts.Comparer,
 		logger:             opts.Logger,
 		version:            cur,
-		beganAt:            beganAt,
 		inputs:             []compactionLevel{{level: -1}, {level: 0}},
 		getValueSeparation: getValueSeparation,
 		maxOutputFileSize:  math.MaxUint64,
 		maxOverlapBytes:    math.MaxUint64,
 		grantHandle:        noopGrantHandle{},
 		tableFormat:        tableFormat,
+		metrics: compactionMetrics{
+			beganAt: beganAt,
+		},
 	}
 	c.flush.flushables = flushing
 	c.flush.l0Limits = l0Organizer.FlushSplitKeys()
@@ -1030,7 +1050,7 @@ func (c *compaction) newInputIters(
 	// iter.
 	pointIter = iters[0]
 	if len(iters) > 1 {
-		pointIter = newMergingIter(c.logger, &c.stats, cmp, nil, iters...)
+		pointIter = newMergingIter(c.logger, &c.metrics.internalIterStats, cmp, nil, iters...)
 	}
 
 	// In normal operation, levelIter iterates over the point operations in a
@@ -1382,10 +1402,10 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 	ingestFlushable := c.flush.flushables[0].flushable.(*ingestedFlushable)
 
 	updateLevelMetricsOnExcise := func(m *manifest.TableMetadata, level int, added []manifest.NewTableEntry) {
-		levelMetrics := c.metrics[level]
+		levelMetrics := c.metrics.perLevel[level]
 		if levelMetrics == nil {
 			levelMetrics = &LevelMetrics{}
-			c.metrics[level] = levelMetrics
+			c.metrics.perLevel[level] = levelMetrics
 		}
 		levelMetrics.TablesCount--
 		levelMetrics.TablesSize -= int64(m.Size)
@@ -1448,11 +1468,7 @@ func (d *DB) runIngestFlush(c *compaction) (*manifest.VersionEdit, error) {
 				level:      level,
 			})
 		}
-		levelMetrics := c.metrics[level]
-		if levelMetrics == nil {
-			levelMetrics = &LevelMetrics{}
-			c.metrics[level] = levelMetrics
-		}
+		levelMetrics := c.metrics.perLevel.level(level)
 		levelMetrics.TableBytesIngested += file.Size
 		levelMetrics.TablesIngested++
 	}
@@ -1628,7 +1644,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 		// oldest unflushed memtable.
 		ve.MinUnflushedLogNum = minUnflushedLogNum
 		if c.kind != compactionKindIngestedFlushable {
-			l0Metrics := c.metrics[0]
+			l0Metrics := c.metrics.perLevel.level(0)
 			if d.opts.DisableWAL {
 				// If the WAL is disabled, every flushable has a zero [logSize],
 				// resulting in zero bytes in. Instead, use the number of bytes we
@@ -1677,7 +1693,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 		return versionUpdate{
 			VE:                      ve,
 			JobID:                   jobID,
-			Metrics:                 c.metrics,
+			Metrics:                 c.metrics.perLevel,
 			InProgressCompactionsFn: func() []compactionInfo { return d.getInProgressCompactionInfoLocked(c) },
 		}, nil
 	})
@@ -1692,7 +1708,8 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 
 	d.clearCompactingState(c, err != nil)
 	delete(d.mu.compact.inProgress, c)
-	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.pickerMetrics, c.bytesWritten.Load(), err)
+	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.metrics.picker,
+		c.metrics.bytesWritten.Load(), err)
 
 	var flushed flushableList
 	if err == nil {
@@ -1702,7 +1719,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 		d.updateTableStatsLocked(ve.NewTables)
 		if ingest {
 			d.mu.versions.metrics.Flush.AsIngestCount++
-			for _, l := range c.metrics {
+			for _, l := range c.metrics.perLevel {
 				if l != nil {
 					d.mu.versions.metrics.Flush.AsIngestBytes += l.TableBytesIngested
 					d.mu.versions.metrics.Flush.AsIngestTableCount += l.TablesIngested
@@ -2476,7 +2493,7 @@ func (d *DB) compact(c *compaction, errChannel chan error) {
 			// must be atomic with the above removal of c from
 			// d.mu.compact.InProgress to ensure Metrics.Compact.Duration does not
 			// miss or double count a completing compaction's duration.
-			d.mu.compact.duration += d.timeNow().Sub(c.beganAt)
+			d.mu.compact.duration += d.timeNow().Sub(c.metrics.beganAt)
 		}()
 		// Done must not be called while holding any lock that needs to be
 		// acquired by Schedule. Also, it must be called after new Version has
@@ -2625,7 +2642,7 @@ func (d *DB) compact1(jobID JobID, c *compaction) (err error) {
 			return versionUpdate{
 				VE:                      ve,
 				JobID:                   jobID,
-				Metrics:                 c.metrics,
+				Metrics:                 c.metrics.perLevel,
 				InProgressCompactionsFn: func() []compactionInfo { return d.getInProgressCompactionInfoLocked(c) },
 			}, nil
 		})
@@ -2646,10 +2663,11 @@ func (d *DB) compact1(jobID JobID, c *compaction) (err error) {
 	// NB: clearing compacting state must occur before updating the read state;
 	// L0Sublevels initialization depends on it.
 	d.clearCompactingState(c, err != nil)
-	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.pickerMetrics, c.bytesWritten.Load(), err)
-	d.mu.versions.incrementCompactionBytes(-c.bytesWritten.Load())
+	d.mu.versions.incrementCompactions(c.kind, c.extraLevels, c.metrics.picker,
+		c.metrics.bytesWritten.Load(), err)
+	d.mu.versions.incrementCompactionBytes(-c.metrics.bytesWritten.Load())
 
-	info.TotalDuration = d.timeNow().Sub(c.beganAt)
+	info.TotalDuration = d.timeNow().Sub(c.metrics.beganAt)
 	d.opts.EventListener.CompactionEnd(info)
 
 	// Update the read state before deleting obsolete files because the
@@ -2813,9 +2831,8 @@ func (d *DB) runCopyCompaction(
 			if errors.Is(err, sstable.ErrEmptySpan) {
 				// The virtual table was empty. Just remove the backing file.
 				// Note that deleteOnExit is true so we will delete the created object.
-				c.metrics[c.outputLevel.level] = &LevelMetrics{
-					TableBytesIn: inputMeta.Size,
-				}
+				outputMetrics := c.metrics.perLevel.level(c.outputLevel.level)
+				outputMetrics.TableBytesIn = inputMeta.Size
 
 				return ve, compact.Stats{}, nil
 			}
@@ -2839,11 +2856,10 @@ func (d *DB) runCopyCompaction(
 	if newMeta.Virtual {
 		ve.CreatedBackingTables = []*manifest.TableBacking{newMeta.TableBacking}
 	}
-	c.metrics[c.outputLevel.level] = &LevelMetrics{
-		TableBytesIn:        inputMeta.Size,
-		TableBytesCompacted: newMeta.Size,
-		TablesCompacted:     1,
-	}
+	outputMetrics := c.metrics.perLevel.level(c.outputLevel.level)
+	outputMetrics.TableBytesIn = inputMeta.Size
+	outputMetrics.TableBytesCompacted = newMeta.Size
+	outputMetrics.TablesCompacted = 1
 
 	if err := d.objProvider.Sync(); err != nil {
 		return nil, compact.Stats{}, err
@@ -3022,12 +3038,11 @@ func (d *DB) runDeleteOnlyCompaction(
 		DeletedTables: map[manifest.DeletedTableEntry]*manifest.TableMetadata{},
 	}
 	for _, cl := range c.inputs {
-		levelMetrics := &LevelMetrics{}
+		levelMetrics := c.metrics.perLevel.level(cl.level)
 		err := d.runDeleteOnlyCompactionForLevel(cl, levelMetrics, ve, snapshots, fragments, c.deleteOnly.exciseEnabled)
 		if err != nil {
 			return nil, stats, err
 		}
-		c.metrics[cl.level] = levelMetrics
 	}
 	// Remove any files that were added and deleted in the same versionEdit.
 	ve.NewTables = slices.DeleteFunc(ve.NewTables, func(e manifest.NewTableEntry) bool {
@@ -3067,10 +3082,9 @@ func (d *DB) runMoveCompaction(
 	if c.cancel.Load() {
 		return ve, stats, ErrCancelledCompaction
 	}
-	c.metrics[c.outputLevel.level] = &LevelMetrics{
-		TableBytesMoved: meta.Size,
-		TablesMoved:     1,
-	}
+	outputMetrics := c.metrics.perLevel.level(c.outputLevel.level)
+	outputMetrics.TableBytesMoved = meta.Size
+	outputMetrics.TablesMoved = 1
 	ve = &manifest.VersionEdit{
 		DeletedTables: map[manifest.DeletedTableEntry]*manifest.TableMetadata{
 			{Level: c.startLevel.level, FileNum: meta.TableNum}: meta,
@@ -3200,7 +3214,7 @@ func (d *DB) compactAndWrite(
 	defer c.bufferPool.Release()
 	blockReadEnv := block.ReadEnv{
 		BufferPool: &c.bufferPool,
-		Stats:      &c.stats,
+		Stats:      &c.metrics.internalIterStats,
 		IterStats: d.fileCache.SSTStatsCollector().Accumulator(
 			uint64(uintptr(unsafe.Pointer(c))),
 			categoryCompaction,
@@ -3333,13 +3347,13 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*manifest.VersionEd
 	}
 
 	startLevelBytes := c.startLevel.files.TableSizeSum()
-	outputMetrics := &LevelMetrics{
-		TableBytesIn: startLevelBytes,
-		// TODO(jackson):  This BytesRead value does not include any blob files
-		// written. It either should, or we should add a separate metric.
-		TableBytesRead:     c.outputLevel.files.TableSizeSum(),
-		BlobBytesCompacted: result.Stats.CumulativeBlobFileSize,
-	}
+
+	outputMetrics := c.metrics.perLevel.level(c.outputLevel.level)
+	outputMetrics.TableBytesIn = startLevelBytes
+	// TODO(jackson):  This BytesRead value does not include any blob files
+	// written. It either should, or we should add a separate metric.
+	outputMetrics.TableBytesRead = c.outputLevel.files.TableSizeSum()
+	outputMetrics.BlobBytesCompacted = result.Stats.CumulativeBlobFileSize
 	if c.flush.flushables != nil {
 		outputMetrics.BlobBytesFlushed = result.Stats.CumulativeBlobFileSize
 	}
@@ -3348,12 +3362,11 @@ func (c *compaction) makeVersionEdit(result compact.Result) (*manifest.VersionEd
 	}
 	outputMetrics.TableBytesRead += outputMetrics.TableBytesIn
 
-	c.metrics[c.outputLevel.level] = outputMetrics
-	if len(c.flush.flushables) == 0 && c.metrics[c.startLevel.level] == nil {
-		c.metrics[c.startLevel.level] = &LevelMetrics{}
+	if len(c.flush.flushables) == 0 {
+		c.metrics.perLevel.level(c.startLevel.level)
 	}
 	if len(c.extraLevels) > 0 {
-		c.metrics[c.extraLevels[0].level] = &LevelMetrics{}
+		c.metrics.perLevel.level(c.extraLevels[0].level)
 		outputMetrics.MultiLevel.TableBytesInTop = startLevelBytes
 		outputMetrics.MultiLevel.TableBytesIn = outputMetrics.TableBytesIn
 		outputMetrics.MultiLevel.TableBytesRead = outputMetrics.TableBytesRead
@@ -3515,7 +3528,7 @@ func (d *DB) newCompactionOutputObj(
 		writable = &compactionWritable{
 			Writable: writable,
 			versions: d.mu.versions,
-			written:  &c.bytesWritten,
+			written:  &c.metrics.bytesWritten,
 		}
 	}
 	return writable, objMeta, nil

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -81,8 +81,7 @@ type compactionInfo struct {
 	versionEditApplied bool
 	inputs             []compactionLevel
 	outputLevel        int
-	smallest           InternalKey
-	largest            InternalKey
+	bounds             base.UserKeyBounds
 }
 
 func (info compactionInfo) String() string {
@@ -200,15 +199,10 @@ type pickedCompaction struct {
 	maxReadCompactionBytes uint64
 
 	// The boundaries of the input data.
-	smallest      InternalKey
-	largest       InternalKey
+	bounds        base.UserKeyBounds
 	version       *manifest.Version
 	l0Organizer   *manifest.L0Organizer
 	pickerMetrics pickedCompactionMetrics
-}
-
-func (pc *pickedCompaction) userKeyBounds() base.UserKeyBounds {
-	return base.UserKeyBoundsFromInternal(pc.smallest, pc.largest)
 }
 
 func defaultOutputLevel(startLevel, baseLevel int) int {
@@ -300,8 +294,7 @@ func (pc *pickedCompaction) String() string {
 	builder.WriteString(fmt.Sprintf(`AdjustedOutputLevel=%d, `, adjustedOutputLevel(pc.outputLevel.level, pc.baseLevel)))
 	builder.WriteString(fmt.Sprintf(`maxOutputFileSize=%d, `, pc.maxOutputFileSize))
 	builder.WriteString(fmt.Sprintf(`maxReadCompactionBytes=%d, `, pc.maxReadCompactionBytes))
-	builder.WriteString(fmt.Sprintf(`smallest=%s, `, pc.smallest))
-	builder.WriteString(fmt.Sprintf(`largest=%s, `, pc.largest))
+	builder.WriteString(fmt.Sprintf(`bounds=%s, `, pc.bounds))
 	builder.WriteString(fmt.Sprintf(`version=%s, `, pc.version))
 	builder.WriteString(fmt.Sprintf(`inputs=%s, `, pc.inputs))
 	builder.WriteString(fmt.Sprintf(`startlevel=%s, `, pc.startLevel))
@@ -323,8 +316,7 @@ func (pc *pickedCompaction) clone() *pickedCompaction {
 		maxOutputFileSize:      pc.maxOutputFileSize,
 		maxOverlapBytes:        pc.maxOverlapBytes,
 		maxReadCompactionBytes: pc.maxReadCompactionBytes,
-		smallest:               pc.smallest.Clone(),
-		largest:                pc.largest.Clone(),
+		bounds:                 pc.bounds.Clone(),
 
 		// TODO(msbutler): properly clone picker metrics
 		pickerMetrics: pc.pickerMetrics,
@@ -357,30 +349,6 @@ func (pc *pickedCompaction) clone() *pickedCompaction {
 	return newPC
 }
 
-// maybeExpandBounds is a helper function for setupInputs which ensures the
-// pickedCompaction's smallest and largest internal keys are updated iff
-// the candidate keys expand the key span. This avoids a bug for multi-level
-// compactions: during the second call to setupInputs, the picked compaction's
-// smallest and largest keys should not decrease the key span.
-func (pc *pickedCompaction) maybeExpandBounds(
-	cmp base.Compare, smallest InternalKey, largest InternalKey,
-) {
-	if len(smallest.UserKey) == 0 && len(largest.UserKey) == 0 {
-		return
-	}
-	if len(pc.smallest.UserKey) == 0 && len(pc.largest.UserKey) == 0 {
-		pc.smallest = smallest
-		pc.largest = largest
-		return
-	}
-	if base.InternalCompare(cmp, pc.smallest, smallest) >= 0 {
-		pc.smallest = smallest
-	}
-	if base.InternalCompare(cmp, pc.largest, largest) <= 0 {
-		pc.largest = largest
-	}
-}
-
 // setupInputs returns true if a compaction has been set up using the provided inputLevel and
 // pc.outputLevel. It returns false if a concurrent compaction is occurring on the start or
 // output level files. Note that inputLevel is not necessarily pc.startLevel. In multiLevel
@@ -397,9 +365,7 @@ func (pc *pickedCompaction) setupInputs(
 	if !canCompactTables(inputLevel.files, inputLevel.level, problemSpans) {
 		return false
 	}
-
-	sm, la := manifest.KeyRange(cmp, inputLevel.files.All())
-	pc.maybeExpandBounds(cmp, sm, la)
+	pc.bounds = manifest.ExtendKeyRange(cmp, pc.bounds, inputLevel.files.All())
 
 	// Setup output files and attempt to grow the inputLevel files with
 	// the expanded key range. No need to do this for intra-L0 compactions;
@@ -407,13 +373,11 @@ func (pc *pickedCompaction) setupInputs(
 	if inputLevel.level != pc.outputLevel.level {
 		// Determine the sstables in the output level which overlap with the compaction
 		// key range.
-		pc.outputLevel.files = pc.version.Overlaps(pc.outputLevel.level, pc.userKeyBounds())
+		pc.outputLevel.files = pc.version.Overlaps(pc.outputLevel.level, pc.bounds)
 		if !canCompactTables(pc.outputLevel.files, pc.outputLevel.level, problemSpans) {
 			return false
 		}
-
-		sm, la = manifest.KeyRange(cmp, pc.outputLevel.files.All())
-		pc.maybeExpandBounds(cmp, sm, la)
+		pc.bounds = manifest.ExtendKeyRange(cmp, pc.bounds, pc.outputLevel.files.All())
 
 		// maxExpandedBytes is the maximum size of an expanded compaction. If
 		// growing a compaction results in a larger size, the original compaction
@@ -426,10 +390,9 @@ func (pc *pickedCompaction) setupInputs(
 		// of sstables included from pc.outputLevel.level.
 		if pc.lcf != nil && inputLevel.level == 0 {
 			pc.growL0ForBase(cmp, maxExpandedBytes)
-		} else if pc.grow(cmp, pc.smallest, pc.largest, maxExpandedBytes, inputLevel, problemSpans) {
+		} else if pc.grow(cmp, pc.bounds, maxExpandedBytes, inputLevel, problemSpans) {
 			// inputLevel was expanded, adjust key range if necessary.
-			sm, la = manifest.KeyRange(cmp, inputLevel.files.All())
-			pc.maybeExpandBounds(cmp, sm, la)
+			pc.bounds = manifest.ExtendKeyRange(cmp, pc.bounds, inputLevel.files.All())
 		}
 	}
 
@@ -437,7 +400,6 @@ func (pc *pickedCompaction) setupInputs(
 		// If L0 is involved, it should always be the startLevel of the compaction.
 		pc.startLevel.l0SublevelInfo = generateSublevelInfo(cmp, pc.startLevel.files)
 	}
-
 	return true
 }
 
@@ -446,7 +408,7 @@ func (pc *pickedCompaction) setupInputs(
 // and la are the smallest and largest InternalKeys in all of the inputs.
 func (pc *pickedCompaction) grow(
 	cmp base.Compare,
-	sm, la InternalKey,
+	bounds base.UserKeyBounds,
 	maxExpandedBytes uint64,
 	inputLevel *compactionLevel,
 	problemSpans *problemspans.ByLevel,
@@ -454,7 +416,7 @@ func (pc *pickedCompaction) grow(
 	if pc.outputLevel.files.Empty() {
 		return false
 	}
-	expandedInputLevel := pc.version.Overlaps(inputLevel.level, base.UserKeyBoundsFromInternal(sm, la))
+	expandedInputLevel := pc.version.Overlaps(inputLevel.level, bounds)
 	if !canCompactTables(expandedInputLevel, inputLevel.level, problemSpans) {
 		return false
 	}
@@ -469,7 +431,7 @@ func (pc *pickedCompaction) grow(
 	// expandedInputLevel's key range not fully cover all files currently in pc.outputLevel,
 	// since pc.outputLevel was created using the entire key range which includes higher levels.
 	expandedOutputLevel := pc.version.Overlaps(pc.outputLevel.level,
-		base.UserKeyBoundsFromInternal(manifest.KeyRange(cmp, expandedInputLevel.All(), pc.outputLevel.files.All())))
+		manifest.KeyRange(cmp, expandedInputLevel.All(), pc.outputLevel.files.All()))
 	if expandedOutputLevel.Len() != pc.outputLevel.files.Len() {
 		return false
 	}
@@ -507,10 +469,10 @@ func (pc *pickedCompaction) growL0ForBase(cmp base.Compare, maxExpandedBytes uin
 	largestBaseKey := base.InvalidInternalKey
 	if pc.outputLevel.files.Empty() {
 		baseIter := pc.version.Levels[pc.outputLevel.level].Iter()
-		if sm := baseIter.SeekLT(cmp, pc.smallest.UserKey); sm != nil {
+		if sm := baseIter.SeekLT(cmp, pc.bounds.Start); sm != nil {
 			smallestBaseKey = sm.Largest()
 		}
-		if la := baseIter.SeekGE(cmp, pc.largest.UserKey); la != nil {
+		if la := baseIter.SeekGE(cmp, pc.bounds.End.Key); la != nil {
 			largestBaseKey = la.Smallest()
 		}
 	} else {
@@ -547,7 +509,7 @@ func (pc *pickedCompaction) growL0ForBase(cmp base.Compare, maxExpandedBytes uin
 	}
 
 	pc.startLevel.files = manifest.NewLevelSliceSeqSorted(newStartLevelFiles)
-	pc.smallest, pc.largest = manifest.KeyRange(cmp,
+	pc.bounds = manifest.ExtendKeyRange(cmp, pc.bounds,
 		pc.startLevel.files.All(), pc.outputLevel.files.All())
 	return true
 }
@@ -1583,7 +1545,7 @@ func (p *compactionPickerByScore) pickedCompactionFromCandidateFile(
 		startLevel, outputLevel, p.baseLevel)
 	pc.kind = kind
 	pc.startLevel.files = inputs
-	pc.smallest, pc.largest = manifest.KeyRange(p.opts.Comparer.Compare, pc.startLevel.files.All())
+	pc.bounds = manifest.KeyRange(p.opts.Comparer.Compare, pc.startLevel.files.All())
 
 	// Fail-safe to protect against compacting the same sstable concurrently.
 	if inputRangeAlreadyCompacting(p.opts.Comparer.Compare, env, pc) {
@@ -1885,7 +1847,7 @@ func pickL0(
 			}
 			// A single-file intra-L0 compaction is unproductive.
 			if iter := pc.startLevel.files.Iter(); iter.First() != nil && iter.Next() != nil {
-				pc.smallest, pc.largest = manifest.KeyRange(opts.Comparer.Compare, pc.startLevel.files.All())
+				pc.bounds = manifest.KeyRange(opts.Comparer.Compare, pc.startLevel.files.All())
 				return pc
 			}
 		} else {
@@ -2040,7 +2002,7 @@ func pickReadTriggeredCompactionHelper(
 	pc.kind = compactionKindRead
 
 	// Prevent read compactions which are too wide.
-	outputOverlaps := pc.version.Overlaps(pc.outputLevel.level, pc.userKeyBounds())
+	outputOverlaps := pc.version.Overlaps(pc.outputLevel.level, pc.bounds)
 	if outputOverlaps.AggregateSizeSum() > pc.maxReadCompactionBytes {
 		return nil
 	}
@@ -2101,11 +2063,9 @@ func inputRangeAlreadyCompacting(cmp base.Compare, env compactionEnv, pc *picked
 			if pc.outputLevel.level != c.outputLevel {
 				continue
 			}
-			if base.InternalCompare(cmp, c.largest, pc.smallest) < 0 ||
-				base.InternalCompare(cmp, c.smallest, pc.largest) > 0 {
+			if !c.bounds.Overlaps(cmp, &pc.bounds) {
 				continue
 			}
-
 			// The picked compaction and the in-progress compaction c are
 			// outputting to the same region of the key space of the same
 			// level.
@@ -2121,7 +2081,7 @@ func conflictsWithInProgress(
 ) bool {
 	for _, c := range inProgressCompactions {
 		if (c.outputLevel == manual.level || c.outputLevel == outputLevel) &&
-			isUserKeysOverlapping(manual.start, manual.end, c.smallest.UserKey, c.largest.UserKey, cmp) {
+			areUserKeysOverlapping(manual.start, manual.end, c.bounds.Start, c.bounds.End.Key, cmp) {
 			return true
 		}
 		for _, in := range c.inputs {
@@ -2132,7 +2092,7 @@ func conflictsWithInProgress(
 			smallest := iter.First().Smallest().UserKey
 			largest := iter.Last().Largest().UserKey
 			if (in.level == manual.level || in.level == outputLevel) &&
-				isUserKeysOverlapping(manual.start, manual.end, smallest, largest, cmp) {
+				areUserKeysOverlapping(manual.start, manual.end, smallest, largest, cmp) {
 				return true
 			}
 		}
@@ -2140,6 +2100,6 @@ func conflictsWithInProgress(
 	return false
 }
 
-func isUserKeysOverlapping(x1, x2, y1, y2 []byte, cmp Compare) bool {
+func areUserKeysOverlapping(x1, x2, y1, y2 []byte, cmp Compare) bool {
 	return cmp(x1, y2) <= 0 && cmp(y1, x2) <= 0
 }

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -291,13 +291,7 @@ func newPickedCompactionFromL0(
 	// any overlapping L0 SSTables that need to be added, and
 	// because compactions built by L0SSTables do not necessarily
 	// pick contiguous sequences of files in pc.version.Levels[0].
-	files := make([]*manifest.TableMetadata, 0, len(lcf.Files))
-	for f := range vers.Levels[0].All() {
-		if lcf.FilesIncluded[f.L0Index] {
-			files = append(files, f)
-		}
-	}
-	pc.startLevel.files = manifest.NewLevelSliceSeqSorted(files)
+	pc.startLevel.files = manifest.NewLevelSliceSeqSorted(lcf.Files)
 	return pc
 }
 

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1058,7 +1058,6 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 			}
 
 			pc := &pickedCompaction{
-				cmp:       DefaultComparer.Compare,
 				baseLevel: 1,
 				inputs:    []compactionLevel{{level: -1}, {level: -1}},
 			}
@@ -1218,7 +1217,6 @@ func TestPickedCompactionExpandInputs(t *testing.T) {
 
 			case "expand-inputs":
 				pc := &pickedCompaction{
-					cmp:    cmp,
 					inputs: []compactionLevel{{level: 1}},
 				}
 				pc.startLevel = &pc.inputs[0]

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2387,7 +2387,7 @@ func TestCompactionCheckOrdering(t *testing.T) {
 					return iterSet{point: &errorIter{}}, nil
 				}
 				result := "OK"
-				_, _, _, err := c.newInputIters(newIters, nil, internalIterOpts{})
+				_, _, _, err := c.newInputIters(newIters, internalIterOpts{})
 				if err != nil {
 					result = fmt.Sprint(err)
 				}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2101,7 +2101,7 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 				var buf bytes.Buffer
 				for _, line := range crstrings.Lines(td.Input) {
 					parts := strings.Fields(line)
-					c.flushing = nil
+					c.flush.flushables = nil
 					c.startLevel.level = -1
 
 					var startFiles, outputFiles []*manifest.TableMetadata
@@ -2110,7 +2110,7 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 					case len(parts) == 1 && parts[0] == "flush":
 						c.outputLevel.level = 0
 						d.mu.Lock()
-						c.flushing = d.mu.mem.queue
+						c.flush.flushables = d.mu.mem.queue
 						d.mu.Unlock()
 
 					default:

--- a/data_test.go
+++ b/data_test.go
@@ -1024,9 +1024,8 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 			return nil, err
 		}
 		c := &compaction{
-			inputs:   []compactionLevel{{}, {level: outputLevel}},
-			smallest: m.Smallest(),
-			largest:  m.Largest(),
+			inputs: []compactionLevel{{}, {level: outputLevel}},
+			bounds: m.UserKeyBounds(),
 		}
 		c.startLevel, c.outputLevel = &c.inputs[0], &c.inputs[1]
 		return c, nil

--- a/db.go
+++ b/db.go
@@ -2862,7 +2862,7 @@ func (d *DB) getEarliestUnflushedSeqNumLocked() base.SeqNum {
 
 func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []compactionInfo) {
 	for c := range d.mu.compact.inProgress {
-		if len(c.flushing) == 0 && (finishing == nil || c != finishing) {
+		if len(c.flush.flushables) == 0 && (finishing == nil || c != finishing) {
 			info := compactionInfo{
 				versionEditApplied: c.versionEditApplied,
 				inputs:             c.inputs,

--- a/db.go
+++ b/db.go
@@ -2866,8 +2866,7 @@ func (d *DB) getInProgressCompactionInfoLocked(finishing *compaction) (rv []comp
 			info := compactionInfo{
 				versionEditApplied: c.versionEditApplied,
 				inputs:             c.inputs,
-				smallest:           c.smallest,
-				largest:            c.largest,
+				bounds:             c.bounds,
 				outputLevel:        -1,
 			}
 			if c.outputLevel != nil {
@@ -2898,8 +2897,7 @@ func inProgressL0Compactions(inProgress []compactionInfo) []manifest.L0Compactio
 			continue
 		}
 		compactions = append(compactions, manifest.L0Compaction{
-			Smallest:  info.smallest,
-			Largest:   info.largest,
+			Bounds:    info.bounds,
 			IsIntraL0: info.outputLevel == 0,
 		})
 	}

--- a/db.go
+++ b/db.go
@@ -2081,7 +2081,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Compact.Duration = d.mu.compact.duration
 	for c := range d.mu.compact.inProgress {
 		if c.kind != compactionKindFlush && c.kind != compactionKindIngestedFlushable {
-			metrics.Compact.Duration += d.timeNow().Sub(c.beganAt)
+			metrics.Compact.Duration += d.timeNow().Sub(c.metrics.beganAt)
 		}
 	}
 	metrics.Compact.NumProblemSpans = d.problemSpans.Len()

--- a/internal/base/key_bounds.go
+++ b/internal/base/key_bounds.go
@@ -6,6 +6,7 @@ package base
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
@@ -205,6 +206,14 @@ func (b *UserKeyBounds) ContainsInternalKey(cmp Compare, key InternalKey) bool {
 		b.End.IsUpperBoundForInternalKey(cmp, key)
 }
 
+// Clone returns a copy of the bounds.
+func (b UserKeyBounds) Clone() UserKeyBounds {
+	return UserKeyBounds{
+		Start: slices.Clone(b.Start),
+		End:   UserKeyBoundary{Key: slices.Clone(b.End.Key), Kind: b.End.Kind},
+	}
+}
+
 func (b UserKeyBounds) String() string {
 	return b.Format(DefaultFormatter)
 }
@@ -217,4 +226,22 @@ func (b UserKeyBounds) Format(fmtKey FormatKey) string {
 		endC = ')'
 	}
 	return fmt.Sprintf("[%s, %s%c", fmtKey(b.Start), fmtKey(b.End.Key), endC)
+}
+
+// Union returns bounds that encompass both the receiver and the provided
+// bounds.
+//
+// If the receiver has nil bounds, the other bounds are returned.
+func (b *UserKeyBounds) Union(cmp Compare, other UserKeyBounds) UserKeyBounds {
+	if b.Start == nil && b.End.Key == nil {
+		return other
+	}
+	union := *b
+	if cmp(union.Start, other.Start) > 0 {
+		union.Start = other.Start
+	}
+	if union.End.CompareUpperBounds(cmp, other.End) < 0 {
+		union.End = other.End
+	}
+	return union
 }

--- a/internal/base/key_bounds_test.go
+++ b/internal/base/key_bounds_test.go
@@ -63,6 +63,9 @@ func TestUserKeyBounds(t *testing.T) {
 	aci := UserKeyBoundsEndExclusiveIf(a, c, false)
 	ace := UserKeyBoundsEndExclusiveIf(a, c, true)
 	cde := UserKeyBoundsEndExclusive(c, d)
+	adi := UserKeyBoundsInclusive(a, d)
+	ade := UserKeyBoundsEndExclusive(a, d)
+	empty := UserKeyBounds{}
 
 	t.Run("Valid", func(t *testing.T) {
 		require.True(t, bb.Valid(cmp))
@@ -128,5 +131,25 @@ func TestUserKeyBounds(t *testing.T) {
 		require.True(t, bdi.ContainsInternalKey(cmp, MakeInternalKey(d, 0, InternalKeyKindSet)))
 		require.False(t, bde.ContainsInternalKey(cmp, MakeInternalKey(d, 0, InternalKeyKindSet)))
 		require.True(t, bde.ContainsInternalKey(cmp, MakeRangeDeleteSentinelKey(d)))
+	})
+
+	t.Run("Union", func(t *testing.T) {
+		// Identity
+		require.Equal(t, bb, bb.Union(cmp, bb))
+		require.Equal(t, bdi, bdi.Union(cmp, bdi))
+		require.Equal(t, bde, bde.Union(cmp, bde))
+		require.Equal(t, aci, aci.Union(cmp, aci))
+
+		require.Equal(t, bdi, bb.Union(cmp, bdi))
+		require.Equal(t, bdi, bdi.Union(cmp, bde))
+		require.Equal(t, bdi, bde.Union(cmp, bdi))
+		require.Equal(t, aci, aci.Union(cmp, ace))
+
+		require.Equal(t, ade, aci.Union(cmp, bde))
+		require.Equal(t, adi, aci.Union(cmp, bdi))
+		require.Equal(t, ade, ace.Union(cmp, bde))
+		require.Equal(t, adi, ace.Union(cmp, bdi))
+
+		require.Equal(t, bde, empty.Union(cmp, bde))
 	})
 }

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -218,8 +218,7 @@ func (b *bitSet) clearAllBits() {
 
 // L0Compaction describes an active compaction with inputs from L0.
 type L0Compaction struct {
-	Smallest  InternalKey
-	Largest   InternalKey
+	Bounds    base.UserKeyBounds
 	IsIntraL0 bool
 }
 
@@ -766,8 +765,8 @@ func (s *l0Sublevels) InitCompactingFileInfo(inProgress []L0Compaction) {
 	// were added after the compaction initiated, and the active compaction
 	// files straddle the input file. Mark these intervals as base compacting.
 	for _, c := range inProgress {
-		startIK := intervalKey{key: c.Smallest.UserKey, isInclusiveEndBound: false}
-		endIK := intervalKey{key: c.Largest.UserKey, isInclusiveEndBound: !c.Largest.IsExclusiveSentinel()}
+		startIK := intervalKey{key: c.Bounds.Start, isInclusiveEndBound: false}
+		endIK := intervalKey{key: c.Bounds.End.Key, isInclusiveEndBound: c.Bounds.End.Kind == base.Inclusive}
 		start, _ := slices.BinarySearchFunc(s.orderedIntervals, startIK, func(a fileInterval, b intervalKey) int {
 			return intervalKeyCompare(s.cmp, a.startKey, b)
 		})

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -479,8 +479,8 @@ func TestL0Sublevels(t *testing.T) {
 				}
 			}
 			slice := NewLevelSliceSeqSorted(files)
-			sm, la := KeyRange(base.DefaultComparer.Compare, slice.All())
-			activeCompactions = append(activeCompactions, L0Compaction{Smallest: sm, Largest: la})
+			bounds := KeyRange(base.DefaultComparer.Compare, slice.All())
+			activeCompactions = append(activeCompactions, L0Compaction{Bounds: bounds})
 			if err := sublevels.UpdateStateForStartedCompaction([]LevelSlice{slice}, true); err != nil {
 				return err.Error()
 			}

--- a/internal/manifest/l0_sublevels_test.go
+++ b/internal/manifest/l0_sublevels_test.go
@@ -447,8 +447,7 @@ func TestL0Sublevels(t *testing.T) {
 		case "l0-check-ordering":
 			for sublevel, files := range sublevels.levelFiles {
 				slice := NewLevelSliceSpecificOrder(files)
-				err := CheckOrdering(base.DefaultComparer.Compare, base.DefaultFormatter,
-					L0Sublevel(sublevel), slice.Iter())
+				err := CheckOrdering(base.DefaultComparer, L0Sublevel(sublevel), slice.Iter())
 				if err != nil {
 					return err.Error()
 				}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -25,26 +25,29 @@ type Compare = base.Compare
 // InternalKey exports the base.InternalKey type.
 type InternalKey = base.InternalKey
 
-// KeyRange returns the minimum smallest and maximum largest internalKey for
-// all the TableMetadata in iters.
-func KeyRange(ucmp Compare, iters ...iter.Seq[*TableMetadata]) (smallest, largest InternalKey) {
-	first := true
+// KeyRange returns the narrowest UserKeyBounds that encompass the bounds of all
+// the TableMetadata in iters.
+func KeyRange(ucmp Compare, iters ...iter.Seq[*TableMetadata]) base.UserKeyBounds {
+	var bounds base.UserKeyBounds
 	for _, iter := range iters {
 		for meta := range iter {
-			if first {
-				first = false
-				smallest, largest = meta.Smallest(), meta.Largest()
-				continue
-			}
-			if base.InternalCompare(ucmp, smallest, meta.Smallest()) >= 0 {
-				smallest = meta.Smallest()
-			}
-			if base.InternalCompare(ucmp, largest, meta.Largest()) <= 0 {
-				largest = meta.Largest()
-			}
+			bounds = bounds.Union(ucmp, meta.UserKeyBounds())
 		}
 	}
-	return smallest, largest
+	return bounds
+}
+
+// ExtendKeyRange returns the narrowest UserKeyBounds that encompass the
+// provided bounds and the bounds of all the TableMetadata in iters.
+func ExtendKeyRange(
+	ucmp Compare, bounds base.UserKeyBounds, iters ...iter.Seq[*TableMetadata],
+) base.UserKeyBounds {
+	for _, iter := range iters {
+		for meta := range iter {
+			bounds = bounds.Union(ucmp, meta.UserKeyBounds())
+		}
+	}
+	return bounds
 }
 
 // SortBySmallest sorts the specified files by smallest key using the supplied

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1284,7 +1284,7 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 		}
 
 		if level == 0 {
-			if err := CheckOrdering(comparer.Compare, comparer.FormatKey, Level(0), v.Levels[level].Iter()); err != nil {
+			if err := CheckOrdering(comparer, Level(0), v.Levels[level].Iter()); err != nil {
 				return nil, errors.Wrap(err, "pebble: internal error")
 			}
 			continue
@@ -1304,7 +1304,7 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 					end.Prev()
 				}
 			})
-			if err := CheckOrdering(comparer.Compare, comparer.FormatKey, Level(level), check.Iter()); err != nil {
+			if err := CheckOrdering(comparer, Level(level), check.Iter()); err != nil {
 				return nil, errors.Wrap(err, "pebble: internal error")
 			}
 		}

--- a/internal/manifest/version_test.go
+++ b/internal/manifest/version_test.go
@@ -84,8 +84,8 @@ func TestIkeyRange(t *testing.T) {
 		}
 		levelMetadata := MakeLevelMetadata(base.DefaultComparer.Compare, 0, f)
 
-		sm, la := KeyRange(base.DefaultComparer.Compare, levelMetadata.All())
-		got := string(sm.UserKey) + "-" + string(la.UserKey)
+		bounds := KeyRange(base.DefaultComparer.Compare, levelMetadata.All())
+		got := string(bounds.Start) + "-" + string(bounds.End.Key)
 		if got != tc.want {
 			t.Errorf("KeyRange(%q) = %q, %q", tc.input, got, tc.want)
 		}

--- a/metrics.go
+++ b/metrics.go
@@ -910,6 +910,13 @@ func (m *Metrics) StringForTests() string {
 // (e.g. from compactions or flushes).
 type levelMetricsDelta [manifest.NumLevels]*LevelMetrics
 
+func (m *levelMetricsDelta) level(level int) *LevelMetrics {
+	if m[level] == nil {
+		m[level] = &LevelMetrics{}
+	}
+	return m[level]
+}
+
 func (m *Metrics) updateLevelMetrics(updates levelMetricsDelta) {
 	for i, u := range updates {
 		if u != nil {


### PR DESCRIPTION
These commits attempt to organize and comment the compaction and pickedCompaction structs. This is motivated by blob-file rewrite 'compactions' which share little of the same state as compactions but need to be considered similarly in some instances (eg, concurrent compaction limiting).