### PR TITLE
compression: improve compression stats string

### DIFF
--- a/internal/compression/adaptive_test.go
+++ b/internal/compression/adaptive_test.go
@@ -37,7 +37,7 @@ func TestAdaptiveCompressorCompressible(t *testing.T) {
 	// Test the adaptive compressor with compressible data and make sure it uses
 	// the slow algorithm.
 	ac := NewAdaptiveCompressor(AdaptiveCompressorParams{
-		Fast:            None,
+		Fast:            NoCompression,
 		Slow:            ZstdLevel1,
 		ReductionCutoff: 0.6,
 		SampleEvery:     10,

--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -19,10 +19,10 @@ import (
 type Algorithm uint8
 
 const (
-	NoCompression Algorithm = iota
-	SnappyAlgorithm
-	Zstd
+	NoAlgorithm Algorithm = iota
+	Snappy
 	MinLZ
+	Zstd
 
 	NumAlgorithms
 
@@ -33,9 +33,9 @@ const (
 // compression algorithm.
 func (a Algorithm) String() string {
 	switch a {
-	case NoCompression:
-		return "NoCompression"
-	case SnappyAlgorithm:
+	case NoAlgorithm:
+		return "None"
+	case Snappy:
 		return "Snappy"
 	case Zstd:
 		return "ZSTD"
@@ -86,8 +86,8 @@ func ParseSetting(s string) (_ Setting, ok bool) {
 
 // Setting presets.
 var (
-	None          = makePreset(NoCompression, 0)
-	Snappy        = makePreset(SnappyAlgorithm, 0)
+	NoCompression = makePreset(NoAlgorithm, 0)
+	SnappySetting = makePreset(Snappy, 0)
 	MinLZFastest  = makePreset(MinLZ, minlz.LevelFastest)
 	MinLZBalanced = makePreset(MinLZ, minlz.LevelBalanced)
 	ZstdLevel1    = makePreset(Zstd, 1)
@@ -110,9 +110,9 @@ type Compressor interface {
 
 func GetCompressor(s Setting) Compressor {
 	switch s.Algorithm {
-	case NoCompression:
+	case NoAlgorithm:
 		return noopCompressor{}
-	case SnappyAlgorithm:
+	case Snappy:
 		return snappyCompressor{}
 	case Zstd:
 		return getZstdCompressor(int(s.Level))
@@ -143,9 +143,9 @@ type Decompressor interface {
 
 func GetDecompressor(a Algorithm) Decompressor {
 	switch a {
-	case NoCompression:
+	case NoAlgorithm:
 		return noopDecompressor{}
-	case SnappyAlgorithm:
+	case Snappy:
 		return snappyDecompressor{}
 	case Zstd:
 		return getZstdDecompressor()

--- a/internal/compression/noop.go
+++ b/internal/compression/noop.go
@@ -9,7 +9,7 @@ type noopCompressor struct{}
 var _ Compressor = noopCompressor{}
 
 func (noopCompressor) Compress(dst, src []byte) ([]byte, Setting) {
-	return append(dst[:0], src...), None
+	return append(dst[:0], src...), NoCompression
 }
 func (noopCompressor) Close() {}
 

--- a/internal/compression/snappy.go
+++ b/internal/compression/snappy.go
@@ -14,11 +14,11 @@ type snappyCompressor struct{}
 
 var _ Compressor = snappyCompressor{}
 
-func (snappyCompressor) Algorithm() Algorithm { return SnappyAlgorithm }
+func (snappyCompressor) Algorithm() Algorithm { return Snappy }
 
 func (snappyCompressor) Compress(dst, src []byte) ([]byte, Setting) {
 	dst = dst[:cap(dst):cap(dst)]
-	return snappy.Encode(dst, src), Snappy
+	return snappy.Encode(dst, src), SnappySetting
 }
 
 func (snappyCompressor) Close() {}

--- a/metrics.go
+++ b/metrics.go
@@ -509,9 +509,9 @@ type CompressionStatsForSetting = block.CompressionStatsForSetting
 func (cm *CompressionMetrics) Add(stats *block.CompressionStats) {
 	for s, cs := range stats.All() {
 		switch s.Algorithm {
-		case compression.NoCompression:
+		case compression.NoAlgorithm:
 			cm.NoCompressionBytes += cs.UncompressedBytes
-		case compression.SnappyAlgorithm:
+		case compression.Snappy:
 			cm.Snappy.Add(cs)
 		case compression.MinLZ:
 			cm.MinLZ.Add(cs)

--- a/replay/testdata/corpus/simple_ingest
+++ b/replay/testdata/corpus/simple_ingest
@@ -101,6 +101,6 @@ simple_ingest/MANIFEST-000008:
   size: 209
 simple_ingest/MANIFEST-000010: stat simple_ingest/MANIFEST-000010: file does not exist
 simple_ingest/000007.sst:
-  size: 770
-simple_ingest/000009.sst:
   size: 765
+simple_ingest/000009.sst:
+  size: 759

--- a/replay/testdata/corpus/simple_val_sep
+++ b/replay/testdata/corpus/simple_val_sep
@@ -103,6 +103,6 @@ stat simple_val_sep/MANIFEST-000013 simple_val_sep/000015.sst simple_val_sep/000
 simple_val_sep/MANIFEST-000013:
   size: 250
 simple_val_sep/000015.sst:
-  size: 878
+  size: 873
 simple_val_sep/000016.blob:
   size: 97

--- a/replay/testdata/replay_ingest
+++ b/replay/testdata/replay_ingest
@@ -6,9 +6,9 @@ tree
           /
             build/
       36      000002.log
-     770      000005.sst
-     770      000007.sst
-     765      000009.sst
+     765      000005.sst
+     765      000007.sst
+     759      000009.sst
        0      LOCK
      172      MANIFEST-000001
      209      MANIFEST-000008
@@ -16,14 +16,14 @@ tree
        0      marker.format-version.000012.025
        0      marker.manifest.000002.MANIFEST-000008
             simple_ingest/
-     770      000007.sst
-     765      000009.sst
+     765      000007.sst
+     759      000009.sst
      172      MANIFEST-000001
      209      MANIFEST-000008
               checkpoint/
       25        000002.log
-     787        000004.sst
-     770        000005.sst
+     782        000004.sst
+     765        000005.sst
      172        MANIFEST-000001
     2800        OPTIONS-000003
        0        marker.format-version.000001.025

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -5,14 +5,14 @@ tree
 ----
           /
             build/
-     906      000005.sst
+     900      000005.sst
      101      000006.blob
-     884      000008.sst
+     879      000008.sst
       97      000009.blob
       92      000011.log
-     769      000012.sst
+     764      000012.sst
       63      000014.log
-     878      000015.sst
+     873      000015.sst
       97      000016.blob
        0      LOCK
      152      MANIFEST-000010
@@ -21,16 +21,16 @@ tree
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
-     878      000015.sst
+     873      000015.sst
       97      000016.blob
      250      MANIFEST-000013
               checkpoint/
-     906        000005.sst
+     900        000005.sst
      101        000006.blob
-     884        000008.sst
+     879        000008.sst
       97        000009.blob
       64        000011.log
-     769        000012.sst
+     764        000012.sst
      187        MANIFEST-000013
     2936        OPTIONS-000003
        0        marker.format-version.000001.024

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -55,8 +55,8 @@ func (p *CompressionProfile) UsesMinLZ() bool {
 }
 
 var (
-	NoCompression     = simpleCompressionProfile("NoCompression", compression.None)
-	SnappyCompression = simpleCompressionProfile("Snappy", compression.Snappy)
+	NoCompression     = simpleCompressionProfile("NoCompression", compression.NoCompression)
+	SnappyCompression = simpleCompressionProfile("Snappy", compression.SnappySetting)
 	ZstdCompression   = simpleCompressionProfile("ZSTD", compression.ZstdLevel3)
 	MinLZCompression  = simpleCompressionProfile("MinLZ", compression.MinLZFastest)
 
@@ -95,7 +95,7 @@ var fastestCompression = func() compression.Setting {
 	if runtime.GOARCH == "arm64" {
 		// MinLZ is generally faster and better than Snappy except for arm64: Snappy
 		// has an arm64 assembly implementation and MinLZ does not.
-		return compression.Snappy
+		return compression.SnappySetting
 	}
 	return compression.MinLZFastest
 }()
@@ -190,9 +190,9 @@ func (i CompressionIndicator) String() string {
 func (i CompressionIndicator) Algorithm() compression.Algorithm {
 	switch i {
 	case NoCompressionIndicator:
-		return compression.NoCompression
+		return compression.NoAlgorithm
 	case SnappyCompressionIndicator:
-		return compression.SnappyAlgorithm
+		return compression.Snappy
 	case ZstdCompressionIndicator:
 		return compression.Zstd
 	case MinLZCompressionIndicator:
@@ -204,9 +204,9 @@ func (i CompressionIndicator) Algorithm() compression.Algorithm {
 
 func compressionIndicatorFromAlgorithm(algo compression.Algorithm) CompressionIndicator {
 	switch algo {
-	case compression.NoCompression:
+	case compression.NoAlgorithm:
 		return NoCompressionIndicator
-	case compression.SnappyAlgorithm:
+	case compression.Snappy:
 		return SnappyCompressionIndicator
 	case compression.Zstd:
 		return ZstdCompressionIndicator

--- a/sstable/block/compression_stats_test.go
+++ b/sstable/block/compression_stats_test.go
@@ -15,38 +15,41 @@ import (
 func TestCompressionStatsString(t *testing.T) {
 	var stats CompressionStats
 
-	stats.addOne(compression.None, CompressionStatsForSetting{CompressedBytes: 100, UncompressedBytes: 100})
-	require.Equal(t, "NoCompression:100/100", stats.String())
+	stats.addOne(compression.NoCompression, CompressionStatsForSetting{CompressedBytes: 100, UncompressedBytes: 100})
+	require.Equal(t, "None:100", stats.String())
 
-	stats.addOne(compression.Snappy, CompressionStatsForSetting{CompressedBytes: 100, UncompressedBytes: 200})
-	require.Equal(t, "NoCompression:100/100,Snappy:100/200", stats.String())
+	stats.addOne(compression.SnappySetting, CompressionStatsForSetting{CompressedBytes: 100, UncompressedBytes: 200})
+	require.Equal(t, "None:100,Snappy:100/200", stats.String())
 
-	stats.addOne(compression.Snappy, CompressionStatsForSetting{CompressedBytes: 100, UncompressedBytes: 200})
-	require.Equal(t, "NoCompression:100/100,Snappy:200/400", stats.String())
+	stats.addOne(compression.SnappySetting, CompressionStatsForSetting{CompressedBytes: 100, UncompressedBytes: 200})
+	require.Equal(t, "None:100,Snappy:200/400", stats.String())
 
 	stats.addOne(compression.MinLZFastest, CompressionStatsForSetting{CompressedBytes: 1000, UncompressedBytes: 4000})
-	require.Equal(t, "MinLZ1:1000/4000,NoCompression:100/100,Snappy:200/400", stats.String())
+	require.Equal(t, "None:100,Snappy:200/400,MinLZ1:1000/4000", stats.String())
 
 	stats.addOne(compression.ZstdLevel1, CompressionStatsForSetting{CompressedBytes: 10000, UncompressedBytes: 80000})
-	require.Equal(t, "MinLZ1:1000/4000,NoCompression:100/100,Snappy:200/400,ZSTD1:10000/80000", stats.String())
+	require.Equal(t, "None:100,Snappy:200/400,MinLZ1:1000/4000,ZSTD1:10000/80000", stats.String())
+
+	stats.addOne(compression.ZstdLevel3, CompressionStatsForSetting{CompressedBytes: 5000, UncompressedBytes: 90000})
+	require.Equal(t, "None:100,Snappy:200/400,MinLZ1:1000/4000,ZSTD1:10000/80000,ZSTD3:5000/90000", stats.String())
 
 	stats = CompressionStats{}
 	stats.addOne(compression.MinLZFastest, CompressionStatsForSetting{CompressedBytes: 1000, UncompressedBytes: 4000})
 	require.Equal(t, "MinLZ1:1000/4000", stats.String())
 
 	stats = CompressionStats{}
-	stats.addOne(compression.Snappy, CompressionStatsForSetting{CompressedBytes: 1000, UncompressedBytes: 4000})
+	stats.addOne(compression.SnappySetting, CompressionStatsForSetting{CompressedBytes: 1000, UncompressedBytes: 4000})
 	require.Equal(t, "Snappy:1000/4000", stats.String())
 }
 
 func TestCompressionStatsRoundtrip(t *testing.T) {
-	settings := []compression.Setting{compression.None, compression.Snappy, compression.MinLZFastest, compression.ZstdLevel1, compression.ZstdLevel3}
+	settings := []compression.Setting{compression.NoCompression, compression.SnappySetting, compression.MinLZFastest, compression.ZstdLevel1, compression.ZstdLevel3}
 	for n := 0; n < 1000; n++ {
 		var stats CompressionStats
 		for _, i := range rand.Perm(len(settings))[:rand.IntN(len(settings)+1)] {
 			compressed := rand.Uint64N(1_000_000)
 			uncompressed := compressed
-			if settings[i] != compression.None {
+			if settings[i] != compression.NoCompression {
 				uncompressed += compressed * rand.Uint64N(20) / 10
 			}
 			stats.addOne(settings[i], CompressionStatsForSetting{CompressedBytes: compressed, UncompressedBytes: uncompressed})
@@ -63,5 +66,14 @@ func TestParseCompressionStatsUnknown(t *testing.T) {
 	stats, err := ParseCompressionStats("MinLZ1:100/200,ZSTD9:100/500,MiddleOut10:13/150000,Magic:15/10000000")
 	require.NoError(t, err)
 	expected := "MinLZ1:100/200,ZSTD9:100/500,unknown:28/10150000"
+	require.Equal(t, expected, stats.String())
+}
+
+// TestParseCompressionStatsOld tests that we can parse the old format of
+// compression stats.
+func TestParseCompressionStatsOldFormat(t *testing.T) {
+	stats, err := ParseCompressionStats("NoCompression:12345/12345,MinLZ1:100/200,ZSTD9:100/500")
+	require.NoError(t, err)
+	expected := "None:12345,MinLZ1:100/200,ZSTD9:100/500"
 	require.Equal(t, expected, stats.String())
 }

--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -87,9 +87,9 @@ func (c *Compressor) Compress(dst, src []byte, kind Kind) (CompressionIndicator,
 	//   after * 100
 	//   -----------  >  100 - MinReductionPercent
 	//      before
-	if setting.Algorithm != compression.NoCompression &&
+	if setting.Algorithm != compression.NoAlgorithm &&
 		int64(len(out))*100 > int64(len(src))*int64(100-c.minReductionPercent) {
-		setting.Algorithm = compression.NoCompression
+		setting.Algorithm = compression.NoAlgorithm
 		out = append(out[:0], src...)
 	}
 	c.stats.addOne(setting, CompressionStatsForSetting{
@@ -103,7 +103,7 @@ func (c *Compressor) Compress(dst, src []byte, kind Kind) (CompressionIndicator,
 // kind was written uncompressed. This is used so that the final statistics are
 // complete.
 func (c *Compressor) UncompressedBlock(size int, kind Kind) {
-	c.stats.addOne(compression.None, CompressionStatsForSetting{
+	c.stats.addOne(compression.NoCompression, CompressionStatsForSetting{
 		UncompressedBytes: uint64(size),
 		CompressedBytes:   uint64(size),
 	})

--- a/sstable/block/compressor_test.go
+++ b/sstable/block/compressor_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestCompressor(t *testing.T) {
 	settings := []compression.Setting{
-		compression.None,
-		compression.Snappy,
+		compression.NoCompression,
+		compression.SnappySetting,
 		compression.MinLZFastest,
 		compression.ZstdLevel3,
 	}

--- a/sstable/compressionanalyzer/buckets.go
+++ b/sstable/compressionanalyzer/buckets.go
@@ -99,9 +99,9 @@ func (c Compressibility) String() string {
 var Profiles = [...]*block.CompressionProfile{
 	{
 		Name:                "Snappy",
-		DataBlocks:          compression.Snappy,
-		ValueBlocks:         compression.Snappy,
-		OtherBlocks:         compression.Snappy,
+		DataBlocks:          compression.SnappySetting,
+		ValueBlocks:         compression.SnappySetting,
+		OtherBlocks:         compression.SnappySetting,
 		MinReductionPercent: 0,
 	},
 

--- a/sstable/testdata/columnar_writer/simple_binary
+++ b/sstable/testdata/columnar_writer/simple_binary
@@ -80,39 +80,39 @@ sstable
  │    ├── 00000    block:0/88
  │    │   
  │    └── trailer [compression=none checksum=0x6147006e]
- ├── properties  offset: 149  length: 661
+ ├── properties  offset: 149  length: 648
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (39)
- │    ├── 00123    pebble.internal.testkeys.suffixes (41)
- │    ├── 00164    pebble.raw.point-tombstone.key.size (32)
- │    ├── 00196    rocksdb.block.based.table.index.type (43)
- │    ├── 00239    rocksdb.comparator (37)
- │    ├── 00276    rocksdb.compression (23)
- │    ├── 00299    rocksdb.compression_options (106)
- │    ├── 00405    rocksdb.data.size (13)
- │    ├── 00418    rocksdb.deleted.keys (15)
- │    ├── 00433    rocksdb.filter.size (15)
- │    ├── 00448    rocksdb.index.size (14)
- │    ├── 00462    rocksdb.merge.operands (18)
- │    ├── 00480    rocksdb.merge.operator (24)
- │    ├── 00504    rocksdb.num.data.blocks (19)
- │    ├── 00523    rocksdb.num.entries (11)
- │    ├── 00534    rocksdb.num.range-deletions (19)
- │    ├── 00553    rocksdb.property.collectors (70)
- │    ├── 00623    rocksdb.raw.key.size (16)
- │    ├── 00639    rocksdb.raw.value.size (14)
+ │    ├── 00084    pebble.compression_stats (26)
+ │    ├── 00110    pebble.internal.testkeys.suffixes (41)
+ │    ├── 00151    pebble.raw.point-tombstone.key.size (32)
+ │    ├── 00183    rocksdb.block.based.table.index.type (43)
+ │    ├── 00226    rocksdb.comparator (37)
+ │    ├── 00263    rocksdb.compression (23)
+ │    ├── 00286    rocksdb.compression_options (106)
+ │    ├── 00392    rocksdb.data.size (13)
+ │    ├── 00405    rocksdb.deleted.keys (15)
+ │    ├── 00420    rocksdb.filter.size (15)
+ │    ├── 00435    rocksdb.index.size (14)
+ │    ├── 00449    rocksdb.merge.operands (18)
+ │    ├── 00467    rocksdb.merge.operator (24)
+ │    ├── 00491    rocksdb.num.data.blocks (19)
+ │    ├── 00510    rocksdb.num.entries (11)
+ │    ├── 00521    rocksdb.num.range-deletions (19)
+ │    ├── 00540    rocksdb.property.collectors (70)
+ │    ├── 00610    rocksdb.raw.key.size (16)
+ │    ├── 00626    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00653 [restart 0]
- │    └── trailer [compression=none checksum=0x78d91a9f]
- ├── meta-index  offset: 815  length: 33
- │    ├── 0000    rocksdb.properties block:149/661 [restart]
+ │    │    └── 00640 [restart 0]
+ │    └── trailer [compression=none checksum=0x5dd6d20e]
+ ├── meta-index  offset: 802  length: 33
+ │    ├── 0000    rocksdb.properties block:149/648 [restart]
  │    ├── restart points
  │    │    └── 00025 [restart 0]
- │    └── trailer [compression=none checksum=0x590655dc]
- └── footer  offset: 853  length: 53
+ │    └── trailer [compression=none checksum=0x3009f55c]
+ └── footer  offset: 840  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=815, length=33
+      ├── 001  meta: offset=802, length=33
       ├── 004  index: offset=93, length=51
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -137,7 +137,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-pebble.compression_stats: NoCompression:139/139
+pebble.compression_stats: None:139
 obsolete-key: hex:01
 pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
 
@@ -230,38 +230,38 @@ sstable
  │    ├── 00000    block:0/116
  │    │   
  │    └── trailer [compression=none checksum=0xcf86ef66]
- ├── properties  offset: 177  length: 629
+ ├── properties  offset: 177  length: 616
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (39)
- │    ├── 00123    pebble.internal.testkeys.suffixes (41)
- │    ├── 00164    rocksdb.block.based.table.index.type (43)
- │    ├── 00207    rocksdb.comparator (37)
- │    ├── 00244    rocksdb.compression (23)
- │    ├── 00267    rocksdb.compression_options (106)
- │    ├── 00373    rocksdb.data.size (13)
- │    ├── 00386    rocksdb.deleted.keys (15)
- │    ├── 00401    rocksdb.filter.size (15)
- │    ├── 00416    rocksdb.index.size (14)
- │    ├── 00430    rocksdb.merge.operands (18)
- │    ├── 00448    rocksdb.merge.operator (24)
- │    ├── 00472    rocksdb.num.data.blocks (19)
- │    ├── 00491    rocksdb.num.entries (11)
- │    ├── 00502    rocksdb.num.range-deletions (19)
- │    ├── 00521    rocksdb.property.collectors (70)
- │    ├── 00591    rocksdb.raw.key.size (16)
- │    ├── 00607    rocksdb.raw.value.size (14)
+ │    ├── 00084    pebble.compression_stats (26)
+ │    ├── 00110    pebble.internal.testkeys.suffixes (41)
+ │    ├── 00151    rocksdb.block.based.table.index.type (43)
+ │    ├── 00194    rocksdb.comparator (37)
+ │    ├── 00231    rocksdb.compression (23)
+ │    ├── 00254    rocksdb.compression_options (106)
+ │    ├── 00360    rocksdb.data.size (13)
+ │    ├── 00373    rocksdb.deleted.keys (15)
+ │    ├── 00388    rocksdb.filter.size (15)
+ │    ├── 00403    rocksdb.index.size (14)
+ │    ├── 00417    rocksdb.merge.operands (18)
+ │    ├── 00435    rocksdb.merge.operator (24)
+ │    ├── 00459    rocksdb.num.data.blocks (19)
+ │    ├── 00478    rocksdb.num.entries (11)
+ │    ├── 00489    rocksdb.num.range-deletions (19)
+ │    ├── 00508    rocksdb.property.collectors (70)
+ │    ├── 00578    rocksdb.raw.key.size (16)
+ │    ├── 00594    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00621 [restart 0]
- │    └── trailer [compression=none checksum=0xf4e8ad4]
- ├── meta-index  offset: 811  length: 33
- │    ├── 0000    rocksdb.properties block:177/629 [restart]
+ │    │    └── 00608 [restart 0]
+ │    └── trailer [compression=none checksum=0x8a2913db]
+ ├── meta-index  offset: 798  length: 33
+ │    ├── 0000    rocksdb.properties block:177/616 [restart]
  │    ├── restart points
  │    │    └── 00025 [restart 0]
- │    └── trailer [compression=none checksum=0xa765d152]
- └── footer  offset: 849  length: 53
+ │    └── trailer [compression=none checksum=0xe26972d2]
+ └── footer  offset: 836  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=811, length=33
+      ├── 001  meta: offset=798, length=33
       ├── 004  index: offset=121, length=51
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -626,38 +626,38 @@ sstable
  │    ├── 00003    block:449/128
  │    │   
  │    └── trailer [compression=none checksum=0xd5c96d3a]
- ├── properties  offset: 697  length: 632
+ ├── properties  offset: 697  length: 619
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (39)
- │    ├── 00123    pebble.internal.testkeys.suffixes (41)
- │    ├── 00164    rocksdb.block.based.table.index.type (43)
- │    ├── 00207    rocksdb.comparator (37)
- │    ├── 00244    rocksdb.compression (23)
- │    ├── 00267    rocksdb.compression_options (106)
- │    ├── 00373    rocksdb.data.size (14)
- │    ├── 00387    rocksdb.deleted.keys (15)
- │    ├── 00402    rocksdb.filter.size (15)
- │    ├── 00417    rocksdb.index.size (14)
- │    ├── 00431    rocksdb.merge.operands (18)
- │    ├── 00449    rocksdb.merge.operator (24)
- │    ├── 00473    rocksdb.num.data.blocks (19)
- │    ├── 00492    rocksdb.num.entries (11)
- │    ├── 00503    rocksdb.num.range-deletions (19)
- │    ├── 00522    rocksdb.property.collectors (70)
- │    ├── 00592    rocksdb.raw.key.size (17)
- │    ├── 00609    rocksdb.raw.value.size (15)
+ │    ├── 00084    pebble.compression_stats (26)
+ │    ├── 00110    pebble.internal.testkeys.suffixes (41)
+ │    ├── 00151    rocksdb.block.based.table.index.type (43)
+ │    ├── 00194    rocksdb.comparator (37)
+ │    ├── 00231    rocksdb.compression (23)
+ │    ├── 00254    rocksdb.compression_options (106)
+ │    ├── 00360    rocksdb.data.size (14)
+ │    ├── 00374    rocksdb.deleted.keys (15)
+ │    ├── 00389    rocksdb.filter.size (15)
+ │    ├── 00404    rocksdb.index.size (14)
+ │    ├── 00418    rocksdb.merge.operands (18)
+ │    ├── 00436    rocksdb.merge.operator (24)
+ │    ├── 00460    rocksdb.num.data.blocks (19)
+ │    ├── 00479    rocksdb.num.entries (11)
+ │    ├── 00490    rocksdb.num.range-deletions (19)
+ │    ├── 00509    rocksdb.property.collectors (70)
+ │    ├── 00579    rocksdb.raw.key.size (17)
+ │    ├── 00596    rocksdb.raw.value.size (15)
  │    ├── restart points
- │    │    └── 00624 [restart 0]
- │    └── trailer [compression=none checksum=0xfdfb788c]
- ├── meta-index  offset: 1334  length: 33
- │    ├── 0000    rocksdb.properties block:697/632 [restart]
+ │    │    └── 00611 [restart 0]
+ │    └── trailer [compression=none checksum=0x665621a7]
+ ├── meta-index  offset: 1321  length: 33
+ │    ├── 0000    rocksdb.properties block:697/619 [restart]
  │    ├── restart points
  │    │    └── 00025 [restart 0]
- │    └── trailer [compression=none checksum=0x31899c86]
- └── footer  offset: 1372  length: 53
+ │    └── trailer [compression=none checksum=0xcb345d4b]
+ └── footer  offset: 1359  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=1334, length=33
+      ├── 001  meta: offset=1321, length=33
       ├── 004  index: offset=582, length=110
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -685,7 +685,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [pebble.internal.testkeys.suffixes,obsolete-key]
-pebble.compression_stats: NoCompression:672/672
+pebble.compression_stats: None:672
 obsolete-key: hex:01
 pebble.internal.testkeys.suffixes: hex:0000ffffffffffffffffff01
 
@@ -1019,38 +1019,38 @@ sstable
  │    ├── 00003    block:449/128
  │    │   
  │    └── trailer [compression=none checksum=0xd5c96d3a]
- ├── properties  offset: 697  length: 632
+ ├── properties  offset: 697  length: 619
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (39)
- │    ├── 00123    pebble.internal.testkeys.suffixes (41)
- │    ├── 00164    rocksdb.block.based.table.index.type (43)
- │    ├── 00207    rocksdb.comparator (37)
- │    ├── 00244    rocksdb.compression (23)
- │    ├── 00267    rocksdb.compression_options (106)
- │    ├── 00373    rocksdb.data.size (14)
- │    ├── 00387    rocksdb.deleted.keys (15)
- │    ├── 00402    rocksdb.filter.size (15)
- │    ├── 00417    rocksdb.index.size (14)
- │    ├── 00431    rocksdb.merge.operands (18)
- │    ├── 00449    rocksdb.merge.operator (24)
- │    ├── 00473    rocksdb.num.data.blocks (19)
- │    ├── 00492    rocksdb.num.entries (11)
- │    ├── 00503    rocksdb.num.range-deletions (19)
- │    ├── 00522    rocksdb.property.collectors (70)
- │    ├── 00592    rocksdb.raw.key.size (17)
- │    ├── 00609    rocksdb.raw.value.size (15)
+ │    ├── 00084    pebble.compression_stats (26)
+ │    ├── 00110    pebble.internal.testkeys.suffixes (41)
+ │    ├── 00151    rocksdb.block.based.table.index.type (43)
+ │    ├── 00194    rocksdb.comparator (37)
+ │    ├── 00231    rocksdb.compression (23)
+ │    ├── 00254    rocksdb.compression_options (106)
+ │    ├── 00360    rocksdb.data.size (14)
+ │    ├── 00374    rocksdb.deleted.keys (15)
+ │    ├── 00389    rocksdb.filter.size (15)
+ │    ├── 00404    rocksdb.index.size (14)
+ │    ├── 00418    rocksdb.merge.operands (18)
+ │    ├── 00436    rocksdb.merge.operator (24)
+ │    ├── 00460    rocksdb.num.data.blocks (19)
+ │    ├── 00479    rocksdb.num.entries (11)
+ │    ├── 00490    rocksdb.num.range-deletions (19)
+ │    ├── 00509    rocksdb.property.collectors (70)
+ │    ├── 00579    rocksdb.raw.key.size (17)
+ │    ├── 00596    rocksdb.raw.value.size (15)
  │    ├── restart points
- │    │    └── 00624 [restart 0]
- │    └── trailer [compression=none checksum=0xfdfb788c]
- ├── meta-index  offset: 1334  length: 33
- │    ├── 0000    rocksdb.properties block:697/632 [restart]
+ │    │    └── 00611 [restart 0]
+ │    └── trailer [compression=none checksum=0x665621a7]
+ ├── meta-index  offset: 1321  length: 33
+ │    ├── 0000    rocksdb.properties block:697/619 [restart]
  │    ├── restart points
  │    │    └── 00025 [restart 0]
- │    └── trailer [compression=none checksum=0x31899c86]
- └── footer  offset: 1372  length: 53
+ │    └── trailer [compression=none checksum=0xcb345d4b]
+ └── footer  offset: 1359  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=1334, length=33
+      ├── 001  meta: offset=1321, length=33
       ├── 004  index: offset=582, length=110
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -1117,40 +1117,40 @@ sstable
  │    │    │         └── 50-50: x  # data[0]:
  │    │    └── 50-51: x 00 # block padding byte
  │    └── trailer [compression=none checksum=0xb1e3982b]
- ├── properties  offset: 89  length: 617
+ ├── properties  offset: 89  length: 605
  │    ├── 00000    obsolete-key (17) [restart]
  │    ├── 00017    pebble.colblk.schema (68)
- │    ├── 00085    pebble.compression_stats (37)
- │    ├── 00122    pebble.internal.testkeys.suffixes (30)
- │    ├── 00152    rocksdb.block.based.table.index.type (43)
- │    ├── 00195    rocksdb.comparator (37)
- │    ├── 00232    rocksdb.compression (23)
- │    ├── 00255    rocksdb.compression_options (106)
- │    ├── 00361    rocksdb.data.size (13)
- │    ├── 00374    rocksdb.deleted.keys (15)
- │    ├── 00389    rocksdb.filter.size (15)
- │    ├── 00404    rocksdb.index.size (14)
- │    ├── 00418    rocksdb.merge.operands (18)
- │    ├── 00436    rocksdb.merge.operator (24)
- │    ├── 00460    rocksdb.num.data.blocks (19)
- │    ├── 00479    rocksdb.num.entries (11)
- │    ├── 00490    rocksdb.num.range-deletions (19)
- │    ├── 00509    rocksdb.property.collectors (70)
- │    ├── 00579    rocksdb.raw.key.size (16)
- │    ├── 00595    rocksdb.raw.value.size (14)
+ │    ├── 00085    pebble.compression_stats (25)
+ │    ├── 00110    pebble.internal.testkeys.suffixes (30)
+ │    ├── 00140    rocksdb.block.based.table.index.type (43)
+ │    ├── 00183    rocksdb.comparator (37)
+ │    ├── 00220    rocksdb.compression (23)
+ │    ├── 00243    rocksdb.compression_options (106)
+ │    ├── 00349    rocksdb.data.size (13)
+ │    ├── 00362    rocksdb.deleted.keys (15)
+ │    ├── 00377    rocksdb.filter.size (15)
+ │    ├── 00392    rocksdb.index.size (14)
+ │    ├── 00406    rocksdb.merge.operands (18)
+ │    ├── 00424    rocksdb.merge.operator (24)
+ │    ├── 00448    rocksdb.num.data.blocks (19)
+ │    ├── 00467    rocksdb.num.entries (11)
+ │    ├── 00478    rocksdb.num.range-deletions (19)
+ │    ├── 00497    rocksdb.property.collectors (70)
+ │    ├── 00567    rocksdb.raw.key.size (16)
+ │    ├── 00583    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00609 [restart 0]
- │    └── trailer [compression=none checksum=0x9dc2b838]
- ├── meta-index  offset: 711  length: 59
- │    ├── 0000    rocksdb.properties block:89/617 [restart]
+ │    │    └── 00597 [restart 0]
+ │    └── trailer [compression=none checksum=0x2b36072]
+ ├── meta-index  offset: 699  length: 59
+ │    ├── 0000    rocksdb.properties block:89/605 [restart]
  │    ├── 0024    rocksdb.range_del2 block:33/51 [restart]
  │    ├── restart points
  │    │    ├── 00047 [restart 0]
  │    │    └── 00051 [restart 24]
- │    └── trailer [compression=none checksum=0xa7304de4]
- └── footer  offset: 775  length: 53
+ │    └── trailer [compression=none checksum=0xdf5a81e9]
+ └── footer  offset: 763  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=711, length=59
+      ├── 001  meta: offset=699, length=59
       ├── 004  index: offset=0, length=28
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -1231,45 +1231,45 @@ sstable
  │    │    │         └── 67-67: x        # data[1]:
  │    │    └── 67-68: x 00 # block padding byte
  │    └── trailer [compression=none checksum=0x45325be7]
- ├── properties  offset: 106  length: 699
+ ├── properties  offset: 106  length: 687
  │    ├── 00000    obsolete-key (17) [restart]
  │    ├── 00017    pebble.colblk.schema (68)
- │    ├── 00085    pebble.compression_stats (37)
- │    ├── 00122    pebble.internal.testkeys.suffixes (32)
- │    ├── 00154    pebble.num.range-key-dels (22)
- │    ├── 00176    pebble.num.range-key-sets (8)
- │    ├── 00184    pebble.num.range-key-unsets (10)
- │    ├── 00194    pebble.raw.range-key.key.size (26)
- │    ├── 00220    pebble.raw.range-key.value.size (14)
- │    ├── 00234    rocksdb.block.based.table.index.type (43)
- │    ├── 00277    rocksdb.comparator (37)
- │    ├── 00314    rocksdb.compression (23)
- │    ├── 00337    rocksdb.compression_options (106)
- │    ├── 00443    rocksdb.data.size (13)
- │    ├── 00456    rocksdb.deleted.keys (15)
- │    ├── 00471    rocksdb.filter.size (15)
- │    ├── 00486    rocksdb.index.size (14)
- │    ├── 00500    rocksdb.merge.operands (18)
- │    ├── 00518    rocksdb.merge.operator (24)
- │    ├── 00542    rocksdb.num.data.blocks (19)
- │    ├── 00561    rocksdb.num.entries (11)
- │    ├── 00572    rocksdb.num.range-deletions (19)
- │    ├── 00591    rocksdb.property.collectors (70)
- │    ├── 00661    rocksdb.raw.key.size (16)
- │    ├── 00677    rocksdb.raw.value.size (14)
+ │    ├── 00085    pebble.compression_stats (25)
+ │    ├── 00110    pebble.internal.testkeys.suffixes (32)
+ │    ├── 00142    pebble.num.range-key-dels (22)
+ │    ├── 00164    pebble.num.range-key-sets (8)
+ │    ├── 00172    pebble.num.range-key-unsets (10)
+ │    ├── 00182    pebble.raw.range-key.key.size (26)
+ │    ├── 00208    pebble.raw.range-key.value.size (14)
+ │    ├── 00222    rocksdb.block.based.table.index.type (43)
+ │    ├── 00265    rocksdb.comparator (37)
+ │    ├── 00302    rocksdb.compression (23)
+ │    ├── 00325    rocksdb.compression_options (106)
+ │    ├── 00431    rocksdb.data.size (13)
+ │    ├── 00444    rocksdb.deleted.keys (15)
+ │    ├── 00459    rocksdb.filter.size (15)
+ │    ├── 00474    rocksdb.index.size (14)
+ │    ├── 00488    rocksdb.merge.operands (18)
+ │    ├── 00506    rocksdb.merge.operator (24)
+ │    ├── 00530    rocksdb.num.data.blocks (19)
+ │    ├── 00549    rocksdb.num.entries (11)
+ │    ├── 00560    rocksdb.num.range-deletions (19)
+ │    ├── 00579    rocksdb.property.collectors (70)
+ │    ├── 00649    rocksdb.raw.key.size (16)
+ │    ├── 00665    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00691 [restart 0]
- │    └── trailer [compression=none checksum=0xc9180526]
- ├── meta-index  offset: 810  length: 57
+ │    │    └── 00679 [restart 0]
+ │    └── trailer [compression=none checksum=0x7a8cc91]
+ ├── meta-index  offset: 798  length: 57
  │    ├── 0000    pebble.range_key block:33/68 [restart]
- │    ├── 0021    rocksdb.properties block:106/699 [restart]
+ │    ├── 0021    rocksdb.properties block:106/687 [restart]
  │    ├── restart points
  │    │    ├── 00045 [restart 0]
  │    │    └── 00049 [restart 21]
- │    └── trailer [compression=none checksum=0x996f900b]
- └── footer  offset: 872  length: 53
+ │    └── trailer [compression=none checksum=0xe1ee4669]
+ └── footer  offset: 860  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=810, length=57
+      ├── 001  meta: offset=798, length=57
       ├── 004  index: offset=0, length=28
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3

--- a/sstable/testdata/copy_span
+++ b/sstable/testdata/copy_span
@@ -99,7 +99,7 @@ d#0,SET: foobar
 
 copy-span test3 test4 b.SET.10 cc.SET.0
 ----
-copied 941 bytes
+copied 928 bytes
 
 iter test4
 ----
@@ -109,7 +109,7 @@ d#0,SET: foobar
 
 copy-span test3 test5 a.SET.10 bb.SET.0
 ----
-copied 936 bytes
+copied 923 bytes
 
 iter test5
 ----
@@ -139,7 +139,7 @@ d#0,SET: foobar
 
 copy-span test32 test33 b.SET.10 cc.SET.0
 ----
-copied 941 bytes
+copied 928 bytes
 
 iter test33
 ----
@@ -149,7 +149,7 @@ d#0,SET: foobar
 
 copy-span test32 test34 a.SET.10 bb.SET.0
 ----
-copied 936 bytes
+copied 923 bytes
 
 iter test34
 ----
@@ -173,7 +173,7 @@ d#0,SET: foobar
 
 copy-span test3 test4 b.SET.10 cc.SET.0
 ----
-copied 958 bytes
+copied 945 bytes
 
 iter test4
 ----
@@ -183,7 +183,7 @@ d#0,SET: foobar
 
 copy-span test3 test5 a.SET.10 bb.SET.0
 ----
-copied 953 bytes
+copied 940 bytes
 
 iter test5
 ----
@@ -213,7 +213,7 @@ d#0,SET: foobar
 
 copy-span test32 test33 b.SET.10 cc.SET.0
 ----
-copied 958 bytes
+copied 945 bytes
 
 iter test33
 ----
@@ -223,7 +223,7 @@ d#0,SET: foobar
 
 copy-span test32 test34 a.SET.10 bb.SET.0
 ----
-copied 953 bytes
+copied 940 bytes
 
 iter test34
 ----
@@ -270,9 +270,9 @@ sstable
  ├── index  offset: 1235  length: 38
  ├── top-index  offset: 1278  length: 83
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 1366  length: 69
- ├── properties  offset: 1440  length: 637
- ├── meta-index  offset: 2082  length: 88
- └── footer  offset: 2175  length: 57
+ ├── properties  offset: 1440  length: 623
+ ├── meta-index  offset: 2068  length: 88
+ └── footer  offset: 2161  length: 57
 
 props bloom-sst
 ----
@@ -296,7 +296,7 @@ rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
 rocksdb.top-level.index.size: 83
-pebble.compression_stats: NoCompression:1257/1257,Snappy:73/84
+pebble.compression_stats: None:1257,Snappy:73/84
 obsolete-key: hex:00
 
 # Ensure that CopySpan copies over a filter block even if the writer options are
@@ -304,7 +304,7 @@ obsolete-key: hex:00
 
 copy-span bloom-sst bloom-sst-copy b.SET.10 cc.SET.0 filter=my-custom-filter/bloom(10)
 ----
-copied 1096 bytes
+copied 1083 bytes
 
 describe bloom-sst-copy
 ----
@@ -314,6 +314,6 @@ sstable
  ├── data  offset: 172  length: 73
  ├── index  offset: 250  length: 45
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 300  length: 69
- ├── properties  offset: 374  length: 567
- ├── meta-index  offset: 946  length: 88
- └── footer  offset: 1039  length: 57
+ ├── properties  offset: 374  length: 554
+ ├── meta-index  offset: 933  length: 88
+ └── footer  offset: 1026  length: 57

--- a/sstable/testdata/rewriter_v5
+++ b/sstable/testdata/rewriter_v5
@@ -45,9 +45,9 @@ sstable
  ├── index  offset: 363  length: 37
  ├── top-index  offset: 405  length: 52
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
- ├── properties  offset: 536  length: 622
- ├── meta-index  offset: 1163  length: 80
- └── footer  offset: 1248  length: 53
+ ├── properties  offset: 536  length: 609
+ ├── meta-index  offset: 1150  length: 80
+ └── footer  offset: 1235  length: 53
 
 scan
 ----
@@ -80,9 +80,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 622
- ├── meta-index  offset: 1171  length: 80
- └── footer  offset: 1256  length: 53
+ ├── properties  offset: 544  length: 609
+ ├── meta-index  offset: 1158  length: 80
+ └── footer  offset: 1243  length: 53
 
 scan
 ----
@@ -115,9 +115,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 622
- ├── meta-index  offset: 1171  length: 80
- └── footer  offset: 1256  length: 53
+ ├── properties  offset: 544  length: 609
+ ├── meta-index  offset: 1158  length: 80
+ └── footer  offset: 1243  length: 53
 
 scan
 ----
@@ -150,9 +150,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 622
- ├── meta-index  offset: 1171  length: 80
- └── footer  offset: 1256  length: 53
+ ├── properties  offset: 544  length: 609
+ ├── meta-index  offset: 1158  length: 80
+ └── footer  offset: 1243  length: 53
 
 scan
 ----
@@ -186,9 +186,9 @@ sstable
  ├── index  offset: 363  length: 37
  ├── top-index  offset: 405  length: 52
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
- ├── properties  offset: 536  length: 622
- ├── meta-index  offset: 1163  length: 80
- └── footer  offset: 1248  length: 53
+ ├── properties  offset: 536  length: 609
+ ├── meta-index  offset: 1150  length: 80
+ └── footer  offset: 1235  length: 53
 
 scan
 ----

--- a/sstable/testdata/rewriter_v6
+++ b/sstable/testdata/rewriter_v6
@@ -45,9 +45,9 @@ sstable
  ├── index  offset: 363  length: 37
  ├── top-index  offset: 405  length: 52
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
- ├── properties  offset: 536  length: 622
- ├── meta-index  offset: 1163  length: 88
- └── footer  offset: 1256  length: 57
+ ├── properties  offset: 536  length: 609
+ ├── meta-index  offset: 1150  length: 88
+ └── footer  offset: 1243  length: 57
 
 scan
 ----
@@ -80,9 +80,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 622
- ├── meta-index  offset: 1171  length: 88
- └── footer  offset: 1264  length: 57
+ ├── properties  offset: 544  length: 609
+ ├── meta-index  offset: 1158  length: 88
+ └── footer  offset: 1251  length: 57
 
 scan
 ----
@@ -115,9 +115,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 622
- ├── meta-index  offset: 1171  length: 88
- └── footer  offset: 1264  length: 57
+ ├── properties  offset: 544  length: 609
+ ├── meta-index  offset: 1158  length: 88
+ └── footer  offset: 1251  length: 57
 
 scan
 ----
@@ -150,9 +150,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 622
- ├── meta-index  offset: 1171  length: 88
- └── footer  offset: 1264  length: 57
+ ├── properties  offset: 544  length: 609
+ ├── meta-index  offset: 1158  length: 88
+ └── footer  offset: 1251  length: 57
 
 scan
 ----
@@ -186,9 +186,9 @@ sstable
  ├── index  offset: 363  length: 37
  ├── top-index  offset: 405  length: 52
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
- ├── properties  offset: 536  length: 622
- ├── meta-index  offset: 1163  length: 88
- └── footer  offset: 1256  length: 57
+ ├── properties  offset: 536  length: 609
+ ├── meta-index  offset: 1150  length: 88
+ └── footer  offset: 1243  length: 57
 
 scan
 ----

--- a/sstable/testdata/rewriter_v7
+++ b/sstable/testdata/rewriter_v7
@@ -45,9 +45,9 @@ sstable
  ├── index  offset: 363  length: 37
  ├── top-index  offset: 405  length: 52
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
- ├── properties  offset: 536  length: 609
- ├── meta-index  offset: 1150  length: 88
- └── footer  offset: 1243  length: 61
+ ├── properties  offset: 536  length: 587
+ ├── meta-index  offset: 1128  length: 88
+ └── footer  offset: 1221  length: 61
 
 scan
 ----
@@ -80,9 +80,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 609
- ├── meta-index  offset: 1158  length: 88
- └── footer  offset: 1251  length: 61
+ ├── properties  offset: 544  length: 587
+ ├── meta-index  offset: 1136  length: 88
+ └── footer  offset: 1229  length: 61
 
 scan
 ----
@@ -115,9 +115,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 609
- ├── meta-index  offset: 1158  length: 88
- └── footer  offset: 1251  length: 61
+ ├── properties  offset: 544  length: 587
+ ├── meta-index  offset: 1136  length: 88
+ └── footer  offset: 1229  length: 61
 
 scan
 ----
@@ -150,9 +150,9 @@ sstable
  ├── index  offset: 367  length: 37
  ├── top-index  offset: 409  length: 56
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 470  length: 69
- ├── properties  offset: 544  length: 609
- ├── meta-index  offset: 1158  length: 88
- └── footer  offset: 1251  length: 61
+ ├── properties  offset: 544  length: 587
+ ├── meta-index  offset: 1136  length: 88
+ └── footer  offset: 1229  length: 61
 
 scan
 ----
@@ -186,9 +186,9 @@ sstable
  ├── index  offset: 363  length: 37
  ├── top-index  offset: 405  length: 52
  ├── fullfilter.rocksdb.BuiltinBloomFilter  offset: 462  length: 69
- ├── properties  offset: 536  length: 609
- ├── meta-index  offset: 1150  length: 88
- └── footer  offset: 1243  length: 61
+ ├── properties  offset: 536  length: 587
+ ├── meta-index  offset: 1128  length: 88
+ └── footer  offset: 1221  length: 61
 
 scan
 ----

--- a/sstable/testdata/virtual_reader_props
+++ b/sstable/testdata/virtual_reader_props
@@ -314,7 +314,7 @@ bounds:  [dd#5,SET-ddd#6,SET]
 filenum: 000008
 props:
   rocksdb.num.entries: 1
-  rocksdb.raw.key.size: 9
+  rocksdb.raw.key.size: 10
   rocksdb.raw.value.size: 2
   rocksdb.num.data.blocks: 1
   rocksdb.compression: Snappy

--- a/sstable/testdata/writer_blob_value_handles
+++ b/sstable/testdata/writer_blob_value_handles
@@ -117,42 +117,42 @@ sstable
  │    ├── 00008 (10)
  │    │    └── block: 0, values size: 303, bitmap size: 6 byte(s), bitmap: [00000000 00100101 00010000 00000000 00001100 00000001]
  │    └── trailer [compression=none checksum=0xed355aac]
- ├── properties  offset: 248  length: 609
+ ├── properties  offset: 248  length: 596
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (39)
- │    ├── 00123    pebble.num.values.in.blob-files (28)
- │    ├── 00151    pebble.raw.point-tombstone.key.size (32)
- │    ├── 00183    rocksdb.block.based.table.index.type (43)
- │    ├── 00226    rocksdb.comparator (37)
- │    ├── 00263    rocksdb.compression (16)
- │    ├── 00279    rocksdb.compression_options (106)
- │    ├── 00385    rocksdb.data.size (14)
- │    ├── 00399    rocksdb.deleted.keys (15)
- │    ├── 00414    rocksdb.filter.size (15)
- │    ├── 00429    rocksdb.index.size (14)
- │    ├── 00443    rocksdb.merge.operands (18)
- │    ├── 00461    rocksdb.merge.operator (24)
- │    ├── 00485    rocksdb.num.data.blocks (19)
- │    ├── 00504    rocksdb.num.entries (11)
- │    ├── 00515    rocksdb.num.range-deletions (19)
- │    ├── 00534    rocksdb.property.collectors (36)
- │    ├── 00570    rocksdb.raw.key.size (16)
- │    ├── 00586    rocksdb.raw.value.size (15)
+ │    ├── 00084    pebble.compression_stats (26)
+ │    ├── 00110    pebble.num.values.in.blob-files (28)
+ │    ├── 00138    pebble.raw.point-tombstone.key.size (32)
+ │    ├── 00170    rocksdb.block.based.table.index.type (43)
+ │    ├── 00213    rocksdb.comparator (37)
+ │    ├── 00250    rocksdb.compression (16)
+ │    ├── 00266    rocksdb.compression_options (106)
+ │    ├── 00372    rocksdb.data.size (14)
+ │    ├── 00386    rocksdb.deleted.keys (15)
+ │    ├── 00401    rocksdb.filter.size (15)
+ │    ├── 00416    rocksdb.index.size (14)
+ │    ├── 00430    rocksdb.merge.operands (18)
+ │    ├── 00448    rocksdb.merge.operator (24)
+ │    ├── 00472    rocksdb.num.data.blocks (19)
+ │    ├── 00491    rocksdb.num.entries (11)
+ │    ├── 00502    rocksdb.num.range-deletions (19)
+ │    ├── 00521    rocksdb.property.collectors (36)
+ │    ├── 00557    rocksdb.raw.key.size (16)
+ │    ├── 00573    rocksdb.raw.value.size (15)
  │    ├── restart points
- │    │    └── 00601 [restart 0]
- │    └── trailer [compression=none checksum=0x27d9426d]
- ├── meta-index  offset: 862  length: 72
+ │    │    └── 00588 [restart 0]
+ │    └── trailer [compression=none checksum=0x9cbe0092]
+ ├── meta-index  offset: 849  length: 72
  │    ├── 0000    pebble.blob_ref_index block:208/35
  │    │   
- │    ├── 0001    rocksdb.properties block:248/609
+ │    ├── 0001    rocksdb.properties block:248/596
  │    │   
- │    └── trailer [compression=none checksum=0xa018e694]
- └── footer  offset: 939  length: 57
+ │    └── trailer [compression=none checksum=0x22f1b6c8]
+ └── footer  offset: 926  length: 57
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=862, length=72
+      ├── 001  meta: offset=849, length=72
       ├── 004  index: offset=167, length=36
-      ├── 041  footer checksum: 0x7b1dc572
+      ├── 041  footer checksum: 0x35d498e
       ├── 045  version: 6
       └── 049  magic number: 0xf09faab3f09faab3
 
@@ -275,41 +275,41 @@ sstable
  │    ├── 00008 (10)
  │    │    └── block: 0, values size: 303, bitmap size: 6 byte(s), bitmap: [00000000 00100101 00010000 00000000 00001100 00000001]
  │    └── trailer [compression=none checksum=0xed355aac]
- ├── properties  offset: 248  length: 584
+ ├── properties  offset: 248  length: 579
  │    ├── 00000    obsolete-key (13)
  │    ├── 00013    pebble.colblk.schema (65)
- │    ├── 00078    pebble.compression_stats (45)
- │    ├── 00123    pebble.num.values.in.blob-files (32)
- │    ├── 00155    pebble.raw.point-tombstone.key.size (36)
- │    ├── 00191    rocksdb.block.based.table.index.type (40)
- │    ├── 00231    rocksdb.comparator (42)
- │    ├── 00273    rocksdb.compression (25)
- │    ├── 00298    rocksdb.compression_options (122)
- │    ├── 00420    rocksdb.data.size (19)
- │    ├── 00439    rocksdb.deleted.keys (21)
- │    ├── 00460    rocksdb.filter.size (20)
- │    ├── 00480    rocksdb.index.size (19)
- │    ├── 00499    rocksdb.merge.operands (23)
- │    ├── 00522    rocksdb.merge.operator (40)
- │    ├── 00562    rocksdb.num.data.blocks (24)
- │    ├── 00586    rocksdb.num.entries (20)
- │    ├── 00606    rocksdb.num.range-deletions (28)
- │    ├── 00634    rocksdb.property.collectors (41)
- │    ├── 00675    rocksdb.raw.key.size (21)
- │    ├── 00696    rocksdb.raw.value.size (24)
- │    └── trailer [compression=snappy checksum=0xc03bcadf]
- ├── meta-index  offset: 837  length: 72
+ │    ├── 00078    pebble.compression_stats (32)
+ │    ├── 00110    pebble.num.values.in.blob-files (32)
+ │    ├── 00142    pebble.raw.point-tombstone.key.size (36)
+ │    ├── 00178    rocksdb.block.based.table.index.type (40)
+ │    ├── 00218    rocksdb.comparator (42)
+ │    ├── 00260    rocksdb.compression (25)
+ │    ├── 00285    rocksdb.compression_options (122)
+ │    ├── 00407    rocksdb.data.size (19)
+ │    ├── 00426    rocksdb.deleted.keys (21)
+ │    ├── 00447    rocksdb.filter.size (20)
+ │    ├── 00467    rocksdb.index.size (19)
+ │    ├── 00486    rocksdb.merge.operands (23)
+ │    ├── 00509    rocksdb.merge.operator (40)
+ │    ├── 00549    rocksdb.num.data.blocks (24)
+ │    ├── 00573    rocksdb.num.entries (20)
+ │    ├── 00593    rocksdb.num.range-deletions (28)
+ │    ├── 00621    rocksdb.property.collectors (41)
+ │    ├── 00662    rocksdb.raw.key.size (21)
+ │    ├── 00683    rocksdb.raw.value.size (24)
+ │    └── trailer [compression=snappy checksum=0x49835ba0]
+ ├── meta-index  offset: 832  length: 72
  │    ├── 0000    pebble.blob_ref_index block:208/35
  │    │   
- │    ├── 0001    rocksdb.properties block:248/584
+ │    ├── 0001    rocksdb.properties block:248/579
  │    │   
- │    └── trailer [compression=none checksum=0xe8c0eecd]
- └── footer  offset: 914  length: 61
+ │    └── trailer [compression=none checksum=0x36041610]
+ └── footer  offset: 909  length: 61
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=837, length=72
+      ├── 001  meta: offset=832, length=72
       ├── 004  index: offset=167, length=36
       ├── 041  attributes: [BlobValues,PointKeys]
-      ├── 045  footer checksum: 0x17acf000
+      ├── 045  footer checksum: 0x9d62c732
       ├── 049  version: 7
       └── 053  magic number: 0xf09faab3f09faab3
 

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -107,7 +107,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
-pebble.compression_stats: NoCompression:107/107
+pebble.compression_stats: None:107
 obsolete-key: hex:0074
 
 # The range tombstone upper bound is exclusive, so a point operation
@@ -236,9 +236,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 602
- ├── meta-index  offset: 1022  length: 33
- └── footer  offset: 1060  length: 53
+ ├── properties  offset: 415  length: 589
+ ├── meta-index  offset: 1009  length: 33
+ └── footer  offset: 1047  length: 53
 
 # Exercise the non-Reader layout-decoding codepath.
 
@@ -252,9 +252,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 602
- ├── meta-index  offset: 1022  length: 33
- └── footer  offset: 1060  length: 53
+ ├── properties  offset: 415  length: 589
+ ├── meta-index  offset: 1009  length: 33
+ └── footer  offset: 1047  length: 53
 
 scan
 ----
@@ -299,9 +299,9 @@ layout
 sstable
  ├── index  offset: 0  length: 28
  ├── range-key  offset: 33  length: 84
- ├── properties  offset: 122  length: 628
- ├── meta-index  offset: 755  length: 57
- └── footer  offset: 817  length: 53
+ ├── properties  offset: 122  length: 615
+ ├── meta-index  offset: 742  length: 57
+ └── footer  offset: 804  length: 53
 
 props
 ----
@@ -327,7 +327,7 @@ pebble.num.range-key-unsets: 0
 rocksdb.property.collectors: [obsolete-key]
 pebble.raw.range-key.key.size: 6
 pebble.raw.range-key.value.size: 9
-pebble.compression_stats: NoCompression:112/112
+pebble.compression_stats: None:112
 obsolete-key: hex:0074
 
 open-writer disable-value-blocks

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -107,7 +107,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
-pebble.compression_stats: NoCompression:107/107
+pebble.compression_stats: None:107
 obsolete-key: hex:0074
 
 # The range tombstone upper bound is exclusive, so a point operation
@@ -236,9 +236,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 602
- ├── meta-index  offset: 1022  length: 46
- └── footer  offset: 1073  length: 57
+ ├── properties  offset: 415  length: 589
+ ├── meta-index  offset: 1009  length: 46
+ └── footer  offset: 1060  length: 57
 
 props
 ----
@@ -261,7 +261,7 @@ rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
 rocksdb.top-level.index.size: 48
-pebble.compression_stats: NoCompression:158/158,Snappy:222/261
+pebble.compression_stats: None:158,Snappy:222/261
 obsolete-key: hex:00
 
 # Exercise the non-Reader layout-decoding codepath.
@@ -276,9 +276,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 602
- ├── meta-index  offset: 1022  length: 46
- └── footer  offset: 1073  length: 57
+ ├── properties  offset: 415  length: 589
+ ├── meta-index  offset: 1009  length: 46
+ └── footer  offset: 1060  length: 57
 
 scan
 ----
@@ -323,9 +323,9 @@ layout
 sstable
  ├── index  offset: 0  length: 28
  ├── range-key  offset: 33  length: 84
- ├── properties  offset: 122  length: 628
- ├── meta-index  offset: 755  length: 65
- └── footer  offset: 825  length: 57
+ ├── properties  offset: 122  length: 615
+ ├── meta-index  offset: 742  length: 65
+ └── footer  offset: 812  length: 57
 
 props
 ----
@@ -351,7 +351,7 @@ pebble.num.range-key-unsets: 0
 rocksdb.property.collectors: [obsolete-key]
 pebble.raw.range-key.key.size: 6
 pebble.raw.range-key.value.size: 9
-pebble.compression_stats: NoCompression:112/112
+pebble.compression_stats: None:112
 obsolete-key: hex:0074
 
 open-writer disable-value-blocks

--- a/sstable/testdata/writer_v7
+++ b/sstable/testdata/writer_v7
@@ -107,7 +107,7 @@ pebble.colblk.schema: DefaultKeySchema(pebble.internal.testkeys,16)
 rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
-pebble.compression_stats: NoCompression:107/107
+pebble.compression_stats: None:107
 obsolete-key: hex:0074
 
 # The range tombstone upper bound is exclusive, so a point operation
@@ -236,9 +236,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 587
- ├── meta-index  offset: 1007  length: 46
- └── footer  offset: 1058  length: 61
+ ├── properties  offset: 415  length: 559
+ ├── meta-index  offset: 979  length: 46
+ └── footer  offset: 1030  length: 61
 
 props
 ----
@@ -261,7 +261,7 @@ rocksdb.merge.operator: pebble.concatenate
 rocksdb.merge.operands: 0
 rocksdb.property.collectors: [obsolete-key]
 rocksdb.top-level.index.size: 48
-pebble.compression_stats: NoCompression:158/158,Snappy:222/261
+pebble.compression_stats: None:158,Snappy:222/261
 obsolete-key: hex:00
 
 # Exercise the non-Reader layout-decoding codepath.
@@ -276,9 +276,9 @@ sstable
  ├── index  offset: 278  length: 37
  ├── index  offset: 320  length: 37
  ├── top-index  offset: 362  length: 48
- ├── properties  offset: 415  length: 587
- ├── meta-index  offset: 1007  length: 46
- └── footer  offset: 1058  length: 61
+ ├── properties  offset: 415  length: 559
+ ├── meta-index  offset: 979  length: 46
+ └── footer  offset: 1030  length: 61
 
 scan
 ----
@@ -323,9 +323,9 @@ layout
 sstable
  ├── index  offset: 0  length: 28
  ├── range-key  offset: 33  length: 84
- ├── properties  offset: 122  length: 605
- ├── meta-index  offset: 732  length: 65
- └── footer  offset: 802  length: 61
+ ├── properties  offset: 122  length: 602
+ ├── meta-index  offset: 729  length: 65
+ └── footer  offset: 799  length: 61
 
 props
 ----
@@ -351,7 +351,7 @@ pebble.num.range-key-unsets: 0
 rocksdb.property.collectors: [obsolete-key]
 pebble.raw.range-key.key.size: 6
 pebble.raw.range-key.value.size: 9
-pebble.compression_stats: NoCompression:112/112
+pebble.compression_stats: None:112
 obsolete-key: hex:0074
 
 open-writer disable-value-blocks

--- a/sstable/testdata/writer_value_blocks
+++ b/sstable/testdata/writer_value_blocks
@@ -643,44 +643,44 @@ sstable
  │    └── trailer [compression=none checksum=0x60e7fb82]
  ├── value-index  offset: 680  length: 8
  │    └── trailer [compression=none checksum=0xb327e021]
- ├── properties  offset: 693  length: 664
+ ├── properties  offset: 693  length: 651
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (54)
- │    ├── 00138    pebble.num.value-blocks (20)
- │    ├── 00158    pebble.num.values.in.value-blocks (21)
- │    ├── 00179    pebble.value-blocks.size (21)
- │    ├── 00200    rocksdb.block.based.table.index.type (43)
- │    ├── 00243    rocksdb.comparator (37)
- │    ├── 00280    rocksdb.compression (16)
- │    ├── 00296    rocksdb.compression_options (106)
- │    ├── 00402    rocksdb.data.size (14)
- │    ├── 00416    rocksdb.deleted.keys (15)
- │    ├── 00431    rocksdb.filter.size (15)
- │    ├── 00446    rocksdb.index.partitions (20)
- │    ├── 00466    rocksdb.index.size (9)
- │    ├── 00475    rocksdb.merge.operands (18)
- │    ├── 00493    rocksdb.merge.operator (24)
- │    ├── 00517    rocksdb.num.data.blocks (19)
- │    ├── 00536    rocksdb.num.entries (11)
- │    ├── 00547    rocksdb.num.range-deletions (19)
- │    ├── 00566    rocksdb.property.collectors (36)
- │    ├── 00602    rocksdb.raw.key.size (16)
- │    ├── 00618    rocksdb.raw.value.size (14)
- │    ├── 00632    rocksdb.top-level.index.size (24)
+ │    ├── 00084    pebble.compression_stats (41)
+ │    ├── 00125    pebble.num.value-blocks (20)
+ │    ├── 00145    pebble.num.values.in.value-blocks (21)
+ │    ├── 00166    pebble.value-blocks.size (21)
+ │    ├── 00187    rocksdb.block.based.table.index.type (43)
+ │    ├── 00230    rocksdb.comparator (37)
+ │    ├── 00267    rocksdb.compression (16)
+ │    ├── 00283    rocksdb.compression_options (106)
+ │    ├── 00389    rocksdb.data.size (14)
+ │    ├── 00403    rocksdb.deleted.keys (15)
+ │    ├── 00418    rocksdb.filter.size (15)
+ │    ├── 00433    rocksdb.index.partitions (20)
+ │    ├── 00453    rocksdb.index.size (9)
+ │    ├── 00462    rocksdb.merge.operands (18)
+ │    ├── 00480    rocksdb.merge.operator (24)
+ │    ├── 00504    rocksdb.num.data.blocks (19)
+ │    ├── 00523    rocksdb.num.entries (11)
+ │    ├── 00534    rocksdb.num.range-deletions (19)
+ │    ├── 00553    rocksdb.property.collectors (36)
+ │    ├── 00589    rocksdb.raw.key.size (16)
+ │    ├── 00605    rocksdb.raw.value.size (14)
+ │    ├── 00619    rocksdb.top-level.index.size (24)
  │    ├── restart points
- │    │    └── 00656 [restart 0]
- │    └── trailer [compression=none checksum=0x5586ef52]
- ├── meta-index  offset: 1362  length: 64
+ │    │    └── 00643 [restart 0]
+ │    └── trailer [compression=none checksum=0x9fab5ba9]
+ ├── meta-index  offset: 1349  length: 64
  │    ├── 0000    pebble.value_index block:680/8 value-blocks-index-lengths: 1(num), 2(offset), 1(length) [restart]
- │    ├── 0027    rocksdb.properties block:693/664 [restart]
+ │    ├── 0027    rocksdb.properties block:693/651 [restart]
  │    ├── restart points
  │    │    ├── 00052 [restart 0]
  │    │    └── 00056 [restart 27]
- │    └── trailer [compression=none checksum=0xf2de4c26]
- └── footer  offset: 1431  length: 53
+ │    └── trailer [compression=none checksum=0x34b3e43d]
+ └── footer  offset: 1418  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=1362, length=64
+      ├── 001  meta: offset=1349, length=64
       ├── 004  index: offset=562, length=77
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -872,38 +872,38 @@ sstable
  │    ├── 00000    block:0/100
  │    │   
  │    └── trailer [compression=none checksum=0x760132f1]
- ├── properties  offset: 146  length: 592
+ ├── properties  offset: 146  length: 580
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (52)
- │    ├── 00136    pebble.raw.point-tombstone.key.size (32)
- │    ├── 00168    rocksdb.block.based.table.index.type (43)
- │    ├── 00211    rocksdb.comparator (37)
- │    ├── 00248    rocksdb.compression (16)
- │    ├── 00264    rocksdb.compression_options (106)
- │    ├── 00370    rocksdb.data.size (13)
- │    ├── 00383    rocksdb.deleted.keys (15)
- │    ├── 00398    rocksdb.filter.size (15)
- │    ├── 00413    rocksdb.index.size (14)
- │    ├── 00427    rocksdb.merge.operands (18)
- │    ├── 00445    rocksdb.merge.operator (24)
- │    ├── 00469    rocksdb.num.data.blocks (19)
- │    ├── 00488    rocksdb.num.entries (11)
- │    ├── 00499    rocksdb.num.range-deletions (19)
- │    ├── 00518    rocksdb.property.collectors (36)
- │    ├── 00554    rocksdb.raw.key.size (16)
- │    ├── 00570    rocksdb.raw.value.size (14)
+ │    ├── 00084    pebble.compression_stats (40)
+ │    ├── 00124    pebble.raw.point-tombstone.key.size (32)
+ │    ├── 00156    rocksdb.block.based.table.index.type (43)
+ │    ├── 00199    rocksdb.comparator (37)
+ │    ├── 00236    rocksdb.compression (16)
+ │    ├── 00252    rocksdb.compression_options (106)
+ │    ├── 00358    rocksdb.data.size (13)
+ │    ├── 00371    rocksdb.deleted.keys (15)
+ │    ├── 00386    rocksdb.filter.size (15)
+ │    ├── 00401    rocksdb.index.size (14)
+ │    ├── 00415    rocksdb.merge.operands (18)
+ │    ├── 00433    rocksdb.merge.operator (24)
+ │    ├── 00457    rocksdb.num.data.blocks (19)
+ │    ├── 00476    rocksdb.num.entries (11)
+ │    ├── 00487    rocksdb.num.range-deletions (19)
+ │    ├── 00506    rocksdb.property.collectors (36)
+ │    ├── 00542    rocksdb.raw.key.size (16)
+ │    ├── 00558    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00584 [restart 0]
- │    └── trailer [compression=none checksum=0x87ef433b]
- ├── meta-index  offset: 743  length: 33
- │    ├── 0000    rocksdb.properties block:146/592 [restart]
+ │    │    └── 00572 [restart 0]
+ │    └── trailer [compression=none checksum=0x5292e7cb]
+ ├── meta-index  offset: 731  length: 33
+ │    ├── 0000    rocksdb.properties block:146/580 [restart]
  │    ├── restart points
  │    │    └── 00025 [restart 0]
- │    └── trailer [compression=none checksum=0x41dda72d]
- └── footer  offset: 781  length: 53
+ │    └── trailer [compression=none checksum=0x22c79622]
+ └── footer  offset: 769  length: 53
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=743, length=33
+      ├── 001  meta: offset=731, length=33
       ├── 004  index: offset=105, length=36
       ├── 041  version: 5
       └── 045  magic number: 0xf09faab3f09faab3
@@ -1017,39 +1017,39 @@ sstable
  │    ├── 00000    block:0/100
  │    │   
  │    └── trailer [compression=none checksum=0x760132f1]
- ├── properties  offset: 146  length: 592
+ ├── properties  offset: 146  length: 580
  │    ├── 00000    obsolete-key (16) [restart]
  │    ├── 00016    pebble.colblk.schema (68)
- │    ├── 00084    pebble.compression_stats (52)
- │    ├── 00136    pebble.raw.point-tombstone.key.size (32)
- │    ├── 00168    rocksdb.block.based.table.index.type (43)
- │    ├── 00211    rocksdb.comparator (37)
- │    ├── 00248    rocksdb.compression (16)
- │    ├── 00264    rocksdb.compression_options (106)
- │    ├── 00370    rocksdb.data.size (13)
- │    ├── 00383    rocksdb.deleted.keys (15)
- │    ├── 00398    rocksdb.filter.size (15)
- │    ├── 00413    rocksdb.index.size (14)
- │    ├── 00427    rocksdb.merge.operands (18)
- │    ├── 00445    rocksdb.merge.operator (24)
- │    ├── 00469    rocksdb.num.data.blocks (19)
- │    ├── 00488    rocksdb.num.entries (11)
- │    ├── 00499    rocksdb.num.range-deletions (19)
- │    ├── 00518    rocksdb.property.collectors (36)
- │    ├── 00554    rocksdb.raw.key.size (16)
- │    ├── 00570    rocksdb.raw.value.size (14)
+ │    ├── 00084    pebble.compression_stats (40)
+ │    ├── 00124    pebble.raw.point-tombstone.key.size (32)
+ │    ├── 00156    rocksdb.block.based.table.index.type (43)
+ │    ├── 00199    rocksdb.comparator (37)
+ │    ├── 00236    rocksdb.compression (16)
+ │    ├── 00252    rocksdb.compression_options (106)
+ │    ├── 00358    rocksdb.data.size (13)
+ │    ├── 00371    rocksdb.deleted.keys (15)
+ │    ├── 00386    rocksdb.filter.size (15)
+ │    ├── 00401    rocksdb.index.size (14)
+ │    ├── 00415    rocksdb.merge.operands (18)
+ │    ├── 00433    rocksdb.merge.operator (24)
+ │    ├── 00457    rocksdb.num.data.blocks (19)
+ │    ├── 00476    rocksdb.num.entries (11)
+ │    ├── 00487    rocksdb.num.range-deletions (19)
+ │    ├── 00506    rocksdb.property.collectors (36)
+ │    ├── 00542    rocksdb.raw.key.size (16)
+ │    ├── 00558    rocksdb.raw.value.size (14)
  │    ├── restart points
- │    │    └── 00584 [restart 0]
- │    └── trailer [compression=none checksum=0x87ef433b]
- ├── meta-index  offset: 743  length: 46
- │    ├── 0000    rocksdb.properties block:146/592
+ │    │    └── 00572 [restart 0]
+ │    └── trailer [compression=none checksum=0x5292e7cb]
+ ├── meta-index  offset: 731  length: 46
+ │    ├── 0000    rocksdb.properties block:146/580
  │    │   
- │    └── trailer [compression=none checksum=0x22504fa3]
- └── footer  offset: 794  length: 57
+ │    └── trailer [compression=none checksum=0x20d32b1e]
+ └── footer  offset: 782  length: 57
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=743, length=46
+      ├── 001  meta: offset=731, length=46
       ├── 004  index: offset=105, length=36
-      ├── 041  footer checksum: 0xdd471806
+      ├── 041  footer checksum: 0xd8a9211c
       ├── 045  version: 6
       └── 049  magic number: 0xf09faab3f09faab3
 
@@ -1223,43 +1223,43 @@ sstable
  │    └── trailer [compression=none checksum=0x460ef26f]
  ├── value-index  offset: 257  length: 3
  │    └── trailer [compression=none checksum=0x762643d7]
- ├── properties  offset: 265  length: 638
+ ├── properties  offset: 265  length: 607
  │    ├── 00000    obsolete-key (13)
  │    ├── 00013    pebble.colblk.schema (65)
- │    ├── 00078    pebble.compression_stats (58)
- │    ├── 00136    pebble.num.value-blocks (24)
- │    ├── 00160    pebble.num.values.in.value-blocks (34)
- │    ├── 00194    pebble.raw.point-tombstone.key.size (36)
- │    ├── 00230    pebble.value-blocks.size (25)
- │    ├── 00255    rocksdb.block.based.table.index.type (40)
- │    ├── 00295    rocksdb.comparator (42)
- │    ├── 00337    rocksdb.compression (25)
- │    ├── 00362    rocksdb.compression_options (122)
- │    ├── 00484    rocksdb.data.size (19)
- │    ├── 00503    rocksdb.deleted.keys (21)
- │    ├── 00524    rocksdb.filter.size (20)
- │    ├── 00544    rocksdb.index.size (19)
- │    ├── 00563    rocksdb.merge.operands (23)
- │    ├── 00586    rocksdb.merge.operator (40)
- │    ├── 00626    rocksdb.num.data.blocks (24)
- │    ├── 00650    rocksdb.num.entries (20)
- │    ├── 00670    rocksdb.num.range-deletions (28)
- │    ├── 00698    rocksdb.property.collectors (41)
- │    ├── 00739    rocksdb.raw.key.size (21)
- │    ├── 00760    rocksdb.raw.value.size (23)
- │    └── trailer [compression=snappy checksum=0xb967fe6e]
- ├── meta-index  offset: 908  length: 72
+ │    ├── 00078    pebble.compression_stats (46)
+ │    ├── 00124    pebble.num.value-blocks (24)
+ │    ├── 00148    pebble.num.values.in.value-blocks (34)
+ │    ├── 00182    pebble.raw.point-tombstone.key.size (36)
+ │    ├── 00218    pebble.value-blocks.size (25)
+ │    ├── 00243    rocksdb.block.based.table.index.type (40)
+ │    ├── 00283    rocksdb.comparator (42)
+ │    ├── 00325    rocksdb.compression (25)
+ │    ├── 00350    rocksdb.compression_options (122)
+ │    ├── 00472    rocksdb.data.size (19)
+ │    ├── 00491    rocksdb.deleted.keys (21)
+ │    ├── 00512    rocksdb.filter.size (20)
+ │    ├── 00532    rocksdb.index.size (19)
+ │    ├── 00551    rocksdb.merge.operands (23)
+ │    ├── 00574    rocksdb.merge.operator (40)
+ │    ├── 00614    rocksdb.num.data.blocks (24)
+ │    ├── 00638    rocksdb.num.entries (20)
+ │    ├── 00658    rocksdb.num.range-deletions (28)
+ │    ├── 00686    rocksdb.property.collectors (41)
+ │    ├── 00727    rocksdb.raw.key.size (21)
+ │    ├── 00748    rocksdb.raw.value.size (23)
+ │    └── trailer [compression=snappy checksum=0x770bf82a]
+ ├── meta-index  offset: 877  length: 72
  │    ├── 0000    pebble.value_index block:257/3 value-blocks-index-lengths: 1(num), 1(offset), 1(length)
  │    │   
- │    ├── 0001    rocksdb.properties block:265/638
+ │    ├── 0001    rocksdb.properties block:265/607
  │    │   
- │    └── trailer [compression=none checksum=0xa018198d]
- └── footer  offset: 985  length: 61
+ │    └── trailer [compression=none checksum=0x2476254c]
+ └── footer  offset: 954  length: 61
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=908, length=72
+      ├── 001  meta: offset=877, length=72
       ├── 004  index: offset=191, length=36
       ├── 041  attributes: [ValueBlocks,PointKeys]
-      ├── 045  footer checksum: 0x743872ab
+      ├── 045  footer checksum: 0xdc973b60
       ├── 049  version: 7
       └── 053  magic number: 0xf09faab3f09faab3
 
@@ -1372,37 +1372,37 @@ sstable
  │    ├── 00000    block:0/100
  │    │   
  │    └── trailer [compression=none checksum=0x760132f1]
- ├── properties  offset: 146  length: 570
+ ├── properties  offset: 146  length: 564
  │    ├── 00000    obsolete-key (13)
  │    ├── 00013    pebble.colblk.schema (65)
- │    ├── 00078    pebble.compression_stats (58)
- │    ├── 00136    pebble.raw.point-tombstone.key.size (36)
- │    ├── 00172    rocksdb.block.based.table.index.type (40)
- │    ├── 00212    rocksdb.comparator (42)
- │    ├── 00254    rocksdb.compression (25)
- │    ├── 00279    rocksdb.compression_options (122)
- │    ├── 00401    rocksdb.data.size (18)
- │    ├── 00419    rocksdb.deleted.keys (21)
- │    ├── 00440    rocksdb.filter.size (20)
- │    ├── 00460    rocksdb.index.size (19)
- │    ├── 00479    rocksdb.merge.operands (23)
- │    ├── 00502    rocksdb.merge.operator (40)
- │    ├── 00542    rocksdb.num.data.blocks (24)
- │    ├── 00566    rocksdb.num.entries (20)
- │    ├── 00586    rocksdb.num.range-deletions (28)
- │    ├── 00614    rocksdb.property.collectors (41)
- │    ├── 00655    rocksdb.raw.key.size (21)
- │    ├── 00676    rocksdb.raw.value.size (23)
- │    └── trailer [compression=snappy checksum=0xf62471e2]
- ├── meta-index  offset: 721  length: 46
- │    ├── 0000    rocksdb.properties block:146/570
+ │    ├── 00078    pebble.compression_stats (46)
+ │    ├── 00124    pebble.raw.point-tombstone.key.size (36)
+ │    ├── 00160    rocksdb.block.based.table.index.type (40)
+ │    ├── 00200    rocksdb.comparator (42)
+ │    ├── 00242    rocksdb.compression (25)
+ │    ├── 00267    rocksdb.compression_options (122)
+ │    ├── 00389    rocksdb.data.size (18)
+ │    ├── 00407    rocksdb.deleted.keys (21)
+ │    ├── 00428    rocksdb.filter.size (20)
+ │    ├── 00448    rocksdb.index.size (19)
+ │    ├── 00467    rocksdb.merge.operands (23)
+ │    ├── 00490    rocksdb.merge.operator (40)
+ │    ├── 00530    rocksdb.num.data.blocks (24)
+ │    ├── 00554    rocksdb.num.entries (20)
+ │    ├── 00574    rocksdb.num.range-deletions (28)
+ │    ├── 00602    rocksdb.property.collectors (41)
+ │    ├── 00643    rocksdb.raw.key.size (21)
+ │    ├── 00664    rocksdb.raw.value.size (23)
+ │    └── trailer [compression=snappy checksum=0x8ce4124e]
+ ├── meta-index  offset: 715  length: 46
+ │    ├── 0000    rocksdb.properties block:146/564
  │    │   
- │    └── trailer [compression=none checksum=0xc5dfa63]
- └── footer  offset: 772  length: 61
+ │    └── trailer [compression=none checksum=0x2d765661]
+ └── footer  offset: 766  length: 61
       ├── 000  checksum type: crc32c
-      ├── 001  meta: offset=721, length=46
+      ├── 001  meta: offset=715, length=46
       ├── 004  index: offset=105, length=36
       ├── 041  attributes: [PointKeys]
-      ├── 045  footer checksum: 0x16afbae8
+      ├── 045  footer checksum: 0x5e57e041
       ├── 049  version: 7
       └── 053  magic number: 0xf09faab3f09faab3

--- a/testdata/blob_rewrite
+++ b/testdata/blob_rewrite
@@ -58,14 +58,14 @@ rewrite-blob 000002 000001 000003
 ----
 # create: 000004.blob
 # open: 000001.sst (options: *vfs.randomReadsOption)
-# read-at(846, 61): 000001.sst
-# read-at(769, 77): 000001.sst
-# read-at(209, 560): 000001.sst
+# read-at(840, 61): 000001.sst
+# read-at(763, 77): 000001.sst
+# read-at(209, 554): 000001.sst
 # read-at(184, 25): 000001.sst
 # open: 000003.sst (options: *vfs.randomReadsOption)
-# read-at(883, 61): 000003.sst
-# read-at(806, 77): 000003.sst
-# read-at(193, 613): 000003.sst
+# read-at(856, 61): 000003.sst
+# read-at(779, 77): 000003.sst
+# read-at(193, 586): 000003.sst
 # read-at(168, 25): 000003.sst
 # open: 000002.blob (options: *vfs.randomReadsOption)
 # read-at(67, 38): 000002.blob

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -254,17 +254,17 @@ close: db/000009.sst
 sync: db
 sync: db/MANIFEST-000001
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(714, 61): db/000005.sst
-read-at(663, 51): db/000005.sst
-read-at(132, 531): db/000005.sst
+read-at(708, 61): db/000005.sst
+read-at(657, 51): db/000005.sst
+read-at(132, 525): db/000005.sst
 open: db/000009.sst (options: *vfs.randomReadsOption)
-read-at(711, 61): db/000009.sst
-read-at(660, 51): db/000009.sst
-read-at(136, 524): db/000009.sst
+read-at(704, 61): db/000009.sst
+read-at(653, 51): db/000009.sst
+read-at(136, 517): db/000009.sst
 open: db/000007.sst (options: *vfs.randomReadsOption)
-read-at(714, 61): db/000007.sst
-read-at(663, 51): db/000007.sst
-read-at(132, 531): db/000007.sst
+read-at(708, 61): db/000007.sst
+read-at(657, 51): db/000007.sst
+read-at(132, 525): db/000007.sst
 read-at(91, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
 read-at(0, 91): db/000005.sst
@@ -334,15 +334,15 @@ close: checkpoints/checkpoint1/000006.log
 scan checkpoints/checkpoint1
 ----
 open: checkpoints/checkpoint1/000007.sst (options: *vfs.randomReadsOption)
-read-at(714, 61): checkpoints/checkpoint1/000007.sst
-read-at(663, 51): checkpoints/checkpoint1/000007.sst
-read-at(132, 531): checkpoints/checkpoint1/000007.sst
+read-at(708, 61): checkpoints/checkpoint1/000007.sst
+read-at(657, 51): checkpoints/checkpoint1/000007.sst
+read-at(132, 525): checkpoints/checkpoint1/000007.sst
 read-at(91, 41): checkpoints/checkpoint1/000007.sst
 read-at(0, 91): checkpoints/checkpoint1/000007.sst
 open: checkpoints/checkpoint1/000005.sst (options: *vfs.randomReadsOption)
-read-at(714, 61): checkpoints/checkpoint1/000005.sst
-read-at(663, 51): checkpoints/checkpoint1/000005.sst
-read-at(132, 531): checkpoints/checkpoint1/000005.sst
+read-at(708, 61): checkpoints/checkpoint1/000005.sst
+read-at(657, 51): checkpoints/checkpoint1/000005.sst
+read-at(132, 525): checkpoints/checkpoint1/000005.sst
 read-at(91, 41): checkpoints/checkpoint1/000005.sst
 read-at(0, 91): checkpoints/checkpoint1/000005.sst
 a 1
@@ -357,9 +357,9 @@ g 10
 scan db
 ----
 open: db/000010.sst (options: *vfs.randomReadsOption)
-read-at(724, 61): db/000010.sst
-read-at(673, 51): db/000010.sst
-read-at(141, 532): db/000010.sst
+read-at(718, 61): db/000010.sst
+read-at(667, 51): db/000010.sst
+read-at(141, 526): db/000010.sst
 read-at(100, 41): db/000010.sst
 read-at(0, 100): db/000010.sst
 a 1
@@ -401,9 +401,9 @@ close: checkpoints/checkpoint2/000006.log
 scan checkpoints/checkpoint2
 ----
 open: checkpoints/checkpoint2/000007.sst (options: *vfs.randomReadsOption)
-read-at(714, 61): checkpoints/checkpoint2/000007.sst
-read-at(663, 51): checkpoints/checkpoint2/000007.sst
-read-at(132, 531): checkpoints/checkpoint2/000007.sst
+read-at(708, 61): checkpoints/checkpoint2/000007.sst
+read-at(657, 51): checkpoints/checkpoint2/000007.sst
+read-at(132, 525): checkpoints/checkpoint2/000007.sst
 read-at(91, 41): checkpoints/checkpoint2/000007.sst
 read-at(0, 91): checkpoints/checkpoint2/000007.sst
 b 5
@@ -443,15 +443,15 @@ close: checkpoints/checkpoint3/000006.log
 scan checkpoints/checkpoint3
 ----
 open: checkpoints/checkpoint3/000007.sst (options: *vfs.randomReadsOption)
-read-at(714, 61): checkpoints/checkpoint3/000007.sst
-read-at(663, 51): checkpoints/checkpoint3/000007.sst
-read-at(132, 531): checkpoints/checkpoint3/000007.sst
+read-at(708, 61): checkpoints/checkpoint3/000007.sst
+read-at(657, 51): checkpoints/checkpoint3/000007.sst
+read-at(132, 525): checkpoints/checkpoint3/000007.sst
 read-at(91, 41): checkpoints/checkpoint3/000007.sst
 read-at(0, 91): checkpoints/checkpoint3/000007.sst
 open: checkpoints/checkpoint3/000005.sst (options: *vfs.randomReadsOption)
-read-at(714, 61): checkpoints/checkpoint3/000005.sst
-read-at(663, 51): checkpoints/checkpoint3/000005.sst
-read-at(132, 531): checkpoints/checkpoint3/000005.sst
+read-at(708, 61): checkpoints/checkpoint3/000005.sst
+read-at(657, 51): checkpoints/checkpoint3/000005.sst
+read-at(132, 525): checkpoints/checkpoint3/000005.sst
 read-at(91, 41): checkpoints/checkpoint3/000005.sst
 read-at(0, 91): checkpoints/checkpoint3/000005.sst
 a 1
@@ -586,9 +586,9 @@ close: checkpoints/checkpoint4/000008.log
 scan checkpoints/checkpoint4
 ----
 open: checkpoints/checkpoint4/000010.sst (options: *vfs.randomReadsOption)
-read-at(724, 61): checkpoints/checkpoint4/000010.sst
-read-at(673, 51): checkpoints/checkpoint4/000010.sst
-read-at(141, 532): checkpoints/checkpoint4/000010.sst
+read-at(718, 61): checkpoints/checkpoint4/000010.sst
+read-at(667, 51): checkpoints/checkpoint4/000010.sst
+read-at(141, 526): checkpoints/checkpoint4/000010.sst
 read-at(100, 41): checkpoints/checkpoint4/000010.sst
 read-at(0, 100): checkpoints/checkpoint4/000010.sst
 a 1
@@ -1031,9 +1031,9 @@ close: checkpoints/checkpoint8/000004.log
 scan checkpoints/checkpoint8
 ----
 open: checkpoints/checkpoint8/000005.sst (options: *vfs.randomReadsOption)
-read-at(862, 61): checkpoints/checkpoint8/000005.sst
-read-at(785, 77): checkpoints/checkpoint8/000005.sst
-read-at(197, 588): checkpoints/checkpoint8/000005.sst
+read-at(838, 61): checkpoints/checkpoint8/000005.sst
+read-at(761, 77): checkpoints/checkpoint8/000005.sst
+read-at(197, 564): checkpoints/checkpoint8/000005.sst
 read-at(131, 41): checkpoints/checkpoint8/000005.sst
 read-at(0, 131): checkpoints/checkpoint8/000005.sst
 open: checkpoints/checkpoint8/000006.blob (options: *vfs.randomReadsOption)
@@ -1141,9 +1141,9 @@ close: checkpoints/checkpoint9/000007.log
 scan checkpoints/checkpoint9
 ----
 open: checkpoints/checkpoint9/000005.sst (options: *vfs.randomReadsOption)
-read-at(862, 61): checkpoints/checkpoint9/000005.sst
-read-at(785, 77): checkpoints/checkpoint9/000005.sst
-read-at(197, 588): checkpoints/checkpoint9/000005.sst
+read-at(838, 61): checkpoints/checkpoint9/000005.sst
+read-at(761, 77): checkpoints/checkpoint9/000005.sst
+read-at(197, 564): checkpoints/checkpoint9/000005.sst
 read-at(131, 41): checkpoints/checkpoint9/000005.sst
 read-at(0, 131): checkpoints/checkpoint9/000005.sst
 open: checkpoints/checkpoint9/000006.blob (options: *vfs.randomReadsOption)

--- a/testdata/compaction/compaction_cancellation
+++ b/testdata/compaction/compaction_cancellation
@@ -34,7 +34,7 @@ manual compaction cancelled: context canceled, current queued compactions: 0
 # One compaction was done.
 compaction-log
 ----
-[JOB 1] compacted(move) L2 [000004] (799B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
+[JOB 1] compacted(move) L2 [000004] (786B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000004] (786B), in 1.0s (1.0s total), output rate 786B/s
 
 compact a-z L2 parallel
 ----
@@ -45,8 +45,8 @@ L3:
 
 compaction-log sort
 ----
-[JOB 1] compacted(move) L2 [000005] (799B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000005] (799B), in 1.0s (1.0s total), output rate 799B/s
-[JOB 1] compacted(move) L2 [000006] (799B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000006] (799B), in 1.0s (1.0s total), output rate 799B/s
+[JOB 1] compacted(move) L2 [000005] (786B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000005] (786B), in 1.0s (1.0s total), output rate 786B/s
+[JOB 1] compacted(move) L2 [000006] (786B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000006] (786B), in 1.0s (1.0s total), output rate 786B/s
 
 # Repeat with only blocking the last of the three manual compactions.
 add-ongoing-compaction startLevel=3 outputLevel=4 start=g end=h
@@ -59,5 +59,5 @@ manual compaction cancelled: context canceled, current queued compactions: 0
 # Two compactions were done.
 compaction-log
 ----
-[JOB 1] compacted(move) L3 [000004] (799B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
-[JOB 1] compacted(move) L3 [000005] (799B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000005] (799B), in 1.0s (1.0s total), output rate 799B/s
+[JOB 1] compacted(move) L3 [000004] (786B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000004] (786B), in 1.0s (1.0s total), output rate 786B/s
+[JOB 1] compacted(move) L3 [000005] (786B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000005] (786B), in 1.0s (1.0s total), output rate 786B/s

--- a/testdata/compaction/score_compaction_picked_before_manual
+++ b/testdata/compaction/score_compaction_picked_before_manual
@@ -15,7 +15,7 @@ L6:
 # compaction.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (799B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
+[JOB 1] compacted(move) L5 [000004] (786B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (786B), in 1.0s (1.0s total), output rate 786B/s
 
 # Do an auto score-based compaction with the same LSM as the previous test.
 define disable-multi-level lbase-max-bytes=1 auto-compactions=off
@@ -33,7 +33,7 @@ L6:
 # Note the score is > 1.0 since these is a score-based compaction.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (799B) Score=998.75 + L6 [] (0B) Score=0.00 -> L6 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
+[JOB 1] compacted(move) L5 [000004] (786B) Score=994.94 + L6 [] (0B) Score=0.00 -> L6 [000004] (786B), in 1.0s (1.0s total), output rate 786B/s
 
 # With the same LSM as the previous test, try to do both a manual and
 # score-based compaction. The score-based compaction runs first.
@@ -64,4 +64,4 @@ set-disable-auto-compact v=true
 # The score-based compaction ran first.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (799B) Score=998.75 + L6 [] (0B) Score=0.00 -> L6 [000004] (799B), in 1.0s (1.0s total), output rate 799B/s
+[JOB 1] compacted(move) L5 [000004] (786B) Score=994.94 + L6 [] (0B) Score=0.00 -> L6 [000004] (786B), in 1.0s (1.0s total), output rate 786B/s

--- a/testdata/compaction/set_with_del_sstable_Pebblev5
+++ b/testdata/compaction/set_with_del_sstable_Pebblev5
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1560
+range-deletions-bytes-estimate: 1536
 
 compact a-e L1
 ----
@@ -106,7 +106,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 780
+range-deletions-bytes-estimate: 768
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/compaction/set_with_del_sstable_Pebblev6
+++ b/testdata/compaction/set_with_del_sstable_Pebblev6
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1594
+range-deletions-bytes-estimate: 1570
 
 compact a-e L1
 ----
@@ -106,7 +106,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 797
+range-deletions-bytes-estimate: 785
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/compaction/set_with_del_sstable_Pebblev7
+++ b/testdata/compaction/set_with_del_sstable_Pebblev7
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1530
+range-deletions-bytes-estimate: 1518
 
 compact a-e L1
 ----
@@ -106,7 +106,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 765
+range-deletions-bytes-estimate: 759
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.
 

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -12,7 +12,7 @@ set b 2
 compact a-b
 ----
 L6:
-  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:862 blobrefs:[(B000006: 2); depth:1]
+  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:857 blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
 
@@ -24,8 +24,8 @@ set d 4
 compact c-d
 ----
 L6:
-  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:862 blobrefs:[(B000006: 2); depth:1]
-  000008:[c#12,SET-d#13,SET] seqnums:[12-13] points:[c#12,SET-d#13,SET] size:862 blobrefs:[(B000009: 2); depth:1]
+  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:857 blobrefs:[(B000006: 2); depth:1]
+  000008:[c#12,SET-d#13,SET] seqnums:[12-13] points:[c#12,SET-d#13,SET] size:857 blobrefs:[(B000009: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
   B000009 physical:{000009 size:[92 (92B)] vals:[2 (2B)]}
@@ -38,7 +38,7 @@ set c 6
 compact a-d
 ----
 L6:
-  000013:[a#0,SET-d#0,SET] seqnums:[0-0] points:[a#0,SET-d#0,SET] size:919 blobrefs:[(B000006: 1), (B000012: 2), (B000009: 1); depth:2]
+  000013:[a#0,SET-d#0,SET] seqnums:[0-0] points:[a#0,SET-d#0,SET] size:895 blobrefs:[(B000006: 1), (B000012: 2), (B000009: 1); depth:2]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
   B000009 physical:{000009 size:[92 (92B)] vals:[2 (2B)]}
@@ -64,7 +64,7 @@ L6 blob-depth=3
   z.SET.0:blob{fileNum=100004 value=zoo}
 ----
 L6:
-  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:921 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:897 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
   B100003 physical:{100003 size:[92 (92B)] vals:[3 (3B)]}
@@ -80,9 +80,9 @@ set e world
 flush
 ----
 L0.0:
-  000006:[d#10,SET-e#11,SET] seqnums:[10-11] points:[d#10,SET-e#11,SET] size:861 blobrefs:[(B000007: 10); depth:1]
+  000006:[d#10,SET-e#11,SET] seqnums:[10-11] points:[d#10,SET-e#11,SET] size:856 blobrefs:[(B000007: 10); depth:1]
 L6:
-  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:921 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:897 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B000007 physical:{000007 size:[100 (100B)] vals:[10 (10B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -95,7 +95,7 @@ Blob files:
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:931 blobrefs:[(B000009: 19); depth:1]
+  000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:907 blobrefs:[(B000009: 19); depth:1]
 Blob files:
   B000009 physical:{000009 size:[112 (112B)] vals:[19 (19B)]}
 
@@ -124,25 +124,25 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 25.88
+    0         0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 25.76
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6        1KB |      1  931B |      0     0 |   112B     0B |   861B |      0    0B |   1  1.21
-total        1KB |      1  931B |      0     0 |   112B     0B |    41B |      0    0B |   1 52.32
+    6        1KB |      1  907B |      0     0 |   112B     0B |   856B |      0    0B |   1  1.19
+total        1KB |      1  907B |      0     0 |   112B     0B |    41B |      0    0B |   1 51.61
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      1   861B   200B
-    1 |     -     0     0 |      1  861B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    2 |     -     0     0 |      1  861B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    3 |     -     0     0 |      1  861B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    4 |     -     0     0 |      1  861B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    5 |     -     0     0 |      1  861B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   372B   84B |      1   931B   112B
+    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      1   856B   200B
+    1 |     -     0     0 |      1  856B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    2 |     -     0     0 |      1  856B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    3 |     -     0     0 |      1  856B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    4 |     -     0     0 |      1  856B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    5 |     -     0     0 |      1  856B |    0B    0B    0B |     0B    0B |      0     0B     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   372B   84B |      1   907B   112B
 total |     -     -     - |      5 4.2KB |    0B    0B    0B |   372B   84B |      2  1.8KB   312B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
@@ -205,7 +205,7 @@ set yaya yaya
 flush
 ----
 L0.0:
-  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:787
+  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:781
 
 batch
 set a a
@@ -220,9 +220,9 @@ set w world
 flush
 ----
 L0.1:
-  000007:[a#14,SET-w#17,SET] seqnums:[14-17] points:[a#14,SET-w#17,SET] size:909 blobrefs:[(B000008: 10); depth:1]
+  000007:[a#14,SET-w#17,SET] seqnums:[14-17] points:[a#14,SET-w#17,SET] size:885 blobrefs:[(B000008: 10); depth:1]
 L0.0:
-  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:787
+  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:781
 Blob files:
   B000008 physical:{000008 size:[100 (100B)] vals:[10 (10B)]}
 
@@ -257,8 +257,8 @@ set m mango
 flush
 ----
 L0.0:
-  000005:[a#10,SET-d#13,SET] seqnums:[10-13] points:[a#10,SET-d#13,SET] size:809
-  000006:[m#14,SET-m#14,SET] seqnums:[14-14] points:[m#14,SET-m#14,SET] size:858 blobrefs:[(B000007: 5); depth:1]
+  000005:[a#10,SET-d#13,SET] seqnums:[10-13] points:[a#10,SET-d#13,SET] size:802
+  000006:[m#14,SET-m#14,SET] seqnums:[14-14] points:[m#14,SET-m#14,SET] size:853 blobrefs:[(B000007: 5); depth:1]
 Blob files:
   B000007 physical:{000007 size:[94 (94B)] vals:[5 (5B)]}
 
@@ -278,9 +278,9 @@ L0 blob-depth=3
   z.SET.1:blob{fileNum=100004 value=zoo}
 ----
 L0.1:
-  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:871 blobrefs:[(B100001: 1); depth:1]
+  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:866 blobrefs:[(B100001: 1); depth:1]
 L0.0:
-  000005:[a#1,SET-z#1,SET] seqnums:[1-1] points:[a#1,SET-z#1,SET] size:921 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000005:[a#1,SET-z#1,SET] seqnums:[1-1] points:[a#1,SET-z#1,SET] size:897 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -290,7 +290,7 @@ Blob files:
 compact a-z
 ----
 L1:
-  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:922 blobrefs:[(B100002: 3), (B100001: 1), (B100003: 3), (B100004: 3); depth:4]
+  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:916 blobrefs:[(B100002: 3), (B100001: 1), (B100003: 3), (B100004: 3); depth:4]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -314,8 +314,8 @@ L0 blob-depth=3
   z.SET.1:blob{fileNum=100004 value=zoo}
 ----
 L0.0:
-  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:871 blobrefs:[(B100001: 1); depth:1]
-  000005:[e#1,SET-z#1,SET] seqnums:[1-1] points:[e#1,SET-z#1,SET] size:921 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:866 blobrefs:[(B100001: 1); depth:1]
+  000005:[e#1,SET-z#1,SET] seqnums:[1-1] points:[e#1,SET-z#1,SET] size:897 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -325,7 +325,7 @@ Blob files:
 compact a-z
 ----
 L1:
-  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:944 blobrefs:[(B100001: 1), (B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:920 blobrefs:[(B100001: 1), (B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -354,7 +354,7 @@ set h honeydew
 flush
 ----
 L0.0:
-  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:954 blobrefs:[(B000006: 60); depth:1]
+  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:930 blobrefs:[(B000006: 60); depth:1]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
 
@@ -367,9 +367,9 @@ set c cherry
 flush
 ----
 L0.1:
-  000008:[c#18,SET-c#18,SET] seqnums:[18-18] points:[c#18,SET-c#18,SET] size:858 blobrefs:[(B000009: 6); depth:1]
+  000008:[c#18,SET-c#18,SET] seqnums:[18-18] points:[c#18,SET-c#18,SET] size:853 blobrefs:[(B000009: 6); depth:1]
 L0.0:
-  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:954 blobrefs:[(B000006: 60); depth:1]
+  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:930 blobrefs:[(B000006: 60); depth:1]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -380,7 +380,7 @@ Blob files:
 compact a-b
 ----
 L6:
-  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:932 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
+  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:908 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -388,7 +388,7 @@ Blob files:
 auto-compact
 ----
 L6:
-  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:932 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
+  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:908 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
 Blob files:
   B000006 physical:{000011 size:[150 (150B)] vals:[53 (53B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -399,25 +399,25 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |   156B |      0    0B |   0 14.83
+    0         0B |      0    0B |      0     0 |     0B     0B |   156B |      0    0B |   0 14.65
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      1.1KB |      1  932B |      0     0 |   232B     0B |  1.8KB |      0    0B |   1  0.51
-total      1.1KB |      1  932B |      0     0 |   232B     0B |   156B |      0    0B |   1 21.81
+    6      1.1KB |      1  908B |      0     0 |   232B     0B |  1.7KB |      0    0B |   1  0.51
+total      1.1KB |      1  908B |      0     0 |   232B     0B |   156B |      0    0B |   1 21.47
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.8KB   502B
+    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.7KB   502B
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   310B    0B |      1   932B     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   310B    0B |      1   908B     0B
 total |     -     -     - |      0    0B |    0B    0B    0B |   310B    0B |      3  2.8KB   502B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
@@ -476,15 +476,15 @@ set c coconut
 compact a-b
 ----
 L6:
-  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:875 blobrefs:[(B000006: 18); depth:1]
+  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:870 blobrefs:[(B000006: 18); depth:1]
 Blob files:
   B000006 physical:{000006 size:[109 (109B)] vals:[18 (18B)]}
 
 excise b ba
 ----
 L6:
-  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(875) blobrefs:[(B000006: 2); depth:1]
-  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(875) blobrefs:[(B000006: 2); depth:1]
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(870) blobrefs:[(B000006: 2); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(870) blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[109 (109B)] vals:[18 (18B)]}
 
@@ -496,8 +496,8 @@ Blob files:
 run-blob-rewrite-compaction
 ----
 L6:
-  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(875) blobrefs:[(B000006: 2); depth:1]
-  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(875) blobrefs:[(B000006: 2); depth:1]
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(870) blobrefs:[(B000006: 2); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(870) blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000009 size:[110 (110B)] vals:[18 (18B)]}
 
@@ -524,25 +524,25 @@ wrote 475254 keys
 flush
 ----
 L0.0:
-  000005:[a@1#10,SET-bkmx@1#25669,SET] seqnums:[10-25669] points:[a@1#10,SET-bkmx@1#25669,SET] size:396639 blobrefs:[(B000006: 1642240); depth:1]
-  000007:[bkmy@1#25670,SET-cv@1#51332,SET] seqnums:[25670-51332] points:[bkmy@1#25670,SET-cv@1#51332,SET] size:396466 blobrefs:[(B000008: 1642432); depth:1]
-  000009:[cva@1#51333,SET-efnh@1#77002,SET] seqnums:[51333-77002] points:[cva@1#51333,SET-efnh@1#77002,SET] size:395950 blobrefs:[(B000010: 1642880); depth:1]
-  000011:[efni@1#77003,SET-fqaj@1#102665,SET] seqnums:[77003-102665] points:[efni@1#77003,SET-fqaj@1#102665,SET] size:396383 blobrefs:[(B000012: 1642432); depth:1]
-  000013:[fqak@1#102666,SET-hamh@1#128297,SET] seqnums:[102666-128297] points:[fqak@1#102666,SET-hamh@1#128297,SET] size:398462 blobrefs:[(B000014: 1640448); depth:1]
-  000015:[hami@1#128298,SET-ikzi@1#153958,SET] seqnums:[128298-153958] points:[hami@1#128298,SET-ikzi@1#153958,SET] size:396585 blobrefs:[(B000016: 1642304); depth:1]
-  000017:[ikzj@1#153959,SET-jvoe@1#179669,SET] seqnums:[153959-179669] points:[ikzj@1#153959,SET-jvoe@1#179669,SET] size:393162 blobrefs:[(B000018: 1645504); depth:1]
-  000019:[jvof@1#179670,SET-lgaf@1#205305,SET] seqnums:[179670-205305] points:[jvof@1#179670,SET-lgaf@1#205305,SET] size:397687 blobrefs:[(B000020: 1640704); depth:1]
-  000021:[lgag@1#205306,SET-mqno@1#230974,SET] seqnums:[205306-230974] points:[lgag@1#205306,SET-mqno@1#230974,SET] size:396029 blobrefs:[(B000022: 1642816); depth:1]
-  000023:[mqnp@1#230975,SET-obac@1#256624,SET] seqnums:[230975-256624] points:[mqnp@1#230975,SET-obac@1#256624,SET] size:397283 blobrefs:[(B000024: 1641600); depth:1]
-  000025:[obad@1#256625,SET-plml@1#282266,SET] seqnums:[256625-282266] points:[obad@1#256625,SET-plml@1#282266,SET] size:397834 blobrefs:[(B000026: 1641088); depth:1]
-  000027:[plmm@1#282267,SET-qvzf@1#307920,SET] seqnums:[282267-307920] points:[plmm@1#282267,SET-qvzf@1#307920,SET] size:396981 blobrefs:[(B000028: 1641856); depth:1]
-  000029:[qvzg@1#307921,SET-sgld@1#333553,SET] seqnums:[307921-333553] points:[qvzg@1#307921,SET-sgld@1#333553,SET] size:398392 blobrefs:[(B000030: 1640512); depth:1]
-  000031:[sgle@1#333554,SET-tqxr@1#359200,SET] seqnums:[333554-359200] points:[sgle@1#333554,SET-tqxr@1#359200,SET] size:397496 blobrefs:[(B000032: 1641408); depth:1]
-  000033:[tqxs@1#359201,SET-vbls@1#384890,SET] seqnums:[359201-384890] points:[tqxs@1#359201,SET-vbls@1#384890,SET] size:394570 blobrefs:[(B000034: 1644160); depth:1]
-  000035:[vblt@1#384891,SET-wlyf@1#410537,SET] seqnums:[384891-410537] points:[vblt@1#384891,SET-wlyf@1#410537,SET] size:397494 blobrefs:[(B000036: 1641408); depth:1]
-  000037:[wlyg@1#410538,SET-xwmc@1#436222,SET] seqnums:[410538-436222] points:[wlyg@1#410538,SET-xwmc@1#436222,SET] size:394940 blobrefs:[(B000038: 1643840); depth:1]
-  000039:[xwmd@1#436223,SET-zhar@1#461926,SET] seqnums:[436223-461926] points:[xwmd@1#436223,SET-zhar@1#461926,SET] size:393606 blobrefs:[(B000040: 1645056); depth:1]
-  000041:[zhas@1#461927,SET-zzzz@1#475263,SET] seqnums:[461927-475263] points:[zhas@1#461927,SET-zzzz@1#475263,SET] size:208259 blobrefs:[(B000042: 853568); depth:1]
+  000005:[a@1#10,SET-bkmx@1#25669,SET] seqnums:[10-25669] points:[a@1#10,SET-bkmx@1#25669,SET] size:396633 blobrefs:[(B000006: 1642240); depth:1]
+  000007:[bkmy@1#25670,SET-cv@1#51332,SET] seqnums:[25670-51332] points:[bkmy@1#25670,SET-cv@1#51332,SET] size:396460 blobrefs:[(B000008: 1642432); depth:1]
+  000009:[cva@1#51333,SET-efnh@1#77002,SET] seqnums:[51333-77002] points:[cva@1#51333,SET-efnh@1#77002,SET] size:395944 blobrefs:[(B000010: 1642880); depth:1]
+  000011:[efni@1#77003,SET-fqaj@1#102665,SET] seqnums:[77003-102665] points:[efni@1#77003,SET-fqaj@1#102665,SET] size:396376 blobrefs:[(B000012: 1642432); depth:1]
+  000013:[fqak@1#102666,SET-hamh@1#128297,SET] seqnums:[102666-128297] points:[fqak@1#102666,SET-hamh@1#128297,SET] size:398456 blobrefs:[(B000014: 1640448); depth:1]
+  000015:[hami@1#128298,SET-ikzi@1#153958,SET] seqnums:[128298-153958] points:[hami@1#128298,SET-ikzi@1#153958,SET] size:396579 blobrefs:[(B000016: 1642304); depth:1]
+  000017:[ikzj@1#153959,SET-jvoe@1#179669,SET] seqnums:[153959-179669] points:[ikzj@1#153959,SET-jvoe@1#179669,SET] size:393157 blobrefs:[(B000018: 1645504); depth:1]
+  000019:[jvof@1#179670,SET-lgaf@1#205305,SET] seqnums:[179670-205305] points:[jvof@1#179670,SET-lgaf@1#205305,SET] size:397681 blobrefs:[(B000020: 1640704); depth:1]
+  000021:[lgag@1#205306,SET-mqno@1#230974,SET] seqnums:[205306-230974] points:[lgag@1#205306,SET-mqno@1#230974,SET] size:396023 blobrefs:[(B000022: 1642816); depth:1]
+  000023:[mqnp@1#230975,SET-obac@1#256624,SET] seqnums:[230975-256624] points:[mqnp@1#230975,SET-obac@1#256624,SET] size:397277 blobrefs:[(B000024: 1641600); depth:1]
+  000025:[obad@1#256625,SET-plml@1#282266,SET] seqnums:[256625-282266] points:[obad@1#256625,SET-plml@1#282266,SET] size:397827 blobrefs:[(B000026: 1641088); depth:1]
+  000027:[plmm@1#282267,SET-qvzf@1#307920,SET] seqnums:[282267-307920] points:[plmm@1#282267,SET-qvzf@1#307920,SET] size:396975 blobrefs:[(B000028: 1641856); depth:1]
+  000029:[qvzg@1#307921,SET-sgld@1#333553,SET] seqnums:[307921-333553] points:[qvzg@1#307921,SET-sgld@1#333553,SET] size:398386 blobrefs:[(B000030: 1640512); depth:1]
+  000031:[sgle@1#333554,SET-tqxr@1#359200,SET] seqnums:[333554-359200] points:[sgle@1#333554,SET-tqxr@1#359200,SET] size:397490 blobrefs:[(B000032: 1641408); depth:1]
+  000033:[tqxs@1#359201,SET-vbls@1#384890,SET] seqnums:[359201-384890] points:[tqxs@1#359201,SET-vbls@1#384890,SET] size:394565 blobrefs:[(B000034: 1644160); depth:1]
+  000035:[vblt@1#384891,SET-wlyf@1#410537,SET] seqnums:[384891-410537] points:[vblt@1#384891,SET-wlyf@1#410537,SET] size:397488 blobrefs:[(B000036: 1641408); depth:1]
+  000037:[wlyg@1#410538,SET-xwmc@1#436222,SET] seqnums:[410538-436222] points:[wlyg@1#410538,SET-xwmc@1#436222,SET] size:394935 blobrefs:[(B000038: 1643840); depth:1]
+  000039:[xwmd@1#436223,SET-zhar@1#461926,SET] seqnums:[436223-461926] points:[xwmd@1#436223,SET-zhar@1#461926,SET] size:393601 blobrefs:[(B000040: 1645056); depth:1]
+  000041:[zhas@1#461927,SET-zzzz@1#475263,SET] seqnums:[461927-475263] points:[zhas@1#461927,SET-zzzz@1#475263,SET] size:208253 blobrefs:[(B000042: 853568); depth:1]
 Blob files:
   B000006 physical:{000006 size:[1704578 (1.6MB)] vals:[1642240 (1.6MB)]}
   B000008 physical:{000008 size:[1704776 (1.6MB)] vals:[1642432 (1.6MB)]}
@@ -573,15 +573,15 @@ Blob files:
 compact a-zzzz
 ----
 L6:
-  000044:[a@1#0,SET-czms@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-czms@1#0,SET] size:715291 blobrefs:[(B000006: 1642240), (B000008: 1642432), (B000010: 201984); depth:1]
-  000045:[czmt@1#0,SET-fyxn@1#0,SET] seqnums:[0-0] points:[czmt@1#0,SET-fyxn@1#0,SET] size:718640 blobrefs:[(B000010: 1440896), (B000012: 1642432), (B000014: 399936); depth:1]
-  000046:[fyxo@1#0,SET-iykr@1#0,SET] seqnums:[0-0] points:[fyxo@1#0,SET-iykr@1#0,SET] size:714594 blobrefs:[(B000014: 1240512), (B000016: 1642304), (B000018: 604544); depth:1]
-  000047:[iyks@1#0,SET-lxxi@1#0,SET] seqnums:[0-0] points:[iyks@1#0,SET-lxxi@1#0,SET] size:715507 blobrefs:[(B000018: 1040960), (B000020: 1640704), (B000022: 804800); depth:1]
-  000048:[lxxj@1#0,SET-oxiv@1#0,SET] seqnums:[0-0] points:[lxxj@1#0,SET-oxiv@1#0,SET] size:716969 blobrefs:[(B000022: 838016), (B000024: 1641600), (B000026: 1004864); depth:1]
-  000049:[oxiw@1#0,SET-rwta@1#0,SET] seqnums:[0-0] points:[oxiw@1#0,SET-rwta@1#0,SET] size:719355 blobrefs:[(B000026: 636224), (B000028: 1641856), (B000030: 1204160); depth:1]
-  000050:[rwtb@1#0,SET-uwen@1#0,SET] seqnums:[0-0] points:[rwtb@1#0,SET-uwen@1#0,SET] size:717499 blobrefs:[(B000030: 436352), (B000032: 1641408), (B000034: 1406720); depth:1]
-  000051:[uweo@1#0,SET-xvqm@1#0,SET] seqnums:[0-0] points:[uweo@1#0,SET-xvqm@1#0,SET] size:716744 blobrefs:[(B000034: 237440), (B000036: 1641408), (B000038: 1606400); depth:1]
-  000052:[xvqn@1#0,SET-zzzz@1#0,SET] seqnums:[0-0] points:[xvqn@1#0,SET-zzzz@1#0,SET] size:521142 blobrefs:[(B000038: 37440), (B000040: 1645056), (B000042: 853568); depth:1]
+  000044:[a@1#0,SET-czms@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-czms@1#0,SET] size:715285 blobrefs:[(B000006: 1642240), (B000008: 1642432), (B000010: 201984); depth:1]
+  000045:[czmt@1#0,SET-fyxn@1#0,SET] seqnums:[0-0] points:[czmt@1#0,SET-fyxn@1#0,SET] size:718634 blobrefs:[(B000010: 1440896), (B000012: 1642432), (B000014: 399936); depth:1]
+  000046:[fyxo@1#0,SET-iykr@1#0,SET] seqnums:[0-0] points:[fyxo@1#0,SET-iykr@1#0,SET] size:714587 blobrefs:[(B000014: 1240512), (B000016: 1642304), (B000018: 604544); depth:1]
+  000047:[iyks@1#0,SET-lxxi@1#0,SET] seqnums:[0-0] points:[iyks@1#0,SET-lxxi@1#0,SET] size:715501 blobrefs:[(B000018: 1040960), (B000020: 1640704), (B000022: 804800); depth:1]
+  000048:[lxxj@1#0,SET-oxiv@1#0,SET] seqnums:[0-0] points:[lxxj@1#0,SET-oxiv@1#0,SET] size:716962 blobrefs:[(B000022: 838016), (B000024: 1641600), (B000026: 1004864); depth:1]
+  000049:[oxiw@1#0,SET-rwta@1#0,SET] seqnums:[0-0] points:[oxiw@1#0,SET-rwta@1#0,SET] size:719348 blobrefs:[(B000026: 636224), (B000028: 1641856), (B000030: 1204160); depth:1]
+  000050:[rwtb@1#0,SET-uwen@1#0,SET] seqnums:[0-0] points:[rwtb@1#0,SET-uwen@1#0,SET] size:717493 blobrefs:[(B000030: 436352), (B000032: 1641408), (B000034: 1406720); depth:1]
+  000051:[uweo@1#0,SET-xvqm@1#0,SET] seqnums:[0-0] points:[uweo@1#0,SET-xvqm@1#0,SET] size:716738 blobrefs:[(B000034: 237440), (B000036: 1641408), (B000038: 1606400); depth:1]
+  000052:[xvqn@1#0,SET-zzzz@1#0,SET] seqnums:[0-0] points:[xvqn@1#0,SET-zzzz@1#0,SET] size:521136 blobrefs:[(B000038: 37440), (B000040: 1645056), (B000042: 853568); depth:1]
 Blob files:
   B000006 physical:{000006 size:[1704578 (1.6MB)] vals:[1642240 (1.6MB)]}
   B000008 physical:{000008 size:[1704776 (1.6MB)] vals:[1642432 (1.6MB)]}
@@ -608,8 +608,8 @@ excise-dryrun b c
 ----
 would excise 1 files.
   del-table:     L6 000044
-  add-table:     L6 000053(000044):[a@1#0,SET-azzz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azzz@1#0,SET] size:242560(715291) blobrefs:[(B000006: 556894), (B000008: 556959), (B000010: 68494); depth:1]
-  add-table:     L6 000054(000044):[c@1#0,SET-czms@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-czms@1#0,SET] size:230320(715291) blobrefs:[(B000006: 528792), (B000008: 528854), (B000010: 65037); depth:1]
+  add-table:     L6 000053(000044):[a@1#0,SET-azzz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azzz@1#0,SET] size:242560(715285) blobrefs:[(B000006: 556899), (B000008: 556964), (B000010: 68494); depth:1]
+  add-table:     L6 000054(000044):[c@1#0,SET-czms@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-czms@1#0,SET] size:230320(715285) blobrefs:[(B000006: 528797), (B000008: 528859), (B000010: 65038); depth:1]
   add-backing:   000044
 
 
@@ -652,9 +652,9 @@ set z helloworld
 flush
 ----
 L0.0:
-  000005:[a#10,SET-e#14,SET] seqnums:[10-14] points:[a#10,SET-e#14,SET] size:813
-  000006:[f#15,SET-n#23,SET] seqnums:[15-23] points:[f#15,SET-n#23,SET] size:957 blobrefs:[(B000007: 63); depth:1]
-  000008:[o#24,SET-z#35,SET] seqnums:[24-35] points:[o#24,SET-z#35,SET] size:870
+  000005:[a#10,SET-e#14,SET] seqnums:[10-14] points:[a#10,SET-e#14,SET] size:807
+  000006:[f#15,SET-n#23,SET] seqnums:[15-23] points:[f#15,SET-n#23,SET] size:933 blobrefs:[(B000007: 63); depth:1]
+  000008:[o#24,SET-z#35,SET] seqnums:[24-35] points:[o#24,SET-z#35,SET] size:844
 Blob files:
   B000007 physical:{000007 size:[115 (115B)] vals:[63 (63B)]}
 

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -88,7 +88,7 @@ maybe-compact
 Deletion hints:
   L0.000004 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (771B) Score=0.00 + L3 [000006] (771B) Score=0.00 + L4 [000007] (771B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (764B) Score=0.00 + L3 [000006] (764B) Score=0.00 + L4 [000007] (764B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # Verify that compaction correctly handles the presence of multiple
 # overlapping hints which might delete a file multiple times. All of the
@@ -127,7 +127,7 @@ maybe-compact
 Deletion hints:
   L1.000005 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (771B) Score=0.00 + L3 [000006] (771B) Score=0.00 + L4 [000007] (771B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (764B) Score=0.00 + L3 [000006] (764B) Score=0.00 + L4 [000007] (764B) Score=0.00 -> L6 [000008] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # Test a range tombstone that is already compacted into L6.
 
@@ -206,7 +206,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (771B) Score=0.00 + L3 [000006] (771B) Score=0.00 + L4 [000007] (771B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (764B) Score=0.00 + L3 [000006] (764B) Score=0.00 + L4 [000007] (764B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
 
 # A deletion hint present on an sstable in a higher level should NOT result in a
 # deletion-only compaction incorrectly removing an sstable in L6 following an
@@ -255,7 +255,7 @@ L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
 close-snapshot
 10
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (843B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (760B), in 1.0s (2.0s total), output rate 760B/s
+[JOB 100] compacted(elision-only) L6 [000004] (837B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (753B), in 1.0s (2.0s total), output rate 753B/s
 
 # In previous versions of the code, the deletion hint was removed by the
 # elision-only compaction because it zeroed sequence numbers of keys with
@@ -430,7 +430,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000006 000007 000008 000009 000011] (4.1KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+  [JOB 100] compacted(delete-only) L6 [000006 000007 000008 000009 000011] (4.0KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Verify that a delete-only compaction can partially excise a file.
 
@@ -474,7 +474,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (750B) Score=0.00 + L2 [000006] (771B) Score=0.00 + L3 [000007] (771B) Score=0.00 + L4 [000008] (771B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (745B) Score=0.00 + L2 [000006] (764B) Score=0.00 + L3 [000007] (764B) Score=0.00 + L4 [000008] (764B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
 
 describe-lsm
 ----
@@ -542,7 +542,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000005] (765B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+  [JOB 100] compacted(delete-only) L6 [000005] (759B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 describe-lsm
 ----
@@ -608,7 +608,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) (excised: 000004) L6 [000004] (976B) Score=0.00 -> L6 [000007 000008] (186B), in 1.0s (2.0s total), output rate 186B/s
+  [JOB 100] compacted(delete-only) (excised: 000004) L6 [000004] (937B) Score=0.00 -> L6 [000007 000008] (186B), in 1.0s (2.0s total), output rate 186B/s
 
 describe-lsm
 ----
@@ -753,4 +753,4 @@ L0.000006 c-h seqnums(tombstone=11-12, file-smallest=10, type=point-and-range-ke
 close-snapshot
 11
 ----
-[JOB 100] compacted(delete-only) L6 [000004] (1.0KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000004] (1006B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s

--- a/testdata/compaction_picker_pick_file
+++ b/testdata/compaction_picker_pick_file
@@ -16,9 +16,9 @@ L2:
 file-sizes
 ----
 L1:
-  000004:[b#11,SET-c#11,SET]: 780 bytes (780B)
+  000004:[b#11,SET-c#11,SET]: 774 bytes (774B)
 L2:
-  000005:[c#0,SET-d#0,SET]: 774 bytes (774B)
+  000005:[c#0,SET-d#0,SET]: 769 bytes (769B)
 
 pick-file L1
 ----
@@ -131,12 +131,12 @@ L6:
 file-sizes
 ----
 L5:
-  000004:[c#11,SET-e#11,SET]: 99408 bytes (97KB)
-  000005:[f#11,SET-f#11,SET]: 58129 bytes (57KB)
+  000004:[c#11,SET-e#11,SET]: 99402 bytes (97KB)
+  000005:[f#11,SET-f#11,SET]: 58123 bytes (57KB)
 L6:
-  000006:[c#0,SET-c#0,SET]: 66323 bytes (65KB)
-  000007:[e#0,SET-e#0,SET]: 66323 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66323 bytes (65KB)
+  000006:[c#0,SET-c#0,SET]: 66317 bytes (65KB)
+  000007:[e#0,SET-e#0,SET]: 66317 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66317 bytes (65KB)
 
 # Sst 5 is picked since 65KB/57KB is less than 130KB/97KB.
 pick-file L5
@@ -168,12 +168,12 @@ file-sizes
 L5:
   000010:[c#11,SET-c#11,SET]: 32862 bytes (32KB)
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
-  000005:[f#11,SET-f#11,SET]: 58129 bytes (57KB)
+  000005:[f#11,SET-f#11,SET]: 58123 bytes (57KB)
 L6:
-  000006:[c#0,SET-c#0,SET]: 66323 bytes (65KB)
-  000009:[d#13,SET-d#13,SET]: 765 bytes (765B)
-  000007:[e#0,SET-e#0,SET]: 66323 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66323 bytes (65KB)
+  000006:[c#0,SET-c#0,SET]: 66317 bytes (65KB)
+  000009:[d#13,SET-d#13,SET]: 759 bytes (759B)
+  000007:[e#0,SET-e#0,SET]: 66317 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66317 bytes (65KB)
 
 # Superficially, sst 10 causes write amp of 65KB/32KB which is worse than sst
 # 5. But the garbage of ~64KB in the backing sst 4 is equally distributed
@@ -207,12 +207,12 @@ file-sizes
 ----
 L5:
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
-  000005:[f#11,SET-f#11,SET]: 58129 bytes (57KB)
+  000005:[f#11,SET-f#11,SET]: 58123 bytes (57KB)
 L6:
-  000012:[c#15,SET-c#15,SET]: 765 bytes (765B)
-  000009:[d#13,SET-d#13,SET]: 765 bytes (765B)
-  000007:[e#0,SET-e#0,SET]: 66323 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66323 bytes (65KB)
+  000012:[c#15,SET-c#15,SET]: 759 bytes (759B)
+  000009:[d#13,SET-d#13,SET]: 759 bytes (759B)
+  000007:[e#0,SET-e#0,SET]: 66317 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66317 bytes (65KB)
 
 # Even though picking sst 11 seems to cause poor write amp of 65KB/126B, it is
 # picked because it is blamed for all the garbage in backing sst 4 (~96KB),

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -24,7 +24,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       759B     0.00     0.01           0.01
+L5       752B     0.00     0.01           0.01
 L6       321KB    1.11     1.11           1.11
 
 enable-table-stats
@@ -37,7 +37,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 328905
+range-deletions-bytes-estimate: 328899
 
 scores
 ----
@@ -47,7 +47,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       759B     0.01     0.01           5.03
+L5       752B     0.01     0.01           5.03
 L6       321KB    1.11     1.11           1.11
 
 # Ensure that point deletions in a higher level result in a compensated level
@@ -80,7 +80,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       816B     0.00     0.01           0.01
+L5       809B     0.00     0.01           0.01
 L6       321KB    1.11     1.11           1.11
 
 enable-table-stats
@@ -103,7 +103,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       816B     0.01     0.01           2.51
+L5       809B     0.01     0.01           2.51
 L6       321KB    1.11     1.11           1.11
 
 # Run a similar test as above, but this time the table containing the DELs is
@@ -212,11 +212,11 @@ L6       386KB    0.00     0.42           0.42
 lsm verbose
 ----
 L5:
-  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET] size:525413
-  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET] size:131868
+  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET] size:525407
+  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET] size:131862
 L6:
-  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET] size:263265
-  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET] size:131868
+  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET] size:263259
+  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET] size:131862
 
 # Attempting to schedule a compaction should begin a L5->L6 compaction.
 

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -41,7 +41,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (750B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (745B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that straddles a snapshot. It should not be compacted.
 define snapshots=(50) auto-compactions=off
@@ -85,7 +85,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (804B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (760B), in 1.0s (2.0s total), output rate 760B/s
+[JOB 100] compacted(elision-only) L6 [000004] (798B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (753B), in 1.0s (2.0s total), output rate 753B/s
 
 version
 ----
@@ -134,7 +134,7 @@ close-snapshot
 close-snapshot
 103
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (997B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (947B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that contains both deletions and non-deletions, but whose
 # non-deletions well outnumber its deletions. The table should not be
@@ -208,7 +208,7 @@ range-deletions-bytes-estimate: 16824
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=89.06 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
+[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=89.05 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
 
 define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
@@ -243,7 +243,7 @@ range-deletions-bytes-estimate: 0
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (808B) Score=6.21 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(default) L5 [000004] (802B) Score=6.19 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -323,7 +323,7 @@ range-deletions-bytes-estimate: 94
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (1004B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (765B), in 1.0s (2.0s total), output rate 765B/s
+[JOB 100] compacted(elision-only) L6 [000004] (998B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (759B), in 1.0s (2.0s total), output rate 759B/s
 
 # Close the DB, asserting that the reference counts balance.
 close
@@ -376,7 +376,7 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (800B) Score=3.13 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
+[JOB 101] compacted(default) L5 [000004] (794B) Score=3.11 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -422,7 +422,7 @@ range-deletions-bytes-estimate: 8380
 maybe-compact
 ----
 [JOB 100] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 101] compacted(default) L5 [000004] (800B) Score=3.13 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
+[JOB 101] compacted(default) L5 [000004] (794B) Score=3.11 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.8KB), in 1.0s (2.0s total), output rate 4.8KB/s
 
 # These tests demonstrate the behavior of the tombstone density compaction feature
 # in Pebble. This feature identifies files with a high density of tombstones and
@@ -497,8 +497,8 @@ tombstone-dense-blocks-ratio: 0.9
 # should indicate "move" as the compaction type.
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L5 [000004] (819B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (765B), in 1.0s (2.0s total), output rate 765B/s
-[JOB 101] compacted(move) L4 [000004] (819B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (819B), in 1.0s (2.0s total), output rate 819B/s
+[JOB 100] compacted(tombstone-density) L5 [000004] (814B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (759B), in 1.0s (2.0s total), output rate 759B/s
+[JOB 101] compacted(move) L4 [000004] (814B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (814B), in 1.0s (2.0s total), output rate 814B/s
 
 # Verify the result - the file should now be in L5
 # The file should maintain its original content since it was just moved rather than recompacted
@@ -556,7 +556,7 @@ tombstone-dense-blocks-ratio: 0.9
 # because there are overlapping files in L5 that prevent the optimization
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L4 [000004] (819B) Score=0.00 + L5 [000005] (771B) Score=0.00 -> L5 [000007] (765B), in 1.0s (2.0s total), output rate 765B/s
+[JOB 100] compacted(tombstone-density) L4 [000004] (814B) Score=0.00 + L5 [000005] (764B) Score=0.00 -> L5 [000007] (759B), in 1.0s (2.0s total), output rate 759B/s
 
 # Verify the result - the file was recompacted with the overlapping L5 file
 # The output file should be different from the input files

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -115,7 +115,7 @@ close: db/marker.manifest.000002.MANIFEST-000006
 remove: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 [JOB 3] MANIFEST created 000006
-[JOB 3] flushed 1 memtable (100B) to L0 [000005] (761B), in 1.0s (2.0s total), output rate 761B/s
+[JOB 3] flushed 1 memtable (100B) to L0 [000005] (755B), in 1.0s (2.0s total), output rate 755B/s
 
 compact
 ----
@@ -139,18 +139,18 @@ close: db/marker.manifest.000003.MANIFEST-000009
 remove: db/marker.manifest.000002.MANIFEST-000006
 sync: db
 [JOB 5] MANIFEST created 000009
-[JOB 5] flushed 1 memtable (100B) to L0 [000008] (761B), in 1.0s (2.0s total), output rate 761B/s
+[JOB 5] flushed 1 memtable (100B) to L0 [000008] (755B), in 1.0s (2.0s total), output rate 755B/s
 remove: db/MANIFEST-000001
 [JOB 5] MANIFEST deleted 000001
 [JOB 6] compacting(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00; OverlappingRatio: Single 0.00, Multi 0.00
 open: db/000005.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): db/000005.sst
-read-at(650, 50): db/000005.sst
-read-at(119, 531): db/000005.sst
+read-at(694, 61): db/000005.sst
+read-at(644, 50): db/000005.sst
+read-at(119, 525): db/000005.sst
 open: db/000008.sst (options: *vfs.randomReadsOption)
-read-at(700, 61): db/000008.sst
-read-at(650, 50): db/000008.sst
-read-at(119, 531): db/000008.sst
+read-at(694, 61): db/000008.sst
+read-at(644, 50): db/000008.sst
+read-at(119, 525): db/000008.sst
 read-at(78, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
 read-at(0, 78): db/000005.sst
@@ -172,7 +172,7 @@ close: db/marker.manifest.000004.MANIFEST-000011
 remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
 [JOB 6] MANIFEST created 000011
-[JOB 6] compacted(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (757B), in 1.0s (3.0s total), output rate 757B/s
+[JOB 6] compacted(default) L0 [000005 000008] (1.5KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (750B), in 1.0s (3.0s total), output rate 750B/s
 close: db/000005.sst
 close: db/000008.sst
 remove: db/MANIFEST-000006
@@ -207,7 +207,7 @@ close: db/marker.manifest.000005.MANIFEST-000014
 remove: db/marker.manifest.000004.MANIFEST-000011
 sync: db
 [JOB 8] MANIFEST created 000014
-[JOB 8] flushed 1 memtable (100B) to L0 [000013] (761B), in 1.0s (2.0s total), output rate 761B/s
+[JOB 8] flushed 1 memtable (100B) to L0 [000013] (755B), in 1.0s (2.0s total), output rate 755B/s
 
 enable-file-deletions
 ----
@@ -217,10 +217,10 @@ remove: db/MANIFEST-000009
 ingest
 ----
 open: ext/0
-read-at(696, 61): ext/0
-read-at(646, 50): ext/0
-read-at(122, 524): ext/0
-read-at(122, 524): ext/0
+read-at(689, 61): ext/0
+read-at(639, 50): ext/0
+read-at(122, 517): ext/0
+read-at(122, 517): ext/0
 read-at(81, 41): ext/0
 read-at(0, 81): ext/0
 close: ext/0
@@ -238,7 +238,7 @@ sync: db
 remove: db/MANIFEST-000011
 [JOB 10] MANIFEST deleted 000011
 remove: ext/0
-[JOB 10] ingested L0:000015 (757B); manifest update took 0.1s; block reads took 0.3s with 7.7KB block bytes read
+[JOB 10] ingested L0:000015 (750B); manifest update took 0.1s; block reads took 0.3s with 7.7KB block bytes read
 
 metrics
 ----
@@ -246,14 +246,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    97B |      1  757B |   2 23.54
+    0      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    97B |      1  750B |   2 23.35
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6       757B |      1  757B |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.50
-total      2.2KB |      3 2.2KB |      0     0 |     0B     0B |   854B |      1  757B |   3  4.56
+    6       750B |      1  750B |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.50
+total      2.2KB |      3 2.2KB |      0     0 |     0B     0B |   847B |      1  750B |   3  4.56
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -264,7 +264,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   218B    0B |      1   757B     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   218B    0B |      1   750B     0B
 total |     -     -     - |      0    0B |    0B    0B    0B |   218B    0B |      4  3.8KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
@@ -317,18 +317,18 @@ ingest-flushable
 ----
 sync-data: wal/000012.log
 open: ext/a
-read-at(696, 61): ext/a
-read-at(646, 50): ext/a
-read-at(122, 524): ext/a
-read-at(122, 524): ext/a
+read-at(689, 61): ext/a
+read-at(639, 50): ext/a
+read-at(122, 517): ext/a
+read-at(122, 517): ext/a
 read-at(81, 41): ext/a
 read-at(0, 81): ext/a
 close: ext/a
 open: ext/b
-read-at(696, 61): ext/b
-read-at(646, 50): ext/b
-read-at(122, 524): ext/b
-read-at(122, 524): ext/b
+read-at(689, 61): ext/b
+read-at(639, 50): ext/b
+read-at(122, 517): ext/b
+read-at(122, 517): ext/b
 read-at(81, 41): ext/b
 read-at(0, 81): ext/b
 close: ext/b
@@ -350,7 +350,7 @@ sync: wal
 [JOB 13] WAL created 000020
 remove: ext/a
 remove: ext/b
-[JOB 11] ingested as flushable, memtable flushes took 0.2s: 000017 (757B), 000018 (757B); manifest update took 0.1s; block reads took 0.3s with 7.7KB block bytes read
+[JOB 11] ingested as flushable, memtable flushes took 0.2s: 000017 (750B), 000018 (750B); manifest update took 0.1s; block reads took 0.3s with 7.7KB block bytes read
 sync-data: wal/000020.log
 close: wal/000020.log
 create: wal/000021.log
@@ -363,7 +363,7 @@ sync-data: db/000022.sst
 close: db/000022.sst
 sync: db
 sync: db/MANIFEST-000016
-[JOB 15] flushed 1 memtable (100B) to L0 [000022] (761B), in 1.0s (2.0s total), output rate 761B/s
+[JOB 15] flushed 1 memtable (100B) to L0 [000022] (755B), in 1.0s (2.0s total), output rate 755B/s
 [JOB 16] flushing 2 ingested tables
 create: db/MANIFEST-000023
 close: db/MANIFEST-000016
@@ -373,7 +373,7 @@ close: db/marker.manifest.000007.MANIFEST-000023
 remove: db/marker.manifest.000006.MANIFEST-000016
 sync: db
 [JOB 16] MANIFEST created 000023
-[JOB 16] flushed 2 ingested flushables L0:000017 (757B) + L6:000018 (757B) in 1.0s (2.0s total), output rate 1.5KB/s
+[JOB 16] flushed 2 ingested flushables L0:000017 (750B) + L6:000018 (750B) in 1.0s (2.0s total), output rate 1.5KB/s
 remove: db/MANIFEST-000014
 [JOB 16] MANIFEST deleted 000014
 [JOB 17] flushing 1 memtable (100B) to L0
@@ -386,26 +386,26 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0        3KB |      4   3KB |      0     0 |     0B     0B |   132B |      2 1.5KB |   4 23.06
+    0      2.9KB |      4 2.9KB |      0     0 |     0B     0B |   132B |      2 1.5KB |   4 22.88
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      1  757B |   1  0.50
+    6      1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      1  750B |   1  0.50
 total      4.4KB |      6 4.4KB |      0     0 |     0B     0B |  2.3KB |      3 2.2KB |   5  2.58
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.80  0.80 |      0    0B |    0B    0B    0B |     0B    0B |      4    3KB     0B
+    0 |     -  0.80  0.80 |      0    0B |    0B    0B    0B |     0B    0B |      4  2.9KB     0B
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   218B    0B |      1   757B     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   218B    0B |      5  6.1KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   218B    0B |      1   750B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   218B    0B |      5    6KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -395,7 +395,7 @@ num-entries: 2
 num-deletions: 2
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1334
+range-deletions-bytes-estimate: 1328
 
 # A set operation takes precedence over a range deletion at the same
 # sequence number as can occur during ingestion.

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -330,8 +330,8 @@ gi: (foo, .)
 lsm verbose
 ----
 L6:
-  000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1389(1389)
-  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:953(953)
+  000004(000004):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1361(1361)
+  000005(000005):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:948(948)
 
 download g h via-backing-file-download
 ----
@@ -341,8 +341,8 @@ ok
 lsm verbose
 ----
 L6:
-  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1033(1033)
-  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:945(945)
+  000006(000006):[gc#10,DELSIZED-gf#inf,RANGEDEL] seqnums:[10-10] points:[gc#10,DELSIZED-gf#inf,RANGEDEL] size:1026(1026)
+  000007(000007):[gg#11,DELSIZED-gj#inf,RANGEDEL] seqnums:[11-11] points:[gg#11,DELSIZED-gj#inf,RANGEDEL] size:940(940)
 
 reopen
 ----

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -12,9 +12,9 @@ L6
   d@2.SET.2:v
 ----
 L5:
-  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:984 blobrefs:[(B000921: 10); depth:1]
+  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:972 blobrefs:[(B000921: 10); depth:1]
 L6:
-  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:979 blobrefs:[(B000921: 6); depth:1]
+  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:967 blobrefs:[(B000921: 6); depth:1]
 Blob files:
   B000921 physical:{000921 size:[106 (106B)] vals:[16 (16B)]}
 
@@ -72,9 +72,9 @@ L6
   f@2.SETWITHDEL.3:blob{fileNum=000039 value=grapes}
 ----
 L5:
-  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:985 blobrefs:[(B000039: 14), (B000921: 20); depth:2]
+  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:973 blobrefs:[(B000039: 14), (B000921: 20); depth:2]
 L6:
-  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:993 blobrefs:[(B000039: 11), (B000921: 13); depth:2]
+  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:981 blobrefs:[(B000039: 11), (B000921: 13); depth:2]
 Blob files:
   B000039 physical:{000039 size:[117 (117B)] vals:[25 (25B)]}
   B000921 physical:{000921 size:[125 (125B)] vals:[33 (33B)]}
@@ -137,7 +137,7 @@ L6
   l.SETWITHDEL.2:blob{fileNum=000009 value=peach blockID=6 valueID=0}
 ----
 L6:
-  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:1083 blobrefs:[(B000009: 96); depth:1]
+  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:1071 blobrefs:[(B000009: 96); depth:1]
 Blob files:
   B000009 physical:{000009 size:[322 (322B)] vals:[96 (96B)]}
 
@@ -210,7 +210,7 @@ L6
   b.SETWITHDEL.2:blob{fileNum=000009 value=keylime}
 ----
 L6:
-  000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:1133 blobrefs:[(B000009: 7); depth:1]
+  000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:1120 blobrefs:[(B000009: 7); depth:1]
 Blob files:
   B000009 physical:{000009 size:[96 (96B)] vals:[7 (7B)]}
 

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -221,9 +221,9 @@ del-range a(p,1000000)rovals a(p,1000000)rove
 flush verbose
 ----
 L0.1:
-  000017:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000854
-  000018:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000868
-  000019:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000826
+  000017:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[39-41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000837
+  000018:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[42-45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000851
+  000019:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[46-47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000809
 L0.0:
   000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] seqnums:[10-12] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] size:423430
   000006:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] seqnums:[13-15] points:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] size:423451
@@ -241,9 +241,9 @@ layout filename=000017.sst
 sstable
  ├── index  offset: 0  length: 28
  ├── range-del  offset: 33  length: 6000129
- ├── properties  offset: 6000167  length: 559
- ├── meta-index  offset: 6000731  length: 65
- └── footer  offset: 6000801  length: 53
+ ├── properties  offset: 6000167  length: 542
+ ├── meta-index  offset: 6000714  length: 65
+ └── footer  offset: 6000784  length: 53
 
 properties file=000017
 rocksdb.raw

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -6,9 +6,9 @@ L1
   d.SET.0:foo
 ----
 L0.0:
-  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:758
+  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:752
 L1:
-  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:769
+  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:763
 
 mark-for-compaction file=000005
 ----
@@ -20,9 +20,9 @@ marked L0.000004
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000005] (769B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (769B), in 1.0s (2.0s total), output rate 769B/s
-[JOB 100] compacted(rewrite) L0 [000004] (758B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (758B), in 1.0s (2.0s total), output rate 758B/s
+[JOB 100] compacted(rewrite) L1 [000005] (763B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (763B), in 1.0s (2.0s total), output rate 763B/s
+[JOB 100] compacted(rewrite) L0 [000004] (752B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (752B), in 1.0s (2.0s total), output rate 752B/s
 L0.0:
-  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:758
+  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:752
 L1:
-  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:769
+  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:763

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -93,26 +93,26 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0       769B |      1  769B |      0     0 |     0B     0B |    28B |      0    0B |   1 27.46
+    0       764B |      1  764B |      0     0 |     0B     0B |    28B |      0    0B |   1 27.29
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-total       769B |      1  769B |      0     0 |     0B     0B |    28B |      0    0B |   1 28.46
+total       764B |      1  764B |      0     0 |     0B     0B |    28B |      0    0B |   1 28.29
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      1   769B     0B
+    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      1   764B     0B
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      1   797B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      1   792B     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       0       0        0     0     0     0        0     0      0     0
@@ -194,14 +194,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 24.03
+    0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 23.88
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6      1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.99
-total      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.94
+total      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.59
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -213,7 +213,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.5KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4  3.1KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4    3KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -278,14 +278,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 24.03
+    0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 23.88
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6      1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.99
-total      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.94
+total      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.59
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -297,7 +297,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.5KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4  3.1KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4    3KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -359,14 +359,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 24.03
+    0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 23.88
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6      1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.99
-total      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.94
+total      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.59
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -378,7 +378,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.5KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4  3.1KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4    3KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -398,7 +398,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |   1 (769B local:769B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+   all loaded |     0 (0B) |   1 (764B local:764B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -443,14 +443,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 24.03
+    0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 23.88
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6      1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.99
-total      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.94
+total      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    64B |      0    0B |   1 48.59
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -462,7 +462,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.5KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4  3.1KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4    3KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -566,19 +566,19 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      6.6KB |      7   6KB |      0     0 |   644B     0B |   165B |      0    0B |   1 54.16
+    0      6.6KB |      7 5.9KB |      0     0 |   644B     0B |   165B |      0    0B |   1 53.89
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6      1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.99
-total      8.1KB |      9 7.5KB |      0     0 |   644B     0B |   165B |      0    0B |   2 64.44
+total        8KB |      9 7.4KB |      0     0 |   644B     0B |   165B |      0    0B |   2 64.09
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  7.5KB  1.3KB
+    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  7.4KB  1.3KB
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
@@ -615,7 +615,7 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-            8.1KB |            0 (0B) |            0 (0B) |                 0 |                  0
+              8KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -674,19 +674,19 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 54.16
+    0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 53.89
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      8.1KB |      9 7.4KB |      0     0 |   644B     0B |  7.5KB |      0    0B |   1  1.00
-total      8.1KB |      9 7.4KB |      0     0 |   644B     0B |   165B |      0    0B |   1 101.4
+    6        8KB |      9 7.4KB |      0     0 |   644B     0B |  7.4KB |      0    0B |   1  1.00
+total        8KB |      9 7.4KB |      0     0 |   644B     0B |   165B |      0    0B |   1 100.8
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  7.5KB  1.3KB
+    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  7.4KB  1.3KB
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
@@ -833,14 +833,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      4.5KB |      6 4.5KB |      0     0 |     0B     0B |   211B |      3 2.2KB |   2 53.29
+    0      4.5KB |      6 4.5KB |      0     0 |     0B     0B |   211B |      3 2.2KB |   2 53.00
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      8.1KB |      9 7.4KB |      0     0 |   644B     0B |  7.5KB |      0    0B |   1  1.00
-total       13KB |     15  12KB |      0     0 |   644B     0B |  2.4KB |      3 2.2KB |   3  8.53
+    6        8KB |      9 7.4KB |      0     0 |   644B     0B |  7.4KB |      0    0B |   1  1.00
+total       12KB |     15  12KB |      0     0 |   644B     0B |  2.4KB |      3 2.2KB |   3  8.54
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -852,7 +852,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  7.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     21   20KB  1.3KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     21   19KB  1.3KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -882,7 +882,7 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-             13KB |            0 (0B) |            0 (0B) |                 0 |                  0
+             12KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -954,14 +954,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      9.8KB |     13 9.8KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 60.03
+    0      9.7KB |     13 9.7KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 59.68
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      8.1KB |      9 7.4KB |      0     0 |   644B     0B |  7.5KB |      0    0B |   1  1.00
-total       18KB |     22  17KB |      0     0 |   644B     0B |  2.5KB |      3 2.2KB |   3 10.43
+    6        8KB |      9 7.4KB |      0     0 |   644B     0B |  7.4KB |      0    0B |   1  1.00
+total       18KB |     22  17KB |      0     0 |   644B     0B |  2.5KB |      3 2.2KB |   3 10.44
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -1087,14 +1087,14 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      8.2KB |     11 8.2KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 60.03
+    0      8.2KB |     11 8.2KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 59.68
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      8.8KB |     10 8.2KB |      0     0 |   644B     0B |  7.5KB |      1  765B |   1  1.00
-total       17KB |     21  16KB |      0     0 |   644B     0B |  3.3KB |      4   3KB |   3  8.27
+    6      8.8KB |     10 8.1KB |      0     0 |   644B     0B |  7.4KB |      1  759B |   1  1.00
+total       17KB |     21  16KB |      0     0 |   644B     0B |  3.2KB |      4   3KB |   3  8.28
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -1264,7 +1264,7 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 2.2KB |   0 60.03
+    0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 2.2KB |   0 59.68
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
@@ -1283,7 +1283,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  2.2KB    0B |     16   13KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |     35   32KB  1.3KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |     35   31KB  1.3KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       3       0        0     0     0     0        0     0      0     0
@@ -1358,19 +1358,19 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      2.3KB |      3 2.3KB |      0     0 |     0B     0B |    38B |      0    0B |   1 60.71
+    0      2.2KB |      3 2.2KB |      0     0 |     0B     0B |    38B |      0    0B |   1 60.32
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-total      2.3KB |      3 2.3KB |      0     0 |     0B     0B |    38B |      0    0B |   1 61.71
+total      2.2KB |      3 2.2KB |      0     0 |     0B     0B |    38B |      0    0B |   1 61.32
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.3KB     0B
+    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.2KB     0B
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
@@ -1438,19 +1438,19 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |    38B |      0    0B |   0 60.71
+    0         0B |      0    0B |      0     0 |     0B     0B |    38B |      0    0B |   0 60.32
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.3KB |      0    0B |   1  0.99
-total      2.2KB |      3 2.2KB |      0     0 |     0B     0B |    38B |      0    0B |   1 122.1
+    6      2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.2KB |      0    0B |   1  0.99
+total      2.2KB |      3 2.2KB |      0     0 |     0B     0B |    38B |      0    0B |   1 121.2
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.3KB     0B
+    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.2KB     0B
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
@@ -1534,26 +1534,26 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0       765B |      1  765B |      0     0 |     0B     0B |    38B |      1  765B |   1 60.71
+    0       759B |      1  759B |      0     0 |     0B     0B |    38B |      1  759B |   1 60.32
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.3KB |      0    0B |   1  0.99
-total        3KB |      4   3KB |      0     0 |     0B     0B |   803B |      1  765B |   2  6.73
+    6      2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.2KB |      0    0B |   1  0.99
+total        3KB |      4   3KB |      0     0 |     0B     0B |   797B |      1  759B |   2  6.73
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.3KB     0B
+    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.2KB     0B
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   336B    0B |      3  2.2KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   336B    0B |      6  5.3KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   336B    0B |      6  5.2KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -1622,14 +1622,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    74B |      1  765B |   2 41.57
+    0      1.5KB |      2 1.5KB |      0     0 |     0B     0B |    74B |      1  759B |   2 41.30
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.3KB |      0    0B |   1  0.99
-total      3.7KB |      5 3.7KB |      0     0 |     0B     0B |   839B |      1  765B |   3  7.40
+    6      2.2KB |      3 2.2KB |      0     0 |     0B     0B |  2.2KB |      0    0B |   1  0.99
+total      3.7KB |      5 3.7KB |      0     0 |     0B     0B |   833B |      1  759B |   3  7.40
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -1641,7 +1641,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   336B    0B |      3  2.2KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   336B    0B |      7  6.1KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   336B    0B |      7    6KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -1797,8 +1797,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   342B    0B |      1   765B     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   342B    0B |      1   765B     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   342B    0B |      1   759B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   342B    0B |      1   759B     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -1897,14 +1897,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      1.5KB |      2 1.5KB |      0     0 |     0B     0B |   106B |      0    0B |   1 36.67
+    0      1.5KB |      2 1.5KB |      0     0 |     0B     0B |   106B |      0    0B |   1 36.41
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6      2.3KB |      3 2.3KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
-total      3.8KB |      5 3.8KB |      0     0 |     0B     0B |   106B |      0    0B |   2 37.67
+total      3.8KB |      5 3.8KB |      0     0 |     0B     0B |   106B |      0    0B |   2 37.41
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -1974,14 +1974,14 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      1.5KB |      2 1.5KB |      0     0 |     0B     0B |   106B |      0    0B |   1 36.67
+    0      1.5KB |      2 1.5KB |      0     0 |     0B     0B |   106B |      0    0B |   1 36.41
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6      2.3KB |      3 2.3KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
-total      3.8KB |      5 3.8KB |      0     0 |     0B     0B |   106B |      0    0B |   2 37.67
+total      3.8KB |      5 3.8KB |      0     0 |     0B     0B |   106B |      0    0B |   2 37.41
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -978,5 +978,5 @@ wait-pending-table-stats
 num-entries: 3
 num-deletions: 3
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 3946
+point-deletions-bytes-estimate: 3942
 range-deletions-bytes-estimate: 0


### PR DESCRIPTION
Improve the compression stats string to be shorter and more readable:
 - `None` instead of `NoCompression`;
 - remove redundant second number for `None`;
 - order algorithms according to the definition.

We also rename some of the compression constants.

We still support the previous format. The previous format is written
out by v25.3, but is never read back/parsed by that version.