### PR TITLE
pebble: prefer L0->Lbase move compactions when possible

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -206,7 +206,7 @@ func TestPickCompaction(t *testing.T) {
 				level:     0,
 				baseLevel: 1,
 			},
-			want: "100,110  ",
+			want: "100  ",
 		},
 
 		{
@@ -1082,15 +1082,32 @@ func TestCompaction(t *testing.T) {
 				return fmt.Sprintf("wrote %d keys\n", count)
 
 			case "auto-compact":
-				d.mu.Lock()
-				prev := d.opts.DisableAutomaticCompactions
-				d.opts.DisableAutomaticCompactions = false
-				d.maybeScheduleCompaction()
-				for d.mu.compact.compactingCount > 0 {
-					d.mu.compact.cond.Wait()
+				expectedCount := int64(1)
+				td.MaybeScanArgs(t, "count", &expectedCount)
+				err := func() error {
+					d.mu.Lock()
+					defer d.mu.Unlock()
+					prevCount := d.mu.versions.metrics.Compact.Count
+					prev := d.opts.DisableAutomaticCompactions
+					d.opts.DisableAutomaticCompactions = false
+					err := try(100*time.Microsecond, 60*time.Second, func() error {
+						d.maybeScheduleCompaction()
+						for d.mu.compact.compactingCount > 0 {
+							d.mu.compact.cond.Wait()
+						}
+						compactions := d.mu.versions.metrics.Compact.Count - prevCount
+						if compactions < expectedCount {
+							return errors.Errorf("expectedCount at least %d automatic compaction(s), got %d, total: %d",
+								expectedCount, compactions, d.mu.versions.metrics.Compact.Count)
+						}
+						return nil
+					})
+					d.opts.DisableAutomaticCompactions = prev
+					return err
+				}()
+				if err != nil {
+					return err.Error() + "\n" + describeLSM(d, verbose)
 				}
-				d.opts.DisableAutomaticCompactions = prev
-				d.mu.Unlock()
 				return describeLSM(d, verbose)
 
 			case "set-disable-auto-compact":
@@ -1201,13 +1218,13 @@ func TestCompaction(t *testing.T) {
 					d.mu.Lock()
 					defer d.mu.Unlock()
 					if len(d.mu.compact.manual) != numBlocked {
-						return errors.Errorf("expected %d waiting manual compactions, versus actual %d",
+						return errors.Errorf("expectedCount %d waiting manual compactions, versus actual %d",
 							numBlocked, len(d.mu.compact.manual))
 					}
 					// Expect to be back to the fake ongoing compactions when the
 					// non-blocked manual compactions are done.
 					if d.mu.compact.compactingCount != 1 {
-						return errors.Errorf("expected 1 ongoing compaction, versus actual %d",
+						return errors.Errorf("expectedCount 1 ongoing compaction, versus actual %d",
 							d.mu.compact.compactingCount)
 					}
 					return nil
@@ -1365,6 +1382,10 @@ func TestCompaction(t *testing.T) {
 		"compaction_cancellation": {
 			// Run at a specific version, so that a single sstable format is used,
 			// since the test prints the compaction log which includes file sizes.
+			minVersion: formatDeprecatedExperimentalValueSeparation,
+			maxVersion: formatDeprecatedExperimentalValueSeparation,
+		},
+		"l0_to_lbase_compaction": {
 			minVersion: formatDeprecatedExperimentalValueSeparation,
 			maxVersion: formatDeprecatedExperimentalValueSeparation,
 		},

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -446,20 +446,21 @@ func TestRangeDelCompactionTruncation2(t *testing.T) {
 	defer snap2.Close()
 	require.NoError(t, d.DeleteRange([]byte("a"), []byte("d"), nil))
 
-	// Compact to produce the L1 tables.
 	require.NoError(t, d.Compact(context.Background(), []byte("b"), []byte("b\x00"), false))
 	expectLSM(`
+L0.0:
+  000007:[a#12,RANGEDEL-b#inf,RANGEDEL]
 L6:
-  000009:[a#12,RANGEDEL-d#inf,RANGEDEL]
-`)
+  000009:[b#12,RANGEDEL-d#inf,RANGEDEL]`)
 
 	require.NoError(t, d.Set([]byte("c"), bytes.Repeat([]byte("d"), 100), nil))
 	require.NoError(t, d.Compact(context.Background(), []byte("c"), []byte("c\x00"), false))
 	expectLSM(`
+L0.0:
+  000007:[a#12,RANGEDEL-b#inf,RANGEDEL]
 L6:
-  000012:[a#12,RANGEDEL-c#inf,RANGEDEL]
-  000013:[c#13,SET-d#inf,RANGEDEL]
-`)
+  000012:[b#12,RANGEDEL-c#inf,RANGEDEL]
+  000013:[c#13,SET-d#inf,RANGEDEL]`)
 }
 
 // TODO(peter): rewrite this test, TestRangeDelCompactionTruncation, and
@@ -523,28 +524,31 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 		require.NoError(t, d.Compact(context.Background(), []byte("b"), []byte("b\x00"), false))
 	}
 	expectLSM(`
+L0.0:
+  000007:[a#12,RANGEDEL-b#inf,RANGEDEL]
 L3:
-  000009:[a#12,RANGEDEL-d#inf,RANGEDEL]
-`)
+  000009:[b#12,RANGEDEL-d#inf,RANGEDEL]`)
 
 	require.NoError(t, d.Set([]byte("c"), bytes.Repeat([]byte("d"), 100), nil))
 
 	require.NoError(t, d.Compact(context.Background(), []byte("c"), []byte("c\x00"), false))
 	expectLSM(`
+L0.0:
+  000007:[a#12,RANGEDEL-b#inf,RANGEDEL]
 L3:
-  000013:[a#12,RANGEDEL-b#inf,RANGEDEL]
-  000014:[b#12,RANGEDEL-c#inf,RANGEDEL]
+  000013:[b#12,RANGEDEL-c#inf,RANGEDEL]
 L4:
-  000015:[c#13,SET-d#inf,RANGEDEL]
+  000014:[c#13,SET-d#inf,RANGEDEL]
 `)
 
 	require.NoError(t, d.Compact(context.Background(), []byte("c"), []byte("c\x00"), false))
 	expectLSM(`
+L0.0:
+  000007:[a#12,RANGEDEL-b#inf,RANGEDEL]
 L3:
-  000013:[a#12,RANGEDEL-b#inf,RANGEDEL]
-  000014:[b#12,RANGEDEL-c#inf,RANGEDEL]
+  000013:[b#12,RANGEDEL-c#inf,RANGEDEL]
 L5:
-  000015:[c#13,SET-d#inf,RANGEDEL]
+  000014:[c#13,SET-d#inf,RANGEDEL]
 `)
 
 	if _, _, err := d.Get([]byte("b")); err != ErrNotFound {
@@ -553,12 +557,12 @@ L5:
 
 	require.NoError(t, d.Compact(context.Background(), []byte("a"), []byte("a\x00"), false))
 	expectLSM(`
+L1:
+  000007:[a#12,RANGEDEL-b#inf,RANGEDEL]
 L3:
-  000014:[b#12,RANGEDEL-c#inf,RANGEDEL]
-L4:
-  000013:[a#12,RANGEDEL-b#inf,RANGEDEL]
+  000013:[b#12,RANGEDEL-c#inf,RANGEDEL]
 L5:
-  000015:[c#13,SET-d#inf,RANGEDEL]
+  000014:[c#13,SET-d#inf,RANGEDEL]
 `)
 
 	if v, _, err := d.Get([]byte("b")); err != ErrNotFound {

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -1,0 +1,89 @@
+# Generate sstables with sequential, non-overlapping keys. When we trigger a compaction
+# from L0 to Lbase, we expect all the compactions to be moves, since there are no
+# overlapping keys being written.
+define l0-compaction-threshold=1 auto-compactions=off
+----
+
+
+populate keylen=4 timestamps=(1) vallen=64
+----
+wrote 475254 keys
+
+
+flush
+----
+L0.0:
+  000005:[a@1#10,SET-boao@1#28148,SET]
+  000006:[boap@1#28149,SET-dcbc@1#56285,SET]
+  000007:[dcbd@1#56286,SET-eqbu@1#84424,SET]
+  000008:[eqbv@1#84425,SET-gecj@1#112562,SET]
+  000009:[geck@1#112563,SET-hsda@1#140701,SET]
+  000010:[hsdb@1#140702,SET-jgdq@1#168839,SET]
+  000011:[jgdr@1#168840,SET-kueg@1#196977,SET]
+  000012:[kueh@1#196978,SET-miev@1#225114,SET]
+  000013:[miew@1#225115,SET-nwfl@1#253252,SET]
+  000014:[nwfm@1#253253,SET-pkga@1#281390,SET]
+  000015:[pkgb@1#281391,SET-qygs@1#309529,SET]
+  000016:[qygt@1#309530,SET-smhh@1#337667,SET]
+  000017:[smhi@1#337668,SET-uahw@1#365804,SET]
+  000018:[uahx@1#365805,SET-voim@1#393942,SET]
+  000019:[voin@1#393943,SET-xcjb@1#422080,SET]
+  000020:[xcjc@1#422081,SET-yqjt@1#450219,SET]
+  000021:[yqju@1#450220,SET-zzzz@1#475263,SET]
+
+
+auto-compact count=17
+----
+L6:
+  000005:[a@1#10,SET-boao@1#28148,SET]
+  000006:[boap@1#28149,SET-dcbc@1#56285,SET]
+  000007:[dcbd@1#56286,SET-eqbu@1#84424,SET]
+  000008:[eqbv@1#84425,SET-gecj@1#112562,SET]
+  000009:[geck@1#112563,SET-hsda@1#140701,SET]
+  000010:[hsdb@1#140702,SET-jgdq@1#168839,SET]
+  000011:[jgdr@1#168840,SET-kueg@1#196977,SET]
+  000012:[kueh@1#196978,SET-miev@1#225114,SET]
+  000013:[miew@1#225115,SET-nwfl@1#253252,SET]
+  000014:[nwfm@1#253253,SET-pkga@1#281390,SET]
+  000015:[pkgb@1#281391,SET-qygs@1#309529,SET]
+  000016:[qygt@1#309530,SET-smhh@1#337667,SET]
+  000017:[smhi@1#337668,SET-uahw@1#365804,SET]
+  000018:[uahx@1#365805,SET-voim@1#393942,SET]
+  000019:[voin@1#393943,SET-xcjb@1#422080,SET]
+  000020:[xcjc@1#422081,SET-yqjt@1#450219,SET]
+  000021:[yqju@1#450220,SET-zzzz@1#475263,SET]
+
+
+metrics
+----
+      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
+------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
+    0 |     0     0B     0B       0 |    -    0    0 |  33MB |     0     0B |     0     0B |    17   34MB |    0B |   0 1.02
+    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
+    6 |    17   34MB     0B       0 |    - 0.53 0.53 |    0B |     0     0B |    17   34MB |     0     0B |    0B |   1    0
+total |    17   34MB     0B       0 |    -    -    - |  33MB |     0     0B |    17   34MB |    17   67MB |    0B |   1 2.02
+----------------------------------------------------------------------------------------------------------------------------
+WAL: 1 files (0B)  in: 33MB  written: 33MB (0% overhead)
+Flushes: 2
+Compactions: 17  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
+             default: 0  delete: 0  elision: 0  move: 17  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
+MemTables: 1 (512KB)  zombie: 1 (512KB)
+Zombie tables: 0 (0B, local: 0B)
+Backing tables: 0 (0B)
+Virtual tables: 0 (0B)
+Local tables size: 34MB
+Compression types: snappy: 17
+Table stats: all loaded
+Block cache: 3.3K entries (7.0MB)  hit rate: 0.1%
+File cache: 17 tables, 0 blobfiles (4.6KB)  hit rate: 97.4%
+Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
+Snapshots: 0  earliest seq num: 0
+Table iters: 0
+Filter utility: 0.0%
+Ingestions: 0  as flushable: 0 (0B in 0 tables)
+Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B

--- a/testdata/compaction/score_compaction_picked_before_manual
+++ b/testdata/compaction/score_compaction_picked_before_manual
@@ -18,7 +18,7 @@ compaction-log
 [JOB 1] compacted(move) L5 [000004] (797B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (797B), in 1.0s (1.0s total), output rate 797B/s
 
 # Do an auto score-based compaction with the same LSM as the previous test.
-define disable-multi-level lbase-max-bytes=1
+define disable-multi-level lbase-max-bytes=1 auto-compactions=off
 L5
   a.SET.2:v c.SET.4:v
 ----

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -302,7 +302,7 @@ Blob files:
 # garbage ratio of 0.0 (no garbage). With this configuration, any blob file that
 # contains any unreferenced values should be immediately compacted.
 
-define value-separation=(true,1,2,0s,0.0)
+define value-separation=(true,1,2,0s,0.0) auto-compactions=off
 ----
 
 batch
@@ -450,12 +450,13 @@ Blob files:
   B000040 physical:{000040 size:[1707508 (1.6MB)] vals:[1645056 (1.6MB)]}
   B000042 physical:{000042 size:[886008 (865KB)] vals:[853568 (834KB)]}
 
-# Schedule automatic compactions. These compactions should write data to L6. The
-# resulting sstables will reference multiple blob files but maintain a blob
-# reference depth of 1 because L6 has no referenced blob files and all the L0
+# Manual compaction of key range so we merge files instead of moving.
+# This compaction should write data to L6. The resulting sstables will
+# reference multiple blob files but maintain a blob reference depth of 1
+# because L6 has no referenced blob files and all the L0
 # input tables have a reference depth of 1.
 
-auto-compact
+compact a-zzzz
 ----
 L6:
   000044:[a@1#0,SET-czms@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-czms@1#0,SET] size:715291 blobrefs:[(B000006: 1642240), (B000008: 1642432), (B000010: 201984); depth:1]


### PR DESCRIPTION
The existing compaction grow logic attempts to add additional start level files
by expanding the output level's initial key range, which is based off of
overlapping files with L0. Previously, we would always try to expand the
compaction range even when the output key range was empty, causing the L0 files
in those empty output ranges to be rewritten instead of being moved.

This commit makes it such that we only expand the compaction output range and
inputs when there is at least one overlapping file in lbase, preferring move
compactions when possible. This behaviour mirrors the grow logic for
LPositive-LPositive compactions.

Fixes: #https://github.com/cockroachdb/pebble/issues/4872