### PR TITLE
db: add initFileOpts for initializing in the FileCache

### DIFF
--- a/internal/genericcache/cache_test.go
+++ b/internal/genericcache/cache_test.go
@@ -36,21 +36,25 @@ func (k intKey) Shard(numShards int) int {
 }
 
 func TestBasic(t *testing.T) {
-	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, string]) error {
-		*v.Value() = fmt.Sprint(k)
+	valStr := func(k intKey, opts int) string {
+		return fmt.Sprintf("%d:%d", k, opts)
+	}
+	initFn := func(
+		ctx context.Context, k intKey, opts int, v ValueRef[intKey, string, int]) error {
+		*v.Value() = valStr(k, opts)
 		return nil
 	}
 	releaseFn := func(v *string) {
 		*v = "bogus"
 	}
-	c := New[intKey, string](10, 1, initFn, releaseFn)
+	c := New[intKey, string, int](10, 1, initFn, releaseFn)
 	ctx := context.Background()
 
 	for i := range 100 {
 		k := intKey(i % 10)
-		ref, err := c.FindOrCreate(ctx, k)
+		ref, err := c.FindOrCreate(ctx, k, int(2*k))
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprint(k), *ref.Value())
+		require.Equal(t, valStr(k, int(2*k)), *ref.Value())
 		ref.Unref()
 	}
 	m := c.Metrics()
@@ -58,9 +62,9 @@ func TestBasic(t *testing.T) {
 
 	for i := range 100 {
 		k := intKey(i % 10)
-		ref, err := c.FindOrCreate(ctx, k)
+		ref, err := c.FindOrCreate(ctx, k, int(2*k))
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprint(k), *ref.Value())
+		require.Equal(t, valStr(k, int(2*k)), *ref.Value())
 		ref.Unref()
 	}
 
@@ -73,7 +77,7 @@ func TestFileCacheClockPro(t *testing.T) {
 	f, err := os.Open("../cache/testdata/cache")
 	require.NoError(t, err)
 
-	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, string]) error {
+	initFn := func(ctx context.Context, k intKey, opts struct{}, v ValueRef[intKey, string, struct{}]) error {
 		*v.Value() = fmt.Sprint(k)
 		return nil
 	}
@@ -82,7 +86,7 @@ func TestFileCacheClockPro(t *testing.T) {
 	}
 	// The cache must have a single shard of size 200 is required for the expected
 	// test values.
-	c := New[intKey, string](200, 1, initFn, releaseFn)
+	c := New[intKey, string, struct{}](200, 1, initFn, releaseFn)
 	defer c.Close()
 
 	scanner := bufio.NewScanner(f)
@@ -95,7 +99,7 @@ func TestFileCacheClockPro(t *testing.T) {
 
 		oldHits := c.shards[0].hits.Load()
 
-		ref, err := c.FindOrCreate(context.Background(), intKey(key))
+		ref, err := c.FindOrCreate(context.Background(), intKey(key), struct{}{})
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprint(key), *ref.Value())
 		ref.Unref()
@@ -110,7 +114,7 @@ func TestFileCacheClockPro(t *testing.T) {
 
 func TestEvict(t *testing.T) {
 	var initialized []int
-	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, int]) error {
+	initFn := func(ctx context.Context, k intKey, opts struct{}, v ValueRef[intKey, int, struct{}]) error {
 		initialized = append(initialized, int(k))
 		*v.Value() = int(k)
 		return nil
@@ -136,23 +140,23 @@ func TestEvict(t *testing.T) {
 	}
 	c := New[intKey, int](20, 1+rand.IntN(4), initFn, releaseFn)
 	ctx := context.Background()
-	testutils.CheckErr(c.FindOrCreate(ctx, 1)).Unref()
-	testutils.CheckErr(c.FindOrCreate(ctx, 2)).Unref()
-	testutils.CheckErr(c.FindOrCreate(ctx, 3)).Unref()
-	testutils.CheckErr(c.FindOrCreate(ctx, 4)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 1, struct{}{})).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 2, struct{}{})).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 3, struct{}{})).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 4, struct{}{})).Unref()
 	expectInitialized(1, 2, 3, 4)
 	expectReleased()
 	c.Evict(2)
 	expectReleased(2)
