### PR TITLE
crl-release-25.3: sstable: use a single compressor in columnar writer

### DIFF
--- a/replay/testdata/corpus/simple_val_sep
+++ b/replay/testdata/corpus/simple_val_sep
@@ -103,6 +103,6 @@ stat simple_val_sep/MANIFEST-000013 simple_val_sep/000015.sst simple_val_sep/000
 simple_val_sep/MANIFEST-000013:
   size: 250
 simple_val_sep/000015.sst:
-  size: 865
+  size: 878
 simple_val_sep/000016.blob:
   size: 97

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -7,12 +7,12 @@ tree
             build/
      906      000005.sst
      101      000006.blob
-     871      000008.sst
+     884      000008.sst
       97      000009.blob
       92      000011.log
-     756      000012.sst
+     769      000012.sst
       63      000014.log
-     865      000015.sst
+     878      000015.sst
       97      000016.blob
        0      LOCK
      152      MANIFEST-000010
@@ -21,16 +21,16 @@ tree
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
-     865      000015.sst
+     878      000015.sst
       97      000016.blob
      250      MANIFEST-000013
               checkpoint/
      906        000005.sst
      101        000006.blob
-     871        000008.sst
+     884        000008.sst
       97        000009.blob
       64        000011.log
-     756        000012.sst
+     769        000012.sst
      187        MANIFEST-000013
     2936        OPTIONS-000003
        0        marker.format-version.000001.024

--- a/sstable/testdata/columnar_writer/simple_binary
+++ b/sstable/testdata/columnar_writer/simple_binary
@@ -80,39 +80,39 @@ sstable
  │    ├── 00000    block:0/88
  │    │   
  │    └── trailer [compression=none checksum=0x6147006e]
- ├── properties  offset: 149  length: 659
+ ├── properties  offset: 149  length: 661
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (37)
- │    ├── 00121    pebble.internal.testkeys.suffixes (41)
- │    ├── 00162    pebble.raw.point-tombstone.key.size (32)
- │    ├── 00194    rocksdb.block.based.table.index.type (43)
- │    ├── 00237    rocksdb.comparator (37)
- │    ├── 00274    rocksdb.compression (23)
- │    ├── 00297    rocksdb.compression_options (106)
- │    ├── 00403    rocksdb.data.size (13)
- │    ├── 00416    rocksdb.deleted.keys (15)
- │    ├── 00431    rocksdb.filter.size (15)
- │    ├── 00446    rocksdb.index.size (14)
- │    ├── 00460    rocksdb.merge.operands (18)
- │    ├── 00478    rocksdb.merge.operator (24)
- │    ├── 00502    rocksdb.num.data.blocks (19)
- │    ├── 00521    rocksdb.num.entries (11)
- │    ├── 00532    rocksdb.num.range-deletions (19)
- │    ├── 00551    rocksdb.property.collectors (70)
- │    ├── 00621    rocksdb.raw.key.size (16)
- │    ├── 00637    rocksdb.raw.value.size (14)
+ │    ├── 00084    pebble.compression_stats (39)
+ │    ├── 00123    pebble.internal.testkeys.suffixes (41)
+ │    ├── 00164    pebble.raw.point-tombstone.key.size (32)
+ │    ├── 00196    rocksdb.block.based.table.index.type (43)
+ │    ├── 00239    rocksdb.comparator (37)
+ │    ├── 00276    rocksdb.compression (23)
+ │    ├── 00299    rocksdb.compression_options (106)
+ │    ├── 00405    rocksdb.data.size (13)
+ │    ├── 00418    rocksdb.deleted.keys (15)
+ │    ├── 00433    rocksdb.filter.size (15)
+ │    ├── 00448    rocksdb.index.size (14)
+ │    ├── 00462    rocksdb.merge.operands (18)
+ │    ├── 00480    rocksdb.merge.operator (24)
+ │    ├── 00504    rocksdb.num.data.blocks (19)
+ │    ├── 00523    rocksdb.num.entries (11)
+ │    ├── 00534    rocksdb.num.range-deletions (19)
+ │    ├── 00553    rocksdb.property.collectors (70)
+ │    ├── 00623    rocksdb.raw.key.size (16)
+ │    ├── 00639    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00651 [restart 0]
- │    └── trailer [compression=none checksum=0x73801b9f]
- ├── meta-index  offset: 813  length: 33
- │    ├── 0000    rocksdb.properties block:149/659 [restart]
+ │    │    └── 00653 [restart 0]
+ │    └── trailer [compression=none checksum=0x78d91a9f]
+ ├── meta-index  offset: 815  length: 33
+ │    ├── 0000    rocksdb.properties block:149/661 [restart]
  │    ├── restart points
  │    │    └── 00025 [restart 0]
- │    └── trailer [compression=none checksum=0x842c7bfd]
- └── footer  offset: 851  length: 53
+ │    └── trailer [compression=none checksum=0x590655dc]
+ └── footer  offset: 853  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=813, length=33
+      ├── 001  meta: offset=815, length=33
       ├── 004  index: offset=93, length=51
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -137,7 +137,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-pebble.compression_stats: NoCompression:88/88
+pebble.compression_stats: NoCompression:139/139
 obsolete-key: hex:01
 pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
 
@@ -253,7 +253,7 @@ sstable
  │    ├── 00607    rocksdb.raw.value.size (14)
  │    ├── restart points
  │    │    └── 00621 [restart 0]
- │    └── trailer [compression=none checksum=0x17600a6]
+ │    └── trailer [compression=none checksum=0xf4e8ad4]
  ├── meta-index  offset: 811  length: 33
  │    ├── 0000    rocksdb.properties block:177/629 [restart]
  │    ├── restart points
@@ -649,7 +649,7 @@ sstable
  │    ├── 00609    rocksdb.raw.value.size (15)
  │    ├── restart points
  │    │    └── 00624 [restart 0]
- │    └── trailer [compression=none checksum=0xaeac6223]
+ │    └── trailer [compression=none checksum=0xfdfb788c]
  ├── meta-index  offset: 1334  length: 33
  │    ├── 0000    rocksdb.properties block:697/632 [restart]
  │    ├── restart points
@@ -685,7 +685,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-pebble.compression_stats: NoCompression:562/562
+pebble.compression_stats: NoCompression:672/672
 obsolete-key: hex:01
 pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
 
@@ -1042,7 +1042,7 @@ sstable
  │    ├── 00609    rocksdb.raw.value.size (15)
  │    ├── restart points
  │    │    └── 00624 [restart 0]
- │    └── trailer [compression=none checksum=0xaeac6223]
+ │    └── trailer [compression=none checksum=0xfdfb788c]
  ├── meta-index  offset: 1334  length: 33
  │    ├── 0000    rocksdb.properties block:697/632 [restart]
  │    ├── restart points
@@ -1117,39 +1117,40 @@ sstable
  │    │    │         └── 50-50: x  # data[0]:
  │    │    └── 50-51: x 00 # block padding byte
  │    └── trailer [compression=none checksum=0xb1e3982b]
- ├── properties  offset: 89  length: 580
+ ├── properties  offset: 89  length: 617
  │    ├── 00000    obsolete-key (17) [restart]
  │    ├── 00017    pebble.colblk.schema (68)
- │    ├── 00085    pebble.internal.testkeys.suffixes (30)
- │    ├── 00115    rocksdb.block.based.table.index.type (43)
- │    ├── 00158    rocksdb.comparator (37)
- │    ├── 00195    rocksdb.compression (23)
- │    ├── 00218    rocksdb.compression_options (106)
- │    ├── 00324    rocksdb.data.size (13)
- │    ├── 00337    rocksdb.deleted.keys (15)
- │    ├── 00352    rocksdb.filter.size (15)
- │    ├── 00367    rocksdb.index.size (14)
- │    ├── 00381    rocksdb.merge.operands (18)
- │    ├── 00399    rocksdb.merge.operator (24)
- │    ├── 00423    rocksdb.num.data.blocks (19)
- │    ├── 00442    rocksdb.num.entries (11)
- │    ├── 00453    rocksdb.num.range-deletions (19)
- │    ├── 00472    rocksdb.property.collectors (70)
- │    ├── 00542    rocksdb.raw.key.size (16)
- │    ├── 00558    rocksdb.raw.value.size (14)
+ │    ├── 00085    pebble.compression_stats (37)
+ │    ├── 00122    pebble.internal.testkeys.suffixes (30)
+ │    ├── 00152    rocksdb.block.based.table.index.type (43)
+ │    ├── 00195    rocksdb.comparator (37)
+ │    ├── 00232    rocksdb.compression (23)
+ │    ├── 00255    rocksdb.compression_options (106)
+ │    ├── 00361    rocksdb.data.size (13)
+ │    ├── 00374    rocksdb.deleted.keys (15)
+ │    ├── 00389    rocksdb.filter.size (15)
+ │    ├── 00404    rocksdb.index.size (14)
+ │    ├── 00418    rocksdb.merge.operands (18)
+ │    ├── 00436    rocksdb.merge.operator (24)
+ │    ├── 00460    rocksdb.num.data.blocks (19)
+ │    ├── 00479    rocksdb.num.entries (11)
+ │    ├── 00490    rocksdb.num.range-deletions (19)
+ │    ├── 00509    rocksdb.property.collectors (70)
+ │    ├── 00579    rocksdb.raw.key.size (16)
+ │    ├── 00595    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00572 [restart 0]
- │    └── trailer [compression=none checksum=0x50f07e7e]
- ├── meta-index  offset: 674  length: 59
- │    ├── 0000    rocksdb.properties block:89/580 [restart]
+ │    │    └── 00609 [restart 0]
+ │    └── trailer [compression=none checksum=0x9dc2b838]
+ ├── meta-index  offset: 711  length: 59
+ │    ├── 0000    rocksdb.properties block:89/617 [restart]
  │    ├── 0024    rocksdb.range_del2 block:33/51 [restart]
  │    ├── restart points
  │    │    ├── 00047 [restart 0]
  │    │    └── 00051 [restart 24]
- │    └── trailer [compression=none checksum=0xb95e4caa]
- └── footer  offset: 738  length: 53
+ │    └── trailer [compression=none checksum=0xa7304de4]
+ └── footer  offset: 775  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=674, length=59
+      ├── 001  meta: offset=711, length=59
       ├── 004  index: offset=0, length=28
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -1230,44 +1231,45 @@ sstable
  │    │    │         └── 67-67: x        # data[1]:
  │    │    └── 67-68: x 00 # block padding byte
  │    └── trailer [compression=none checksum=0x45325be7]
- ├── properties  offset: 106  length: 662
+ ├── properties  offset: 106  length: 699
  │    ├── 00000    obsolete-key (17) [restart]
  │    ├── 00017    pebble.colblk.schema (68)
- │    ├── 00085    pebble.internal.testkeys.suffixes (32)
- │    ├── 00117    pebble.num.range-key-dels (22)
- │    ├── 00139    pebble.num.range-key-sets (8)
- │    ├── 00147    pebble.num.range-key-unsets (10)
- │    ├── 00157    pebble.raw.range-key.key.size (26)
- │    ├── 00183    pebble.raw.range-key.value.size (14)
- │    ├── 00197    rocksdb.block.based.table.index.type (43)
- │    ├── 00240    rocksdb.comparator (37)
- │    ├── 00277    rocksdb.compression (23)
- │    ├── 00300    rocksdb.compression_options (106)
- │    ├── 00406    rocksdb.data.size (13)
- │    ├── 00419    rocksdb.deleted.keys (15)
- │    ├── 00434    rocksdb.filter.size (15)
- │    ├── 00449    rocksdb.index.size (14)
- │    ├── 00463    rocksdb.merge.operands (18)
- │    ├── 00481    rocksdb.merge.operator (24)
- │    ├── 00505    rocksdb.num.data.blocks (19)
- │    ├── 00524    rocksdb.num.entries (11)
- │    ├── 00535    rocksdb.num.range-deletions (19)
- │    ├── 00554    rocksdb.property.collectors (70)
- │    ├── 00624    rocksdb.raw.key.size (16)
- │    ├── 00640    rocksdb.raw.value.size (14)
+ │    ├── 00085    pebble.compression_stats (37)
+ │    ├── 00122    pebble.internal.testkeys.suffixes (32)
+ │    ├── 00154    pebble.num.range-key-dels (22)
+ │    ├── 00176    pebble.num.range-key-sets (8)
+ │    ├── 00184    pebble.num.range-key-unsets (10)
+ │    ├── 00194    pebble.raw.range-key.key.size (26)
+ │    ├── 00220    pebble.raw.range-key.value.size (14)
+ │    ├── 00234    rocksdb.block.based.table.index.type (43)
+ │    ├── 00277    rocksdb.comparator (37)
+ │    ├── 00314    rocksdb.compression (23)
+ │    ├── 00337    rocksdb.compression_options (106)
+ │    ├── 00443    rocksdb.data.size (13)
+ │    ├── 00456    rocksdb.deleted.keys (15)
+ │    ├── 00471    rocksdb.filter.size (15)
+ │    ├── 00486    rocksdb.index.size (14)
+ │    ├── 00500    rocksdb.merge.operands (18)
+ │    ├── 00518    rocksdb.merge.operator (24)
+ │    ├── 00542    rocksdb.num.data.blocks (19)
+ │    ├── 00561    rocksdb.num.entries (11)
+ │    ├── 00572    rocksdb.num.range-deletions (19)
+ │    ├── 00591    rocksdb.property.collectors (70)
+ │    ├── 00661    rocksdb.raw.key.size (16)
+ │    ├── 00677    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00654 [restart 0]
- │    └── trailer [compression=none checksum=0x29bae4b8]
- ├── meta-index  offset: 773  length: 57
+ │    │    └── 00691 [restart 0]
+ │    └── trailer [compression=none checksum=0xc9180526]
+ ├── meta-index  offset: 810  length: 57
  │    ├── 0000    pebble.range_key block:33/68 [restart]
