### PR TITLE
replay: adding ingest and ingest-and-exicse testing

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1593,6 +1593,7 @@ func (d *DB) runIngestFlush(c *tableCompaction) (*manifest.VersionEdit, error) {
 				Bounds: exciseBounds,
 				SeqNum: ingestFlushable.exciseSeqNum,
 			})
+			d.mu.versions.metrics.Ingest.ExciseIngestCount++
 		}
 		// Iterate through all levels and find files that intersect with exciseSpan.
 		for layer, ls := range version.AllLevelsAndSublevels() {

--- a/ingest.go
+++ b/ingest.go
@@ -2082,6 +2082,7 @@ func (d *DB) ingestApply(
 		var exciseBounds base.UserKeyBounds
 		if exciseSpan.Valid() {
 			exciseBounds = exciseSpan.UserKeyBounds()
+			d.mu.versions.metrics.Ingest.ExciseIngestCount++
 			// Iterate through all levels and find files that intersect with exciseSpan.
 			//
 			// TODO(bilal): We could drop the DB mutex here as we don't need it for

--- a/metrics.go
+++ b/metrics.go
@@ -260,6 +260,8 @@ type Metrics struct {
 	Ingest struct {
 		// The total number of ingestions
 		Count uint64
+		// The number of excise operations during ingestion
+		ExciseIngestCount int64
 	}
 
 	Flush struct {

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -118,6 +118,7 @@ type Metrics struct {
 		// effective heuristics are at ingesting files into lower levels, saving
 		// write amplification.
 		BytesWeightedByLevel uint64
+		ExciseIngestCount    int64
 	}
 	// PaceDuration is the time waiting for the pacer to allow the workload to
 	// continue.
@@ -203,6 +204,9 @@ func (m *Metrics) WriteBenchmarkString(name string, w io.Writer) error {
 		}},
 		{label: "EstimatedDebt/max", values: []benchfmt.Value{
 			{Value: float64(m.EstimatedDebt.Max()), Unit: "bytes"},
+		}},
+		{label: "ExciseDuringIngestion", values: []benchfmt.Value{
+			{Value: float64(m.Ingest.ExciseIngestCount), Unit: "excise"},
 		}},
 		{label: "FlushUtilization", values: []benchfmt.Value{
 			{Value: m.Final.Flush.WriteThroughput.Utilization(), Unit: "util"},
@@ -563,6 +567,7 @@ func (r *Runner) Wait() (Metrics, error) {
 	m.CompactionCounts.Rewrite = pm.Compact.RewriteCount
 	m.CompactionCounts.Copy = pm.Compact.CopyCount
 	m.CompactionCounts.MultiLevel = pm.Compact.MultiLevelCount
+	m.Ingest.ExciseIngestCount = pm.Ingest.ExciseIngestCount
 	m.Ingest.BytesIntoL0 = pm.Levels[0].TableBytesIngested
 	m.Ingest.BytesWeightedByLevel = ingestBytesWeighted
 	return m, err
@@ -584,8 +589,10 @@ type workloadStep struct {
 	// readAmp estimation for the LSM *before* ve was applied.
 	previousReadAmp int
 	// non-nil for flushStepKind
-	flushBatch           *pebble.Batch
-	tablesToIngest       []string
+	flushBatch     *pebble.Batch
+	tablesToIngest []string
+	// exciseSpan is set for ingestAndExciseStepKind
+	exciseSpan           pebble.KeyRange
 	cumulativeWriteBytes uint64
 }
 
@@ -595,6 +602,7 @@ const (
 	flushStepKind stepKind = iota
 	ingestStepKind
 	compactionStepKind
+	ingestAndExciseStepKind
 )
 
 // eventListener returns a Pebble EventListener that is installed on the replay
@@ -688,6 +696,12 @@ func (r *Runner) applyWorkloadSteps(ctx context.Context) error {
 			r.stepsApplied <- step
 		case ingestStepKind:
 			if err := r.d.Ingest(context.Background(), step.tablesToIngest); err != nil {
+				return err
+			}
+			r.metrics.writeBytes.Store(step.cumulativeWriteBytes)
+			r.stepsApplied <- step
+		case ingestAndExciseStepKind:
+			if _, err := r.d.IngestAndExcise(context.Background(), step.tablesToIngest, nil /* shared */, nil /* external */, step.exciseSpan); err != nil {
 				return err
 			}
 			r.metrics.writeBytes.Store(step.cumulativeWriteBytes)
@@ -795,12 +809,22 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 					// flush.
 					s.kind = ingestStepKind
 				}
+				if len(ve.ExciseBoundsRecord) > 0 {
+					// If a version edit contains excise bounds records, it's an excise operation.
+					// In practice, there should typically be only one excise bounds record per version edit.
+					exciseEntry := ve.ExciseBoundsRecord[0]
+					s.exciseSpan = pebble.KeyRange{
+						Start: exciseEntry.Bounds.Start,
+						End:   exciseEntry.Bounds.End.Key,
+					}
+					s.kind = ingestAndExciseStepKind
+				}
 				var newFiles []base.DiskFileNum
 				blobRefMap := make(map[base.DiskFileNum]manifest.BlobReferences)
 				blobFileMap := make(map[base.BlobFileID]base.DiskFileNum)
 				for _, nf := range ve.NewTables {
 					newFiles = append(newFiles, nf.Meta.TableBacking.DiskFileNum)
-					if s.kind == ingestStepKind && (nf.Meta.SmallestSeqNum != nf.Meta.LargestSeqNum || nf.Level != 0) {
+					if s.kind == ingestStepKind && (nf.Meta.SmallestSeqNum != nf.Meta.LargestSeqNum) {
 						s.kind = flushStepKind
 					}
 					if nf.Meta.BlobReferenceDepth > 0 {
@@ -870,7 +894,7 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 						return errors.Wrapf(err, "flush in %q at offset %d", manifestName, rr.Offset())
 					}
 					cumulativeWriteBytes += uint64(s.flushBatch.Len())
-				case ingestStepKind:
+				case ingestStepKind, ingestAndExciseStepKind:
 					// Copy the ingested sstables into a staging area within the
 					// run dir. This is necessary for two reasons:
 					//  a) Ingest will remove the source file, and we don't want

--- a/replay/testdata/corpus/simple_ingest
+++ b/replay/testdata/corpus/simple_ingest
@@ -1,0 +1,106 @@
+open-ingest-excise
+----
+
+list-files build
+----
+build:
+  000002.log
+  LOCK
+  MANIFEST-000001
+  OPTIONS-000003
+  marker.format-version.000012.025
+  marker.manifest.000001.MANIFEST-000001
+
+build-sst foo.sst
+a#0,SET = a
+b#0,SET = byaya
+c#0,SET = cyuumi
+d#0,SET = d
+----
+
+ingest foo.sst
+----
+ingested
+
+build-sst f.sst
+p#0,SET = p
+q#0,SET = q
+----
+
+ingest-and-excise f.sst excise=a-d
+----
+ingest-and-excised
+
+list-files build
+----
+build:
+  000002.log
+  000004.sst
+  000005.sst
+  LOCK
+  MANIFEST-000001
+  OPTIONS-000003
+  marker.format-version.000012.025
+  marker.manifest.000001.MANIFEST-000001
+
+start
+----
+started
+
+list-files simple_ingest
+----
+simple_ingest:
+  checkpoint
+
+list-files simple_ingest/checkpoint
+----
+simple_ingest/checkpoint:
+  000002.log
+  000004.sst
+  000005.sst
+  MANIFEST-000001
+  OPTIONS-000003
+  marker.format-version.000001.025
+  marker.manifest.000001.MANIFEST-000001
+
+build-sst loo.sst
+x#0,SET = x
+y#0,SET = y
+----
+
+ingest loo.sst
+----
+ingested
+
+build-sst l.sst
+z#0,SET = z
+----
+
+ingest-and-excise l.sst excise=d-p
+----
+ingest-and-excised
+
+stop
+----
+stopped
+
+list-files simple_ingest
+----
+simple_ingest:
+  000007.sst
+  000009.sst
+  MANIFEST-000001
+  MANIFEST-000008
+  checkpoint
+
+stat simple_ingest/MANIFEST-000001 simple_ingest/MANIFEST-000008 simple_ingest/MANIFEST-000010 simple_ingest/000007.sst simple_ingest/000009.sst
+----
+simple_ingest/MANIFEST-000001:
+  size: 172
+simple_ingest/MANIFEST-000008:
+  size: 209
+simple_ingest/MANIFEST-000010: stat simple_ingest/MANIFEST-000010: file does not exist
+simple_ingest/000007.sst:
+  size: 757
+simple_ingest/000009.sst:
+  size: 763

--- a/replay/testdata/replay_ingest
+++ b/replay/testdata/replay_ingest
@@ -1,0 +1,172 @@
+corpus simple_ingest
+----
+
+tree
+----
+          /
+            build/
+      36      000002.log
+     757      000005.sst
+     757      000007.sst
+     763      000009.sst
+       0      LOCK
+     172      MANIFEST-000001
+     209      MANIFEST-000008
+    2800      OPTIONS-000003
+       0      marker.format-version.000012.025
+       0      marker.manifest.000002.MANIFEST-000008
+            simple_ingest/
+     757      000007.sst
+     763      000009.sst
+     172      MANIFEST-000001
+     209      MANIFEST-000008
+              checkpoint/
+      25        000002.log
+     774        000004.sst
+     757        000005.sst
+     172        MANIFEST-000001
+    2800        OPTIONS-000003
+       0        marker.format-version.000001.025
+       0        marker.manifest.000001.MANIFEST-000001
+
+cat build/OPTIONS-000003
+----
+----
+[Version]
+  pebble_version=0.1
+
+[Options]
+  bytes_per_sync=524288
+  cache_size=8388608
+  cleaner=replay.WorkloadCollector("delete")
+  compaction_debt_concurrency=1073741824
+  compaction_garbage_fraction_for_max_concurrency=0.40
+  comparer=pebble.internal.testkeys
+  disable_wal=false
+  enable_columnar_blocks=true
+  flush_delay_delete_range=0s
+  flush_delay_range_key=0s
+  flush_split_bytes=4194304
+  format_major_version=25
+  key_schema=DefaultKeySchema(pebble.internal.testkeys,16)
+  l0_compaction_concurrency=10
+  l0_compaction_file_threshold=500
+  l0_compaction_threshold=4
+  l0_stop_writes_threshold=12
+  lbase_max_bytes=67108864
+  concurrent_compactions=1
+  max_concurrent_compactions=1
+  max_concurrent_downloads=1
+  max_manifest_file_size=156
+  max_open_files=1000
+  mem_table_size=4194304
+  mem_table_stop_writes_threshold=2
+  min_deletion_rate=0
+  free_space_threshold_bytes=17179869184
+  free_space_timeframe=10s
+  obsolete_bytes_max_ratio=0.200000
+  obsolete_bytes_timeframe=5m0s
+  merger=pebble.concatenate
+  multilevel_compaction_heuristic=wamp(0.00, false)
+  read_compaction_rate=16000
+  read_sampling_multiplier=16
+  num_deletions_threshold=100
+  deletion_size_ratio_threshold=0.500000
+  tombstone_dense_compaction_threshold=0.100000
+  strict_wal_tail=true
+  table_cache_shards=2
+  validate_on_ingest=false
+  wal_dir=
+  wal_bytes_per_sync=0
+  secondary_cache_size_bytes=0
+  create_on_shared=0
+
+[Level "0"]
+  block_restart_interval=16
+  block_size=4096
+  block_size_threshold=90
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=2097152
+
+[Level "1"]
+  block_restart_interval=16
+  block_size=4096
+  block_size_threshold=90
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=4194304
+
+[Level "2"]
+  block_restart_interval=16
+  block_size=4096
+  block_size_threshold=90
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=8388608
+
+[Level "3"]
+  block_restart_interval=16
+  block_size=4096
+  block_size_threshold=90
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=16777216
+
+[Level "4"]
+  block_restart_interval=16
+  block_size=4096
+  block_size_threshold=90
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=33554432
+
+[Level "5"]
+  block_restart_interval=16
+  block_size=4096
+  block_size_threshold=90
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=67108864
+
+[Level "6"]
+  block_restart_interval=16
+  block_size=4096
+  block_size_threshold=90
+  compression=Snappy
+  filter_policy=none
+  filter_type=table
+  index_block_size=4096
+  target_file_size=134217728
+----
+----
+
+replay simple_ingest unpaced
+----
+
+wait
+----
+replayed 1.5KB in writes
+
+scan-keys
+----
+p: p
+q: q
+x: x
+y: y
+z: z
+
+close
+----


### PR DESCRIPTION
this commit adds ingestion and ingest-and-excise tests on replay package for improving benchmarks and accounts for excise operations during ingestion as well.

see #5048 