### PR TITLE
sstable: free physical buffers on write

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -99,7 +99,7 @@ type RawColumnWriter struct {
 
 	writeQueue struct {
 		wg  sync.WaitGroup
-		ch  chan block.PhysicalBlock
+		ch  chan block.OwnedPhysicalBlock
 		err error
 	}
 	layout layoutWriter
@@ -189,7 +189,7 @@ func newColumnarWriter(
 	w.props.KeySchemaName = o.KeySchema.Name
 	w.props.MergerName = o.MergerName
 
-	w.writeQueue.ch = make(chan block.PhysicalBlock)
+	w.writeQueue.ch = make(chan block.OwnedPhysicalBlock)
 	w.writeQueue.wg.Add(1)
 	w.cpuMeasurer = cpuMeasurer
 	go w.drainWriteQueue()
@@ -710,15 +710,17 @@ func (w *RawColumnWriter) enqueueDataBlock(
 
 	// Compress and checksum the data block and send it to the write queue.
 	pb := w.layout.physBlockMaker.Make(serializedBlock, blockkind.SSTableData, block.NoFlags)
-	return w.enqueuePhysicalBlock(pb, separator)
+	return w.enqueuePhysicalBlock(pb.Take(), separator)
 }
 
 // enqueuePhysicalBlock enqueues a physical block to the write queue; the
 // physical block will be automatically released.
-func (w *RawColumnWriter) enqueuePhysicalBlock(pb block.PhysicalBlock, separator []byte) error {
+func (w *RawColumnWriter) enqueuePhysicalBlock(
+	pb block.OwnedPhysicalBlock, separator []byte,
+) error {
 	dataBlockHandle := block.Handle{
 		Offset: w.queuedDataSize,
-		Length: uint64(pb.LengthWithoutTrailer()),
+		Length: uint64(pb.Length().WithoutTrailer()),
 	}
 	w.queuedDataSize += dataBlockHandle.Length + block.TrailerLen
 	w.writeQueue.ch <- pb
@@ -881,7 +883,6 @@ func (w *RawColumnWriter) drainWriteQueue() {
 		if _, err := w.layout.WritePrecompressedDataBlock(pb); err != nil {
 			w.writeQueue.err = err
 		}
-		pb.Release()
 		// Report to the CPU measurer immediately after writing (note that there
 		// may be a time lag until the next block is available to write).
 		w.cpuMeasurer.MeasureCPU(base.CompactionGoroutineSSTableSecondary)
@@ -1125,7 +1126,7 @@ func (w *RawColumnWriter) rewriteSuffixes(
 			w.separatorBuf = w.comparer.Successor(w.separatorBuf[:0], blocks[i].end.UserKey)
 			separator = w.separatorBuf
 		}
-		if err := w.enqueuePhysicalBlock(blocks[i].physical, separator); err != nil {
+		if err := w.enqueuePhysicalBlock(blocks[i].physical.Take(), separator); err != nil {
 			return err
 		}
 	}
@@ -1207,7 +1208,7 @@ func (w *RawColumnWriter) copyDataBlocks(
 			offsetDiff := blocks[i].bh.Offset - blocks[firstBlockIdx].bh.Offset
 			dataWithTrailer := buf[offsetDiff : offsetDiff+blocks[i].bh.Length+block.TrailerLen]
 			pb := block.AlreadyEncodedPhysicalBlock(dataWithTrailer)
-			if err := w.enqueuePhysicalBlock(pb, blocks[i].sep); err != nil {
+			if err := w.enqueuePhysicalBlock(pb.Take(), blocks[i].sep); err != nil {
 				return err
 			}
 		}
@@ -1242,7 +1243,7 @@ func (w *RawColumnWriter) copyDataBlocks(
 func (w *RawColumnWriter) addDataBlock(b, sep []byte, bhp block.HandleWithProperties) error {
 	// Compress and checksum the data block and send it to the write queue.
 	pb := w.layout.physBlockMaker.Make(b, blockkind.SSTableData, block.NoFlags)
-	if err := w.enqueuePhysicalBlock(pb, sep); err != nil {
+	if err := w.enqueuePhysicalBlock(pb.Take(), sep); err != nil {
 		return err
 	}
 	return nil

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -1810,7 +1810,7 @@ func (w *RawRowWriter) rewriteSuffixes(
 
 	for i := range blocks {
 		// Write the rewritten block to the file.
-		bh, err := w.layout.WritePrecompressedDataBlock(blocks[i].physical)
+		bh, err := w.layout.WritePrecompressedDataBlock(blocks[i].physical.Take())
 		blocks[i].physical.Release()
 		if err != nil {
 			return err
@@ -1922,8 +1922,7 @@ func (w *RawRowWriter) addDataBlock(b, sep []byte, bhp block.HandleWithPropertie
 
 	// layout.writePhysicalBlock keeps layout.offset up-to-date for us.
 	// Note that this can mangle the pb data.
-	bh, err := w.layout.writePhysicalBlock(pb)
-	pb.Release()
+	bh, err := w.layout.writePhysicalBlock(pb.Take())
 	if err != nil {
 		return err
 	}

--- a/sstable/write_queue.go
+++ b/sstable/write_queue.go
@@ -60,8 +60,7 @@ func newWriteQueue(size int, writer *RawRowWriter) *writeQueue {
 }
 
 func (w *writeQueue) performWrite(task *writeTask) error {
-	handle, err := w.writer.layout.WritePrecompressedDataBlock(task.buf.physical)
-	task.buf.physical.Release()
+	handle, err := w.writer.layout.WritePrecompressedDataBlock(task.buf.physical.Take())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change moves the responsibility of releasing the `PhysicalBlock`s
to the code that writes out the block. This makes the higher level
code simpler and more robust.

To avoid misuse, we add an `OwnedPhysicalBlock` type which is used to
indicate that once passed, the function takes responsibility for
releasing the block. The only way to create an `OwnedPhysicalBlock`
clears the `PhysicalBlock` so it can't be incorrectly used again.