- │    ├── 0021    rocksdb.properties block:106/662 [restart]
+ │    ├── 0021    rocksdb.properties block:106/699 [restart]
  │    ├── restart points
  │    │    ├── 00045 [restart 0]
  │    │    └── 00049 [restart 21]
- │    └── trailer [compression=none checksum=0x1a6d95f4]
- └── footer  offset: 835  length: 53
+ │    └── trailer [compression=none checksum=0x996f900b]
+ └── footer  offset: 872  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=773, length=57
+      ├── 001  meta: offset=810, length=57
       ├── 004  index: offset=0, length=28
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3

--- a/sstable/testdata/copy_span
+++ b/sstable/testdata/copy_span
@@ -99,7 +99,7 @@ d#0,SET: foobar
 
 copy-span test3 test4 b.SET.10 cc.SET.0
 ----
-copied 939 bytes
+copied 941 bytes
 
 iter test4
 ----
@@ -109,7 +109,7 @@ d#0,SET: foobar
 
 copy-span test3 test5 a.SET.10 bb.SET.0
 ----
-copied 934 bytes
+copied 936 bytes
 
 iter test5
 ----
@@ -139,7 +139,7 @@ d#0,SET: foobar
 
 copy-span test32 test33 b.SET.10 cc.SET.0
 ----
-copied 939 bytes
+copied 941 bytes
 
 iter test33
 ----
@@ -149,7 +149,7 @@ d#0,SET: foobar
 
 copy-span test32 test34 a.SET.10 bb.SET.0
 ----
-copied 934 bytes
+copied 936 bytes
 
 iter test34
 ----
@@ -173,7 +173,7 @@ d#0,SET: foobar
 
 copy-span test3 test4 b.SET.10 cc.SET.0
 ----
-copied 956 bytes
+copied 958 bytes
 
 iter test4
 ----
@@ -183,7 +183,7 @@ d#0,SET: foobar
 
 copy-span test3 test5 a.SET.10 bb.SET.0
 ----
-copied 951 bytes
+copied 953 bytes
 
 iter test5
 ----
@@ -213,7 +213,7 @@ d#0,SET: foobar
 
 copy-span test32 test33 b.SET.10 cc.SET.0
 ----
-copied 956 bytes
+copied 958 bytes
 
 iter test33
 ----
@@ -223,7 +223,7 @@ d#0,SET: foobar
 
 copy-span test32 test34 a.SET.10 bb.SET.0
 ----
-copied 951 bytes
+copied 953 bytes
 
 iter test34
 ----
@@ -270,9 +270,9 @@ sstable
  ├── index  offset: 1235  length: 38
  ├── top-index  offset: 1278  length: 83
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 1366  length: 69
- ├── properties  offset: 1440  length: 635
- ├── meta-index  offset: 2080  length: 88
- └── footer  offset: 2173  length: 57
+ ├── properties  offset: 1440  length: 637
+ ├── meta-index  offset: 2082  length: 88
+ └── footer  offset: 2175  length: 57
 
 props bloom-sst
 ----
@@ -296,7 +296,7 @@ rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
 rocksdb.top-level.index.size: 83
-pebble.compression_stats: NoCompression:729/729,Snappy:73/84
+pebble.compression_stats: NoCompression:1257/1257,Snappy:73/84
 obsolete-key: hex:00
 
 # Ensure that CopySpan copies over a filter block even if the writer options are
@@ -304,7 +304,7 @@ obsolete-key: hex:00
 
 copy-span bloom-sst bloom-sst-copy b.SET.10 cc.SET.0 filter=my-custom-filter/bloom(10)
 ----
-copied 1057 bytes
+copied 1096 bytes
 
 describe bloom-sst-copy
 ----
