### PR TITLE
block,cache: trace and stats for wait duration (for concurrent reads)

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
-	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/cockroachdb/pebble/wal"
@@ -1493,7 +1492,7 @@ func (t *testTracer) IsTracingEnabled(ctx context.Context) bool {
 }
 
 func TestTracing(t *testing.T) {
-	defer block.DeterministicReadBlockDurationForTesting()()
+	defer base.DeterministicReadDurationForTesting()()
 
 	var tracer testTracer
 	buf := &tracer.buf

--- a/internal/base/stopwatch.go
+++ b/internal/base/stopwatch.go
@@ -1,0 +1,43 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import (
+	"time"
+
+	"github.com/cockroachdb/crlib/crtime"
+)
+
+// DeterministicReadDurationForTesting is for tests that want a deterministic
+// value of the time to read (that is not in the cache). The return value is a
+// function that must be called before the test exits.
+func DeterministicReadDurationForTesting() func() {
+	drbdForTesting := deterministicReadDurationForTesting
+	deterministicReadDurationForTesting = true
+	return func() {
+		deterministicReadDurationForTesting = drbdForTesting
+	}
+}
+
+var deterministicReadDurationForTesting = false
+
+type deterministicStopwatchForTesting struct {
+	startTime crtime.Mono
+}
+
+func MakeStopwatch() deterministicStopwatchForTesting {
+	return deterministicStopwatchForTesting{startTime: crtime.NowMono()}
+}
+
+func (w deterministicStopwatchForTesting) Stop() time.Duration {
+	dur := w.startTime.Elapsed()
+	if deterministicReadDurationForTesting {
+		dur = SlowReadTracingThreshold
+	}
+	return dur
+}
+
+// TODO(sumeer): should the threshold be configurable.
+const SlowReadTracingThreshold = 5 * time.Millisecond

--- a/internal/cache/read_shard_test.go
+++ b/internal/cache/read_shard_test.go
@@ -254,7 +254,7 @@ func TestReadShardConcurrent(t *testing.T) {
 	for _, r := range differentReaders {
 		for j := 0; j < r.numReaders; j++ {
 			go func(r *testSyncReaders, index int) {
-				v, rh, _, _, err := r.handle.GetWithReadHandle(context.Background(), r.fileNum, r.offset)
+				v, rh, _, _, _, err := r.handle.GetWithReadHandle(context.Background(), r.fileNum, r.offset)
 				require.NoError(t, err)
 				if v != nil {
 					require.Equal(t, r.val, v.RawBuffer())

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -195,7 +195,7 @@ func TestMetrics(t *testing.T) {
 	if runtime.GOARCH == "386" {
 		t.Skip("skipped on 32-bit due to slightly varied output")
 	}
-	defer block.DeterministicReadBlockDurationForTesting()()
+	defer base.DeterministicReadDurationForTesting()()
 
 	var d *DB
 	var iters map[string]*Iterator

--- a/sstable/block/category_stats.go
+++ b/sstable/block/category_stats.go
@@ -161,7 +161,10 @@ type CategoryStats struct {
 	// cache.
 	BlockBytesInCache uint64
 	// BlockReadDuration is the total duration to read the bytes not in the
-	// cache, i.e., BlockBytes-BlockBytesInCache.
+	// cache, i.e., BlockBytes-BlockBytesInCache. When multiple concurrent
+	// readers wait for each other, and only one does the read, this will
+	// account for the total time spent waiting plus potentially reading for all
+	// those readers, so it can over count. Such over counting should be rare.
 	BlockReadDuration time.Duration
 }
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -157,7 +157,7 @@ on disk bytes |  36B     76B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
 ----
 ----
 
@@ -258,7 +258,7 @@ on disk bytes | 230B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -342,7 +342,7 @@ on disk bytes | 230B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -423,7 +423,7 @@ on disk bytes | 230B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -507,7 +507,7 @@ on disk bytes | 230B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -630,7 +630,7 @@ on disk bytes | 622B    630B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -738,7 +738,7 @@ on disk bytes | 622B    615B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -897,7 +897,7 @@ on disk bytes |  1KB    843B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1018,7 +1018,7 @@ on disk bytes | 1.3KB   1.3KB
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1151,7 +1151,7 @@ on disk bytes | 1.3KB   1.2KB
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1328,7 +1328,7 @@ on disk bytes | 1.5KB    682B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:2235 BlockBytesInCache:457 BlockReadDuration:150ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:10ms}
+                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----

--- a/testdata/tracing
+++ b/testdata/tracing
@@ -2,14 +2,17 @@ build
 set hello foo
 ----
 
+# The first 3 reads are for initializing the Reader, which don't use
+# cache.Handle.GetWithReadHandle, while the remaining do. For the latter,
+# cache misses result in deterministic 5ms of wait time and 5ms of read time.
 get
 hello
 ----
 reading footer of 61 bytes took 5ms
-reading block of 37 bytes took 5ms (<redacted>)
-reading block of 311 bytes took 5ms (<redacted>)
-reading block of 31 bytes took 5ms (<redacted>)
-reading block of 32 bytes took 5ms (<redacted>)
+reading block kind metadata of 37 bytes took 5ms (<redacted>)
+reading block kind metadata of 311 bytes took 5ms (<redacted>)
+reading block kind index of 31 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind data of 32 bytes took 5ms + 5ms wait (<redacted>)
 hello:foo
 
 # If we disable background tracing, we should see no traces with Get.
@@ -21,22 +24,22 @@ hello:foo
 iter
 seek-ge hello
 ----
-reading block of 31 bytes took 5ms (<redacted>)
-reading block of 32 bytes took 5ms (<redacted>)
+reading block kind index of 31 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind data of 32 bytes took 5ms + 5ms wait (<redacted>)
 hello: (foo, .)
 
 snapshot-iter
 seek-ge hello
 ----
-reading block of 31 bytes took 5ms (<redacted>)
-reading block of 32 bytes took 5ms (<redacted>)
+reading block kind index of 31 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind data of 32 bytes took 5ms + 5ms wait (<redacted>)
 hello: (foo, .)
 
 indexed-batch-iter
 seek-ge hello
 ----
-reading block of 31 bytes took 5ms (<redacted>)
-reading block of 32 bytes took 5ms (<redacted>)
+reading block kind index of 31 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind data of 32 bytes took 5ms + 5ms wait (<redacted>)
 hello: (foo, .)
 
 build
@@ -45,14 +48,18 @@ range-key-set a z @4 foo2
 ----
 
 # This operation should not read the range key block.
+#
+# The first 3 reads are for initializing the Reader, which don't use
+# cache.Handle.GetWithReadHandle, while the remaining do. For the latter,
+# cache misses result in deterministic 5ms of wait time and 5ms of read time.
 get
 hello@2
 ----
 reading footer of 61 bytes took 5ms
-reading block of 62 bytes took 5ms (<redacted>)
-reading block of 398 bytes took 5ms (<redacted>)
-reading block of 27 bytes took 5ms (<redacted>)
-reading block of 35 bytes took 5ms (<redacted>)
+reading block kind metadata of 62 bytes took 5ms (<redacted>)
+reading block kind metadata of 398 bytes took 5ms (<redacted>)
+reading block kind index of 27 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind data of 35 bytes took 5ms + 5ms wait (<redacted>)
 hello@2:foo1
 
 # These operations should read the range key block, which shows up as a third
@@ -61,9 +68,9 @@ iter
 seek-ge hello
 next
 ----
-reading block of 27 bytes took 5ms (<redacted>)
-reading block of 35 bytes took 5ms (<redacted>)
-reading block of 35 bytes took 5ms (<redacted>)
+reading block kind index of 27 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind data of 35 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind rangekey of 35 bytes took 5ms + 5ms wait (<redacted>)
 hello: (., [a-z) @4=foo2 UPDATED)
 hello@2: (foo1, [a-z) @4=foo2)
 
@@ -71,9 +78,9 @@ snapshot-iter
 seek-ge hello
 next
 ----
-reading block of 27 bytes took 5ms (<redacted>)
-reading block of 35 bytes took 5ms (<redacted>)
-reading block of 35 bytes took 5ms (<redacted>)
+reading block kind index of 27 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind data of 35 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind rangekey of 35 bytes took 5ms + 5ms wait (<redacted>)
 hello: (., [a-z) @4=foo2 UPDATED)
 hello@2: (foo1, [a-z) @4=foo2)
 
@@ -81,8 +88,8 @@ indexed-batch-iter
 seek-ge hello
 next
 ----
-reading block of 27 bytes took 5ms (<redacted>)
-reading block of 35 bytes took 5ms (<redacted>)
-reading block of 35 bytes took 5ms (<redacted>)
+reading block kind index of 27 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind data of 35 bytes took 5ms + 5ms wait (<redacted>)
+reading block kind rangekey of 35 bytes took 5ms + 5ms wait (<redacted>)
 hello: (., [a-z) @4=foo2 UPDATED)
 hello@2: (foo1, [a-z) @4=foo2)


### PR DESCRIPTION
cache.Handle.GetWithReadHandle returns a non-zero wait duration on
a cache miss, which resulted in the request waiting for a turn
to do the read, or to wait for the block to be read by another
reader.

Tracing now happens on high wait duration. Wait duration is included
in iterator stats, since this is a block miss. And wait duration is
included in the read duration when the block was read by the caller
after waiting.
