### PR TITLE
test: introduce single level iterator lazy load benchmark test

### DIFF
--- a/sstable/single_lvl_iter_benchmark_test.go
+++ b/sstable/single_lvl_iter_benchmark_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+var (
+	benchReader   *Reader
+	benchIterOpts IterOptions
+)
+
+func init() {
+	mem := vfs.NewMem()
+	f, err := mem.Create("bench.sst", vfs.WriteCategoryUnspecified)
+	if err != nil {
+		panic(err)
+	}
+
+	w := NewWriter(objstorageprovider.NewFileWritable(f), WriterOptions{
+		BlockSize:      4096,
+		IndexBlockSize: 4096,
+		FilterPolicy:   bloom.FilterPolicy(10),
+		TableFormat:    TableFormatPebblev3,
+		Comparer:       base.DefaultComparer,
+		MergerName:     base.DefaultMerger.Name,
+	})
+
+	const numKeys = 10000
+	for i := range numKeys {
+		key := fmt.Appendf(nil, "key%08d", i)
+		value := fmt.Sprintf("value%d", i)
+		if err := w.Set(key, []byte(value)); err != nil {
+			panic(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+
+	f2, err := mem.Open("bench.sst")
+	if err != nil {
+		panic(err)
+	}
+
+	benchReader, err = newReader(f2, ReaderOptions{
+		Comparer: base.DefaultComparer,
+		Merger:   base.DefaultMerger,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+
+	benchIterOpts = IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: NeverUseFilterBlock,
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(benchReader),
+	}
+}
+
+// BenchmarkIteratorConstruction measures pure iterator construction performance
+// How to: go test -bench=BenchmarkIteratorConstruction -run=^$ ./sstable
+func BenchmarkIteratorConstruction(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), benchReader, benchIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		iter.Close()
+	}
+}
+
+// BenchmarkIteratorFirst measures first-access First() call performance
+// How to: go test -bench=BenchmarkIteratorFirst -run=^$ ./sstable
+func BenchmarkIteratorFirst(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), benchReader, benchIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		_ = iter.First() // Only this is timed
+		b.StopTimer()
+		iter.Close()
+	}
+}
+
+// BenchmarkIteratorSeekGE measures first-access SeekGE() call performance
+// How to: go test -bench=BenchmarkIteratorSeekGE -run=^$ ./sstable
+func BenchmarkIteratorSeekGE(b *testing.B) {
+	key := []byte("key00005000") // Middle key
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), benchReader, benchIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		_ = iter.SeekGE(key, base.SeekGEFlagsNone) // Only this is timed
+		b.StopTimer()
+		iter.Close()
+	}
+}
+
+// BenchmarkIteratorSeekPrefixGE_Hit measures first-access SeekPrefixGE() call performance with existing prefix
+// How to: go test -bench=BenchmarkIteratorSeekPrefixGE_Hit -run=^$ ./sstable
+func BenchmarkIteratorSeekPrefixGE_Hit(b *testing.B) {
+	// Setup iterator options with bloom filter enabled
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+	defer bufferPool.Release()
+
+	iterOpts := IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: AlwaysUseFilterBlock, // Enable bloom filter
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(benchReader),
+	}
+
+	// Use existing prefix that will be found
+	prefix := []byte("key00005000")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), benchReader, iterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		_ = iter.SeekPrefixGE(prefix, prefix, base.SeekGEFlagsNone) // Only this is timed
+		b.StopTimer()
+		iter.Close()
+	}
+}
+
+// BenchmarkIteratorSeekPrefixGE_NoHit measures first-access SeekPrefixGE() call performance with non-existing prefix
+// How to: go test -bench=BenchmarkIteratorSeekPrefixGE_NoHit -run=^$ ./sstable
+func BenchmarkIteratorSeekPrefixGE_NoHit(b *testing.B) {
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+	defer bufferPool.Release()
+
+	iterOpts := IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: AlwaysUseFilterBlock, // Enable bloom filter
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(benchReader),
+	}
+
+	// Use non-existing prefix that will be rejected by bloom filter
+	prefix := []byte("notfound")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), benchReader, iterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		_ = iter.SeekPrefixGE(prefix, prefix, base.SeekGEFlagsNone) // Only this is timed
+		b.StopTimer()
+		iter.Close()
+	}
+}


### PR DESCRIPTION
Here is the benchmark between eager load and lazy load behavior of the single level iterator. The tests just run against the iterator, in order to get the metrics, you will need to run before and after the commit #4916 

Ideally I expect to see the difference between construction time (or the index block load overhead, or 444 ns here) is similar to other differences. However, it seems they are higher. I believe the main reason is the Timer overhead introduced given the way the code is written+other noise. Given the difference is small (~200 ns at most), I'd argue it's good enough.

I'm only interested in the first-time access of these functions, which will trigger index block loading when the lazy load logic is applied. Therefore I cannot organize the test in form of

```
b.StartTimer()
for i := 0; i < b.N; i++ {
    doSomething()
}
b.StopTimer()
```
But have to do it like below
```
for i := 0; i < b.N; i++ {
    prepare()
    b.StartTimer()
    doWork()
    b.StopTimer()
}
```

| Operation | Lazy Loading | Eager Loading | Performance |
| ---------- | -------------- | ------------- | ------------- |
| Constructor Only | 55 ns/op | 499 ns/op  | -444 ns |
| First Access (First()) | 2000 ns/op | 1451 ns/op |  +549 ns |
| First Access (SeekGE()) | 2240 ns/op | 1617 ns/op | +623 ns |
| SeekPrefixGE() hit | 2254 ns/op | 1623 ns/op | +631 ns |
| SeekPrefixGE() no hit | 771 ns/op | 120 ns/op | +651 ns |

Related to #3248 and #4916