### PR TITLE
db: check FormatExciseBoundsRecord against the current format version

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1588,11 +1588,12 @@ func (d *DB) runIngestFlush(c *tableCompaction) (*manifest.VersionEdit, error) {
 	}
 	if ingestFlushable.exciseSpan.Valid() {
 		exciseBounds := ingestFlushable.exciseSpan.UserKeyBounds()
-		ve.ExciseBoundsRecord = append(ve.ExciseBoundsRecord, manifest.ExciseOpEntry{
-			Bounds: exciseBounds,
-			SeqNum: ingestFlushable.exciseSeqNum,
-		})
-
+		if d.FormatMajorVersion() >= FormatExciseBoundsRecord {
+			ve.ExciseBoundsRecord = append(ve.ExciseBoundsRecord, manifest.ExciseOpEntry{
+				Bounds: exciseBounds,
+				SeqNum: ingestFlushable.exciseSeqNum,
+			})
+		}
 		// Iterate through all levels and find files that intersect with exciseSpan.
 		for layer, ls := range version.AllLevelsAndSublevels() {
 			for m := range ls.Overlaps(d.cmp, ingestFlushable.exciseSpan.UserKeyBounds()).All() {

--- a/ingest.go
+++ b/ingest.go
@@ -2108,10 +2108,12 @@ func (d *DB) ingestApply(
 					updateLevelMetricsOnExcise(m, layer.Level(), newFiles)
 				}
 			}
-			ve.ExciseBoundsRecord = append(ve.ExciseBoundsRecord, manifest.ExciseOpEntry{
-				Bounds: exciseBounds,
-				SeqNum: exciseSeqNum,
-			})
+			if d.FormatMajorVersion() >= FormatExciseBoundsRecord {
+				ve.ExciseBoundsRecord = append(ve.ExciseBoundsRecord, manifest.ExciseOpEntry{
+					Bounds: exciseBounds,
+					SeqNum: exciseSeqNum,
+				})
+			}
 		}
 		if len(filesToSplit) > 0 {
 			// For the same reasons as the above call to excise, we hold the db mutex


### PR DESCRIPTION
Only populate the ve.ExciseBoundsRecord if the version is eligible