### PR TITLE
pebble: fix wal recovery dir lock acquisition in Open

### DIFF
--- a/open.go
+++ b/open.go
@@ -395,10 +395,12 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	}()
 	for i, dir := range opts.WALRecoveryDirs {
 		dir.Dirname = resolveStorePath(dirname, dir.Dirname)
-		// Acquire a lock on the WAL recovery directory.
-		walRecoveryLocks[i], err = base.AcquireOrValidateDirectoryLock(dir.Lock, dir.Dirname, dir.FS)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error acquiring lock on WAL recovery directory %q", dir.Dirname)
+		if dir.Dirname != dirname {
+			// Acquire a lock on the WAL recovery directory.
+			walRecoveryLocks[i], err = base.AcquireOrValidateDirectoryLock(dir.Lock, dir.Dirname, dir.FS)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error acquiring lock on WAL recovery directory %q", dir.Dirname)
+			}
 		}
 		walDirs = append(walDirs, dir)
 	}

--- a/open_test.go
+++ b/open_test.go
@@ -427,6 +427,8 @@ func TestOpenAlreadyLocked(t *testing.T) {
 					Secondary: wal.Dir{FS: fs, Dirname: opts.WALFailover.Secondary.Dirname},
 				},
 				FS: fs,
+				// Setting the recovery dir to be the same as the dir being opened should not error.
+				WALRecoveryDirs: []wal.Dir{{FS: fs, Dirname: dataDir2}},
 			})
 			_, err := Open(dataDir2, opts2)
 			require.Error(t, err, "Expected error when opening another database with the same secondary WAL directory")


### PR DESCRIPTION
Do not attempt to reacquire lock on the  wal recovery dir when it is the same as the dir being opened.

Fixes: #5051