### PR TITLE
[tiered prototype] options: change SpanPolicyFunc to take UserKeyBounds

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3389,7 +3389,10 @@ func (d *DB) compactAndWrite(
 			(len(spanPolicy.KeyRange.End) > 0 && d.cmp(firstKey, spanPolicy.KeyRange.End) >= 0) {
 			var err error
 			if d.opts.Experimental.SpanPolicyFunc != nil {
-				spanPolicy, err = d.opts.Experimental.SpanPolicyFunc(firstKey)
+				spanPolicy, err = d.opts.Experimental.SpanPolicyFunc(base.UserKeyBounds{
+					Start: firstKey,
+					End:   c.bounds.End,
+				})
 				if err != nil {
 					return runner.Finish().WithError(err)
 				}

--- a/internal.go
+++ b/internal.go
@@ -42,6 +42,9 @@ type InternalKey = base.InternalKey
 // KeyRange exports the base.KeyRange type.
 type KeyRange = base.KeyRange
 
+// UserKeyBounds exports the base.UserKeyBounds type.
+type UserKeyBounds = base.UserKeyBounds
+
 // MakeInternalKey constructs an internal key from a specified user key,
 // sequence number and kind.
 func MakeInternalKey(userKey []byte, seqNum SeqNum, kind InternalKeyKind) InternalKey {

--- a/options_test.go
+++ b/options_test.go
@@ -628,7 +628,7 @@ func TestStaticSpanPolicyFunc(t *testing.T) {
 
 		spf := MakeStaticSpanPolicyFunc(testkeys.Comparer.Compare, inputSpanPolicies...)
 		for _, key := range strings.Fields(td.Input) {
-			policy, err := spf([]byte(key))
+			policy, err := spf(UserKeyBounds{Start: []byte(key)})
 			require.NoError(t, err)
 			// TODO(sumeer): also output KeyRange.Start.
 			if policy.KeyRange.End == nil {


### PR DESCRIPTION
If the span policy function is non-trivial, it might have to do a lot
of work to find the end key at which e.g. the empty policy doesn't
apply anymore.

We switch to passing `UserKeyBounds`, since we only care about the
policy up to the compaction end bound.