### PR TITLE
db: validate sstable's blob value liveness during DebugCheckLevels

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3224,10 +3224,6 @@ func (d *DB) runCompaction(
 	defer d.mu.Lock()
 
 	// Determine whether we should separate values into blob files.
-	//
-	// TODO(jackson): Currently we never separate values in non-tests. Choose
-	// and initialize the appropriate ValueSeparation implementation based on
-	// Options and the compaction inputs.
 	valueSeparation := c.getValueSeparation(jobID, c, c.tableFormat)
 
 	result := d.compactAndWrite(jobID, c, snapshots, c.tableFormat, valueSeparation)

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -20,9 +20,8 @@ import (
 // Result stores the result of a compaction - more specifically, the "data" part
 // where we use the compaction iterator to write output tables.
 type Result struct {
-	// Err is the result of the compaction. On success, Err is nil and Tables
-	// stores the output tables. On failure, Err is set and Tables stores the
-	// tables created so far (and which need to be cleaned up).
+	// Err is the result of the compaction. On failure, Err is set, Tables/Blobs
+	// stores the tables/blobs created so far (and which need to be cleaned up).
 	Err    error
 	Tables []OutputTable
 	Blobs  []OutputBlob

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -155,7 +155,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   4 (1.6KB) |       77.6% |     1 (376B) |       86.9% |         0.0% |           0 |           0
+   5 (1.9KB) |       81.8% |     1 (376B) |       89.2% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -423,7 +423,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   6 (2.3KB) |       48.6% |     1 (472B) |       73.9% |         0.0% |           0 |           0
+   7 (2.7KB) |       59.6% |     1 (472B) |       78.6% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -486,6 +486,12 @@ L6:
   000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000009 size:[110 (110B)] vals:[18 (18B)]}
+
+validate-blob-reference-index-block
+000007.sst
+000008.sst
+----
+validated
 
 define value-separation=(true,5,5,0s,1.0) l0-compaction-threshold=1
 ----


### PR DESCRIPTION
In `DebugCheckLevels`, we now validate all sstables in the LSM
by checking the correctness of their blob reference
liveness index block (if existent). We perform this validation by scanning
over each sst, gathering all blob handle references, and comparing each
referenced valueID with the bitmap encoded in our blob reference livenss index
block. We also ensure that the total value size for said referenced values are
tracked correctly.

We do not try to do this validation sometimes during invariants as
validation will effectively make any test that prints file cache
stats non-deterministic.

Fixes: #4975