### PR TITLE
add compaction, pickedCompaction interfaces

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -73,7 +73,7 @@ type pickedCompaction interface {
 	// compaction is not a result of a manual compaction.
 	ManualID() uint64
 	// ConstructCompaction creates a compaction from the picked compaction.
-	ConstructCompaction(*DB, CompactionGrantHandle) *compaction
+	ConstructCompaction(*DB, CompactionGrantHandle) compaction
 	// WaitingCompaction returns a WaitingCompaction description of this
 	// compaction for consumption by the compaction scheduler.
 	WaitingCompaction() WaitingCompaction
@@ -236,7 +236,7 @@ func (pc *pickedTableCompaction) Score() float64 { return pc.score }
 // pickedTableCompaction.
 func (pc *pickedTableCompaction) ConstructCompaction(
 	d *DB, grantHandle CompactionGrantHandle,
-) *compaction {
+) compaction {
 	return newCompaction(
 		pc,
 		d.opts,

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1654,7 +1654,7 @@ func TestCompactionPickerScores(t *testing.T) {
 						d.mu.Lock()
 						wait := len(d.mu.compact.inProgress) > 0
 						for c := range d.mu.compact.inProgress {
-							wait = wait && !c.versionEditApplied
+							wait = wait && !c.VersionEditApplied()
 						}
 						d.mu.Unlock()
 						if !wait {

--- a/compaction_scheduler.go
+++ b/compaction_scheduler.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 )
 
@@ -147,17 +146,6 @@ func init() {
 		compactionOptionalAndPriority{optional: true, priority: 40}
 	scheduledCompactionMap[compactionKindRewrite] =
 		compactionOptionalAndPriority{optional: true, priority: 30}
-}
-
-func makeWaitingCompaction(manual bool, kind compactionKind, score float64) WaitingCompaction {
-	if manual {
-		return WaitingCompaction{Priority: manualCompactionPriority, Score: score}
-	}
-	entry, ok := scheduledCompactionMap[kind]
-	if !ok {
-		panic(errors.AssertionFailedf("unexpected compactionKind %s", kind))
-	}
-	return WaitingCompaction{Optional: entry.optional, Priority: entry.priority, Score: score}
 }
 
 // noopGrantHandle is used in cases that don't interact with a CompactionScheduler.

--- a/data_test.go
+++ b/data_test.go
@@ -948,7 +948,7 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 		if err != nil {
 			return err
 		}
-		c.getValueSeparation = func(JobID, *compaction, sstable.TableFormat) compact.ValueSeparation {
+		c.getValueSeparation = func(JobID, *tableCompaction, sstable.TableFormat) compact.ValueSeparation {
 			return valueSeparator
 		}
 		// NB: define allows the test to exactly specify which keys go
@@ -1018,12 +1018,12 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 	}
 
 	// Example, compact: a-c.
-	parseCompaction := func(outputLevel int, s string) (*compaction, error) {
+	parseCompaction := func(outputLevel int, s string) (*tableCompaction, error) {
 		m, err := parseMeta(s)
 		if err != nil {
 			return nil, err
 		}
-		c := &compaction{
+		c := &tableCompaction{
 			inputs: []compactionLevel{{}, {level: outputLevel}},
 			bounds: m.UserKeyBounds(),
 		}

--- a/download.go
+++ b/download.go
@@ -449,7 +449,7 @@ func (d *DB) tryLaunchDownloadForFile(
 	c := newCompaction(pc, d.opts, d.timeNow(), d.objProvider, noopGrantHandle{}, d.TableFormat(), d.determineCompactionValueSeparation)
 	c.isDownload = true
 	d.mu.compact.downloadingCount++
-	d.addInProgressCompaction(c)
+	c.AddInProgressLocked(d)
 	go d.compact(c, doneCh)
 	return doneCh, true
 }

--- a/open.go
+++ b/open.go
@@ -274,7 +274,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		d.mu.mem.nextSize = initialMemTableSize
 	}
 	d.mu.compact.cond.L = &d.mu.Mutex
-	d.mu.compact.inProgress = make(map[*compaction]struct{})
+	d.mu.compact.inProgress = make(map[compaction]struct{})
 	d.mu.compact.noOngoingFlushStartTime = crtime.NowMono()
 	d.mu.snapshots.init()
 	// logSeqNum is the next sequence number that will be assigned.

--- a/value_separation.go
+++ b/value_separation.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-var neverSeparateValues getValueSeparation = func(JobID, *compaction, sstable.TableFormat) compact.ValueSeparation {
+var neverSeparateValues getValueSeparation = func(JobID, *tableCompaction, sstable.TableFormat) compact.ValueSeparation {
 	return compact.NeverSeparateValues{}
 }
 
@@ -27,7 +27,7 @@ var neverSeparateValues getValueSeparation = func(JobID, *compaction, sstable.Ta
 // separate values into blob files. It returns a compact.ValueSeparation
 // implementation that should be used for the compaction.
 func (d *DB) determineCompactionValueSeparation(
-	jobID JobID, c *compaction, tableFormat sstable.TableFormat,
+	jobID JobID, c *tableCompaction, tableFormat sstable.TableFormat,
 ) compact.ValueSeparation {
 	if tableFormat < sstable.TableFormatPebblev7 || d.FormatMajorVersion() < FormatValueSeparation ||
 		d.opts.Experimental.ValueSeparationPolicy == nil {
@@ -75,7 +75,7 @@ func (d *DB) determineCompactionValueSeparation(
 // maximum blob reference depth to assign to output sstables (the actual value
 // may be lower iff the output table references fewer distinct blob files).
 func shouldWriteBlobFiles(
-	c *compaction, policy ValueSeparationPolicy,
+	c *tableCompaction, policy ValueSeparationPolicy,
 ) (writeBlobs bool, referenceDepth manifest.BlobReferenceDepth) {
 	// Flushes will have no existing references to blob files and should write
 	// their values to new blob files.


### PR DESCRIPTION
Introduce interfaces for compaction and pickedCompaction types in preparation for blob file rewrite compactions. These interfaces are gross at the moment. Future work will refactor the interfaces to more cleanly abstract over the different types of compactions.