### PR TITLE
wal: hint sequential reads when reading WAL files

### DIFF
--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -332,7 +332,7 @@ close: checkpoints/checkpoint1/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
 open: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
-open: checkpoints/checkpoint1/000006.log
+open: checkpoints/checkpoint1/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint1/000006.log
 
 scan checkpoints/checkpoint1
@@ -399,7 +399,7 @@ close: checkpoints/checkpoint2/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
 open: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
-open: checkpoints/checkpoint2/000006.log
+open: checkpoints/checkpoint2/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint2/000006.log
 
 scan checkpoints/checkpoint2
@@ -441,7 +441,7 @@ close: checkpoints/checkpoint3/MANIFEST-000001
 open-dir: checkpoints/checkpoint3
 open: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
-open: checkpoints/checkpoint3/000006.log
+open: checkpoints/checkpoint3/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint3/000006.log
 
 scan checkpoints/checkpoint3
@@ -584,7 +584,7 @@ close: checkpoints/checkpoint4/MANIFEST-000001
 open-dir: checkpoints/checkpoint4
 open: checkpoints/checkpoint4/OPTIONS-000003
 close: checkpoints/checkpoint4/OPTIONS-000003
-open: checkpoints/checkpoint4/000008.log
+open: checkpoints/checkpoint4/000008.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint4/000008.log
 
 scan checkpoints/checkpoint4
@@ -699,7 +699,7 @@ close: checkpoints/checkpoint5/MANIFEST-000001
 open-dir: checkpoints/checkpoint5
 open: checkpoints/checkpoint5/OPTIONS-000003
 close: checkpoints/checkpoint5/OPTIONS-000003
-open: checkpoints/checkpoint5/000008.log
+open: checkpoints/checkpoint5/000008.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint5/000008.log
 create: checkpoints/checkpoint5/000018.sst
 sync-data: checkpoints/checkpoint5/000018.sst
@@ -800,7 +800,7 @@ close: checkpoints/checkpoint6/MANIFEST-000001
 open-dir: checkpoints/checkpoint6
 open: checkpoints/checkpoint6/OPTIONS-000003
 close: checkpoints/checkpoint6/OPTIONS-000003
-open: checkpoints/checkpoint6/000008.log
+open: checkpoints/checkpoint6/000008.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint6/000008.log
 create: checkpoints/checkpoint6/000018.sst
 sync-data: checkpoints/checkpoint6/000018.sst
@@ -1031,7 +1031,7 @@ close: checkpoints/checkpoint8/MANIFEST-000001
 open-dir: checkpoints/checkpoint8
 open: checkpoints/checkpoint8/OPTIONS-000003
 close: checkpoints/checkpoint8/OPTIONS-000003
-open: checkpoints/checkpoint8/000004.log
+open: checkpoints/checkpoint8/000004.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint8/000004.log
 
 # Ensure that we can read values contained in the blob file.
@@ -1143,7 +1143,7 @@ close: checkpoints/checkpoint9/MANIFEST-000001
 open-dir: checkpoints/checkpoint9
 open: checkpoints/checkpoint9/OPTIONS-000003
 close: checkpoints/checkpoint9/OPTIONS-000003
-open: checkpoints/checkpoint9/000007.log
+open: checkpoints/checkpoint9/000007.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint9/000007.log
 
 scan checkpoints/checkpoint9

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -315,7 +315,7 @@ close: checkpoints/checkpoint1/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
 open: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
-open: checkpoints/checkpoint1/000006.log
+open: checkpoints/checkpoint1/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint1/000006.log
 
 scan checkpoints/checkpoint1
@@ -367,7 +367,7 @@ close: checkpoints/checkpoint2/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
 open: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
-open: checkpoints/checkpoint2/000006.log
+open: checkpoints/checkpoint2/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint2/000006.log
 
 scan checkpoints/checkpoint2

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -247,7 +247,7 @@ lock: db1_wal/LOCK
 open-dir: db1_wal
 open: db1/OPTIONS-000003
 close: db1/OPTIONS-000003
-open: db1_wal/000004.log
+open: db1_wal/000004.log (options: *vfs.sequentialReadsOption)
 close: db1_wal/000004.log
 create: db1/MANIFEST-000458
 sync: db1/MANIFEST-000458

--- a/wal/reader.go
+++ b/wal/reader.go
@@ -370,7 +370,7 @@ func (r *virtualWALReader) nextFile() error {
 	r.off.PhysicalFile = path
 	r.off.Physical = 0
 	var err error
-	if r.currFile, err = fs.Open(path); err != nil {
+	if r.currFile, err = fs.Open(path, vfs.SequentialReadsOption); err != nil {
 		return errors.Wrapf(err, "opening WAL file segment %q", path)
 	}
 	r.currReader = record.NewReader(r.currFile, base.DiskFileNum(r.Num))


### PR DESCRIPTION
When reading WAL files, pass the vfs.SequentialReadsOption option to indicate that reads will be sequential. This enables OS-mediated readahead on Linux.