### PR TITLE
db: remove redundant blob files in datadriven output

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1640,13 +1640,6 @@ func describeLSM(d *DB, verbose bool) string {
 	} else {
 		buf.WriteString(d.mu.versions.currentVersion().String())
 	}
-	if blobFileMetas := d.mu.versions.latest.blobFiles.Metadatas(); len(blobFileMetas) > 0 {
-		buf.WriteString("Blob files:\n")
-		for _, meta := range blobFileMetas {
-			fmt.Fprintf(&buf, "  %s: [%s] %d physical bytes, %d value bytes\n",
-				meta.FileID, meta.Physical.FileNum, meta.Physical.Size, meta.Physical.ValueSize)
-		}
-	}
 	return buf.String()
 }
 

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -15,8 +15,6 @@ L6:
   000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:821 blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
-Blob files:
-  B000006: [000006] 92 physical bytes, 2 value bytes
 
 batch
 set c 3
@@ -31,9 +29,6 @@ L6:
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
   B000009 physical:{000009 size:[92 (92B)] vals:[2 (2B)]}
-Blob files:
-  B000006: [000006] 92 physical bytes, 2 value bytes
-  B000009: [000009] 92 physical bytes, 2 value bytes
 
 batch
 set b 5
@@ -48,10 +43,6 @@ Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
   B000009 physical:{000009 size:[92 (92B)] vals:[2 (2B)]}
   B000012 physical:{000012 size:[92 (92B)] vals:[2 (2B)]}
-Blob files:
-  B000006: [000006] 92 physical bytes, 2 value bytes
-  B000009: [000009] 92 physical bytes, 2 value bytes
-  B000012: [000012] 92 physical bytes, 2 value bytes
 
 batch
 del-range a e
@@ -97,11 +88,6 @@ Blob files:
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
   B100003 physical:{100003 size:[92 (92B)] vals:[3 (3B)]}
   B100004 physical:{100004 size:[92 (92B)] vals:[3 (3B)]}
-Blob files:
-  B000007: [000007] 100 physical bytes, 10 value bytes
-  B100002: [100002] 92 physical bytes, 3 value bytes
-  B100003: [100003] 92 physical bytes, 3 value bytes
-  B100004: [100004] 92 physical bytes, 3 value bytes
 
 # Compacting these two sstables should result in writing the values to a new
 # blob file and the removal of the no longer referenced blob files.
@@ -112,8 +98,6 @@ L6:
   000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:870 blobrefs:[(B000009: 19); depth:1]
 Blob files:
   B000009 physical:{000009 size:[112 (112B)] vals:[19 (19B)]}
-Blob files:
-  B000009: [000009] 112 physical bytes, 19 value bytes
 
 # Ensure we can read the separated values by iterating over the database.
 
@@ -206,8 +190,6 @@ L0.0:
   000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:772
 Blob files:
   B000008 physical:{000008 size:[100 (100B)] vals:[10 (10B)]}
-Blob files:
-  B000008: [000008] 100 physical bytes, 10 value bytes
 
 get
 a
