### PR TITLE
strparse: add (*Parser).Offset

### DIFF
--- a/internal/strparse/strparse_test.go
+++ b/internal/strparse/strparse_test.go
@@ -1,0 +1,53 @@
+// Copyright 2024 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package strparse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserOffsets(t *testing.T) {
+	tests := []struct {
+		sep   string
+		input string
+		want  []token
+	}{
+		{sep: "|", input: "a   |  b   |c",
+			want: []token{
+				{tok: "a", offset: 0},
+				{tok: "|", offset: 4},
+				{tok: "b", offset: 7},
+				{tok: "|", offset: 11},
+				{tok: "c", offset: 12},
+			},
+		},
+		{sep: "|", input: "a|b|c",
+			want: []token{
+				{tok: "a", offset: 0},
+				{tok: "|", offset: 1},
+				{tok: "b", offset: 2},
+				{tok: "|", offset: 3},
+				{tok: "c", offset: 4},
+			},
+		},
+		{sep: "()", input: "a    (   (  b )            ) c       ",
+			want: []token{
+				{tok: "a", offset: 0},
+				{tok: "(", offset: 5},
+				{tok: "(", offset: 9},
+				{tok: "b", offset: 12},
+				{tok: ")", offset: 14},
+				{tok: ")", offset: 27},
+				{tok: "c", offset: 29},
+			},
+		},
+	}
+	for _, test := range tests {
+		p := MakeParser(test.sep, test.input)
+		require.Equal(t, test.want, p.tokens)
+	}
+}


### PR DESCRIPTION
Add an Offset method to the strparse Parser to allow the retrieval of the next token's byte offset within the original input string.

Additionally, add a ExpectAll func allowing a caller to expect a variable-length token of a set of characters indicated by a predicate.