### PR TITLE
db: remove EnableColumnarBlocks option

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -45,7 +45,6 @@ func testCheckpointImpl(t *testing.T, ddFile string, createOnShared bool) {
 			DisableAutomaticCompactions: true,
 			Logger:                      testLogger{t},
 		}
-		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": remoteMem,
 		})

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -76,9 +76,6 @@ func newPebbleDB(dir string) DB {
 			return 1, 3
 		},
 	}
-	// In FormatColumnarBlocks (the value of FormatNewest at the time of
-	// writing), columnar blocks are only written if explicitly opted into.
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	// Enable value separation. Note the minimum size of 512 means that only the
 	// variant of the ycsb benchmarks that uses 1024 values will result in any
 	// value separation.

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1321,7 +1321,6 @@ func TestCompactionPickerPickFile(t *testing.T) {
 		FormatMajorVersion: FormatNewest,
 		FS:                 fs,
 	}
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 
 	d, err := Open("", opts)
@@ -1465,7 +1464,6 @@ func TestCompactionPickerScores(t *testing.T) {
 		FormatMajorVersion:          FormatNewest,
 		FS:                          fs,
 	}
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 
 	d, err := Open("", opts)

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -924,7 +924,6 @@ func TestCompaction(t *testing.T) {
 			FormatMajorVersion:          randVersion(minVersion, maxVersion),
 		}
 		opts.WithFSDefaults()
-		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 
 		var err error
@@ -1027,7 +1026,6 @@ func TestCompaction(t *testing.T) {
 					DisableAutomaticCompactions: true,
 				}
 				opts.WithFSDefaults()
-				opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 				opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 				if d != nil {
 					opts.CompactionConcurrencyRange = d.opts.CompactionConcurrencyRange
@@ -1592,7 +1590,6 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 		}
 		opts.WithFSDefaults()
 		opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool { return true }
-		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		return opts, nil
 	}
 
@@ -1902,7 +1899,6 @@ func TestCompactionTombstones(t *testing.T) {
 				}
 				opts.WithFSDefaults()
 				opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool { return true }
-				opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 				opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 				var err error
 				d, err = runDBDefineCmd(td, opts)
