### PR TITLE
db: fix double Close of directory lock during failed Open

### DIFF
--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -15,7 +15,6 @@ open-dir: db_wal
 close: db_wal
 open-dir: db
 lock: db/LOCK
-lock: db_wal/LOCK
 open-dir: db
 open-dir: db
 open-dir: db
@@ -24,6 +23,7 @@ sync: db/MANIFEST-000001
 create: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
 sync: db
+lock: db_wal/LOCK
 open-dir: db_wal
 create: db_wal/000002.log
 sync: db_wal
@@ -146,7 +146,6 @@ open-dir: db1_wal
 close: db1_wal
 open-dir: db1
 lock: db1/LOCK
-lock: db1_wal/LOCK
 open-dir: db1
 open-dir: db1
 open-dir: db1
@@ -155,6 +154,7 @@ sync: db1/MANIFEST-000001
 create: db1/marker.manifest.000001.MANIFEST-000001
 close: db1/marker.manifest.000001.MANIFEST-000001
 sync: db1
+lock: db1_wal/LOCK
 open-dir: db1_wal
 create: db1_wal/000002.log
 sync: db1_wal
@@ -238,12 +238,12 @@ open-dir: db1_wal
 close: db1_wal
 open-dir: db1
 lock: db1/LOCK
-lock: db1_wal/LOCK
 open-dir: db1
 open-dir: db1
 open-dir: db1
 open: db1/MANIFEST-000001
 close: db1/MANIFEST-000001
+lock: db1_wal/LOCK
 open-dir: db1_wal
 open: db1/OPTIONS-000003
 close: db1/OPTIONS-000003

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -14,7 +14,6 @@ open-dir: wal
 close: wal
 open-dir: db
 lock: db/LOCK
-lock: wal/LOCK
 open-dir: db
 open-dir: db
 open-dir: db
@@ -24,6 +23,7 @@ create: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 [JOB 1] MANIFEST created 000001
+lock: wal/LOCK
 open-dir: wal
 create: wal/000002.log
 sync: wal


### PR DESCRIPTION
Previously if an error occurred during Open after the WAL manager had been initialized, it was possible for a directory lock to be Closed multiple times. This commit refactors the error handling to ensure we release the WALDir and WALFailover.Secondary locks at most once.