### PR TITLE
pebble: add additional constraints to running multiLevel compactions

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1114,6 +1114,11 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 		setupInputTest)
 
 	t.Logf("Turning multi level compaction on")
+	opts.CompactionConcurrencyRange = func() (int, int) {
+		// Setting an upper limit greater than 1 is necessary to allow
+		// multilevel compactions to be picked.
+		return 1, 2
+	}
 	opts.Experimental.MultiLevelCompactionHeuristic = optionAlwaysMultiLevel
 	datadriven.RunTest(t, "testdata/compaction_setup_inputs_multilevel_dummy",
 		setupInputTest)

--- a/testdata/compaction/multilevel
+++ b/testdata/compaction/multilevel
@@ -2,7 +2,43 @@
 # The multilevel compaction tests mainly live in
 # /testdata/compaction_setup_inputs_multilevel_write_amp
 
+# By default, multi level compactions should be disable due to the
+# default compaction concurrency of 1.
+
+define level-max-bytes=(L2 : 5) auto-compactions=off
+L1
+  a.SET.3:v b.SET.2:v
+L2
+  a.SET.2:v c.SET.4:v
+L3
+  c.SET.3:v d.SET.2:v
+L4
+  c.SET.2:v d.SET.1:v
+----
+L1:
+  000004:[a#3,SET-b#2,SET]
+L2:
+  000005:[a#2,SET-c#4,SET]
+L3:
+  000006:[c#3,SET-d#2,SET]
+L4:
+  000007:[c#2,SET-d#1,SET]
+
+compact a-b L1
+----
+L2:
+  000008:[a#3,SET-c#4,SET]
+L3:
+  000006:[c#3,SET-d#2,SET]
+L4:
+  000007:[c#2,SET-d#1,SET]
+
 # A vanilla multi level compaction
+
+# Set concurrent compactions to 2 for the remainder of the tests.
+set-concurrent-compactions max=2
+----
+
 define level-max-bytes=(L2 : 5) auto-compactions=off
 L1
   a.SET.3:v b.SET.2:v
@@ -79,7 +115,7 @@ L4:
   000006:[c#2,SET-d#1,SET]
 
 # Conduct a multi input compaction without intermediate or output level, basically a move.
-define level-max-bytes=(L2 : 5) auto-compactions=off multi-input-level
+define level-max-bytes=(L2 : 5) auto-compactions=off
 L1
   a.SET.3:v b.SET.2:v
 L4
@@ -98,7 +134,7 @@ L4:
   000005:[c#2,SET-d#1,SET]
 
 # Don't conduct a multi level compaction on L0.
-define level-max-bytes=(L1 : 5) auto-compactions=off multi-input-level
+define level-max-bytes=(L1 : 5) auto-compactions=off
 L0
   a.SET.1:v b.SET.2:v
 L1
@@ -119,3 +155,87 @@ L1:
   000007:[a#3,SET-c#4,SET]
 L2:
   000006:[c#2,SET-d#2,SET]
+
+
+# Only one multiLevel compaction should be picked at a time.
+define auto-compactions=off
+L1
+  a.SET.21:v f.SET.22:v
+L1
+  k.SET.25:v n.SET.26:v
+L2
+  k.SET.7:v m.SET.10:v
+L2
+  a.SET.11:v d.SET.13:v
+L3
+  a.SET.1:v f.SET.2:v
+L3
+  k.SET.3:v n.SET.5:v
+----
+L1:
+  000004:[a#21,SET-f#22,SET]
+  000005:[k#25,SET-n#26,SET]
+L2:
+  000007:[a#11,SET-d#13,SET]
+  000006:[k#7,SET-m#10,SET]
+L3:
+  000008:[a#1,SET-f#2,SET]
+  000009:[k#3,SET-n#5,SET]
+
+add-ongoing-compaction startLevel=1 extraLevels=(2) outputLevel=3 start=k end=n
+----
+
+compact a-b L1
+----
+L1:
+  000005:[k#25,SET-n#26,SET]
+L2:
+  000010:[a#21,SET-f#22,SET]
+  000006:[k#7,SET-m#10,SET]
+L3:
+  000008:[a#1,SET-f#2,SET]
+  000009:[k#3,SET-n#5,SET]
+
+
+remove-ongoing-compaction
+----
+
+
+# Define the same LSM as above and run the compaction on a-b again. This time there
+# is no ongoing multilevel compaction, which should allow the compaction on a-b to
+# expand to include L3.
+
+
+define auto-compactions=off
+L1
+  a.SET.21:v f.SET.22:v
+L1
+  k.SET.25:v n.SET.26:v
+L2
+  k.SET.7:v m.SET.10:v
+L2
+  a.SET.11:v d.SET.13:v
+L3
+  a.SET.1:v f.SET.2:v
+L3
+  k.SET.3:v n.SET.5:v
+----
+L1:
+  000004:[a#21,SET-f#22,SET]
+  000005:[k#25,SET-n#26,SET]
+L2:
+  000007:[a#11,SET-d#13,SET]
+  000006:[k#7,SET-m#10,SET]
+L3:
+  000008:[a#1,SET-f#2,SET]
+  000009:[k#3,SET-n#5,SET]
+
+compact a-b L1
+----
+L1:
+  000005:[k#25,SET-n#26,SET]
+L2:
+  000006:[k#7,SET-m#10,SET]
+L3:
+  000010:[a#0,SET-f#0,SET]
+  000009:[k#3,SET-n#5,SET]

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -120,22 +120,22 @@ z: (zoo, .)
 
 metrics
 ----
-      |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |     multilevel
-level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  |    top   in  read
-------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+------------------
-    0 |     0     0B     0B       0 |    -    0    0 |   41B |     0     0B |     0     0B |     1   848B |    0B |   0 25.6 |    0B    0B    0B
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0 |    0B    0B    0B
-    6 |     1   899B     0B       0 |    - 0.00 0.00 |  848B |     0     0B |     0     0B |     1   899B | 1.7KB |   1 1.19 |    0B    0B    0B
-total |     1   899B     0B       0 |    -    -    - |   41B |     0     0B |     3  2.5KB |     2  1.7KB | 1.7KB |   1 51.2 |    0B    0B    0B
-------------------------------------------------------------------------------------------------------------------------------------------------
+      |                             |                |       |   ingested   |     moved    |    written   |       |    amp
+level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w
+------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+---------
+    0 |     0     0B     0B       0 |    -    0    0 |   41B |     0     0B |     0     0B |     1   848B |    0B |   0 25.6
+    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0
+    2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0
+    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0
+    4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0
+    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0
+    6 |     1   899B     0B       0 |    - 0.00 0.00 |  848B |     0     0B |     0     0B |     1   899B | 1.7KB |   1 1.19
+total |     1   899B     0B       0 |    -    -    - |   41B |     0     0B |     5  4.1KB |     2  1.7KB | 1.7KB |   1 51.2
+----------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 30B  written: 41B (37% overhead)
 Flushes: 1
-Compactions: 4  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
-             default: 1  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 2  blob-file-rewrite:  0
+Compactions: 6  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
+             default: 1  delete: 0  elision: 0  move: 5  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
@@ -143,8 +143,8 @@ Virtual tables: 0 (0B)
 Local tables size: 899B
 Compression types: snappy: 1
 Table stats: all loaded
-Block cache: 4 entries (1.6KB)  hit rate: 70.3%
-File cache: 1 tables, 1 blobfiles (376B)  hit rate: 82.2%
+Block cache: 4 entries (1.6KB)  hit rate: 77.6%
+File cache: 1 tables, 1 blobfiles (376B)  hit rate: 86.9%
 Range key sets: 0  Tombstones: 0  Total missized tombstones encountered: 0
 Snapshots: 0  earliest seq num: 0
 Table iters: 0

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -157,7 +157,7 @@ L0.000004 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 compact a-z
 ----
 L5:
-  000009:[b#230,RANGEDEL-u#0,SET]
+  000010:[b#230,RANGEDEL-u#0,SET]
 
 maybe-compact
 ----


### PR DESCRIPTION
Previously, we decide to run a multilevel compaction if the write amp with the additional level is less than that of the original compaction. We now add these additional constraints:
- The max compaction concurrency for the db must be greater than 1. This is to prevent the ML compaction from being the only compaction running, which could spike L0.
- At most one multiLevel compaction may be running at any time.

Part of: #4139