### PR TITLE
sstable: add separated value retrieval internal iterator stats

### DIFF
--- a/internal/base/iterator.go
+++ b/internal/base/iterator.go
@@ -432,6 +432,11 @@ type InternalIteratorStats struct {
 		// in the heap got positioned. The count here includes every sstable
 		// iterator that got positioned in the heap.
 		Count uint64
+		// CountFetched is the subset of Count that were fetched.
+		CountFetched uint64
+		// ReaderCacheMisses is the count of separated value retrievals that did
+		// not find the named blob file reader in the iterator's reader cache.
+		ReaderCacheMisses uint64
 		// ValueBytes represent the total byte length of the values (in value
 		// blocks) of the points corresponding to Count.
 		ValueBytes uint64
@@ -454,6 +459,8 @@ func (s *InternalIteratorStats) Merge(from InternalIteratorStats) {
 	s.PointCount += from.PointCount
 	s.PointsCoveredByRangeTombstones += from.PointsCoveredByRangeTombstones
 	s.SeparatedPointValue.Count += from.SeparatedPointValue.Count
+	s.SeparatedPointValue.CountFetched += from.SeparatedPointValue.CountFetched
+	s.SeparatedPointValue.ReaderCacheMisses += from.SeparatedPointValue.ReaderCacheMisses
 	s.SeparatedPointValue.ValueBytes += from.SeparatedPointValue.ValueBytes
 	s.SeparatedPointValue.ValueBytesFetched += from.SeparatedPointValue.ValueBytesFetched
 }

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -164,9 +164,13 @@ func (r *ValueFetcher) retrieve(ctx context.Context, vh Handle) (val []byte, err
 		cr.blobFileID = vh.BlobFileID
 		cr.diskFileNum = diskFileNum
 		cr.rh = cr.r.InitReadHandle(&cr.preallocRH)
+		if r.env.Stats != nil {
+			r.env.Stats.SeparatedPointValue.ReaderCacheMisses++
+		}
 	}
 
 	if r.env.Stats != nil {
+		r.env.Stats.SeparatedPointValue.CountFetched++
 		r.env.Stats.SeparatedPointValue.ValueBytesFetched += uint64(vh.ValueLen)
 	}
 

--- a/sstable/valblk/reader.go
+++ b/sstable/valblk/reader.go
@@ -261,6 +261,7 @@ func (f *valueBlockFetcher) getValueInternal(handle []byte, valLen uint32) (val 
 		f.valueBlockPtr = unsafe.Pointer(&f.valueBlock[0])
 	}
 	if f.stats != nil {
+		f.stats.SeparatedPointValue.CountFetched++
 		f.stats.SeparatedPointValue.ValueBytesFetched += uint64(valLen)
 	}
 	return f.valueBlock[vh.OffsetInBlock : vh.OffsetInBlock+vh.ValueLen], nil


### PR DESCRIPTION
Add internal iterator stats for the count of separated value retrievals and the subset of them that miss the iterator's reader cache.

Informs cockroachdb/cockroach#149422.