### PR TITLE
manifest: explicitly encode excise operations in the MANIFEST

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1587,6 +1587,11 @@ func (d *DB) runIngestFlush(c *tableCompaction) (*manifest.VersionEdit, error) {
 	}
 	if ingestFlushable.exciseSpan.Valid() {
 		exciseBounds := ingestFlushable.exciseSpan.UserKeyBounds()
+		ve.ExciseBoundsRecord = append(ve.ExciseBoundsRecord, manifest.ExciseOpEntry{
+			Bounds: exciseBounds,
+			SeqNum: ingestFlushable.exciseSeqNum,
+		})
+
 		// Iterate through all levels and find files that intersect with exciseSpan.
 		for layer, ls := range version.AllLevelsAndSublevels() {
 			for m := range ls.Overlaps(d.cmp, ingestFlushable.exciseSpan.UserKeyBounds()).All() {

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -235,6 +235,9 @@ const (
 	FormatValueSeparation
 
 	// -- Add new versions here --
+	// FormatExciseBoundsRecord is a format major version that adds support for
+	// persisting excise bounds records in the manifest (VersionEdit).
+	FormatExciseBoundsRecord
 
 	// FormatNewest is the most recent format major version.
 	FormatNewest FormatMajorVersion = iota - 1
@@ -276,7 +279,7 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 		return sstable.TableFormatPebblev5
 	case FormatTableFormatV6, formatDeprecatedExperimentalValueSeparation:
 		return sstable.TableFormatPebblev6
-	case formatFooterAttributes, FormatValueSeparation:
+	case formatFooterAttributes, FormatValueSeparation, FormatExciseBoundsRecord:
 		return sstable.TableFormatPebblev7
 	default:
 		panic(fmt.Sprintf("pebble: unsupported format major version: %s", v))
@@ -290,7 +293,7 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	case FormatDefault, FormatFlushableIngest, FormatPrePebblev1MarkedCompacted,
 		FormatDeleteSizedAndObsolete, FormatVirtualSSTables, FormatSyntheticPrefixSuffix,
 		FormatFlushableIngestExcises, FormatColumnarBlocks, FormatWALSyncChunks,
-		FormatTableFormatV6, formatDeprecatedExperimentalValueSeparation, formatFooterAttributes,
+		FormatExciseBoundsRecord, FormatTableFormatV6, formatDeprecatedExperimentalValueSeparation, formatFooterAttributes,
 		FormatValueSeparation:
 		return sstable.TableFormatPebblev1
 	default:
@@ -348,6 +351,9 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	},
 	FormatValueSeparation: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatValueSeparation)
+	},
+	FormatExciseBoundsRecord: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(FormatExciseBoundsRecord)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -35,8 +35,9 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 
 	// When we add a new version, we should add a check for the new version in
 	// addition to updating these expected values.
-	require.Equal(t, FormatNewest, FormatMajorVersion(24))
-	require.Equal(t, internalFormatNewest, FormatMajorVersion(24))
+	require.Equal(t, FormatNewest, FormatMajorVersion(25))
+	require.Equal(t, internalFormatNewest, FormatMajorVersion(25))
+	require.Equal(t, FormatExciseBoundsRecord, FormatMajorVersion(25))
 }
 
 func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
