### PR TITLE
manifest: improve API around TableStats

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2810,9 +2810,11 @@ func (d *DB) runCopyCompaction(
 		SmallestSeqNum:           inputMeta.SmallestSeqNum,
 		LargestSeqNum:            inputMeta.LargestSeqNum,
 		LargestSeqNumAbsolute:    inputMeta.LargestSeqNumAbsolute,
-		Stats:                    inputMeta.Stats,
 		Virtual:                  inputMeta.Virtual,
 		SyntheticPrefixAndSuffix: inputMeta.SyntheticPrefixAndSuffix,
+	}
+	if inputStats, ok := inputMeta.Stats(); ok {
+		newMeta.PopulateStats(inputStats)
 	}
 	if inputMeta.HasPointKeys {
 		newMeta.ExtendPointKeyBounds(c.comparer.Compare,

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3390,18 +3390,17 @@ func TestTombstoneDensityCompactionMoveOptimization(t *testing.T) {
 	meta := &manifest.TableMetadata{
 		TableNum: 1,
 		Size:     1024,
-		Stats: manifest.TableStats{
-			NumEntries:                10,
-			NumDeletions:              8,
-			TombstoneDenseBlocksRatio: 0.9, // Above threshold
-		},
 	}
+	meta.PopulateStats(&manifest.TableStats{
+		NumEntries:                10,
+		NumDeletions:              8,
+		TombstoneDenseBlocksRatio: 0.9, // Above threshold
+	})
 	meta.ExtendPointKeyBounds(opts.Comparer.Compare,
 		base.ParseInternalKey("a.SET.1"),
 		base.ParseInternalKey("z.SET.2"),
 	)
 	meta.InitPhysicalBacking()
-	meta.StatsMarkValid()
 
 	// Set up the version: L4 has the file, L5 and L6 are empty.
 	var files [numLevels][]*manifest.TableMetadata
@@ -3490,18 +3489,17 @@ func TestTombstoneDensityCompactionMoveOptimization_NoMoveWithOverlap(t *testing
 	metaL4 := &manifest.TableMetadata{
 		TableNum: 1,
 		Size:     1024,
-		Stats: manifest.TableStats{
-			NumEntries:                10,
-			NumDeletions:              8,
-			TombstoneDenseBlocksRatio: 0.9, // Above threshold
-		},
 	}
+	metaL4.PopulateStats(&manifest.TableStats{
+		NumEntries:                10,
+		NumDeletions:              8,
+		TombstoneDenseBlocksRatio: 0.9, // Above threshold
+	})
 	metaL4.ExtendPointKeyBounds(opts.Comparer.Compare,
 		base.ParseInternalKey("a.SET.1"),
 		base.ParseInternalKey("z.SET.2"),
 	)
 	metaL4.InitPhysicalBacking()
-	metaL4.StatsMarkValid()
 
 	// Create an overlapping file in L5.
 	metaL5 := &manifest.TableMetadata{
@@ -3513,7 +3511,7 @@ func TestTombstoneDensityCompactionMoveOptimization_NoMoveWithOverlap(t *testing
 		base.ParseInternalKey("z.SET.3"),
 	)
 	metaL5.InitPhysicalBacking()
-	metaL5.StatsMarkValid()
+	metaL5.PopulateStats(&manifest.TableStats{})
 
 	// Set up the version: L4 has metaL4, L5 has metaL5.
 	var files [numLevels][]*manifest.TableMetadata
@@ -3571,18 +3569,17 @@ func TestTombstoneDensityCompactionMoveOptimization_GrandparentOverlapTooLarge(t
 	metaL4 := &manifest.TableMetadata{
 		TableNum: 1,
 		Size:     1024,
-		Stats: manifest.TableStats{
-			NumEntries:                10,
-			NumDeletions:              8,
-			TombstoneDenseBlocksRatio: 0.9,
-		},
 	}
+	metaL4.PopulateStats(&manifest.TableStats{
+		NumEntries:                10,
+		NumDeletions:              8,
+		TombstoneDenseBlocksRatio: 0.9,
+	})
 	metaL4.ExtendPointKeyBounds(opts.Comparer.Compare,
 		base.ParseInternalKey("a.SET.1"),
 		base.ParseInternalKey("z.SET.2"),
 	)
 	metaL4.InitPhysicalBacking()
-	metaL4.StatsMarkValid()
 
 	// Large overlapping file in L6 (grandparent level).
 	metaL6 := &manifest.TableMetadata{
@@ -3594,7 +3591,7 @@ func TestTombstoneDensityCompactionMoveOptimization_GrandparentOverlapTooLarge(t
 		base.ParseInternalKey("z.SET.3"),
 	)
 	metaL6.InitPhysicalBacking()
-	metaL6.StatsMarkValid()
+	metaL6.PopulateStats(&manifest.TableStats{})
 
 	var files [numLevels][]*manifest.TableMetadata
 	files[inputLevel] = []*manifest.TableMetadata{metaL4}
@@ -3634,18 +3631,17 @@ func TestTombstoneDensityCompactionMoveOptimization_BelowDensityThreshold(t *tes
 	meta := &manifest.TableMetadata{
 		TableNum: 1,
 		Size:     1024,
-		Stats: manifest.TableStats{
-			NumEntries:                10,
-			NumDeletions:              5,
-			TombstoneDenseBlocksRatio: 0.5, // Below threshold
-		},
 	}
+	meta.PopulateStats(&manifest.TableStats{
+		NumEntries:                10,
+		NumDeletions:              5,
+		TombstoneDenseBlocksRatio: 0.5, // Below threshold
+	})
 	meta.ExtendPointKeyBounds(opts.Comparer.Compare,
 		base.ParseInternalKey("a.SET.1"),
 		base.ParseInternalKey("z.SET.2"),
 	)
 	meta.InitPhysicalBacking()
-	meta.StatsMarkValid()
 
 	var files [numLevels][]*manifest.TableMetadata
 	files[inputLevel] = []*manifest.TableMetadata{meta}

--- a/db.go
+++ b/db.go
@@ -2350,13 +2350,11 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 					continue
 				}
 			}
-			var tableStats manifest.TableStats
-			if m.StatsValid() {
-				tableStats = m.Stats
-			}
 			destTables[j] = SSTableInfo{
-				TableInfo:  m.TableInfo(),
-				TableStats: tableStats,
+				TableInfo: m.TableInfo(),
+			}
+			if stats, ok := m.Stats(); ok {
+				destTables[j].TableStats = *stats
 			}
 			if opt.withProperties {
 				p, err := d.fileCache.getTableProperties(

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -358,7 +358,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 		base.MakeInternalKey([]byte{'a'}, seqNumA, InternalKeyKindSet))
 	v1.ExtendPointKeyBounds(DefaultComparer.Compare, v1.PointKeyBounds.Smallest(), v1.PointKeyBounds.Largest())
 	v1.AttachVirtualBacking(parentFile.TableBacking)
-	v1.Stats.NumEntries = 1
+	v1.PopulateStats(&manifest.TableStats{NumEntries: 1})
 
 	v2 := &manifest.TableMetadata{
 		TableNum:              f2,
@@ -378,7 +378,7 @@ func TestVirtualReadsWiring(t *testing.T) {
 		base.MakeInternalKey([]byte{'k'}, seqNumRangeUnset, InternalKeyKindRangeKeyUnset))
 	v2.ExtendPointKeyBounds(DefaultComparer.Compare, v2.PointKeyBounds.Smallest(), v2.PointKeyBounds.Largest())
 	v2.AttachVirtualBacking(parentFile.TableBacking)
-	v2.Stats.NumEntries = 6
+	v2.PopulateStats(&manifest.TableStats{NumEntries: 6})
 
 	v1.PointKeyBounds.SetInternalKeyBounds(v1.Smallest(), v1.Largest())
 

--- a/internal/manifest/table_metadata_test.go
+++ b/internal/manifest/table_metadata_test.go
@@ -148,7 +148,7 @@ func TestTableMetadataSize(t *testing.T) {
 	}
 	structSize := unsafe.Sizeof(TableMetadata{})
 
-	const tableMetadataSize = 352
+	const tableMetadataSize = 344
 	if structSize != tableMetadataSize {
 		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableMetadataSize)

--- a/testdata/compaction_picker_target_level
+++ b/testdata/compaction_picker_target_level
@@ -1096,11 +1096,11 @@ L0->L5: 5.0
   000010:[0001#10,SET-0001#10,SET] marked as compacting
   500001:[0001#1,SET-0001#1,SET] marked as compacting
 L5->L6: 10.8
-  500005:[0005#5,SET-0005#5,SET] marked as compacting
-  600005:[0005#5,SET-0005#5,SET] marked as compacting
-L5->L6: 8.4
   500002:[0002#2,SET-0002#2,SET] marked as compacting
   600002:[0002#2,SET-0002#2,SET] marked as compacting
+L5->L6: 8.4
+  500003:[0003#3,SET-0003#3,SET] marked as compacting
+  600003:[0003#3,SET-0003#3,SET] marked as compacting
 
 init l-base-max-bytes=5 compaction-debt-concurrency=10
 0: 10
@@ -1363,14 +1363,14 @@ L0->L5: 4.4
   000007:[0001#7,SET-0001#7,SET] marked as compacting
   500001:[0001#1,SET-0001#1,SET] marked as compacting
 L5->L6: 6.6
-  500004:[0004#4,SET-0004#4,SET] marked as compacting
-  600004:[0004#4,SET-0004#4,SET] marked as compacting
-L5->L6: 5.0
   500002:[0002#2,SET-0002#2,SET] marked as compacting
   600002:[0002#2,SET-0002#2,SET] marked as compacting
-L5->L6: 3.9
+L5->L6: 5.0
   500003:[0003#3,SET-0003#3,SET] marked as compacting
   600003:[0003#3,SET-0003#3,SET] marked as compacting
+L5->L6: 3.9
+  500004:[0004#4,SET-0004#4,SET] marked as compacting
+  600004:[0004#4,SET-0004#4,SET] marked as compacting
 
 # The compaction concurrency is 4 since 3/11 = 0.27 fraction of the DB is
 # garbage.


### PR DESCRIPTION
Using `TableMetadata.TableStats` is very fragile; any code that uses
it must first check that the stats are valid. Code that doesn't do so
relies on subtle higher level synchronization assumptions.

We improve this with a simple change: we unexport the stats and add an
getter which only returns the `*TableStats` if they have been
populated, and a setter with can be called at most once.

All access through these methods is safe (without assumptions about
any external locks), as long as we populate the stats only once.