### PR TITLE
Fix issue #5098: sstable: don't intern CompressionStats

### DIFF
--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -339,7 +339,13 @@ func (p *Properties) load(i iter.Seq2[[]byte, []byte]) error {
 				n, _ := binary.Uvarint(val)
 				field.SetUint(n)
 			case reflect.String:
-				field.SetString(intern.Bytes(val))
+				// Don't intern CompressionStats as it's unique per sstable and would
+				// cause a memory leak by accumulating strings over the program lifetime.
+				if string(key) == "pebble.compression_stats" {
+					field.SetString(string(val))
+				} else {
+					field.SetString(intern.Bytes(val))
+				}
 			default:
 				panic("not reached")
 			}


### PR DESCRIPTION
Fixes #5098

## Summary
Automated fix for: sstable: don't intern CompressionStats

## Changes
- Generated solution using Claude CLI
- Focused on minimal, targeted changes

## Test Plan
Manual testing and existing test suite

🤖 Generated with [Claude Code](https://claude.ai/code)