### PR TITLE
manual: sometimes mangle freed buffers in invariants builds

### DIFF
--- a/internal/manual/manual_cgo.go
+++ b/internal/manual/manual_cgo.go
@@ -75,6 +75,7 @@ func New(purpose Purpose, n uintptr) Buf {
 // returned by New.
 func Free(purpose Purpose, b Buf) {
 	if b.n != 0 {
+		invariants.MaybeMangle(b.Slice())
 		recordFree(purpose, b.n)
 
 		if !invariants.RaceEnabled || !useGoAllocation {

--- a/internal/manual/manual_nocgo.go
+++ b/internal/manual/manual_nocgo.go
@@ -6,7 +6,11 @@
 
 package manual
 
-import "unsafe"
+import (
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
 
 // Provides versions of New and Free when cgo is not available (e.g. cross
 // compilation).
@@ -27,5 +31,6 @@ func New(purpose Purpose, n uintptr) Buf {
 // Free frees the specified slice. It has to be exactly the slice that was
 // returned by New.
 func Free(purpose Purpose, b Buf) {
+	invariants.MaybeMangle(b.Slice())
 	recordFree(purpose, b.n)
 }


### PR DESCRIPTION
In invariants builds, sometimes mangle manually-managed buffers just before freeing them. This can help surface code paths that are inadvertently using the memory after it's been freed.