@@ -244,8 +226,6 @@ L0.0:
   000006:[m#14,SET-m#14,SET] seqnums:[14-14] points:[m#14,SET-m#14,SET] size:817 blobrefs:[(B000007: 5); depth:1]
 Blob files:
   B000007 physical:{000007 size:[94 (94B)] vals:[5 (5B)]}
-Blob files:
-  B000007: [000007] 94 physical bytes, 5 value bytes
 
 # Construct an initial state with two overlapping files in L0, both with blob
 # references. Because these files overlap and are in separate sublevels, a
@@ -281,11 +261,6 @@ Blob files:
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
   B100003 physical:{100003 size:[92 (92B)] vals:[3 (3B)]}
   B100004 physical:{100004 size:[92 (92B)] vals:[3 (3B)]}
-Blob files:
-  B100001: [100001] 90 physical bytes, 1 value bytes
-  B100002: [100002] 92 physical bytes, 3 value bytes
-  B100003: [100003] 92 physical bytes, 3 value bytes
-  B100004: [100004] 92 physical bytes, 3 value bytes
 
 # Construct an initial state with two non-overlapping files in L0, both with
 # blob references. Because these files do NOT overlap and are in the same
@@ -321,11 +296,6 @@ Blob files:
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
   B100003 physical:{100003 size:[92 (92B)] vals:[3 (3B)]}
   B100004 physical:{100004 size:[92 (92B)] vals:[3 (3B)]}
-Blob files:
-  B100001: [100001] 90 physical bytes, 1 value bytes
-  B100002: [100002] 92 physical bytes, 3 value bytes
-  B100003: [100003] 92 physical bytes, 3 value bytes
-  B100004: [100004] 92 physical bytes, 3 value bytes
 
 define value-separation=(true,5,5) l0-compaction-threshold=1
 ----
@@ -383,26 +353,6 @@ Blob files:
   B000038 physical:{000038 size:[1706254 (1.6MB)] vals:[1643840 (1.6MB)]}
   B000040 physical:{000040 size:[1707508 (1.6MB)] vals:[1645056 (1.6MB)]}
   B000042 physical:{000042 size:[886008 (865KB)] vals:[853568 (834KB)]}
-Blob files:
-  B000006: [000006] 1704578 physical bytes, 1642240 value bytes
-  B000008: [000008] 1704776 physical bytes, 1642432 value bytes
-  B000010: [000010] 1705238 physical bytes, 1642880 value bytes
-  B000012: [000012] 1704776 physical bytes, 1642432 value bytes
-  B000014: [000014] 1702730 physical bytes, 1640448 value bytes
-  B000016: [000016] 1704644 physical bytes, 1642304 value bytes
-  B000018: [000018] 1707970 physical bytes, 1645504 value bytes
-  B000020: [000020] 1702994 physical bytes, 1640704 value bytes
-  B000022: [000022] 1705172 physical bytes, 1642816 value bytes
-  B000024: [000024] 1703918 physical bytes, 1641600 value bytes
-  B000026: [000026] 1703390 physical bytes, 1641088 value bytes
-  B000028: [000028] 1704182 physical bytes, 1641856 value bytes
-  B000030: [000030] 1702796 physical bytes, 1640512 value bytes
-  B000032: [000032] 1703720 physical bytes, 1641408 value bytes
-  B000034: [000034] 1706584 physical bytes, 1644160 value bytes
-  B000036: [000036] 1703720 physical bytes, 1641408 value bytes
-  B000038: [000038] 1706254 physical bytes, 1643840 value bytes
-  B000040: [000040] 1707508 physical bytes, 1645056 value bytes
-  B000042: [000042] 886008 physical bytes, 853568 value bytes
 
 # Schedule automatic compactions. These compactions should write data to L6. The
 # resulting sstables will reference multiple blob files but maintain a blob
@@ -441,26 +391,6 @@ Blob files:
   B000038 physical:{000038 size:[1706254 (1.6MB)] vals:[1643840 (1.6MB)]}
   B000040 physical:{000040 size:[1707508 (1.6MB)] vals:[1645056 (1.6MB)]}
   B000042 physical:{000042 size:[886008 (865KB)] vals:[853568 (834KB)]}
-Blob files:
-  B000006: [000006] 1704578 physical bytes, 1642240 value bytes
-  B000008: [000008] 1704776 physical bytes, 1642432 value bytes
-  B000010: [000010] 1705238 physical bytes, 1642880 value bytes
-  B000012: [000012] 1704776 physical bytes, 1642432 value bytes
-  B000014: [000014] 1702730 physical bytes, 1640448 value bytes
-  B000016: [000016] 1704644 physical bytes, 1642304 value bytes
-  B000018: [000018] 1707970 physical bytes, 1645504 value bytes
-  B000020: [000020] 1702994 physical bytes, 1640704 value bytes
-  B000022: [000022] 1705172 physical bytes, 1642816 value bytes
-  B000024: [000024] 1703918 physical bytes, 1641600 value bytes
-  B000026: [000026] 1703390 physical bytes, 1641088 value bytes
-  B000028: [000028] 1704182 physical bytes, 1641856 value bytes
-  B000030: [000030] 1702796 physical bytes, 1640512 value bytes
-  B000032: [000032] 1703720 physical bytes, 1641408 value bytes
-  B000034: [000034] 1706584 physical bytes, 1644160 value bytes
-  B000036: [000036] 1703720 physical bytes, 1641408 value bytes
-  B000038: [000038] 1706254 physical bytes, 1643840 value bytes
-  B000040: [000040] 1707508 physical bytes, 1645056 value bytes
-  B000042: [000042] 886008 physical bytes, 853568 value bytes
 
 
 excise-dryrun b c

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -17,8 +17,6 @@ L6:
   000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:927 blobrefs:[(B000921: 6); depth:1]
 Blob files:
   B000921 physical:{000921 size:[106 (106B)] vals:[16 (16B)]}
-Blob files:
-  B000921: [000921] 106 physical bytes, 16 value bytes
 
 combined-iter
 first
@@ -80,9 +78,6 @@ L6:
 Blob files:
   B000039 physical:{000039 size:[117 (117B)] vals:[25 (25B)]}
   B000921 physical:{000921 size:[125 (125B)] vals:[33 (33B)]}
-Blob files:
-  B000039: [000039] 117 physical bytes, 25 value bytes
-  B000921: [000921] 125 physical bytes, 33 value bytes
 
 # The iterator stats should indicate that only the first value from each file
 # should trigger a read of the blob file. Once loaded, subsequent reads of the
@@ -145,8 +140,6 @@ L6:
   000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:1031 blobrefs:[(B000009: 96); depth:1]
 Blob files:
   B000009 physical:{000009 size:[322 (322B)] vals:[96 (96B)]}
-Blob files:
-  B000009: [000009] 322 physical bytes, 96 value bytes
 
 combined-iter
 first
@@ -220,8 +213,6 @@ L6:
   000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:1080 blobrefs:[(B000009: 7); depth:1]
 Blob files:
   B000009 physical:{000009 size:[96 (96B)] vals:[7 (7B)]}
-Blob files:
-  B000009: [000009] 96 physical bytes, 7 value bytes
 
 combined-iter
 seek-lt c


### PR DESCRIPTION
Now that the Version.DebugString prints a Version's blob files, the datadriven test helpers don't need to explicitly print it too.