### PR TITLE
blockkind: remove the Index Kind

### DIFF
--- a/sstable/block/blockkind/kind.go
+++ b/sstable/block/blockkind/kind.go
@@ -16,7 +16,6 @@ const (
 	SSTableValue
 	BlobValue
 	BlobReferenceValueLivenessIndex
-	Index
 	Filter
 	RangeDel
 	RangeKey
@@ -28,8 +27,8 @@ const (
 var kindString = [...]string{
 	Unknown:                         "unknown",
 	SSTableData:                     "data",
-	SSTableValue:                    "sstval",
 	SSTableIndex:                    "index",
+	SSTableValue:                    "sstval",
 	BlobValue:                       "blobval",
 	BlobReferenceValueLivenessIndex: "blobrefval",
 	Filter:                          "filter",

--- a/sstable/block/compressor_test.go
+++ b/sstable/block/compressor_test.go
@@ -41,7 +41,7 @@ func TestCompressor(t *testing.T) {
 		ci, _ = compressor.Compress(dst, src, blockkind.BlobValue)
 		require.Equal(t, compressionIndicatorFromAlgorithm(profile.ValueBlocks.Algorithm), ci)
 
-		ci, _ = compressor.Compress(dst, src, blockkind.Index)
+		ci, _ = compressor.Compress(dst, src, blockkind.SSTableIndex)
 		require.Equal(t, compressionIndicatorFromAlgorithm(profile.OtherBlocks.Algorithm), ci)
 
 		ci, _ = compressor.Compress(dst, src, blockkind.Metadata)

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -354,7 +354,7 @@ func (r *Reader) readTopLevelIndexBlock(
 func (r *Reader) readIndexBlock(
 	ctx context.Context, env block.ReadEnv, readHandle objstorage.ReadHandle, bh block.Handle,
 ) (block.BufferHandle, error) {
-	return r.blockReader.Read(ctx, env, readHandle, bh, blockkind.Index, r.initIndexBlockMetadata)
+	return r.blockReader.Read(ctx, env, readHandle, bh, blockkind.SSTableIndex, r.initIndexBlockMetadata)
 }
 
 // initIndexBlockMetadata initializes the Metadata for a data block. This will


### PR DESCRIPTION
It is used in the same way as the SSTableIndex Kind, and its entry in the kindString was never populated.