### PR TITLE
blob: verify virtual BlockID is in bounds

### DIFF
--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -264,6 +264,7 @@ func (cr *cachedReader) GetUnsafeValue(
 		var physicalBlockIndex int = int(vh.BlockID)
 		var valueIDOffset BlockValueID
 		if cr.indexBlock.dec.virtualBlockCount > 0 {
+			invariants.CheckBounds(int(vh.BlockID), cr.indexBlock.dec.virtualBlockCount)
 			physicalBlockIndex, valueIDOffset = cr.indexBlock.dec.RemapVirtualBlockID(vh.BlockID)
 			if valueIDOffset == virtualBlockIndexMask {
 				return nil, errors.AssertionFailedf("blob file indicates virtual block ID %d in %s should be unreferenced",


### PR DESCRIPTION
During invariant builds, when looking up a BlockID in a blob file that's been rewritten, validate that the BlockID is within bounds of the number of virtual blocks encoded within the custom block header.