### PR TITLE
sstable: set up proper iterator transforms during EstimateDiskUsage

### DIFF
--- a/file_cache.go
+++ b/file_cache.go
@@ -328,7 +328,7 @@ func (h *fileCacheHandle) estimateSize(
 	meta *manifest.TableMetadata, lower, upper []byte,
 ) (size uint64, err error) {
 	err = h.withReader(context.TODO(), block.NoReadEnv, meta, func(r *sstable.Reader, env sstable.ReadEnv) error {
-		size, err = r.EstimateDiskUsage(lower, upper, env)
+		size, err = r.EstimateDiskUsage(lower, upper, env, meta.IterTransforms())
 		return err
 	})
 	return size, err

--- a/ingest.go
+++ b/ingest.go
@@ -1172,7 +1172,7 @@ type ExternalFile struct {
 	// ingestion.
 	HasPointKey, HasRangeKey bool
 
-	// SyntheticPrefix will prepend this suffix to all keys in the file during
+	// SyntheticPrefix will prepend this prefix to all keys in the file during
 	// iteration. Note that the backing file itself is not modified.
 	//
 	// SyntheticPrefix must be a prefix of both Bounds.Start and Bounds.End.

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -345,3 +345,25 @@ props:
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy
   rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;
+
+# Test virtual sstable with a synthetic prefix.
+build
+a.SET.1:a
+b.SET.1:b
+c.SET.1:c
+d.SET.1:d
+----
+point:    [a#1,SET-d#1,SET]
+seqnums:  [1-1]
+
+virtualize lower=poi-b.SET.1 upper=poi-c.SET.1 prefix=poi- show-props
+----
+bounds:  [poi-b#1,SET-poi-c#1,SET]
+filenum: 000010
+props:
+  rocksdb.num.entries: 1
+  rocksdb.raw.key.size: 4
+  rocksdb.raw.value.size: 1
+  rocksdb.num.data.blocks: 1
+  rocksdb.compression: Snappy
+  rocksdb.compression_options: window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;

--- a/table_stats.go
+++ b/table_stats.go
@@ -440,7 +440,7 @@ func (d *DB) loadTableRangeDelStats(
 		// the size of the range key block relative to the overall size of the
 		// table is expected to be small.
 		if level == numLevels-1 && meta.SmallestSeqNum < maxRangeDeleteSeqNum {
-			size, err := r.EstimateDiskUsage(start, end, env)
+			size, err := r.EstimateDiskUsage(start, end, env, meta.IterTransforms())
 			if err != nil {
 				return nil, err
 			}
@@ -649,7 +649,7 @@ func (d *DB) estimateReclaimedSizeBeneath(
 				var size uint64
 				err := d.fileCache.withReader(ctx, block.NoReadEnv, file,
 					func(r *sstable.Reader, env sstable.ReadEnv) (err error) {
-						size, err = r.EstimateDiskUsage(start, end, env)
+						size, err = r.EstimateDiskUsage(start, end, env, file.IterTransforms())
 						return err
 					})
 				if err != nil {

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -542,7 +542,7 @@ func (s *sstableT) runScan(cmd *cobra.Command, args []string) {
 func (s *sstableT) runSpace(cmd *cobra.Command, args []string) {
 	stdout, stderr := cmd.OutOrStdout(), cmd.OutOrStderr()
 	s.foreachSstable(stderr, args, func(path string, r *sstable.Reader, props sstable.Properties) {
-		bytes, err := r.EstimateDiskUsage(s.start, s.end, sstable.NoReadEnv)
+		bytes, err := r.EstimateDiskUsage(s.start, s.end, sstable.NoReadEnv, sstable.NoTransforms)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
 			return


### PR DESCRIPTION
Previously, we did not set up any iterator transforms during EstimateDiskUsage -- leading to an inaccurate disk usage estimation that was eventually used in compaction heuristics. This patch fixes this bug by grabbing the IterTransforms from the table we are reading and using it during disk usage estimation.

Fixes: #4597