-	testutils.CheckErr(c.FindOrCreate(ctx, 2)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 2, struct{}{})).Unref()
 	expectInitialized(2)
 	c.EvictAll(func(k intKey) bool {
 		return k%2 == 1
 	})
 	expectReleased(1, 3)
-	testutils.CheckErr(c.FindOrCreate(ctx, 2)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 2, struct{}{})).Unref()
 	expectInitialized()
-	testutils.CheckErr(c.FindOrCreate(ctx, 3)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 3, struct{}{})).Unref()
 	expectInitialized(3)
 
 	c.Close()
@@ -160,7 +164,7 @@ func TestEvict(t *testing.T) {
 }
 
 func TestEvictPanic(t *testing.T) {
-	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, int]) error {
+	initFn := func(ctx context.Context, k intKey, opts struct{}, v ValueRef[intKey, int, struct{}]) error {
 		*v.Value() = int(k)
 		return nil
 	}
@@ -171,17 +175,17 @@ func TestEvictPanic(t *testing.T) {
 	// test values.
 	c := New[intKey, int](20, 4, initFn, releaseFn)
 	ctx := context.Background()
-	testutils.CheckErr(c.FindOrCreate(ctx, 1)).Unref()
-	testutils.CheckErr(c.FindOrCreate(ctx, 2)).Unref()
-	testutils.CheckErr(c.FindOrCreate(ctx, 3)).Unref()
-	testutils.CheckErr(c.FindOrCreate(ctx, 4)).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 1, struct{}{})).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 2, struct{}{})).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 3, struct{}{})).Unref()
+	testutils.CheckErr(c.FindOrCreate(ctx, 4, struct{}{})).Unref()
 
-	ref := testutils.CheckErr(c.FindOrCreate(ctx, 3))
+	ref := testutils.CheckErr(c.FindOrCreate(ctx, 3, struct{}{}))
 	require.Panics(t, func() {
 		c.Evict(3)
 	})
 	ref.Unref()
-	_, _ = c.FindOrCreate(ctx, 2)
+	_, _ = c.FindOrCreate(ctx, 2, struct{}{})
 	require.Panics(t, func() {
 		c.Close()
 	})
