### PR TITLE
manifest: store the tombstone-dense block ratio in TableBackingStats

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3515,7 +3515,6 @@ func (c *tableCompaction) makeVersionEdit(result compact.Result) (*manifest.Vers
 			fileMeta.LargestSeqNumAbsolute = t.WriterMeta.LargestSeqNum
 		}
 		fileMeta.InitPhysicalBacking()
-		fileMeta.TableBacking.PopulateProperties(&t.WriterMeta.Properties)
 
 		// If the file didn't contain any range deletions, we can fill its
 		// table stats now, avoiding unnecessarily loading the table later.

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1779,17 +1779,16 @@ func (p *compactionPickerByScore) pickTombstoneDensityCompaction(
 			if !propsValid {
 				continue
 			}
-			tombstoneDenseBlocksRatio := props.TombstoneDenseBlocksRatio()
-			if tombstoneDenseBlocksRatio < p.opts.Experimental.TombstoneDenseCompactionThreshold {
+			if props.TombstoneDenseBlocksRatio < p.opts.Experimental.TombstoneDenseCompactionThreshold {
 				continue
 			}
 			overlaps := p.vers.Overlaps(lastNonEmptyLevel, f.UserKeyBounds())
 			if float64(overlaps.AggregateSizeSum())/float64(f.Size) > maxOverlappingRatio {
 				continue
 			}
-			if candidate == nil || candidateTombstoneDenseBlocksRatio < tombstoneDenseBlocksRatio {
+			if candidate == nil || candidateTombstoneDenseBlocksRatio < props.TombstoneDenseBlocksRatio {
 				candidate = f
-				candidateTombstoneDenseBlocksRatio = tombstoneDenseBlocksRatio
+				candidateTombstoneDenseBlocksRatio = props.TombstoneDenseBlocksRatio
 				level = l
 			}
 		}

--- a/data_test.go
+++ b/data_test.go
@@ -1262,13 +1262,11 @@ func runTableStatsCmd(td *datadriven.TestData, d *DB) string {
 
 			// If requested, override the tombstone density ratio for testing
 			if forceTombstoneDensityRatio >= 0 {
-				backingProps.NumDataBlocks = 100
-				backingProps.NumTombstoneDenseBlocks = uint64(100 * forceTombstoneDensityRatio)
+				backingProps.TombstoneDenseBlocksRatio = forceTombstoneDensityRatio
 			}
 			// Only include the tombstone-dense-blocks-ratio if it was forced or is non-zero
-			tombstoneDenseBlocksRatio := backingProps.TombstoneDenseBlocksRatio()
-			if forceTombstoneDensityRatio >= 0 || tombstoneDenseBlocksRatio > 0 {
-				fmt.Fprintf(&b, "tombstone-dense-blocks-ratio: %0.1f\n", tombstoneDenseBlocksRatio)
+			if forceTombstoneDensityRatio >= 0 || backingProps.TombstoneDenseBlocksRatio > 0 {
+				fmt.Fprintf(&b, "tombstone-dense-blocks-ratio: %0.1f\n", backingProps.TombstoneDenseBlocksRatio)
 			}
 
 			if compressionStats := backingProps.CompressionStats; !compressionStats.IsEmpty() {

--- a/ingest.go
+++ b/ingest.go
@@ -312,7 +312,6 @@ func ingestLoad1(
 	meta.Size = max(uint64(readable.Size()), 1)
 	meta.CreationTime = time.Now().Unix()
 	meta.InitPhysicalBacking()
-	meta.TableBacking.PopulateProperties(&props)
 
 	// Avoid loading into the file cache for collecting stats if we
 	// don't need to. If there are no range deletions, we have all the

--- a/internal/manifest/table_metadata_test.go
+++ b/internal/manifest/table_metadata_test.go
@@ -155,7 +155,7 @@ func TestTableMetadataSize(t *testing.T) {
 			structSize, tableMetadataSize)
 	}
 
-	const tableBackingSize = 160
+	const tableBackingSize = 152
 	if structSize := unsafe.Sizeof(TableBacking{}); structSize != tableBackingSize {
 		t.Errorf("TableBacking struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableBackingSize)

--- a/table_stats.go
+++ b/table_stats.go
@@ -299,7 +299,6 @@ func (d *DB) loadTableStats(
 	ctx context.Context, v *manifest.Version, level int, meta *manifest.TableMetadata,
 ) (manifest.TableStats, []deleteCompactionHint, error) {
 	var compactionHints []deleteCompactionHint
-	var props sstable.CommonProperties
 	var rangeDeletionsBytesEstimate uint64
 
 	backingProps, backingPropsOk := meta.TableBacking.Properties()
@@ -329,17 +328,13 @@ func (d *DB) loadTableStats(
 			return manifest.TableStats{}, nil, err
 		}
 	}
-	props = backingProps.CommonProperties
-	if meta.Virtual {
-		props = props.GetScaledProperties(meta.TableBacking.Size, meta.Size)
-	}
 
 	var stats manifest.TableStats
 	stats.RangeDeletionsBytesEstimate = rangeDeletionsBytesEstimate
 
-	if props.NumPointDeletions() > 0 {
+	if backingProps.NumPointDeletions() > 0 {
 		var err error
-		stats.PointDeletionsBytesEstimate, err = d.loadTablePointKeyStats(ctx, &props, v, level, meta)
+		stats.PointDeletionsBytesEstimate, err = d.loadTablePointKeyStats(ctx, backingProps, v, level, meta)
 		if err != nil {
 			return stats, nil, err
 		}
@@ -349,9 +344,11 @@ func (d *DB) loadTableStats(
 
 // loadTablePointKeyStats calculates the point key statistics for the given
 // table.
+//
+// The backing props are scaled as necessary if the table is virtual.
 func (d *DB) loadTablePointKeyStats(
 	ctx context.Context,
-	props *sstable.CommonProperties,
+	props *manifest.TableBackingProperties,
 	v *manifest.Version,
 	level int,
 	meta *manifest.TableMetadata,
@@ -367,6 +364,7 @@ func (d *DB) loadTablePointKeyStats(
 		return 0, err
 	}
 	pointDeletionsBytes = pointDeletionsBytesEstimate(props, avgValLogicalSize, compressionRatio)
+	pointDeletionsBytes = meta.ScaleStatistic(pointDeletionsBytes)
 	return pointDeletionsBytes, nil
 }
 
@@ -487,7 +485,7 @@ func (d *DB) estimateSizesBeneath(
 	v *manifest.Version,
 	level int,
 	meta *manifest.TableMetadata,
-	fileProps *sstable.CommonProperties,
+	fileProps *manifest.TableBackingProperties,
 ) (avgValueLogicalSize, compressionRatio float64, err error) {
 	// Find all files in lower levels that overlap with meta,
 	// summing their value sizes and entry counts.
@@ -527,14 +525,10 @@ func (d *DB) estimateSizesBeneath(
 					return 0, 0, err
 				}
 			}
-			props := backingProps.CommonProperties
-			if tableBeneath.Virtual {
-				props = backingProps.GetScaledProperties(tableBeneath.TableBacking.Size, tableBeneath.Size)
-			}
 
-			entryCount += props.NumEntries
-			keySum += props.RawKeySize
-			valSum += props.RawValueSize
+			entryCount += tableBeneath.ScaleStatistic(backingProps.NumEntries)
+			keySum += tableBeneath.ScaleStatistic(backingProps.RawKeySize)
+			valSum += tableBeneath.ScaleStatistic(backingProps.RawValueSize)
 			continue
 		}
 	}
@@ -695,9 +689,16 @@ func sanityCheckStats(
 	}
 }
 
+// maybeSetStatsFromProperties sets the table backing properties and attempts to
+// set the table stats from the properties, for a table that was created by an
+// ingestion or compaction.
 func maybeSetStatsFromProperties(
 	meta *manifest.TableMetadata, props *sstable.Properties, logger Logger,
 ) bool {
+	backingProps := meta.TableBacking.PopulateProperties(props)
+	if invariants.Enabled && meta.Virtual {
+		panic("table expected to be physical")
+	}
 	// If a table contains range deletions or range key deletions, we defer the
 	// stats collection. There are two main reasons for this:
 	//
@@ -729,7 +730,7 @@ func maybeSetStatsFromProperties(
 		// deletions in the file is low, the error introduced by this crude
 		// estimate is expected to be small.
 		avgValSize, compressionRatio := estimatePhysicalSizes(meta, &props.CommonProperties)
-		pointEstimate = pointDeletionsBytesEstimate(&props.CommonProperties, avgValSize, compressionRatio)
+		pointEstimate = pointDeletionsBytesEstimate(backingProps, avgValSize, compressionRatio)
 	}
 
 	stats := manifest.TableStats{
@@ -741,8 +742,11 @@ func maybeSetStatsFromProperties(
 	return true
 }
 
+// pointDeletionBytesEstimate returns an estimation of the total disk space that
+// may be dropped by the physical table's point deletions by compacting them.
+// The results should be scaled accordingly for virtual tables.
 func pointDeletionsBytesEstimate(
-	props *sstable.CommonProperties, avgValLogicalSize, compressionRatio float64,
+	props *manifest.TableBackingProperties, avgValLogicalSize, compressionRatio float64,
 ) (estimate uint64) {
 	if props.NumEntries == 0 {
 		return 0

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -671,7 +671,7 @@ wait-pending-table-stats
 num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 3
+point-deletions-bytes-estimate: 1
 range-deletions-bytes-estimate: 0
 
 wait-pending-table-stats
@@ -680,7 +680,7 @@ wait-pending-table-stats
 num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 3
+point-deletions-bytes-estimate: 1
 range-deletions-bytes-estimate: 0
 
 # Create an sstable with a range key set.


### PR DESCRIPTION
#### manifest: don't embed CommonProperties in TableBackingProperties

This will allow us to derive more concise backing properties (for
example the tombstone-dense ratio).

We no longer rely on scaling the entire `CommonProperties`; this was
really only used for the point deletion bytes estimate, which we now
scale after calculating.

#### manifest: store the tombstone-dense block ratio in TableBackingStats