### PR TITLE
metamorphic: propagate FS changes to TestOptions

### DIFF
--- a/external_test.go
+++ b/external_test.go
@@ -53,10 +53,9 @@ func TestIteratorErrors(t *testing.T) {
 	// at most once. We would need to skip retrying on the second invocation
 	// of DebugCheckLevels. It's all likely more trouble than it's worth.
 	testOpts.Opts.DebugCheck = nil
-	// Disable the physical FS so we don't need to worry about paths down below.
-	if fs := testOpts.Opts.FS; fs == nil || fs == vfs.Default {
-		testOpts.Opts.FS = vfs.NewMem()
-	}
+	// The FS should be in-memory, so we don't need to worry about paths down
+	// below.
+	_ = vfs.Root(testOpts.Opts.FS).(*vfs.MemFS)
 
 	{
 		test, err := metamorphic.New(metamorphic.GenerateOps(

--- a/metamorphic/meta.go
+++ b/metamorphic/meta.go
@@ -612,6 +612,9 @@ func RunOnce(t TestingT, runDir string, seed uint64, historyPath string, rOpts .
 
 // Execute runs the provided test, writing the execution history into the Test's
 // sink.
+//
+// Note that the test execution might change the filesystems in the TestOptions
+// used with New(); see the restart operation.
 func Execute(m *Test) error {
 	if m.testOpts.Threads <= 1 {
 		for m.step(m.h, nil /* optionalRecordf */) {

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -28,6 +28,8 @@ import (
 // against a database using the provided TestOptions and outputs the history of
 // events to an io.Writer.
 //
+// Note that the test aliases the TestOptions and can change the filesystems.
+//
 // dir specifies the path within opts.Opts.FS to open the database.
 func New(ops Ops, opts *TestOptions, dir string, w io.Writer) (*Test, error) {
 	t := newTest(ops)
@@ -346,8 +348,12 @@ func (t *Test) restartDB(dbID objID) error {
 	}
 	t.opts.FS = crashFS
 	t.opts.WithFSDefaults()
+	// We want to set the new FS in testOpts too, so they are propagated to the
+	// TestOptions that were used with metamorphic.New().
+	t.testOpts.Opts.FS = t.opts.FS
 	if t.opts.WALFailover != nil {
 		t.opts.WALFailover.Secondary.FS = t.opts.FS
+		t.testOpts.Opts.WALFailover.Secondary.FS = t.opts.FS
 	}
 
 	// TODO(jackson): Audit errorRate and ensure custom options' hooks semantics


### PR DESCRIPTION
Tests that run a meta test and then run another one on the same
filesystem currently start over from the place of the first restart
operation.

This commit propagates the restart FS changes to the `*TestOptions`.
Note that `New()` was already modifying them (by calling `WithFSDefaults()`).