### PR TITLE
compression: deflake TestAdaptiveCompressorCompressible

### DIFF
--- a/internal/compression/adaptive_test.go
+++ b/internal/compression/adaptive_test.go
@@ -46,7 +46,7 @@ func TestAdaptiveCompressorCompressible(t *testing.T) {
 	})
 	defer ac.Close()
 	for i := 0; i < 100; i++ {
-		data := make([]byte, 10+rand.IntN(64*1024))
+		data := make([]byte, 512+rand.IntN(64*1024))
 		for j := range data {
 			data[j] = byte(j / 100)
 		}


### PR DESCRIPTION
Deflake TestAdaptiveCompressorCompressible by increasing the minimum size of the payload that's compressed. If the payload is too small, compression cannot result in a significant enough reduction in the size of the compressed payload and the compressor yields the uncompressed payload instead.

Fix #5012.