### PR TITLE
db: TestCompaction: fix async-compact usage

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1113,18 +1113,12 @@ func TestCompaction(t *testing.T) {
 					close(ch)
 				}()
 
-				manualDone := func() bool {
+				// Wait until the manual compaction is queued.
+				err := try(100*time.Microsecond, 20*time.Second, func() error {
 					select {
 					case <-ch:
-						return true
+						td.Fatalf(t, "manual compaction did not block for ongoing\n%s", s)
 					default:
-						return false
-					}
-				}
-
-				err := try(100*time.Microsecond, 20*time.Second, func() error {
-					if manualDone() {
-						return nil
 					}
 
 					d.mu.Lock()
@@ -1138,8 +1132,11 @@ func TestCompaction(t *testing.T) {
 					return err.Error()
 				}
 
-				if manualDone() {
-					return "manual compaction did not block for ongoing\n" + s
+				// Make sure the manual compaction doesn't complete.
+				select {
+				case <-ch:
+					td.Fatalf(t, "manual compaction did not block for ongoing\n%s", s)
+				case <-time.After(10 * time.Millisecond):
 				}
 
 				d.mu.Lock()
@@ -1216,7 +1213,7 @@ func TestCompaction(t *testing.T) {
 					return err.Error()
 				}
 				if compDone {
-					return "manual compaction did not block for ongoing\n" + s
+					td.Fatalf(t, "manual compaction did not block for ongoing\n%s", s)
 				}
 				// Cancel the manual compaction.
 				(*cancelFunc.Load())()

--- a/testdata/compaction/set_with_del_sstable_Pebblev4
+++ b/testdata/compaction/set_with_del_sstable_Pebblev4
@@ -646,9 +646,8 @@ add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 set-concurrent-compactions max=2
 ----
 
-async-compact a-b L3
+compact a-b L3
 ----
-manual compaction did not block for ongoing
 L4:
   000012:[a#0,SET-a#0,SET]
   000013:[b#0,SET-b#0,SET]

--- a/testdata/compaction/set_with_del_sstable_Pebblev5
+++ b/testdata/compaction/set_with_del_sstable_Pebblev5
@@ -648,9 +648,8 @@ add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 set-concurrent-compactions max=2
 ----
 
-async-compact a-b L3
+compact a-b L3
 ----
-manual compaction did not block for ongoing
 L4:
   000012:[a#0,SET-a#0,SET]
   000013:[b#0,SET-b#0,SET]

--- a/testdata/compaction/set_with_del_sstable_Pebblev6
+++ b/testdata/compaction/set_with_del_sstable_Pebblev6
@@ -648,9 +648,8 @@ add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 set-concurrent-compactions max=2
 ----
 
-async-compact a-b L3
+compact a-b L3
 ----
-manual compaction did not block for ongoing
 L4:
   000012:[a#0,SET-a#0,SET]
   000013:[b#0,SET-b#0,SET]

--- a/testdata/compaction/set_with_del_sstable_Pebblev7
+++ b/testdata/compaction/set_with_del_sstable_Pebblev7
@@ -648,9 +648,8 @@ add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 set-concurrent-compactions max=2
 ----
 
-async-compact a-b L3
+compact a-b L3
 ----
-manual compaction did not block for ongoing
 L4:
   000012:[a#0,SET-a#0,SET]
   000013:[b#0,SET-b#0,SET]


### PR DESCRIPTION
The `async-compact` directive is supposed to be used when the
compaction is expected to block. It is currently also used when the
compaction does not block; in this mode it is flaky because it checks
if the compaction is done immediately after seeing it go into the
queue.  There's a chance the compaction is not blocked but takes a
little bit to complete.

We change this case to a `Fatalf` and switch to using `compact` for
the cases where it's not supposed to block.

Fixes #4939