### PR TITLE
go.mod: require go1.24

### DIFF
--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.23', '1.24' ]
+        go: [ '1.24' ]
     uses: ./.github/workflows/tests.yaml
     with:
       sha: ${{ github.sha }}
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.23', '1.24' ]
+        go: [ '1.24' ]
     uses: ./.github/workflows/s390x.yaml
     with:
       sha: ${{ github.sha }}
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.23', '1.24' ]
+        go: [ '1.24' ]
     uses: ./.github/workflows/stress.yaml
     with:
       sha: ${{ github.sha }}
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.23', '1.24' ]
+        go: [ '1.24' ]
     uses: ./.github/workflows/instrumented.yaml
     with:
       sha: ${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ stress-crossversion:
 
 .PHONY: test-s390x-qemu
 test-s390x-qemu: TAGS += slowbuild
-test-s390x-qemu: S390X_GOVERSION := 1.23
+test-s390x-qemu: S390X_GOVERSION := 1.24
 test-s390x-qemu:
 	@echo "Running tests on s390x using QEMU"
 	@echo "Requires a recent linux with docker and qemu-user-static installed"

--- a/go.mod
+++ b/go.mod
@@ -53,4 +53,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.23
+go 1.24.5

--- a/internal/devtools/go.mod
+++ b/internal/devtools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/pebble/internal/devtools
 
-go 1.23.6
+go 1.24.5
 
 require (
 	github.com/cockroachdb/cockroach v0.0.0-20250225003441-0fd08b1c5cc1


### PR DESCRIPTION
Cockroach now uses 1.24.5; change go.mod to use the same version and
stop testing nightlies on 1.23.