### PR TITLE
pebble: deflake move compaction datadriven test

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1283,7 +1283,7 @@ func TestCompaction(t *testing.T) {
 				lower := 1
 				upper := 1
 				td.MaybeScanArgs(t, "max", &upper)
-				td.MaybeScanArgs(t, "range", &lower, upper)
+				td.MaybeScanArgs(t, "range", &lower, &upper)
 				d.opts.CompactionConcurrencyRange = func() (int, int) {
 					return lower, upper
 				}

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -5,7 +5,11 @@ define l0-compaction-threshold=1 auto-compactions=off
 ----
 
 
-populate keylen=4 timestamps=(1) vallen=64
+set-concurrent-compactions range=(3,3)
+----
+
+
+populate keylen=4 timestamps=(1) vallen=1
 ----
 wrote 475254 keys
 
@@ -13,45 +17,17 @@ wrote 475254 keys
 flush
 ----
 L0.0:
-  000005:[a@1#10,SET-boao@1#28148,SET]
-  000006:[boap@1#28149,SET-dcbc@1#56285,SET]
-  000007:[dcbd@1#56286,SET-eqbu@1#84424,SET]
-  000008:[eqbv@1#84425,SET-gecj@1#112562,SET]
-  000009:[geck@1#112563,SET-hsda@1#140701,SET]
-  000010:[hsdb@1#140702,SET-jgdq@1#168839,SET]
-  000011:[jgdr@1#168840,SET-kueg@1#196977,SET]
-  000012:[kueh@1#196978,SET-miev@1#225114,SET]
-  000013:[miew@1#225115,SET-nwfl@1#253252,SET]
-  000014:[nwfm@1#253253,SET-pkga@1#281390,SET]
-  000015:[pkgb@1#281391,SET-qygs@1#309529,SET]
-  000016:[qygt@1#309530,SET-smhh@1#337667,SET]
-  000017:[smhi@1#337668,SET-uahw@1#365804,SET]
-  000018:[uahx@1#365805,SET-voim@1#393942,SET]
-  000019:[voin@1#393943,SET-xcjb@1#422080,SET]
-  000020:[xcjc@1#422081,SET-yqjt@1#450219,SET]
-  000021:[yqju@1#450220,SET-zzzz@1#475263,SET]
+  000005:[a@1#10,SET-itbq@1#159645,SET]
+  000006:[itbr@1#159646,SET-rmbh@1#319226,SET]
+  000007:[rmbi@1#319227,SET-zzzz@1#475263,SET]
 
 
-auto-compact count=17
+auto-compact count=3
 ----
 L6:
-  000005:[a@1#10,SET-boao@1#28148,SET]
-  000006:[boap@1#28149,SET-dcbc@1#56285,SET]
-  000007:[dcbd@1#56286,SET-eqbu@1#84424,SET]
-  000008:[eqbv@1#84425,SET-gecj@1#112562,SET]
-  000009:[geck@1#112563,SET-hsda@1#140701,SET]
-  000010:[hsdb@1#140702,SET-jgdq@1#168839,SET]
-  000011:[jgdr@1#168840,SET-kueg@1#196977,SET]
-  000012:[kueh@1#196978,SET-miev@1#225114,SET]
-  000013:[miew@1#225115,SET-nwfl@1#253252,SET]
-  000014:[nwfm@1#253253,SET-pkga@1#281390,SET]
-  000015:[pkgb@1#281391,SET-qygs@1#309529,SET]
-  000016:[qygt@1#309530,SET-smhh@1#337667,SET]
-  000017:[smhi@1#337668,SET-uahw@1#365804,SET]
-  000018:[uahx@1#365805,SET-voim@1#393942,SET]
-  000019:[voin@1#393943,SET-xcjb@1#422080,SET]
-  000020:[xcjc@1#422081,SET-yqjt@1#450219,SET]
-  000021:[yqju@1#450220,SET-zzzz@1#475263,SET]
+  000005:[a@1#10,SET-itbq@1#159645,SET]
+  000006:[itbr@1#159646,SET-rmbh@1#319226,SET]
+  000007:[rmbi@1#319227,SET-zzzz@1#475263,SET]
 
 
 metrics
@@ -59,28 +35,28 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
-    0 |     0     0B     0B       0 |    -    0    0 |  33MB |     0     0B |     0     0B |    17   34MB |    0B |   0 1.02
+    0 |     0     0B     0B       0 |    -    0    0 | 4.5MB |     0     0B |     0     0B |     3  6.0MB |    0B |   0 1.32
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0
-    6 |    17   34MB     0B       0 |    - 0.53 0.53 |    0B |     0     0B |    17   34MB |     0     0B |    0B |   1    0
-total |    17   34MB     0B       0 |    -    -    - |  33MB |     0     0B |    17   34MB |    17   67MB |    0B |   1 2.02
+    6 |     3  6.0MB     0B       0 |    - 0.09 0.09 |    0B |     0     0B |     3  6.0MB |     0     0B |    0B |   1    0
+total |     3  6.0MB     0B       0 |    -    -    - | 4.5MB |     0     0B |     3  6.0MB |     3   10MB |    0B |   1 2.32
 ----------------------------------------------------------------------------------------------------------------------------
-WAL: 1 files (0B)  in: 33MB  written: 33MB (0% overhead)
+WAL: 1 files (0B)  in: 4.5MB  written: 4.5MB (0% overhead)
 Flushes: 2
-Compactions: 17  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 0  delete: 0  elision: 0  move: 17  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
+Compactions: 3  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
+             default: 0  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
 MemTables: 1 (512KB)  zombie: 1 (512KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 34MB
-Compression types: snappy: 17
+Local tables size: 6.0MB
+Compression types: snappy: 3
 Table stats: all loaded
-Block cache: 3.3K entries (7.0MB)  hit rate: 0.1%
-File cache: 17 tables, 0 blobfiles (4.6KB)  hit rate: 97.4%
+Block cache: 1.5K entries (6.4MB)  hit rate: 60.0%
+File cache: 3 tables, 0 blobfiles (840B)  hit rate: 90.0%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 0


### PR DESCRIPTION
Reduce the number of expected compactions in l0_to_lbase_compaction from 17 to
3. This still exercises the conditions we'd like to test by having more than 1
file in L0.

Fixes: #4981