### PR TITLE
blob: add FileFormatV2 which has a properties block

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -291,7 +291,7 @@ func (d *DB) runBlobFileRewriteLocked(
 		env,
 		objMeta.DiskFileNum,
 		writable,
-		d.opts.MakeBlobWriterOptions(6),
+		d.opts.MakeBlobWriterOptions(6, d.BlobFileFormat()),
 		c.referencingTables,
 		c.input,
 	)

--- a/internal/blobtest/handles.go
+++ b/internal/blobtest/handles.go
@@ -212,6 +212,11 @@ func (bv *Values) ParseInlineHandle(
 	return h, remaining, nil
 }
 
+// IsEmpty returns true if the Values has no tracked handles.
+func (bv *Values) IsEmpty() bool {
+	return len(bv.trackedHandles) == 0
+}
+
 // WriteFiles writes all the blob files referenced by Values, using
 // newBlobObject to construct new objects.
 //

--- a/metrics.go
+++ b/metrics.go
@@ -1058,7 +1058,7 @@ func (m *Metrics) StringForTests() string {
 	// We recalculate the file cache size using the 64-bit sizes, and we ignore
 	// the genericcache metadata size which is harder to adjust.
 	const sstableReaderSize64bit = 280
-	const blobFileReaderSize64bit = 96
+	const blobFileReaderSize64bit = 112
 	mCopy.FileCache.Size = mCopy.FileCache.TableCount*sstableReaderSize64bit + mCopy.FileCache.BlobFileCount*blobFileReaderSize64bit
 	if math.MaxInt == math.MaxInt64 {
 		// Verify the 64-bit sizes, so they are kept updated.

--- a/open_test.go
+++ b/open_test.go
@@ -502,7 +502,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000012.025",
+			"marker.format-version.000013.026",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/options.go
+++ b/options.go
@@ -2543,9 +2543,10 @@ func (o *Options) MakeWriterOptions(level int, format sstable.TableFormat) sstab
 
 // MakeBlobWriterOptions constructs blob.FileWriterOptions from the corresponding
 // options in the receiver.
-func (o *Options) MakeBlobWriterOptions(level int) blob.FileWriterOptions {
+func (o *Options) MakeBlobWriterOptions(level int, format blob.FileFormat) blob.FileWriterOptions {
 	lo := o.Levels[level]
 	return blob.FileWriterOptions{
+		Format:       format,
 		Compression:  lo.Compression(),
 		ChecksumType: block.ChecksumTypeCRC32c,
 		FlushGovernor: block.MakeFlushGovernor(

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/block/blockkind"
+	"github.com/cockroachdb/pebble/sstable/colblk"
 )
 
 var (
@@ -30,6 +31,8 @@ type FileFormat uint8
 // String implements the fmt.Stringer interface.
 func (f FileFormat) String() string {
 	switch f {
+	case FileFormatV2:
+		return "blobV2"
 	case FileFormatV1:
 		return "blobV1"
 	default:
@@ -40,15 +43,22 @@ func (f FileFormat) String() string {
 const (
 	// FileFormatV1 is the first version of the blob file format.
 	FileFormatV1 FileFormat = 1
+	// FileFormatV2 adds a property block. The property block offset and length
+	// are encoded in a separate v2 footer that comes before the v1 file footer.
+	FileFormatV2 FileFormat = 2
+
+	latestFileFormat FileFormat = iota
 )
 
 const (
-	fileFooterLength = 38
-	fileMagic        = "\xf0\x9f\xaa\xb3\xf0\x9f\xa6\x80" // 🪳🦀
+	fileFooterLength   = 38
+	fileMagic          = "\xf0\x9f\xaa\xb3\xf0\x9f\xa6\x80" // 🪳🦀
+	v2FileFooterLength = 4 + 8 + 8
 )
 
 // FileWriterOptions are used to configure the FileWriter.
 type FileWriterOptions struct {
+	Format        FileFormat
 	Compression   *block.CompressionProfile
 	ChecksumType  block.ChecksumType
 	FlushGovernor block.FlushGovernor
@@ -57,6 +67,9 @@ type FileWriterOptions struct {
 }
 
 func (o *FileWriterOptions) ensureDefaults() {
+	if o.Format == 0 {
+		o.Format = FileFormatV1
+	}
 	if o.Compression == nil {
 		o.Compression = block.SnappyCompression
 	}
@@ -97,6 +110,7 @@ type FileWriter struct {
 	fileNum       base.DiskFileNum
 	w             objstorage.Writable
 	err           error
+	format        FileFormat
 	valuesEncoder blobValueBlockEncoder
 	// indexEncoder is an encoder for the index block. Every blob file has an
 	// index block encoding the offsets at which each block is written.
@@ -125,6 +139,7 @@ func NewFileWriter(fn base.DiskFileNum, w objstorage.Writable, opts FileWriterOp
 	fw := writerPool.Get().(*FileWriter)
 	fw.fileNum = fn
 	fw.w = w
+	fw.format = opts.Format
 	fw.valuesEncoder.Init()
 	fw.flushGov = opts.FlushGovernor
 	fw.indexEncoder.Init()
@@ -257,63 +272,67 @@ func (w *FileWriter) Close() (FileWriterStats, error) {
 	// for it to complete.
 	close(w.writeQueue.ch)
 	w.writeQueue.wg.Wait()
-	var err error
-	if w.writeQueue.err != nil {
-		err = w.writeQueue.err
-		if w.w != nil {
-			w.w.Abort()
-		}
-		return FileWriterStats{}, err
-	}
-	stats := w.stats
-	if stats.BlockCount != uint32(w.indexEncoder.countBlocks) {
-		panic(errors.AssertionFailedf("block count mismatch: %d vs %d",
-			stats.BlockCount, w.indexEncoder.countBlocks))
-	}
-	if stats.BlockCount == 0 {
-		panic(errors.AssertionFailedf("no blocks written"))
-	}
 
-	// Write the index block.
-	var indexBlockHandle block.Handle
-	{
-		indexBlock := w.indexEncoder.Finish()
-		pb := w.physBlockMaker.Make(indexBlock, blockkind.Metadata, block.DontCompress)
-		length, err := block.WriteAndReleasePhysicalBlock(pb.Take(), w.w)
+	err := func() error {
+		if w.writeQueue.err != nil {
+			return w.writeQueue.err
+		}
+
+		if w.stats.BlockCount != uint32(w.indexEncoder.countBlocks) {
+			panic(errors.AssertionFailedf("block count mismatch: %d vs %d",
+				w.stats.BlockCount, w.indexEncoder.countBlocks))
+		}
+		if w.stats.BlockCount == 0 {
+			panic(errors.AssertionFailedf("no blocks written"))
+		}
+
+		// Write the index block.
+		indexBlockHandle, err := w.writeMetadataBlock(w.indexEncoder.Finish())
 		if err != nil {
-			w.err = err
-			if w.w != nil {
-				w.w.Abort()
-			}
-			return FileWriterStats{}, err
+			return err
 		}
-		indexBlockHandle.Offset = stats.FileLen
-		indexBlockHandle.Length = uint64(length.WithoutTrailer())
-		stats.FileLen += uint64(length.WithTrailer())
-	}
 
-	// Write the footer.
-	footer := fileFooter{
-		format:          FileFormatV1,
-		checksum:        w.physBlockMaker.Checksummer.Type,
-		indexHandle:     indexBlockHandle,
-		originalFileNum: w.fileNum,
-	}
-	footerBuf := make([]byte, fileFooterLength)
-	footer.encode(footerBuf)
-	if w.err = w.w.Write(footerBuf); w.err != nil {
-		err = w.err
-		if w.w != nil {
-			w.w.Abort()
+		// Write the properties and the v2 footer if the file format is v2.
+		var propBlockHandle block.Handle
+		if w.format >= FileFormatV2 {
+			var cw colblk.KeyValueBlockWriter
+			cw.Init()
+			p := Properties{
+				CompressionStats: w.physBlockMaker.Compressor.Stats().String(),
+			}
+			p.writeTo(&cw)
+			propBlockHandle, err = w.writeMetadataBlock(cw.Finish(cw.Rows()))
+			if err != nil {
+				return err
+			}
 		}
-		return FileWriterStats{}, err
-	}
-	stats.FileLen += fileFooterLength
-	if w.err = w.w.Finish(); w.err != nil {
-		err = w.err
-		if w.w != nil {
-			w.w.Abort()
+		// Write the footer.
+		footer := fileFooter{
+			format:          w.format,
+			checksumType:    w.physBlockMaker.Checksummer.Type,
+			indexHandle:     indexBlockHandle,
+			originalFileNum: w.fileNum,
 		}
+		var footerBuf [v2FileFooterLength + fileFooterLength]byte
+		footer.encode((*[fileFooterLength]byte)(footerBuf[v2FileFooterLength:]))
+		footerLength := fileFooterLength
+		if w.format >= FileFormatV2 {
+			footerLength += v2FileFooterLength
+			v2footer := v2FileFooter{
+				propertiesHandle: propBlockHandle,
+			}
+			v2footer.encode((*[v2FileFooterLength]byte)(footerBuf[:]))
+		}
+		if err := w.w.Write(footerBuf[len(footerBuf)-footerLength:]); err != nil {
+			return err
+		}
+		w.stats.FileLen += uint64(footerLength)
+		return w.w.Finish()
+	}()
+	if err != nil {
+		w.err = err
+		w.w.Abort()
+		w.w = nil
 		return FileWriterStats{}, err
 	}
 
@@ -321,12 +340,27 @@ func (w *FileWriter) Close() (FileWriterStats, error) {
 	w.indexEncoder.Reset()
 	w.valuesEncoder.Reset()
 	w.w = nil
+	stats := w.stats
 	w.stats = FileWriterStats{}
 	w.err = errClosed
 	w.writeQueue.ch = nil
 	w.writeQueue.err = nil
 	writerPool.Put(w)
 	return stats, nil
+}
+
+func (w *FileWriter) writeMetadataBlock(data []byte) (block.Handle, error) {
+	pb := w.physBlockMaker.Make(data, blockkind.Metadata, block.DontCompress)
+	length, err := block.WriteAndReleasePhysicalBlock(pb.Take(), w.w)
+	if err != nil {
+		return block.Handle{}, err
+	}
+	h := block.Handle{
+		Offset: w.stats.FileLen,
+		Length: uint64(length.WithoutTrailer()),
+	}
+	w.stats.FileLen += uint64(length.WithTrailer())
+	return h, nil
 }
 
 // fileFooter contains the information contained within the footer of a blob
@@ -342,25 +376,25 @@ func (w *FileWriter) Close() (FileWriterStats, error) {
 //   - blob file magic string (8 bytes)
 type fileFooter struct {
 	format          FileFormat
-	checksum        block.ChecksumType
+	checksumType    block.ChecksumType
 	indexHandle     block.Handle
 	originalFileNum base.DiskFileNum
 }
 
 func (f *fileFooter) decode(b []byte) error {
-	if uint64(len(b)) != fileFooterLength {
+	if len(b) != fileFooterLength {
 		return errors.AssertionFailedf("invalid blob file footer length")
 	}
 	encodedChecksum := binary.LittleEndian.Uint32(b[0:])
 	computedChecksum := crc.New(b[4:]).Value()
 	if encodedChecksum != computedChecksum {
-		return base.CorruptionErrorf("invalid blob file checksum 0x%04x, expected: 0x%04x", encodedChecksum, computedChecksum)
+		return base.CorruptionErrorf("invalid blob file footer checksum 0x%04x, expected: 0x%04x", encodedChecksum, computedChecksum)
 	}
 	f.indexHandle.Offset = binary.LittleEndian.Uint64(b[4:])
 	f.indexHandle.Length = binary.LittleEndian.Uint64(b[12:])
-	f.checksum = block.ChecksumType(b[20])
+	f.checksumType = block.ChecksumType(b[20])
 	f.format = FileFormat(b[21])
-	if f.format != FileFormatV1 {
+	if f.format < FileFormatV1 || f.format > latestFileFormat {
 		return base.CorruptionErrorf("invalid blob file format %x", f.format)
 	}
 	f.originalFileNum = base.DiskFileNum(binary.LittleEndian.Uint64(b[22:]))
@@ -370,14 +404,46 @@ func (f *fileFooter) decode(b []byte) error {
 	return nil
 }
 
-func (f *fileFooter) encode(b []byte) {
+func (f *fileFooter) encode(b *[fileFooterLength]byte) {
 	binary.LittleEndian.PutUint64(b[4:], f.indexHandle.Offset)
 	binary.LittleEndian.PutUint64(b[12:], f.indexHandle.Length)
-	b[20] = byte(f.checksum)
+	b[20] = byte(f.checksumType)
 	b[21] = byte(f.format)
 	binary.LittleEndian.PutUint64(b[22:], uint64(f.originalFileNum))
 	copy(b[30:], fileMagic)
-	footerChecksum := crc.New(b[4 : 30+len(fileMagic)]).Value()
+	footerChecksum := crc.New(b[4:]).Value()
+	binary.LittleEndian.PutUint32(b[:4], footerChecksum)
+}
+
+// v2FileFooter is an extra footer for blob files in FileFormatV2, which is
+// always right before the fileFooter.
+//
+// Blob v2 extra footer format:
+//   - checksum CRC over v2 footer data (4 bytes)
+//   - properties block offset (8 bytes)
+//   - properties block length (8 bytes)
+type v2FileFooter struct {
+	propertiesHandle block.Handle
+}
+
+func (f *v2FileFooter) decode(b []byte) error {
+	if len(b) != v2FileFooterLength {
+		return errors.AssertionFailedf("invalid blob file footer length")
+	}
+	encodedChecksum := binary.LittleEndian.Uint32(b[0:])
+	computedChecksum := crc.New(b[4:]).Value()
+	if encodedChecksum != computedChecksum {
+		return base.CorruptionErrorf("invalid blob file v2 footer checksum 0x%04x, expected: 0x%04x", encodedChecksum, computedChecksum)
+	}
+	f.propertiesHandle.Offset = binary.LittleEndian.Uint64(b[4:])
+	f.propertiesHandle.Length = binary.LittleEndian.Uint64(b[12:])
+	return nil
+}
+
+func (f *v2FileFooter) encode(b *[v2FileFooterLength]byte) {
+	binary.LittleEndian.PutUint64(b[4:], f.propertiesHandle.Offset)
+	binary.LittleEndian.PutUint64(b[12:], f.propertiesHandle.Length)
+	footerChecksum := crc.New(b[4:]).Value()
 	binary.LittleEndian.PutUint32(b[:4], footerChecksum)
 }
 
@@ -385,8 +451,9 @@ func (f *fileFooter) encode(b []byte) {
 // If you update this struct, make sure you also update the magic number in
 // StringForTests() in metrics.go.
 type FileReader struct {
-	r      block.Reader
-	footer fileFooter
+	r        block.Reader
+	footer   fileFooter
+	v2Footer v2FileFooter
 }
 
 // Assert that FileReader implements the ValueReader interface.
@@ -415,28 +482,39 @@ func NewFileReader(
 
 	fileNum := ro.CacheOpts.FileNum
 
-	var footerBuf [fileFooterLength]byte
+	footerBuf := make([]byte, v2FileFooterLength+fileFooterLength)
 	size := r.Size()
-	off := size - fileFooterLength
 	if size < fileFooterLength {
 		return nil, base.CorruptionErrorf("pebble: invalid blob file %s (file size is too small)",
 			errors.Safe(fileNum))
 	}
-	var preallocRH objstorageprovider.PreallocatedReadHandle
-	rh := objstorageprovider.UsePreallocatedReadHandle(
-		r, objstorage.ReadBeforeForNewReader, &preallocRH)
+	if size < fileFooterLength+v2FileFooterLength {
+		footerBuf = footerBuf[v2FileFooterLength:]
+	}
 
-	encodedFooter, err := block.ReadRaw(ctx, r, rh, ro.LoggerAndTracer, fileNum, footerBuf[:], off)
+	rh := r.NewReadHandle(objstorage.ReadBeforeForNewReader)
+
+	offset := size - int64(len(footerBuf))
+	encodedFooter, err := block.ReadRaw(ctx, r, rh, ro.LoggerAndTracer, fileNum, footerBuf, offset)
 	_ = rh.Close()
 	if err != nil {
 		return nil, err
 	}
 
 	fr := &FileReader{}
-	if err := fr.footer.decode(encodedFooter); err != nil {
+	if err := fr.footer.decode(encodedFooter[len(encodedFooter)-fileFooterLength:]); err != nil {
 		return nil, err
 	}
-	fr.r.Init(r, ro.ReaderOptions, fr.footer.checksum)
+	if fr.footer.format >= FileFormatV2 {
+		if size < fileFooterLength+v2FileFooterLength {
+			return nil, base.CorruptionErrorf("pebble: invalid blob file %s (v2 file size is too small)",
+				errors.Safe(fileNum))
+		}
+		if err := fr.v2Footer.decode(encodedFooter[:v2FileFooterLength]); err != nil {
+			return nil, err
+		}
+	}
+	fr.r.Init(r, ro.ReaderOptions, fr.footer.checksumType)
 	return fr, nil
 }
 
@@ -475,6 +553,12 @@ func (r *FileReader) IndexHandle() block.Handle {
 // Layout returns the layout (block organization) as a string for a blob file.
 func (r *FileReader) Layout() (string, error) {
 	ctx := context.TODO()
+	var buf bytes.Buffer
+
+	if r.footer.format == FileFormatV2 {
+		h := r.v2Footer.propertiesHandle
+		fmt.Fprintf(&buf, "properties block: offset=%d length=%d\n", h.Offset, h.Length)
+	}
 
 	indexH, err := r.ReadIndexBlock(ctx, block.NoReadEnv, nil /* rh */)
 	if err != nil {
@@ -482,7 +566,6 @@ func (r *FileReader) Layout() (string, error) {
 	}
 	defer indexH.Release()
 
-	var buf bytes.Buffer
 	indexDecoder := indexBlockDecoder{}
 	indexDecoder.Init(indexH.BlockData())
 
@@ -516,4 +599,61 @@ func (r *FileReader) Layout() (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+type Properties struct {
+	CompressionStats string
+}
+
+// String returns any set properties, one per line.
+func (p *Properties) String() string {
+	var buf bytes.Buffer
+	if p.CompressionStats != "" {
+		fmt.Fprintf(&buf, "%s: %s\n", propertyKeyCompressionStats, p.CompressionStats)
+	}
+	return buf.String()
+}
+
+func (p *Properties) set(key []byte, value []byte) {
+	switch string(key) {
+	case propertyKeyCompressionStats:
+		p.CompressionStats = string(value)
+	default:
+		// Ignore unknown properties (for forward compatibility).
+	}
+}
+
+func (p *Properties) writeTo(w *colblk.KeyValueBlockWriter) {
+	if p.CompressionStats != "" {
+		w.AddKV([]byte(propertyKeyCompressionStats), []byte(p.CompressionStats))
+	}
+}
+
+const propertyKeyCompressionStats = "compression_stats"
+
+// ReadProperties reads the properties block from the file, if it exists.
+func (r *FileReader) ReadProperties(ctx context.Context) (Properties, error) {
+	if r.footer.format != FileFormatV2 {
+		return Properties{}, nil
+	}
+	// We don't want the property block to go into the block cache, so we use a
+	// buffer pool.
+	var bufferPool block.BufferPool
+	bufferPool.Init(1)
+	defer bufferPool.Release()
+	b, err := r.r.Read(
+		ctx, block.NoReadEnv, nil /* readHandle */, r.v2Footer.propertiesHandle, blockkind.Metadata,
+		func(*block.Metadata, []byte) error { return nil },
+	)
+	if err != nil {
+		return Properties{}, err
+	}
+	defer b.Release()
+	var decoder colblk.KeyValueBlockDecoder
+	decoder.Init(b.BlockData())
+	var p Properties
+	for k, v := range decoder.All() {
+		p.set(k, v)
+	}
+	return p, nil
 }

--- a/sstable/blob/blob_test.go
+++ b/sstable/blob/blob_test.go
@@ -60,20 +60,24 @@ func TestBlobWriter(t *testing.T) {
 				}
 			}
 			stats, err := w.Close()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			printFileWriterStats(&buf, stats)
 			return buf.String()
 		case "open":
 			r, err := NewFileReader(context.Background(), obj, FileReaderOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer r.Close()
-			fmt.Fprintf(&buf, "TableFormat: %s\n", r.footer.format)
-			fmt.Fprintf(&buf, "ChecksumType: %s\n", r.footer.checksum)
+			fmt.Fprintf(&buf, "FileFormat: %s\n", r.footer.format)
+			fmt.Fprintf(&buf, "ChecksumType: %s\n", r.footer.checksumType)
 			fmt.Fprintf(&buf, "IndexHandle: %s\n", r.footer.indexHandle.String())
+			if r.footer.format >= FileFormatV2 {
+				fmt.Fprintf(&buf, "PropsHandle: %s\n", r.v2Footer.propertiesHandle.String())
+			}
+			props, err := r.ReadProperties(context.Background())
+			require.NoError(t, err)
+			if propsStr := props.String(); propsStr != "" {
+				fmt.Fprintf(&buf, "Properties:\n%s", crstrings.Indent("  ", propsStr))
+			}
 			return buf.String()
 		default:
 			panic(fmt.Sprintf("unknown command: %s", td.Cmd))
@@ -85,6 +89,7 @@ func scanFileWriterOptions(t *testing.T, td *datadriven.TestData) FileWriterOpti
 	var (
 		targetBlockSize    int = 128
 		blockSizeThreshold int = 90
+		format                 = 0
 	)
 	td.MaybeScanArgs(t, "target-block-size", &targetBlockSize)
 	td.MaybeScanArgs(t, "block-size-threshold", &blockSizeThreshold)
@@ -95,7 +100,9 @@ func scanFileWriterOptions(t *testing.T, td *datadriven.TestData) FileWriterOpti
 			t.Fatalf("unknown compression %q", cmdArg.SingleVal(t))
 		}
 	}
+	td.MaybeScanArgs(t, "format", &format)
 	return FileWriterOptions{
+		Format:        FileFormat(format),
 		Compression:   compression,
 		ChecksumType:  block.ChecksumTypeCRC32c,
 		FlushGovernor: block.MakeFlushGovernor(targetBlockSize, blockSizeThreshold, 0, nil),

--- a/sstable/blob/testdata/writer
+++ b/sstable/blob/testdata/writer
@@ -60,9 +60,78 @@ Stats:
 
 open
 ----
-TableFormat: blobV1
+FileFormat: blobV1
 ChecksumType: crc32c
 IndexHandle: (308, 35)
+
+build target-block-size=64 block-size-threshold=90 format=2
+canteloupe
+apple
+orange
+blueberry
+kiwi
+tangerine
+pear
+pomegranate
+guava
+watermelon
+fig
+plum
+raspberry
+strawberry
+durian
+honeydew
+starfruit
+mango
+grape
+papaya
+lychee
+persimmon
+mandarin
+peach
+apricot
+nectarine
+----
+(B000001,blk0,id0,len10) : "canteloupe"
+(B000001,blk0,id1,len5)  : "apple"
+(B000001,blk0,id2,len6)  : "orange"
+(B000001,blk0,id3,len9)  : "blueberry"
+(B000001,blk0,id4,len4)  : "kiwi"
+(B000001,blk0,id5,len9)  : "tangerine"
+(B000001,blk1,id0,len4)  : "pear"
+(B000001,blk1,id1,len11) : "pomegranate"
+(B000001,blk1,id2,len5)  : "guava"
+(B000001,blk1,id3,len10) : "watermelon"
+(B000001,blk1,id4,len3)  : "fig"
+(B000001,blk1,id5,len4)  : "plum"
+(B000001,blk2,id0,len9)  : "raspberry"
+(B000001,blk2,id1,len10) : "strawberry"
+(B000001,blk2,id2,len6)  : "durian"
+(B000001,blk2,id3,len8)  : "honeydew"
+(B000001,blk2,id4,len9)  : "starfruit"
+(B000001,blk3,id0,len5)  : "mango"
+(B000001,blk3,id1,len5)  : "grape"
+(B000001,blk3,id2,len6)  : "papaya"
+(B000001,blk3,id3,len6)  : "lychee"
+(B000001,blk3,id4,len9)  : "persimmon"
+(B000001,blk3,id5,len8)  : "mandarin"
+(B000001,blk4,id0,len5)  : "peach"
+(B000001,blk4,id1,len7)  : "apricot"
+(B000001,blk4,id2,len9)  : "nectarine"
+Stats:
+  BlockCount: 5
+  ValueCount: 26
+  UncompressedValueBytes: 182
+  FileLen: 473
+
+open
+----
+FileFormat: blobV2
+ChecksumType: crc32c
+IndexHandle: (308, 35)
+PropsHandle: (348, 62)
+Properties:
+  compression_stats: NoCompression:318/318
 
 # Build a sparse table containing a subset of the previous block's values.
 
@@ -103,6 +172,6 @@ Stats:
 
 open
 ----
-TableFormat: blobV1
+FileFormat: blobV1
 ChecksumType: crc32c
 IndexHandle: (130, 33)

--- a/testdata/blob_rewrite
+++ b/testdata/blob_rewrite
@@ -68,7 +68,7 @@ rewrite-blob 000002 000001 000003
 # read-at(193, 613): 000003.sst
 # read-at(168, 25): 000003.sst
 # open: 000002.blob (options: *vfs.randomReadsOption)
-# read-at(67, 38): 000002.blob
+# read-at(47, 58): 000002.blob
 # read-at(37, 30): 000002.blob
 # read-at(0, 37): 000002.blob
 # sync-data: 000004.blob

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -67,6 +67,10 @@ create: db/marker.format-version.000012.025
 close: db/marker.format-version.000012.025
 remove: db/marker.format-version.000011.024
 sync: db
+create: db/marker.format-version.000013.026
+close: db/marker.format-version.000013.026
+remove: db/marker.format-version.000012.025
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -133,9 +137,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.025
-close: checkpoints/checkpoint1/marker.format-version.000001.025
+create: checkpoints/checkpoint1/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.026
+close: checkpoints/checkpoint1/marker.format-version.000001.026
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -177,9 +181,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.025
-close: checkpoints/checkpoint2/marker.format-version.000001.025
+create: checkpoints/checkpoint2/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.026
+close: checkpoints/checkpoint2/marker.format-version.000001.026
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -216,9 +220,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.025
-close: checkpoints/checkpoint3/marker.format-version.000001.025
+create: checkpoints/checkpoint3/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.026
+close: checkpoints/checkpoint3/marker.format-version.000001.026
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -302,7 +306,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -312,7 +316,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.025
+marker.format-version.000001.026
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -379,7 +383,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.025
+marker.format-version.000001.026
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -421,7 +425,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.025
+marker.format-version.000001.026
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -540,9 +544,9 @@ sync-data: checkpoints/checkpoint4/OPTIONS-000003
 close: checkpoints/checkpoint4/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.025
-close: checkpoints/checkpoint4/marker.format-version.000001.025
+create: checkpoints/checkpoint4/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.026
+close: checkpoints/checkpoint4/marker.format-version.000001.026
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -630,7 +634,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -649,9 +653,9 @@ sync-data: checkpoints/checkpoint5/OPTIONS-000003
 close: checkpoints/checkpoint5/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.025
-close: checkpoints/checkpoint5/marker.format-version.000001.025
+create: checkpoints/checkpoint5/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.026
+close: checkpoints/checkpoint5/marker.format-version.000001.026
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -751,9 +755,9 @@ sync-data: checkpoints/checkpoint6/OPTIONS-000003
 close: checkpoints/checkpoint6/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.025
-close: checkpoints/checkpoint6/marker.format-version.000001.025
+create: checkpoints/checkpoint6/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.026
+close: checkpoints/checkpoint6/marker.format-version.000001.026
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst
@@ -934,6 +938,10 @@ create: valsepdb/marker.format-version.000012.025
 close: valsepdb/marker.format-version.000012.025
 remove: valsepdb/marker.format-version.000011.024
 sync: valsepdb
+create: valsepdb/marker.format-version.000013.026
+close: valsepdb/marker.format-version.000013.026
+remove: valsepdb/marker.format-version.000012.025
+sync: valsepdb
 create: valsepdb/temporary.000003.dbtmp
 sync: valsepdb/temporary.000003.dbtmp
 close: valsepdb/temporary.000003.dbtmp
@@ -982,9 +990,9 @@ sync-data: checkpoints/checkpoint8/OPTIONS-000003
 close: checkpoints/checkpoint8/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint8
-create: checkpoints/checkpoint8/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint8/marker.format-version.000001.025
-close: checkpoints/checkpoint8/marker.format-version.000001.025
+create: checkpoints/checkpoint8/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint8/marker.format-version.000001.026
+close: checkpoints/checkpoint8/marker.format-version.000001.026
 sync: checkpoints/checkpoint8
 close: checkpoints/checkpoint8
 link: valsepdb/000006.blob -> checkpoints/checkpoint8/000006.blob
@@ -1037,7 +1045,7 @@ read-at(197, 588): checkpoints/checkpoint8/000005.sst
 read-at(131, 41): checkpoints/checkpoint8/000005.sst
 read-at(0, 131): checkpoints/checkpoint8/000005.sst
 open: checkpoints/checkpoint8/000006.blob (options: *vfs.randomReadsOption)
-read-at(62, 38): checkpoints/checkpoint8/000006.blob
+read-at(127, 58): checkpoints/checkpoint8/000006.blob
 read-at(32, 30): checkpoints/checkpoint8/000006.blob
 read-at(0, 32): checkpoints/checkpoint8/000006.blob
 a a
@@ -1096,9 +1104,9 @@ sync-data: checkpoints/checkpoint9/OPTIONS-000003
 close: checkpoints/checkpoint9/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint9
-create: checkpoints/checkpoint9/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint9/marker.format-version.000001.025
-close: checkpoints/checkpoint9/marker.format-version.000001.025
+create: checkpoints/checkpoint9/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint9/marker.format-version.000001.026
+close: checkpoints/checkpoint9/marker.format-version.000001.026
 sync: checkpoints/checkpoint9
 close: checkpoints/checkpoint9
 link: valsepdb/000006.blob -> checkpoints/checkpoint9/000006.blob
@@ -1147,7 +1155,7 @@ read-at(197, 588): checkpoints/checkpoint9/000005.sst
 read-at(131, 41): checkpoints/checkpoint9/000005.sst
 read-at(0, 131): checkpoints/checkpoint9/000005.sst
 open: checkpoints/checkpoint9/000006.blob (options: *vfs.randomReadsOption)
-read-at(62, 38): checkpoints/checkpoint9/000006.blob
+read-at(127, 58): checkpoints/checkpoint9/000006.blob
 read-at(32, 30): checkpoints/checkpoint9/000006.blob
 read-at(0, 32): checkpoints/checkpoint9/000006.blob
 a a

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -55,6 +55,10 @@ create: db/marker.format-version.000009.025
 close: db/marker.format-version.000009.025
 remove: db/marker.format-version.000008.024
 sync: db
+create: db/marker.format-version.000010.026
+close: db/marker.format-version.000010.026
+remove: db/marker.format-version.000009.025
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -121,9 +125,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.025
-close: checkpoints/checkpoint1/marker.format-version.000001.025
+create: checkpoints/checkpoint1/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.026
+close: checkpoints/checkpoint1/marker.format-version.000001.026
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -174,9 +178,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.025
-close: checkpoints/checkpoint2/marker.format-version.000001.025
+create: checkpoints/checkpoint2/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.026
+close: checkpoints/checkpoint2/marker.format-version.000001.026
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -223,9 +227,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.025
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.025
-close: checkpoints/checkpoint3/marker.format-version.000001.025
+create: checkpoints/checkpoint3/marker.format-version.000001.026
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.026
+close: checkpoints/checkpoint3/marker.format-version.000001.026
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -282,7 +286,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000009.025
+marker.format-version.000010.026
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -292,7 +296,7 @@ list checkpoints/checkpoint1
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.025
+marker.format-version.000001.026
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -344,7 +348,7 @@ list checkpoints/checkpoint2
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.025
+marker.format-version.000001.026
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -158,7 +158,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   5 (1.8KB) |       81.8% |     1 (376B) |       89.2% |         0.0% |           0 |           0
+   5 (1.8KB) |       81.8% |     1 (392B) |       89.2% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -433,7 +433,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   7 (2.5KB) |       59.6% |     1 (472B) |       78.6% |         0.0% |           0 |           0
+   7 (2.5KB) |       59.6% |     1 (504B) |       78.6% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -87,6 +87,11 @@ close: db/marker.format-version.000012.025
 remove: db/marker.format-version.000011.024
 sync: db
 upgraded to format version: 025
+create: db/marker.format-version.000013.026
+close: db/marker.format-version.000013.026
+remove: db/marker.format-version.000012.025
+sync: db
+upgraded to format version: 026
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -473,9 +478,9 @@ sync-data: checkpoint/OPTIONS-000003
 close: checkpoint/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.025
-sync-data: checkpoint/marker.format-version.000001.025
-close: checkpoint/marker.format-version.000001.025
+create: checkpoint/marker.format-version.000001.026
+sync-data: checkpoint/marker.format-version.000001.026
+close: checkpoint/marker.format-version.000001.026
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -38,7 +38,7 @@ ext
 ext1
 ext2
 ext3
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 # Ingest can complete despite the flush being blocked.
@@ -62,7 +62,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 allowFlush
@@ -96,7 +96,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -117,7 +117,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -210,7 +210,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext5
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 allowFlush
@@ -440,7 +440,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -460,7 +460,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -493,7 +493,7 @@ MANIFEST-000001
 MANIFEST-000011
 OPTIONS-000014
 ext
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000002.MANIFEST-000011
 
 # Make sure that the new mutable memtable can accept writes.
@@ -636,7 +636,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -655,7 +655,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext1
-marker.format-version.000012.025
+marker.format-version.000013.026
 marker.manifest.000001.MANIFEST-000001
 
 open

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -1,7 +1,7 @@
 # Test a simple scenario where two distinct sstables contain blob handles
 # referencing the same file.
 
-define verbose format-major-version=21
+define verbose format-major-version=24
 L5
   b@9.SET.9:v
   c@9.SET.9:blob{fileNum=000921 value=helloworld}
@@ -12,9 +12,9 @@ L6
   d@2.SET.2:v
 ----
 L5:
-  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:984 blobrefs:[(B000921: 10); depth:1]
+  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:949 blobrefs:[(B000921: 10); depth:1]
 L6:
-  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:979 blobrefs:[(B000921: 6); depth:1]
+  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:944 blobrefs:[(B000921: 6); depth:1]
 Blob files:
   B000921 physical:{000921 size:[106 (106B)] vals:[16 (16B)]}
 
@@ -59,7 +59,7 @@ stats: seeked 1 times (1 internal); stepped 5 times (6 internal); blocks: 365B c
 
 # Test a couple of blob files interleaved.
 
-define verbose format-major-version=21
+define verbose format-major-version=24
 L5
   b@9.SETWITHDEL.9:blob{fileNum=000039 value=orange}
   c@9.SETWITHDEL.9:blob{fileNum=000921 value=canteloupe}
@@ -72,9 +72,9 @@ L6
   f@2.SETWITHDEL.3:blob{fileNum=000039 value=grapes}
 ----
 L5:
-  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:985 blobrefs:[(B000039: 14), (B000921: 20); depth:2]
+  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:950 blobrefs:[(B000039: 14), (B000921: 20); depth:2]
 L6:
-  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:993 blobrefs:[(B000039: 11), (B000921: 13); depth:2]
+  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:958 blobrefs:[(B000039: 11), (B000921: 13); depth:2]
 Blob files:
   B000039 physical:{000039 size:[117 (117B)] vals:[25 (25B)]}
   B000921 physical:{000921 size:[125 (125B)] vals:[33 (33B)]}
@@ -121,7 +121,7 @@ stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cac
 # Test scanning a table, stepping into new blocks of the blob file. The stats
 # should reflect that a block is only loaded when stepping into a new block.
 
-define verbose format-major-version=21
+define verbose format-major-version=24
 L6
   a.SETWITHDEL.2:blob{fileNum=000009 value=lemonmeringue}
   b.SETWITHDEL.2:blob{fileNum=000009 value=keylime}
@@ -137,7 +137,7 @@ L6
   l.SETWITHDEL.2:blob{fileNum=000009 value=peach blockID=6 valueID=0}
 ----
 L6:
-  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:1083 blobrefs:[(B000009: 96); depth:1]
+  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:1043 blobrefs:[(B000009: 96); depth:1]
 Blob files:
   B000009 physical:{000009 size:[322 (322B)] vals:[96 (96B)]}
 
@@ -204,13 +204,13 @@ stats: seeked 1 times (1 internal); stepped 12 times (12 internal); blocks: 0B c
 # retrieve the value length. This resulted in a data race if the underlying
 # sstable iterator backing a LazyValue stored in i.value was pooled and reused.
 
-define verbose format-major-version=21
+define verbose format-major-version=24
 L6
   rangekey:a-d:{(#5,RANGEKEYSET,@2,foo)}
   b.SETWITHDEL.2:blob{fileNum=000009 value=keylime}
 ----
 L6:
-  000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:1133 blobrefs:[(B000009: 7); depth:1]
+  000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:1089 blobrefs:[(B000009: 7); depth:1]
 Blob files:
   B000009 physical:{000009 size:[96 (96B)] vals:[7 (7B)]}
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -552,13 +552,13 @@ L6:
   000008:[a#0,SET-a#0,SET]
   000009:[b#0,SET-b#0,SET]
 Blob files:
-  B000012 physical:{000012 size:[92 (92B)] vals:[3 (3B)]}
-  B000014 physical:{000014 size:[92 (92B)] vals:[3 (3B)]}
-  B000016 physical:{000016 size:[92 (92B)] vals:[3 (3B)]}
-  B000018 physical:{000018 size:[92 (92B)] vals:[3 (3B)]}
-  B000020 physical:{000020 size:[92 (92B)] vals:[3 (3B)]}
-  B000022 physical:{000022 size:[92 (92B)] vals:[3 (3B)]}
-  B000024 physical:{000024 size:[92 (92B)] vals:[3 (3B)]}
+  B000012 physical:{000012 size:[177 (177B)] vals:[3 (3B)]}
+  B000014 physical:{000014 size:[177 (177B)] vals:[3 (3B)]}
+  B000016 physical:{000016 size:[177 (177B)] vals:[3 (3B)]}
+  B000018 physical:{000018 size:[177 (177B)] vals:[3 (3B)]}
+  B000020 physical:{000020 size:[177 (177B)] vals:[3 (3B)]}
+  B000022 physical:{000022 size:[177 (177B)] vals:[3 (3B)]}
+  B000024 physical:{000024 size:[177 (177B)] vals:[3 (3B)]}
 
 metrics
 ----
@@ -566,26 +566,26 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      6.6KB |      7   6KB |      0     0 |   644B     0B |   165B |      0    0B |   1 54.16
+    0      7.2KB |      7   6KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 61.38
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     6      1.5KB |      2 1.5KB |      0     0 |     0B     0B |  1.5KB |      0    0B |   1  0.99
-total      8.1KB |      9 7.5KB |      0     0 |   644B     0B |   165B |      0    0B |   2 64.44
+total      8.7KB |      9 7.5KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   2 71.65
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  7.5KB  1.3KB
+    0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  7.5KB  2.4KB
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.5KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |     11  9.1KB  1.3KB
+total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |     11  9.1KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -605,7 +605,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |   7 (644B) |     0 (0B) |    21B | 100% (21B)
+   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -615,7 +615,7 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-            8.1KB |            0 (0B) |            0 (0B) |                 0 |                  0
+            8.7KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -660,13 +660,13 @@ L6:
   000030:[c@15#0,SET-c@15#0,SET]
   000031:[c@14#0,SET-c@14#0,SET]
 Blob files:
-  B000012 physical:{000012 size:[92 (92B)] vals:[3 (3B)]}
-  B000014 physical:{000014 size:[92 (92B)] vals:[3 (3B)]}
-  B000016 physical:{000016 size:[92 (92B)] vals:[3 (3B)]}
-  B000018 physical:{000018 size:[92 (92B)] vals:[3 (3B)]}
-  B000020 physical:{000020 size:[92 (92B)] vals:[3 (3B)]}
-  B000022 physical:{000022 size:[92 (92B)] vals:[3 (3B)]}
-  B000024 physical:{000024 size:[92 (92B)] vals:[3 (3B)]}
+  B000012 physical:{000012 size:[177 (177B)] vals:[3 (3B)]}
+  B000014 physical:{000014 size:[177 (177B)] vals:[3 (3B)]}
+  B000016 physical:{000016 size:[177 (177B)] vals:[3 (3B)]}
+  B000018 physical:{000018 size:[177 (177B)] vals:[3 (3B)]}
+  B000020 physical:{000020 size:[177 (177B)] vals:[3 (3B)]}
+  B000022 physical:{000022 size:[177 (177B)] vals:[3 (3B)]}
+  B000024 physical:{000024 size:[177 (177B)] vals:[3 (3B)]}
 
 metrics
 ----
@@ -674,26 +674,26 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 54.16
+    0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 61.38
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      8.1KB |      9 7.4KB |      0     0 |   644B     0B |  7.5KB |      0    0B |   1  1.00
-total      8.1KB |      9 7.4KB |      0     0 |   644B     0B |   165B |      0    0B |   1 101.4
+    6      8.7KB |      9 7.4KB |      0     0 |  1.2KB     0B |  7.5KB |      0    0B |   1  1.00
+total      8.7KB |      9 7.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 108.6
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  7.5KB  1.3KB
+    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  7.5KB  2.4KB
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  7.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     18   15KB  1.3KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     18   15KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -713,7 +713,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |   7 (644B) |     0 (0B) |    21B | 100% (21B)
+   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -814,13 +814,13 @@ L6:
   000030:[c@15#0,SET-c@15#0,SET]
   000031:[c@14#0,SET-c@14#0,SET]
 Blob files:
-  B000012 physical:{000012 size:[92 (92B)] vals:[3 (3B)]}
-  B000014 physical:{000014 size:[92 (92B)] vals:[3 (3B)]}
-  B000016 physical:{000016 size:[92 (92B)] vals:[3 (3B)]}
-  B000018 physical:{000018 size:[92 (92B)] vals:[3 (3B)]}
-  B000020 physical:{000020 size:[92 (92B)] vals:[3 (3B)]}
-  B000022 physical:{000022 size:[92 (92B)] vals:[3 (3B)]}
-  B000024 physical:{000024 size:[92 (92B)] vals:[3 (3B)]}
+  B000012 physical:{000012 size:[177 (177B)] vals:[3 (3B)]}
+  B000014 physical:{000014 size:[177 (177B)] vals:[3 (3B)]}
+  B000016 physical:{000016 size:[177 (177B)] vals:[3 (3B)]}
+  B000018 physical:{000018 size:[177 (177B)] vals:[3 (3B)]}
+  B000020 physical:{000020 size:[177 (177B)] vals:[3 (3B)]}
+  B000022 physical:{000022 size:[177 (177B)] vals:[3 (3B)]}
+  B000024 physical:{000024 size:[177 (177B)] vals:[3 (3B)]}
 
 # We expect the ingested-as-flushable count to be three (one for each ingested
 # table). The unknown category in the iter category stats is because of a gap
@@ -833,26 +833,26 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      4.5KB |      6 4.5KB |      0     0 |     0B     0B |   211B |      3 2.2KB |   2 53.29
+    0      4.5KB |      6 4.5KB |      0     0 |     0B     0B |   211B |      3 2.2KB |   2 58.93
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      8.1KB |      9 7.4KB |      0     0 |   644B     0B |  7.5KB |      0    0B |   1  1.00
-total       13KB |     15  12KB |      0     0 |   644B     0B |  2.4KB |      3 2.2KB |   3  8.53
+    6      8.7KB |      9 7.4KB |      0     0 |  1.2KB     0B |  7.5KB |      0    0B |   1  1.00
+total       13KB |     15  12KB |      0     0 |  1.2KB     0B |  2.4KB |      3 2.2KB |   3  9.01
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     12  9.7KB  1.3KB
+    0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     12  9.7KB  2.4KB
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  7.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     21   20KB  1.3KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     21   20KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -872,7 +872,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |   7 (644B) |     0 (0B) |    21B | 100% (21B)
+   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -940,13 +940,13 @@ L6:
   000030:[c@15#0,SET-c@15#0,SET]
   000031:[c@14#0,SET-c@14#0,SET]
 Blob files:
-  B000012 physical:{000012 size:[92 (92B)] vals:[3 (3B)]}
-  B000014 physical:{000014 size:[92 (92B)] vals:[3 (3B)]}
-  B000016 physical:{000016 size:[92 (92B)] vals:[3 (3B)]}
-  B000018 physical:{000018 size:[92 (92B)] vals:[3 (3B)]}
-  B000020 physical:{000020 size:[92 (92B)] vals:[3 (3B)]}
-  B000022 physical:{000022 size:[92 (92B)] vals:[3 (3B)]}
-  B000024 physical:{000024 size:[92 (92B)] vals:[3 (3B)]}
+  B000012 physical:{000012 size:[177 (177B)] vals:[3 (3B)]}
+  B000014 physical:{000014 size:[177 (177B)] vals:[3 (3B)]}
+  B000016 physical:{000016 size:[177 (177B)] vals:[3 (3B)]}
+  B000018 physical:{000018 size:[177 (177B)] vals:[3 (3B)]}
+  B000020 physical:{000020 size:[177 (177B)] vals:[3 (3B)]}
+  B000022 physical:{000022 size:[177 (177B)] vals:[3 (3B)]}
+  B000024 physical:{000024 size:[177 (177B)] vals:[3 (3B)]}
 
 metrics
 ----
@@ -954,26 +954,26 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      9.8KB |     13 9.8KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 60.03
+    0      9.8KB |     13 9.8KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 64.32
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      8.1KB |      9 7.4KB |      0     0 |   644B     0B |  7.5KB |      0    0B |   1  1.00
-total       18KB |     22  17KB |      0     0 |   644B     0B |  2.5KB |      3 2.2KB |   3 10.43
+    6      8.7KB |      9 7.4KB |      0     0 |  1.2KB     0B |  7.5KB |      0    0B |   1  1.00
+total       18KB |     22  17KB |      0     0 |  1.2KB     0B |  2.5KB |      3 2.2KB |   3 10.89
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   15KB  1.3KB
+    0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   15KB  2.4KB
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  7.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     28   25KB  1.3KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     28   25KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -993,7 +993,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |   7 (644B) |     0 (0B) |    21B | 100% (21B)
+   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1058,13 +1058,13 @@ L6:
   000031:[c@14#0,SET-c@14#0,SET]
   000051:[z#33,SET-z#33,SET]
 Blob files:
-  B000012 physical:{000012 size:[92 (92B)] vals:[3 (3B)]}
-  B000014 physical:{000014 size:[92 (92B)] vals:[3 (3B)]}
-  B000016 physical:{000016 size:[92 (92B)] vals:[3 (3B)]}
-  B000018 physical:{000018 size:[92 (92B)] vals:[3 (3B)]}
-  B000020 physical:{000020 size:[92 (92B)] vals:[3 (3B)]}
-  B000022 physical:{000022 size:[92 (92B)] vals:[3 (3B)]}
-  B000024 physical:{000024 size:[92 (92B)] vals:[3 (3B)]}
+  B000012 physical:{000012 size:[177 (177B)] vals:[3 (3B)]}
+  B000014 physical:{000014 size:[177 (177B)] vals:[3 (3B)]}
+  B000016 physical:{000016 size:[177 (177B)] vals:[3 (3B)]}
+  B000018 physical:{000018 size:[177 (177B)] vals:[3 (3B)]}
+  B000020 physical:{000020 size:[177 (177B)] vals:[3 (3B)]}
+  B000022 physical:{000022 size:[177 (177B)] vals:[3 (3B)]}
+  B000024 physical:{000024 size:[177 (177B)] vals:[3 (3B)]}
 
 # There should be 2 backing tables. Note that tiny sstables have inaccurate
 # virtual sstable sizes.
@@ -1087,26 +1087,26 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0      8.2KB |     11 8.2KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 60.03
+    0      8.2KB |     11 8.2KB |      0     0 |     0B     0B |   277B |      3 2.2KB |   2 64.32
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6      8.8KB |     10 8.2KB |      0     0 |   644B     0B |  7.5KB |      1  765B |   1  1.00
-total       17KB |     21  16KB |      0     0 |   644B     0B |  3.3KB |      4   3KB |   3  8.27
+    6      9.4KB |     10 8.2KB |      0     0 |  1.2KB     0B |  7.5KB |      1  765B |   1  1.00
+total       18KB |     21  16KB |      0     0 |  1.2KB     0B |  3.3KB |      4   3KB |   3  8.62
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   15KB  1.3KB
+    0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   15KB  2.4KB
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  7.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     28   26KB  1.3KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     28   26KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -1126,7 +1126,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |   7 (644B) |     0 (0B) |    21B | 100% (21B)
+   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1136,7 +1136,7 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-             17KB |            0 (0B) |            0 (0B) |                 0 |                  0
+             18KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1193,13 +1193,13 @@ L6:
   000051:[z#33,SET-z#33,SET]
   000052:[zz#35,SET-zz#35,SET]
 Blob files:
-  B000012 physical:{000012 size:[92 (92B)] vals:[3 (3B)]}
-  B000014 physical:{000014 size:[92 (92B)] vals:[3 (3B)]}
-  B000016 physical:{000016 size:[92 (92B)] vals:[3 (3B)]}
-  B000018 physical:{000018 size:[92 (92B)] vals:[3 (3B)]}
-  B000020 physical:{000020 size:[92 (92B)] vals:[3 (3B)]}
-  B000022 physical:{000022 size:[92 (92B)] vals:[3 (3B)]}
-  B000024 physical:{000024 size:[92 (92B)] vals:[3 (3B)]}
+  B000012 physical:{000012 size:[177 (177B)] vals:[3 (3B)]}
+  B000014 physical:{000014 size:[177 (177B)] vals:[3 (3B)]}
+  B000016 physical:{000016 size:[177 (177B)] vals:[3 (3B)]}
+  B000018 physical:{000018 size:[177 (177B)] vals:[3 (3B)]}
+  B000020 physical:{000020 size:[177 (177B)] vals:[3 (3B)]}
+  B000022 physical:{000022 size:[177 (177B)] vals:[3 (3B)]}
+  B000024 physical:{000024 size:[177 (177B)] vals:[3 (3B)]}
 
 metrics-value
 num-backing
@@ -1236,13 +1236,13 @@ L6:
   000051:[z#33,SET-z#33,SET]
   000052:[zz#35,SET-zz#35,SET]
 Blob files:
-  B000012 physical:{000012 size:[92 (92B)] vals:[3 (3B)]}
-  B000014 physical:{000014 size:[92 (92B)] vals:[3 (3B)]}
-  B000016 physical:{000016 size:[92 (92B)] vals:[3 (3B)]}
-  B000018 physical:{000018 size:[92 (92B)] vals:[3 (3B)]}
-  B000020 physical:{000020 size:[92 (92B)] vals:[3 (3B)]}
-  B000022 physical:{000022 size:[92 (92B)] vals:[3 (3B)]}
-  B000024 physical:{000024 size:[92 (92B)] vals:[3 (3B)]}
+  B000012 physical:{000012 size:[177 (177B)] vals:[3 (3B)]}
+  B000014 physical:{000014 size:[177 (177B)] vals:[3 (3B)]}
+  B000016 physical:{000016 size:[177 (177B)] vals:[3 (3B)]}
+  B000018 physical:{000018 size:[177 (177B)] vals:[3 (3B)]}
+  B000020 physical:{000020 size:[177 (177B)] vals:[3 (3B)]}
+  B000022 physical:{000022 size:[177 (177B)] vals:[3 (3B)]}
+  B000024 physical:{000024 size:[177 (177B)] vals:[3 (3B)]}
 
 # Virtual sstables metrics should be gone after the compaction.
 metrics-value
@@ -1264,26 +1264,26 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-    0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 2.2KB |   0 60.03
+    0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 2.2KB |   0 64.32
     1         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     2         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     3         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     4         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
     5         0B |      0    0B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
-    6       15KB |     18  14KB |      0     0 |   644B     0B |   15KB |      2 1.5KB |   1  0.85
-total       15KB |     18  14KB |      0     0 |   644B     0B |    4KB |      5 3.7KB |   1  8.23
+    6       15KB |     18  14KB |      0     0 |  1.2KB     0B |   15KB |      2 1.5KB |   1  0.85
+total       15KB |     18  14KB |      0     0 |  1.2KB     0B |    4KB |      5 3.7KB |   1  8.52
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |     19   15KB  1.3KB
+    0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |     19   15KB  2.4KB
     1 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     2 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  2.2KB    0B |     16   13KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |     35   32KB  1.3KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |     35   32KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       3       0        0     0     0     0        0     0      0     0
@@ -1303,7 +1303,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |   7 (644B) |     0 (0B) |    21B | 100% (21B)
+   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot

--- a/tool/testdata/db_upgrade
+++ b/tool/testdata/db_upgrade
@@ -27,7 +27,7 @@ db get foo yellow
 db upgrade foo
 ----
 ----
-Upgrading DB from internal version 16 to 25.
+Upgrading DB from internal version 16 to 26.
 WARNING!!!
 This DB will not be usable with older versions of Pebble!
 
@@ -43,7 +43,7 @@ Continue? [Y/N] Error: EOF
 
 db upgrade foo --yes
 ----
-Upgrading DB from internal version 16 to 25.
+Upgrading DB from internal version 16 to 26.
 Upgrade complete.
 
 db get foo blue
@@ -56,4 +56,4 @@ db get foo yellow
 
 db upgrade foo
 ----
-DB is already at internal version 25.
+DB is already at internal version 26.

--- a/value_separation.go
+++ b/value_separation.go
@@ -61,7 +61,7 @@ func (d *DB) determineCompactionValueSeparation(
 				jobID, c.kind, c.outputLevel.level, &c.metrics.bytesWritten, c.objCreateOpts)
 		},
 		shortAttrExtractor: d.opts.Experimental.ShortAttributeExtractor,
-		writerOpts:         d.opts.MakeBlobWriterOptions(c.outputLevel.level),
+		writerOpts:         d.opts.MakeBlobWriterOptions(c.outputLevel.level, d.BlobFileFormat()),
 		minimumSize:        policy.MinimumSize,
 		globalMinimumSize:  policy.MinimumSize,
 		invalidValueCallback: func(userKey []byte, value []byte, err error) {


### PR DESCRIPTION
We extend the blob file format by adding a new V2 footer which encodes
a properties block handle. The V2 footer precedes the V1 footer when
the version in that footer is >= 2. The properties block contains a
key/value for compression statistics.