@@ -77,6 +78,8 @@ func TestRatchetFormat(t *testing.T) {
 	require.Equal(t, formatFooterAttributes, d.FormatMajorVersion())
 	require.NoError(t, d.RatchetFormatMajorVersion(FormatValueSeparation))
 	require.Equal(t, FormatValueSeparation, d.FormatMajorVersion())
+	require.NoError(t, d.RatchetFormatMajorVersion(FormatExciseBoundsRecord))
+	require.Equal(t, FormatExciseBoundsRecord, d.FormatMajorVersion())
 
 	require.NoError(t, d.Close())
 
@@ -239,6 +242,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		formatDeprecatedExperimentalValueSeparation: {sstable.TableFormatPebblev1, sstable.TableFormatPebblev6},
 		formatFooterAttributes:                      {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 		FormatValueSeparation:                       {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
+		FormatExciseBoundsRecord:                    {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 	}
 
 	// Valid versions.

--- a/ingest.go
+++ b/ingest.go
@@ -2108,6 +2108,10 @@ func (d *DB) ingestApply(
 					updateLevelMetricsOnExcise(m, layer.Level(), newFiles)
 				}
 			}
+			ve.ExciseBoundsRecord = append(ve.ExciseBoundsRecord, manifest.ExciseOpEntry{
+				Bounds: exciseBounds,
+				SeqNum: exciseSeqNum,
+			})
 		}
 		if len(filesToSplit) > 0 {
 			// For the same reasons as the above call to excise, we hold the db mutex

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -187,6 +187,7 @@ apply v6
   add-table: L1 000003(000009):[a#2,SET-b#2,SET]
   add-table: L1 000004(000009):[c#2,SET-e#2,SET]
   add-backing: 000009
+  excise-op: [b, c] #3
 ----
 L1:
   000003(000009):[a#2,SET-b#2,SET] seqnums:[0-0] points:[a#2,SET-b#2,SET]

--- a/internal/manifest/testdata/version_edit_decode
+++ b/internal/manifest/testdata/version_edit_decode
@@ -64,31 +64,37 @@ f9a006                       #   . ValueSize    = 102521
 6c                           # <tagDeleteBlobFile>
 21                           #   . BlobFileID   = 000033
 21                           #   . FileNum      = 000033
+0a016201630103               # <tagExciseBoundsRecord>, [b, c] #3
 ----
-021903660484106b2929d8a301f9a0069f9485bd066c2121
+021903660484106b2929d8a301f9a0069f9485bd066c21210a0162016301
+03
   log-num:       25
   next-file-num: 102
   last-seq-num:  2052
   add-blob-file: B000041 physical:{000041 size:[20952 (20KB)] vals:[102521 (100KB)]}
   del-blob-file: B000033 000033
+  excise-op:     [b, c] #3
 
 encode
   add-table:     L6 000029:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952); depth:1]
   add-blob-file: B000943 physical:{000041 size:[20952 (20KB)] vals:[102521 (100KB)]}
   del-blob-file: B000033 000033
+  excise-op: [b, c] #3
 ----
 67061d000b626172000e0000000000000b666f6f010d0000000000000000
-45010129d8a301016baf0729d8a301f9a006006c2121
+45010129d8a301016baf0729d8a301f9a006006c21210a016201630103
   add-table:     L6 000029:[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952); depth:1]
   add-blob-file: B000943 physical:{000041 size:[20952 (20KB)] vals:[102521 (100KB)]}
   del-blob-file: B000033 000033
+  excise-op:     [b, c] #3
 
 decode
 67061d000b626172000e0000000000000b666f6f010d0000000000000000
-45010129d8a301016baf0729d8a301f9a006006c2121
+45010129d8a301016baf0729d8a301f9a006006c21210a016201630103
 ----
 67061d000b626172000e0000000000000b666f6f010d0000000000000000
-45010129d8a301016baf0729d8a301f9a006006c2121
+45010129d8a301016baf0729d8a301f9a006006c21210a016201630103
   add-table:     L6 000029:[bar#14,DEL-foo#13,SET]
   add-blob-file: B000943 physical:{000041 size:[20952 (20KB)] vals:[102521 (100KB)]}
   del-blob-file: B000033 000033
+  excise-op:     [b, c] #3

--- a/open_test.go
+++ b/open_test.go
@@ -335,7 +335,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000011.024",
+			"marker.format-version.000012.025",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -63,6 +63,10 @@ create: db/marker.format-version.000011.024
 close: db/marker.format-version.000011.024
 remove: db/marker.format-version.000010.023
 sync: db
+create: db/marker.format-version.000012.025
+close: db/marker.format-version.000012.025
+remove: db/marker.format-version.000011.024
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -129,9 +133,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.024
-close: checkpoints/checkpoint1/marker.format-version.000001.024
+create: checkpoints/checkpoint1/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.025
+close: checkpoints/checkpoint1/marker.format-version.000001.025
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -173,9 +177,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.024
-close: checkpoints/checkpoint2/marker.format-version.000001.024
+create: checkpoints/checkpoint2/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.025
+close: checkpoints/checkpoint2/marker.format-version.000001.025
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -212,9 +216,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.024
-close: checkpoints/checkpoint3/marker.format-version.000001.024
+create: checkpoints/checkpoint3/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.025
+close: checkpoints/checkpoint3/marker.format-version.000001.025
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -298,7 +302,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -308,7 +312,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.024
+marker.format-version.000001.025
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -375,7 +379,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.024
+marker.format-version.000001.025
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -417,7 +421,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.024
+marker.format-version.000001.025
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -536,9 +540,9 @@ sync-data: checkpoints/checkpoint4/OPTIONS-000003
 close: checkpoints/checkpoint4/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.024
-close: checkpoints/checkpoint4/marker.format-version.000001.024
+create: checkpoints/checkpoint4/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.025
+close: checkpoints/checkpoint4/marker.format-version.000001.025
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -626,7 +630,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -645,9 +649,9 @@ sync-data: checkpoints/checkpoint5/OPTIONS-000003
 close: checkpoints/checkpoint5/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.024
-close: checkpoints/checkpoint5/marker.format-version.000001.024
+create: checkpoints/checkpoint5/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.025
+close: checkpoints/checkpoint5/marker.format-version.000001.025
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -747,9 +751,9 @@ sync-data: checkpoints/checkpoint6/OPTIONS-000003
 close: checkpoints/checkpoint6/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.024
-close: checkpoints/checkpoint6/marker.format-version.000001.024
+create: checkpoints/checkpoint6/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.025
+close: checkpoints/checkpoint6/marker.format-version.000001.025
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst
@@ -926,6 +930,10 @@ create: valsepdb/marker.format-version.000011.024
 close: valsepdb/marker.format-version.000011.024
 remove: valsepdb/marker.format-version.000010.023
 sync: valsepdb
+create: valsepdb/marker.format-version.000012.025
+close: valsepdb/marker.format-version.000012.025
+remove: valsepdb/marker.format-version.000011.024
+sync: valsepdb
 create: valsepdb/temporary.000003.dbtmp
 sync: valsepdb/temporary.000003.dbtmp
 close: valsepdb/temporary.000003.dbtmp
@@ -974,9 +982,9 @@ sync-data: checkpoints/checkpoint8/OPTIONS-000003
 close: checkpoints/checkpoint8/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint8
-create: checkpoints/checkpoint8/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint8/marker.format-version.000001.024
-close: checkpoints/checkpoint8/marker.format-version.000001.024
+create: checkpoints/checkpoint8/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint8/marker.format-version.000001.025
+close: checkpoints/checkpoint8/marker.format-version.000001.025
 sync: checkpoints/checkpoint8
 close: checkpoints/checkpoint8
 link: valsepdb/000006.blob -> checkpoints/checkpoint8/000006.blob
@@ -1088,9 +1096,9 @@ sync-data: checkpoints/checkpoint9/OPTIONS-000003
 close: checkpoints/checkpoint9/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint9
-create: checkpoints/checkpoint9/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint9/marker.format-version.000001.024
-close: checkpoints/checkpoint9/marker.format-version.000001.024
+create: checkpoints/checkpoint9/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint9/marker.format-version.000001.025
+close: checkpoints/checkpoint9/marker.format-version.000001.025
 sync: checkpoints/checkpoint9
 close: checkpoints/checkpoint9
 link: valsepdb/000006.blob -> checkpoints/checkpoint9/000006.blob

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -51,6 +51,10 @@ create: db/marker.format-version.000008.024
 close: db/marker.format-version.000008.024
 remove: db/marker.format-version.000007.023
 sync: db
+create: db/marker.format-version.000009.025
+close: db/marker.format-version.000009.025
+remove: db/marker.format-version.000008.024
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -117,9 +121,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.024
-close: checkpoints/checkpoint1/marker.format-version.000001.024
+create: checkpoints/checkpoint1/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.025
+close: checkpoints/checkpoint1/marker.format-version.000001.025
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -170,9 +174,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.024
-close: checkpoints/checkpoint2/marker.format-version.000001.024
+create: checkpoints/checkpoint2/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.025
+close: checkpoints/checkpoint2/marker.format-version.000001.025
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -219,9 +223,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.024
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.024
-close: checkpoints/checkpoint3/marker.format-version.000001.024
+create: checkpoints/checkpoint3/marker.format-version.000001.025
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.025
+close: checkpoints/checkpoint3/marker.format-version.000001.025
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -278,7 +282,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000008.024
+marker.format-version.000009.025
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -288,7 +292,7 @@ list checkpoints/checkpoint1
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.024
+marker.format-version.000001.025
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -340,7 +344,7 @@ list checkpoints/checkpoint2
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.024
+marker.format-version.000001.025
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -81,6 +81,11 @@ close: db/marker.format-version.000011.024
 remove: db/marker.format-version.000010.023
 sync: db
 upgraded to format version: 024
+create: db/marker.format-version.000012.025
+close: db/marker.format-version.000012.025
+remove: db/marker.format-version.000011.024
+sync: db
+upgraded to format version: 025
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -397,9 +402,9 @@ sync-data: checkpoint/OPTIONS-000003
 close: checkpoint/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.024
-sync-data: checkpoint/marker.format-version.000001.024
-close: checkpoint/marker.format-version.000001.024
+create: checkpoint/marker.format-version.000001.025
+sync-data: checkpoint/marker.format-version.000001.025
+close: checkpoint/marker.format-version.000001.025
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -38,7 +38,7 @@ ext
 ext1
 ext2
 ext3
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 # Ingest can complete despite the flush being blocked.
@@ -62,7 +62,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 allowFlush
@@ -96,7 +96,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -117,7 +117,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -210,7 +210,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext5
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 allowFlush
@@ -440,7 +440,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -460,7 +460,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -493,7 +493,7 @@ MANIFEST-000001
 MANIFEST-000011
 OPTIONS-000014
 ext
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000002.MANIFEST-000011
 
 # Make sure that the new mutable memtable can accept writes.
@@ -636,7 +636,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -655,7 +655,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext1
-marker.format-version.000011.024
+marker.format-version.000012.025
 marker.manifest.000001.MANIFEST-000001
 
 open

--- a/tool/testdata/db_upgrade
+++ b/tool/testdata/db_upgrade
@@ -27,7 +27,7 @@ db get foo yellow
 db upgrade foo
 ----
 ----
-Upgrading DB from internal version 16 to 24.
+Upgrading DB from internal version 16 to 25.
 WARNING!!!
 This DB will not be usable with older versions of Pebble!
 
@@ -43,7 +43,7 @@ Continue? [Y/N] Error: EOF
 
 db upgrade foo --yes
 ----
-Upgrading DB from internal version 16 to 24.
+Upgrading DB from internal version 16 to 25.
 Upgrade complete.
 
 db get foo blue
@@ -56,4 +56,4 @@ db get foo yellow
 
 db upgrade foo
 ----
-DB is already at internal version 24.
+DB is already at internal version 25.


### PR DESCRIPTION
This adds a new struct field that maps excise span to the sequence number at which it was performed, this will allow to strengthen invariant checking on manifest replay as it was not updated with excise operations, this field is also implemented in version_edit_apply and version_edit_decode tests.

Addresses #4798