### PR TITLE
db: propagate *PhysicalBlobFile to reportCorruption

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -181,11 +181,12 @@ func (c *blobFileRewriteCompaction) Execute(jobID JobID, d *DB) error {
 			// Now that we have the manifest lock, check if the blob file is
 			// still current. If not, we bubble up ErrCancelledCompaction.
 			v := d.mu.versions.currentVersion()
-			currentDiskFileNum, ok := v.BlobFiles.Lookup(c.input.FileID)
+			currentDiskFile, ok := v.BlobFiles.Lookup(c.input.FileID)
 			if !ok {
 				return versionUpdate{}, errors.Wrapf(ErrCancelledCompaction,
 					"blob file %s became unreferenced", c.input.FileID)
 			}
+			currentDiskFileNum := currentDiskFile.DiskFileNum()
 			// Assert that the current version's disk file number for the blob
 			// matches the one we rewrote. This compaction should be the only
 			// rewrite compaction running for this blob file.

--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -296,7 +296,7 @@ func TestBlobRewriteRandomized(t *testing.T) {
 			base.MakeInternalKey(keys[i], base.SeqNum(i), base.InternalKeyKindSet),
 			blob.InlineHandle{
 				InlineHandlePreface: blob.InlineHandlePreface{
-					ReferenceID: blob.ReferenceID(0),
+					ReferenceID: base.BlobReferenceID(0),
 					ValueLen:    uint32(len(values[i])),
 				},
 				HandleSuffix: blob.HandleSuffix{
@@ -415,11 +415,11 @@ func TestBlobRewriteRandomized(t *testing.T) {
 	}
 }
 
-// constantFileMapping implements blob.FileMapping and always maps to itself.
+// constantFileMapping implements base.BlobFileMapping and always maps to itself.
 type constantFileMapping base.DiskFileNum
 
-// Assert that (*inputFileMapping) implements blob.FileMapping.
-var _ blob.FileMapping = constantFileMapping(0)
+// Assert that (*inputFileMapping) implements base.BlobFileMapping.
+var _ base.BlobFileMapping = constantFileMapping(0)
 
 func (m constantFileMapping) Lookup(fileID base.BlobFileID) (base.DiskFileNum, bool) {
 	return base.DiskFileNum(m), true

--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -421,6 +421,6 @@ type constantFileMapping base.DiskFileNum
 // Assert that (*inputFileMapping) implements base.BlobFileMapping.
 var _ base.BlobFileMapping = constantFileMapping(0)
 
-func (m constantFileMapping) Lookup(fileID base.BlobFileID) (base.DiskFileNum, bool) {
+func (m constantFileMapping) Lookup(fileID base.BlobFileID) (base.DiskFile, bool) {
 	return base.DiskFileNum(m), true
 }

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -326,11 +326,11 @@ func (d *DB) Checkpoint(
 						includedBlobFiles[ref.FileID] = struct{}{}
 
 						// Map the BlobFileID to a DiskFileNum in the current version.
-						diskFileNum, ok := current.BlobFiles.Lookup(ref.FileID)
+						diskFile, ok := current.BlobFiles.Lookup(ref.FileID)
 						if !ok {
 							return errors.Errorf("blob file %s not found", ref.FileID)
 						}
-						ckErr = copyFile(base.FileTypeBlob, diskFileNum)
+						ckErr = copyFile(base.FileTypeBlob, diskFile.DiskFileNum())
 						if ckErr != nil {
 							return ckErr
 						}

--- a/db.go
+++ b/db.go
@@ -633,7 +633,11 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 		}
 		return nil, nil, ErrNotFound
 	}
-	return i.Value(), i, nil
+	val, err := i.ValueAndErr()
+	if err != nil {
+		return nil, nil, errors.CombineErrors(err, i.Close())
+	}
+	return val, i, nil
 }
 
 // Set sets the value for the given key. It overwrites any previous value

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -1089,13 +1089,13 @@ func TestFileCacheRetryAfterFailure(t *testing.T) {
 		h, fs := fct.newTestHandle()
 
 		fs.setOpenError(true /* enabled */)
-		_, _, err := h.GetValueReader(ctx, fileCacheTestNumTables)
+		_, _, err := h.GetValueReader(ctx, base.DiskFileNum(fileCacheTestNumTables))
 		if err == nil {
 			t.Fatalf("expected failure, but found success")
 		}
 		require.Equal(t, "pebble: backing file 000200 error: injected error", err.Error())
 		fs.setOpenError(false /* enabled */)
-		_, closeFunc, err := h.GetValueReader(ctx, fileCacheTestNumTables)
+		_, closeFunc, err := h.GetValueReader(ctx, base.DiskFileNum(fileCacheTestNumTables))
 		require.NoError(t, err)
 		closeFunc()
 		fs.validateAndCloseHandle(t, h, nil)

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -59,6 +59,20 @@ func (id BlobFileID) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("B%06d", redact.SafeUint(id))
 }
 
+// BlobReferenceID identifies a particular blob reference within a table. It's
+// implemented as an index into the slice of the BlobReferences recorded in the
+// manifest.
+type BlobReferenceID uint32
+
+// BlobFileMapping defines the mapping between blob file IDs and disk file numbers.
+// It's implemented by *manifest.BlobFileSet.
+type BlobFileMapping interface {
+	// Lookup returns the disk file number for the given blob file ID. It
+	// returns false for the second return value if the blob file ID is not
+	// present in the mapping.
+	Lookup(BlobFileID) (DiskFileNum, bool)
+}
+
 // A DiskFileNum identifies a file or object with exists on disk.
 type DiskFileNum uint64
 

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -64,13 +64,19 @@ func (id BlobFileID) SafeFormat(w redact.SafePrinter, _ rune) {
 // manifest.
 type BlobReferenceID uint32
 
+// DiskFile is an interface that provides access to a disk file number.
+type DiskFile interface {
+	// DiskFileNum returns the disk file number.
+	DiskFileNum() DiskFileNum
+}
+
 // BlobFileMapping defines the mapping between blob file IDs and disk file numbers.
 // It's implemented by *manifest.BlobFileSet.
 type BlobFileMapping interface {
-	// Lookup returns the disk file number for the given blob file ID. It
+	// Lookup returns a DiskFile for the given blob file ID. It
 	// returns false for the second return value if the blob file ID is not
 	// present in the mapping.
-	Lookup(BlobFileID) (DiskFileNum, bool)
+	Lookup(BlobFileID) (DiskFile, bool)
 }
 
 // A DiskFileNum identifies a file or object with exists on disk.
@@ -81,6 +87,11 @@ func (dfn DiskFileNum) String() string { return fmt.Sprintf("%06d", dfn) }
 // SafeFormat implements redact.SafeFormatter.
 func (dfn DiskFileNum) SafeFormat(w redact.SafePrinter, verb rune) {
 	w.Printf("%06d", redact.SafeUint(dfn))
+}
+
+// DiskFileNum implements the DiskFile interface.
+func (fdn DiskFileNum) DiskFileNum() DiskFileNum {
+	return fdn
 }
 
 // FileType enumerates the types of files found in a DB.

--- a/internal/blobtest/handles.go
+++ b/internal/blobtest/handles.go
@@ -292,13 +292,13 @@ type References struct {
 }
 
 // MapToReferenceID maps the given file number to a reference ID.
-func (b *References) MapToReferenceID(fileID base.BlobFileID) blob.ReferenceID {
+func (b *References) MapToReferenceID(fileID base.BlobFileID) base.BlobReferenceID {
 	for i, fn := range b.fileIDs {
 		if fn == fileID {
-			return blob.ReferenceID(i)
+			return base.BlobReferenceID(i)
 		}
 	}
 	i := uint32(len(b.fileIDs))
 	b.fileIDs = append(b.fileIDs, fileID)
-	return blob.ReferenceID(i)
+	return base.BlobReferenceID(i)
 }

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -148,6 +148,11 @@ func (m *PhysicalBlobFile) String() string {
 	return redact.StringWithoutMarkers(m)
 }
 
+// DiskFileNum implements base.DiskFile.
+func (m *PhysicalBlobFile) DiskFileNum() base.DiskFileNum {
+	return m.FileNum
+}
+
 // ref increments the reference count for the blob file.
 func (m *PhysicalBlobFile) ref() {
 	m.refs.Add(+1)
@@ -338,15 +343,14 @@ func (s *BlobFileSet) Count() int {
 	return s.tree.Count()
 }
 
-// Lookup returns the file number of the physical blob file backing the given
-// file ID. It returns false for the second return value if the FileID is not
-// present in the set.
-func (s *BlobFileSet) Lookup(fileID base.BlobFileID) (base.DiskFileNum, bool) {
+// Lookup returns the physical blob file backing the given file ID. It returns
+// false for the second return value if the FileID is not present in the set.
+func (s *BlobFileSet) Lookup(fileID base.BlobFileID) (base.DiskFile, bool) {
 	phys, ok := s.LookupPhysical(fileID)
 	if !ok {
-		return 0, false
+		return nil, false
 	}
-	return phys.FileNum, true
+	return phys, true
 }
 
 // LookupPhysical returns the *PhysicalBlobFile backing the given file ID. It

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/strparse"
 	"github.com/cockroachdb/pebble/sstable"
-	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/redact"
 )
 
@@ -291,20 +290,20 @@ type BlobReferences []BlobReference
 var _ sstable.BlobReferences = (*BlobReferences)(nil)
 
 // BlobFileIDByID returns the BlobFileID for the identified BlobReference.
-func (br *BlobReferences) BlobFileIDByID(i blob.ReferenceID) base.BlobFileID {
+func (br *BlobReferences) BlobFileIDByID(i base.BlobReferenceID) base.BlobFileID {
 	return (*br)[i].FileID
 }
 
 // IDByBlobFileID returns the reference ID for the given BlobFileID. If the
 // blob file ID is not found, the second return value is false.
 // IDByBlobFileID is linear in the length of the BlobReferences slice.
-func (br *BlobReferences) IDByBlobFileID(fileID base.BlobFileID) (blob.ReferenceID, bool) {
+func (br *BlobReferences) IDByBlobFileID(fileID base.BlobFileID) (base.BlobReferenceID, bool) {
 	for i, ref := range *br {
 		if ref.FileID == fileID {
-			return blob.ReferenceID(i), true
+			return base.BlobReferenceID(i), true
 		}
 	}
-	return blob.ReferenceID(len(*br)), false
+	return base.BlobReferenceID(len(*br)), false
 }
 
 // BlobFileSet contains a set of blob files that are referenced by a version.
@@ -386,8 +385,8 @@ func (s *BlobFileSet) LookupPhysical(fileID base.BlobFileID) (*PhysicalBlobFile,
 	return nil, false
 }
 
-// Assert that (*BlobFileSet) implements blob.FileMapping.
-var _ blob.FileMapping = (*BlobFileSet)(nil)
+// Assert that (*BlobFileSet) implements base.BlobFileMapping.
+var _ base.BlobFileMapping = (*BlobFileSet)(nil)
 
 // clone returns a copy-on-write clone of the blob file set.
 func (s *BlobFileSet) clone() BlobFileSet {

--- a/internal/manifest/blob_metadata_test.go
+++ b/internal/manifest/blob_metadata_test.go
@@ -182,7 +182,7 @@ func TestBlobFileSet_Lookup(t *testing.T) {
 	for i := 0; i < numBlobFiles; i++ {
 		fn, ok := set.Lookup(base.BlobFileID(i))
 		require.True(t, ok)
-		require.Equal(t, files[i].FileNum, fn)
+		require.Equal(t, files[i].FileNum, fn.DiskFileNum())
 	}
 }
 

--- a/level_checker.go
+++ b/level_checker.go
@@ -786,7 +786,7 @@ func validateBlobValueLiveness(
 		}
 		if err := fc.withReader(ctx, readEnv, t, func(r *sstable.Reader, readEnv sstable.ReadEnv) error {
 			// For this sstable, gather all the blob handles -- tracking
-			// each blob.ReferenceID + blob.BlockID's referenced
+			// each base.BlobReferenceID + blob.BlockID's referenced
 			// blob.BlockValueIDs.
 			referenced, err := gatherBlobHandles(ctx, r, t.BlobReferences, valueFetcher)
 			if err != nil {

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -1025,9 +1025,12 @@ func findManifestStart(
 
 type blobFileMap map[base.BlobFileID]base.DiskFileNum
 
-func (m blobFileMap) Lookup(fileID base.BlobFileID) (base.DiskFileNum, bool) {
+func (m blobFileMap) Lookup(fileID base.BlobFileID) (base.DiskFile, bool) {
 	diskFileNum, ok := m[fileID]
-	return diskFileNum, ok
+	if !ok {
+		return nil, false
+	}
+	return diskFileNum, true
 }
 
 // loadFlushedSSTableKeys copies keys from the sstables specified by `fileNums`

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -144,10 +144,11 @@ func (r *ValueFetcher) retrieve(ctx context.Context, vh Handle) (val []byte, err
 				return nil, err
 			}
 		}
-		diskFileNum, ok := r.fileMapping.Lookup(vh.BlobFileID)
+		diskFile, ok := r.fileMapping.Lookup(vh.BlobFileID)
 		if !ok {
 			return nil, errors.AssertionFailedf("blob file %s not found", vh.BlobFileID)
 		}
+		diskFileNum := diskFile.DiskFileNum()
 		if cr.r, cr.closeFunc, err = r.readerProvider.GetValueReader(ctx, diskFileNum); err != nil {
 			return nil, err
 		}

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -38,15 +38,6 @@ type ValueReader interface {
 	ReadIndexBlock(context.Context, block.ReadEnv, objstorage.ReadHandle) (block.BufferHandle, error)
 }
 
-// A FileMapping defines the mapping between blob file IDs and disk file numbers.
-// It's implemented by *manifest.BlobFileSet.
-type FileMapping interface {
-	// Lookup returns the disk file number for the given blob file ID. It
-	// returns false for the second return value if the blob file ID is not
-	// present in the mapping.
-	Lookup(base.BlobFileID) (base.DiskFileNum, bool)
-}
-
 // A ReaderProvider is an interface that can be used to retrieve a ValueReader
 // for a given file number.
 type ReaderProvider interface {
@@ -64,7 +55,7 @@ type ReaderProvider interface {
 // When finished with a ValueFetcher, one must call Close to release all cached
 // readers and block buffers.
 type ValueFetcher struct {
-	fileMapping    FileMapping
+	fileMapping    base.BlobFileMapping
 	readerProvider ReaderProvider
 	env            block.ReadEnv
 	fetchCount     int
@@ -78,7 +69,7 @@ type ValueFetcher struct {
 var _ base.ValueFetcher = (*ValueFetcher)(nil)
 
 // Init initializes the ValueFetcher.
-func (r *ValueFetcher) Init(fm FileMapping, rp ReaderProvider, env block.ReadEnv) {
+func (r *ValueFetcher) Init(fm base.BlobFileMapping, rp ReaderProvider, env block.ReadEnv) {
 	r.fileMapping = fm
 	r.readerProvider = rp
 	r.env = env

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -41,8 +41,8 @@ type ValueReader interface {
 // A ReaderProvider is an interface that can be used to retrieve a ValueReader
 // for a given file number.
 type ReaderProvider interface {
-	// GetValueReader returns a ValueReader for the given file number.
-	GetValueReader(ctx context.Context, fileNum base.DiskFileNum) (r ValueReader, closeFunc func(), err error)
+	// GetValueReader returns a ValueReader for the given disk file.
+	GetValueReader(ctx context.Context, diskFile base.DiskFile) (r ValueReader, closeFunc func(), err error)
 }
 
 // A ValueFetcher retrieves values stored out-of-band in separate blob files.
@@ -148,12 +148,11 @@ func (r *ValueFetcher) retrieve(ctx context.Context, vh Handle) (val []byte, err
 		if !ok {
 			return nil, errors.AssertionFailedf("blob file %s not found", vh.BlobFileID)
 		}
-		diskFileNum := diskFile.DiskFileNum()
-		if cr.r, cr.closeFunc, err = r.readerProvider.GetValueReader(ctx, diskFileNum); err != nil {
+		if cr.r, cr.closeFunc, err = r.readerProvider.GetValueReader(ctx, diskFile); err != nil {
 			return nil, err
 		}
 		cr.blobFileID = vh.BlobFileID
-		cr.diskFileNum = diskFileNum
+		cr.diskFileNum = diskFile.DiskFileNum()
 		cr.rh = cr.r.InitReadHandle(&cr.preallocRH)
 		if r.env.Stats != nil {
 			r.env.Stats.SeparatedPointValue.ReaderCacheMisses++

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -32,7 +32,7 @@ type identityFileMapping struct{}
 // Assert that (identityFileMapping) implements base.BlobFileMapping.
 var _ base.BlobFileMapping = identityFileMapping{}
 
-func (identityFileMapping) Lookup(blobFileID base.BlobFileID) (base.DiskFileNum, bool) {
+func (identityFileMapping) Lookup(blobFileID base.BlobFileID) (base.DiskFile, bool) {
 	return base.DiskFileNum(blobFileID), true
 }
 

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -44,8 +44,9 @@ type mockReaderProvider struct {
 }
 
 func (rp *mockReaderProvider) GetValueReader(
-	ctx context.Context, fileNum base.DiskFileNum,
+	ctx context.Context, diskFile base.DiskFile,
 ) (r ValueReader, closeFunc func(), err error) {
+	fileNum := diskFile.DiskFileNum()
 	if rp.w != nil {
 		fmt.Fprintf(rp.w, "# GetValueReader(%s)\n", fileNum)
 	}

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// identityFileMapping is an implementation of FileMapping that casts a
+// identityFileMapping is an implementation of base.BlobFileMapping that casts a
 // BlobFileID to a DiskFileNum.
 type identityFileMapping struct{}
 
-// Assert that (identityFileMapping) implements FileMapping.
-var _ FileMapping = identityFileMapping{}
+// Assert that (identityFileMapping) implements base.BlobFileMapping.
+var _ base.BlobFileMapping = identityFileMapping{}
 
 func (identityFileMapping) Lookup(blobFileID base.BlobFileID) (base.DiskFileNum, bool) {
 	return base.DiskFileNum(blobFileID), true

--- a/sstable/blob/handle.go
+++ b/sstable/blob/handle.go
@@ -67,15 +67,10 @@ type InlineHandle struct {
 	HandleSuffix
 }
 
-// ReferenceID identifies a particular blob reference within a table. It's
-// implemented as an index into the slice of the BlobReferences recorded in the
-// manifest.
-type ReferenceID uint32
-
 // InlineHandlePreface is the prefix of an inline handle. It's eagerly decoded
 // when returning an InternalValue to higher layers.
 type InlineHandlePreface struct {
-	ReferenceID ReferenceID
+	ReferenceID base.BlobReferenceID
 	ValueLen    uint32
 }
 
@@ -158,7 +153,7 @@ func DecodeInlineHandlePreface(src []byte) (InlineHandlePreface, []byte) {
 	}
 
 	return InlineHandlePreface{
-		ReferenceID: ReferenceID(refIdx),
+		ReferenceID: base.BlobReferenceID(refIdx),
 		ValueLen:    valueLen,
 	}, src
 }

--- a/sstable/blob/rewrite.go
+++ b/sstable/blob/rewrite.go
@@ -116,6 +116,6 @@ type inputFileMapping base.DiskFileNum
 // Assert that (*inputFileMapping) implements base.BlobFileMapping.
 var _ base.BlobFileMapping = inputFileMapping(0)
 
-func (m inputFileMapping) Lookup(fileID base.BlobFileID) (base.DiskFileNum, bool) {
+func (m inputFileMapping) Lookup(fileID base.BlobFileID) (base.DiskFile, bool) {
 	return base.DiskFileNum(m), true
 }

--- a/sstable/blob/rewrite.go
+++ b/sstable/blob/rewrite.go
@@ -110,11 +110,11 @@ func (rw *FileRewriter) Close() (FileWriterStats, error) {
 	return stats, errors.CombineErrors(err, rw.f.Close())
 }
 
-// inputFileMapping implements blob.FileMapping and always maps to itself.
+// inputFileMapping implements base.BlobFileMapping and always maps to itself.
 type inputFileMapping base.DiskFileNum
 
-// Assert that (*inputFileMapping) implements blob.FileMapping.
-var _ FileMapping = inputFileMapping(0)
+// Assert that (*inputFileMapping) implements base.BlobFileMapping.
+var _ base.BlobFileMapping = inputFileMapping(0)
 
 func (m inputFileMapping) Lookup(fileID base.BlobFileID) (base.DiskFileNum, bool) {
 	return base.DiskFileNum(m), true

--- a/sstable/blob_reference_index.go
+++ b/sstable/blob_reference_index.go
@@ -65,7 +65,7 @@ func (s *blobReferenceValues) finishCurrentBlock() {
 // blocks for a sstable's blob references. It maintains a refState, a slice of
 // blobRefValueLivenessState. This tracks the in-progress value liveness for
 // each blob value block for our sstable's blob references. The index of the
-// slice corresponds to the blob.ReferenceID.
+// slice corresponds to the base.BlobReferenceID.
 type blobRefValueLivenessWriter struct {
 	refState []blobReferenceValues
 }
@@ -87,10 +87,10 @@ func (w *blobRefValueLivenessWriter) numReferences() int {
 // blockID, a new state is created.
 //
 // addLiveValue adds a new state for the provided refID if one does
-// not already exist. It assumes that any new blob.ReferenceIDs are visited in
+// not already exist. It assumes that any new base.BlobReferenceIDs are visited in
 // monotonically increasing order.
 func (w *blobRefValueLivenessWriter) addLiveValue(
-	refID blob.ReferenceID, blockID blob.BlockID, valueID blob.BlockValueID, valueSize uint64,
+	refID base.BlobReferenceID, blockID blob.BlockID, valueID blob.BlockValueID, valueSize uint64,
 ) error {
 	// Compute the minimum expected length of the state slice in order for our
 	// refID to be indexable.
@@ -123,12 +123,12 @@ func (w *blobRefValueLivenessWriter) addLiveValue(
 
 // finish finishes encoding the per-blob reference liveness encodings, and
 // returns an in-order sequence of (referenceID, encoding) pairs.
-func (w *blobRefValueLivenessWriter) finish() iter.Seq2[blob.ReferenceID, []byte] {
-	return func(yield func(blob.ReferenceID, []byte) bool) {
-		// N.B. `i` is equivalent to blob.ReferenceID.
+func (w *blobRefValueLivenessWriter) finish() iter.Seq2[base.BlobReferenceID, []byte] {
+	return func(yield func(base.BlobReferenceID, []byte) bool) {
+		// N.B. `i` is equivalent to base.BlobReferenceID.
 		for i, state := range w.refState {
 			state.finishCurrentBlock()
-			if !yield(blob.ReferenceID(i), state.encodedFinishedBlocks) {
+			if !yield(base.BlobReferenceID(i), state.encodedFinishedBlocks) {
 				return
 			}
 		}

--- a/sstable/blob_reference_index_test.go
+++ b/sstable/blob_reference_index_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,7 @@ func TestBlobRefValueLivenessWriter(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		w := &blobRefValueLivenessWriter{}
 		w.init()
-		refID := blob.ReferenceID(0)
+		refID := base.BlobReferenceID(0)
 		blockID := blob.BlockID(0)
 
 		require.NoError(t, w.addLiveValue(refID, blockID, 0 /* valueID */, 24 /* valueSize */))
@@ -60,7 +61,7 @@ func TestBlobRefValueLivenessWriter(t *testing.T) {
 	t.Run("all-ones", func(t *testing.T) {
 		w := &blobRefValueLivenessWriter{}
 		w.init()
-		refID := blob.ReferenceID(0)
+		refID := base.BlobReferenceID(0)
 		blockID := blob.BlockID(0)
 
 		// Add only live values.
@@ -87,7 +88,7 @@ func TestBlobRefLivenessEncoding_Randomized(t *testing.T) {
 	prng := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))
 	w := blobRefValueLivenessWriter{}
 
-	collectSlice := func(i iter.Seq2[blob.ReferenceID, []byte]) [][]byte {
+	collectSlice := func(i iter.Seq2[base.BlobReferenceID, []byte]) [][]byte {
 		var s [][]byte
 		for _, enc := range i {
 			s = append(s, enc)
@@ -113,7 +114,7 @@ func TestBlobRefLivenessEncoding_Randomized(t *testing.T) {
 				currentValueID := blob.BlockValueID(testutils.RandIntInRange(prng, 0, 4))
 				for range numValues {
 					require.NoError(t, w.addLiveValue(
-						blob.ReferenceID(refID),
+						base.BlobReferenceID(refID),
 						currentBlockID,
 						currentValueID,
 						valueSize,
@@ -133,7 +134,7 @@ func TestBlobRefLivenessEncoding_Randomized(t *testing.T) {
 				// the writer.
 				for valueID := range IterSetBitsInRunLengthBitmap(block.Bitmap) {
 					require.NoError(t, w.addLiveValue(
-						blob.ReferenceID(refID),
+						base.BlobReferenceID(refID),
 						block.BlockID,
 						blob.BlockValueID(valueID),
 						valueSize,

--- a/sstable/colblk/value_liveness_block.go
+++ b/sstable/colblk/value_liveness_block.go
@@ -22,7 +22,7 @@ const (
 // ReferenceLivenessBlockEncoder encodes a reference liveness block.
 // A reference liveness block is a columnar block that contains a single column:
 // an array of bytes encoding the liveness of values within a sstable's blob
-// references. The indexes into this array are the blob.ReferenceIDs contained
+// references. The indexes into this array are the base.BlobReferenceIDs contained
 // within the sstable.
 type ReferenceLivenessBlockEncoder struct {
 	values RawBytesBuilder

--- a/sstable/values.go
+++ b/sstable/values.go
@@ -52,7 +52,7 @@ var DebugHandlesBlobContext = TableBlobContext{
 // sstable iterator to fetch the value stored in a blob file. It is the
 // caller's responsibility to close the ValueFetcher returned.
 func LoadValBlobContext(
-	fm blob.FileMapping, rp blob.ReaderProvider, blobRefs BlobReferences,
+	fm base.BlobFileMapping, rp blob.ReaderProvider, blobRefs BlobReferences,
 ) (*blob.ValueFetcher, TableBlobContext) {
 	vf := &blob.ValueFetcher{}
 	vf.Init(fm, rp, block.ReadEnv{})
@@ -67,10 +67,10 @@ func LoadValBlobContext(
 // manifest.BlobReferences.
 type BlobReferences interface {
 	// BlobFileIDByID returns the BlobFileID for the identified BlobReference.
-	BlobFileIDByID(i blob.ReferenceID) base.BlobFileID
+	BlobFileIDByID(i base.BlobReferenceID) base.BlobFileID
 	// IDByBlobFileID returns the reference ID for the given BlobFileID. If the
 	// blob file ID is not found, the second return value is false.
-	IDByBlobFileID(fileID base.BlobFileID) (blob.ReferenceID, bool)
+	IDByBlobFileID(fileID base.BlobFileID) (base.BlobReferenceID, bool)
 }
 
 // TableBlobContext configures how values that reference external blob files

--- a/tool/blob_files.go
+++ b/tool/blob_files.go
@@ -46,11 +46,11 @@ func (m *blobFileMappings) LoadValueBlobContext(tableNum base.TableNum) sstable.
 	}
 }
 
-// Lookup implements blob.FileLookupFunc.
-func (m *blobFileMappings) Lookup(fileID base.BlobFileID) (base.DiskFileNum, bool) {
+// Lookup implements base.BlobFileMapping.
+func (m *blobFileMappings) Lookup(fileID base.BlobFileID) (base.DiskFile, bool) {
 	files, ok := m.physicalFiles[fileID]
 	if !ok || len(files) == 0 {
-		return 0, false
+		return nil, false
 	}
 	// TODO(jackson): Consider checking for the existence of each file and using
 	// the most recent existing file (and log the missing files).

--- a/tool/blob_files.go
+++ b/tool/blob_files.go
@@ -24,7 +24,7 @@ import (
 // file.
 //
 // An sstable alone does not contain sufficient information to read a value from
-// a blob file. The sstable encodes a ReferenceID which first must be translated
+// a blob file. The sstable encodes a BlobReferenceID which first must be translated
 // to a BlobFileID and then from a BlobFileID to a DiskFileNum. The manifest
 // contains this metadata. The blobFileMappings type contains this state, loaded
 // from the manifest.

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -228,8 +228,9 @@ var _ blob.ReaderProvider = (*debugReaderProvider)(nil)
 // GetValueReader returns a blob.ValueReader for a blob file identified by
 // fileNum.
 func (p *debugReaderProvider) GetValueReader(
-	ctx context.Context, fileNum base.DiskFileNum,
+	ctx context.Context, diskFile base.DiskFile,
 ) (blob.ValueReader, func(), error) {
+	fileNum := diskFile.DiskFileNum()
 	readable, err := p.objProvider.OpenForReading(ctx, base.FileTypeBlob, fileNum, objstorage.OpenOptions{})
 	if err != nil {
 		return nil, nil, err

--- a/value_separation.go
+++ b/value_separation.go
@@ -362,7 +362,7 @@ type preserveBlobReferences struct {
 	buf []byte
 	// currReferences holds the pending references that have been referenced by
 	// the current output sstable. The index of a reference with a given blob
-	// file ID is the value of the blob.ReferenceID used by its value handles
+	// file ID is the value of the base.BlobReferenceID used by its value handles
 	// within the output sstable.
 	currReferences []pendingReference
 	// totalValueSize is the sum of currReferenceValueSizes.
@@ -428,13 +428,13 @@ func (vs *preserveBlobReferences) Add(
 	lv := kv.V.LazyValue()
 	fileID := lv.Fetcher.BlobFileID
 
-	var refID blob.ReferenceID
+	var refID base.BlobReferenceID
 	if refIdx := slices.IndexFunc(vs.currReferences, func(ref pendingReference) bool {
 		return ref.blobFileID == fileID
 	}); refIdx != -1 {
-		refID = blob.ReferenceID(refIdx)
+		refID = base.BlobReferenceID(refIdx)
 	} else {
-		refID = blob.ReferenceID(len(vs.currReferences))
+		refID = base.BlobReferenceID(len(vs.currReferences))
 		vs.currReferences = append(vs.currReferences, pendingReference{
 			blobFileID: fileID,
 			valueSize:  0,


### PR DESCRIPTION
If corruption is encountered while reading a blob file, propagate the blob
file's *PhysicalBlobFile metadata struct to DB.reportCorruption. This fixes a
nil pointer that would previously result while handling blob file corruption.

Fixes https://github.com/cockroachdb/pebble/issues/5127.