### PR TITLE
release-24.1: metamorphic: disable crossversion tests for 24.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,19 +44,6 @@ jobs:
 
       - run: GOTRACEBACK=all GOARCH=386 make test
 
-  linux-crossversion:
-    name: go-linux-crossversion
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: "${{ env.GO_VERSION }}"
-
-    - run: make crossversion-meta
-
   linux-race:
     name: go-linux-race
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ stressmeta: stress
 
 .PHONY: crossversion-meta
 crossversion-meta:
-	$(eval LATEST_RELEASE := $(shell git fetch origin && git branch -r --list '*/crl-release-*' | grep -o 'crl-release-.*$$' | sort | tail -1))
+	LATEST_RELEASE := crl-release-23.2
 	git checkout ${LATEST_RELEASE}; \
 		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/${LATEST_RELEASE}.test'; \
 		git checkout -; \


### PR DESCRIPTION
Crossversion tests are currently broken for branches <24.1 so we disable crossversion tests that upgrade to 24.1.