### PR TITLE
compression: fix zstd Compression to return Setting

### DIFF
--- a/internal/compression/zstd_nocgo.go
+++ b/internal/compression/zstd_nocgo.go
@@ -34,7 +34,7 @@ func getZstdCompressor(level int) *zstdCompressor {
 // relies on CGo.
 const UseStandardZstdLib = false
 
-func (z *zstdCompressor) Compress(compressedBuf, b []byte) []byte {
+func (z *zstdCompressor) Compress(compressedBuf, b []byte) ([]byte, Setting) {
 	if len(compressedBuf) < binary.MaxVarintLen64 {
 		compressedBuf = append(compressedBuf, make([]byte, binary.MaxVarintLen64-len(compressedBuf))...)
 	}


### PR DESCRIPTION
One of the commits in https://github.com/cockroachdb/pebble/pull/4937 accidentally reverted the change to return Setting from Compress.