### PR TITLE
sstable: avoid overflow in GetScaledProperties

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/RaduBerinde/axisds v0.0.0-20250419182453-5135a0650657
 	github.com/cespare/xxhash/v2 v2.2.0
-	github.com/cockroachdb/crlib v0.0.0-20250617202621-0794c595bbe6
+	github.com/cockroachdb/crlib v0.0.0-20250718215705-7ff5051265b9
 	github.com/cockroachdb/datadriven v1.0.3-0.20250407164829-2945557346d5
 	github.com/cockroachdb/errors v1.11.3
 	github.com/cockroachdb/metamorphic v0.0.0-20231108215700-4ba948b56895

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cockroachdb/crlib v0.0.0-20250617202621-0794c595bbe6 h1:PZVolkXzVqPQQZ7Jm8/lGpI9ZM086mB55oOWqy0wG6E=
-github.com/cockroachdb/crlib v0.0.0-20250617202621-0794c595bbe6/go.mod h1:Gq51ZeKaFCXk6QwuGM0w1dnaOqc/F5zKT2zA9D6Xeac=
+github.com/cockroachdb/crlib v0.0.0-20250718215705-7ff5051265b9 h1:eNjHrT3pPlP1q/4VT/IRGzl8Jiq1XHrSpLJmrGFJDT8=
+github.com/cockroachdb/crlib v0.0.0-20250718215705-7ff5051265b9/go.mod h1:Gq51ZeKaFCXk6QwuGM0w1dnaOqc/F5zKT2zA9D6Xeac=
 github.com/cockroachdb/datadriven v1.0.3-0.20250407164829-2945557346d5 h1:UycK/E0TkisVrQbSoxvU827FwgBBcZ95nRRmpj/12QI=
 github.com/cockroachdb/datadriven v1.0.3-0.20250407164829-2945557346d5/go.mod h1:jsaKMvD3RBCATk1/jbUZM8C9idWBJME9+VRZ5+Liq1g=
 github.com/cockroachdb/errors v1.11.3 h1:5bA+k2Y6r+oz/6Z/RFlNeVCesGARKuC6YymtcDrbC/I=

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/cockroachdb/crlib/crmath"
 	"github.com/cockroachdb/pebble/internal/intern"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/sstable/colblk"
@@ -143,7 +144,7 @@ func (c *CommonProperties) GetScaledProperties(backingSize, size uint64) CommonP
 	backingSize = max(backingSize, size)
 
 	scale := func(a uint64) uint64 {
-		return (a*size + backingSize - 1) / backingSize
+		return crmath.ScaleUint64(a, size, backingSize)
 	}
 	// It's important that no non-zero fields (like NumDeletions, NumRangeKeySets)
 	// become zero (or vice-versa).

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -138,12 +138,10 @@ func TestPropertiesSave(t *testing.T) {
 func TestScalePropertiesBadSizes(t *testing.T) {
 	// Verify that GetScaledProperties works even if the given sizes are not
 	// valid.
-	p := Properties{
-		CommonProperties: CommonProperties{
-			NumDeletions:  0,
-			NumEntries:    1,
-			NumDataBlocks: 10,
-		},
+	p := CommonProperties{
+		NumDeletions:  0,
+		NumEntries:    1,
+		NumDataBlocks: 10,
 	}
 	scaled := p.GetScaledProperties(100, 0)
 	require.Equal(t, uint64(0), scaled.NumDeletions)
@@ -154,6 +152,23 @@ func TestScalePropertiesBadSizes(t *testing.T) {
 	require.Equal(t, uint64(0), scaled.NumDeletions)
 	require.Equal(t, uint64(1), scaled.NumEntries)
 	require.Equal(t, uint64(10), scaled.NumDataBlocks)
+}
+
+func TestScalePropertiesOverflow(t *testing.T) {
+	// Verify that GetScaledProperties works even if the given sizes are not
+	// valid.
+	p := CommonProperties{
+		RawKeySize:   1 << 40,
+		RawValueSize: 1 << 50,
+	}
+	scaled := p.GetScaledProperties(1<<60, 1<<60)
+	require.Equal(t, p, scaled)
+
+	scaled = p.GetScaledProperties(1<<60, 1<<50)
+	require.Equal(t, scaled, CommonProperties{
+		RawKeySize:   1 << 30,
+		RawValueSize: 1 << 40,
+	})
 }
 
 func BenchmarkPropertiesLoad(b *testing.B) {


### PR DESCRIPTION
#### go.mod: update crlib


#### sstable: move GetScaledProperties

This method belongs on the `CommonProperties` type.

#### sstable: avoid overflow in GetScaledProperties