### PR TITLE
pebble: lock wal directories on Open

### DIFF
--- a/db.go
+++ b/db.go
@@ -290,8 +290,8 @@ type DB struct {
 	// objProvider is used to access and manage SSTs.
 	objProvider objstorage.Provider
 
-	fileLock *Lock
-	dataDir  vfs.File
+	dataDirLock *base.DirLock
+	dataDir     vfs.File
 
 	fileCache            *fileCacheHandle
 	newIters             tableNewIters
@@ -1734,7 +1734,7 @@ func (d *DB) Close() error {
 		panic("pebble: log-writer should be nil in read-only mode")
 	}
 	err = firstError(err, d.mu.log.manager.Close())
-	err = firstError(err, d.fileLock.Close())
+	err = firstError(err, d.dataDirLock.Close())
 
 	// Note that versionSet.close() only closes the MANIFEST. The versions list
 	// is still valid for the checks below.

--- a/internal/base/directory_lock.go
+++ b/internal/base/directory_lock.go
@@ -1,0 +1,120 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import (
+	"io"
+	"os"
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// AcquireOrValidateDirectoryLock attempts to acquire a lock on the
+// provided directory, or validates a pre-acquired DirLock.
+func AcquireOrValidateDirectoryLock(
+	preAcquiredLock *DirLock, dirname string, fs vfs.FS,
+) (*DirLock, error) {
+	// If a pre-acquired lock is provided, check that it matches the directory
+	// we're trying to open.
+	if preAcquiredLock != nil {
+		if err := preAcquiredLock.pathMatches(dirname); err != nil {
+			return preAcquiredLock, err
+		}
+		return preAcquiredLock, preAcquiredLock.refForOpen()
+	}
+
+	// Otherwise, acquire the lock for the directory.
+	return LockDirectory(dirname, fs)
+}
+
+// LockDirectory acquires the directory lock in the named directory, preventing
+// another process from opening the database. LockDirectory returns a
+// handle to the held lock that may be passed to Open, skipping lock acquisition
+// during Open.
+//
+// LockDirectory may be used to expand the critical section protected by the
+// database lock to include setup before the call to Open.
+func LockDirectory(dirname string, fs vfs.FS) (*DirLock, error) {
+	fileLock, err := fs.Lock(MakeFilepath(fs, dirname, FileTypeLock, DiskFileNum(0)))
+	if err != nil {
+		return nil, err
+	}
+	l := &DirLock{dirname: dirname, fileLock: fileLock}
+	l.refs.Store(1)
+	invariants.SetFinalizer(l, func(obj interface{}) {
+		if refs := obj.(*DirLock).refs.Load(); refs > 0 {
+			panic(errors.AssertionFailedf("lock for %q finalized with %d refs", dirname, refs))
+		}
+	})
+	return l, nil
+}
+
+// DirLock represents a file lock on a directory. It may be passed to Open through
+// Options.Lock to elide lock aquisition during Open.
+type DirLock struct {
+	dirname  string
+	fileLock io.Closer
+	// refs is a count of the number of handles on the lock. refs must be 0, 1
+	// or 2.
+	//
+	// When acquired by the client and passed to Open, refs = 1 and the Open
+	// call increments it to 2. When the database is closed, it's decremented to
+	// 1. Finally when the original caller, calls Close on the Lock, it's
+	// drecemented to zero and the underlying file lock is released.
+	//
+	// When Open acquires the file lock, refs remains at 1 until the database is
+	// closed.
+	refs atomic.Int32
+}
+
+func (l *DirLock) refForOpen() error {
+	// During Open, when a user passed in a lock, the reference count must be
+	// exactly 1. If it's zero, the lock is no longer held and is invalid. If
+	// it's 2, the lock is already in use by another database within the
+	// process.
+	if !l.refs.CompareAndSwap(1, 2) {
+		return errors.Errorf("pebble: unexpected Lock reference count; is the lock already in use?")
+	}
+	return nil
+}
+
+func (l *DirLock) Refs() int {
+	// Return the current reference count. This is used for testing purposes.
+	return int(l.refs.Load())
+}
+
+// Close releases the lock, permitting another process to lock and open the
+// database. Close must not be called until after a database using the Lock has
+// been closed.
+func (l *DirLock) Close() error {
+	if l.refs.Add(-1) > 0 {
+		return nil
+	}
+	defer func() { l.fileLock = nil }()
+	return l.fileLock.Close()
+}
+
+func (l *DirLock) pathMatches(dirname string) error {
+	if dirname == l.dirname {
+		return nil
+	}
+	// Check for relative paths, symlinks, etc. This isn't ideal because we're
+	// circumventing the vfs.FS interface here.
+	//
+	// TODO(jackson): We could add support for retrieving file inodes through Stat
+	// calls in the VFS interface on platforms where it's available and use that
+	// to differentiate.
+	dirStat, err1 := os.Stat(dirname)
+	lockDirStat, err2 := os.Stat(l.dirname)
+	if err1 == nil && err2 == nil && os.SameFile(dirStat, lockDirStat) {
+		return nil
+	}
+	return errors.Join(
+		errors.Newf("pebble: opts.Lock acquired in %q not %q", l.dirname, dirname),
+		err1, err2)
+}

--- a/open_test.go
+++ b/open_test.go
@@ -277,53 +277,217 @@ func TestOpen_WALFailover(t *testing.T) {
 	})
 }
 
