### PR TITLE
[tiered prototype] db: add blob.FileFormatV3

### DIFF
--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -266,7 +266,7 @@ func TestBlobRewriteRandomized(t *testing.T) {
 			if rng.IntN(20) == 0 {
 				blobWriter.FlushForTesting()
 			}
-			handles[i] = blobWriter.AddValue(values[i])
+			handles[i] = blobWriter.AddValue(values[i], base.TieringMeta{})
 		}
 		stats, err := blobWriter.Close()
 		require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestBlobRewriteRandomized(t *testing.T) {
 			defer func() { _ = valueFetcher.Close() }()
 			for _, valueIndex := range newFile.valueIndices {
 				handle := handles[valueIndex]
-				val, _, err := valueFetcher.Fetch(ctx, blobFileID, handle.BlockID, handle.ValueID)
+				val, _, _, err := valueFetcher.Fetch(ctx, blobFileID, handle.BlockID, handle.ValueID)
 				require.NoError(t, err)
 				require.Equal(t, values[valueIndex], val)
 			}

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -237,7 +237,7 @@ func (t *fileCacheTest) newTestHandle() (*fileCacheHandle, *fileCacheTestFS) {
 			t.Fatal(err)
 		}
 		bw := blob.NewFileWriter(fn, w, blob.FileWriterOptions{})
-		_ = bw.AddValue(xxx[:fn])
+		_ = bw.AddValue(xxx[:fn], base.TieringMeta{})
 		if _, err := bw.Close(); err != nil {
 			t.Fatal(err)
 		}

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -319,6 +319,8 @@ func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 func (v FormatMajorVersion) MaxBlobFileFormat() blob.FileFormat {
 	v = v.resolveDefault()
 	switch {
+	case v >= FormatTieredStorage:
+		return blob.FileFormatV3
 	case v >= FormatV2BlobFiles:
 		return blob.FileFormatV2
 	case v >= FormatValueSeparation:

--- a/internal/blobtest/handles.go
+++ b/internal/blobtest/handles.go
@@ -261,14 +261,14 @@ func (bv *Values) WriteFiles(
 					BlockID:    handle.BlockID,
 					ValueID:    blob.BlockValueID(prevID),
 					ValueLen:   12,
-				}))
+				}), base.TieringMeta{})
 				prevID++
 			}
 
 			if value, ok := bv.trackedHandles[handle]; ok {
-				writer.AddValue([]byte(value))
+				writer.AddValue([]byte(value), base.TieringMeta{})
 			} else {
-				writer.AddValue(deriveValueFromHandle(handle))
+				writer.AddValue(deriveValueFromHandle(handle), base.TieringMeta{})
 			}
 		}
 		fileStats, err := writer.Close()

--- a/sstable/blob/blob_test.go
+++ b/sstable/blob/blob_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestBlobWriter(t *testing.T) {
 			obj = &objstorage.MemObj{}
 			w := NewFileWriter(000001, obj, opts)
 			for _, l := range crstrings.Lines(td.Input) {
-				h := w.AddValue([]byte(l))
+				h := w.AddValue([]byte(l), base.TieringMeta{})
 				fmt.Fprintf(&buf, "%-25s: %q\n", h, l)
 			}
 			stats, err := w.Close()
@@ -55,7 +56,7 @@ func TestBlobWriter(t *testing.T) {
 					w.beginNewVirtualBlock(BlockID(vBlockID))
 					vBlockID++
 				default:
-					h := w.AddValue([]byte(l))
+					h := w.AddValue([]byte(l), base.TieringMeta{})
 					fmt.Fprintf(&buf, "%-25s: %q\n", h, l)
 				}
 			}

--- a/sstable/blob/doc.go
+++ b/sstable/blob/doc.go
@@ -59,9 +59,11 @@
 //
 // ## Blob Value Blocks
 //
-// A blob value block is a columnar block encoding blob values. It encodes a
-// single column: a RawBytes of values. The colblk.RawBytes encoding allows
-// constant-time access to the i'th value within the block.
+// A blob value block is a columnar block encoding blob values. The primary
+// column is the RawBytes of values. The colblk.RawBytes encoding allows
+// constant-time access to the i'th value within the block. In FileFormatV3
+// onwards, there are two secondary columns, a tieringSpanID and a
+// tieringAttribute, both of which may be 0 (representing they are absent).
 //
 // ## Sparseness
 //
@@ -92,15 +94,18 @@
 // |                              Value Block #0                                  |
 // |   +----------------------------------------------------------------------+   |
 // |   | RawBytes[...]                                                        |   |
+// |   | tieringSpanID[...] tieringAttribute[...]                             |   |
 // |   +----------------------------------------------------------------------+   |
 // |                              Value Block #1                                  |
 // |   +----------------------------------------------------------------------+   |
 // |   | RawBytes[...]                                                        |   |
+// |   | tieringSpanID[...] tieringAttribute[...]                             |   |
 // |   +----------------------------------------------------------------------+   |
 // |                                 ...                                          |
 // |                              Value Block #N                                  |
 // |   +----------------------------------------------------------------------+   |
 // |   | RawBytes[...]                                                        |   |
+// |   | tieringSpanID[...] tieringAttribute[...]                             |   |
 // |   +----------------------------------------------------------------------+   |
 // |                                                                              |
 // +------------------------------- Index Block ----------------------------------+

--- a/sstable/blob/rewrite.go
+++ b/sstable/blob/rewrite.go
@@ -84,11 +84,11 @@ func (rw *FileRewriter) CopyBlock(
 		// block. See the doc.go comment for more details on sparseness.
 		for missingValueID := previousValueID + 1; missingValueID < valueID; missingValueID++ {
 			rw.w.stats.ValueCount++
-			rw.w.valuesEncoder.AddValue(nil)
+			rw.w.valuesEncoder.AddValue(nil, base.TieringMeta{})
 		}
 
 		// Retrieve the value and copy it to the output blob file.
-		value, _, err := rw.f.Fetch(ctx, rw.fileID, blockID, BlockValueID(valueID))
+		value, meta, _, err := rw.f.Fetch(ctx, rw.fileID, blockID, BlockValueID(valueID))
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ func (rw *FileRewriter) CopyBlock(
 		}
 		rw.w.stats.ValueCount++
 		rw.w.stats.UncompressedValueBytes += uint64(len(value))
-		rw.w.valuesEncoder.AddValue(value)
+		rw.w.valuesEncoder.AddValue(value, meta)
 		previousValueID = valueID
 	}
 	return nil

--- a/value_separation.go
+++ b/value_separation.go
@@ -291,7 +291,7 @@ func (vs *writeNewBlobFiles) Add(
 	}
 
 	// Append the value to the blob file.
-	handle := vs.writer.AddValue(v)
+	handle := vs.writer.AddValue(v, kv.M.Tiering)
 
 	// Write the key and the handle to the sstable. We need to map the
 	// blob.Handle into a blob.InlineHandle. Everything is copied verbatim,


### PR DESCRIPTION
This format stores the base.TieringMeta with each value. Also added
plumbing to write and read the TieringMeta and propagate it during
compactions (including blob rewrite compactions).
