### PR TITLE
internal/testutils: move Logger

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/itertest"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -298,7 +299,8 @@ func testBatchEmpty(t *testing.T, size int, opts ...BatchOption) {
 	b = &Batch{}
 
 	d, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 	defer d.Close()
@@ -322,7 +324,8 @@ func testBatchEmpty(t *testing.T, size int, opts ...BatchOption) {
 
 func TestBatchApplyNoSyncWait(t *testing.T) {
 	db, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -348,7 +351,8 @@ func TestBatchApplyNoSyncWait(t *testing.T) {
 
 func TestBatchReset(t *testing.T) {
 	db, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -419,7 +423,8 @@ func TestBatchReset(t *testing.T) {
 
 func TestBatchReuse(t *testing.T) {
 	db, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 
@@ -509,7 +514,8 @@ func TestIndexedBatchReset(t *testing.T) {
 		return count
 	}
 	db, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -595,6 +601,7 @@ func TestIndexedBatchMutation(t *testing.T) {
 		Comparer:           testkeys.Comparer,
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: internalFormatNewest,
+		Logger:             testutils.Logger{T: t},
 	}
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -701,6 +708,7 @@ func TestIndexedBatch_GlobalVisibility(t *testing.T) {
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: internalFormatNewest,
 		Comparer:           testkeys.Comparer,
+		Logger:             testutils.Logger{T: t},
 	}
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -884,6 +892,7 @@ func TestBatchGet(t *testing.T) {
 			d, err := Open("", &Options{
 				FS:           vfs.NewMem(),
 				MemTableSize: c.memTableSize,
+				Logger:       testutils.Logger{T: t},
 			})
 			if err != nil {
 				t.Fatalf("Open: %v", err)
@@ -1284,7 +1293,8 @@ func TestEmptyFlushableBatch(t *testing.T) {
 func TestBatchCommitStats(t *testing.T) {
 	testFunc := func() error {
 		db, err := Open("", &Options{
-			FS: vfs.NewMem(),
+			FS:     vfs.NewMem(),
+			Logger: testutils.Logger{T: t},
 		})
 		require.NoError(t, err)
 		defer db.Close()
@@ -1571,9 +1581,9 @@ func BenchmarkIndexedBatchSetDeferred(b *testing.B) {
 }
 
 func TestBatchMemTableSizeOverflow(t *testing.T) {
-	opts := &Options{
+	opts := testingRandomized(t, &Options{
 		FS: vfs.NewMem(),
-	}
+	})
 	opts.EnsureDefaults()
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -1599,6 +1609,7 @@ func TestBatchSpanCaching(t *testing.T) {
 		Comparer:           testkeys.Comparer,
 		FS:                 vfs.NewMem(),
 		FormatMajorVersion: internalFormatNewest,
+		Logger:             testutils.Logger{T: t},
 	}
 	d, err := Open("", opts)
 	require.NoError(t, err)

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -43,7 +44,7 @@ func testCheckpointImpl(t *testing.T, ddFile string, createOnShared bool) {
 			FormatMajorVersion:          internalFormatNewest,
 			L0CompactionThreshold:       10,
 			DisableAutomaticCompactions: true,
-			Logger:                      testLogger{t},
+			Logger:                      testutils.Logger{T: t},
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			"": remoteMem,
@@ -287,7 +288,7 @@ func TestCheckpoint(t *testing.T) {
 
 func TestCheckpointCompaction(t *testing.T) {
 	fs := vfs.NewMem()
-	d, err := Open("", &Options{FS: fs, Logger: testLogger{t: t}})
+	d, err := Open("", &Options{FS: fs, Logger: testutils.Logger{T: t}})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -333,7 +334,7 @@ func TestCheckpointCompaction(t *testing.T) {
 		}
 	}()
 	go func() {
-		opts := &Options{FS: fs, Logger: testLogger{t: t}}
+		opts := &Options{FS: fs, Logger: testutils.Logger{T: t}}
 		defer cancel()
 		defer wg.Done()
 		for dir := range check {
@@ -370,7 +371,7 @@ func TestCheckpointCompaction(t *testing.T) {
 func TestCheckpointFlushWAL(t *testing.T) {
 	const checkpointPath = "checkpoints/checkpoint"
 	fs := vfs.NewCrashableMem()
-	opts := &Options{FS: fs, Logger: testLogger{t: t}}
+	opts := &Options{FS: fs, Logger: testutils.Logger{T: t}}
 	key, value := []byte("key"), []byte("value")
 
 	// Create a checkpoint from an unsynced DB.
@@ -429,7 +430,7 @@ func TestCheckpointManyFiles(t *testing.T) {
 		FS:                          vfs.NewMem(),
 		FormatMajorVersion:          internalFormatNewest,
 		DisableAutomaticCompactions: true,
-		Logger:                      testLogger{t},
+		Logger:                      testutils.Logger{T: t},
 	}
 	// Disable compression to speed up the test.
 	opts.EnsureDefaults()

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/problemspans"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -1320,6 +1321,7 @@ func TestCompactionPickerPickFile(t *testing.T) {
 		Comparer:           testkeys.Comparer,
 		FormatMajorVersion: FormatNewest,
 		FS:                 fs,
+		Logger:             testutils.Logger{T: t},
 	}
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 
@@ -1463,6 +1465,7 @@ func TestCompactionPickerScores(t *testing.T) {
 		DisableAutomaticCompactions: true,
 		FormatMajorVersion:          FormatNewest,
 		FS:                          fs,
+		Logger:                      testutils.Logger{T: t},
 	}
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -576,6 +576,7 @@ func TestAutomaticFlush(t *testing.T) {
 		DebugCheck:            DebugCheckLevels,
 		FS:                    mem,
 		L0CompactionThreshold: 8,
+		Logger:                testutils.Logger{T: t},
 		MemTableSize:          memTableSize,
 	}
 	opts = opts.testingRandomized(t)
@@ -922,6 +923,7 @@ func TestCompaction(t *testing.T) {
 			DisableAutomaticCompactions: true,
 			EventListener:               compactionLogEventListener,
 			FormatMajorVersion:          randVersion(minVersion, maxVersion),
+			Logger:                      testutils.Logger{T: t},
 		}
 		opts.WithFSDefaults()
 		opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
@@ -1024,6 +1026,7 @@ func TestCompaction(t *testing.T) {
 					EventListener:               compactionLogEventListener,
 					FormatMajorVersion:          randVersion(minVersion, maxVersion),
 					DisableAutomaticCompactions: true,
+					Logger:                      testutils.Logger{T: t},
 				}
 				opts.WithFSDefaults()
 				opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
@@ -1587,6 +1590,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				},
 			},
 			FormatMajorVersion: internalFormatNewest,
+			Logger:             testutils.Logger{T: t},
 		}
 		opts.WithFSDefaults()
 		opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool { return true }
@@ -1896,6 +1900,7 @@ func TestCompactionTombstones(t *testing.T) {
 						},
 					},
 					FormatMajorVersion: internalFormatNewest,
+					Logger:             testutils.Logger{T: t},
 				}
 				opts.WithFSDefaults()
 				opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool { return true }
@@ -2103,6 +2108,7 @@ func TestCompactionReadTriggered(t *testing.T) {
 							compactInfo = &info
 						},
 					},
+					Logger: testutils.Logger{T: t},
 				}
 				opts.WithFSDefaults()
 				var err error
@@ -2217,7 +2223,7 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 				}
 
 				var err error
-				if d, err = runDBDefineCmd(td, nil /* options */); err != nil {
+				if d, err = runDBDefineCmd(td, &Options{Logger: testutils.Logger{T: t}}); err != nil {
 					return err.Error()
 				}
 
@@ -2369,6 +2375,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 				}
 			},
 		},
+		Logger: testutils.Logger{T: t},
 	}
 	opts.WithFSDefaults()
 	for i := range opts.TargetFileSizes {
@@ -2551,7 +2558,8 @@ func TestCompactFlushQueuedMemTableAndFlushMetrics(t *testing.T) {
 
 		mem := vfs.NewMem()
 		opts := &Options{
-			FS: mem,
+			FS:     mem,
+			Logger: testutils.Logger{T: t},
 		}
 		opts.WithFSDefaults()
 		d, err := Open("", testingRandomized(t, opts))
@@ -2614,7 +2622,8 @@ func TestCompactFlushQueuedLargeBatch(t *testing.T) {
 
 	mem := vfs.NewMem()
 	opts := &Options{
-		FS: mem,
+		FS:     mem,
+		Logger: testutils.Logger{T: t},
 	}
 	opts.WithFSDefaults()
 	d, err := Open("", testingRandomized(t, opts))
@@ -2664,6 +2673,7 @@ func TestFlushError(t *testing.T) {
 				t.Log(err)
 			},
 		},
+		Logger: testutils.Logger{T: t},
 	}
 	opts.WithFSDefaults()
 	d, err := Open("", testingRandomized(t, opts))
@@ -2718,7 +2728,8 @@ func TestCompactionInvalidBounds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	opts := &Options{
-		FS: vfs.NewMem(),
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
 	}
 	opts.WithFSDefaults()
 	db, err := Open("", testingRandomized(t, opts))
@@ -2755,6 +2766,7 @@ func TestMarkedForCompaction(t *testing.T) {
 				fmt.Fprintln(&buf, info)
 			},
 		},
+		Logger: testutils.Logger{T: t},
 	}
 	opts.WithFSDefaults()
 
@@ -2980,7 +2992,7 @@ func TestSharedObjectDeletePacing(t *testing.T) {
 	})
 	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 	opts.TargetByteDeletionRate = 1
-	opts.Logger = testLogger{t}
+	opts.Logger = testutils.Logger{T: t}
 
 	d, err := Open("", &opts)
 	require.NoError(t, err)
@@ -3092,6 +3104,7 @@ func TestCompactionErrorStats(t *testing.T) {
 				}
 			},
 		},
+		Logger: testutils.Logger{T: t},
 	}
 	opts.WithFSDefaults()
 	for i := range opts.TargetFileSizes {
@@ -3185,6 +3198,7 @@ func TestCompactionCorruption(t *testing.T) {
 		},
 		L0CompactionThreshold:     1,
 		L0CompactionFileThreshold: 5,
+		Logger:                    testutils.Logger{T: t},
 	}
 	opts.WithFSDefaults()
 	remoteStorage := remote.NewInMem()

--- a/error_test.go
+++ b/error_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/stretchr/testify/require"
@@ -459,7 +460,7 @@ func TestDBCompactionCrash(t *testing.T) {
 		opts := &Options{
 			DisableTableStats:           true,
 			FS:                          fs,
-			Logger:                      testLogger{t: t},
+			Logger:                      testutils.Logger{T: t},
 			MemTableSize:                128 << 10,
 			CompactionConcurrencyRange:  func() (int, int) { return 1, maxConcurrentCompactions },
 			LBaseMaxBytes:               64 << 10,

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -622,7 +622,7 @@ func TestBlobCorruptionEvent(t *testing.T) {
 			fs := vfs.NewMem()
 			opts := &Options{
 				FS:                 fs,
-				Logger:             testLogger{t},
+				Logger:             testutils.Logger{T: t},
 				FormatMajorVersion: FormatValueSeparation,
 				EventListener: &EventListener{
 					DataCorruption: func(info DataCorruptionInfo) {

--- a/excise_test.go
+++ b/excise_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
@@ -77,7 +78,7 @@ func TestExcise(t *testing.T) {
 				flushed = true
 			}},
 			FormatMajorVersion: FormatFlushableIngestExcises,
-			Logger:             testLogger{t},
+			Logger:             testutils.Logger{T: t},
 		}
 		if blockSize != 0 {
 			opts.Levels[0].BlockSize = blockSize
@@ -398,7 +399,7 @@ func TestConcurrentExcise(t *testing.T) {
 		compactionErrs = make(chan error, 5)
 
 		var el EventListener
-		el.EnsureDefaults(testLogger{t: t})
+		el.EnsureDefaults(testutils.Logger{T: t})
 		el.FlushBegin = func(info FlushInfo) {
 			// Don't block flushes
 		}
@@ -444,9 +445,9 @@ func TestConcurrentExcise(t *testing.T) {
 			L0StopWritesThreshold: 100,
 			DebugCheck:            DebugCheckLevels,
 			FormatMajorVersion:    FormatVirtualSSTables,
-			Logger:                testLogger{t},
+			Logger:                testutils.Logger{T: t},
 		}
-		lel := MakeLoggingEventListener(testLogger{t})
+		lel := MakeLoggingEventListener(testutils.Logger{T: t})
 		tel := TeeEventListener(lel, el)
 		opts1.EventListener = &tel
 		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{

--- a/filenames_test.go
+++ b/filenames_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +23,7 @@ func TestSetCurrentFileCrash(t *testing.T) {
 
 	// Initialize a fresh database to write the initial MANIFEST.
 	{
-		d, err := Open("", &Options{FS: mem})
+		d, err := Open("", &Options{FS: mem, Logger: testutils.Logger{T: t}})
 		require.NoError(t, err)
 		require.NoError(t, d.Close())
 	}
@@ -59,7 +60,7 @@ func TestSetCurrentFileCrash(t *testing.T) {
 			FS:                    mem,
 			MaxManifestFileSize:   1,
 			L0CompactionThreshold: 10,
-			Logger:                testLogger{t},
+			Logger:                testutils.Logger{T: t},
 		})
 		require.NoError(t, err)
 		require.NoError(t, d.Close())

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/vfs"
@@ -69,7 +70,7 @@ func TestRatchetFormat(t *testing.T) {
 
 	// If we Open the database again, leaving the default format, the
 	// database should Open using the persisted internalFormatNewest.
-	opts = &Options{FS: fs, Logger: testLogger{t}}
+	opts = &Options{FS: fs, Logger: testutils.Logger{T: t}}
 	opts.WithFSDefaults()
 	d, err = Open("", opts)
 	require.NoError(t, err)
@@ -121,7 +122,7 @@ func TestFormatMajorVersions(t *testing.T) {
 			opts := &Options{
 				FS:                 fs,
 				FormatMajorVersion: vers,
-				Logger:             testLogger{t},
+				Logger:             testutils.Logger{T: t},
 			}
 			opts.WithFSDefaults()
 

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 )
 
 func TestGetIter(t *testing.T) {
@@ -456,7 +457,7 @@ func TestGetIter(t *testing.T) {
 			get.snapshot = ikey.SeqNum() + 1
 			get.iterOpts = IterOptions{
 				Category:                      categoryGet,
-				logger:                        testLogger{t},
+				logger:                        testutils.Logger{T: t},
 				snapshotForHideObsoletePoints: get.snapshot,
 			}
 

--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package testutils
+
+import "testing"
+
+// Logger is a logger that writes to a testing.TB.
+type Logger struct {
+	T testing.TB
+}
+
+func (l Logger) Infof(format string, args ...interface{}) {
+	l.T.Logf(format, args...)
+}
+
+func (l Logger) Errorf(format string, args ...interface{}) {
+	l.T.Logf(format, args...)
+}
+
+func (l Logger) Fatalf(format string, args ...interface{}) {
+	l.T.Helper()
+	l.T.Fatalf(format, args...)
+}

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -51,7 +52,7 @@ func TestIterHistories(t *testing.T) {
 				BlockPropertyCollectors: []func() BlockPropertyCollector{
 					sstable.NewTestKeysBlockPropertyCollector,
 				},
-				Logger: testLogger{t},
+				Logger: testutils.Logger{T: t},
 			}
 			opts.DisableAutomaticCompactions = true
 			opts.EnsureDefaults()

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/sstableinternal"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/blob"
@@ -43,7 +44,7 @@ func TestCheckLevelsBasics(t *testing.T) {
 			}
 			d, err := Open(tc, &Options{
 				FS:     fs,
-				Logger: testLogger{t},
+				Logger: testutils.Logger{T: t},
 			})
 			if err != nil {
 				t.Fatalf("%s: Open failed: %v", tc, err)

--- a/obsolete_files_test.go
+++ b/obsolete_files_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -96,7 +97,7 @@ func TestCleaner(t *testing.T) {
 			opts := &Options{
 				FS:     fs,
 				WALDir: dir + "_wal",
-				Logger: testLogger{t},
+				Logger: testutils.Logger{T: t},
 			}
 			opts.WithFSDefaults()
 

--- a/options_test.go
+++ b/options_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/strparse"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/wal"
@@ -31,7 +32,7 @@ func (o *Options) testingRandomized(t testing.TB) *Options {
 		o = &Options{}
 	}
 	if o.Logger == nil {
-		o.Logger = testLogger{t: t}
+		o.Logger = testutils.Logger{T: t}
 	}
 	if o.FormatMajorVersion == FormatDefault {
 		// Pick a random format major version from the range

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -34,8 +35,10 @@ func TestRangeDel(t *testing.T) {
 			require.NoError(t, d.Close())
 		}
 	}()
-	opts := &Options{}
-	opts.DisableAutomaticCompactions = true
+	opts := &Options{
+		DisableAutomaticCompactions: true,
+		Logger:                      testutils.Logger{T: t},
+	}
 
 	datadriven.RunTest(t, "testdata/range_del", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -104,7 +107,7 @@ func TestFlushDelay(t *testing.T) {
 		FlushDelayDeleteRange: 10 * time.Millisecond,
 		FlushDelayRangeKey:    10 * time.Millisecond,
 		FormatMajorVersion:    internalFormatNewest,
-		Logger:                testLogger{t: t},
+		Logger:                testutils.Logger{T: t},
 	}
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -205,7 +208,7 @@ func TestFlushDelayStress(t *testing.T) {
 		FlushDelayRangeKey:    time.Duration(rng.IntN(10)+1) * time.Millisecond,
 		FormatMajorVersion:    internalFormatNewest,
 		MemTableSize:          8192,
-		Logger:                testLogger{t: t},
+		Logger:                testutils.Logger{T: t},
 	}
 
 	runs := 100
@@ -269,6 +272,7 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 			},
 			DebugCheck:         DebugCheckLevels,
 			FormatMajorVersion: formatVersion,
+			Logger:             testutils.Logger{T: t},
 		})
 		require.NoError(t, err)
 		defer d.Close()
@@ -415,6 +419,7 @@ func TestRangeDelCompactionTruncation2(t *testing.T) {
 			2: 1,
 		},
 		DebugCheck: DebugCheckLevels,
+		Logger:     testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 	defer d.Close()
@@ -476,6 +481,7 @@ func TestRangeDelCompactionTruncation3(t *testing.T) {
 			2: 1,
 		},
 		DebugCheck: DebugCheckLevels,
+		Logger:     testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 	defer d.Close()
@@ -595,6 +601,7 @@ func benchmarkRangeDelIterate(b *testing.B, entries, deleted int, snapshotCompac
 		Cache:      cache,
 		FS:         mem,
 		DebugCheck: DebugCheckLevels,
+		Logger:     testutils.Logger{T: b},
 	})
 	if err != nil {
 		b.Fatal(err)

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/itertest"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
@@ -46,7 +47,7 @@ func TestScanStatistics(t *testing.T) {
 	getOpts := func() *Options {
 		opts := &Options{
 			FS:                 vfs.NewMem(),
-			Logger:             testLogger{t: t},
+			Logger:             testutils.Logger{T: t},
 			Comparer:           testkeys.Comparer,
 			FormatMajorVersion: FormatMinForSharedObjects,
 			BlockPropertyCollectors: []func() BlockPropertyCollector{
@@ -230,7 +231,7 @@ func TestScanInternal(t *testing.T) {
 	parseOpts := func(td *datadriven.TestData) (*Options, error) {
 		opts := &Options{
 			FS:                 vfs.NewMem(),
-			Logger:             testLogger{t: t},
+			Logger:             testutils.Logger{T: t},
 			Comparer:           testkeys.Comparer,
 			FormatMajorVersion: FormatVirtualSSTables,
 			BlockPropertyCollectors: []func() BlockPropertyCollector{

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -76,6 +77,7 @@ func testSnapshotImpl(t *testing.T, newSnapshot func(d *DB) Reader) {
 			options := &Options{
 				FS:                 vfs.NewMem(),
 				FormatMajorVersion: randVersion(),
+				Logger:             testutils.Logger{T: t},
 			}
 			if td.HasArg("block-size") {
 				var blockSize int
@@ -213,7 +215,8 @@ func TestEventuallyFileOnlySnapshot(t *testing.T) {
 
 func TestSnapshotClosed(t *testing.T) {
 	d, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 
@@ -241,7 +244,8 @@ func TestSnapshotRangeDeletionStress(t *testing.T) {
 	const middleKey = runs * runs
 
 	d, err := Open("", &Options{
-		FS: vfs.NewMem(),
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
 	})
 	require.NoError(t, err)
 
@@ -322,7 +326,10 @@ func TestSnapshotRangeDeletionStress(t *testing.T) {
 // snapshot could drop keys required by the snapshot.
 func TestNewSnapshotRace(t *testing.T) {
 	const runs = 10
-	d, err := Open("", &Options{FS: vfs.NewMem()})
+	d, err := Open("", &Options{
+		FS:     vfs.NewMem(),
+		Logger: testutils.Logger{T: t},
+	})
 	require.NoError(t, err)
 
 	v := []byte(`foo`)

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/colblk"
@@ -36,7 +37,7 @@ func TestTableStats(t *testing.T) {
 				loadedInfo = &info
 			},
 		},
-		Logger: testLogger{t},
+		Logger: testutils.Logger{T: t},
 	}
 
 	d, err := Open("", opts)

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/strparse"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/record"
@@ -50,7 +51,7 @@ func TestVersionSet(t *testing.T) {
 	opts := &Options{
 		FS:       vfs.NewMem(),
 		Comparer: base.DefaultComparer,
-		Logger:   testLogger{t},
+		Logger:   testutils.Logger{T: t},
 	}
 	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
@@ -275,7 +276,7 @@ func TestVersionSetCheckpoint(t *testing.T) {
 	opts := &Options{
 		FS:                  mem,
 		MaxManifestFileSize: 1,
-		Logger:              testLogger{t: t},
+		Logger:              testutils.Logger{T: t},
 	}
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -308,7 +309,7 @@ func TestVersionSetSeqNums(t *testing.T) {
 	opts := &Options{
 		FS:                  mem,
 		MaxManifestFileSize: 1,
-		Logger:              testLogger{t: t},
+		Logger:              testutils.Logger{T: t},
 	}
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -377,7 +378,7 @@ func TestLargeKeys(t *testing.T) {
 		Comparer:                    &largeKeyComparer,
 		FormatMajorVersion:          internalFormatNewest,
 		FS:                          vfs.NewMem(),
-		Logger:                      testLogger{t: t},
+		Logger:                      testutils.Logger{T: t},
 		MemTableStopWritesThreshold: 4,
 		DisableTableStats:           true,
 	}
@@ -527,7 +528,7 @@ func TestCrashDuringManifestWrite_LargeKeys(t *testing.T) {
 		}))
 	}
 
-	opts := &Options{Logger: testLogger{t: t}}
+	opts := &Options{Logger: testutils.Logger{T: t}}
 	lel := MakeLoggingEventListener(opts.Logger)
 	opts.EventListener = &lel
 


### PR DESCRIPTION
Move the testLogger type into testutils and use it in a few additional tests to silence some additional stdout spam.