### PR TITLE
crl-release-25.3: db: don't ref version until blob rewrite compaction is scheduled

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -50,6 +50,9 @@ func (c *pickedBlobFileCompaction) WaitingCompaction() WaitingCompaction {
 func (c *pickedBlobFileCompaction) ConstructCompaction(
 	d *DB, grantHandle CompactionGrantHandle,
 ) compaction {
+	// Add a reference to the version. The compaction will release the reference
+	// when it completes.
+	c.vers.Ref()
 	return &blobFileRewriteCompaction{
 		beganAt:           d.timeNow(),
 		grantHandle:       grantHandle,

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1707,9 +1707,6 @@ func (p *compactionPickerByScore) pickBlobFileRewriteCompaction(
 		// None meet the heuristic.
 		return nil
 	}
-	// Add a reference to the version. The compaction will release the reference
-	// when it completes.
-	p.vers.Ref()
 	return &pickedBlobFileCompaction{
 		vers:              p.vers,
 		file:              candidate,


### PR DESCRIPTION
Blob rewrite compactions reference the version they use for the duration of the compaction. Previously the reference was added during compaction picking. This allowed the reference to be leaked if the compaction was picked and cached but never got an opportunity to run before the DB was closed. This commit defers referencing the Version until the compaction is scheduled.