### PR TITLE
github: stress new unit tests in PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,3 +102,24 @@ jobs:
 
       - run: GOTRACEBACK=all make test
 
+  stress-new-tests:
+    if: github.event_name == 'pull_request'  # Skip job unless it's a PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Stress new tests
+        env:
+          BASE_BRANCH: origin/${{ github.base_ref }}
+        run: |
+          go install github.com/cockroachdb/stress@latest
+          bash scripts/stress-new-tests.sh

--- a/scripts/stress-new-tests.sh
+++ b/scripts/stress-new-tests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# Base branch to diff against
+BASE_BRANCH="${BASE_BRANCH:-origin/master}"
+MODULE_PREFIX="github.com/cockroachdb/pebble"
+
+# Loop through each Go package
+echo "Checking packages for new tests..."
+for pkg in $(go list ./...); do
+  # Strip module prefix to get relative path
+  pkg=${pkg#${MODULE_PREFIX}}
+  pkg="./${pkg#/}"  # Ensure ./ and remove any leading /
+
+  # Get added test functions in this package
+  added_tests=$(git diff --no-ext-diff "$BASE_BRANCH" --unified=0 -- "$pkg"/*.go 2>/dev/null \
+    | grep '^+func Test' \
+    | awk '{print $2}' \
+    | cut -d'(' -f1 \
+    | sort -u || true)
+
+  if [[ -z "$added_tests" ]]; then
+    continue
+  fi
+
+  # Build regex for go test -run
+  regex=$(echo "$added_tests" | paste -sd '|' -)
+  full_regex="^($regex)$"
+
+  echo ""
+  echo "Found new tests in $pkg"
+
+  echo "go test --tags invariants --exec 'stress -p 2 --maxruns 1000 --maxtime 10m --timeout 2m' -v -run \"$full_regex\" \"$pkg\""
+  go test --tags invariants --exec 'stress -p 2 --maxruns 1000 --maxtime 10m --timeout 2m' -v -run "$full_regex" "$pkg" || {
+    echo ""
+    echo "❌ Failure in $pkg with new tests: $regex"
+    exit 1
+  }
+done
+
+echo "✅ All stress tests passed."


### PR DESCRIPTION
This commit adds a script that detects any new top-level unit tests
and runs them under stress; and adds a corresponding CI job that only
runs on PRs.

Fixes #5038

Tested on my fork here: https://github.com/RaduBerinde/pebble/actions/runs/16260112264/job/45903413151?pr=3