### PR TITLE
sstable: use correct blockkind for checksum validation of blob ref index

### DIFF
--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -369,7 +369,7 @@ func (l *Layout) Describe(
 				// We have already read the value-index to construct the list of
 				// value-blocks, so no need to do it again.
 			case "blob-reference-index":
-				h, err = r.readBlobRefIndexBlock(ctx, block.NoReadEnv, noReadHandle)
+				h, err = r.readBlobRefIndexBlock(ctx, block.NoReadEnv, noReadHandle, r.blobRefIndexBH)
 				if err != nil {
 					return err
 				}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -425,13 +425,13 @@ func (r *Reader) readValueBlock(
 func (r *Reader) ReadBlobRefIndexBlock(
 	ctx context.Context, env block.ReadEnv,
 ) (block.BufferHandle, error) {
-	return r.readBlobRefIndexBlock(ctx, env, noReadHandle)
+	return r.readBlobRefIndexBlock(ctx, env, noReadHandle, r.blobRefIndexBH)
 }
 
 func (r *Reader) readBlobRefIndexBlock(
-	ctx context.Context, env block.ReadEnv, readHandle objstorage.ReadHandle,
+	ctx context.Context, env block.ReadEnv, readHandle objstorage.ReadHandle, bh block.Handle,
 ) (block.BufferHandle, error) {
-	return r.blockReader.Read(ctx, env, readHandle, r.blobRefIndexBH, blockkind.BlobReferenceValueLivenessIndex, noInitBlockMetadataFn)
+	return r.blockReader.Read(ctx, env, readHandle, bh, blockkind.BlobReferenceValueLivenessIndex, noInitBlockMetadataFn)
 }
 
 // metaBufferPools is a sync pool of BufferPools used exclusively when opening a
@@ -756,7 +756,7 @@ func (r *Reader) ValidateBlockChecksums() error {
 	})
 	blocks = append(blocks, blk{
 		bh:     l.BlobReferenceIndex,
-		readFn: readNoInit,
+		readFn: r.readBlobRefIndexBlock,
 	})
 
 	// Sorting by offset ensures we are performing a sequential scan of the


### PR DESCRIPTION
Previously, we were using a read function with `blockkind.Metadata` when we should have passed in the `readBlobRefIndexBlock` read function (the only difference here is the proper blockkind, `blockkind.BlobReferenceValueLivenessIndex`, is used)