### PR TITLE
crl-release-25.3: db: merge in obsolete blob file during failed blob rewrite compaction

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -215,16 +215,18 @@ func (c *blobFileRewriteCompaction) Execute(jobID JobID, d *DB) error {
 	// Ensure we clean up the blob file we created on failure.
 	if err != nil {
 		if objMeta.DiskFileNum != 0 {
-			d.mu.versions.obsoleteBlobs = append(d.mu.versions.obsoleteBlobs, obsoleteFile{
-				fileType: base.FileTypeBlob,
-				fs:       d.opts.FS,
-				path:     d.objProvider.Path(objMeta),
-				fileNum:  objMeta.DiskFileNum,
-				// We don't know the size of the output blob file--it may have
-				// been half-written. We use the input blob file size as an
-				// approximation for deletion pacing.
-				fileSize: c.input.Physical.Size,
-				isLocal:  true,
+			d.mu.versions.obsoleteBlobs = mergeObsoleteFiles(d.mu.versions.obsoleteBlobs, []obsoleteFile{
+				{
+					fileType: base.FileTypeBlob,
+					fs:       d.opts.FS,
+					path:     d.objProvider.Path(objMeta),
+					fileNum:  objMeta.DiskFileNum,
+					// We don't know the size of the output blob file--it may have
+					// been half-written. We use the input blob file size as an
+					// approximation for deletion pacing.
+					fileSize: c.input.Physical.Size,
+					isLocal:  true,
+				},
 			})
 		}
 	}


### PR DESCRIPTION
If a blob rewrite compaction fails for any reason (eg, the blob becomes unreferenced while the compaction is in-progress), we enqueue the blob file we created as an 'obsolete' blob file. This enqueue did not insert the blob file in sorted order.

Fix #5022.