@@ -314,6 +314,6 @@ sstable
  ├── data  offset: 172  length: 73
  ├── index  offset: 250  length: 45
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 300  length: 69
- ├── properties  offset: 374  length: 528
- ├── meta-index  offset: 907  length: 88
- └── footer  offset: 1000  length: 57
+ ├── properties  offset: 374  length: 567
+ ├── meta-index  offset: 946  length: 88
+ └── footer  offset: 1039  length: 57

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -314,7 +314,7 @@ bounds:  [dd#5,SET-ddd#6,SET]
 filenum: 000008
 props:
   rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 10
+  rocksdb.raw.key.size: 9
   rocksdb.raw.value.size: 2
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -141,7 +141,7 @@ sstable
  │    ├── 00586    rocksdb.raw.value.size (15)
  │    ├── restart points
  │    │    └── 00601 [restart 0]
- │    └── trailer [compression=none checksum=0x1d3282d8]
+ │    └── trailer [compression=none checksum=0x27d9426d]
  ├── meta-index  offset: 862  length: 72
  │    ├── 0000    pebble.blob_ref_index block:208/35
  │    │   
@@ -297,7 +297,7 @@ sstable
  │    ├── 00634    rocksdb.property.collectors (41)
  │    ├── 00675    rocksdb.raw.key.size (21)
  │    ├── 00696    rocksdb.raw.value.size (24)
- │    └── trailer [compression=snappy checksum=0x6413fc6d]
+ │    └── trailer [compression=snappy checksum=0xc03bcadf]
  ├── meta-index  offset: 837  length: 72
  │    ├── 0000    pebble.blob_ref_index block:208/35
  │    │   

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -107,6 +107,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
+pebble.compression_stats: NoCompression:107/107
 obsolete-key: hex:0074
 
 # The range tombstone upper bound is exclusive, so a point operation
@@ -235,9 +236,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 580
- ├── meta-index  offset: 1000  length: 33
- └── footer  offset: 1038  length: 53
+ ├── properties  offset: 415  length: 602
+ ├── meta-index  offset: 1022  length: 33
+ └── footer  offset: 1060  length: 53
 
 # Exercise the non-Reader layout-decoding codepath.
 
@@ -251,9 +252,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 580
- ├── meta-index  offset: 1000  length: 33
- └── footer  offset: 1038  length: 53
+ ├── properties  offset: 415  length: 602
+ ├── meta-index  offset: 1022  length: 33
+ └── footer  offset: 1060  length: 53
 
 scan
 ----
@@ -298,9 +299,9 @@ layout
 sstable
  ├── index  offset: 0  length: 28
  ├── range-key  offset: 33  length: 84
- ├── properties  offset: 122  length: 589
- ├── meta-index  offset: 716  length: 57
- └── footer  offset: 778  length: 53
+ ├── properties  offset: 122  length: 628
+ ├── meta-index  offset: 755  length: 57
+ └── footer  offset: 817  length: 53
 
 props
 ----
@@ -326,6 +327,7 @@ pebble.num.range-key-unsets: 0
 rocksdb.property.collectors: [obsolete-key]
 pebble.raw.range-key.key.size: 6
 pebble.raw.range-key.value.size: 9
+pebble.compression_stats: NoCompression:112/112
 obsolete-key: hex:0074
 
 open-writer disable-value-blocks

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -107,6 +107,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
+pebble.compression_stats: NoCompression:107/107
 obsolete-key: hex:0074
 
 # The range tombstone upper bound is exclusive, so a point operation
@@ -235,9 +236,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 580
- ├── meta-index  offset: 1000  length: 46
- └── footer  offset: 1051  length: 57
+ ├── properties  offset: 415  length: 602
+ ├── meta-index  offset: 1022  length: 46
+ └── footer  offset: 1073  length: 57
 
 props
 ----
@@ -260,7 +261,7 @@ rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
 rocksdb.top-level.index.size: 48
-pebble.compression_stats: Snappy:222/261
+pebble.compression_stats: Snappy:222/261,NoCompression:158/158
 obsolete-key: hex:00
 
 # Exercise the non-Reader layout-decoding codepath.
@@ -275,9 +276,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 580
- ├── meta-index  offset: 1000  length: 46
- └── footer  offset: 1051  length: 57
+ ├── properties  offset: 415  length: 602
+ ├── meta-index  offset: 1022  length: 46
+ └── footer  offset: 1073  length: 57
 
 scan
 ----
@@ -322,9 +323,9 @@ layout
 sstable
  ├── index  offset: 0  length: 28
  ├── range-key  offset: 33  length: 84
- ├── properties  offset: 122  length: 589
- ├── meta-index  offset: 716  length: 65
- └── footer  offset: 786  length: 57
+ ├── properties  offset: 122  length: 628
+ ├── meta-index  offset: 755  length: 65
+ └── footer  offset: 825  length: 57
 
 props
 ----
@@ -350,6 +351,7 @@ pebble.num.range-key-unsets: 0
 rocksdb.property.collectors: [obsolete-key]
 pebble.raw.range-key.key.size: 6
 pebble.raw.range-key.value.size: 9
+pebble.compression_stats: NoCompression:112/112
 obsolete-key: hex:0074
 
 open-writer disable-value-blocks

--- a/sstable/testdata/writer_v7
+++ b/sstable/testdata/writer_v7
@@ -107,6 +107,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
+pebble.compression_stats: NoCompression:107/107
 obsolete-key: hex:0074
 
 # The range tombstone upper bound is exclusive, so a point operation
@@ -235,9 +236,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 550
- ├── meta-index  offset: 970  length: 46
- └── footer  offset: 1021  length: 61
+ ├── properties  offset: 415  length: 587
+ ├── meta-index  offset: 1007  length: 46
+ └── footer  offset: 1058  length: 61
 
 props
 ----
@@ -260,7 +261,7 @@ rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
 rocksdb.top-level.index.size: 48
-pebble.compression_stats: Snappy:222/261
+pebble.compression_stats: Snappy:222/261,NoCompression:158/158
 obsolete-key: hex:00
 
 # Exercise the non-Reader layout-decoding codepath.
@@ -275,9 +276,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 550
- ├── meta-index  offset: 970  length: 46
- └── footer  offset: 1021  length: 61
+ ├── properties  offset: 415  length: 587
+ ├── meta-index  offset: 1007  length: 46
+ └── footer  offset: 1058  length: 61
 
 scan
 ----
@@ -322,9 +323,9 @@ layout
 sstable
  ├── index  offset: 0  length: 28
  ├── range-key  offset: 33  length: 84
- ├── properties  offset: 122  length: 577
- ├── meta-index  offset: 704  length: 65
- └── footer  offset: 774  length: 61
+ ├── properties  offset: 122  length: 605
+ ├── meta-index  offset: 732  length: 65
+ └── footer  offset: 802  length: 61
 
 props
 ----
@@ -350,6 +351,7 @@ pebble.num.range-key-unsets: 0
 rocksdb.property.collectors: [obsolete-key]
 pebble.raw.range-key.key.size: 6
 pebble.raw.range-key.value.size: 9
+pebble.compression_stats: NoCompression:112/112
 obsolete-key: hex:0074
 
 open-writer disable-value-blocks

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -643,44 +643,44 @@ sstable
  │    └── trailer [compression=none checksum=0x60e7fb82]
  ├── value-index  offset: 680  length: 8
  │    └── trailer [compression=none checksum=0xb327e021]
- ├── properties  offset: 693  length: 662
+ ├── properties  offset: 693  length: 664
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (52)
- │    ├── 00136    pebble.num.value-blocks (20)
- │    ├── 00156    pebble.num.values.in.value-blocks (21)
- │    ├── 00177    pebble.value-blocks.size (21)
- │    ├── 00198    rocksdb.block.based.table.index.type (43)
- │    ├── 00241    rocksdb.comparator (37)
- │    ├── 00278    rocksdb.compression (16)
- │    ├── 00294    rocksdb.compression_options (106)
- │    ├── 00400    rocksdb.data.size (14)
- │    ├── 00414    rocksdb.deleted.keys (15)
- │    ├── 00429    rocksdb.filter.size (15)
- │    ├── 00444    rocksdb.index.partitions (20)
- │    ├── 00464    rocksdb.index.size (9)
- │    ├── 00473    rocksdb.merge.operands (18)
- │    ├── 00491    rocksdb.merge.operator (24)
- │    ├── 00515    rocksdb.num.data.blocks (19)
- │    ├── 00534    rocksdb.num.entries (11)
- │    ├── 00545    rocksdb.num.range-deletions (19)
- │    ├── 00564    rocksdb.property.collectors (36)
- │    ├── 00600    rocksdb.raw.key.size (16)
- │    ├── 00616    rocksdb.raw.value.size (14)
- │    ├── 00630    rocksdb.top-level.index.size (24)
+ │    ├── 00084    pebble.compression_stats (54)
+ │    ├── 00138    pebble.num.value-blocks (20)
+ │    ├── 00158    pebble.num.values.in.value-blocks (21)
+ │    ├── 00179    pebble.value-blocks.size (21)
+ │    ├── 00200    rocksdb.block.based.table.index.type (43)
+ │    ├── 00243    rocksdb.comparator (37)
+ │    ├── 00280    rocksdb.compression (16)
+ │    ├── 00296    rocksdb.compression_options (106)
+ │    ├── 00402    rocksdb.data.size (14)
+ │    ├── 00416    rocksdb.deleted.keys (15)
+ │    ├── 00431    rocksdb.filter.size (15)
+ │    ├── 00446    rocksdb.index.partitions (20)
+ │    ├── 00466    rocksdb.index.size (9)
+ │    ├── 00475    rocksdb.merge.operands (18)
+ │    ├── 00493    rocksdb.merge.operator (24)
+ │    ├── 00517    rocksdb.num.data.blocks (19)
+ │    ├── 00536    rocksdb.num.entries (11)
+ │    ├── 00547    rocksdb.num.range-deletions (19)
+ │    ├── 00566    rocksdb.property.collectors (36)
+ │    ├── 00602    rocksdb.raw.key.size (16)
+ │    ├── 00618    rocksdb.raw.value.size (14)
+ │    ├── 00632    rocksdb.top-level.index.size (24)
  │    ├── restart points
- │    │    └── 00654 [restart 0]
- │    └── trailer [compression=none checksum=0x3508516e]
- ├── meta-index  offset: 1360  length: 64
+ │    │    └── 00656 [restart 0]
+ │    └── trailer [compression=none checksum=0x39f21738]
+ ├── meta-index  offset: 1362  length: 64
  │    ├── 0000    pebble.value_index block:680/8 value-blocks-index-lengths: 1(num), 2(offset), 1(length) [restart]
- │    ├── 0027    rocksdb.properties block:693/662 [restart]
+ │    ├── 0027    rocksdb.properties block:693/664 [restart]
  │    ├── restart points
  │    │    ├── 00052 [restart 0]
  │    │    └── 00056 [restart 27]
- │    └── trailer [compression=none checksum=0xea069734]
- └── footer  offset: 1429  length: 53
+ │    └── trailer [compression=none checksum=0xf2de4c26]
+ └── footer  offset: 1431  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=1360, length=64
+      ├── 001  meta: offset=1362, length=64
       ├── 004  index: offset=562, length=77
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -872,38 +872,38 @@ sstable
  │    ├── 00000    block:0/100
  │    │   
  │    └── trailer [compression=none checksum=0x760132f1]
- ├── properties  offset: 146  length: 572
+ ├── properties  offset: 146  length: 592
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (32)
- │    ├── 00116    pebble.raw.point-tombstone.key.size (32)
- │    ├── 00148    rocksdb.block.based.table.index.type (43)
- │    ├── 00191    rocksdb.comparator (37)
- │    ├── 00228    rocksdb.compression (16)
- │    ├── 00244    rocksdb.compression_options (106)
- │    ├── 00350    rocksdb.data.size (13)
- │    ├── 00363    rocksdb.deleted.keys (15)
- │    ├── 00378    rocksdb.filter.size (15)
- │    ├── 00393    rocksdb.index.size (14)
- │    ├── 00407    rocksdb.merge.operands (18)
- │    ├── 00425    rocksdb.merge.operator (24)
- │    ├── 00449    rocksdb.num.data.blocks (19)
- │    ├── 00468    rocksdb.num.entries (11)
- │    ├── 00479    rocksdb.num.range-deletions (19)
- │    ├── 00498    rocksdb.property.collectors (36)
- │    ├── 00534    rocksdb.raw.key.size (16)
- │    ├── 00550    rocksdb.raw.value.size (14)
+ │    ├── 00084    pebble.compression_stats (52)
+ │    ├── 00136    pebble.raw.point-tombstone.key.size (32)
+ │    ├── 00168    rocksdb.block.based.table.index.type (43)
+ │    ├── 00211    rocksdb.comparator (37)
+ │    ├── 00248    rocksdb.compression (16)
+ │    ├── 00264    rocksdb.compression_options (106)
+ │    ├── 00370    rocksdb.data.size (13)
+ │    ├── 00383    rocksdb.deleted.keys (15)
+ │    ├── 00398    rocksdb.filter.size (15)
+ │    ├── 00413    rocksdb.index.size (14)
+ │    ├── 00427    rocksdb.merge.operands (18)
+ │    ├── 00445    rocksdb.merge.operator (24)
+ │    ├── 00469    rocksdb.num.data.blocks (19)
+ │    ├── 00488    rocksdb.num.entries (11)
+ │    ├── 00499    rocksdb.num.range-deletions (19)
+ │    ├── 00518    rocksdb.property.collectors (36)
+ │    ├── 00554    rocksdb.raw.key.size (16)
+ │    ├── 00570    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00564 [restart 0]
- │    └── trailer [compression=none checksum=0x2a939c82]
- ├── meta-index  offset: 723  length: 33
- │    ├── 0000    rocksdb.properties block:146/572 [restart]
+ │    │    └── 00584 [restart 0]
+ │    └── trailer [compression=none checksum=0xb0db559e]
+ ├── meta-index  offset: 743  length: 33
+ │    ├── 0000    rocksdb.properties block:146/592 [restart]
  │    ├── restart points
  │    │    └── 00025 [restart 0]
- │    └── trailer [compression=none checksum=0x6483c3e0]
- └── footer  offset: 761  length: 53
+ │    └── trailer [compression=none checksum=0x41dda72d]
+ └── footer  offset: 781  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=723, length=33
+      ├── 001  meta: offset=743, length=33
       ├── 004  index: offset=105, length=36
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -1017,39 +1017,39 @@ sstable
  │    ├── 00000    block:0/100
  │    │   
  │    └── trailer [compression=none checksum=0x760132f1]
- ├── properties  offset: 146  length: 572
+ ├── properties  offset: 146  length: 592
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (32)
- │    ├── 00116    pebble.raw.point-tombstone.key.size (32)
- │    ├── 00148    rocksdb.block.based.table.index.type (43)
- │    ├── 00191    rocksdb.comparator (37)
- │    ├── 00228    rocksdb.compression (16)
- │    ├── 00244    rocksdb.compression_options (106)
- │    ├── 00350    rocksdb.data.size (13)
- │    ├── 00363    rocksdb.deleted.keys (15)
- │    ├── 00378    rocksdb.filter.size (15)
- │    ├── 00393    rocksdb.index.size (14)
- │    ├── 00407    rocksdb.merge.operands (18)
- │    ├── 00425    rocksdb.merge.operator (24)
- │    ├── 00449    rocksdb.num.data.blocks (19)
- │    ├── 00468    rocksdb.num.entries (11)
- │    ├── 00479    rocksdb.num.range-deletions (19)
- │    ├── 00498    rocksdb.property.collectors (36)
- │    ├── 00534    rocksdb.raw.key.size (16)
- │    ├── 00550    rocksdb.raw.value.size (14)
+ │    ├── 00084    pebble.compression_stats (52)
+ │    ├── 00136    pebble.raw.point-tombstone.key.size (32)
+ │    ├── 00168    rocksdb.block.based.table.index.type (43)
+ │    ├── 00211    rocksdb.comparator (37)
+ │    ├── 00248    rocksdb.compression (16)
+ │    ├── 00264    rocksdb.compression_options (106)
+ │    ├── 00370    rocksdb.data.size (13)
+ │    ├── 00383    rocksdb.deleted.keys (15)
+ │    ├── 00398    rocksdb.filter.size (15)
+ │    ├── 00413    rocksdb.index.size (14)
+ │    ├── 00427    rocksdb.merge.operands (18)
+ │    ├── 00445    rocksdb.merge.operator (24)
+ │    ├── 00469    rocksdb.num.data.blocks (19)
+ │    ├── 00488    rocksdb.num.entries (11)
+ │    ├── 00499    rocksdb.num.range-deletions (19)
+ │    ├── 00518    rocksdb.property.collectors (36)
+ │    ├── 00554    rocksdb.raw.key.size (16)
+ │    ├── 00570    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00564 [restart 0]
- │    └── trailer [compression=none checksum=0x2a939c82]
- ├── meta-index  offset: 723  length: 46
- │    ├── 0000    rocksdb.properties block:146/572
+ │    │    └── 00584 [restart 0]
+ │    └── trailer [compression=none checksum=0xb0db559e]
+ ├── meta-index  offset: 743  length: 46
+ │    ├── 0000    rocksdb.properties block:146/592
  │    │   
- │    └── trailer [compression=none checksum=0xefc171d9]
- └── footer  offset: 774  length: 57
+ │    └── trailer [compression=none checksum=0x22504fa3]
+ └── footer  offset: 794  length: 57
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=723, length=46
+      ├── 001  meta: offset=743, length=46
       ├── 004  index: offset=105, length=36
-      ├── 041  footer checksum: 0xc96f3ee8
+      ├── 041  footer checksum: 0xdd471806
       ├── 045  version: 6
       └── 049  magic number: 0xf09faab3f09faab3
 
@@ -1247,7 +1247,7 @@ sstable
  │    ├── 00698    rocksdb.property.collectors (41)
  │    ├── 00739    rocksdb.raw.key.size (21)
  │    ├── 00760    rocksdb.raw.value.size (23)
- │    └── trailer [compression=snappy checksum=0xf941a001]
+ │    └── trailer [compression=snappy checksum=0xc153389a]
  ├── meta-index  offset: 908  length: 72
  │    ├── 0000    pebble.value_index block:257/3 value-blocks-index-lengths: 1(num), 1(offset), 1(length)
  │    │   
@@ -1372,37 +1372,37 @@ sstable
  │    ├── 00000    block:0/100
  │    │   
  │    └── trailer [compression=none checksum=0x760132f1]
- ├── properties  offset: 146  length: 556
+ ├── properties  offset: 146  length: 570
  │    ├── 00000    obsolete-key (13)
  │    ├── 00013    pebble.colblk.schema (65)
- │    ├── 00078    pebble.compression_stats (38)
- │    ├── 00116    pebble.raw.point-tombstone.key.size (36)
- │    ├── 00152    rocksdb.block.based.table.index.type (40)
- │    ├── 00192    rocksdb.comparator (42)
- │    ├── 00234    rocksdb.compression (25)
- │    ├── 00259    rocksdb.compression_options (122)
- │    ├── 00381    rocksdb.data.size (18)
- │    ├── 00399    rocksdb.deleted.keys (21)
- │    ├── 00420    rocksdb.filter.size (20)
- │    ├── 00440    rocksdb.index.size (19)
- │    ├── 00459    rocksdb.merge.operands (23)
- │    ├── 00482    rocksdb.merge.operator (40)
- │    ├── 00522    rocksdb.num.data.blocks (24)
- │    ├── 00546    rocksdb.num.entries (20)
- │    ├── 00566    rocksdb.num.range-deletions (28)
- │    ├── 00594    rocksdb.property.collectors (41)
- │    ├── 00635    rocksdb.raw.key.size (21)
- │    ├── 00656    rocksdb.raw.value.size (23)
- │    └── trailer [compression=snappy checksum=0x46ab18a9]
- ├── meta-index  offset: 707  length: 46
- │    ├── 0000    rocksdb.properties block:146/556
+ │    ├── 00078    pebble.compression_stats (58)
+ │    ├── 00136    pebble.raw.point-tombstone.key.size (36)
+ │    ├── 00172    rocksdb.block.based.table.index.type (40)
+ │    ├── 00212    rocksdb.comparator (42)
+ │    ├── 00254    rocksdb.compression (25)
+ │    ├── 00279    rocksdb.compression_options (122)
+ │    ├── 00401    rocksdb.data.size (18)
+ │    ├── 00419    rocksdb.deleted.keys (21)
+ │    ├── 00440    rocksdb.filter.size (20)
+ │    ├── 00460    rocksdb.index.size (19)
+ │    ├── 00479    rocksdb.merge.operands (23)
+ │    ├── 00502    rocksdb.merge.operator (40)
+ │    ├── 00542    rocksdb.num.data.blocks (24)
+ │    ├── 00566    rocksdb.num.entries (20)
+ │    ├── 00586    rocksdb.num.range-deletions (28)
+ │    ├── 00614    rocksdb.property.collectors (41)
+ │    ├── 00655    rocksdb.raw.key.size (21)
+ │    ├── 00676    rocksdb.raw.value.size (23)
+ │    └── trailer [compression=snappy checksum=0x9f389d66]
+ ├── meta-index  offset: 721  length: 46
+ │    ├── 0000    rocksdb.properties block:146/570
  │    │   
- │    └── trailer [compression=none checksum=0xd1c840a0]
- └── footer  offset: 758  length: 61
+ │    └── trailer [compression=none checksum=0xc5dfa63]
+ └── footer  offset: 772  length: 61
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=707, length=46
+      ├── 001  meta: offset=721, length=46
       ├── 004  index: offset=105, length=36
       ├── 041  attributes: [PointKeys]
-      ├── 045  footer checksum: 0x7660297f
+      ├── 045  footer checksum: 0x16afbae8
       ├── 049  version: 7
       └── 053  magic number: 0xf09faab3f09faab3

--- a/testdata/blob_rewrite
+++ b/testdata/blob_rewrite
@@ -63,9 +63,9 @@ rewrite-blob 000002 000001 000003
 # read-at(209, 560): 000001.sst
 # read-at(184, 25): 000001.sst
 # open: 000003.sst (options: *vfs.randomReadsOption)
-# read-at(848, 61): 000003.sst
-# read-at(771, 77): 000003.sst
-# read-at(193, 578): 000003.sst
+# read-at(883, 61): 000003.sst
+# read-at(806, 77): 000003.sst
+# read-at(193, 613): 000003.sst
 # read-at(168, 25): 000003.sst
 # open: 000002.blob (options: *vfs.randomReadsOption)
 # read-at(67, 38): 000002.blob

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -250,17 +250,17 @@ close: db/000009.sst
 sync: db
 sync: db/MANIFEST-000001
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): db/000005.sst
-read-at(649, 51): db/000005.sst
-read-at(132, 517): db/000005.sst
+read-at(714, 61): db/000005.sst
+read-at(663, 51): db/000005.sst
+read-at(132, 531): db/000005.sst
 open: db/000009.sst (options: *vfs.randomReadsOption)