@@ -2761,7 +2757,6 @@ func TestMarkedForCompaction(t *testing.T) {
 		},
 	}
 	opts.WithFSDefaults()
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 
 	reset := func() {
 		if d != nil {
@@ -3382,7 +3377,6 @@ func TestTombstoneDensityCompactionMoveOptimization(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Experimental.TombstoneDenseCompactionThreshold = 0.5 // Lower for test
 	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	opts.WithFSDefaults()
 
@@ -3481,7 +3475,6 @@ func TestTombstoneDensityCompactionMoveOptimization_NoMoveWithOverlap(t *testing
 	opts := DefaultOptions()
 	opts.Experimental.TombstoneDenseCompactionThreshold = 0.5 // Lower for test
 	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	opts.WithFSDefaults()
 
@@ -3561,7 +3554,6 @@ func TestTombstoneDensityCompactionMoveOptimization_GrandparentOverlapTooLarge(t
 	opts := DefaultOptions()
 	opts.Experimental.TombstoneDenseCompactionThreshold = 0.5
 	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	opts.WithFSDefaults()
 
@@ -3624,7 +3616,6 @@ func TestTombstoneDensityCompactionMoveOptimization_BelowDensityThreshold(t *tes
 	opts := DefaultOptions()
 	opts.Experimental.TombstoneDenseCompactionThreshold = 0.9 // Set high threshold
 	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	opts.WithFSDefaults()
 
@@ -3672,7 +3663,6 @@ func TestTombstoneDensityCompactionMoveOptimization_InvalidStats(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Experimental.TombstoneDenseCompactionThreshold = 0.5
 	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	opts.WithFSDefaults()
 

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -77,7 +77,6 @@ func TestEventListener(t *testing.T) {
 				L0CompactionThreshold: 10,
 				WALDir:                "wal",
 			}
-			opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 			var err error
 			d, err = Open("db", opts)
 			if err != nil {

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -28,7 +28,6 @@ func TestExternalIterator(t *testing.T) {
 		FormatMajorVersion: internalFormatNewest,
 		Comparer:           testkeys.Comparer,
 	}
-	o.Experimental.EnableColumnarBlocks = func() bool { return true }
 	o.testingRandomized(t)
 	o.EnsureDefaults()
 	d, err := Open("", o)

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -428,19 +428,13 @@ func (d *DB) TableFormat() sstable.TableFormat {
 	// The table is typically written at the maximum allowable format implied by
 	// the current format major version of the DB.
 	f := d.FormatMajorVersion().MaxTableFormat()
-	switch f {
-	case sstable.TableFormatPebblev3:
+	if f == sstable.TableFormatPebblev3 {
 		// In format major versions with maximum table formats of Pebblev3,
 		// value blocks were conditional on an experimental setting. In format
 		// major versions with maximum table formats of Pebblev4 and higher,
 		// value blocks are always enabled.
 		if d.opts.Experimental.EnableValueBlocks == nil || !d.opts.Experimental.EnableValueBlocks() {
 			f = sstable.TableFormatPebblev2
-		}
-	default:
-		if f.BlockColumnar() && (d.opts.Experimental.EnableColumnarBlocks == nil ||
-			!d.opts.Experimental.EnableColumnarBlocks()) {
-			f = sstable.TableFormatPebblev4
 		}
 	}
 	return f

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -266,69 +266,39 @@ func TestFormatMajorVersions_BlobFileFormat(t *testing.T) {
 	require.Panics(t, func() { _ = (FormatValueSeparation - 1).MaxBlobFileFormat() })
 }
 
-// TestFormatMajorVersions_ColumnarBlocks ensures that
-// Experimental.EnableColumnarBlocks is respected on recent format major
-// versions.
-func TestFormatMajorVersions_ColumnarBlocks(t *testing.T) {
+func TestFormatMajorVersions_MaxTableFormat(t *testing.T) {
 	type testCase struct {
-		fmv     FormatMajorVersion
-		colBlks bool
-		want    sstable.TableFormat
+		fmv  FormatMajorVersion
+		want sstable.TableFormat
 	}
 	testCases := []testCase{
 		{
-			fmv:     FormatTableFormatV6,
-			colBlks: true,
-			want:    sstable.TableFormatPebblev6,
+			fmv:  FormatTableFormatV6,
+			want: sstable.TableFormatPebblev6,
 		},
 		{
-			fmv:     FormatTableFormatV6,
-			colBlks: false,
-			want:    sstable.TableFormatPebblev4,
+			fmv:  FormatColumnarBlocks,
+			want: sstable.TableFormatPebblev5,
 		},
 		{
-			fmv:     FormatColumnarBlocks,
-			colBlks: true,
-			want:    sstable.TableFormatPebblev5,
+			fmv:  FormatFlushableIngestExcises,
+			want: sstable.TableFormatPebblev4,
 		},
 		{
-			fmv:     FormatColumnarBlocks,
-			colBlks: false,
-			want:    sstable.TableFormatPebblev4,
+			fmv:  formatDeprecatedExperimentalValueSeparation,
+			want: sstable.TableFormatPebblev6,
 		},
 		{
-			fmv:     FormatFlushableIngestExcises,
-			colBlks: true,
-			want:    sstable.TableFormatPebblev4,
-		},
-		{
-			fmv:     FormatNewest,
-			colBlks: false,
-			want:    sstable.TableFormatPebblev4,
-		},
-		{
-			fmv:     formatDeprecatedExperimentalValueSeparation,
-			colBlks: true,
-			want:    sstable.TableFormatPebblev6,
-		},
-		{
-			fmv:     formatDeprecatedExperimentalValueSeparation,
-			colBlks: false,
-			want:    sstable.TableFormatPebblev4,
-		},
-		{
-			fmv:     FormatNewest,
-			colBlks: true,
-			want:    sstable.TableFormatPebblev7,
+			fmv:  FormatNewest,
+			want: sstable.TableFormatPebblev7,
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("(%s,%t)", tc.fmv, tc.colBlks), func(t *testing.T) {
+		t.Run(tc.fmv.String(), func(t *testing.T) {
 			opts := &Options{
 				FS:                 vfs.NewMem(),
 				FormatMajorVersion: tc.fmv,
 			}
-			opts.Experimental.EnableColumnarBlocks = func() bool { return tc.colBlks }
 			d, err := Open("", opts)
 			require.NoError(t, err)
 			defer func() { _ = d.Close() }()

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -500,7 +500,6 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 			Logger:                      testLogger{t},
 		}
 		opts.WithFSDefaults()
-		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		if testing.Verbose() {
 			lel := MakeLoggingEventListener(DefaultLogger)
 			opts.EventListener = &lel
@@ -1172,7 +1171,6 @@ func TestIngestExternal(t *testing.T) {
 			FormatMajorVersion: majorVersion,
 			Logger:             testLogger{t},
 		}
-		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"external-locator": remoteStorage,
 		})
@@ -1702,7 +1700,6 @@ func TestIngest(t *testing.T) {
 			}},
 			FormatMajorVersion: internalFormatNewest,
 		}
-		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		opts.Experimental.IngestSplit = func() bool {
 			return split
 		}

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -53,7 +53,6 @@ func TestIterHistories(t *testing.T) {
 				},
 				Logger: testLogger{t},
 			}
-			opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 			opts.DisableAutomaticCompactions = true
 			opts.EnsureDefaults()
 			opts.WithFSDefaults()

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -614,7 +614,6 @@ func TestIteratorStats(t *testing.T) {
 		opts := &Options{Comparer: testkeys.Comparer, FS: mem, FormatMajorVersion: internalFormatNewest}
 		// Automatic compactions may make some testcases non-deterministic.
 		opts.DisableAutomaticCompactions = true
-		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		var err error
 		d, err = Open("", opts)
 		require.NoError(t, err)

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -336,7 +336,6 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 	}
 	opts.Levels[0].FilterPolicy = bloom.FilterPolicy(10)
 	opts.Experimental.IngestSplit = func() bool { return false }
-	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 
 	opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 		return pebble.ValueSeparationPolicy{

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -227,7 +227,6 @@ func TestMetrics(t *testing.T) {
 			MaxOpenFiles: 10000,
 		}
 		opts.Experimental.EnableValueBlocks = func() bool { return true }
-		opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 		opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 			return ValueSeparationPolicy{
 				Enabled:               true,

--- a/options.go
+++ b/options.go
@@ -700,14 +700,6 @@ type Options struct {
 		// level to a conventional two level compaction.
 		MultiLevelCompactionHeuristic func() MultiLevelHeuristic
 
-		// EnableColumnarBlocks is used to decide whether to enable writing
-		// TableFormatPebblev5 sstables. This setting is only respected by
-		// FormatColumnarBlocks. In lower format major versions, the
-		// TableFormatPebblev5 format is prohibited. If EnableColumnarBlocks is
-		// nil and the DB is at FormatColumnarBlocks, the DB defaults to not
-		// writing columnar blocks.
-		EnableColumnarBlocks func() bool
-
 		// EnableValueBlocks is used to decide whether to enable writing
 		// TableFormatPebblev3 sstables. This setting is only respected by a
 		// specific subset of format major versions: FormatSSTableValueBlocks,
@@ -1588,9 +1580,6 @@ func (o *Options) EnsureDefaults() {
 	if o.Experimental.DeletionSizeRatioThreshold == 0 {
 		o.Experimental.DeletionSizeRatioThreshold = sstable.DefaultDeletionSizeRatioThreshold
 	}
-	if o.Experimental.EnableColumnarBlocks == nil {
-		o.Experimental.EnableColumnarBlocks = func() bool { return true }
-	}
 	if o.Experimental.TombstoneDenseCompactionThreshold == 0 {
 		o.Experimental.TombstoneDenseCompactionThreshold = 0.10
 	}
@@ -1699,9 +1688,6 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  disable_wal=%t\n", o.DisableWAL)
 	if o.Experimental.DisableIngestAsFlushable != nil && o.Experimental.DisableIngestAsFlushable() {
 		fmt.Fprintf(&buf, "  disable_ingest_as_flushable=%t\n", true)
-	}
-	if o.Experimental.EnableColumnarBlocks != nil && o.Experimental.EnableColumnarBlocks() {
-		fmt.Fprintf(&buf, "  enable_columnar_blocks=%t\n", true)
 	}
 	fmt.Fprintf(&buf, "  flush_delay_delete_range=%s\n", o.FlushDelayDeleteRange)
 	fmt.Fprintf(&buf, "  flush_delay_range_key=%s\n", o.FlushDelayRangeKey)
@@ -1997,10 +1983,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "disable_wal":
 				o.DisableWAL, err = strconv.ParseBool(value)
 			case "enable_columnar_blocks":
-				var v bool
-				if v, err = strconv.ParseBool(value); err == nil {
-					o.Experimental.EnableColumnarBlocks = func() bool { return v }
-				}
+				// Do nothing; option existed in older versions of pebble.
 			case "flush_delay_delete_range":
 				o.FlushDelayDeleteRange, err = time.ParseDuration(value)
 			case "flush_delay_range_key":

--- a/options_test.go
+++ b/options_test.go
@@ -40,10 +40,6 @@ func (o *Options) testingRandomized(t testing.TB) *Options {
 		o.FormatMajorVersion = FormatMinSupported + FormatMajorVersion(n)
 		t.Logf("Running %s with format major version %s", t.Name(), o.FormatMajorVersion.String())
 	}
-	// Enable columnar blocks if using a format major version that supports it.
-	if o.FormatMajorVersion >= FormatColumnarBlocks && o.Experimental.EnableColumnarBlocks == nil && rand.Int64N(4) > 0 {
-		o.Experimental.EnableColumnarBlocks = func() bool { return true }
-	}
 	// Enable value separation if using a format major version that supports it.
 	if o.FormatMajorVersion >= FormatValueSeparation && o.Experimental.ValueSeparationPolicy == nil && rand.Int64N(4) > 0 {
 		policy := ValueSeparationPolicy{
@@ -105,7 +101,6 @@ func TestDefaultOptionsString(t *testing.T) {
   compaction_garbage_fraction_for_max_concurrency=0.40
   comparer=leveldb.BytewiseComparator
   disable_wal=false
-  enable_columnar_blocks=true
   flush_delay_delete_range=0s
   flush_delay_range_key=0s
   flush_split_bytes=4194304

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -11,7 +11,7 @@ tree
      508      000007.sst
        0      LOCK
      133      MANIFEST-000001
-    2799      OPTIONS-000003
+    2769      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000001.MANIFEST-000001
             simple/
@@ -21,7 +21,7 @@ tree
       25        000004.log
      480        000005.sst
       85        MANIFEST-000001
-    2799        OPTIONS-000003
+    2769        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -39,7 +39,6 @@ cat build/OPTIONS-000003
   compaction_garbage_fraction_for_max_concurrency=0.40
   comparer=pebble.internal.testkeys
   disable_wal=false
-  enable_columnar_blocks=true
   flush_delay_delete_range=0s
   flush_delay_range_key=0s
   flush_split_bytes=4194304

--- a/replay/testdata/replay_ingest
+++ b/replay/testdata/replay_ingest
@@ -12,7 +12,7 @@ tree
        0      LOCK
      172      MANIFEST-000001
      209      MANIFEST-000008
-    2800      OPTIONS-000003
+    2770      OPTIONS-000003
        0      marker.format-version.000012.025
        0      marker.manifest.000002.MANIFEST-000008
             simple_ingest/
@@ -25,7 +25,7 @@ tree
      678        000004.sst
      661        000005.sst
      172        MANIFEST-000001
-    2800        OPTIONS-000003
+    2770        OPTIONS-000003
        0        marker.format-version.000001.025
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -43,7 +43,6 @@ cat build/OPTIONS-000003
   compaction_garbage_fraction_for_max_concurrency=0.40
   comparer=pebble.internal.testkeys
   disable_wal=false
-  enable_columnar_blocks=true
   flush_delay_delete_range=0s
   flush_delay_range_key=0s
   flush_split_bytes=4194304

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -14,7 +14,7 @@ tree
        0      LOCK
      133      MANIFEST-000001
      205      MANIFEST-000010
-    2799      OPTIONS-000003
+    2769      OPTIONS-000003
        0      marker.format-version.000001.013
        0      marker.manifest.000002.MANIFEST-000010
             high_read_amp/
@@ -26,7 +26,7 @@ tree
       39        000008.log
      454        000009.sst
      157        MANIFEST-000010
-    2799        OPTIONS-000003
+    2769        OPTIONS-000003
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000010
 

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -17,7 +17,7 @@ tree
        0      LOCK
      152      MANIFEST-000010
      250      MANIFEST-000013
-    2936      OPTIONS-000003
+    2906      OPTIONS-000003
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
@@ -32,7 +32,7 @@ tree
       64        000011.log
      660        000012.sst
      187        MANIFEST-000013
-    2936        OPTIONS-000003
+    2906        OPTIONS-000003
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013
 
@@ -53,7 +53,6 @@ cat build/OPTIONS-000003
   compaction_garbage_fraction_for_max_concurrency=0.40
   comparer=pebble.internal.testkeys
   disable_wal=false
-  enable_columnar_blocks=true
   flush_delay_delete_range=0s
   flush_delay_range_key=0s
   flush_split_bytes=4194304

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -163,7 +163,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.6KB
+3.5KB
 
 batch
 set b 2
@@ -265,7 +265,7 @@ Iter category stats:
 
 disk-usage
 ----
-5.7KB
+5.6KB
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -514,7 +514,7 @@ Iter category stats:
 
 disk-usage
 ----
-4.4KB
+4.3KB
 
 additional-metrics
 ----


### PR DESCRIPTION
Remove the ability to disable columnar blocks; columnar blocks are now always enabled on a sufficiently high format major version.