### PR TITLE
[tiered prototype] compact: extract (spanId, attribute) if not already extracted

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3422,7 +3422,7 @@ func (d *DB) compactAndWrite(
 		if err != nil {
 			return runner.Finish().WithError(err)
 		}
-		runner.WriteTable(objMeta, tw, spanPolicy.KeyRange.End, vSep)
+		runner.WriteTable(objMeta, tw, spanPolicy.KeyRange.End, vSep, spanPolicy.TieringPolicy)
 	}
 	result = runner.Finish()
 	if result.Err == nil {

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -621,11 +621,13 @@ type InternalKV struct {
 }
 
 // The zero values of TieringSpanID and TieringAttribute are reserved to
-// represent absence of these fields.
+// represent absence of these fields. A non-zero TieringSpanID with a zero
+// TieringAttribute represents an error in extraction.
 
 type TieringSpanID uint64
 type TieringAttribute uint64
 
+// TieringMeta can only be populated for SET or SETWITHDEL key-value pairs.
 type TieringMeta struct {
 	SpanID TieringSpanID
 	// Attribute is a user-specified attribute for the key-value pair.
@@ -712,4 +714,88 @@ func (asn *AtomicSeqNum) Add(delta SeqNum) SeqNum {
 // CompareAndSwap executes the compare-and-swap operation.
 func (asn *AtomicSeqNum) CompareAndSwap(old, new SeqNum) bool {
 	return asn.value.CompareAndSwap(uint64(old), uint64(new))
+}
+
+// TieringPolicy defines a policy for tiering key-value pairs into warm and
+// cold tiers.
+type TieringPolicy struct {
+	// SpanID is an immutable id for the key span to which this policy applies.
+	// The actual span is specified by the SpanPolicy.KeyRange context in which
+	// this policy is returned.
+	SpanID TieringSpanID
+	// ColdTierLTThreshold is the threshold such that 0 < attribute < threshold
+	// belongs in the cold tier. For a SpanID, this threshold can change over
+	// time, because the typical policy uses the age of data, and (a) the age
+	// changes as time advances, (b) the user can change the age threshold that
+	// qualifies data for the cold tier.
+	ColdTierLTThreshold TieringAttribute
+}
+
+// TieringPolicyAndExtractor defines a tiering policy and an extractor for the
+// tiering attribute for that policy.
+//
+// Currently, the only way to retrieve a TieringPolicyAndExtractor is via
+// SpanPolicyFunc, by passing a key parameter. The policy is needed by Pebble
+// in the following cases:
+//
+//   - During the execution phase of a flush or a sstable compaction, to do
+//     attribute extraction, or to decide which tier a particular row belongs
+//     to. Since the key is known, the SpanPolicy can be retrieved with that
+//     key. Typically, attribute extraction is done during flushes, and we
+//     never re-extract during compactions. However, due to the eventual
+//     consistency of the tiering policies, we may need to extract for the
+//     first time during a sstable compaction. Note that we cannot extract for
+//     the first time when doing a blob file rewrite compaction since the key
+//     that determines the policy is not known.
+//
+//   - During a blob file rewrite compaction. We do not store the key with
+//     each value in the blob file, but we store a non-tight key span for the
+//     whole blob file. The start key of that span is used to retrieve the
+//     first SpanPolicy, and the SpanPolicy.KeyRange.End is used to iterate
+//     until we reach the blob file end key. Since the blob file may be have
+//     been rewritten in the past (hence the key span is not tight), we may
+//     retrieve some unnecessary policies, but we will have all the SpanIDs
+//     that could possibly apply to these values and can stash them into a
+//     SpanID => TieringPolicy map, for use in this compaction. NB: due to
+//     weak consistency, the SpanIDs in this map may be a subset of the
+//     SpanIDs in the blob file. For the ones with an unknown policy, we will
+//     not change the tier.
+//
+//   - Before starting a sstable compaction, a decision needs to be made
+//     whether to rewrite certain warm and cold blob files referenced in the
+//     compaction. This rewrite decision uses the latest tiering policies for
+//     all the spanIDs in the inputs of the compactions, and their tiering
+//     attribute histograms. It may result in a decision to rewrite a blob
+//     file, if it allows for significant movement of data between tiers. In a
+//     similar vein, when writing new blob files, a decision needs to be made
+//     up front whether there is enough cold data to justify writing a cold
+//     blob file (to avoid having tiny files). The same iteration approach
+//     mentioned earlier is used.
+//
+//   - Periodic calls, to learn the latest ColdTierLTThresholds, so that it
+//     can initiate explicit rewrites of files that are not being rewritten
+//     normally, to move data between tiers. The same iteration approach
+//     mentioned earlier is used to iterate over *all* tiering policies.
+//
+//   - Called when DB.TieringPolicyChange is called, when the aforementioned
+//     periodic calls are insufficient. The same iteration approach mentioned
+//     earlier is used. to iterate over *all* tiering policies.
+//
+// There is a concern that iteration over policies in the cases that are not
+// using actual keys stored in Pebble will result in unnecessary iteration
+// over 100s of policies for CockroachDB tenants that have no ranges on this
+// DB. One way to mitigate this is by adding an interface to lookup the
+// TieringPolicy by SpanID.
+type TieringPolicyAndExtractor interface {
+	// Policy returns the tiering policy.
+	Policy() TieringPolicy
+	// ExtractAttribute extracts the tiering attribute from the key-value pair.
+	// Once extracted, the attribute can be remembered since it must never
+	// change for this key-value pair during the lifetime of the DB.
+	//
+	// Successful extraction must not return a 0 attribute. Pebble reserves the
+	// 0 attribute (with a non-zero SpanID) to represent an extraction error,
+	// and stats are maintained for this so that users can enquire about the
+	// bytes in the system that have such errors.
+	ExtractAttribute(userKey []byte, value []byte) (TieringAttribute, error)
 }

--- a/options.go
+++ b/options.go
@@ -1376,85 +1376,8 @@ func MakeStaticSpanPolicyFunc(cmp base.Compare, inputPolicies ...SpanPolicy) Spa
 
 type TieringMeta base.TieringMeta
 type TieringAttribute base.TieringAttribute
-
-// TieringPolicy defines a policy for tiering key-value pairs into warm and
-// cold tiers.
-type TieringPolicy struct {
-	// SpanID is an immutable id for the key span to which this policy applies.
-	// The actual span is specified by the SpanPolicy.KeyRange context in which
-	// this policy is returned.
-	SpanID uint64
-	// ColdTierLTThreshold is the threshold such that attribute < threshold
-	// belongs in the cold tier. For a SpanID, this threshold can change over
-	// time, because the typical policy uses the age of data, and (a) the age
-	// changes as time advances, (b) the user can change the age threshold that
-	// qualifies data for the cold tier.
-	ColdTierLTThreshold TieringAttribute
-}
-
-// TieringPolicyAndExtractor defines a tiering policy and an extractor for the
-// tiering attribute for that policy.
-//
-// Currently, the only way to retrieve a TieringPolicyAndExtractor is via
-// SpanPolicyFunc, by passing a key parameter. The policy is needed by Pebble
-// in the following cases:
-//
-//   - During the execution phase of a flush or a sstable compaction, to do
-//     attribute extraction, or to decide which tier a particular row belongs
-//     to. Since the key is known, the SpanPolicy can be retrieved with that
-//     key. Typically, attribute extraction is done during flushes, and we
-//     never re-extract during compactions. However, due to the eventual
-//     consistency of the tiering policies, we may need to extract for the
-//     first time during a sstable compaction. Note that we cannot extract for
-//     the first time when doing a blob file rewrite compaction since the key
-//     that determines the policy is not known.
-//
-//   - During a blob file rewrite compaction. We do not store the key with
-//     each value in the blob file, but we store a non-tight key span for the
-//     whole blob file. The start key of that span is used to retrieve the
-//     first SpanPolicy, and the SpanPolicy.KeyRange.End is used to iterate
-//     until we reach the blob file end key. Since the blob file may be have
-//     been rewritten in the past (hence the key span is not tight), we may
-//     retrieve some unnecessary policies, but we will have all the SpanIDs
-//     that could possibly apply to these values and can stash them into a
-//     SpanID => TieringPolicy map, for use in this compaction. NB: due to
-//     weak consistency, the SpanIDs in this map may be a subset of the
-//     SpanIDs in the blob file. For the ones with an unknown policy, we will
-//     not change the tier.
-//
-//   - Before starting a sstable compaction, a decision needs to be made
-//     whether to rewrite certain warm and cold blob files referenced in the
-//     compaction. This rewrite decision uses the latest tiering policies for
-//     all the spanIDs in the inputs of the compactions, and their tiering
-//     attribute histograms. It may result in a decision to rewrite a blob
-//     file, if it allows for significant movement of data between tiers. In a
-//     similar vein, when writing new blob files, a decision needs to be made
-//     up front whether there is enough cold data to justify writing a cold
-//     blob file (to avoid having tiny files). The same iteration approach
-//     mentioned earlier is used.
-//
-//   - Periodic calls, to learn the latest ColdTierLTThresholds, so that it
-//     can initiate explicit rewrites of files that are not being rewritten
-//     normally, to move data between tiers. The same iteration approach
-//     mentioned earlier is used to iterate over *all* tiering policies.
-//
-//   - Called when DB.TieringPolicyChange is called, when the aforementioned
-//     periodic calls are insufficient. The same iteration approach mentioned
-//     earlier is used. to iterate over *all* tiering policies.
-//
-// There is a concern that iteration over policies in the cases that are not
-// using actual keys stored in Pebble will result in unnecessary iteration
-// over 100s of policies for CockroachDB tenants that have no ranges on this
-// DB. One way to mitigate this is by adding an interface to lookup the
-// TieringPolicy by SpanID.
-type TieringPolicyAndExtractor interface {
-	// Policy returns the tiering policy.
-	Policy() TieringPolicy
-	// ExtractAttribute extracts the tiering attribute from the key-value pair.
-	// Once extracted, the attribute can be remembered since it must never
-	// change for this key-value pair during the lifetime of the DB.
-	ExtractAttribute(userKey []byte, value []byte) (TieringAttribute, error)
-}
+type TieringPolicy base.TieringPolicy
+type TieringPolicyAndExtractor base.TieringPolicyAndExtractor
 
 // WALFailoverOptions configures the WAL failover mechanics to use during
 // transient write unavailability on the primary WAL volume.

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -323,11 +323,13 @@ type RawWriter interface {
 	// that strict-obsolete ssts must satisfy. S2, due to RANGEDELs, is solely the
 	// responsibility of the caller. S1 is solely the responsibility of the
 	// callee.
-	Add(key InternalKey, value []byte, forceObsolete bool, meta KVMeta) error
+	Add(key InternalKey, value []byte, forceObsolete bool, meta base.KVMeta) error
 	// AddWithBlobHandle adds a key to the sstable, but encoding a blob value
 	// handle instead of an in-place value. See Add for more details. The caller
 	// must provide the already-extracted ShortAttribute for the value.
-	AddWithBlobHandle(key InternalKey, h blob.InlineHandle, attr base.ShortAttribute, forceObsolete bool, meta KVMeta) error
+	AddWithBlobHandle(
+		key InternalKey, h blob.InlineHandle, attr base.ShortAttribute, forceObsolete bool,
+		meta base.KVMeta) error
 	// EncodeSpan encodes the keys in the given span. The span can contain
 	// either only RANGEDEL keys or only range keys.
 	//
@@ -382,8 +384,6 @@ type RawWriter interface {
 	// using CopySpan().
 	copyProperties(props Properties)
 }
-
-type KVMeta = base.KVMeta
 
 // WriterMetadata holds info about a finished sstable.
 type WriterMetadata struct {

--- a/value_separation.go
+++ b/value_separation.go
@@ -453,7 +453,8 @@ func (vs *preserveBlobReferences) Add(
 		},
 		HandleSuffix: handleSuffix,
 	}
-	err := tw.AddWithBlobHandle(kv.K, inlineHandle, lv.Fetcher.Attribute.ShortAttribute, forceObsolete, base.KVMeta{})
+	err := tw.AddWithBlobHandle(
+		kv.K, inlineHandle, lv.Fetcher.Attribute.ShortAttribute, forceObsolete, kv.M)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is some additional commentary on what this tuple represents. And all
the tiering declarations are moved to base so that they can be utilized in
lower level packages.