-read-at(709, 61): db/000009.sst
-read-at(658, 51): db/000009.sst
-read-at(136, 522): db/000009.sst
+read-at(711, 61): db/000009.sst
+read-at(660, 51): db/000009.sst
+read-at(136, 524): db/000009.sst
 open: db/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): db/000007.sst
-read-at(649, 51): db/000007.sst
-read-at(132, 517): db/000007.sst
+read-at(714, 61): db/000007.sst
+read-at(663, 51): db/000007.sst
+read-at(132, 531): db/000007.sst
 read-at(91, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
 read-at(0, 91): db/000005.sst
@@ -330,15 +330,15 @@ close: checkpoints/checkpoint1/000006.log
 scan checkpoints/checkpoint1
 ----
 open: checkpoints/checkpoint1/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): checkpoints/checkpoint1/000007.sst
-read-at(649, 51): checkpoints/checkpoint1/000007.sst
-read-at(132, 517): checkpoints/checkpoint1/000007.sst
+read-at(714, 61): checkpoints/checkpoint1/000007.sst
+read-at(663, 51): checkpoints/checkpoint1/000007.sst
+read-at(132, 531): checkpoints/checkpoint1/000007.sst
 read-at(91, 41): checkpoints/checkpoint1/000007.sst
 read-at(0, 91): checkpoints/checkpoint1/000007.sst
 open: checkpoints/checkpoint1/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): checkpoints/checkpoint1/000005.sst
-read-at(649, 51): checkpoints/checkpoint1/000005.sst
-read-at(132, 517): checkpoints/checkpoint1/000005.sst
+read-at(714, 61): checkpoints/checkpoint1/000005.sst
+read-at(663, 51): checkpoints/checkpoint1/000005.sst
+read-at(132, 531): checkpoints/checkpoint1/000005.sst
 read-at(91, 41): checkpoints/checkpoint1/000005.sst
 read-at(0, 91): checkpoints/checkpoint1/000005.sst
 a 1
@@ -353,9 +353,9 @@ g 10
 scan db
 ----
 open: db/000010.sst (options: *vfs.randomReadsOption)
-read-at(710, 61): db/000010.sst
-read-at(659, 51): db/000010.sst
-read-at(141, 518): db/000010.sst
+read-at(724, 61): db/000010.sst
+read-at(673, 51): db/000010.sst
+read-at(141, 532): db/000010.sst
 read-at(100, 41): db/000010.sst
 read-at(0, 100): db/000010.sst
 a 1
@@ -397,9 +397,9 @@ close: checkpoints/checkpoint2/000006.log
 scan checkpoints/checkpoint2
 ----
 open: checkpoints/checkpoint2/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): checkpoints/checkpoint2/000007.sst
-read-at(649, 51): checkpoints/checkpoint2/000007.sst
-read-at(132, 517): checkpoints/checkpoint2/000007.sst
+read-at(714, 61): checkpoints/checkpoint2/000007.sst
+read-at(663, 51): checkpoints/checkpoint2/000007.sst
+read-at(132, 531): checkpoints/checkpoint2/000007.sst
 read-at(91, 41): checkpoints/checkpoint2/000007.sst
 read-at(0, 91): checkpoints/checkpoint2/000007.sst
 b 5
@@ -439,15 +439,15 @@ close: checkpoints/checkpoint3/000006.log
 scan checkpoints/checkpoint3
 ----
 open: checkpoints/checkpoint3/000007.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): checkpoints/checkpoint3/000007.sst
-read-at(649, 51): checkpoints/checkpoint3/000007.sst
-read-at(132, 517): checkpoints/checkpoint3/000007.sst
+read-at(714, 61): checkpoints/checkpoint3/000007.sst
+read-at(663, 51): checkpoints/checkpoint3/000007.sst
+read-at(132, 531): checkpoints/checkpoint3/000007.sst
 read-at(91, 41): checkpoints/checkpoint3/000007.sst
 read-at(0, 91): checkpoints/checkpoint3/000007.sst
 open: checkpoints/checkpoint3/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): checkpoints/checkpoint3/000005.sst
-read-at(649, 51): checkpoints/checkpoint3/000005.sst
-read-at(132, 517): checkpoints/checkpoint3/000005.sst
+read-at(714, 61): checkpoints/checkpoint3/000005.sst
+read-at(663, 51): checkpoints/checkpoint3/000005.sst
+read-at(132, 531): checkpoints/checkpoint3/000005.sst
 read-at(91, 41): checkpoints/checkpoint3/000005.sst
 read-at(0, 91): checkpoints/checkpoint3/000005.sst
 a 1
@@ -582,9 +582,9 @@ close: checkpoints/checkpoint4/000008.log
 scan checkpoints/checkpoint4
 ----
 open: checkpoints/checkpoint4/000010.sst (options: *vfs.randomReadsOption)
-read-at(710, 61): checkpoints/checkpoint4/000010.sst
-read-at(659, 51): checkpoints/checkpoint4/000010.sst
-read-at(141, 518): checkpoints/checkpoint4/000010.sst
+read-at(724, 61): checkpoints/checkpoint4/000010.sst
+read-at(673, 51): checkpoints/checkpoint4/000010.sst
+read-at(141, 532): checkpoints/checkpoint4/000010.sst
 read-at(100, 41): checkpoints/checkpoint4/000010.sst
 read-at(0, 100): checkpoints/checkpoint4/000010.sst
 a 1
@@ -1023,9 +1023,9 @@ close: checkpoints/checkpoint8/000004.log
 scan checkpoints/checkpoint8
 ----
 open: checkpoints/checkpoint8/000005.sst (options: *vfs.randomReadsOption)
-read-at(830, 61): checkpoints/checkpoint8/000005.sst
-read-at(753, 77): checkpoints/checkpoint8/000005.sst
-read-at(197, 556): checkpoints/checkpoint8/000005.sst
+read-at(862, 61): checkpoints/checkpoint8/000005.sst
+read-at(785, 77): checkpoints/checkpoint8/000005.sst
+read-at(197, 588): checkpoints/checkpoint8/000005.sst
 read-at(131, 41): checkpoints/checkpoint8/000005.sst
 read-at(0, 131): checkpoints/checkpoint8/000005.sst
 open: checkpoints/checkpoint8/000006.blob (options: *vfs.randomReadsOption)
@@ -1133,9 +1133,9 @@ close: checkpoints/checkpoint9/000007.log
 scan checkpoints/checkpoint9
 ----
 open: checkpoints/checkpoint9/000005.sst (options: *vfs.randomReadsOption)
-read-at(830, 61): checkpoints/checkpoint9/000005.sst
-read-at(753, 77): checkpoints/checkpoint9/000005.sst
-read-at(197, 556): checkpoints/checkpoint9/000005.sst
+read-at(862, 61): checkpoints/checkpoint9/000005.sst
+read-at(785, 77): checkpoints/checkpoint9/000005.sst
+read-at(197, 588): checkpoints/checkpoint9/000005.sst
 read-at(131, 41): checkpoints/checkpoint9/000005.sst
 read-at(0, 131): checkpoints/checkpoint9/000005.sst
 open: checkpoints/checkpoint9/000006.blob (options: *vfs.randomReadsOption)

--- a/testdata/compaction/compaction_cancellation
+++ b/testdata/compaction/compaction_cancellation
@@ -34,7 +34,7 @@ manual compaction cancelled: context canceled, current queued compactions: 0
 # One compaction was done.
 compaction-log
 ----
