### PR TITLE
sstable: remove checksummer from blockBuf

### DIFF
--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -600,7 +600,7 @@ func TestBlockBufClear(t *testing.T) {
 
 func TestClearDataBlockBuf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	d := newDataBlockBuf(1, block.ChecksumTypeCRC32c)
+	d := newDataBlockBuf(1)
 	d.blockBuf.dataBuf = make([]byte, 1)
 	require.NoError(t, d.dataBlock.Add(ikey("apple"), nil))
 	require.NoError(t, d.dataBlock.Add(ikey("banana"), nil))


### PR DESCRIPTION
The compressor and checksummer are used together but in many code
paths we use a checksummer in a blockBuf. Remove this and always use a
checksummer initialized alongside the compressor.