### PR TITLE
cmd/pebble: enable blob file rewriting

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -88,8 +88,7 @@ func newPebbleDB(dir string) DB {
 			MinimumSize:           512,
 			MaxBlobReferenceDepth: 10,
 			RewriteMinimumAge:     5 * time.Minute,
-			// TODO(jackson): Adjust the TargetGarbageRatio to allow blob file rewrites.
-			TargetGarbageRatio: 1.0, // Disabled.
+			TargetGarbageRatio:    0.1,
 		}
 	}
 


### PR DESCRIPTION
Adjust the TargetGarbageRatio setting to enable blob file rewrites. This effectively enables blob file rewrite compactions in the ycsb nightly benchmarks that make use of value separation.