+// TestOpenAlreadyLocked verifies that we acquire the directory locks
+// required by the database during Open.
+// Each test case:
+// - Sets up pre-acquired locks according to the scenario.
+// - Opens a database.
+// - Attempts to open the same database again (should fail).
+// - Closes the database reopens the database (should now succeed).
+// - Closes and cleans up all locks.
 func TestOpenAlreadyLocked(t *testing.T) {
-	runTest := func(t *testing.T, lockPath, dirname string, fs vfs.FS) {
-		opts := testingRandomized(t, &Options{FS: fs})
-		var err error
-		opts.Lock, err = LockDirectory(lockPath, fs)
+	testCases := []struct {
+		name       string
+		setupLocks func(opts *Options, dirname, walDirname, secondaryWalDirname string, fs vfs.FS) error
+	}{
+		{
+			name: "no_pre_acquired_locks",
+			setupLocks: func(opts *Options, _, _, _ string, fs vfs.FS) error {
+				// No pre-acquired locks. Open should acquire them automatically.
+				return nil
+			},
+		},
+		{
+			name: "data_dir_lock",
+			setupLocks: func(opts *Options, dirname, _, _ string, fs vfs.FS) error {
+				var err error
+				opts.Lock, err = base.LockDirectory(dirname, fs)
+				return err
+			},
+		},
+		{
+			name: "wal_dir_lock",
+			setupLocks: func(opts *Options, dirname, walDirname, _ string, fs vfs.FS) error {
+				opts.WALDir = walDirname
+				var err error
+				opts.WALDirLock, err = base.LockDirectory(walDirname, fs)
+				return err
+			},
+		},
+		{
+			name: "secondary_wal_lock",
+			setupLocks: func(opts *Options, dirname, _, secondaryWalDirname string, fs vfs.FS) error {
+				opts.WALFailover = &WALFailoverOptions{
+					Secondary: wal.Dir{FS: fs, Dirname: secondaryWalDirname},
+				}
+				var err error
+				opts.WALFailover.Secondary.Lock, err = base.LockDirectory(secondaryWalDirname, fs)
+				return err
+			},
+		},
+		{
+			name: "data_and_primary_wal_locks",
+			setupLocks: func(opts *Options, dirname, walDirname, _ string, fs vfs.FS) error {
+				opts.WALDir = walDirname
+				var err error
+				opts.Lock, err = base.LockDirectory(dirname, fs)
+				if err != nil {
+					return err
+				}
+				opts.WALDirLock, err = base.LockDirectory(walDirname, fs)
+				return err
+			},
+		},
+		{
+			name: "all_locks",
+			setupLocks: func(opts *Options, dirname, walDirname, secondaryWalDirname string, fs vfs.FS) error {
+				opts.WALDir = walDirname
+				opts.WALFailover = &WALFailoverOptions{
+					Secondary: wal.Dir{FS: fs, Dirname: secondaryWalDirname},
+				}
+				var err error
+				opts.Lock, err = base.LockDirectory(dirname, fs)
+				if err != nil {
+					return err
+				}
+				opts.WALDirLock, err = base.LockDirectory(walDirname, fs)
+				if err != nil {
+					return err
+				}
+				opts.WALFailover.Secondary.Lock, err = base.LockDirectory(secondaryWalDirname, fs)
+				return err
+			},
+		},
+		{
+			name: "wal_dir_same_as_data_dir",
+			setupLocks: func(opts *Options, dirname, _, _ string, fs vfs.FS) error {
+				// WAL dir same as data dir - should not require separate lock.
+				opts.WALDir = dirname
+				var err error
+				opts.Lock, err = base.LockDirectory(dirname, fs)
+				return err
+			},
+		},
+	}
+	// We'll provide the same WAL recovery directory for all tests to
+	// verify that the lock acquired during Open is properly released.
+	walRecoveryDir := t.TempDir()
+	recoveryLock, err := base.LockDirectory(walRecoveryDir, vfs.Default)
+	require.NoError(t, err)
+	defer recoveryLock.Close()
+	walRecoveryDirs := []wal.Dir{
+		{FS: vfs.Default, Dirname: t.TempDir()},
+		{Lock: recoveryLock, FS: vfs.Default, Dirname: walRecoveryDir},
+	}
+
+	runTest := func(t *testing.T, tmpDirs [4]string, setupLocks func(opts *Options, dirname, walDirname, secondaryWalDirname string, fs vfs.FS) error, fs vfs.FS) {
+		dataDir := tmpDirs[0]
+		dataDir2 := tmpDirs[1]
+		walDir := tmpDirs[2]
+		secondaryWalDir := tmpDirs[3]
+
+		// Setup directory locks.
+		opts := testingRandomized(t, &Options{FS: fs, WALRecoveryDirs: walRecoveryDirs})
+		err := setupLocks(opts, dataDir, walDir, secondaryWalDir, fs)
 		require.NoError(t, err)
 
-		d, err := Open(dirname, opts)
+		defer func() {
+			if opts.Lock != nil {
+				require.NoError(t, opts.Lock.Close(), "Failed to close data dir lock")
+				require.Zero(t, opts.Lock.Refs(), "Data dir lock should have no remaining refs")
+			}
+			if opts.WALDirLock != nil {
+				require.NoError(t, opts.WALDirLock.Close(), "Failed to close WAL dir lock")
+				require.Zero(t, opts.WALDirLock.Refs(), "WAL dir lock should have no remaining refs")
+			}
+			if opts.WALFailover != nil && opts.WALFailover.Secondary.Lock != nil {
+				require.NoError(t, opts.WALFailover.Secondary.Lock.Close(), "Failed to close secondary WAL lock")
+				require.Zero(t, opts.WALFailover.Secondary.Lock.Refs(), "Secondary WAL lock should have no remaining refs")
+			}
+		}()
+
+		d, err := Open(dataDir, opts)
 		require.NoError(t, err)
 		require.NoError(t, d.Set([]byte("foo"), []byte("bar"), Sync))
 
-		// Try to open the same database reusing the Options containing the same
-		// Lock. It should error when it observes that it's already referenced.
-		_, err = Open(dirname, opts)
-		require.Error(t, err)
+		_, err = Open(dataDir, opts)
+		require.Error(t, err, "Expected error when opening already locked database")
+
+		if opts.WALDir != "" {
+			// Try opening a different database with the same wal directory.
+			opts2 := testingRandomized(t, &Options{WALDir: opts.WALDir, FS: fs})
+			_, err := Open(dataDir2, opts2)
+			require.Error(t, err, "Expected error when opening another database with the same WAL directory")
+		}
+
+		if opts.WALFailover != nil {
+			// Try opening a different database with the same secondary WAL directory.
+			opts2 := testingRandomized(t, &Options{
+				WALFailover: &WALFailoverOptions{
+					Secondary: wal.Dir{FS: fs, Dirname: opts.WALFailover.Secondary.Dirname},
+				},
+				FS: fs,
+			})
+			_, err := Open(dataDir2, opts2)
+			require.Error(t, err, "Expected error when opening another database with the same secondary WAL directory")
+		}
 
 		// Close the database.
 		require.NoError(t, d.Close())
 
-		// Now Opening should succeed again.
-		d, err = Open(dirname, opts)
+		// Now Open should succeed again.
+		d, err = Open(dataDir, opts)
 		require.NoError(t, err)
 		require.NoError(t, d.Close())
-
-		require.NoError(t, opts.Lock.Close())
-		// There should be no more remaining references.
-		require.Equal(t, int32(0), opts.Lock.refs.Load())
 	}
+
+	// Run tests for different filesystems.
 	t.Run("memfs", func(t *testing.T) {
-		runTest(t, "", "", vfs.NewMem())
+		for _, tc := range testCases {
+			mem := vfs.NewMem()
+			var tmpDirs [4]string
+			for i := range tmpDirs {
+				tmpDirs[i] = mem.PathJoin("dir", fmt.Sprintf("%d", i))
+				require.NoError(t, mem.MkdirAll(tmpDirs[i], 0755), "Failed to create temp dir %s", tmpDirs[i])
+			}
+			runTest(t, tmpDirs, tc.setupLocks, mem)
+		}
 	})
+
 	t.Run("disk", func(t *testing.T) {
 		t.Run("absolute", func(t *testing.T) {
-			dir := t.TempDir()
-			runTest(t, dir, dir, vfs.Default)
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					var tmpDirs [4]string
+					for i := range tmpDirs {
+						tmpDirs[i] = t.TempDir()
+					}
+					runTest(t, tmpDirs, tc.setupLocks, vfs.Default)
+				})
+			}
 		})
+
 		t.Run("relative", func(t *testing.T) {
-			dir := t.TempDir()
 			original, err := os.Getwd()
 			require.NoError(t, err)
 			defer func() { require.NoError(t, os.Chdir(original)) }()
 
-			wd := filepath.Dir(dir)
-			require.NoError(t, os.Chdir(wd))
-			lockPath, err := filepath.Rel(wd, dir)
-			require.NoError(t, err)
-			runTest(t, lockPath, dir, vfs.Default)
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					// Create a temporary directory structure for relative paths.
+					tempRoot := t.TempDir()
+					wd := filepath.Dir(tempRoot)
+					require.NoError(t, os.Chdir(wd))
+
+					var tmpDirs [4]string
+					for i := range tmpDirs {
+						tmpDirs[i] = filepath.Join(tempRoot, fmt.Sprintf("dir%d", i))
+						require.NoError(t, os.MkdirAll(tmpDirs[i], 0755), "Failed to create temp dir %s", tmpDirs[i])
+					}
+
+					runTest(t, tmpDirs, tc.setupLocks, vfs.Default)
+				})
+			}
 		})
 	})
 }

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -15,6 +15,7 @@ open-dir: db_wal
 close: db_wal
 open-dir: db
 lock: db/LOCK
