### PR TITLE
crl-release-25.3: backport deflake of TestAdaptiveCompressorCompressible

### DIFF
--- a/internal/compression/adaptive_test.go
+++ b/internal/compression/adaptive_test.go
@@ -44,9 +44,10 @@ func TestAdaptiveCompressorCompressible(t *testing.T) {
 		SampleHalfLife:  128 * 1024,
 		SamplingSeed:    1,
 	})
+	rng := rand.New(rand.NewPCG(0, 0))
 	defer ac.Close()
 	for i := 0; i < 100; i++ {
-		data := make([]byte, 512+rand.IntN(64*1024))
+		data := make([]byte, 512+rng.IntN(64*1024))
 		for j := range data {
 			data[j] = byte(j / 100)
 		}


### PR DESCRIPTION
Fixes #5065
Fixes #5066

#### compression: deflake TestAdaptiveCompressorCompressible

Deflake TestAdaptiveCompressorCompressible by increasing the minimum size of
the payload that's compressed. If the payload is too small, compression cannot
result in a significant enough reduction in the size of the compressed payload
and the compressor yields the uncompressed payload instead.

Fix #5012.

#### compression: deflake TestAdaptiveCompressorCompressible

Fix the prng seed to deflake the test. At a handful of rare, random sizes we'd
choose the fast algorithm.

Close #5037.