### PR TITLE
crl-release-25.3: blob: deduplicate values during rewrite

### DIFF
--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -343,9 +343,8 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 			Enabled:               true,
 			MinimumSize:           5,
 			MaxBlobReferenceDepth: 3,
-			RewriteMinimumAge:     time.Second,
-			// TODO(jackson): Adjust the TargetGarbageRatio to allow blob file rewrites.
-			TargetGarbageRatio: 1.0, // Disabled
+			RewriteMinimumAge:     50 * time.Millisecond,
+			TargetGarbageRatio:    0.1,
 		}
 	}
 
@@ -921,10 +920,9 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 		policy := pebble.ValueSeparationPolicy{
 			Enabled:               true,
 			MinimumSize:           1 + rng.IntN(maxValueSize),
-			MaxBlobReferenceDepth: 2 + rng.IntN(9),                           // 2-10
-			RewriteMinimumAge:     time.Duration(rng.IntN(10)) * time.Second, // [0, 10s)
-			// TODO(jackson): Begin enabling blob file rewrite compactions.
-			TargetGarbageRatio: 1.0,
+			MaxBlobReferenceDepth: 2 + rng.IntN(9),                                   // 2-10
+			RewriteMinimumAge:     time.Duration(rng.IntN(90)+10) * time.Millisecond, // [10ms, 100ms)
+			TargetGarbageRatio:    max(rng.Float64(), 0.05),
 		}
 		opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 			return policy

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -164,12 +164,24 @@ func expectEqualFn[T any](t *testing.T, expected func() T, actual func() T) {
 		require.Nil(t, actual)
 	} else {
 		require.NotNil(t, actual)
-		var zeroT T
-		if reflect.TypeOf(zeroT) == reflect.TypeOf(float64(0)) {
-			require.InDelta(t, expected(), actual(), 1e-5)
-		} else {
-			require.Equal(t, expected(), actual())
+		ev, av := expected(), actual()
+		expectEqualValue(t, reflect.ValueOf(ev).Interface(), reflect.ValueOf(av).Interface())
+	}
+}
+
+func expectEqualValue(t *testing.T, expected any, actual any) {
+	t.Helper()
+	typ := reflect.TypeOf(expected)
+	switch typ.Kind() {
+	case reflect.Float64:
+		require.InDelta(t, expected, actual, 1e-2)
+	case reflect.Struct:
+		for i := range typ.NumField() {
+			expectEqualValue(t, reflect.ValueOf(expected).Field(i).Interface(),
+				reflect.ValueOf(actual).Field(i).Interface())
 		}
+	default:
+		require.Equal(t, expected, actual)
 	}
 }
 

--- a/testdata/blob_rewrite
+++ b/testdata/blob_rewrite
@@ -76,4 +76,4 @@ rewrite-blob 000002 000001 000003
 Successfully rewrote blob file 000002 to 000004
 Input SSTables: [000001 000003]
 SSTables with blob references: 2
-{BlockCount: 1, ValueCount: 4, UncompressedValueBytes: 30, FileLen: 123}
+{BlockCount: 1, ValueCount: 2, UncompressedValueBytes: 15, FileLen: 106}

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -392,6 +392,44 @@ Filter utility: 0.0%
 Ingestions: 0  as flushable: 0 (0B in 0 tables)
 Cgo memory usage: 0B  block cache: 0B (data: 0B, maps: 0B, entries: 0B)  memtables: 0B
 
+# Test a blob file rewrite compaction with virtual sstable references.
+
+define value-separation=(true,1,10,0s,0.01)
+----
+
+batch
+set a apple
+set b banana
+set c coconut
+----
+
+compact a-b
+----
+L6:
+  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:862 blobrefs:[(B000006: 18); depth:1]
+Blob files:
+  B000006 physical:{000006 size:[109 (109B)] vals:[18 (18B)]}
+
+excise b ba
+----
+L6:
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
+Blob files:
+  B000006 physical:{000006 size:[109 (109B)] vals:[18 (18B)]}
+
+# Run a blob-rewrite compaction. It'll rewrite the blob file, but it won't
+# actually reclaim disk space. This is a known limitation due to the lack of
+# accurate blob value liveness for virtual sstables. See
+# https://github.com/cockroachdb/pebble/issues/4915.
+
+run-blob-rewrite-compaction
+----
+L6:
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
+Blob files:
+  B000006 physical:{000009 size:[110 (110B)] vals:[18 (18B)]}
 
 define value-separation=(true,5,5,0s,1.0) l0-compaction-threshold=1
 ----


### PR DESCRIPTION
25.3 backport of #5011.