+lock: db_wal/LOCK
 open-dir: db
 open-dir: db
 open-dir: db
@@ -115,6 +116,7 @@ marker.manifest.000001.MANIFEST-000001
 list db_wal
 ----
 000006.log
+LOCK
 archive
 
 list db/archive
@@ -144,6 +146,7 @@ open-dir: db1_wal
 close: db1_wal
 open-dir: db1
 lock: db1/LOCK
+lock: db1_wal/LOCK
 open-dir: db1
 open-dir: db1
 open-dir: db1
@@ -235,6 +238,7 @@ open-dir: db1_wal
 close: db1_wal
 open-dir: db1
 lock: db1/LOCK
+lock: db1_wal/LOCK
 open-dir: db1
 open-dir: db1
 open-dir: db1

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -14,6 +14,7 @@ open-dir: wal
 close: wal
 open-dir: db
 lock: db/LOCK
+lock: wal/LOCK
 open-dir: db
 open-dir: db
 open-dir: db

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -715,6 +715,12 @@ func (wm *failoverManager) Close() error {
 	for _, f := range wm.dirHandles {
 		err = firstError(err, f.Close())
 	}
+	if wm.opts.Primary.Lock != nil {
+		err = firstError(err, wm.opts.Primary.Lock.Close())
+	}
+	if wm.opts.Secondary.Lock != nil {
+		err = firstError(err, wm.opts.Secondary.Lock.Close())
+	}
 	return err
 }
 

--- a/wal/standalone_manager.go
+++ b/wal/standalone_manager.go
@@ -250,7 +250,11 @@ func (m *StandaloneManager) Close() error {
 	if m.w != nil {
 		_, err = m.w.Close()
 	}
-	return firstError(err, m.walDir.Close())
+	err = firstError(err, m.walDir.Close())
+	if m.o.Primary.Lock != nil {
+		err = firstError(err, m.o.Primary.Lock.Close())
+	}
+	return err
 }
 
 // RecyclerForTesting implements Manager.

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -23,6 +23,7 @@ import (
 
 // Dir is used for storing log files.
 type Dir struct {
+	Lock    *base.DirLock
 	FS      vfs.FS
 	Dirname string
 }


### PR DESCRIPTION
Ensure that we acquire locks for WAL directories when they are configured.

Fixes: #4919