@@ -189,7 +193,7 @@ func TestEvictPanic(t *testing.T) {
 
 func TestErrorHandling(t *testing.T) {
 	var fail atomic.Int32
-	initFn := func(ctx context.Context, k intKey, v ValueRef[intKey, int]) error {
+	initFn := func(ctx context.Context, k intKey, opts struct{}, v ValueRef[intKey, int, struct{}]) error {
 		if errVal := fail.Load(); errVal != 0 {
 			time.Sleep(10 * time.Millisecond)
 			return errors.Newf("%d", errVal)
@@ -209,7 +213,7 @@ func TestErrorHandling(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		go func() {
 			defer wg.Done()
-			_, err := c.FindOrCreate(ctx, 1)
+			_, err := c.FindOrCreate(ctx, 1, struct{}{})
 			require.ErrorContains(t, err, "1")
 		}()
 	}
@@ -217,12 +221,12 @@ func TestErrorHandling(t *testing.T) {
 
 	fail.Store(2)
 	// A new attempt should try again and return the new error.
-	_, err := c.FindOrCreate(ctx, 1)
+	_, err := c.FindOrCreate(ctx, 1, struct{}{})
 	require.ErrorContains(t, err, "2")
 
 	fail.Store(0)
 	// A new attempt should succeed.
-	v, err := c.FindOrCreate(ctx, 1)
+	v, err := c.FindOrCreate(ctx, 1, struct{}{})
 	require.NoError(t, err)
 	require.Equal(t, *v.Value(), 1)
 	v.Unref()

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -49,7 +49,7 @@ type mockReaderProvider struct {
 }
 
 func (rp *mockReaderProvider) GetValueReader(
-	ctx context.Context, obj base.ObjectInfo,
+	ctx context.Context, obj base.ObjectInfo, _ block.InitFileReadStats,
 ) (r ValueReader, closeFunc func(), err error) {
 	_, fileNum := obj.FileInfo()
 	if rp.w != nil {

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -590,3 +590,23 @@ func ReadRaw(
 	}
 	return buf, nil
 }
+
+// InitFileReadStats is used to capture file reading stats when a file is
+// initialized in the file cache. The primary use case is when such
+// initialization is triggered because an iterator needs to read that file,
+// and we are able to capture these initialization stats in the iterator
+// stats.
+type InitFileReadStats struct {
+	// Stats and IterStats are slightly different. Stats is a shared struct
+	// supplied from the outside, and represents stats for the whole iterator
+	// tree and can be reset from the outside (e.g. when the pebble.Iterator is
+	// being reused). It is currently only provided when the iterator tree is
+	// rooted at pebble.Iterator. IterStats contains an sstable iterator's
+	// private stats that are reported to a CategoryStatsCollector when this
+	// iterator is closed. In the important code paths, the
+	// CategoryStatsCollector is managed by the fileCacheContainer.
+	//
+	// Both can be nil.
+	Stats     *base.InternalIteratorStats
+	IterStats *CategoryStatsShard
+}

--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -91,11 +91,11 @@ func CopySpan(
 	defer metaBufferPools.Put(bufferPool)
 	defer bufferPool.Release()
 
-	metaIndex, _, err := r.readAndDecodeMetaindex(ctx, bufferPool, rh)
+	metaIndex, _, err := r.readAndDecodeMetaindex(ctx, block.ReadEnv{BufferPool: bufferPool}, rh)
 	if err != nil {
 		return 0, errors.Wrap(err, "reading metaindex")
 	}
-	props, err := r.readPropertiesBlockInternal(ctx, bufferPool, rh)
+	props, err := r.readPropertiesBlockInternal(ctx, block.ReadEnv{BufferPool: bufferPool}, rh)
 	if err != nil {
 		return 0, errors.Wrap(err, "reading properties")
 	}

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -108,6 +108,10 @@ type ReaderOptions struct {
 
 	// FilterMetricsTracker is optionally used to track filter metrics.
 	FilterMetricsTracker *FilterMetricsTracker
+
+	// InitFileReadStats is to only be used for reads in NewReader and forgotten
+	// after.
+	InitFileReadStats block.InitFileReadStats
 }
 
 func (o ReaderOptions) ensureDefaults() ReaderOptions {

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -176,7 +176,8 @@ func newColumnBlockTwoLevelIterator(
 		// versions of keys, and therefore never expose a LazyValue that is
 		// separated to their callers, they can put this valueBlockReader into a
 		// sync.Pool.
-		i.secondLevel.internalValueConstructor.vbReader = valblk.MakeReader(&i.secondLevel, opts.ReaderProvider, r.valueBIH, opts.Env.Block.Stats)
+		i.secondLevel.internalValueConstructor.vbReader = valblk.MakeReader(
+			&i.secondLevel, opts.ReaderProvider, r.valueBIH, opts.Env.Block.Stats, opts.Env.Block.IterStats)
 		i.secondLevel.vbRH = r.blockReader.UsePreallocatedReadHandle(
 			objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
@@ -225,7 +226,8 @@ func newRowBlockTwoLevelIterator(
 			// versions of keys, and therefore never expose a LazyValue that is
 			// separated to their callers, they can put this valueBlockReader into a
 			// sync.Pool.
-			i.secondLevel.internalValueConstructor.vbReader = valblk.MakeReader(&i.secondLevel, opts.ReaderProvider, r.valueBIH, opts.Env.Block.Stats)
+			i.secondLevel.internalValueConstructor.vbReader = valblk.MakeReader(
+				&i.secondLevel, opts.ReaderProvider, r.valueBIH, opts.Env.Block.Stats, opts.Env.Block.IterStats)
 			// We can set the GetLazyValuer directly to the vbReader because
 			// rowblk sstables never contain blob value handles.
 			i.secondLevel.data.SetGetLazyValuer(&i.secondLevel.internalValueConstructor.vbReader)

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -269,8 +269,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   218B    0B |      1   652B     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   218B    0B |      4  3.3KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      1   652B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |      4  3.3KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -409,8 +409,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   218B    0B |      1   652B     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   218B    0B |      5  5.2KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      1   652B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |      5  5.2KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -35,7 +35,7 @@ c@2: (foobar, .)
 d@9: (v, .)
 d@2: (v, .)
 .
-stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 365B not cached (read time: 0s); points: 6 (18B keys, 8B values); separated: 2 (16B, 16B fetched)
+stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 1.4KB not cached (read time: 0s); points: 6 (18B keys, 8B values); separated: 2 (16B, 16B fetched)
 
 # Try the same but avoid fetching one of the values (by using NextPrefix to step
 # over it).
@@ -104,19 +104,19 @@ next
 stats
 ----
 b@9: (orange, .)
-stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 381B not cached (read time: 0s); points: 1 (3B keys, 2B values); separated: 2 (11B, 6B fetched)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 1 (3B keys, 2B values); separated: 2 (11B, 6B fetched)
 b@2: (lemon, .)
-stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 381B not cached (read time: 0s); points: 2 (6B keys, 4B values); separated: 3 (21B, 11B fetched)
+stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 2 (6B keys, 4B values); separated: 3 (21B, 11B fetched)
 c@9: (canteloupe, .)
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 458B not cached (read time: 0s); points: 3 (9B keys, 6B values); separated: 4 (25B, 21B fetched)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 3 (9B keys, 6B values); separated: 4 (25B, 21B fetched)
 c@2: (kiwi, .)
 d@9: (honeydew, .)
 d@2: (tangerine, .)
-stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 458B not cached (read time: 0s); points: 6 (18B keys, 12B values); separated: 7 (52B, 42B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 6 (18B keys, 12B values); separated: 7 (52B, 42B fetched)
 e@1: (watermelon, .)
 f@2: (grapes, .)
 .
-stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 458B not cached (read time: 0s); points: 8 (24B keys, 16B values); separated: 8 (58B, 58B fetched)
+stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 8 (24B keys, 16B values); separated: 8 (58B, 58B fetched)
 
 # Test scanning a table, stepping into new blocks of the blob file. The stats
 # should reflect that a block is only loaded when stepping into a new block.
@@ -170,31 +170,31 @@ next
 stats
 ----
 a: (lemonmeringue, .)
-stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 289B not cached (read time: 0s); points: 1 (1B keys, 2B values); separated: 1 (13B, 13B fetched)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 850B not cached (read time: 0s); points: 1 (1B keys, 2B values); separated: 1 (13B, 13B fetched)
 b: (keylime, .)
-stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 289B not cached (read time: 0s); points: 2 (2B keys, 4B values); separated: 2 (20B, 20B fetched)
+stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 850B not cached (read time: 0s); points: 2 (2B keys, 4B values); separated: 2 (20B, 20B fetched)
 c: (pecan, .)
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 323B not cached (read time: 0s); points: 3 (3B keys, 6B values); separated: 3 (25B, 25B fetched)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 884B not cached (read time: 0s); points: 3 (3B keys, 6B values); separated: 3 (25B, 25B fetched)
 d: (cherry, .)
-stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 0B cached, 323B not cached (read time: 0s); points: 4 (4B keys, 8B values); separated: 4 (31B, 31B fetched)
+stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 0B cached, 884B not cached (read time: 0s); points: 4 (4B keys, 8B values); separated: 4 (31B, 31B fetched)
 e: (apple, .)
-stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 0B cached, 323B not cached (read time: 0s); points: 5 (5B keys, 10B values); separated: 5 (36B, 36B fetched)
+stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 0B cached, 884B not cached (read time: 0s); points: 5 (5B keys, 10B values); separated: 5 (36B, 36B fetched)
 f: (bananacream, .)
-stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 360B not cached (read time: 0s); points: 6 (6B keys, 12B values); separated: 6 (47B, 47B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 921B not cached (read time: 0s); points: 6 (6B keys, 12B values); separated: 6 (47B, 47B fetched)
 g: (chocolate, .)
-stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 360B not cached (read time: 0s); points: 7 (7B keys, 14B values); separated: 7 (56B, 56B fetched)
+stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 921B not cached (read time: 0s); points: 7 (7B keys, 14B values); separated: 7 (56B, 56B fetched)
 h: (strawberry, .)
-stats: seeked 1 times (1 internal); stepped 7 times (7 internal); blocks: 0B cached, 394B not cached (read time: 0s); points: 8 (8B keys, 16B values); separated: 8 (66B, 66B fetched)
+stats: seeked 1 times (1 internal); stepped 7 times (7 internal); blocks: 0B cached, 955B not cached (read time: 0s); points: 8 (8B keys, 16B values); separated: 8 (66B, 66B fetched)
 i: (custard, .)
-stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 394B not cached (read time: 0s); points: 9 (9B keys, 18B values); separated: 9 (73B, 73B fetched)
+stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 955B not cached (read time: 0s); points: 9 (9B keys, 18B values); separated: 9 (73B, 73B fetched)
 j: (blueberry, .)
-stats: seeked 1 times (1 internal); stepped 9 times (9 internal); blocks: 0B cached, 419B not cached (read time: 0s); points: 10 (10B keys, 20B values); separated: 10 (82B, 82B fetched)
+stats: seeked 1 times (1 internal); stepped 9 times (9 internal); blocks: 0B cached, 980B not cached (read time: 0s); points: 10 (10B keys, 20B values); separated: 10 (82B, 82B fetched)
 k: (raspberry, .)
-stats: seeked 1 times (1 internal); stepped 10 times (10 internal); blocks: 0B cached, 444B not cached (read time: 0s); points: 11 (11B keys, 22B values); separated: 11 (91B, 91B fetched)
+stats: seeked 1 times (1 internal); stepped 10 times (10 internal); blocks: 0B cached, 1005B not cached (read time: 0s); points: 11 (11B keys, 22B values); separated: 11 (91B, 91B fetched)
 l: (peach, .)
-stats: seeked 1 times (1 internal); stepped 11 times (11 internal); blocks: 0B cached, 465B not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
+stats: seeked 1 times (1 internal); stepped 11 times (11 internal); blocks: 0B cached, 1.0KB not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
 .
-stats: seeked 1 times (1 internal); stepped 12 times (12 internal); blocks: 0B cached, 465B not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
+stats: seeked 1 times (1 internal); stepped 12 times (12 internal); blocks: 0B cached, 1.0KB not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
 
 # Regression test for #4741.
 #

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -199,7 +199,7 @@ stats
 ----
 lastPositioningOp="unknown"
 b@5: (b@5, .)
-stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 119B not cached (read time: 0s); points: 1 (3B keys, 3B values)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 530B not cached (read time: 0s); points: 1 (3B keys, 3B values)
 
 mutate batch=foo
 set h@2 h@2
@@ -214,7 +214,7 @@ stats
 .
 lastPositioningOp="seekprefixge"
 c@3: (c@3, .)
-stats: seeked 2 times (2 internal); stepped 0 times (0 internal); blocks: 0B cached, 119B not cached (read time: 0s); points: 2 (6B keys, 6B values)
+stats: seeked 2 times (2 internal); stepped 0 times (0 internal); blocks: 0B cached, 530B not cached (read time: 0s); points: 2 (6B keys, 6B values)
 
 mutate batch=foo
 set i@1 i@1
@@ -229,7 +229,7 @@ stats
 .
 lastPositioningOp="seekprefixge"
 d@9: (d@9, .)
-stats: seeked 3 times (3 internal); stepped 0 times (0 internal); blocks: 0B cached, 119B not cached (read time: 0s); points: 3 (9B keys, 9B values)
+stats: seeked 3 times (3 internal); stepped 0 times (0 internal); blocks: 0B cached, 530B not cached (read time: 0s); points: 3 (9B keys, 9B values)
 
 mutate batch=foo
 set j@6 j@6
@@ -244,7 +244,7 @@ stats
 .
 lastPositioningOp="seekprefixge"
 e@8: (e@8, .)
-stats: seeked 4 times (4 internal); stepped 0 times (0 internal); blocks: 0B cached, 119B not cached (read time: 0s); points: 4 (12B keys, 12B values)
+stats: seeked 4 times (4 internal); stepped 0 times (0 internal); blocks: 0B cached, 530B not cached (read time: 0s); points: 4 (12B keys, 12B values)
 
 # Ensure that a case eligible for TrySeekUsingNext across a SetOptions correctly
 # sees new batch mutations. The batch iterator should ignore the

--- a/testdata/iter_histories/range_key_masking
+++ b/testdata/iter_histories/range_key_masking
@@ -153,7 +153,7 @@ stats
 ----
 a: (., [a-z) @5=boop UPDATED)
 .
-stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 1.1KB not cached (read time: 0s); points: 25 (75B keys, 75B values), range keys: 1, contained points: 25 (25 skipped)
+stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 1.6KB not cached (read time: 0s); points: 25 (75B keys, 75B values), range keys: 1, contained points: 25 (25 skipped)
 
 # Repeat the above test, but with an iterator that uses a block-property filter
 # mask. The internal stats should reflect fewer bytes read and fewer points

--- a/testdata/iter_histories/stats_no_invariants
+++ b/testdata/iter_histories/stats_no_invariants
@@ -33,12 +33,12 @@ stats
 stats: seeked 0 times (0 internal); stepped 0 times (0 internal)
 a: (a, .)
 b: (b, [b-c) @5=boop UPDATED)
-stats: seeked 1 times (1 internal); stepped 1 times (2 internal); blocks: 0B cached, 89B not cached (read time: 0s); points: 2 (2B keys, 2B values), range keys: 1, contained points: 1 (0 skipped)
+stats: seeked 1 times (1 internal); stepped 1 times (2 internal); blocks: 0B cached, 614B not cached (read time: 0s); points: 2 (2B keys, 2B values), range keys: 1, contained points: 1 (0 skipped)
 c: (c, . UPDATED)
 cat: (., [cat-dog) @3=beep UPDATED)
 d: (d, [cat-dog) @3=beep)
 .
-stats: seeked 1 times (1 internal); stepped 5 times (6 internal); blocks: 0B cached, 89B not cached (read time: 0s); points: 4 (4B keys, 4B values), range keys: 2, contained points: 2 (0 skipped)
+stats: seeked 1 times (1 internal); stepped 5 times (6 internal); blocks: 0B cached, 614B not cached (read time: 0s); points: 4 (4B keys, 4B values), range keys: 2, contained points: 2 (0 skipped)
 
 # Do the above forward iteration but with a mask suffix. The results should be
 # identical despite range keys serving as masks, because none of the point keys

--- a/testdata/iterator_stats
+++ b/testdata/iterator_stats
@@ -17,7 +17,7 @@ stats
 a: (1, .)
 c: (2, .)
 .
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 113B cached; points: 2 (2B keys, 2B values)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 113B cached, 468B not cached (read time: 0s); points: 2 (2B keys, 2B values)
 
 # Perform the same operation again with a new iterator. It should yield
 # identical statistics.
@@ -64,10 +64,10 @@ c: (2, .)
 stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 113B cached; points: 1 (1B keys, 1B values)
 d@10: (d10, .)
 d@9: (d9, .)
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 303B cached, 10B not cached (read time: 0s); points: 3 (8B keys, 6B values); separated: 1 (2B, 2B fetched)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 303B cached, 540B not cached (read time: 0s); points: 3 (8B keys, 6B values); separated: 1 (2B, 2B fetched)
 d@8: (d8, .)
-stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 303B cached, 10B not cached (read time: 0s); points: 4 (11B keys, 8B values); separated: 2 (4B, 4B fetched)
+stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 303B cached, 540B not cached (read time: 0s); points: 4 (11B keys, 8B values); separated: 2 (4B, 4B fetched)
 e@20: (e20, .)
-stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 303B cached, 10B not cached (read time: 0s); points: 5 (15B keys, 11B values); separated: 2 (4B, 4B fetched)
+stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 303B cached, 540B not cached (read time: 0s); points: 5 (15B keys, 11B values); separated: 2 (4B, 4B fetched)
 e@18: (e18, .)
-stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 303B cached, 10B not cached (read time: 0s); points: 6 (19B keys, 13B values); separated: 3 (7B, 7B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 303B cached, 540B not cached (read time: 0s); points: 6 (19B keys, 13B values); separated: 3 (7B, 7B fetched)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -157,7 +157,7 @@ on disk bytes |  36B     76B
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
 ----
 ----
 
@@ -212,8 +212,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.3KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4  2.6KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |      4  2.6KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -256,9 +256,9 @@ on disk bytes | 230B
            CR |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -296,8 +296,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.3KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4  2.6KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |      4  2.6KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -340,9 +340,9 @@ on disk bytes | 230B
            CR |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -377,8 +377,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.3KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4  2.6KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |      4  2.6KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -421,9 +421,9 @@ on disk bytes | 230B
            CR |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -461,8 +461,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.3KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |      4  2.6KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |      4  2.6KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -505,9 +505,9 @@ on disk bytes | 230B
            CR |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -584,8 +584,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   224B    0B |      2  1.3KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   224B    0B |     11  7.9KB  2.4KB
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |     11  7.9KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -628,9 +628,9 @@ on disk bytes | 622B    630B
            CR |         1.27
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:224 BlockBytesInCache:112 BlockReadDuration:10ms}
+   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -692,8 +692,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  6.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     18   13KB  2.4KB
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     18   13KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -736,9 +736,9 @@ on disk bytes | 622B    615B
            CR |          1.3
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
+   pebble-compaction, non-latency: {BlockBytes:5234 BlockBytesInCache:112 BlockReadDuration:160ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -851,8 +851,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  6.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     21   17KB  2.4KB
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     21   17KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -895,9 +895,9 @@ on disk bytes |  1KB    843B
            CR |         1.26
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
+   pebble-compaction, non-latency: {BlockBytes:5234 BlockBytesInCache:112 BlockReadDuration:160ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -972,8 +972,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  6.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     28   22KB  2.4KB
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     28   22KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -1016,9 +1016,9 @@ on disk bytes | 1.3KB   1.3KB
            CR |          1.21
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
+   pebble-compaction, non-latency: {BlockBytes:5234 BlockBytesInCache:112 BlockReadDuration:160ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1105,8 +1105,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.1KB    0B |      9  6.4KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.1KB    0B |     28   22KB  2.4KB
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     28   22KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       2       0        0     0     0     0        0     0      0     0
@@ -1149,9 +1149,9 @@ on disk bytes | 1.3KB   1.2KB
            CR |          1.22
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:1106 BlockBytesInCache:112 BlockReadDuration:80ms}
+   pebble-compaction, non-latency: {BlockBytes:5234 BlockBytesInCache:112 BlockReadDuration:160ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1282,8 +1282,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  2.2KB    0B |     16   11KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |  2.2KB    0B |     35   27KB  2.4KB
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   11KB    0B |     16   11KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   11KB    0B |     35   27KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       3       0        0     0     0     0        0     0      0     0
@@ -1326,9 +1326,9 @@ on disk bytes | 1.5KB    682B
            CR |           1.3
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:2235 BlockBytesInCache:457 BlockReadDuration:150ms}
+   pebble-compaction, non-latency: {BlockBytes:11009 BlockBytesInCache:457 BlockReadDuration:330ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:112 BlockBytesInCache:0 BlockReadDuration:20ms}
+                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1456,8 +1456,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   336B    0B |      3  1.9KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   336B    0B |      6  3.9KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.7KB    0B |      3  1.9KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.7KB    0B |      6  3.9KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -1500,7 +1500,7 @@ on disk bytes | 345B
            CR |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
+   pebble-compaction, non-latency: {BlockBytes:1737 BlockBytesInCache:0 BlockReadDuration:60ms}
 ----
 ----
 
@@ -1552,8 +1552,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   336B    0B |      3  1.9KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   336B    0B |      6  4.5KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.7KB    0B |      3  1.9KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.7KB    0B |      6  4.5KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -1596,7 +1596,7 @@ on disk bytes | 460B
            CR |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
+   pebble-compaction, non-latency: {BlockBytes:1737 BlockBytesInCache:0 BlockReadDuration:60ms}
 ----
 ----
 
@@ -1640,8 +1640,8 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
     3 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     4 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
     5 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      0     0B     0B
-    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   336B    0B |      3  1.9KB     0B
-total |     -     -     - |      0    0B |    0B    0B    0B |   336B    0B |      7  5.2KB     0B
+    6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.7KB    0B |      3  1.9KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.7KB    0B |      7  5.2KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
 count |       1       0        0     0     0     0        0     0      0     0
@@ -1684,7 +1684,7 @@ on disk bytes | 496B     76B
            CR |         1.14
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:336 BlockBytesInCache:0 BlockReadDuration:30ms}
+   pebble-compaction, non-latency: {BlockBytes:1737 BlockBytesInCache:0 BlockReadDuration:60ms}
 ----
 ----
 

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/blob"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
@@ -228,7 +229,7 @@ var _ blob.ReaderProvider = (*debugReaderProvider)(nil)
 // GetValueReader returns a blob.ValueReader for a blob file identified by
 // fileNum.
 func (p *debugReaderProvider) GetValueReader(
-	ctx context.Context, diskFile base.ObjectInfo,
+	ctx context.Context, diskFile base.ObjectInfo, _ block.InitFileReadStats,
 ) (blob.ValueReader, func(), error) {
 	ftyp, fileNum := diskFile.FileInfo()
 	readable, err := p.objProvider.OpenForReading(ctx, ftyp, fileNum, objstorage.OpenOptions{})


### PR DESCRIPTION
initFileOpts only contains InitFileReadStats, which allows the caller to provide stats collected by iterators. Reads done when creating a Reader specifically because an iterator was needed on that file, will now be captured in the corresponding iterator stats.

This reduces the uncertainty when we see slowness in traces around iteration, and are unsure whether it happened prior to operations on the iterator. We continue to have some unaccounted latency:
- Footer reads are not included in the stats.
- File cache entry initialization is shared when there are concurrent attempts to create the entry, and the latency (via iterator stats) is only accounted in the one that did the Reader creation.

initFileOpts are also plumbed to valblk.blockProviderWhenClosed, when
it needs to open a sstable.Reader. As part of this change, we also
fix the missing stats for valblk.ReadValueBlockExternal, and the
missing category stats in general when reading value blocks.
