### PR TITLE
colblk: remove unnecessary start ptr from RawBytes

### DIFF
--- a/cockroachkvs/cockroachkvs_64bit_test.go
+++ b/cockroachkvs/cockroachkvs_64bit_test.go
@@ -1,0 +1,17 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build arm64 || amd64
+
+package cockroachkvs
+
+import (
+	"unsafe"
+
+	"github.com/cockroachdb/pebble/sstable/colblk"
+)
+
+// Assert that KeySeekerMetadata isn't larger than it needs to be to fit a
+// cockroachKeySeeker on a 64-bit platform.
+var _ uint = uint(unsafe.Sizeof(cockroachKeySeeker{})) - colblk.KeySeekerMetadataSize

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -257,7 +257,7 @@ func CastMetadata[T any](md *Metadata) *T {
 
 // MetadataSize is the size of the metadata. The value is chosen to fit a
 // colblk.DataBlockDecoder and a CockroachDB colblk.KeySeeker.
-const MetadataSize = 336
+const MetadataSize = 312
 
 // Assert that MetadataSize is a multiple of 8. This is necessary to keep the
 // block data buffer aligned.

--- a/sstable/block/testdata/flush_governor
+++ b/sstable/block/testdata/flush_governor
@@ -29,8 +29,8 @@ should not flush
 init target-block-size=800 size-class-aware-threshold=60 size-classes=(820, 1020, 1320, 1820)
 ----
 low watermark: 480
-high watermark: 952
-targetBoundary: 652
+high watermark: 976
+targetBoundary: 676
 
 # Should not flush when the "after" block fits in the same size class.
 should-flush size-before=600 size-after=650
@@ -51,7 +51,7 @@ should not flush
 
 should-flush size-before=600 size-after=960
 ----
-should flush
+should not flush
 
 # Should flush when the after size is above the high watermark.
 should-flush size-before=600 size-after=1500
@@ -82,8 +82,8 @@ targetBoundary: 1000
 init target-block-size=32768 jemalloc-size-classes
 ----
 low watermark: 19661
-high watermark: 40592
-targetBoundary: 32400
+high watermark: 40616
+targetBoundary: 32424
 
 # We should not flush until exceeding the boundary.
 should-flush size-before=30000 size-after=31000

--- a/sstable/colblk/colblk_64bit_test.go
+++ b/sstable/colblk/colblk_64bit_test.go
@@ -1,0 +1,13 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build arm64 || amd64
+
+package colblk
+
+import "github.com/cockroachdb/pebble/sstable/block"
+
+// Assert that block.MetadataSize is not larger than it needs to be on a 64-bit
+// platform.
+const _ uint = uint(dataBlockDecoderSize) + KeySeekerMetadataSize - block.MetadataSize

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -66,7 +66,7 @@ type KeySeekerMetadata [KeySeekerMetadataSize]byte
 
 // KeySeekerMetadataSize is chosen to fit the CockroachDB key seeker
 // implementation.
-const KeySeekerMetadataSize = 176
+const KeySeekerMetadataSize = 160
 
 // A KeyWriter maintains ColumnWriters for a data block for writing user keys
 // into the database-specific key schema. Users may define their own key schema

--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -615,13 +615,16 @@ func prefixBytesToBinFormatter(
 	if sliceFormatter == nil {
 		sliceFormatter = defaultSliceFormatter
 	}
-	pb, _ := DecodePrefixBytes(f.RelativeData(), uint32(f.RelativeOffset()), count)
+	data := f.RelativeData()
+	off := f.RelativeOffset()
+	start := unsafe.Pointer(&data[off])
+	pb, _ := DecodePrefixBytes(data, uint32(off), count)
 
 	f.HexBytesln(1, "bundle size: %d", 1<<pb.bundleShift)
 	f.ToTreePrinter(tp)
 
 	n := tp.Child("offsets table")
-	dataOffset := uint64(f.RelativeOffset()) + uint64(uintptr(pb.rawBytes.data)-uintptr(pb.rawBytes.start))
+	dataOffset := uint64(off) + uint64(uintptr(pb.rawBytes.data)-uintptr(start))
 	uintsToBinFormatter(f, n, pb.rawBytes.slices+1, func(offsetDelta, offsetBase uint64) string {
 		// NB: offsetBase will always be zero for PrefixBytes columns.
 		return fmt.Sprintf("%d [%d overall]", offsetDelta+offsetBase, offsetDelta+offsetBase+dataOffset)

--- a/sstable/colblk/unsafe_uints.go
+++ b/sstable/colblk/unsafe_uints.go
@@ -19,8 +19,8 @@ import (
 //
 // The At() method is defined in endian_little.go and endian_big.go.
 type UnsafeUints struct {
-	base  uint64
 	ptr   unsafe.Pointer
+	base  uint64
 	width uint8
 }
 

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -155,7 +155,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   5 (1.9KB) |       81.8% |     1 (376B) |       89.2% |         0.0% |           0 |           0
+   5 (1.8KB) |       81.8% |     1 (376B) |       89.2% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -423,7 +423,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   7 (2.7KB) |       59.6% |     1 (472B) |       78.6% |         0.0% |           0 |           0
+   7 (2.5KB) |       59.6% |     1 (472B) |       78.6% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -277,7 +277,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (784B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+    2 (736B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -410,7 +410,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   6 (2.3KB) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+   6 (2.2KB) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -66,7 +66,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   3 (1.1KB) |       15.4% |     1 (280B) |       50.0% |         0.0% |           0 |           0
+   3 (1020B) |       15.4% |     1 (280B) |       50.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -120,7 +120,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (795B) |        0.0% |     1 (280B) |        0.0% |         0.0% |           1 |           0
+    2 (747B) |        0.0% |     1 (280B) |        0.0% |         0.0% |           1 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -213,7 +213,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (795B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+    2 (747B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -289,7 +289,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (795B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+    2 (747B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -362,7 +362,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (795B) |       33.3% |     1 (280B) |       66.7% |         0.0% |           1 |           0
+    2 (747B) |       33.3% |     1 (280B) |       66.7% |         0.0% |           1 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -804,7 +804,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   6 (2.3KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+   6 (2.2KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -917,7 +917,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   6 (2.3KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+   6 (2.2KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -1457,7 +1457,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (787B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+    2 (739B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -1537,7 +1537,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (787B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+    2 (739B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -1788,7 +1788,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (774B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
+    2 (726B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %
@@ -1857,7 +1857,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (774B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
+    2 (726B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
 --------------------------------------------------------------------------------------------------
 FILES                 tables                      |     blob files     |        blob values
    stats prog |   backing |    zombie |  loc zomb |    live |   zombie |  total |  refed | refed %


### PR DESCRIPTION
Remove an unnecessary 'start' pointer from RawBytes. It was only used when formatting the structure. This allows us to reduce the size of the block.Metadata by 24 bytes. Additionally, we add test assertions on 64-bit platforms that ensure we don't leave MetadataSize larger than is necessary.

MetadataSize is allocated per block in the block cache (~ on the order of hundreds of thousands), so its overhead can be material.