### PR TITLE
[tiered-prototype] db: partial code for new column format

### DIFF
--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -292,21 +292,16 @@ func TestBlobRewriteRandomized(t *testing.T) {
 		tw := sstable.NewRawWriter(w, sstable.WriterOptions{
 			TableFormat: sstable.TableFormatMax,
 		})
-		require.NoError(t, tw.AddWithBlobHandle(
-			base.MakeInternalKey(keys[i], base.SeqNum(i), base.InternalKeyKindSet),
-			blob.InlineHandle{
-				InlineHandlePreface: blob.InlineHandlePreface{
-					ReferenceID: base.BlobReferenceID(0),
-					ValueLen:    uint32(len(values[i])),
-				},
-				HandleSuffix: blob.HandleSuffix{
-					BlockID: handles[i].BlockID,
-					ValueID: handles[i].ValueID,
-				},
+		require.NoError(t, tw.AddWithBlobHandle(base.MakeInternalKey(keys[i], base.SeqNum(i), base.InternalKeyKindSet), blob.InlineHandle{
+			InlineHandlePreface: blob.InlineHandlePreface{
+				ReferenceID: base.BlobReferenceID(0),
+				ValueLen:    uint32(len(values[i])),
 			},
-			base.ShortAttribute(0),
-			false, /* forceObsolete */
-		))
+			HandleSuffix: blob.HandleSuffix{
+				BlockID: handles[i].BlockID,
+				ValueID: handles[i].ValueID,
+			},
+		}, base.ShortAttribute(0), false, base.KVMeta{}))
 		require.NoError(t, tw.Close())
 		originalValueIndices[i] = i
 		originalTables[i] = &manifest.TableMetadata{

--- a/cockroachkvs/cockroachkvs_bench_test.go
+++ b/cockroachkvs/cockroachkvs_bench_test.go
@@ -193,7 +193,7 @@ func benchmarkCockroachDataColBlockWriter(b *testing.B, keyConfig KeyGenConfig, 
 	_, keys, values := generateDataBlock(rng, targetBlockSize, keyConfig, valueLen)
 
 	var w colblk.DataBlockEncoder
-	w.Init(&KeySchema)
+	w.Init(colblk.ColumnFormatv1, &KeySchema)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -202,7 +202,8 @@ func benchmarkCockroachDataColBlockWriter(b *testing.B, keyConfig KeyGenConfig, 
 		for w.Size() < targetBlockSize {
 			ik := base.MakeInternalKey(keys[count], base.SeqNum(rng.Uint64N(uint64(base.SeqNumMax))), base.InternalKeyKindSet)
 			kcmp := w.KeyWriter.ComparePrev(ik.UserKey)
-			w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp, false /* isObsolete */)
+			w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp,
+				false /* isObsolete */, base.KVMeta{})
 			count++
 		}
 		_, _ = w.Finish(w.Rows(), w.Size())
@@ -315,10 +316,11 @@ func benchmarkCockroachDataColBlockIter(
 
 	var decoder colblk.DataBlockDecoder
 	var it colblk.DataBlockIter
-	it.InitOnce(&KeySchema, &Comparer, getInternalValuer(func([]byte) base.InternalValue {
-		return base.MakeInPlaceValue([]byte("mock external value"))
-	}))
-	decoder.Init(&KeySchema, serializedBlock)
+	it.InitOnce(colblk.ColumnFormatv1, &KeySchema, &Comparer,
+		getInternalValuer(func([]byte) base.InternalValue {
+			return base.MakeInPlaceValue([]byte("mock external value"))
+		}))
+	decoder.Init(colblk.ColumnFormatv1, &KeySchema, serializedBlock)
 	if err := it.Init(&decoder, transforms); err != nil {
 		b.Fatal(err)
 	}

--- a/cockroachkvs/cockroachkvs_test.go
+++ b/cockroachkvs/cockroachkvs_test.go
@@ -206,7 +206,7 @@ func TestKeySchema_KeySeeker(t *testing.T) {
 	var dec colblk.DataBlockDecoder
 	var ks colblk.KeySeeker
 	var maxKeyLen int
-	enc.Init(&KeySchema)
+	enc.Init(colblk.ColumnFormatv1, &KeySchema)
 
 	initKeySeeker := func() {
 		ksPointer := &cockroachKeySeeker{}
@@ -230,11 +230,12 @@ func TestKeySchema_KeySeeker(t *testing.T) {
 					UserKey: k,
 					Trailer: pebble.MakeInternalKeyTrailer(0, base.InternalKeyKindSet),
 				}
-				enc.Add(ikey, k, block.InPlaceValuePrefix(false), kcmp, false /* isObsolete */)
+				enc.Add(
+					ikey, k, block.InPlaceValuePrefix(false), kcmp, false /* isObsolete */, base.KVMeta{})
 				rows++
 			}
 			blk, _ := enc.Finish(rows, enc.Size())
-			dec.Init(&KeySchema, blk)
+			dec.Init(colblk.ColumnFormatv1, &KeySchema, blk)
 			return buf.String()
 		case "is-lower-bound":
 			initKeySeeker()
@@ -409,10 +410,11 @@ func testCockroachDataColBlock(t *testing.T, seed uint64, keyCfg KeyGenConfig) {
 
 	var decoder colblk.DataBlockDecoder
 	var it colblk.DataBlockIter
-	it.InitOnce(&KeySchema, &Comparer, getInternalValuer(func([]byte) base.InternalValue {
-		return base.MakeInPlaceValue([]byte("mock external value"))
-	}))
-	decoder.Init(&KeySchema, serializedBlock)
+	it.InitOnce(colblk.ColumnFormatv1, &KeySchema, &Comparer,
+		getInternalValuer(func([]byte) base.InternalValue {
+			return base.MakeInPlaceValue([]byte("mock external value"))
+		}))
+	decoder.Init(colblk.ColumnFormatv1, &KeySchema, serializedBlock)
 	if err := it.Init(&decoder, blockiter.Transforms{}); err != nil {
 		t.Fatal(err)
 	}
@@ -459,12 +461,13 @@ func generateDataBlock(
 	keys, values = RandomKVs(rng, targetBlockSize/valueLen, cfg, valueLen)
 
 	var w colblk.DataBlockEncoder
-	w.Init(&KeySchema)
+	w.Init(colblk.ColumnFormatv1, &KeySchema)
 	count := 0
 	for w.Size() < targetBlockSize {
 		ik := base.MakeInternalKey(keys[count], base.SeqNum(rng.Uint64N(uint64(base.SeqNumMax))), base.InternalKeyKindSet)
 		kcmp := w.KeyWriter.ComparePrev(ik.UserKey)
-		w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp, false /* isObsolete */)
+		w.Add(ik, values[count], block.InPlaceValuePrefix(kcmp.PrefixEqual()), kcmp,
+			false /* isObsolete */, base.KVMeta{})
 		count++
 	}
 	data, _ = w.Finish(w.Rows(), w.Size())

--- a/data_test.go
+++ b/data_test.go
@@ -672,13 +672,13 @@ func runBuildCmd(
 			if err != nil {
 				return err
 			}
-			if err := w.Raw().AddWithBlobHandle(tmp, handle, base.ShortAttribute(0), false); err != nil {
+			if err := w.Raw().AddWithBlobHandle(tmp, handle, base.ShortAttribute(0), false, base.KVMeta{}); err != nil {
 				return err
 			}
 			continue
 		}
 		// Otherwise add it as an ordinary value.
-		if err := w.Raw().Add(tmp, v, false); err != nil {
+		if err := w.Raw().Add(tmp, v, false, base.KVMeta{}); err != nil {
 			return err
 		}
 	}

--- a/excise_test.go
+++ b/excise_test.go
@@ -592,7 +592,7 @@ func TestConcurrentExcise(t *testing.T) {
 				VisitPointKey: func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
-					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
+					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false, base.KVMeta{}))
 					return nil
 				},
 				VisitRangeDel: func(start, end []byte, seqNum base.SeqNum) error {

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -220,7 +220,7 @@ func (t *fileCacheTest) newTestHandle() (*fileCacheHandle, *fileCacheTestFS) {
 		}
 		tw := sstable.NewWriter(w, sstable.WriterOptions{TableFormat: sstable.TableFormatPebblev2})
 		ik := base.ParseInternalKey(fmt.Sprintf("k.SET.%d", i))
-		if err := tw.Raw().Add(ik, xxx[:i], false); err != nil {
+		if err := tw.Raw().Add(ik, xxx[:i], false, base.KVMeta{}); err != nil {
 			t.Fatal(err)
 		}
 		if err := tw.RangeKeySet([]byte("k"), []byte("l"), nil, xxx[:i]); err != nil {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -127,12 +127,12 @@ func TestIngestLoad(t *testing.T) {
 				if blobtest.IsBlobHandle(data[j+1:]) {
 					ih, _, err := bv.ParseInlineHandle(data[j+1:])
 					require.NoError(t, err)
-					if err := w.AddWithBlobHandle(key, ih, base.ShortAttribute(0), false /* forceObsolete */); err != nil {
+					if err := w.AddWithBlobHandle(key, ih, base.ShortAttribute(0), false, base.KVMeta{}); err != nil {
 						return err.Error()
 					}
 				} else {
 					value := []byte(data[j+1:])
-					if err := w.Add(key, value, false /* forceObsolete */); err != nil {
+					if err := w.Add(key, value, false, base.KVMeta{}); err != nil {
 						return err.Error()
 					}
 				}
@@ -221,7 +221,7 @@ func TestIngestLoadRand(t *testing.T) {
 					// Duplicate key, ignore.
 					continue
 				}
-				require.NoError(t, w.Add(keys[i], nil, false /* forceObsolete */))
+				require.NoError(t, w.Add(keys[i], nil, false, base.KVMeta{}))
 				count++
 				rawKeySize += uint64(keys[i].Size())
 			}
@@ -851,7 +851,7 @@ func testIngestSharedImpl(
 				VisitPointKey: func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
-					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
+					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false, base.KVMeta{}))
 					return nil
 				},
 				VisitRangeDel: func(start, end []byte, seqNum base.SeqNum) error {
@@ -1375,7 +1375,7 @@ func TestIngestExternal(t *testing.T) {
 				VisitPointKey: func(key *InternalKey, value LazyValue, _ IteratorLevel) error {
 					val, _, err := value.Value(nil)
 					require.NoError(t, err)
-					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false /* forceObsolete */))
+					require.NoError(t, w.Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false, base.KVMeta{}))
 					return nil
 				},
 				VisitRangeDel: func(start, end []byte, seqNum base.SeqNum) error {
@@ -1921,7 +1921,7 @@ func TestIngestCompact(t *testing.T) {
 
 	w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{})
 	key := []byte("a")
-	require.NoError(t, w.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), nil, false /* forceObsolete */))
+	require.NoError(t, w.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), nil, false, base.KVMeta{}))
 	require.NoError(t, w.Close())
 
 	// Make N copies of the sstable.
@@ -2564,7 +2564,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 			}
 			key := base.ParseInternalKey(data[:j])
 			value := []byte(data[j+1:])
-			if err := w.Add(key, value, false /* forceObsolete */); err != nil {
+			if err := w.Add(key, value, false, base.KVMeta{}); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -617,6 +617,34 @@ func MakeInternalKV(k InternalKey, v []byte) InternalKV {
 type InternalKV struct {
 	K InternalKey
 	V InternalValue
+	M KVMeta
+}
+
+type TieringAttribute uint64
+
+type TieringMeta struct {
+	SpanID uint64
+	// Attribute is a user-specified attribute for the key-value pair.
+	//
+	// TODO(sumeer): For CockroachDB decide on units for this attribute, which
+	// will be a timestamp, since unix nanos is unnecessarily large.
+	// log2(24*365*100) = 19.74, i.e., number of hours in 100 years fits in 3
+	// bytes.
+	Attribute TieringAttribute
+}
+
+// KVMeta is optional information that is known about the InternalKV. For now,
+// this is available only for KVs read from an sstable. Placing this in
+// InternalKV allows this to be exposed via the InternalIterator interface.
+//
+// TODO(sumeer): we are doing this only because we need this information
+// during a sstable compaction. It is not needed for normal iteration, so we
+// shouldn't be adding additional overhead for the common path. We should
+// specialize levelIter and the sstable iterators to have FirstWithMeta and
+// NextWithMeta methods that can be used for the limited use case of
+// compaction.Iter.
+type KVMeta struct {
+	Tiering TieringMeta
 }
 
 // Kind returns the KV's internal key kind.

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -503,7 +503,7 @@ func (NeverSeparateValues) Add(
 	if err != nil {
 		return err
 	}
-	return tw.Add(kv.K, v, forceObsolete)
+	return tw.Add(kv.K, v, forceObsolete, kv.M)
 }
 
 // FinishOutput implements the ValueSeparation interface.

--- a/level_checker_test.go
+++ b/level_checker_test.go
@@ -216,7 +216,7 @@ func TestCheckLevelsCornerCases(t *testing.T) {
 					j := strings.Index(kv, ":")
 					ikey := base.ParseInternalKey(kv[:j])
 					value := []byte(kv[j+1:])
-					err = w.Add(ikey, value, false /* forceObsolete */)
+					err = w.Add(ikey, value, false, base.KVMeta{})
 					if err != nil {
 						return err.Error()
 					}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -267,7 +267,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 				return err.Error()
 			}
 		default:
-			if err := w.Add(ikey, value, false /* forceObsolete */); err != nil {
+			if err := w.Add(ikey, value, false, base.KVMeta{}); err != nil {
 				return err.Error()
 			}
 		}
@@ -542,7 +542,7 @@ func buildLevelIterTables(
 			key := []byte(fmt.Sprintf("%08d", i))
 			keys = append(keys, key)
 			ikey := base.MakeInternalKey(key, 0, InternalKeyKindSet)
-			require.NoError(b, w.Add(ikey, nil, false /* forceObsolete */))
+			require.NoError(b, w.Add(ikey, nil, false, base.KVMeta{}))
 		}
 		if err := w.Close(); err != nil {
 			b.Fatal(err)

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -243,7 +243,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 							case InternalKeyKindRangeDelete:
 								frag.Add(keyspan.Span{Start: ikey.UserKey, End: value, Keys: []keyspan.Key{{Trailer: ikey.Trailer}}})
 							default:
-								if err := w.Add(ikey, value, false /* forceObsolete */); err != nil {
+								if err := w.Add(ikey, value, false, base.KVMeta{}); err != nil {
 									return err.Error()
 								}
 							}
@@ -371,7 +371,7 @@ func buildMergingIterTables(
 		ikey.UserKey = key
 		j := rand.IntN(len(writers))
 		w := writers[j]
-		w.Add(ikey, nil, false /* forceObsolete */)
+		w.Add(ikey, nil, false, base.KVMeta{})
 	}
 
 	for _, w := range writers {
@@ -602,7 +602,7 @@ func buildLevelsForMergingIterSeqSeek(
 		key := makeKey(i)
 		keys = append(keys, key)
 		ikey := base.MakeInternalKey(key, 0, InternalKeyKindSet)
-		require.NoError(b, w.Add(ikey, nil, false /* forceObsolete */))
+		require.NoError(b, w.Add(ikey, nil, false, base.KVMeta{}))
 	}
 	if writeRangeTombstoneToLowestLevel {
 		require.NoError(b, w.EncodeSpan(keyspan.Span{
@@ -616,14 +616,14 @@ func buildLevelsForMergingIterSeqSeek(
 	for j := 1; j < len(files); j++ {
 		for _, k := range []int{0, len(keys) - 1} {
 			ikey := base.MakeInternalKey(keys[k], base.SeqNum(j), InternalKeyKindSet)
-			require.NoError(b, writers[j][0].Add(ikey, nil, false /* forceObsolete */))
+			require.NoError(b, writers[j][0].Add(ikey, nil, false, base.KVMeta{}))
 		}
 	}
 	lastKey := makeKey(i)
 	keys = append(keys, lastKey)
 	for j := 0; j < len(files); j++ {
 		lastIKey := base.MakeInternalKey(lastKey, base.SeqNum(j), InternalKeyKindSet)
-		require.NoError(b, writers[j][1].Add(lastIKey, nil, false /* forceObsolete */))
+		require.NoError(b, writers[j][1].Add(lastIKey, nil, false, base.KVMeta{}))
 	}
 	for _, levelWriters := range writers {
 		for j, w := range levelWriters {

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -98,7 +98,7 @@ func writeSSTForIngestion(
 			return nil, err
 		}
 		t.opts.Comparer.ValidateKey.MustValidate(k.K.UserKey)
-		if err := w.Raw().Add(k.K, valBytes, false); err != nil {
+		if err := w.Raw().Add(k.K, valBytes, false, base.KVMeta{}); err != nil {
 			return nil, err
 		}
 	}

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -2011,7 +2011,7 @@ func (r *replicateOp) runSharedReplicate(
 			if err != nil {
 				panic(err)
 			}
-			return w.Raw().Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false)
+			return w.Raw().Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false, base.KVMeta{})
 		},
 		VisitRangeDel: func(start, end []byte, seqNum base.SeqNum) error {
 			return w.DeleteRange(start, end)
@@ -2079,7 +2079,7 @@ func (r *replicateOp) runExternalReplicate(
 				panic(err)
 			}
 			t.opts.Comparer.ValidateKey.MustValidate(key.UserKey)
-			return w.Raw().Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false)
+			return w.Raw().Add(base.MakeInternalKey(key.UserKey, 0, key.Kind()), val, false, base.KVMeta{})
 		},
 		VisitRangeDel: func(start, end []byte, seqNum base.SeqNum) error {
 			t.opts.Comparer.ValidateKey.MustValidate(start)

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -623,7 +623,7 @@ func benchmarkRangeDelIterate(b *testing.B, entries, deleted int, snapshotCompac
 	})
 	for i := 0; i < entries; i++ {
 		key := base.MakeInternalKey(makeKey(i), 0, InternalKeyKindSet)
-		if err := w.Add(key, nil, false /* forceObsolete */); err != nil {
+		if err := w.Add(key, nil, false, base.KVMeta{}); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -433,7 +433,7 @@ func TestScanInternal(t *testing.T) {
 					var err error
 					value, _, err = kv.Value(value)
 					require.NoError(t, err)
-					require.NoError(t, w.Raw().Add(kv.K, value, false))
+					require.NoError(t, w.Raw().Add(kv.K, value, false, base.KVMeta{}))
 				}
 				points.Close()
 				require.NoError(t, w.Close())

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -242,8 +242,9 @@ func CastMetadata[T any](md *Metadata) *T {
 }
 
 // MetadataSize is the size of the metadata. The value is chosen to fit a
-// colblk.DataBlockDecoder and a CockroachDB colblk.KeySeeker.
-const MetadataSize = 312
+// colblk.DataBlockDecoder and a CockroachDB colblk.KeySeeker. It is never
+// persisted.
+const MetadataSize = 360
 
 // Assert that MetadataSize is a multiple of 8. This is necessary to keep the
 // block data buffer aligned.

--- a/sstable/block/testdata/flush_governor
+++ b/sstable/block/testdata/flush_governor
@@ -25,8 +25,8 @@ should-flush size-before=899 size-after=10000
 ----
 should not flush
 
-# Size classes. Note that the block allocation overhead is 360.
-init target-block-size=800 size-class-aware-threshold=60 size-classes=(820, 1020, 1320, 1820)
+# Size classes. Note that the block allocation overhead is 392.
+init target-block-size=800 size-class-aware-threshold=60 size-classes=(820, 1068, 1368, 1820)
 ----
 low watermark: 480
 high watermark: 976
@@ -82,8 +82,8 @@ targetBoundary: 1000
 init target-block-size=32768 jemalloc-size-classes
 ----
 low watermark: 19661
-high watermark: 40616
-targetBoundary: 32424
+high watermark: 40568
+targetBoundary: 32376
 
 # We should not flush until exceeding the boundary.
 should-flush size-before=30000 size-after=31000

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -456,6 +456,7 @@ func (ks *defaultKeySeeker) MaterializeUserKeyWithSyntheticSuffix(
 
 // DataBlockEncoder encodes columnar data blocks using a user-defined schema.
 type DataBlockEncoder struct {
+	format    ColumnarFormat
 	Schema    *KeySchema
 	KeyWriter KeyWriter
 	// trailers is the column writer for InternalKey uint64 trailers.
@@ -476,6 +477,18 @@ type DataBlockEncoder struct {
 	// when a key is known to be obsolete/non-live (i.e., shadowed by another
 	// identical point key or range deletion with a higher sequence number).
 	isObsolete BitmapBuilder
+	// These two columns are only accessed when the sstable is rewritten, so we
+	// stick them at the end of the data block. Both will be accessed together
+	// for each key, and we expect that in most cases there will be at most one
+	// unique spanID.
+	//
+	// Alternatively, we could have added these fields to the custom
+	// serialization we do for values when it is a value block handle or blob
+	// handle, but then we need to add a custom serialization for the in-place
+	// value case too, and all that serialization predated support for columnar
+	// blocks.
+	tieringSpanIDs    UintBuilder
+	tieringAttributes UintBuilder
 
 	enc              BlockEncoder
 	rows             int
@@ -490,7 +503,72 @@ const (
 	dataBlockColumnValue
 	dataBlockColumnIsValueExternal
 	dataBlockColumnIsObsolete
-	dataBlockColumnMax
+	dataBlockColumnMaxV1
+	dataBlockColumnTieringSpanID    = dataBlockColumnMaxV1
+	dataBlockColumnTieringAttribute = dataBlockColumnTieringSpanID + 1
+	dataBlockColumnMaxV2            = dataBlockColumnTieringAttribute + 1
+)
+
+type ColumnarFormat uint8
+
+const (
+	ColumnFormatv1 ColumnarFormat = iota
+	// ColumnFormatv2 adds support for a tiering (spanID, attribute) pair, for
+	// use in tiered storage.
+	//
+	// Why spanID? An attribute extraction policy for a SQL index is immutable
+	// in CockroachDB. It can be represented by the [start, end) span at the
+	// Pebble layer, and/or a spanID. The age at which data becomes cold is the
+	// tiering policy and is mutable. Pebble needs the following information:
+	//
+	// - Extract the attribute from the key-value pair for the first time. We
+	//   want to do this once when first generating a sstable (and possibly a
+	//   blob file) containing that key-value pair. With key and value
+	//   separation, we are moving into a world where we want to continue to be
+	//   able to rewrite sstables without reading the value from the blob file
+	//   and rewrite blob files without reading the key from the sstable. And
+	//   even though we start with only cold blob files, we plan to extend this
+	//   to cold sstables too, so the attribute is stored with the key in the
+	//   sstable, and with the value in the blob file.
+	//
+	// - Get the current tiering policy for a key (sstable rewriting) or for the
+	//   value (when rewriting a blob file for policy enforcement or for space
+	//   reclamation). A spanID permits easier/faster policy lookup for the key
+	//   case, but is not necessary. For the value case, we need a way to lookup
+	//   the policy. With a single conceptual spanID in an sstable or blob file,
+	//   we can store a single key belonging to that span in the blob file and
+	//   use it for policy lookup. So a spanID is again not necessary. If we
+	//   allow multiple conceptual spanIDs in a sstable or blob file, having a
+	//   spanID becomes necessary for a blob file since we can store the spanID
+	//   concisely with each value. For blob files in higher levels, splitting
+	//   per spanID may result in unnecessarily small files. Arguably, we could
+	//   have two approaches where blob files in higher levels are not split by
+	//   spanID, since these blob files may never need to be cold, and when we
+	//   write blob files for lower level sstable compactions we would extract
+	//   the tiering policy using the sstable key and make the blob file have a
+	//   single spanID. Having blob files that are not self contained wrt us
+	//   being able to compute how much cold data is in them (by reading them)
+	//   is not ideal, IMHO, so we don't do this (yet).
+	//
+	// - Store the histogram of attributes inside a sstable and blob file. This
+	//   is needed to decide when to rewrite to make a hot => cold transition.
+	//   With a single spanID per file, we don't need a spanID. There is some
+	//   concern that users could easily abuse the system by creating 1000s of
+	//   tiny SQL tables with different attribute extraction policies, resulting
+	//   in many tiny files. With multiple extraction policies per file, a
+	//   spanID provides a convenient key.
+	//
+	// - Tiering policy change: At the Pebble layer we will keep aggregate
+	//   histograms of each attribute extraction policy, so we can compare these
+	//   to the current tiering policy (which may have changed since the last
+	//   time we checked), to decide if there is substantial amount of data in
+	//   the wrong tier. A spanID is a convenient key, though we could also
+	//   accomplish this with the start key of the policy.
+	//
+	// TODO(sumeer): decide later if we can remove spanID, if the data-structure
+	// simplification is not worthwhile.
+	ColumnFormatv2
+	numColumnFormats
 )
 
 // The data block header is a 4-byte uint32 encoding the maximum length of a key
@@ -501,7 +579,8 @@ const (
 const dataBlockCustomHeaderSize = 4
 
 // Init initializes the data block writer.
-func (w *DataBlockEncoder) Init(schema *KeySchema) {
+func (w *DataBlockEncoder) Init(format ColumnarFormat, schema *KeySchema) {
+	w.format = format
 	w.Schema = schema
 	w.KeyWriter = schema.NewKeyWriter()
 	w.trailers.Init()
@@ -509,6 +588,10 @@ func (w *DataBlockEncoder) Init(schema *KeySchema) {
 	w.values.Init()
 	w.isValueExternal.Reset()
 	w.isObsolete.Reset()
+	if format > ColumnFormatv1 {
+		w.tieringSpanIDs.InitWithDefault()
+		w.tieringAttributes.InitWithDefault()
+	}
 	w.rows = 0
 	w.maximumKeyLength = 0
 	w.lastUserKeyTmp = w.lastUserKeyTmp[:0]
@@ -523,6 +606,10 @@ func (w *DataBlockEncoder) Reset() {
 	w.values.Reset()
 	w.isValueExternal.Reset()
 	w.isObsolete.Reset()
+	if w.format > ColumnFormatv1 {
+		w.tieringSpanIDs.Reset()
+		w.tieringAttributes.Reset()
+	}
 	w.rows = 0
 	w.maximumKeyLength = 0
 	w.lastUserKeyTmp = w.lastUserKeyTmp[:0]
@@ -556,6 +643,16 @@ func (w *DataBlockEncoder) String() string {
 	w.isObsolete.WriteDebug(&buf, w.rows)
 	fmt.Fprintln(&buf)
 
+	if w.format > ColumnFormatv1 {
+		fmt.Fprintf(&buf, "%d: tiering-span-id: ", len(w.Schema.ColumnTypes)+dataBlockColumnTieringSpanID)
+		w.tieringSpanIDs.WriteDebug(&buf, w.rows)
+		fmt.Fprintln(&buf)
+
+		fmt.Fprintf(&buf, "%d: tiering-attribute:    ", len(w.Schema.ColumnTypes)+dataBlockColumnTieringAttribute)
+		w.tieringAttributes.WriteDebug(&buf, w.rows)
+		fmt.Fprintln(&buf)
+	}
+
 	return buf.String()
 }
 
@@ -573,6 +670,7 @@ func (w *DataBlockEncoder) Add(
 	valuePrefix block.ValuePrefix,
 	kcmp KeyComparison,
 	isObsolete bool,
+	meta base.KVMeta,
 ) {
 	w.KeyWriter.WriteKey(w.rows, ikey.UserKey, kcmp.PrefixLen, kcmp.CommonPrefixLen)
 	if kcmp.PrefixEqual() {
@@ -592,6 +690,10 @@ func (w *DataBlockEncoder) Add(
 		// bitmap and know there is no value prefix byte if !isValueExternal.
 		w.values.Put(value)
 	}
+	if w.format > ColumnFormatv1 && meta != (base.KVMeta{}) {
+		w.tieringSpanIDs.Set(w.rows, meta.Tiering.SpanID)
+		w.tieringAttributes.Set(w.rows, uint64(meta.Tiering.Attribute))
+	}
 	if len(ikey.UserKey) > int(w.maximumKeyLength) {
 		w.maximumKeyLength = len(ikey.UserKey)
 	}
@@ -605,13 +707,18 @@ func (w *DataBlockEncoder) Rows() int {
 
 // Size returns the size of the current pending data block.
 func (w *DataBlockEncoder) Size() int {
-	off := HeaderSize(len(w.Schema.ColumnTypes)+dataBlockColumnMax, dataBlockCustomHeaderSize+w.Schema.HeaderSize)
+	off := HeaderSize(len(w.Schema.ColumnTypes)+w.numFormatColumns(),
+		dataBlockCustomHeaderSize+w.Schema.HeaderSize)
 	off = w.KeyWriter.Size(w.rows, off)
 	off = w.trailers.Size(w.rows, off)
 	off = w.prefixSame.InvertedSize(w.rows, off)
 	off = w.values.Size(w.rows, off)
 	off = w.isValueExternal.Size(w.rows, off)
 	off = w.isObsolete.Size(w.rows, off)
+	if w.format > ColumnFormatv1 {
+		off = w.tieringSpanIDs.Size(w.rows, off)
+		off = w.tieringAttributes.Size(w.rows, off)
+	}
 	off++ // trailer padding byte
 	return int(off)
 }
@@ -619,6 +726,14 @@ func (w *DataBlockEncoder) Size() int {
 // MaterializeLastUserKey materializes the last added user key.
 func (w *DataBlockEncoder) MaterializeLastUserKey(appendTo []byte) []byte {
 	return w.KeyWriter.MaterializeKey(appendTo, w.rows-1)
+}
+
+func (w *DataBlockEncoder) numFormatColumns() int {
+	formatColumns := dataBlockColumnMaxV1
+	if w.format > ColumnFormatv1 {
+		formatColumns = dataBlockColumnMaxV2
+	}
+	return formatColumns
 }
 
 // Finish serializes the pending data block, including the first [rows] rows.
@@ -635,7 +750,7 @@ func (w *DataBlockEncoder) Finish(rows, size int) (finished []byte, lastKey base
 		panic(errors.AssertionFailedf("data block has %d rows; asked to finish %d", w.rows, rows))
 	}
 
-	cols := len(w.Schema.ColumnTypes) + dataBlockColumnMax
+	cols := len(w.Schema.ColumnTypes) + w.numFormatColumns()
 	h := Header{
 		Version: Version1,
 		Columns: uint16(cols),
@@ -658,6 +773,10 @@ func (w *DataBlockEncoder) Finish(rows, size int) (finished []byte, lastKey base
 	w.enc.Encode(rows, &w.values)
 	w.enc.Encode(rows, &w.isValueExternal)
 	w.enc.Encode(rows, &w.isObsolete)
+	if w.format > ColumnFormatv1 {
+		w.enc.Encode(rows, &w.tieringSpanIDs)
+		w.enc.Encode(rows, &w.tieringAttributes)
+	}
 	finished = w.enc.Finish()
 
 	w.lastUserKeyTmp = w.lastUserKeyTmp[:0]
@@ -671,6 +790,7 @@ func (w *DataBlockEncoder) Finish(rows, size int) (finished []byte, lastKey base
 
 // DataBlockRewriter rewrites data blocks. See RewriteSuffixes.
 type DataBlockRewriter struct {
+	format    ColumnarFormat
 	KeySchema *KeySchema
 
 	encoder   DataBlockEncoder
@@ -686,8 +806,11 @@ type DataBlockRewriter struct {
 }
 
 // NewDataBlockRewriter creates a block rewriter.
-func NewDataBlockRewriter(keySchema *KeySchema, comparer *base.Comparer) *DataBlockRewriter {
+func NewDataBlockRewriter(
+	format ColumnarFormat, keySchema *KeySchema, comparer *base.Comparer,
+) *DataBlockRewriter {
 	return &DataBlockRewriter{
+		format:    format,
 		KeySchema: keySchema,
 		comparer:  comparer,
 	}
@@ -718,8 +841,8 @@ func (rw *DataBlockRewriter) RewriteSuffixes(
 	input []byte, from []byte, to []byte,
 ) (start, end base.InternalKey, rewritten []byte, err error) {
 	if !rw.initialized {
-		rw.iter.InitOnce(rw.KeySchema, rw.comparer, assertNoExternalValues{})
-		rw.encoder.Init(rw.KeySchema)
+		rw.iter.InitOnce(rw.format, rw.KeySchema, rw.comparer, assertNoExternalValues{})
+		rw.encoder.Init(rw.format, rw.KeySchema)
 		rw.initialized = true
 	}
 
@@ -744,7 +867,7 @@ func (rw *DataBlockRewriter) RewriteSuffixes(
 	// better spent dropping support for the physical rewriting of data blocks
 	// we're performing here and instead use a read-time IterTransform.
 
-	rw.decoder.Init(rw.KeySchema, input)
+	rw.decoder.Init(rw.format, rw.KeySchema, input)
 	meta := &KeySeekerMetadata{}
 	rw.KeySchema.InitKeySeekerMetadata(meta, &rw.decoder)
 	rw.keySeeker = rw.KeySchema.KeySeeker(meta)
@@ -784,7 +907,7 @@ func (rw *DataBlockRewriter) RewriteSuffixes(
 			start.Trailer = kv.K.Trailer
 		}
 		k := base.InternalKey{UserKey: rw.keyBuf, Trailer: kv.K.Trailer}
-		rw.encoder.Add(k, value, valuePrefix, kcmp, rw.decoder.isObsolete.At(i))
+		rw.encoder.Add(k, value, valuePrefix, kcmp, rw.decoder.isObsolete.At(i), kv.M)
 	}
 	rewritten, end = rw.encoder.Finish(int(rw.decoder.d.header.Rows), rw.encoder.Size())
 	end.UserKey, rw.keyAlloc = rw.keyAlloc.Copy(end.UserKey)
@@ -805,7 +928,9 @@ const _ uint = uint(-(unsafe.Offsetof(blockDecoderAndKeySeekerMetadata{}.keySche
 const _ uint = block.MetadataSize - uint(unsafe.Sizeof(blockDecoderAndKeySeekerMetadata{}))
 
 // InitDataBlockMetadata initializes the metadata for a data block.
-func InitDataBlockMetadata(schema *KeySchema, md *block.Metadata, data []byte) (err error) {
+func InitDataBlockMetadata(
+	format ColumnarFormat, schema *KeySchema, md *block.Metadata, data []byte,
+) (err error) {
 	metadatas := block.CastMetadataZero[blockDecoderAndKeySeekerMetadata](md)
 	// Initialization can panic; convert panics to corruption errors (so higher
 	// layers can add file number and offset information).
@@ -814,7 +939,7 @@ func InitDataBlockMetadata(schema *KeySchema, md *block.Metadata, data []byte) (
 			err = base.CorruptionErrorf("error initializing data block metadata: %v", r)
 		}
 	}()
-	metadatas.d.Init(schema, data)
+	metadatas.d.Init(format, schema, data)
 	schema.InitKeySeekerMetadata(&metadatas.keySchemaMeta, &metadatas.d)
 	return nil
 }
@@ -875,7 +1000,9 @@ type DataBlockDecoder struct {
 	isValueExternal Bitmap
 	// isObsolete is the column reader for the is-obsolete bitmap
 	// that indicates whether a key is obsolete/non-live.
-	isObsolete Bitmap
+	isObsolete        Bitmap
+	tieringSpanIDs    UnsafeUints
+	tieringAttributes UnsafeUints
 	// maximumKeyLength is the maximum length of a user key in the block.
 	// Iterators may use it to allocate a sufficiently large buffer up front,
 	// and elide size checks during iteration. Note that iterators should add +1
@@ -901,7 +1028,7 @@ func (d *DataBlockDecoder) KeySchemaHeader() []byte {
 }
 
 // Init initializes the data block reader with the given serialized data block.
-func (d *DataBlockDecoder) Init(schema *KeySchema, data []byte) {
+func (d *DataBlockDecoder) Init(format ColumnarFormat, schema *KeySchema, data []byte) {
 	if uintptr(unsafe.Pointer(unsafe.SliceData(data)))&7 != 0 {
 		panic("data buffer not 8-byte aligned")
 	}
@@ -911,6 +1038,10 @@ func (d *DataBlockDecoder) Init(schema *KeySchema, data []byte) {
 	d.values = d.d.RawBytes(len(schema.ColumnTypes) + dataBlockColumnValue)
 	d.isValueExternal = d.d.Bitmap(len(schema.ColumnTypes) + dataBlockColumnIsValueExternal)
 	d.isObsolete = d.d.Bitmap(len(schema.ColumnTypes) + dataBlockColumnIsObsolete)
+	if format > ColumnFormatv1 {
+		d.tieringSpanIDs = d.d.Uints(len(schema.ColumnTypes) + dataBlockColumnTieringSpanID)
+		d.tieringAttributes = d.d.Uints(len(schema.ColumnTypes) + dataBlockColumnTieringAttribute)
+	}
 	d.maximumKeyLength = binary.LittleEndian.Uint32(data[schema.HeaderSize:])
 }
 
@@ -951,9 +1082,9 @@ type DataBlockValidator struct {
 // Validate validates the provided block. It returns an error if the block is
 // invalid.
 func (v *DataBlockValidator) Validate(
-	data []byte, comparer *base.Comparer, keySchema *KeySchema,
+	format ColumnarFormat, data []byte, comparer *base.Comparer, keySchema *KeySchema,
 ) error {
-	v.dec.Init(keySchema, data)
+	v.dec.Init(format, keySchema, data)
 	n := v.dec.d.header.Rows
 	keySchema.InitKeySeekerMetadata(&v.keySeekerMeta, &v.dec)
 	keySeeker := keySchema.KeySeeker(&v.keySeekerMeta)
@@ -1009,6 +1140,7 @@ type DataBlockIter struct {
 	// keySchema configures the DataBlockIterConfig to use the provided
 	// KeySchema when initializing the DataBlockIter for iteration over a new
 	// block.
+	format    ColumnarFormat
 	keySchema *KeySchema
 	suffixCmp base.ComparePointSuffixes
 	split     base.Split
@@ -1045,10 +1177,12 @@ type DataBlockIter struct {
 // handler. The iterator must be initialized with a block before it can be used.
 // It may be reinitialized with new blocks without calling InitOnce again.
 func (i *DataBlockIter) InitOnce(
+	format ColumnarFormat,
 	keySchema *KeySchema,
 	comparer *base.Comparer,
 	getLazyValuer block.GetInternalValueForPrefixAndValueHandler,
 ) {
+	i.format = format
 	i.keySchema = keySchema
 	i.suffixCmp = comparer.ComparePointSuffixes
 	i.split = comparer.Split
@@ -1329,6 +1463,7 @@ func (i *DataBlockIter) Next() *base.InternalKV {
 			i.kv.K.SetSeqNum(base.SeqNum(n))
 		}
 	}
+	i.decodeMeta()
 	invariants.CheckBounds(i.row, i.d.values.slices)
 	// Inline i.d.values.At(row).
 	v := i.d.values.Slice(i.d.values.offsets.At2(i.row))
@@ -1507,6 +1642,7 @@ func (i *DataBlockIter) decodeRow() *base.InternalKV {
 		} else {
 			i.kv.V = base.MakeInPlaceValue(v)
 		}
+		i.decodeMeta()
 		i.kvRow = i.row
 		return &i.kv
 	}
@@ -1535,6 +1671,15 @@ func (i *DataBlockIter) decodeKey() {
 			i.kv.K.SetSeqNum(base.SeqNum(n))
 		}
 	}
+	i.decodeMeta()
+}
+
+func (i *DataBlockIter) decodeMeta() {
+	if i.format < ColumnFormatv2 {
+		return
+	}
+	i.kv.M.Tiering.SpanID = i.d.tieringSpanIDs.At(i.row)
+	i.kv.M.Tiering.Attribute = base.TieringAttribute(i.d.tieringAttributes.At(i.row))
 }
 
 var _ = (*DataBlockIter).decodeKey

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -142,7 +142,7 @@ func runBuildRawCmd(
 		j := strings.Index(data, ":")
 		key := base.ParseInternalKey(data[:j])
 		value := []byte(data[j+1:])
-		if err := w.Add(key, value, false); err != nil {
+		if err := w.Add(key, value, false, base.KVMeta{}); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/sstable/format_test.go
+++ b/sstable/format_test.go
@@ -77,6 +77,12 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 			version: 7,
 			want:    TableFormatPebblev7,
 		},
+		{
+			name:    "PebbleDBv8",
+			magic:   pebbleDBMagic,
+			version: 8,
+			want:    TableFormatPebblev8,
+		},
 		// Invalid cases.
 		{
 			name:    "Invalid RocksDB version",
@@ -87,8 +93,8 @@ func TestTableFormat_RoundTrip(t *testing.T) {
 		{
 			name:    "Invalid PebbleDB version",
 			magic:   pebbleDBMagic,
-			version: 8,
-			wantErr: "pebble/table: invalid table 000001: (unsupported pebble format version 8)",
+			version: 9,
+			wantErr: "pebble/table: invalid table 000001: (unsupported pebble format version 9)",
 		},
 		{
 			name:    "Unknown magic string",

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -455,13 +455,14 @@ func formatColblkDataBlock(
 	fmtKV func(key *base.InternalKey, value []byte) string,
 ) error {
 	var decoder colblk.DataBlockDecoder
-	decoder.Init(r.keySchema, data)
+	colFormat := sstableFormatToColumnarFormat(r.tableFormat)
+	decoder.Init(colFormat, r.keySchema, data)
 	f := binfmt.New(data)
 	decoder.Describe(f, tp)
 
 	if fmtKV != nil {
 		var iter colblk.DataBlockIter
-		iter.InitOnce(r.keySchema, r.Comparer, describingLazyValueHandler{})
+		iter.InitOnce(colFormat, r.keySchema, r.Comparer, describingLazyValueHandler{})
 		if err := iter.Init(&decoder, blockiter.Transforms{}); err != nil {
 			return err
 		}

--- a/sstable/random_test.go
+++ b/sstable/random_test.go
@@ -397,7 +397,7 @@ func buildRandomSSTable(f vfs.File, cfg randomTableConfig) (*WriterMetadata, err
 				value[j] = byte(cfg.rng.Uint32())
 			}
 		}
-		if err := w.Add(keys[i], value, false /* forceObsolete */); err != nil {
+		if err := w.Add(keys[i], value, false, base.KVMeta{}); err != nil {
 			return nil, err
 		}
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -376,7 +376,8 @@ func (r *Reader) readDataBlock(
 // later be used (and reused) when reading from the block.
 func (r *Reader) initDataBlockMetadata(metadata *block.Metadata, data []byte) error {
 	if r.tableFormat.BlockColumnar() {
-		return colblk.InitDataBlockMetadata(r.keySchema, metadata, data)
+		return colblk.InitDataBlockMetadata(
+			sstableFormatToColumnarFormat(r.tableFormat), r.keySchema, metadata, data)
 	}
 	return nil
 }

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -213,7 +213,8 @@ func newColumnBlockSingleLevelIterator(
 		i.internalValueConstructor.vbReader = valblk.MakeReader(i, opts.ReaderProvider, r.valueBIH, opts.Env.Block.Stats)
 		i.vbRH = r.blockReader.UsePreallocatedReadHandle(objstorage.NoReadBefore, &i.vbRHPrealloc)
 	}
-	i.data.InitOnce(r.keySchema, r.Comparer, &i.internalValueConstructor)
+	i.data.InitOnce(sstableFormatToColumnarFormat(r.tableFormat),
+		r.keySchema, r.Comparer, &i.internalValueConstructor)
 	indexH, err := r.readTopLevelIndexBlock(ctx, i.readEnv.Block, i.indexFilterRH)
 	if err == nil {
 		err = i.index.InitHandle(r.Comparer, indexH, opts.Transforms)

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -180,7 +180,8 @@ func newColumnBlockTwoLevelIterator(
 		i.secondLevel.vbRH = r.blockReader.UsePreallocatedReadHandle(
 			objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
-	i.secondLevel.data.InitOnce(r.keySchema, r.Comparer, &i.secondLevel.internalValueConstructor)
+	i.secondLevel.data.InitOnce(sstableFormatToColumnarFormat(r.tableFormat),
+		r.keySchema, r.Comparer, &i.secondLevel.internalValueConstructor)
 	topLevelIndexH, err := r.readTopLevelIndexBlock(ctx, i.secondLevel.readEnv.Block, i.secondLevel.indexFilterRH)
 	if err == nil {
 		err = i.topLevelIndex.InitHandle(r.Comparer, topLevelIndexH, opts.Transforms)

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -1849,7 +1849,7 @@ func buildTestTableWithProvider(
 		value := make([]byte, i%100)
 		key = binary.BigEndian.AppendUint64(key, i)
 		ikey.UserKey = key
-		require.NoError(t, w.Add(ikey, value, false /* forceObsolete */))
+		require.NoError(t, w.Add(ikey, value, false, base.KVMeta{}))
 	}
 
 	require.NoError(t, w.Close())
@@ -1887,7 +1887,7 @@ func buildBenchmarkTable(
 		binary.BigEndian.PutUint64(key, i+uint64(offset))
 		keys = append(keys, key)
 		ikey.UserKey = key
-		require.NoError(b, w.Add(ikey, nil, false /* forceObsolete */))
+		require.NoError(b, w.Add(ikey, nil, false, base.KVMeta{}))
 	}
 
 	if err := w.Close(); err != nil {
@@ -2486,8 +2486,7 @@ func BenchmarkIteratorScanObsolete(b *testing.B) {
 			if i == 0 {
 				forceObsolete = false
 			}
-			require.NoError(b, w.Add(
-				base.MakeInternalKey(key, 0, InternalKeyKindSet), val, forceObsolete))
+			require.NoError(b, w.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), val, forceObsolete, base.KVMeta{}))
 		}
 		require.NoError(b, w.Close())
 		// Re-open the Filename for reading.

--- a/sstable/rowblk/rowblk_fragment_iter_test.go
+++ b/sstable/rowblk/rowblk_fragment_iter_test.go
@@ -25,7 +25,7 @@ import (
 func TestBlockFragmentIterator(t *testing.T) {
 	comparer := testkeys.Comparer
 	var cacheVal *cache.Value
-	c := cache.New(2048)
+	c := cache.New(3072)
 	cacheHandle := c.NewHandle()
 	defer func() {
 		cacheHandle.Close()

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -515,7 +515,9 @@ type bufferedIndexBlock struct {
 // that strict-obsolete ssts must satisfy. S2, due to RANGEDELs, is solely the
 // responsibility of the caller. S1 is solely the responsibility of the
 // callee.
-func (w *RawRowWriter) Add(key InternalKey, value []byte, forceObsolete bool) error {
+func (w *RawRowWriter) Add(
+	key InternalKey, value []byte, forceObsolete bool, meta base.KVMeta,
+) error {
 	if w.err != nil {
 		return w.err
 	}
@@ -536,7 +538,11 @@ func (w *RawRowWriter) Add(key InternalKey, value []byte, forceObsolete bool) er
 // AddWithBlobHandle implements the RawWriter interface. This implementation
 // does not support writing blob value handles.
 func (w *RawRowWriter) AddWithBlobHandle(
-	key InternalKey, h blob.InlineHandle, attr base.ShortAttribute, forceObsolete bool,
+	key InternalKey,
+	h blob.InlineHandle,
+	attr base.ShortAttribute,
+	forceObsolete bool,
+	meta base.KVMeta,
 ) error {
 	w.err = errors.Newf("pebble: blob value handles are not supported in %s", w.tableFormat.String())
 	return w.err

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -356,7 +356,7 @@ func RewriteKeySuffixesViaWriter(
 		if err != nil {
 			return nil, err
 		}
-		if err := w.Add(scratch, val, false); err != nil {
+		if err := w.Add(scratch, val, false, kv.M); err != nil {
 			return nil, err
 		}
 		kv = i.Next()

--- a/sstable/suffix_rewriter_test.go
+++ b/sstable/suffix_rewriter_test.go
@@ -197,8 +197,7 @@ func makeTestkeySSTable(
 	for i := 0; i < keys; i++ {
 		n := testkeys.WriteKey(keyBuf[len(sharedPrefix):], alphabet, int64(i))
 		key := append(keyBuf[:len(sharedPrefix)+n], suffix...)
-		err := w.Raw().Add(
-			base.MakeInternalKey(key, 0, InternalKeyKindSet), key, false)
+		err := w.Raw().Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), key, false, base.KVMeta{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -468,7 +468,7 @@ func supportsTwoLevelIndex(format TableFormat) bool {
 	case TableFormatLevelDB:
 		return false
 	case TableFormatRocksDBv2, TableFormatPebblev1, TableFormatPebblev2, TableFormatPebblev3, TableFormatPebblev4,
-		TableFormatPebblev5, TableFormatPebblev6, TableFormatPebblev7:
+		TableFormatPebblev5, TableFormatPebblev6, TableFormatPebblev7, TableFormatPebblev8:
 		return true
 	default:
 		panic("sstable: unspecified table format version")

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -455,7 +455,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 						IndexBlockSize: indexBlockSize,
 					})
 					for _, k := range keys[:nk] {
-						if err := w.Add(InternalKey{UserKey: []byte(k)}, xxx[:vLen], false /* forceObsolete */); err != nil {
+						if err := w.Add(InternalKey{UserKey: []byte(k)}, xxx[:vLen], false, base.KVMeta{}); err != nil {
 							t.Errorf("nk=%d, vLen=%d: set: %v", nk, vLen, err)
 							continue loop
 						}

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -217,9 +217,9 @@ func ParseTestSST(w RawWriter, input string, bv *blobtest.Values) error {
 		case kv.IsKeySpan():
 			err = w.EncodeSpan(*kv.Span)
 		case kv.HasBlobValue():
-			err = w.AddWithBlobHandle(kv.Key, kv.BlobHandle, kv.Attr, kv.ForceObsolete)
+			err = w.AddWithBlobHandle(kv.Key, kv.BlobHandle, kv.Attr, kv.ForceObsolete, base.KVMeta{})
 		default:
-			err = w.Add(kv.Key, kv.Value, kv.ForceObsolete)
+			err = w.Add(kv.Key, kv.Value, kv.ForceObsolete, base.KVMeta{})
 		}
 		if err != nil {
 			return errors.Wrapf(err, "failed to write %s", kv)

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -124,7 +124,7 @@ func (w *Writer) Set(key, value []byte) error {
 	}
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable delete the added points.
-	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), value, false)
+	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindSet), value, false, base.KVMeta{})
 }
 
 // Delete deletes the value for the given key. The sequence number is set to
@@ -141,7 +141,7 @@ func (w *Writer) Delete(key []byte) error {
 	}
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable delete the added points.
-	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindDelete), nil, false)
+	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindDelete), nil, false, base.KVMeta{})
 }
 
 // DeleteRange deletes all of the keys (and values) in the range [start,end)
@@ -182,7 +182,7 @@ func (w *Writer) Merge(key, value []byte) error {
 	// forceObsolete is false based on the assumption that no RANGEDELs in the
 	// sstable that delete the added points. If the user configured this writer
 	// to be strict-obsolete, addPoint will reject the addition of this MERGE.
-	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindMerge), value, false)
+	return w.rw.Add(base.MakeInternalKey(key, 0, InternalKeyKindMerge), value, false, base.KVMeta{})
 }
 
 // RangeKeySet sets a range between start (inclusive) and end (exclusive) with
@@ -323,11 +323,11 @@ type RawWriter interface {
 	// that strict-obsolete ssts must satisfy. S2, due to RANGEDELs, is solely the
 	// responsibility of the caller. S1 is solely the responsibility of the
 	// callee.
-	Add(key InternalKey, value []byte, forceObsolete bool) error
+	Add(key InternalKey, value []byte, forceObsolete bool, meta base.KVMeta) error
 	// AddWithBlobHandle adds a key to the sstable, but encoding a blob value
 	// handle instead of an in-place value. See Add for more details. The caller
 	// must provide the already-extracted ShortAttribute for the value.
-	AddWithBlobHandle(key InternalKey, h blob.InlineHandle, attr base.ShortAttribute, forceObsolete bool) error
+	AddWithBlobHandle(key InternalKey, h blob.InlineHandle, attr base.ShortAttribute, forceObsolete bool, meta base.KVMeta) error
 	// EncodeSpan encodes the keys in the given span. The span can contain
 	// either only RANGEDEL keys or only range keys.
 	//

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -972,7 +972,7 @@ func TestWriterBlockPropertiesErrors(t *testing.T) {
 				}
 			}()
 
-			err = w.Add(k1, v1, false /* forceObsolete */)
+			err = w.Add(k1, v1, false, base.KVMeta{})
 			switch tc {
 			case errSiteAdd:
 				require.Error(t, err)
@@ -981,18 +981,18 @@ func TestWriterBlockPropertiesErrors(t *testing.T) {
 			case errSiteFinishBlock:
 				require.NoError(t, err)
 				// Addition of a second key completes the first block.
-				err = w.Add(k2, v2, false /* forceObsolete */)
+				err = w.Add(k2, v2, false, base.KVMeta{})
 				require.Error(t, err)
 				require.Equal(t, blockPropErr, err)
 				return
 			case errSiteFinishIndex:
 				require.NoError(t, err)
 				// Addition of a second key completes the first block.
-				err = w.Add(k2, v2, false /* forceObsolete */)
+				err = w.Add(k2, v2, false, base.KVMeta{})
 				require.NoError(t, err)
 				// The index entry for the first block is added after the completion of
 				// the second block, which is triggered by adding a third key.
-				err = w.Add(k3, v3, false /* forceObsolete */)
+				err = w.Add(k3, v3, false, base.KVMeta{})
 				require.Error(t, err)
 				require.Equal(t, blockPropErr, err)
 				return
@@ -1101,7 +1101,8 @@ func TestWriterRace(t *testing.T) {
 			w := newRowWriter(f, opts)
 			for ki := 0; ki < len(keys); ki++ {
 				require.NoError(t, w.Add(
-					base.MakeInternalKey(keys[ki], base.SeqNum(ki), InternalKeyKindSet), val, false /* forceObsolete */))
+					base.MakeInternalKey(keys[ki], base.SeqNum(ki), InternalKeyKindSet), val,
+					false /* forceObsolete */, base.KVMeta{}))
 				require.Equal(
 					t, w.dataBlockBuf.dataBlock.CurKey().UserKey, keys[ki],
 				)

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -70,7 +70,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-1.5K (6.4MB) |       60.0% |     3 (840B) |       90.0% |         0.0% |           0 |           0
+1.5K (6.5MB) |       60.0% |     3 (840B) |       90.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -158,7 +158,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   5 (1.8KB) |       81.8% |     1 (392B) |       89.2% |         0.0% |           0 |           0
+     5 (2KB) |       81.8% |     1 (392B) |       89.2% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -433,7 +433,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   7 (2.5KB) |       59.6% |     1 (504B) |       78.6% |         0.0% |           0 |           0
+   7 (2.8KB) |       59.6% |     1 (504B) |       78.6% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -285,7 +285,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (736B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+    2 (832B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -425,7 +425,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   6 (2.2KB) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+   6 (2.4KB) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -69,7 +69,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-     3 (1KB) |       15.4% |     1 (280B) |       50.0% |         0.0% |           0 |           0
+   3 (1.1KB) |       15.4% |     1 (280B) |       50.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -127,7 +127,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (747B) |        0.0% |     1 (280B) |        0.0% |         0.0% |           1 |           0
+    2 (843B) |        0.0% |     1 (280B) |        0.0% |         0.0% |           1 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -228,7 +228,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (747B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+    2 (843B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -312,7 +312,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (747B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+    2 (843B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -393,7 +393,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (747B) |       33.3% |     1 (280B) |       66.7% |         0.0% |           1 |           0
+    2 (843B) |       33.3% |     1 (280B) |       66.7% |         0.0% |           1 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -867,7 +867,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   6 (2.2KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+   6 (2.4KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -988,7 +988,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   6 (2.2KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+   6 (2.4KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1568,7 +1568,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (739B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+    2 (835B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1656,7 +1656,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (739B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+    2 (835B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1931,7 +1931,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (726B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
+    2 (822B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -2008,7 +2008,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (726B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
+    2 (822B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/value_separation.go
+++ b/value_separation.go
@@ -248,12 +248,12 @@ func (vs *writeNewBlobFiles) Add(
 
 	// Values that are too small are never separated.
 	if len(v) < vs.minimumSize {
-		return tw.Add(kv.K, v, forceObsolete)
+		return tw.Add(kv.K, v, forceObsolete, kv.M)
 	}
 	// Merge and deletesized keys are never separated.
 	switch kv.K.Kind() {
 	case base.InternalKeyKindMerge, base.InternalKeyKindDeleteSized:
-		return tw.Add(kv.K, v, forceObsolete)
+		return tw.Add(kv.K, v, forceObsolete, kv.M)
 	}
 
 	// This KV met all the criteria and its value will be separated.
@@ -272,7 +272,7 @@ func (vs *writeNewBlobFiles) Add(
 			// fallback to writing the value verbatim to the sstable. Otherwise
 			// a flush could busy loop, repeatedly attempting to write the same
 			// memtable and repeatedly unable to extract a key's short attribute.
-			return tw.Add(kv.K, v, forceObsolete)
+			return tw.Add(kv.K, v, forceObsolete, kv.M)
 		}
 	}
 
@@ -310,7 +310,7 @@ func (vs *writeNewBlobFiles) Add(
 			ValueID: handle.ValueID,
 		},
 	}
-	return tw.AddWithBlobHandle(kv.K, inlineHandle, shortAttr, forceObsolete)
+	return tw.AddWithBlobHandle(kv.K, inlineHandle, shortAttr, forceObsolete, kv.M)
 }
 
 // FinishOutput closes the current blob file (if any). It returns the stats
@@ -420,7 +420,7 @@ func (vs *preserveBlobReferences) Add(
 		if callerOwned {
 			vs.buf = v[:0]
 		}
-		return tw.Add(kv.K, v, forceObsolete)
+		return tw.Add(kv.K, v, forceObsolete, kv.M)
 	}
 
 	// The value is an existing blob handle. We can copy it into the output
@@ -453,7 +453,7 @@ func (vs *preserveBlobReferences) Add(
 		},
 		HandleSuffix: handleSuffix,
 	}
-	err := tw.AddWithBlobHandle(kv.K, inlineHandle, lv.Fetcher.Attribute.ShortAttribute, forceObsolete)
+	err := tw.AddWithBlobHandle(kv.K, inlineHandle, lv.Fetcher.Attribute.ShortAttribute, forceObsolete, base.KVMeta{})
 	if err != nil {
 		return err
 	}

--- a/value_separation_test.go
+++ b/value_separation_test.go
@@ -181,16 +181,22 @@ type loggingRawWriter struct {
 	sstable.RawWriter
 }
 
-func (w *loggingRawWriter) Add(key InternalKey, value []byte, forceObsolete bool) error {
+func (w *loggingRawWriter) Add(
+	key InternalKey, value []byte, forceObsolete bool, meta base.KVMeta,
+) error {
 	fmt.Fprintf(w.w, "RawWriter.Add(%q, %q, %t)\n", key, value, forceObsolete)
-	return w.RawWriter.Add(key, value, forceObsolete)
+	return w.RawWriter.Add(key, value, forceObsolete, meta)
 }
 
 func (w *loggingRawWriter) AddWithBlobHandle(
-	key InternalKey, h blob.InlineHandle, attr base.ShortAttribute, forceObsolete bool,
+	key InternalKey,
+	h blob.InlineHandle,
+	attr base.ShortAttribute,
+	forceObsolete bool,
+	meta base.KVMeta,
 ) error {
 	fmt.Fprintf(w.w, "RawWriter.AddWithBlobHandle(%q, %q, %x, %t)\n", key, h, attr, forceObsolete)
-	return w.RawWriter.AddWithBlobHandle(key, h, attr, forceObsolete)
+	return w.RawWriter.AddWithBlobHandle(key, h, attr, forceObsolete, meta)
 }
 
 // defineDBValueSeparator is a compact.ValueSeparation implementation used by
@@ -232,7 +238,7 @@ func (vs *defineDBValueSeparator) Add(
 	v := kv.V.InPlaceValue()
 	// If the value doesn't begin with "blob", don't separate it.
 	if !bytes.HasPrefix(v, []byte("blob")) {
-		return tw.Add(kv.K, v, forceObsolete)
+		return tw.Add(kv.K, v, forceObsolete, base.KVMeta{})
 	}
 
 	// This looks like a blob reference. Parse it.

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -42,7 +42,7 @@ func writeAndIngest(t *testing.T, mem vfs.FS, d *DB, k InternalKey, v []byte, fi
 	f, err := mem.Create(path, vfs.WriteCategoryUnspecified)
 	require.NoError(t, err)
 	w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{})
-	require.NoError(t, w.Add(k, v, false /* forceObsolete */))
+	require.NoError(t, w.Add(k, v, false, base.KVMeta{}))
 	require.NoError(t, w.Close())
 	require.NoError(t, d.Ingest(context.Background(), []string{path}))
 }


### PR DESCRIPTION
ColumnFormatv2 adds tiering (spanId, attribute) columns. These columns are 
native to Pebble, and not part of the code in cockroachkvs.go, since after 
initial extraction, these will be used internally to Pebble for tiering.

There is a long comment in data_block.go explaining the tentative choice
to have a spanID column (which will be revisited later). The corresponding
sstable formats and format major version is also added.

InternalKV is enhanced with a KVMeta field to carry these columns through
the iterator tree. This is just a prototyping choice as explained in the
todo.

The code changes are all just plumbing. The new format is not yet tested.
