### PR TITLE
options: use adaptive compression in new DBCompressionSettings

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -589,7 +589,7 @@ func TestApplyDBCompressionSettings(t *testing.T) {
 		return profile
 	})
 
-	profile = UniformDBCompressionSettings("Test", block.FastestCompression)
+	profile = UniformDBCompressionSettings(block.FastestCompression)
 	profile.Levels[1] = block.FastestCompression
 	profile.Levels[2] = block.BalancedCompression
 	profile.Levels[3] = block.GoodCompression
@@ -597,7 +597,7 @@ func TestApplyDBCompressionSettings(t *testing.T) {
 	require.Equal(t, block.BalancedCompression, o.Levels[2].Compression())
 	require.Equal(t, block.GoodCompression, o.Levels[3].Compression())
 
-	profile = UniformDBCompressionSettings("Test2", block.FastestCompression)
+	profile = UniformDBCompressionSettings(block.FastestCompression)
 	require.Equal(t, block.FastestCompression, o.Levels[1].Compression())
 	require.Equal(t, block.FastestCompression, o.Levels[2].Compression())
 	require.Equal(t, block.FastestCompression, o.Levels[3].Compression())

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -69,55 +69,30 @@ var (
 	FastestCompression = simpleCompressionProfile("Fastest", fastestCompression)
 
 	FastCompression = registerCompressionProfile(CompressionProfile{
-		Name:                "Fast",
-		DataBlocks:          fastestCompression,
-		ValueBlocks:         compression.ZstdLevel1,
-		OtherBlocks:         fastestCompression,
-		MinReductionPercent: 10,
+		Name:                           "Fast",
+		DataBlocks:                     fastestCompression,
+		ValueBlocks:                    compression.ZstdLevel1,
+		OtherBlocks:                    fastestCompression,
+		MinReductionPercent:            10,
+		AdaptiveReductionCutoffPercent: 30,
 	})
 
 	BalancedCompression = registerCompressionProfile(CompressionProfile{
 		Name:                           "Balanced",
 		DataBlocks:                     compression.ZstdLevel1,
-		ValueBlocks:                    compression.ZstdLevel3,
+		ValueBlocks:                    compression.ZstdLevel1,
 		OtherBlocks:                    fastestCompression,
-		AdaptiveReductionCutoffPercent: 30,
 		MinReductionPercent:            5,
+		AdaptiveReductionCutoffPercent: 20,
 	})
 
 	GoodCompression = registerCompressionProfile(CompressionProfile{
-		Name:                "Good",
-		DataBlocks:          compression.ZstdLevel3,
-		ValueBlocks:         compression.ZstdLevel3,
-		OtherBlocks:         fastestCompression,
-		MinReductionPercent: 5,
-	})
-
-	// Adaptive compression profiles are experimental.
-
-	FastAdaptiveCompression = registerCompressionProfile(CompressionProfile{
-		Name:                           "Fast adaptive",
-		DataBlocks:                     fastestCompression,
-		ValueBlocks:                    compression.ZstdLevel1,
+		Name:                           "Good",
+		DataBlocks:                     compression.ZstdLevel3,
+		ValueBlocks:                    compression.ZstdLevel3,
 		OtherBlocks:                    fastestCompression,
-		AdaptiveReductionCutoffPercent: 30,
-		MinReductionPercent:            10,
-	})
-
-	BalancedAdaptiveCompression = registerCompressionProfile(CompressionProfile{
-		Name:                "Balanced adaptive",
-		DataBlocks:          compression.ZstdLevel1,
-		ValueBlocks:         compression.ZstdLevel3,
-		OtherBlocks:         fastestCompression,
-		MinReductionPercent: 5,
-	})
-
-	GoodAdaptiveCompression = registerCompressionProfile(CompressionProfile{
-		Name:                "Good adaptive",
-		DataBlocks:          compression.ZstdLevel3,
-		ValueBlocks:         compression.ZstdLevel3,
-		OtherBlocks:         fastestCompression,
-		MinReductionPercent: 5,
+		MinReductionPercent:            5,
+		AdaptiveReductionCutoffPercent: 10,
 	})
 )
 

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -138,8 +138,11 @@ var (
 	ZstdCompression    = block.ZstdCompression
 	// MinLZCompression is only supported with table formats v6+. Older formats
 	// fall back to snappy.
-	MinLZCompression   = block.MinLZCompression
-	FastestCompression = block.FastestCompression
+	MinLZCompression    = block.MinLZCompression
+	FastestCompression  = block.FastestCompression
+	FastCompression     = block.FastCompression
+	BalancedCompression = block.BalancedCompression
+	GoodCompression     = block.GoodCompression
 )
 
 // WriterOptions holds the parameters used to control building an sstable.


### PR DESCRIPTION
Also fix up the sstable compression profile definitions, where the
adaptive knob wasn't set correctly. We also change the "balanced"
profile to use only Zstd1 (Zstd3 has so far proven significantly
slower with not much benefit over 1).