### PR TITLE
metamorphic: disable blob file rewriting for now

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -88,6 +88,8 @@ func newPebbleDB(dir string) DB {
 			MinimumSize:           512,
 			MaxBlobReferenceDepth: 10,
 			RewriteMinimumAge:     5 * time.Minute,
+			// TODO(jackson): Adjust the TargetGarbageRatio to allow blob file rewrites.
+			TargetGarbageRatio: 1.0, // Disabled.
 		}
 	}
 

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -344,6 +344,8 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 			MinimumSize:           5,
 			MaxBlobReferenceDepth: 3,
 			RewriteMinimumAge:     time.Second,
+			// TODO(jackson): Adjust the TargetGarbageRatio to allow blob file rewrites.
+			TargetGarbageRatio: 1.0, // Disabled
 		}
 	}
 


### PR DESCRIPTION
Disable blob file rewriting compactions for now in the standard options.

Close #4955.