### PR TITLE
fix: deflake metamorphic tests in reduction

### DIFF
--- a/internal/metamorphic/reduce_test.go
+++ b/internal/metamorphic/reduce_test.go
@@ -235,6 +235,11 @@ func (r *reducer) Run(t *testing.T) {
 	for removeProbability := 0.1; removeProbability > 1e-5 && removeProbability > 0.1/float64(len(ops)); removeProbability *= 0.5 {
 		t.Logf("removeProbability %.2f%%", removeProbability*100.0)
 		for i := 0; i < r.reduceAttempts; i++ {
+			// Only try to reduce if we have more than 1 op
+			if len(ops) <= 1 {
+				break
+			}
+
 			if o := randomSubset(t, ops, removeProbability); r.try(t, o) {
 				ops = o
 				// Reset the counter.


### PR DESCRIPTION
There are two Intermittent failures addressed here.

### Panic in TestMetaCockroachKVs with reduction
```
--- FAIL: TestMetaCockroachKVs (86.96s)                                                                                                                                                                               
panic: invalid test mvcc timestamp "@0.000000001,1" [recovered]
        panic: invalid test mvcc timestamp "@0.000000001,1" [recovered]
        panic: invalid test mvcc timestamp "@0.000000001,1"
```
#### What happened?
The reduction code always uses `TestkeysKeyFormat` rather than `CockroachKeyFormat`, where `testkeys.compareTimestamps()` always expect an integer in the code. e.g., `parseUintBytes(a[1:], 10, 64)`. If the timestamp is like `@1234`, then everything is fine. Otherwise, the code panics as above.

### Failure when there is one operation left in reduction
```
    reduce_test.go:207: Reduced to 1 ops.
    reduce_test.go:208:   Log: _meta/reduce-250709-145247.725850699008/log
    reduce_test.go:222:   go test ./internal/metamorphic -tags invariants -test.run "TestMetaCockroachKVs$" -test.v -test.timeout 10s --keep --run-dir _meta/reduce-250709-145247.725850699008/random-015
    reduce_test.go:257: 
                Error Trace:    /Users/xxm/workspaces/pebble-xxm/internal/metamorphic/reduce_test.go:257
                                                        /Users/xxm/workspaces/pebble-xxm/internal/metamorphic/reduce_test.go:238
                                                        /Users/xxm/workspaces/pebble-xxm/internal/metamorphic/reduce_test.go:42
                                                        /Users/xxm/workspaces/pebble-xxm/internal/metamorphic/meta_test.go:112
                                                        /Users/xxm/workspaces/pebble-xxm/internal/metamorphic/meta_test.go:67
                Error:          "1" is not greater than "1"
                Test:           TestMetaCockroachKVs
--- FAIL: TestMetaCockroachKVs (533.83s)
```
#### What happened?
The random test sometimes reduces the operation down to just 1 op, but the `randomSubset()` requires `require.Greater(t, len(ops), 1)`, hence the annoying `"1" is not greater than "1"` message.