### PR TITLE
db,blob: blob file rewrite bug fixes, randomized test

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -466,6 +466,7 @@ func (rw *blobFileRewriter) Rewrite(ctx context.Context) (blob.FileWriterStats, 
 			if err != nil {
 				return blob.FileWriterStats{}, err
 			}
+			pending = blockValues{blockID: nextBlock.BlockID, liveValueIDs: pending.liveValueIDs[:0]}
 		}
 		// Update the accumulated encoding for this block.
 		pending.valuesSize += nextBlock.ValuesSize


### PR DESCRIPTION
### db: fix blob file rewrite bug
Fix bug in which during blob file rewriting, the pending BlockID was not
updated.

### blob: fix ValueFetcher value index lookup
Previously the ValueFetcher did not correctly translate the ValueID of a
blob.Handle to the index of the value in the block if the blob file was
rewritten. This commit fixes the bug. Unit tests covering this case will be
added in future commits.

### db: add TestBlobRewriteRandomized
Add a randomized test of blob file rewrites.

TestBlobRewriteRandomized tests blob file rewriting by constructing a blob file
and n sstables that each reference one value in the blob file.

It then runs a blob rewrite repeatedly, passing in a random subset of the
sstables as extant references. Each blob rewrite may rewrite the original blob
file, or one of the previous iteration's rewritten blob files.
