### PR TITLE
crl-release-24.3: compact: convert MERGE keys to SET when bottommost

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2023,7 +2023,7 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 					c.delElision, c.rangeKeyElision = compact.SetupTombstoneElision(
 						c.cmp, c.version, c.outputLevel.level, base.UserKeyBoundsFromInternal(c.smallest, c.largest),
 					)
-					fmt.Fprintf(&buf, "%t\n", c.allowZeroSeqNum())
+					fmt.Fprintf(&buf, "%t\n", c.isBottommostDataLayer())
 				}
 				return buf.String()
 

--- a/internal/compact/iterator.go
+++ b/internal/compact/iterator.go
@@ -263,11 +263,17 @@ type IterConfig struct {
 	TombstoneElision TombstoneElision
 	RangeKeyElision  TombstoneElision
 
-	// AllowZeroSeqNum allows the sequence number of KVs in the bottom snapshot
-	// stripe to be simplified to 0 (which improves compression and enables an
-	// optimization during forward iteration). This can be enabled if there are no
-	// tables overlapping the output at lower levels (than the output) in the LSM.
-	AllowZeroSeqNum bool
+	// IsBottommostDataLayer indicates that the compaction inputs form the
+	// bottommost layer of data for the compaction's key range. This allows the
+	// sequence number of KVs in the bottom snapshot stripe to be simplified to
+	// 0 (which improves compression and enables an optimization during forward
+	// iteration). This can be enabled if there are no tables overlapping the
+	// output at lower levels (than the output) in the LSM.
+	//
+	// This field may be false even when nothing is overlapping in lower levels.
+	// At the time of writing, flushes always set this to false (because flushes
+	// almost never form the bottommost layer of data).
+	IsBottommostDataLayer bool
 
 	// IneffectualPointDeleteCallback is called if a SINGLEDEL is being elided
 	// without deleting a point set/merge.
@@ -591,8 +597,24 @@ func (i *Iter) Next() (*base.InternalKey, []byte) {
 			}
 			var needDelete bool
 			if i.err == nil {
-				// includesBase is true whenever we've transformed the MERGE record
-				// into a SET.
+				// If this is the oldest version of this key (the bottommost
+				// snapshot stripe), we can transform the sequence number to
+				// zero. This can improve compression and enables an
+				// optimization during forward iteration to skip some key
+				// comparisons. Additionally, we can transform the key kind to
+				// SET so that iteration and future compactions do not need to
+				// invoke the user's Merge operator.
+				if i.isBottommostSnapshotStripe(origSnapshotIdx) {
+					i.key.SetSeqNum(base.SeqNumZero)
+					// During the merge (see mergeNext), we may have already
+					// transformed the key kind to SET or SETWITHDEL, in which case we want to preserve the existing key kind.
+					if i.key.Kind() == base.InternalKeyKindMerge {
+						i.key.SetKind(base.InternalKeyKindSet)
+					}
+				}
+
+				// includesBase is true when we've merged the oldest operand in
+				// the LSM.
 				var includesBase bool
 				switch i.key.Kind() {
 				case base.InternalKeyKindSet, base.InternalKeyKindSetWithDelete:
@@ -611,8 +633,6 @@ func (i *Iter) Next() (*base.InternalKey, []byte) {
 					}
 					continue
 				}
-
-				i.maybeZeroSeqnum(origSnapshotIdx)
 				return &i.key, i.value
 			}
 			if i.err != nil {
@@ -780,7 +800,14 @@ func (i *Iter) setNext() {
 	// Save the current key.
 	i.saveKey()
 	i.value = i.iterValue
-	i.maybeZeroSeqnum(i.curSnapshotIdx)
+
+	// If this is the oldest version of this key (the bottommost snapshot
+	// stripe), we can transform the sequence number to zero. This can improve
+	// compression and enables an optimization during forward iteration to skip
+	// some key comparisons.
+	if i.isBottommostSnapshotStripe(i.curSnapshotIdx) {
+		i.key.SetSeqNum(base.SeqNumZero)
+	}
 
 	// If this key is already a SETWITHDEL we can early return and skip the remaining
 	// records in the stripe:
@@ -1345,23 +1372,21 @@ func (i *Iter) lastRangeDelSpanFrontierReached(key []byte) []byte {
 	return nil
 }
 
-// maybeZeroSeqnum attempts to set the seqnum for the current key to 0. Doing
-// so improves compression and enables an optimization during forward iteration
-// to skip some key comparisons. The seqnum for an entry can be zeroed if the
-// entry is on the bottom snapshot stripe and on the bottom level of the LSM.
-func (i *Iter) maybeZeroSeqnum(snapshotIdx int) {
-	if !i.cfg.AllowZeroSeqNum {
-		// TODO(peter): allowZeroSeqNum applies to the entire compaction. We could
-		// make the determination on a key by key basis, similar to what is done
-		// for elideTombstone. Need to add a benchmark for Iter to verify
-		// that isn't too expensive.
-		return
-	}
-	if snapshotIdx > 0 {
-		// This is not the last snapshot
-		return
-	}
-	i.key.SetSeqNum(base.SeqNumZero)
+// isBottommostSnapshotStripe returns true if the compaction's inputs form the
+// bottommost layer of the LSM for the compaction's key range and the provided
+// snapshot stripe is the last stripe.
+//
+// When isBottommostSnapshotStripe returns true, it is guaranteed there does not
+// exist any overlapping keys with lower sequence numbers than the keys in the
+// provided snapshot stripe. However isBottommostSnapshotStripe is permitted to
+// return false even when there is no overlapping data in lower levels (eg,
+// flushes).
+func (i *Iter) isBottommostSnapshotStripe(snapshotIdx int) bool {
+	// TODO(peter): This determination applies to the entire compaction. We
+	// could make the determination on a key by key basis, similar to what is
+	// done for elideTombstone. Need to add a benchmark for Iter to verify that
+	// isn't too expensive.
+	return i.cfg.IsBottommostDataLayer && snapshotIdx == 0
 }
 
 func finishValueMerger(

--- a/internal/compact/iterator_test.go
+++ b/internal/compact/iterator_test.go
@@ -52,8 +52,7 @@ func TestCompactionIter(t *testing.T) {
 	var rangeDels []keyspan.Span
 	var snapshots Snapshots
 	var elideTombstones bool
-	var allowZeroSeqnum bool
-
+	var isBottommostDataLayer bool
 	var ineffectualSingleDeleteKeys []string
 	var invariantViolationSingleDeleteKeys []string
 	resetSingleDelStats := func() {
@@ -75,12 +74,12 @@ func TestCompactionIter(t *testing.T) {
 			elision = ElideTombstonesOutsideOf(nil)
 		}
 		cfg := IterConfig{
-			Comparer:         base.DefaultComparer,
-			Merge:            merge,
-			Snapshots:        snapshots,
-			TombstoneElision: elision,
-			RangeKeyElision:  elision,
-			AllowZeroSeqNum:  allowZeroSeqnum,
+			Comparer:              base.DefaultComparer,
+			Merge:                 merge,
+			Snapshots:             snapshots,
+			TombstoneElision:      elision,
+			RangeKeyElision:       elision,
+			IsBottommostDataLayer: isBottommostDataLayer,
 			IneffectualSingleDeleteCallback: func(userKey []byte) {
 				ineffectualSingleDeleteKeys = append(ineffectualSingleDeleteKeys, string(userKey))
 			},
@@ -150,7 +149,7 @@ func TestCompactionIter(t *testing.T) {
 			case "iter":
 				snapshots = snapshots[:0]
 				elideTombstones = false
-				allowZeroSeqnum = false
+				isBottommostDataLayer = false
 				printSnapshotPinned := false
 				printMissizedDels := false
 				printForceObsolete := false
@@ -166,9 +165,9 @@ func TestCompactionIter(t *testing.T) {
 						if err != nil {
 							return err.Error()
 						}
-					case "allow-zero-seqnum":
+					case "is-bottommost-layer":
 						var err error
-						allowZeroSeqnum, err = strconv.ParseBool(arg.Vals[0])
+						isBottommostDataLayer, err = strconv.ParseBool(arg.Vals[0])
 						if err != nil {
 							return err.Error()
 						}

--- a/internal/compact/testdata/iter
+++ b/internal/compact/testdata/iter
@@ -947,14 +947,14 @@ a.RANGEDEL.1:b
 a.MERGE.1:v1
 ----
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 next
 next
 ----
 a#inf,RANGEDEL:; Span() = a-b:{(#1,RANGEDEL)}
-a#0,MERGE:v1v2
+a#0,SET:v1v2[base]
 .
 .
 
@@ -973,7 +973,7 @@ next
 a#5,SETWITHDEL:5[base]
 .
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 ----
@@ -1023,13 +1023,13 @@ a#inf,RANGEDEL:; Span() = a-c:{(#3,RANGEDEL)}
 b#5,MERGE:5
 .
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 next
 ----
 a#inf,RANGEDEL:; Span() = a-c:{(#3,RANGEDEL)}
-b#0,MERGE:5
+b#0,SET:5[base]
 .
 
 iter snapshots=2

--- a/internal/compact/testdata/iter_delete_sized
+++ b/internal/compact/testdata/iter_delete_sized
@@ -974,13 +974,13 @@ a.RANGEDEL.1:b
 a.MERGE.1:v1
 ----
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 next
 ----
 a#inf,RANGEDEL:; Span() = a-b:{(#1,RANGEDEL)}
-a#0,MERGE:v1v2
+a#0,SET:v1v2[base]
 .
 
 # Verify that we transform merge+del -> set.
@@ -998,7 +998,7 @@ next
 a#5,SETWITHDEL:5[base]
 .
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 ----
@@ -1048,13 +1048,13 @@ a#inf,RANGEDEL:; Span() = a-c:{(#3,RANGEDEL)}
 b#5,MERGE:5
 .
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 next
 ----
 a#inf,RANGEDEL:; Span() = a-c:{(#3,RANGEDEL)}
-b#0,MERGE:5
+b#0,SET:5[base]
 .
 
 iter snapshots=2
@@ -1211,7 +1211,7 @@ a.SET.2:b
 a.DEL.1:
 ----
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 next
@@ -1220,7 +1220,7 @@ a#inf,RANGEDEL:; Span() = a-z:{(#2,RANGEDEL)}
 a#0,SET:c
 .
 
-iter allow-zero-seqnum=true snapshots=3
+iter is-bottommost-layer=true snapshots=3
 first
 next
 next
@@ -1231,7 +1231,7 @@ a#3,SET:c
 a#0,SET:b
 .
 
-iter allow-zero-seqnum=true snapshots=2
+iter is-bottommost-layer=true snapshots=2
 first
 next
 next
@@ -1573,7 +1573,7 @@ next
 
 # Try the same test as above, but with allowing sequence number zeroing as well.
 
-iter elide-tombstones=t allow-zero-seqnum=t
+iter elide-tombstones=t is-bottommost-layer=t
 first
 next
 ----
@@ -1670,7 +1670,7 @@ next
 a#inf,RANGEDEL:; Span() = a-d:{(#5,RANGEDEL)}
 .
 
-iter elide-tombstones=t allow-zero-seqnum=t
+iter elide-tombstones=t is-bottommost-layer=t
 first
 next
 ----

--- a/internal/compact/testdata/iter_set_with_del
+++ b/internal/compact/testdata/iter_set_with_del
@@ -938,13 +938,13 @@ a.RANGEDEL.1:b
 a.MERGE.1:v1
 ----
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 next
 ----
 a#inf,RANGEDEL:; Span() = a-b:{(#1,RANGEDEL)}
-a#0,MERGE:v1v2
+a#0,SET:v1v2[base]
 .
 
 # Verify that we transform merge+del -> set.
@@ -962,7 +962,7 @@ next
 a#5,SETWITHDEL:5[base]
 .
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 ----
@@ -1012,13 +1012,13 @@ a#inf,RANGEDEL:; Span() = a-c:{(#3,RANGEDEL)}
 b#5,MERGE:5
 .
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 next
 ----
 a#inf,RANGEDEL:; Span() = a-c:{(#3,RANGEDEL)}
-b#0,MERGE:5
+b#0,SET:5[base]
 .
 
 iter snapshots=2
@@ -1172,7 +1172,7 @@ a.SET.2:b
 a.DEL.1:
 ----
 
-iter allow-zero-seqnum=true
+iter is-bottommost-layer=true
 first
 next
 next
@@ -1181,7 +1181,7 @@ a#inf,RANGEDEL:; Span() = a-z:{(#2,RANGEDEL)}
 a#0,SET:c
 .
 
-iter allow-zero-seqnum=true snapshots=3
+iter is-bottommost-layer=true snapshots=3
 first
 next
 next
@@ -1192,7 +1192,7 @@ a#3,SET:c
 a#0,SET:b
 .
 
-iter allow-zero-seqnum=true snapshots=2
+iter is-bottommost-layer=true snapshots=2
 first
 next
 next

--- a/testdata/excise
+++ b/testdata/excise
@@ -402,7 +402,7 @@ lsm
 L0.0:
   000009:[bd#17,RANGEKEYSET-f#17,MERGE]
 L6:
-  000008:[a@3#0,SET-z#0,MERGE]
+  000008:[a@3#0,SET-z#0,SET]
 
 build ext3
 set z updated
@@ -417,8 +417,8 @@ L0.0:
   000011(000009):[cc#17,RANGEKEYSET-f#17,MERGE]
   000010:[z#19,SET-z#19,SET]
 L6:
-  000012(000008):[a@3#0,SET-bbsomethinglong@4#0,MERGE]
-  000013(000008):[d@6#0,MERGE-z#0,MERGE]
+  000012(000008):[a@3#0,SET-bbsomethinglong@4#0,SET]
+  000013(000008):[d@6#0,SET-z#0,SET]
 
 iter range-key-masking=@10
 first


### PR DESCRIPTION
This commit refactors the compaction iterator to perform an additional transformation to MERGE keys that are known to be the oldest version of their key in the LSM, transforming their key kind to SET. This ensures that iterators or compactions stepping over the key avoid invoking the merge operator when unnecessary.

Fix #5178.