### PR TITLE
Makefile: set crl-release-25.2 as previous version and update crossversion target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ stressmeta: override TESTS = TestMeta$$
 stressmeta: stress
 
 .PHONY: crossversion-meta
+crossversion-meta: LATEST_RELEASE := crl-release-25.2
 crossversion-meta:
-	$(eval LATEST_RELEASE := $(shell git fetch origin && git branch -r --list '*/crl-release-*' | grep -o 'crl-release-.*$$' | sort | tail -1))
 	git checkout ${LATEST_RELEASE}; \
 		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/${LATEST_RELEASE}.test'; \
 		git checkout -; \
@@ -78,7 +78,7 @@ crossversion-meta:
 
 .PHONY: stress-crossversion
 stress-crossversion:
-	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-24.1 crl-release-24.3 crl-release-25.1 crl-release-25.2 master
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-24.1 crl-release-24.3 crl-release-25.1 crl-release-25.2 crl-release-25.3
 
 .PHONY: test-s390x-qemu
 test-s390x-qemu: TAGS += slowbuild


### PR DESCRIPTION
set crl-release-25.2 as previous version and update crossversion target

I accidentally pushed the change to upstream directly rather than origin :(
This is the commit to cockroachdb/pebble crl-release-25.3: https://github.com/cockroachdb/pebble/commit/35f8f8027691a32bbe753d8db15e76d33c5327d1

I create a separate commit in my own forked branch to cut this PR.