### PR TITLE
compact: include expected size in MissizedDeleteCallback

### DIFF
--- a/internal/compact/testdata/iter_delete_sized
+++ b/internal/compact/testdata/iter_delete_sized
@@ -1877,3 +1877,24 @@ b#7,DEL:
 c#6,DELSIZED:
 missized-dels=2
 missized-delete-info: a (elided=4, expected=20); b (elided=4, expected=15)
+
+# Test a delete sized that doesn't delete a key, because it meets another
+# tombstone.
+
+define
+a.SET.1:hello
+b.DELSIZED.9:varint(6)
+b.DELSIZED.4:varint(6)
+b.SET.2:world
+----
+
+iter print-missized-dels print-missized-del-info
+first
+next
+next
+----
+a#1,SET:hello
+b#9,DELSIZED:
+.
+missized-dels=1
+missized-delete-info: b (elided=0, expected=6)


### PR DESCRIPTION
Fix one of the instances where we report a missized DELSIZED tombstone but did not include the expected tombstone size. If a DELSIZED tombstone with a non-zero value meets another tombstone during a compaction, it indicates the more recent DELSIZED was missized--it deleted a key that did not exist (and was already deleted). Previously when invoking a callback to report this missizing, the compaction iterator passed expectedSize=0. This was misleading because the DELSIZED explicitly carried a non-zero size which allowed to us to determine there was a missizing in the first place.

This commit adapts the compaction iterator to decode the DELSIZED's value in this case and propagate it into the missized delete callback.