-[JOB 1] compacted(move) L2 [000004] (797B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000004] (797B), in 1.0s (1.0s total), output rate 797B/s
+[JOB 1] compacted(move) L2 [000004] (799B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
 
 compact a-z L2 parallel
 ----
@@ -45,8 +45,8 @@ L3:
 
 compaction-log sort
 ----
-[JOB 1] compacted(move) L2 [000005] (797B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000005] (797B), in 1.0s (1.0s total), output rate 797B/s
-[JOB 1] compacted(move) L2 [000006] (797B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000006] (797B), in 1.0s (1.0s total), output rate 797B/s
+[JOB 1] compacted(move) L2 [000005] (799B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000005] (799B), in 1.0s (1.0s total), output rate 799B/s
+[JOB 1] compacted(move) L2 [000006] (799B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000006] (799B), in 1.0s (1.0s total), output rate 799B/s
 
 # Repeat with only blocking the last of the three manual compactions.
 add-ongoing-compaction startLevel=3 outputLevel=4 start=g end=h
@@ -59,5 +59,5 @@ manual compaction cancelled: context canceled, current queued compactions: 0
 # Two compactions were done.
 compaction-log
 ----
-[JOB 1] compacted(move) L3 [000004] (797B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000004] (797B), in 1.0s (1.0s total), output rate 797B/s
-[JOB 1] compacted(move) L3 [000005] (797B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000005] (797B), in 1.0s (1.0s total), output rate 797B/s
+[JOB 1] compacted(move) L3 [000004] (799B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
+[JOB 1] compacted(move) L3 [000005] (799B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000005] (799B), in 1.0s (1.0s total), output rate 799B/s

--- a/testdata/compaction/score_compaction_picked_before_manual
+++ b/testdata/compaction/score_compaction_picked_before_manual
@@ -15,7 +15,7 @@ L6:
 # compaction.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (797B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (797B), in 1.0s (1.0s total), output rate 797B/s
+[JOB 1] compacted(move) L5 [000004] (799B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
 
 # Do an auto score-based compaction with the same LSM as the previous test.
 define disable-multi-level lbase-max-bytes=1
@@ -33,7 +33,7 @@ L6:
 # Note the score is > 1.0 since these is a score-based compaction.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (797B) Score=996.25 + L6 [] (0B) Score=0.00 -> L6 [000004] (797B), in 1.0s (1.0s total), output rate 797B/s
+[JOB 1] compacted(move) L5 [000004] (799B) Score=998.75 + L6 [] (0B) Score=0.00 -> L6 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
 
 # With the same LSM as the previous test, try to do both a manual and
 # score-based compaction. The score-based compaction runs first.
@@ -64,4 +64,4 @@ set-disable-auto-compact v=true
 # The score-based compaction ran first.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (797B) Score=996.25 + L6 [] (0B) Score=0.00 -> L6 [000004] (797B), in 1.0s (1.0s total), output rate 797B/s
+[JOB 1] compacted(move) L5 [000004] (799B) Score=998.75 + L6 [] (0B) Score=0.00 -> L6 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s

--- a/testdata/compaction/set_with_del_sstable_Pebblev5
+++ b/testdata/compaction/set_with_del_sstable_Pebblev5
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1520
+range-deletions-bytes-estimate: 1560
 
 compact a-e L1
 ----
@@ -106,7 +106,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 760
+range-deletions-bytes-estimate: 780
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/compaction/set_with_del_sstable_Pebblev6
+++ b/testdata/compaction/set_with_del_sstable_Pebblev6
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1554
+range-deletions-bytes-estimate: 1594
 
 compact a-e L1
 ----
@@ -106,7 +106,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 777
+range-deletions-bytes-estimate: 797
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/compaction/set_with_del_sstable_Pebblev7
+++ b/testdata/compaction/set_with_del_sstable_Pebblev7
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1502
+range-deletions-bytes-estimate: 1530
 
 compact a-e L1
 ----
@@ -106,7 +106,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 751
+range-deletions-bytes-estimate: 765
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -12,7 +12,7 @@ set b 2
 compact a-b
 ----
 L6:
-  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:849 blobrefs:[(B000006: 2); depth:1]
+  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:862 blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
 
@@ -24,8 +24,8 @@ set d 4
 compact c-d
 ----
 L6:
-  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:849 blobrefs:[(B000006: 2); depth:1]
-  000008:[c#12,SET-d#13,SET] seqnums:[12-13] points:[c#12,SET-d#13,SET] size:849 blobrefs:[(B000009: 2); depth:1]
+  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:862 blobrefs:[(B000006: 2); depth:1]
+  000008:[c#12,SET-d#13,SET] seqnums:[12-13] points:[c#12,SET-d#13,SET] size:862 blobrefs:[(B000009: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
   B000009 physical:{000009 size:[92 (92B)] vals:[2 (2B)]}
@@ -38,7 +38,7 @@ set c 6
 compact a-d
 ----
 L6:
-  000013:[a#0,SET-d#0,SET] seqnums:[0-0] points:[a#0,SET-d#0,SET] size:887 blobrefs:[(B000006: 1), (B000012: 2), (B000009: 1); depth:2]
+  000013:[a#0,SET-d#0,SET] seqnums:[0-0] points:[a#0,SET-d#0,SET] size:919 blobrefs:[(B000006: 1), (B000012: 2), (B000009: 1); depth:2]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
   B000009 physical:{000009 size:[92 (92B)] vals:[2 (2B)]}
@@ -64,7 +64,7 @@ L6 blob-depth=3
   z.SET.0:blob{fileNum=100004 value=zoo}
 ----
 L6:
-  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:889 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:921 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
   B100003 physical:{100003 size:[92 (92B)] vals:[3 (3B)]}
@@ -80,9 +80,9 @@ set e world
 flush
 ----
 L0.0:
-  000006:[d#10,SET-e#11,SET] seqnums:[10-11] points:[d#10,SET-e#11,SET] size:848 blobrefs:[(B000007: 10); depth:1]
+  000006:[d#10,SET-e#11,SET] seqnums:[10-11] points:[d#10,SET-e#11,SET] size:861 blobrefs:[(B000007: 10); depth:1]
 L6:
-  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:889 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:921 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B000007 physical:{000007 size:[100 (100B)] vals:[10 (10B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -95,7 +95,7 @@ Blob files:
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:899 blobrefs:[(B000009: 19); depth:1]
+  000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:931 blobrefs:[(B000009: 19); depth:1]
 Blob files:
   B000009 physical:{000009 size:[112 (112B)] vals:[19 (19B)]}
 
@@ -123,14 +123,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep    |     multilevel
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk |   top   in  read
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+---------------+------------------
-    0 |     0     0B     0B       0 |    -    0    0 |   41B |     0     0B |     0     0B |     1   848B |    0B |   0 25.6 |    0B      0B |    0B    0B    0B
-    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0 |    0B      0B |    0B    0B    0B
+    0 |     0     0B     0B       0 |    -    0    0 |   41B |     0     0B |     0     0B |     1   861B |    0B |   0 25.9 |    0B      0B |    0B    0B    0B
+    1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   861B |     0     0B |    0B |   0    0 |    0B      0B |    0B    0B    0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B |    0B    0B    0B
-    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0 |    0B      0B |    0B    0B    0B
+    3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   861B |     0     0B |    0B |   0    0 |    0B      0B |    0B    0B    0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B |    0B    0B    0B
-    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   848B |     0     0B |    0B |   0    0 |    0B      0B |    0B    0B    0B
-    6 |     1   899B     0B       0 |    - 0.00 0.00 |  848B |     0     0B |     0     0B |     1   899B | 1.7KB |   1 1.19 |  112B      0B |    0B    0B    0B
-total |     1   899B     0B       0 |    -    -    - |   41B |     0     0B |     3  2.5KB |     2  1.7KB | 1.7KB |   1 51.2 |  112B      0B |    0B    0B    0B
+    5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     1   861B |     0     0B |    0B |   0    0 |    0B      0B |    0B    0B    0B
+    6 |     1   931B     0B       0 |    - 0.00 0.00 |  861B |     0     0B |     0     0B |     1   931B | 1.7KB |   1 1.21 |  112B      0B |    0B    0B    0B
+total |     1   931B     0B       0 |    -    -    - |   41B |     0     0B |     3  2.5KB |     2  1.8KB | 1.7KB |   1 52.3 |  112B      0B |    0B    0B    0B
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 30B  written: 41B (37% overhead)
 Flushes: 1
@@ -140,7 +140,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 899B
+Local tables size: 931B
 Compression types: snappy: 1
 Table stats: all loaded
 Block cache: 4 entries (1.6KB)  hit rate: 70.3%
@@ -170,7 +170,7 @@ set yaya yaya
 flush
 ----
 L0.0:
-  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:773
+  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:787
 
 batch
 set a a
@@ -185,9 +185,9 @@ set w world
 flush
 ----
 L0.1:
-  000007:[a#14,SET-w#17,SET] seqnums:[14-17] points:[a#14,SET-w#17,SET] size:877 blobrefs:[(B000008: 10); depth:1]
+  000007:[a#14,SET-w#17,SET] seqnums:[14-17] points:[a#14,SET-w#17,SET] size:909 blobrefs:[(B000008: 10); depth:1]
 L0.0:
-  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:773
+  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:787
 Blob files:
   B000008 physical:{000008 size:[100 (100B)] vals:[10 (10B)]}
 
@@ -223,7 +223,7 @@ flush
 ----
 L0.0:
   000005:[a#10,SET-d#13,SET] seqnums:[10-13] points:[a#10,SET-d#13,SET] size:809
-  000006:[m#14,SET-m#14,SET] seqnums:[14-14] points:[m#14,SET-m#14,SET] size:845 blobrefs:[(B000007: 5); depth:1]
+  000006:[m#14,SET-m#14,SET] seqnums:[14-14] points:[m#14,SET-m#14,SET] size:858 blobrefs:[(B000007: 5); depth:1]
 Blob files:
   B000007 physical:{000007 size:[94 (94B)] vals:[5 (5B)]}
 
@@ -243,9 +243,9 @@ L0 blob-depth=3
   z.SET.1:blob{fileNum=100004 value=zoo}
 ----
 L0.1:
-  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:858 blobrefs:[(B100001: 1); depth:1]
+  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:871 blobrefs:[(B100001: 1); depth:1]
 L0.0:
-  000005:[a#1,SET-z#1,SET] seqnums:[1-1] points:[a#1,SET-z#1,SET] size:889 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000005:[a#1,SET-z#1,SET] seqnums:[1-1] points:[a#1,SET-z#1,SET] size:921 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -279,8 +279,8 @@ L0 blob-depth=3
   z.SET.1:blob{fileNum=100004 value=zoo}
 ----
 L0.0:
-  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:858 blobrefs:[(B100001: 1); depth:1]
-  000005:[e#1,SET-z#1,SET] seqnums:[1-1] points:[e#1,SET-z#1,SET] size:889 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:871 blobrefs:[(B100001: 1); depth:1]
+  000005:[e#1,SET-z#1,SET] seqnums:[1-1] points:[e#1,SET-z#1,SET] size:921 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -290,7 +290,7 @@ Blob files:
 compact a-z
 ----
 L1:
-  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:912 blobrefs:[(B100001: 1), (B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:944 blobrefs:[(B100001: 1), (B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -319,7 +319,7 @@ set h honeydew
 flush
 ----
 L0.0:
-  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:922 blobrefs:[(B000006: 60); depth:1]
+  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:954 blobrefs:[(B000006: 60); depth:1]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
 
@@ -332,9 +332,9 @@ set c cherry
 flush
 ----
 L0.1:
-  000008:[c#18,SET-c#18,SET] seqnums:[18-18] points:[c#18,SET-c#18,SET] size:845 blobrefs:[(B000009: 6); depth:1]
+  000008:[c#18,SET-c#18,SET] seqnums:[18-18] points:[c#18,SET-c#18,SET] size:858 blobrefs:[(B000009: 6); depth:1]
 L0.0:
-  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:922 blobrefs:[(B000006: 60); depth:1]
+  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:954 blobrefs:[(B000006: 60); depth:1]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -345,7 +345,7 @@ Blob files:
 compact a-b
 ----
 L6:
-  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:900 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
+  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:932 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -353,7 +353,7 @@ Blob files:
 auto-compact
 ----
 L6:
-  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:900 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
+  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:932 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
 Blob files:
   B000006 physical:{000011 size:[150 (150B)] vals:[53 (53B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -363,14 +363,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     0     0B     0B       0 |    -    0    0 |  156B |     0     0B |     0     0B |     2  1.7KB |    0B |   0 14.5 |    0B      0B
+    0 |     0     0B     0B       0 |    -    0    0 |  156B |     0     0B |     0     0B |     2  1.8KB |    0B |   0 14.8 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     1   900B     0B       0 |    - 0.00 0.00 | 1.7KB |     0     0B |     0     0B |     1   900B | 1.7KB |   1 0.51 |  232B      0B
-total |     1   900B     0B       0 |    -    -    - |  156B |     0     0B |     0     0B |     3  2.8KB | 1.7KB |   1 21.3 |  232B      0B
+    6 |     1   932B     0B       0 |    - 0.00 0.00 | 1.8KB |     0     0B |     0     0B |     1   932B | 1.8KB |   1 0.51 |  232B      0B
+total |     1   932B     0B       0 |    -    -    - |  156B |     0     0B |     0     0B |     3  2.8KB | 1.8KB |   1 21.8 |  232B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 126B  written: 156B (24% overhead)
 Flushes: 2
@@ -380,7 +380,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 900B
+Local tables size: 932B
 Compression types: snappy: 1
 Table stats: all loaded
 Block cache: 6 entries (2.3KB)  hit rate: 48.6%
@@ -406,15 +406,15 @@ set c coconut
 compact a-b
 ----
 L6:
-  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:862 blobrefs:[(B000006: 18); depth:1]
+  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:875 blobrefs:[(B000006: 18); depth:1]
 Blob files:
   B000006 physical:{000006 size:[109 (109B)] vals:[18 (18B)]}
 
 excise b ba
 ----
 L6:
-  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
-  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(875) blobrefs:[(B000006: 2); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(875) blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[109 (109B)] vals:[18 (18B)]}
 
@@ -426,8 +426,8 @@ Blob files:
 run-blob-rewrite-compaction
 ----
 L6:
-  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
-  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(862) blobrefs:[(B000006: 2); depth:1]
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(875) blobrefs:[(B000006: 2); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(875) blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000009 size:[110 (110B)] vals:[18 (18B)]}
 
@@ -448,7 +448,7 @@ wrote 475254 keys
 flush
 ----
 L0.0:
-  000005:[a@1#10,SET-bkmx@1#25669,SET] seqnums:[10-25669] points:[a@1#10,SET-bkmx@1#25669,SET] size:396640 blobrefs:[(B000006: 1642240); depth:1]
+  000005:[a@1#10,SET-bkmx@1#25669,SET] seqnums:[10-25669] points:[a@1#10,SET-bkmx@1#25669,SET] size:396639 blobrefs:[(B000006: 1642240); depth:1]
   000007:[bkmy@1#25670,SET-cv@1#51332,SET] seqnums:[25670-51332] points:[bkmy@1#25670,SET-cv@1#51332,SET] size:396466 blobrefs:[(B000008: 1642432); depth:1]
   000009:[cva@1#51333,SET-efnh@1#77002,SET] seqnums:[51333-77002] points:[cva@1#51333,SET-efnh@1#77002,SET] size:395950 blobrefs:[(B000010: 1642880); depth:1]
   000011:[efni@1#77003,SET-fqaj@1#102665,SET] seqnums:[77003-102665] points:[efni@1#77003,SET-fqaj@1#102665,SET] size:396383 blobrefs:[(B000012: 1642432); depth:1]
@@ -464,7 +464,7 @@ L0.0:
   000031:[sgle@1#333554,SET-tqxr@1#359200,SET] seqnums:[333554-359200] points:[sgle@1#333554,SET-tqxr@1#359200,SET] size:397496 blobrefs:[(B000032: 1641408); depth:1]
   000033:[tqxs@1#359201,SET-vbls@1#384890,SET] seqnums:[359201-384890] points:[tqxs@1#359201,SET-vbls@1#384890,SET] size:394570 blobrefs:[(B000034: 1644160); depth:1]
   000035:[vblt@1#384891,SET-wlyf@1#410537,SET] seqnums:[384891-410537] points:[vblt@1#384891,SET-wlyf@1#410537,SET] size:397494 blobrefs:[(B000036: 1641408); depth:1]
-  000037:[wlyg@1#410538,SET-xwmc@1#436222,SET] seqnums:[410538-436222] points:[wlyg@1#410538,SET-xwmc@1#436222,SET] size:394941 blobrefs:[(B000038: 1643840); depth:1]
+  000037:[wlyg@1#410538,SET-xwmc@1#436222,SET] seqnums:[410538-436222] points:[wlyg@1#410538,SET-xwmc@1#436222,SET] size:394940 blobrefs:[(B000038: 1643840); depth:1]
   000039:[xwmd@1#436223,SET-zhar@1#461926,SET] seqnums:[436223-461926] points:[xwmd@1#436223,SET-zhar@1#461926,SET] size:393606 blobrefs:[(B000040: 1645056); depth:1]
   000041:[zhas@1#461927,SET-zzzz@1#475263,SET] seqnums:[461927-475263] points:[zhas@1#461927,SET-zzzz@1#475263,SET] size:208259 blobrefs:[(B000042: 853568); depth:1]
 Blob files:
@@ -500,7 +500,7 @@ L6:
   000045:[czmt@1#0,SET-fyxn@1#0,SET] seqnums:[0-0] points:[czmt@1#0,SET-fyxn@1#0,SET] size:718640 blobrefs:[(B000010: 1440896), (B000012: 1642432), (B000014: 399936); depth:1]
   000046:[fyxo@1#0,SET-iykr@1#0,SET] seqnums:[0-0] points:[fyxo@1#0,SET-iykr@1#0,SET] size:714594 blobrefs:[(B000014: 1240512), (B000016: 1642304), (B000018: 604544); depth:1]
   000047:[iyks@1#0,SET-lxxi@1#0,SET] seqnums:[0-0] points:[iyks@1#0,SET-lxxi@1#0,SET] size:715507 blobrefs:[(B000018: 1040960), (B000020: 1640704), (B000022: 804800); depth:1]
-  000048:[lxxj@1#0,SET-oxiv@1#0,SET] seqnums:[0-0] points:[lxxj@1#0,SET-oxiv@1#0,SET] size:716968 blobrefs:[(B000022: 838016), (B000024: 1641600), (B000026: 1004864); depth:1]
+  000048:[lxxj@1#0,SET-oxiv@1#0,SET] seqnums:[0-0] points:[lxxj@1#0,SET-oxiv@1#0,SET] size:716969 blobrefs:[(B000022: 838016), (B000024: 1641600), (B000026: 1004864); depth:1]
   000049:[oxiw@1#0,SET-rwta@1#0,SET] seqnums:[0-0] points:[oxiw@1#0,SET-rwta@1#0,SET] size:719355 blobrefs:[(B000026: 636224), (B000028: 1641856), (B000030: 1204160); depth:1]
   000050:[rwtb@1#0,SET-uwen@1#0,SET] seqnums:[0-0] points:[rwtb@1#0,SET-uwen@1#0,SET] size:717499 blobrefs:[(B000030: 436352), (B000032: 1641408), (B000034: 1406720); depth:1]
   000051:[uweo@1#0,SET-xvqm@1#0,SET] seqnums:[0-0] points:[uweo@1#0,SET-xvqm@1#0,SET] size:716744 blobrefs:[(B000034: 237440), (B000036: 1641408), (B000038: 1606400); depth:1]

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -88,7 +88,7 @@ maybe-compact
 Deletion hints:
   L0.000004 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (769B) Score=0.00 + L3 [000006] (769B) Score=0.00 + L4 [000007] (769B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (771B) Score=0.00 + L3 [000006] (771B) Score=0.00 + L4 [000007] (771B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # Verify that compaction correctly handles the presence of multiple
 # overlapping hints which might delete a file multiple times. All of the
@@ -127,7 +127,7 @@ maybe-compact
 Deletion hints:
   L1.000005 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (769B) Score=0.00 + L3 [000006] (769B) Score=0.00 + L4 [000007] (769B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (771B) Score=0.00 + L3 [000006] (771B) Score=0.00 + L4 [000007] (771B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # Test a range tombstone that is already compacted into L6.
 
@@ -206,7 +206,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (769B) Score=0.00 + L3 [000006] (769B) Score=0.00 + L4 [000007] (769B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (771B) Score=0.00 + L3 [000006] (771B) Score=0.00 + L4 [000007] (771B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # A deletion hint present on an sstable in a higher level should NOT result in a
 # deletion-only compaction incorrectly removing an sstable in L6 following an
@@ -255,7 +255,7 @@ L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
 close-snapshot
 10
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (829B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (758B), in 1.0s (2.0s total), output rate 758B/s
+[JOB 100] compacted(elision-only) L6 [000004] (843B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (760B), in 1.0s (2.0s total), output rate 760B/s
 
 # In previous versions of the code, the deletion hint was removed by the
 # elision-only compaction because it zeroed sequence numbers of keys with
@@ -430,7 +430,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000006 000007 000008 000009 000011] (3.9KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+  [JOB 100] compacted(delete-only) L6 [000006 000007 000008 000009 000011] (4.1KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Verify that a delete-only compaction can partially excise a file.
 
@@ -474,7 +474,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (756B) Score=0.00 + L2 [000006] (769B) Score=0.00 + L3 [000007] (769B) Score=0.00 + L4 [000008] (769B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (750B) Score=0.00 + L2 [000006] (771B) Score=0.00 + L3 [000007] (771B) Score=0.00 + L4 [000008] (771B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
 
 describe-lsm
 ----
@@ -542,7 +542,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000005] (751B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+  [JOB 100] compacted(delete-only) L6 [000005] (765B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 describe-lsm
 ----
@@ -608,7 +608,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) (excised: 000004) L6 [000004] (928B) Score=0.00 -> L6 [000007 000008] (186B), in 1.0s (2.0s total), output rate 186B/s
+  [JOB 100] compacted(delete-only) (excised: 000004) L6 [000004] (973B) Score=0.00 -> L6 [000007 000008] (186B), in 1.0s (2.0s total), output rate 186B/s
 
 describe-lsm
 ----
@@ -753,4 +753,4 @@ L0.000006 c-h seqnums(tombstone=11-12, file-smallest=10, type=point-and-range-ke
 close-snapshot
 11
 ----
-[JOB 100] compacted(delete-only) L6 [000004] (997B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000004] (1.0KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s

--- a/testdata/compaction_picker_pick_file
+++ b/testdata/compaction_picker_pick_file
@@ -16,9 +16,9 @@ L2:
 file-sizes
 ----
 L1:
-  000004:[b#11,SET-c#11,SET]: 778 bytes (778B)
+  000004:[b#11,SET-c#11,SET]: 780 bytes (780B)
 L2:
-  000005:[c#0,SET-d#0,SET]: 761 bytes (761B)
+  000005:[c#0,SET-d#0,SET]: 774 bytes (774B)
 
 pick-file L1
 ----
@@ -171,7 +171,7 @@ L5:
   000005:[f#11,SET-f#11,SET]: 58129 bytes (57KB)
 L6:
   000006:[c#0,SET-c#0,SET]: 66323 bytes (65KB)
-  000009:[d#13,SET-d#13,SET]: 763 bytes (763B)
+  000009:[d#13,SET-d#13,SET]: 765 bytes (765B)
   000007:[e#0,SET-e#0,SET]: 66323 bytes (65KB)
   000008:[f#0,SET-f#0,SET]: 66323 bytes (65KB)
 
@@ -209,8 +209,8 @@ L5:
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
   000005:[f#11,SET-f#11,SET]: 58129 bytes (57KB)
 L6:
-  000012:[c#15,SET-c#15,SET]: 763 bytes (763B)
-  000009:[d#13,SET-d#13,SET]: 763 bytes (763B)
+  000012:[c#15,SET-c#15,SET]: 765 bytes (765B)
+  000009:[d#13,SET-d#13,SET]: 765 bytes (765B)
   000007:[e#0,SET-e#0,SET]: 66323 bytes (65KB)
   000008:[f#0,SET-f#0,SET]: 66323 bytes (65KB)
 

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -24,7 +24,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       754B     0.00     0.01           0.01
+L5       759B     0.00     0.01           0.01
 L6       321KB    1.11     1.11           1.11
 
 enable-table-stats
@@ -47,7 +47,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       754B     0.01     0.01           5.03
+L5       759B     0.01     0.01           5.03
 L6       321KB    1.11     1.11           1.11
 
 # Ensure that point deletions in a higher level result in a compensated level

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -41,7 +41,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (756B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (750B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that straddles a snapshot. It should not be compacted.
 define snapshots=(50) auto-compactions=off
@@ -85,7 +85,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (802B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (758B), in 1.0s (2.0s total), output rate 758B/s
+[JOB 100] compacted(elision-only) L6 [000004] (804B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (760B), in 1.0s (2.0s total), output rate 760B/s
 
 version
 ----
@@ -134,7 +134,7 @@ close-snapshot
 close-snapshot
 103
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (939B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (988B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that contains both deletions and non-deletions, but whose
 # non-deletions well outnumber its deletions. The table should not be
@@ -243,7 +243,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (806B) Score=6.20 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(default) L5 [000004] (808B) Score=6.21 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -323,7 +323,7 @@ range-deletions-bytes-estimate: 94
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (1003B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (751B), in 1.0s (2.0s total), output rate 751B/s
+[JOB 100] compacted(elision-only) L6 [000004] (1004B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (765B), in 1.0s (2.0s total), output rate 765B/s
 
 # Close the DB, asserting that the reference counts balance.
 close
@@ -376,7 +376,7 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (798B) Score=3.10 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
+[JOB 101] compacted(default) L5 [000004] (800B) Score=3.13 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -422,7 +422,7 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (798B) Score=3.10 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
+[JOB 101] compacted(default) L5 [000004] (800B) Score=3.13 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
 
 # These tests demonstrate the behavior of the tombstone density compaction feature
 # in Pebble. This feature identifies files with a high density of tombstones and
@@ -497,8 +497,8 @@ tombstone-dense-blocks-ratio: 0.9
 # should indicate "move" as the compaction type.
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L5 [000004] (806B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (751B), in 1.0s (2.0s total), output rate 751B/s
-[JOB 101] compacted(move) L4 [000004] (806B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (806B), in 1.0s (2.0s total), output rate 806B/s
+[JOB 100] compacted(tombstone-density) L5 [000004] (819B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (765B), in 1.0s (2.0s total), output rate 765B/s
+[JOB 101] compacted(move) L4 [000004] (819B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (819B), in 1.0s (2.0s total), output rate 819B/s
 
 # Verify the result - the file should now be in L5
 # The file should maintain its original content since it was just moved rather than recompacted
@@ -556,7 +556,7 @@ tombstone-dense-blocks-ratio: 0.9
 # because there are overlapping files in L5 that prevent the optimization
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L4 [000004] (806B) Score=0.00 + L5 [000005] (769B) Score=0.00 -> L5 [000007] (751B), in 1.0s (2.0s total), output rate 751B/s
+[JOB 100] compacted(tombstone-density) L4 [000004] (819B) Score=0.00 + L5 [000005] (771B) Score=0.00 -> L5 [000007] (765B), in 1.0s (2.0s total), output rate 765B/s
 
 # Verify the result - the file was recompacted with the overlapping L5 file
 # The output file should be different from the input files

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -109,7 +109,7 @@ close: db/marker.manifest.000002.MANIFEST-000006
 remove: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 [JOB 3] MANIFEST created 000006
-[JOB 3] flushed 1 memtable (100B) to L0 [000005] (747B), in 1.0s (2.0s total), output rate 747B/s
+[JOB 3] flushed 1 memtable (100B) to L0 [000005] (761B), in 1.0s (2.0s total), output rate 761B/s
 
 compact
 ----
@@ -133,18 +133,18 @@ close: db/marker.manifest.000003.MANIFEST-000009
 remove: db/marker.manifest.000002.MANIFEST-000006
 sync: db
 [JOB 5] MANIFEST created 000009
-[JOB 5] flushed 1 memtable (100B) to L0 [000008] (747B), in 1.0s (2.0s total), output rate 747B/s
+[JOB 5] flushed 1 memtable (100B) to L0 [000008] (761B), in 1.0s (2.0s total), output rate 761B/s
 remove: db/MANIFEST-000001
 [JOB 5] MANIFEST deleted 000001
 [JOB 6] compacting(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00; OverlappingRatio: Single 0.00, Multi 0.00
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(686, 61): db/000005.sst
-read-at(636, 50): db/000005.sst
-read-at(119, 517): db/000005.sst
+read-at(700, 61): db/000005.sst
+read-at(650, 50): db/000005.sst
+read-at(119, 531): db/000005.sst
 open: db/000008.sst (options: *vfs.randomReadsOption)
-read-at(686, 61): db/000008.sst
-read-at(636, 50): db/000008.sst
-read-at(119, 517): db/000008.sst
+read-at(700, 61): db/000008.sst
+read-at(650, 50): db/000008.sst
+read-at(119, 531): db/000008.sst
 read-at(78, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
 read-at(0, 78): db/000005.sst
@@ -166,7 +166,7 @@ close: db/marker.manifest.000004.MANIFEST-000011
 remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
 [JOB 6] MANIFEST created 000011
-[JOB 6] compacted(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (755B), in 1.0s (3.0s total), output rate 755B/s
+[JOB 6] compacted(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (757B), in 1.0s (3.0s total), output rate 757B/s
 close: db/000005.sst
 close: db/000008.sst
 remove: db/MANIFEST-000006
@@ -201,7 +201,7 @@ close: db/marker.manifest.000005.MANIFEST-000014
 remove: db/marker.manifest.000004.MANIFEST-000011
 sync: db
 [JOB 8] MANIFEST created 000014
-[JOB 8] flushed 1 memtable (100B) to L0 [000013] (747B), in 1.0s (2.0s total), output rate 747B/s
+[JOB 8] flushed 1 memtable (100B) to L0 [000013] (761B), in 1.0s (2.0s total), output rate 761B/s
 
 enable-file-deletions
 ----
@@ -211,10 +211,10 @@ remove: db/MANIFEST-000009
 ingest
 ----
 open: ext/0
-read-at(694, 61): ext/0
-read-at(644, 50): ext/0
-read-at(122, 522): ext/0
-read-at(122, 522): ext/0
+read-at(696, 61): ext/0
+read-at(646, 50): ext/0
+read-at(122, 524): ext/0
+read-at(122, 524): ext/0
 read-at(81, 41): ext/0
 read-at(0, 81): ext/0
 close: ext/0
@@ -232,21 +232,21 @@ sync: db
 remove: db/MANIFEST-000011
 [JOB 10] MANIFEST deleted 000011
 remove: ext/0
-[JOB 10] ingested L0:000015 (755B)
+[JOB 10] ingested L0:000015 (757B)
 
 metrics
 ----
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     2  1.5KB     0B       0 |    - 0.40 0.40 |   97B |     1   755B |     0     0B |     3  2.2KB |    0B |   2 23.1 |    0B      0B
+    0 |     2  1.5KB     0B       0 |    - 0.40 0.40 |   97B |     1   757B |     0     0B |     3  2.2KB |    0B |   2 23.5 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     1   755B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   755B | 1.5KB |   1 0.51 |    0B      0B
-total |     3  2.2KB     0B       0 |    -    -    - |  852B |     1   755B |     0     0B |     4  3.8KB | 1.5KB |   3 4.52 |    0B      0B
+    6 |     1   757B     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   757B | 1.5KB |   1 0.50 |    0B      0B
+total |     3  2.2KB     0B       0 |    -    -    - |  854B |     1   757B |     0     0B |     4  3.8KB | 1.5KB |   3 4.56 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 48B  written: 97B (102% overhead)
 Flushes: 3
@@ -276,18 +276,18 @@ ingest-flushable
 ----
 sync-data: wal/000012.log
 open: ext/a
-read-at(694, 61): ext/a
-read-at(644, 50): ext/a
-read-at(122, 522): ext/a
-read-at(122, 522): ext/a
+read-at(696, 61): ext/a
+read-at(646, 50): ext/a
+read-at(122, 524): ext/a
+read-at(122, 524): ext/a
 read-at(81, 41): ext/a
 read-at(0, 81): ext/a
 close: ext/a
 open: ext/b
-read-at(694, 61): ext/b
-read-at(644, 50): ext/b
-read-at(122, 522): ext/b
-read-at(122, 522): ext/b
+read-at(696, 61): ext/b
+read-at(646, 50): ext/b
+read-at(122, 524): ext/b
+read-at(122, 524): ext/b
 read-at(81, 41): ext/b
 read-at(0, 81): ext/b
 close: ext/b
@@ -309,7 +309,7 @@ sync: wal
 [JOB 13] WAL created 000020
 remove: ext/a
 remove: ext/b
-[JOB 11] ingested as flushable 000017 (755B), 000018 (755B)
+[JOB 11] ingested as flushable 000017 (757B), 000018 (757B)
 sync-data: wal/000020.log
 close: wal/000020.log
 create: wal/000021.log
@@ -322,7 +322,7 @@ sync-data: db/000022.sst
 close: db/000022.sst
 sync: db
 sync: db/MANIFEST-000016
-[JOB 15] flushed 1 memtable (100B) to L0 [000022] (747B), in 1.0s (2.0s total), output rate 747B/s
+[JOB 15] flushed 1 memtable (100B) to L0 [000022] (761B), in 1.0s (2.0s total), output rate 761B/s
 [JOB 16] flushing 2 ingested tables
 create: db/MANIFEST-000023
 close: db/MANIFEST-000016
@@ -332,7 +332,7 @@ close: db/marker.manifest.000007.MANIFEST-000023
 remove: db/marker.manifest.000006.MANIFEST-000016
 sync: db
 [JOB 16] MANIFEST created 000023
-[JOB 16] flushed 2 ingested flushables L0:000017 (755B) + L6:000018 (755B) in 1.0s (2.0s total), output rate 1.5KB/s
+[JOB 16] flushed 2 ingested flushables L0:000017 (757B) + L6:000018 (757B) in 1.0s (2.0s total), output rate 1.5KB/s
 remove: db/MANIFEST-000014
 [JOB 16] MANIFEST deleted 000014
 [JOB 17] flushing 1 memtable (100B) to L0
@@ -344,14 +344,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     4  2.9KB     0B       0 |    - 0.80 0.80 |  132B |     2  1.5KB |     0     0B |     4  2.9KB |    0B |   4 22.6 |    0B      0B
+    0 |     4  3.0KB     0B       0 |    - 0.80 0.80 |  132B |     2  1.5KB |     0     0B |     4  3.0KB |    0B |   4 23.1 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     1   755B |     0     0B |     1   755B | 1.5KB |   1 0.51 |    0B      0B
-total |     6  4.4KB     0B       0 |    -    -    - | 2.3KB |     3  2.2KB |     0     0B |     5  6.0KB | 1.5KB |   5 2.56 |    0B      0B
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     1   757B |     0     0B |     1   757B | 1.5KB |   1 0.50 |    0B      0B
+total |     6  4.4KB     0B       0 |    -    -    - | 2.3KB |     3  2.2KB |     0     0B |     5  6.1KB | 1.5KB |   5 2.58 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 82B  written: 132B (61% overhead)
 Flushes: 6

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -360,7 +360,7 @@ num-entries: 2
 num-deletions: 2
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1320
+range-deletions-bytes-estimate: 1334
 
 # A set operation takes precedence over a range deletion at the same
 # sequence number as can occur during ingestion.

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -331,7 +331,7 @@ lsm verbose
 ----
 L6:
   000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1389(1389)
-  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:940(940)
+  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:953(953)
 
 download g h via-backing-file-download
 ----
@@ -342,7 +342,7 @@ lsm verbose
 ----
 L6:
   000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1033(1033)
-  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:932(932)
+  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:945(945)
 
 reopen
 ----

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -12,9 +12,9 @@ L6
   d@2.SET.2:v
 ----
 L5:
-  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:964 blobrefs:[(B000921: 10); depth:1]
+  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:984 blobrefs:[(B000921: 10); depth:1]
 L6:
-  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:959 blobrefs:[(B000921: 6); depth:1]
+  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:979 blobrefs:[(B000921: 6); depth:1]
 Blob files:
   B000921 physical:{000921 size:[106 (106B)] vals:[16 (16B)]}
 
@@ -72,9 +72,9 @@ L6
   f@2.SETWITHDEL.3:blob{fileNum=000039 value=grapes}
 ----
 L5:
-  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:965 blobrefs:[(B000039: 14), (B000921: 20); depth:2]
+  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:985 blobrefs:[(B000039: 14), (B000921: 20); depth:2]
 L6:
-  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:973 blobrefs:[(B000039: 11), (B000921: 13); depth:2]
+  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:993 blobrefs:[(B000039: 11), (B000921: 13); depth:2]
 Blob files:
   B000039 physical:{000039 size:[117 (117B)] vals:[25 (25B)]}
   B000921 physical:{000921 size:[125 (125B)] vals:[33 (33B)]}
@@ -137,7 +137,7 @@ L6
   l.SETWITHDEL.2:blob{fileNum=000009 value=peach blockID=6 valueID=0}
 ----
 L6:
-  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:1063 blobrefs:[(B000009: 96); depth:1]
+  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:1083 blobrefs:[(B000009: 96); depth:1]
 Blob files:
   B000009 physical:{000009 size:[322 (322B)] vals:[96 (96B)]}
 
@@ -210,7 +210,7 @@ L6
   b.SETWITHDEL.2:blob{fileNum=000009 value=keylime}
 ----
 L6:
-  000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:1111 blobrefs:[(B000009: 7); depth:1]
+  000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:1133 blobrefs:[(B000009: 7); depth:1]
 Blob files:
   B000009 physical:{000009 size:[96 (96B)] vals:[7 (7B)]}
 

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -177,7 +177,7 @@ L0.0:
   000011:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] seqnums:[28-30] points:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] size:423436
   000012:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] seqnums:[31-33] points:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] size:423442
   000013:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] seqnums:[34-36] points:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] size:423449
-  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[37-38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282525
+  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[37-38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282526
 
 layout filename=000006.sst
 ----
@@ -221,9 +221,9 @@ del-range a(p,1000000)rovals a(p,1000000)rove
 flush verbose
 ----
 L0.1:
-  000017:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000807
-  000018:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000821
-  000019:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000779
+  000017:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000854
+  000018:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000868
+  000019:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000826
 L0.0:
   000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] seqnums:[10-12] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] size:423430
   000006:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] seqnums:[13-15] points:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] size:423451
@@ -234,16 +234,16 @@ L0.0:
   000011:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] seqnums:[28-30] points:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] size:423436
   000012:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] seqnums:[31-33] points:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] size:423442
   000013:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] seqnums:[34-36] points:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] size:423449
-  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[37-38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282525
+  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[37-38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282526
 
 layout filename=000017.sst
 ----
 sstable
  ├── index  offset: 0  length: 28
  ├── range-del  offset: 33  length: 6000129
- ├── properties  offset: 6000167  length: 512
- ├── meta-index  offset: 6000684  length: 65
- └── footer  offset: 6000754  length: 53
+ ├── properties  offset: 6000167  length: 559
+ ├── meta-index  offset: 6000731  length: 65
+ └── footer  offset: 6000801  length: 53
 
 properties file=000017
 rocksdb.raw

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -6,9 +6,9 @@ L1
   d.SET.0:foo
 ----
 L0.0:
-  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:744
+  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:758
 L1:
-  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:755
+  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:769
 
 mark-for-compaction file=000005
 ----
@@ -20,9 +20,9 @@ marked L0.000004
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000005] (755B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (755B), in 1.0s (2.0s total), output rate 755B/s
-[JOB 100] compacted(rewrite) L0 [000004] (744B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (744B), in 1.0s (2.0s total), output rate 744B/s
+[JOB 100] compacted(rewrite) L1 [000005] (769B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (769B), in 1.0s (2.0s total), output rate 769B/s
+[JOB 100] compacted(rewrite) L0 [000004] (758B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (758B), in 1.0s (2.0s total), output rate 758B/s
 L0.0:
-  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:744
+  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:758
 L1:
-  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:755
+  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:769

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -57,14 +57,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     1   756B     0B       0 |    - 0.25 0.25 |   28B |     0     0B |     0     0B |     1   756B |    0B |   1 27.0 |    0B      0B
+    0 |     1   769B     0B       0 |    - 0.25 0.25 |   28B |     0     0B |     0     0B |     1   769B |    0B |   1 27.5 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     6 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-total |     1   756B     0B       0 |    -    -    - |   28B |     0     0B |     0     0B |     1   784B |    0B |   1 28.0 |    0B      0B
+total |     1   769B     0B       0 |    -    -    - |   28B |     0     0B |     0     0B |     1   797B |    0B |   1 28.5 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 17B  written: 28B (65% overhead)
 Flushes: 1
@@ -74,7 +74,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 756B
+Local tables size: 769B
 Compression types: snappy: 1
 Table stats: all loaded
 Block cache: 2 entries (795B)  hit rate: 0.0%
@@ -122,14 +122,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.6 |    0B      0B
+    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 24.0 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.01 |    0B      0B
-total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.5 |    0B      0B
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 0.99 |    0B      0B
+total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.1KB | 1.5KB |   1 48.9 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -170,14 +170,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.6 |    0B      0B
+    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 24.0 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.01 |    0B      0B
-total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.5 |    0B      0B
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 0.99 |    0B      0B
+total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.1KB | 1.5KB |   1 48.9 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -215,21 +215,21 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.6 |    0B      0B
+    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 24.0 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.01 |    0B      0B
-total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.5 |    0B      0B
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 0.99 |    0B      0B
+total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.1KB | 1.5KB |   1 48.9 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
 Compactions: 1  estimated debt: 0B  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
 MemTables: 1 (256KB)  zombie: 2 (512KB)
-Zombie tables: 1 (756B, local: 756B)
+Zombie tables: 1 (769B, local: 769B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
 Local tables size: 1.5KB
@@ -263,14 +263,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 23.6 |    0B      0B
+    0 |     0     0B     0B       0 |    -    0    0 |   64B |     0     0B |     0     0B |     2  1.5KB |    0B |   0 24.0 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.01 |    0B      0B
-total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.0KB | 1.5KB |   1 48.5 |    0B      0B
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 0.99 |    0B      0B
+total |     2  1.5KB     0B       0 |    -    -    - |   64B |     0     0B |     0     0B |     4  3.1KB | 1.5KB |   1 48.9 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 34B  written: 64B (88% overhead)
 Flushes: 2
@@ -350,24 +350,24 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     7  5.9KB     0B       0 |    - 0.25 0.25 |  165B |     0     0B |     0     0B |     9  7.4KB |    0B |   1 53.5 |  644B      0B
+    0 |     7  6.0KB     0B       0 |    - 0.25 0.25 |  165B |     0     0B |     0     0B |     9  7.5KB |    0B |   1 54.2 |  644B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 1.01 |    0B      0B
-total |     9  7.4KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    11  9.0KB | 1.5KB |   2 63.7 |  644B      0B
+    6 |     2  1.5KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     2  1.5KB | 1.5KB |   1 0.99 |    0B      0B
+total |     9  7.5KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    11  9.1KB | 1.5KB |   2 64.4 |  644B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
 Flushes: 3
-Compactions: 1  estimated debt: 8.0KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
+Compactions: 1  estimated debt: 8.1KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
              default: 1  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 7.4KB
+Local tables size: 7.5KB
 Compression types: snappy: 9
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 33.3%
@@ -422,14 +422,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     0     0B     0B       0 |    -    0    0 |  165B |     0     0B |     0     0B |     9  7.4KB |    0B |   0 53.5 |    0B      0B
+    0 |     0     0B     0B       0 |    -    0    0 |  165B |     0     0B |     0     0B |     9  7.5KB |    0B |   0 54.2 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     9  7.4KB     0B       0 |    - 0.00 0.00 | 7.4KB |     0     0B |     0     0B |     9  7.4KB | 7.4KB |   1 1.00 |  644B      0B
-total |     9  7.4KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    18   15KB | 7.4KB |   1  100 |  644B      0B
+    6 |     9  7.4KB     0B       0 |    - 0.00 0.00 | 7.5KB |     0     0B |     0     0B |     9  7.4KB | 7.5KB |   1 1.00 |  644B      0B
+total |     9  7.4KB     0B       0 |    -    -    - |  165B |     0     0B |     0     0B |    18   15KB | 7.5KB |   1  101 |  644B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 116B  written: 165B (42% overhead)
 Flushes: 3
@@ -545,18 +545,18 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     6  4.5KB     0B       0 |    - 0.50 0.50 |  211B |     3  2.2KB |     0     0B |    12  9.6KB |    0B |   2 52.5 |    0B      0B
+    0 |     6  4.5KB     0B       0 |    - 0.50 0.50 |  211B |     3  2.2KB |     0     0B |    12  9.7KB |    0B |   2 53.3 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     9  7.4KB     0B       0 |    - 0.00 0.00 | 7.4KB |     0     0B |     0     0B |     9  7.4KB | 7.4KB |   1 1.00 |  644B      0B
-total |    15   12KB     0B       0 |    -    -    - | 2.4KB |     3  2.2KB |     0     0B |    21   19KB | 7.4KB |   3 8.45 |  644B      0B
+    6 |     9  7.4KB     0B       0 |    - 0.00 0.00 | 7.5KB |     0     0B |     0     0B |     9  7.4KB | 7.5KB |   1 1.00 |  644B      0B
+total |    15   12KB     0B       0 |    -    -    - | 2.4KB |     3  2.2KB |     0     0B |    21   20KB | 7.5KB |   3 8.53 |  644B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 176B  written: 211B (20% overhead)
 Flushes: 8
-Compactions: 2  estimated debt: 12KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
+Compactions: 2  estimated debt: 13KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
              default: 2  delete: 0  elision: 0  move: 0  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
 MemTables: 1 (1.0MB)  zombie: 1 (1.0MB)
 Zombie tables: 0 (0B, local: 0B)
@@ -630,14 +630,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |    13  9.6KB     0B       0 |    - 0.50 0.50 |  277B |     3  2.2KB |     0     0B |    19   15KB |    0B |   2 59.1 |    0B      0B
+    0 |    13  9.8KB     0B       0 |    - 0.50 0.50 |  277B |     3  2.2KB |     0     0B |    19   15KB |    0B |   2 60.0 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     9  7.4KB     0B       0 |    - 0.00 0.00 | 7.4KB |     0     0B |     0     0B |     9  7.4KB | 7.4KB |   1 1.00 |  644B      0B
-total |    22   17KB     0B       0 |    -    -    - | 2.5KB |     3  2.2KB |     0     0B |    28   25KB | 7.4KB |   3 10.3 |  644B      0B
+    6 |     9  7.4KB     0B       0 |    - 0.00 0.00 | 7.5KB |     0     0B |     0     0B |     9  7.4KB | 7.5KB |   1 1.00 |  644B      0B
+total |    22   17KB     0B       0 |    -    -    - | 2.5KB |     3  2.2KB |     0     0B |    28   25KB | 7.5KB |   3 10.4 |  644B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
@@ -727,14 +727,14 @@ metrics zero-cache-hits-misses
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |    11  8.1KB     0B       0 |    - 0.50 0.50 |  277B |     3  2.2KB |     0     0B |    19   15KB |    0B |   2 59.1 |    0B      0B
+    0 |    11  8.2KB     0B       0 |    - 0.50 0.50 |  277B |     3  2.2KB |     0     0B |    19   15KB |    0B |   2 60.0 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |    10  8.1KB     0B       0 |    - 0.00 0.00 | 7.4KB |     1   763B |     0     0B |     9  7.4KB | 7.4KB |   1 1.00 |  644B      0B
-total |    21   16KB     0B       0 |    -    -    - | 3.3KB |     4  3.0KB |     0     0B |    28   25KB | 7.4KB |   3 8.18 |  644B      0B
+    6 |    10  8.2KB     0B       0 |    - 0.00 0.00 | 7.5KB |     1   765B |     0     0B |     9  7.4KB | 7.5KB |   1 1.00 |  644B      0B
+total |    21   16KB     0B       0 |    -    -    - | 3.3KB |     4  3.0KB |     0     0B |    28   26KB | 7.5KB |   3 8.27 |  644B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
@@ -868,14 +868,14 @@ metrics zero-cache-hits-misses
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     0     0B     0B       0 |    -    0    0 |  277B |     3  2.2KB |     0     0B |    19   15KB |    0B |   0 59.1 |    0B      0B
+    0 |     0     0B     0B       0 |    -    0    0 |  277B |     3  2.2KB |     0     0B |    19   15KB |    0B |   0 60.0 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     6 |    18   14KB     0B       0 |    - 0.00 0.00 |  15KB |     2  1.5KB |     0     0B |    16   13KB |  15KB |   1 0.85 |  644B      0B
-total |    18   14KB     0B       0 |    -    -    - | 4.0KB |     5  3.7KB |     0     0B |    35   31KB |  15KB |   1 8.18 |  644B      0B
+total |    18   14KB     0B       0 |    -    -    - | 4.0KB |     5  3.7KB |     0     0B |    35   32KB |  15KB |   1 8.23 |  644B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 223B  written: 277B (24% overhead)
 Flushes: 9
@@ -926,14 +926,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     3  2.2KB     0B       0 |    - 0.25 0.25 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   1 59.7 |    0B      0B
+    0 |     3  2.3KB     0B       0 |    - 0.25 0.25 |   38B |     0     0B |     0     0B |     3  2.3KB |    0B |   1 60.7 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     6 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-total |     3  2.2KB     0B       0 |    -    -    - |   38B |     0     0B |     0     0B |     3  2.3KB |    0B |   1 60.7 |    0B      0B
+total |     3  2.3KB     0B       0 |    -    -    - |   38B |     0     0B |     0     0B |     3  2.3KB |    0B |   1 61.7 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -943,7 +943,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 2.2KB
+Local tables size: 2.3KB
 Compression types: snappy: 3
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
@@ -970,14 +970,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     0     0B     0B       0 |    -    0    0 |   38B |     0     0B |     0     0B |     3  2.2KB |    0B |   0 59.7 |    0B      0B
+    0 |     0     0B     0B       0 |    -    0    0 |   38B |     0     0B |     0     0B |     3  2.3KB |    0B |   0 60.7 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.01 |    0B      0B
-total |     3  2.2KB     0B       0 |    -    -    - |   38B |     0     0B |     0     0B |     6  4.5KB | 2.2KB |   1  121 |    0B      0B
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.3KB |     0     0B |     0     0B |     3  2.2KB | 2.3KB |   1 0.99 |    0B      0B
+total |     3  2.2KB     0B       0 |    -    -    - |   38B |     0     0B |     0     0B |     6  4.5KB | 2.3KB |   1  122 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -1030,14 +1030,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     1   763B     0B       0 |    - 0.25 0.25 |   38B |     1   763B |     0     0B |     3  2.2KB |    0B |   1 59.7 |    0B      0B
+    0 |     1   765B     0B       0 |    - 0.25 0.25 |   38B |     1   765B |     0     0B |     3  2.3KB |    0B |   1 60.7 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.01 |    0B      0B
-total |     4  3.0KB     0B       0 |    -    -    - |  801B |     1   763B |     0     0B |     6  5.2KB | 2.2KB |   2 6.69 |    0B      0B
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.3KB |     0     0B |     0     0B |     3  2.2KB | 2.3KB |   1 0.99 |    0B      0B
+total |     4  3.0KB     0B       0 |    -    -    - |  803B |     1   765B |     0     0B |     6  5.3KB | 2.3KB |   2 6.73 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 27B  written: 38B (41% overhead)
 Flushes: 1
@@ -1082,14 +1082,14 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     2  1.5KB     0B       0 |    - 0.50 0.50 |   74B |     1   763B |     0     0B |     4  3.0KB |    0B |   2 40.9 |    0B      0B
+    0 |     2  1.5KB     0B       0 |    - 0.50 0.50 |   74B |     1   765B |     0     0B |     4  3.0KB |    0B |   2 41.6 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.2KB |     0     0B |     0     0B |     3  2.2KB | 2.2KB |   1 1.01 |    0B      0B
-total |     5  3.7KB     0B       0 |    -    -    - |  837B |     1   763B |     0     0B |     7  6.0KB | 2.2KB |   3 7.35 |    0B      0B
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 2.3KB |     0     0B |     0     0B |     3  2.2KB | 2.3KB |   1 0.99 |    0B      0B
+total |     5  3.7KB     0B       0 |    -    -    - |  839B |     1   765B |     0     0B |     7  6.1KB | 2.3KB |   3 7.40 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 44B  written: 74B (68% overhead)
 Flushes: 2
@@ -1099,7 +1099,7 @@ MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 756B
+Local tables size: 769B
 Compression types: snappy: 5
 Table stats: all loaded
 Block cache: 2 entries (787B)  hit rate: 0.0%
@@ -1140,7 +1140,7 @@ MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 756B
+Local tables size: 769B
 Compression types: snappy: 5
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
@@ -1173,8 +1173,8 @@ level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | ta
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
-    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   763B | 2.2KB |   1 0.50 |    0B      0B
-total |     3  2.2KB     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     1   763B | 2.2KB |   1    0 |    0B      0B
+    6 |     3  2.2KB     0B       0 |    - 0.00 0.00 | 1.5KB |     0     0B |     0     0B |     1   765B | 2.2KB |   1 0.50 |    0B      0B
+total |     3  2.2KB     0B       0 |    -    -    - |    0B |     0     0B |     0     0B |     1   765B | 2.2KB |   1    0 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
 Flushes: 1
@@ -1184,7 +1184,7 @@ MemTables: 1 (512KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 763B
+Local tables size: 765B
 Compression types: snappy: 3
 Table stats: all loaded
 Block cache: 0 entries (0B)  hit rate: 0.0%
@@ -1249,24 +1249,24 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     2  1.5KB     0B       0 |    - 0.25 0.25 |  106B |     0     0B |     0     0B |     5  3.7KB |    0B |   1 36.2 |    0B      0B
+    0 |     2  1.5KB     0B       0 |    - 0.25 0.25 |  106B |     0     0B |     0     0B |     5  3.8KB |    0B |   1 36.7 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     6 |     3  2.3KB     0B       0 |    - 0.00 0.00 |    0B |     0     0B |     3  2.3KB |     0     0B |    0B |   1    0 |    0B      0B
-total |     5  3.7KB     0B       0 |    -    -    - |  106B |     0     0B |     3  2.3KB |     5  3.9KB |    0B |   2 37.2 |    0B      0B
+total |     5  3.8KB     0B       0 |    -    -    - |  106B |     0     0B |     3  2.3KB |     5  3.9KB |    0B |   2 37.7 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 57B  written: 106B (86% overhead)
 Flushes: 3
-Compactions: 3  estimated debt: 3.7KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
+Compactions: 3  estimated debt: 3.8KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 0
              default: 0  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 3.7KB
+Local tables size: 3.8KB
 Compression types: snappy: 5
 Garbage: point-deletions 502B range-deletions 1.5KB
 Table stats: all loaded
@@ -1291,24 +1291,24 @@ metrics
       |                             |                |       |   ingested   |     moved    |    written   |       |    amp   |    val sep
 level | tables  size val-bl vtables | score  ff  cff |   in  | tables  size | tables  size | tables  size |  read |   r   w  | refsz  valblk
 ------+-----------------------------+----------------+-------+--------------+--------------+--------------+-------+----------+--------------
-    0 |     2  1.5KB     0B       0 |    - 0.25 0.25 |  106B |     0     0B |     0     0B |     5  3.7KB |    0B |   1 36.2 |    0B      0B
+    0 |     2  1.5KB     0B       0 |    - 0.25 0.25 |  106B |     0     0B |     0     0B |     5  3.8KB |    0B |   1 36.7 |    0B      0B
     1 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     2 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     3 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     4 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     5 |     0     0B     0B       0 |    -    0    0 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0    0 |    0B      0B
     6 |     3  2.3KB     0B       0 |    - 0.00 0.00 |    0B |     0     0B |     3  2.3KB |     0     0B |    0B |   1    0 |    0B      0B
-total |     5  3.7KB     0B       0 |    -    -    - |  106B |     0     0B |     3  2.3KB |     5  3.9KB |    0B |   2 37.2 |    0B      0B
+total |     5  3.8KB     0B       0 |    -    -    - |  106B |     0     0B |     3  2.3KB |     5  3.9KB |    0B |   2 37.7 |    0B      0B
 --------------------------------------------------------------------------------------------------------------------------------------------
 WAL: 1 files (0B)  in: 57B  written: 106B (86% overhead)
 Flushes: 3
-Compactions: 3  estimated debt: 3.7KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 2
+Compactions: 3  estimated debt: 3.8KB  in progress: 0 (0B)  canceled: 0 (0B)  failed: 0  problem spans: 2
              default: 0  delete: 0  elision: 0  move: 3  read: 0  tombstone-density: 0  rewrite: 0  copy: 0  multi-level: 0  blob-file-rewrite:  0
 MemTables: 1 (256KB)  zombie: 1 (256KB)
 Zombie tables: 0 (0B, local: 0B)
 Backing tables: 0 (0B)
 Virtual tables: 0 (0B)
-Local tables size: 3.7KB
+Local tables size: 3.8KB
 Compression types: snappy: 5
 Garbage: point-deletions 502B range-deletions 1.5KB
 Table stats: all loaded

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -978,5 +978,5 @@ wait-pending-table-stats
 num-entries: 3
 num-deletions: 3
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 3940
+point-deletions-bytes-estimate: 3946
 range-deletions-bytes-estimate: 0


### PR DESCRIPTION
The columnar writer has its own compressor and the layout writer has
one too. Using both leads to incomplete stats. Consolidate and use
only the layout writer.