### PR TITLE
crl-release-25.1: sstable: prevent block metadata pointers to garbage

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
+	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/cockroachdb/crlib/crtime"
@@ -180,11 +181,40 @@ func ValidateChecksum(checksumType ChecksumType, b []byte, bh Handle) error {
 // when the block is read from disk.
 //
 // Portions of this buffer can be cast to the structures we need (through
-// unsafe.Pointer), but note that any pointers in these structures will be
-// invisible to the GC. Pointers to the block's data buffer are ok, since the
-// metadata and the data have the same lifetime (sharing the underlying
-// allocation).
+// CastMetadata[Zero]), but note that any pointers in these structures should be
+// considered invisible to the GC for the purpose of preserving lifetime.
+// Pointers to the block's data buffer are ok, since the metadata and the data
+// have the same lifetime (sharing the underlying allocation).
 type Metadata [MetadataSize]byte
+
+// CastMetadataZero casts the provided metadata to the type parameter T, zeroing
+// the memory backing the metadata first. This zeroing is necessary when first
+// initializing the data structure to ensure that the Go garbage collector
+// doesn't misinterpret any of T's pointer fields, falsely detecting them as
+// invalid pointers.
+func CastMetadataZero[T any](md *Metadata) *T {
+	var z T
+	if invariants.Enabled {
+		if uintptr(unsafe.Pointer(md))%unsafe.Alignof(z) != 0 {
+			panic(errors.AssertionFailedf("incorrect alignment for %T (%p)", z, unsafe.Pointer(md)))
+		}
+	}
+	clear((*md)[:unsafe.Sizeof(z)])
+	return (*T)(unsafe.Pointer(md))
+}
+
+// CastMetadata casts the provided metadata to the type parameter T. If the
+// Metadata has not already been initialized, callers should use
+// CastMetadataZero.
+func CastMetadata[T any](md *Metadata) *T {
+	var z T
+	if invariants.Enabled {
+		if uintptr(unsafe.Pointer(md))%unsafe.Alignof(z) != 0 {
+			panic(errors.AssertionFailedf("incorrect alignment for %T (%p)", z, unsafe.Pointer(md)))
+		}
+	}
+	return (*T)(unsafe.Pointer(md))
+}
 
 // MetadataSize is the size of the metadata. The value is chosen to fit a
 // colblk.DataBlockDecoder and a CockroachDB colblk.KeySeeker.

--- a/sstable/block/buffer_pool.go
+++ b/sstable/block/buffer_pool.go
@@ -187,7 +187,9 @@ func (p *BufferPool) Release() {
 		if p.pool[i].b != nil {
 			panic(errors.AssertionFailedf("Release called on a BufferPool with in-use buffers"))
 		}
-		cache.Free(p.pool[i].v)
+		v := p.pool[i].v
+		p.pool[i].v = nil
+		cache.Free(v)
 	}
 	*p = BufferPool{}
 }


### PR DESCRIPTION
When allocating memory for a new block, we allocate an additional block.MetadataSize bytes for holding a Go structure containing decoded data describing the block and maintaining pointers into the block's contents. This allows us to decode the block structure once when the block is loaded into the block cache. Readers that find the block in the cache simply cast this 'block metadata' preamble into the appropriate type.

When a block is not found within the block cache, we: load the block, decode the block's header and initialize the block's unique metadata. We initialize the metadata by first casting the allocation's pointer to the appropriate Go pointer type. Then we decode the block's data, initializing the metadata struct accordingly. In the interim between the pointer cast and the initialization, the contents of the metadata are undefined.

The per-block metadata types typically contain pointer fields. Once initialized, these pointers point into the block's data, all part of the same CGo manual allocation. If the Go garbage collector examines this Go struct before it's been fully initialized, it may observe arbitrary garbage within the pointer fields. If one of these values looks like a pointer to a Go-allocated part of the address space, the Go garbage collector crashes the process. It's a little unclear the circumstances in which the Go garbage collector will examine these metadata structs that exist within CGo memory, but experimentally it appears to be the case.

This commit fixes the issue by always zeroing block metadata memory before casting it into the appropriate metadata struct. Additionally, it solves an analogous problem during de-allocation by nil-ing metadata pointers into blocks before we release the blocks back to the cache or buffer pool. Together, these changes ensure that whenever we have a pointer to a block metadata Go structure, the structure's backing memory is either zeroed or the result of initialization based on decoding the block.

Informs cockroachdb/cockroach#149955.
Informs cockroachdb/cockroach#150216.