### PR TITLE
manifest: add BackingValueSize field for blob refs

### DIFF
--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -142,7 +142,11 @@ func TestBlobRewrite(t *testing.T) {
 				} else {
 					fmt.Fprintln(&buf, "blobrefs:[")
 					for i, ref := range meta.BlobReferences {
-						fmt.Fprintf(&buf, " %d: %s %d\n", i, ref.FileID, ref.ValueSize)
+						fmt.Fprintf(&buf, " %d: %s %d", i, ref.FileID, ref.ValueSize)
+						if ref.ValueSize != ref.BackingValueSize && ref.BackingValueSize > 0 {
+							fmt.Fprintf(&buf, "/%d", ref.BackingValueSize)
+						}
+						fmt.Fprintf(&buf, "\n")
 					}
 					fmt.Fprintln(&buf, "]")
 				}
@@ -309,13 +313,14 @@ func TestBlobRewriteRandomized(t *testing.T) {
 		))
 		require.NoError(t, tw.Close())
 		originalValueIndices[i] = i
+		valueSize := uint64(len(values[i]))
 		originalTables[i] = &manifest.TableMetadata{
 			TableNum: base.TableNum(i),
 			TableBacking: &manifest.TableBacking{
 				DiskFileNum: base.DiskFileNum(i),
 			},
 			BlobReferences: []manifest.BlobReference{
-				{FileID: base.BlobFileID(blobFileID), ValueSize: uint64(len(values[i]))},
+				{FileID: base.BlobFileID(blobFileID), ValueSize: valueSize, BackingValueSize: valueSize},
 			},
 		}
 	}

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1716,7 +1716,8 @@ func (p *compactionPickerByScore) pickBlobFileRewriteCompaction(
 		// Blob file rewrite compactions are disabled.
 		return nil
 	}
-	garbagePct := float64(aggregateStats.ValueSize-aggregateStats.ReferencedValueSize) /
+
+	garbagePct := float64(aggregateStats.ValueSize-aggregateStats.ReferencedBackingValueSize) /
 		float64(aggregateStats.ValueSize)
 	if garbagePct <= policy.TargetGarbageRatio {
 		// Not enough garbage to warrant a rewrite compaction.

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1508,6 +1508,11 @@ func TestCompaction(t *testing.T) {
 			minVersion: formatDeprecatedExperimentalValueSeparation,
 			maxVersion: formatDeprecatedExperimentalValueSeparation,
 		},
+		"backing_value_size": {
+			minVersion: FormatBackingValueSize,
+			maxVersion: FormatBackingValueSize,
+			verbose:    true,
+		},
 	}
 	datadriven.Walk(t, "testdata/compaction", func(t *testing.T, path string) {
 		filename := filepath.Base(path)

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -243,6 +243,11 @@ const (
 	// file format (which adds compression statistics).
 	FormatV2BlobFiles
 
+	// FormatBackingValueSize is a format major version that adds support for
+	// persisting the value size of the backing sst for virtual sstables in the
+	// manifest (VersionEdit).
+	FormatBackingValueSize
+
 	// -- Add new versions here --
 
 	// FormatNewest is the most recent format major version.
@@ -374,6 +379,9 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	},
 	FormatV2BlobFiles: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatV2BlobFiles)
+	},
+	FormatBackingValueSize: func(d *DB) error {
+		return d.finalizeFormatVersUpgrade(FormatBackingValueSize)
 	},
 }
 

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -36,11 +36,12 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatValueSeparation, FormatMajorVersion(24))
 	require.Equal(t, FormatExciseBoundsRecord, FormatMajorVersion(25))
 	require.Equal(t, FormatV2BlobFiles, FormatMajorVersion(26))
+	require.Equal(t, FormatBackingValueSize, FormatMajorVersion(27))
 
 	// When we add a new version, we should add a check for the new version above
 	// in addition to updating the expected values below.
-	require.Equal(t, FormatNewest, FormatMajorVersion(26))
-	require.Equal(t, internalFormatNewest, FormatMajorVersion(26))
+	require.Equal(t, FormatNewest, FormatMajorVersion(27))
+	require.Equal(t, internalFormatNewest, FormatMajorVersion(27))
 }
 
 func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
@@ -229,6 +230,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatValueSeparation:                       {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 		FormatExciseBoundsRecord:                    {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 		FormatV2BlobFiles:                           {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
+		FormatBackingValueSize:                      {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 	}
 
 	// Valid versions.
@@ -254,6 +256,7 @@ func TestFormatMajorVersions_BlobFileFormat(t *testing.T) {
 		FormatValueSeparation:    blob.FileFormatV1,
 		FormatExciseBoundsRecord: blob.FileFormatV1,
 		FormatV2BlobFiles:        blob.FileFormatV2,
+		FormatBackingValueSize:   blob.FileFormatV2,
 	}
 
 	// Valid versions.

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -36,6 +36,10 @@ type BlobReference struct {
 	// any of the referencing tables are virtualized tables, the ValueSize may
 	// be approximate.
 	ValueSize uint64
+	// BackingValueSize is the sum of the lengths of the uncompressed values within the
+	// blob file for which there exists a reference in the backing sstable. For non-virtual
+	// sstables, this is the same as ValueSize.
+	BackingValueSize uint64
 	// EstimatedPhysicalSize is an estimate of the physical size of the blob
 	// reference, in bytes. It's calculated by scaling the blob file's physical
 	// size according to the ValueSize of the blob reference relative to the
@@ -46,7 +50,7 @@ type BlobReference struct {
 // MakeBlobReference creates a BlobReference from the given file ID, value size,
 // and physical blob file.
 func MakeBlobReference(
-	fileID base.BlobFileID, valueSize uint64, phys *PhysicalBlobFile,
+	fileID base.BlobFileID, valueSize uint64, backingValueSize uint64, phys *PhysicalBlobFile,
 ) BlobReference {
 	if invariants.Enabled {
 		switch {
@@ -60,8 +64,9 @@ func MakeBlobReference(
 		}
 	}
 	return BlobReference{
-		FileID:    fileID,
-		ValueSize: valueSize,
+		FileID:           fileID,
+		ValueSize:        valueSize,
+		BackingValueSize: backingValueSize,
 		//                        valueSize
 		//   Reference size =  -----------------  ×  phys.Size
 		//                      phys.ValueSize
@@ -441,6 +446,12 @@ type AggregateBlobFileStats struct {
 	// in all blob files in the set that are still referenced by live tables
 	// (i.e., in the latest version).
 	ReferencedValueSize uint64
+	// ReferencedBackingValueSize is the sum of the length of the uncompressed
+	// values in all blob files in the set that are still referenced by live
+	// backing tables (i.e., in the latest version). Note that this may
+	// overcount values when virtual sstables with the same backing are present,
+	// as each virtual sstable contributes the full backing table's value size.
+	ReferencedBackingValueSize uint64
 	// ReferencesCount is the total number of tracked references in live tables
 	// (i.e., in the latest version). When virtual sstables are present, this
 	// count is per-virtual sstable (not per backing physical sstable).
@@ -449,8 +460,8 @@ type AggregateBlobFileStats struct {
 
 // String implements fmt.Stringer.
 func (s AggregateBlobFileStats) String() string {
-	return fmt.Sprintf("Files:{Count: %d, Size: %d, ValueSize: %d}, References:{ValueSize: %d, Count: %d}",
-		s.Count, s.PhysicalSize, s.ValueSize, s.ReferencedValueSize, s.ReferencesCount)
+	return fmt.Sprintf("Files:{Count: %d, Size: %d, ValueSize: %d}, References:{ValueSize: %d, BackingValueSize: %d, Count: %d}",
+		s.Count, s.PhysicalSize, s.ValueSize, s.ReferencedValueSize, s.ReferencedBackingValueSize, s.ReferencesCount)
 }
 
 // CurrentBlobFileSet describes the set of blob files that are currently live in
@@ -502,7 +513,10 @@ type currentBlobFile struct {
 	// (and we can pool the B-Tree nodes to further reduce allocs)
 	references map[*TableMetadata]struct{}
 	// referencedValueSize is the sum of the length of uncompressed values in
-	// this blob file that are still live.
+	// this blob file that are still live (referenced by backing tables).
+	// This value can be greater than the physical ValueSize of the blob file,
+	// since virtual sstables contribute the referenced value size of the original
+	// backing table.
 	referencedValueSize uint64
 	// heapState holds a pointer to the heap that the blob file is in (if any)
 	// and its index in the heap's items slice. If referencedValueSize is less
@@ -602,7 +616,11 @@ func (s *CurrentBlobFileSet) Init(bve *BulkVersionEdit, h BlobRewriteHeuristic) 
 					panic(errors.AssertionFailedf("pebble: referenced blob file %d not found", ref.FileID))
 				}
 				cbf.references[table] = struct{}{}
-				cbf.referencedValueSize += ref.ValueSize
+				refSize := ref.BackingValueSize
+				if refSize == 0 {
+					refSize = ref.ValueSize
+				}
+				cbf.referencedValueSize += refSize
 				s.stats.ReferencedValueSize += ref.ValueSize
 				s.stats.ReferencesCount++
 			}
@@ -753,8 +771,14 @@ func (s *CurrentBlobFileSet) ApplyAndUpdateVersionEdit(ve *VersionEdit) error {
 				return errors.AssertionFailedf("pebble: referenced blob file %d not found", ref.FileID)
 			}
 			cbf.references[e.Meta] = struct{}{}
-			cbf.referencedValueSize += ref.ValueSize
+			refSize := ref.BackingValueSize
+			if refSize == 0 {
+				// Fall back to using ValueSize to estimate reference size.
+				refSize = ref.ValueSize
+			}
+			cbf.referencedValueSize += refSize
 			s.stats.ReferencedValueSize += ref.ValueSize
+			s.stats.ReferencedBackingValueSize += refSize
 			s.stats.ReferencesCount++
 		}
 	}
@@ -771,10 +795,6 @@ func (s *CurrentBlobFileSet) ApplyAndUpdateVersionEdit(ve *VersionEdit) error {
 				return errors.AssertionFailedf("pebble: referenced blob file %d not found", ref.FileID)
 			}
 			if invariants.Enabled {
-				if ref.ValueSize > cbf.referencedValueSize {
-					return errors.AssertionFailedf("pebble: referenced value size %d for blob file %s is greater than the referenced value size %d",
-						ref.ValueSize, cbf.metadata.FileID, cbf.referencedValueSize)
-				}
 				if _, ok := cbf.references[meta]; !ok {
 					return errors.AssertionFailedf("pebble: deleted table %s's reference to blob file %s not known",
 						meta.TableNum, ref.FileID)
@@ -784,7 +804,13 @@ func (s *CurrentBlobFileSet) ApplyAndUpdateVersionEdit(ve *VersionEdit) error {
 			// Decrement the stats for this reference. We decrement even if the
 			// table is being moved, because we incremented the stats when we
 			// iterated over the version edit's new tables.
-			cbf.referencedValueSize -= ref.ValueSize
+			refSize := ref.BackingValueSize
+			if refSize == 0 {
+				// Fall back to using ValueSize to estimate reference size.
+				refSize = ref.ValueSize
+			}
+			cbf.referencedValueSize -= refSize
+			s.stats.ReferencedBackingValueSize -= refSize
 			s.stats.ReferencedValueSize -= ref.ValueSize
 			s.stats.ReferencesCount--
 			if _, ok := newTables[meta.TableNum]; ok {

--- a/internal/manifest/testdata/current_blob_file_set
+++ b/internal/manifest/testdata/current_blob_file_set
@@ -1,7 +1,7 @@
 init
 ----
 CurrentBlobFileSet:
-Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, Count: 0}
+Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, BackingValueSize: 0, Count: 0}
 Counts:{FullyReferenced: 0, Eligible: 0, TooRecent: 0}
 
 # A version edit that does not contain blob files leaves the set unchanged.
@@ -14,7 +14,7 @@ modified version edit:
   add-table:     L3 000010:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET]
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, Count: 0}
+Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, BackingValueSize: 0, Count: 0}
 Counts:{FullyReferenced: 0, Eligible: 0, TooRecent: 0}
 
 # A version edit that adds a new blob file records the new file and reference.
@@ -29,7 +29,7 @@ modified version edit:
   add-blob-file: B000012 physical:{000012 size:[20535 (20KB)] vals:[25935 (25KB)]}
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 25935, Count: 1}
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 25935, BackingValueSize: 25935, Count: 1}
 Counts:{FullyReferenced: 1, Eligible: 0, TooRecent: 0}
 
 # A version edit that moves a referencing table from one level to another should
@@ -45,7 +45,7 @@ modified version edit:
   add-table:     L4 000013:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] blobrefs:[(B000012: 25935); depth:1]
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 25935, Count: 1}
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 25935, BackingValueSize: 25935, Count: 1}
 Counts:{FullyReferenced: 1, Eligible: 0, TooRecent: 0}
 
 # A version edit that moves references from deleted tables to created tables
@@ -63,7 +63,7 @@ modified version edit:
   add-table:     L5 000015:[f#1,SET-g#1,SET] seqnums:[0-0] points:[f#1,SET-g#1,SET] blobrefs:[(B000012: 15935); depth:2]
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 15945, Count: 2}
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 15945, BackingValueSize: 15945, Count: 2}
 Counts:{FullyReferenced: 0, Eligible: 1, TooRecent: 0}
 NextRewrite: B000012 physical:{000012 size:[20535 (20KB)] vals:[25935 (25KB)]} (61.5% live, created at 0)
 
@@ -77,7 +77,7 @@ modified version edit:
   del-table:     L5 000014
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 15935, Count: 1}
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 15935, BackingValueSize: 15935, Count: 1}
 Counts:{FullyReferenced: 0, Eligible: 1, TooRecent: 0}
 NextRewrite: B000012 physical:{000012 size:[20535 (20KB)] vals:[25935 (25KB)]} (61.4% live, created at 0)
 
@@ -93,7 +93,7 @@ modified version edit:
   del-blob-file: B000012 000012
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, Count: 0}
+Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, BackingValueSize: 0, Count: 0}
 Counts:{FullyReferenced: 0, Eligible: 0, TooRecent: 0}
 
 applyAndUpdateVersionEdit
@@ -106,7 +106,7 @@ modified version edit:
   add-blob-file: B000017 physical:{000017 size:[20535 (20KB)] vals:[25935 (25KB)]}
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 25935, Count: 1}
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 25935, BackingValueSize: 25935, Count: 1}
 Counts:{FullyReferenced: 1, Eligible: 0, TooRecent: 0}
 
 applyAndUpdateVersionEdit
@@ -119,7 +119,7 @@ modified version edit:
   add-table:     L4 000018:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] blobrefs:[(B000017: 15935); depth:1]
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 15935, Count: 1}
+Files:{Count: 1, Size: 20535, ValueSize: 25935}, References:{ValueSize: 15935, BackingValueSize: 15935, Count: 1}
 Counts:{FullyReferenced: 0, Eligible: 1, TooRecent: 0}
 NextRewrite: B000017 physical:{000017 size:[20535 (20KB)] vals:[25935 (25KB)]} (61.4% live, created at 0)
 
@@ -139,7 +139,7 @@ modified version edit:
   del-blob-file: B000017 000017
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 10535, ValueSize: 15935}, References:{ValueSize: 15935, Count: 1}
+Files:{Count: 1, Size: 10535, ValueSize: 15935}, References:{ValueSize: 15935, BackingValueSize: 15935, Count: 1}
 Counts:{FullyReferenced: 1, Eligible: 0, TooRecent: 0}
 
 # Initialize a blob file set with a minimum rewrite age of 5 seconds.
@@ -147,7 +147,7 @@ Counts:{FullyReferenced: 1, Eligible: 0, TooRecent: 0}
 init rw-minimum-age=5s
 ----
 CurrentBlobFileSet:
-Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, Count: 0}
+Files:{Count: 0, Size: 0, ValueSize: 0}, References:{ValueSize: 0, BackingValueSize: 0, Count: 0}
 Counts:{FullyReferenced: 0, Eligible: 0, TooRecent: 0}
 
 applyAndUpdateVersionEdit
@@ -160,7 +160,7 @@ modified version edit:
   add-blob-file: B000002 physical:{000002 size:[1000 (1000B)] vals:[2000 (2.0KB)]}
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 1000, Count: 1}
+Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 1000, BackingValueSize: 1000, Count: 1}
 Counts:{FullyReferenced: 1, Eligible: 0, TooRecent: 0}
 
 # Rewrite the referencing sstable to reduce the blob file's referenced value
@@ -176,7 +176,7 @@ modified version edit:
   add-table:     L6 000004:[d#1,SET-e#1,SET] seqnums:[0-0] points:[d#1,SET-e#1,SET] blobrefs:[(B000002: 500); depth:1]
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 500, Count: 1}
+Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 500, BackingValueSize: 500, Count: 1}
 Counts:{FullyReferenced: 0, Eligible: 0, TooRecent: 1}
 NextEligible: B000002 physical:{000002 size:[1000 (1000B)] vals:[2000 (2.0KB)]} (25.0% live, created at 1)
 
@@ -190,7 +190,7 @@ modified version edit:
   add-table:     L6 000005:[f#1,SET-g#1,SET] seqnums:[0-0] points:[f#1,SET-g#1,SET]
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 500, Count: 1}
+Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 500, BackingValueSize: 500, Count: 1}
 Counts:{FullyReferenced: 0, Eligible: 0, TooRecent: 1}
 NextEligible: B000002 physical:{000002 size:[1000 (1000B)] vals:[2000 (2.0KB)]} (25.0% live, created at 1)
 
@@ -202,7 +202,7 @@ modified version edit:
   add-table:     L0 000006:[a#2,SET-b#3,SET] seqnums:[0-0] points:[a#2,SET-b#3,SET]
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 500, Count: 1}
+Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 500, BackingValueSize: 500, Count: 1}
 Counts:{FullyReferenced: 0, Eligible: 0, TooRecent: 1}
 NextEligible: B000002 physical:{000002 size:[1000 (1000B)] vals:[2000 (2.0KB)]} (25.0% live, created at 1)
 
@@ -217,6 +217,6 @@ modified version edit:
   add-table:     L6 000007:[x#9,SET-y#10,SET] seqnums:[0-0] points:[x#9,SET-y#10,SET]
 current blob file set:
 CurrentBlobFileSet:
-Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 500, Count: 1}
+Files:{Count: 1, Size: 1000, ValueSize: 2000}, References:{ValueSize: 500, BackingValueSize: 500, Count: 1}
 Counts:{FullyReferenced: 0, Eligible: 1, TooRecent: 0}
 NextRewrite: B000002 physical:{000002 size:[1000 (1000B)] vals:[2000 (2.0KB)]} (25.0% live, created at 1)

--- a/internal/manifest/testdata/version_edit_decode
+++ b/internal/manifest/testdata/version_edit_decode
@@ -49,7 +49,7 @@ c505                         #   . FileSize        = 709
   log-num:       5
   next-file-num: 6
   last-seq-num:  14
-  add-table:     L0 000004:[bar#14,DEL-foo#13,SET] (2023-12-04T17:57:24Z)
+  add-table:     L0 000004:[bar#14,DEL-foo#13,SET] seqnums:[12-14] points:[bar#14,DEL-foo#13,SET] size:709 (2023-12-04T17:57:24Z)
 
 decode
 0219                         # <tagLogNumber>, 19
@@ -94,7 +94,42 @@ decode
 ----
 67061d000b626172000e0000000000000b666f6f010d0000000000000000
 45010129d8a301016baf0729d8a301f9a006006c21210a016201630103
-  add-table:     L6 000029:[bar#14,DEL-foo#13,SET]
+  add-table:     L6 000029:[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952); depth:1]
   add-blob-file: B000943 physical:{000041 size:[20952 (20KB)] vals:[102521 (100KB)]}
   del-blob-file: B000033 000033
   excise-op:     [b, c] #3
+
+encode
+  add-table:     L3 000029 (000009):[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952 / 30952); depth:1]
+  add-backing:   000009
+----
+69096467031d000b626172000e0000000000000b666f6f010d0000000000
+000000420946010129d8a301e8f10101
+  add-table:     L3 000029(000009):[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952/30952); depth:1]
+  add-backing:   000009
+
+decode virtual
+69096467031d000b626172000e0000000000000b666f6f010d0000000000
+000000420946010129d8a301e8f10101
+----
+69096467031d000b626172000e0000000000000b666f6f010d0000000000
+000000420946010129d8a301e8f10101
+  add-table:     L3 000029(000009):[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952/30952); depth:1]
+  add-backing:   000009
+
+# Encoding a non-virtual SST with backing value size should skip the backing size info.
+encode
+  add-table:     L3 000029:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952 / 30952); depth:1]
+----
+67031d000b626172000e0000000000000b666f6f010d0000000000000000
+45010129d8a30101
+  add-table:     L3 000029:[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952/30952); depth:1]
+
+
+decode
+67031d000b626172000e0000000000000b666f6f010d0000000000000000
+45010129d8a30101
+----
+67031d000b626172000e0000000000000b666f6f010d0000000000000000
+45010129d8a30101
+  add-table:     L3 000029:[bar#14,DEL-foo#13,SET] seqnums:[0-0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952); depth:1]

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -73,6 +73,8 @@ const (
 	customTagSyntheticPrefix   = 67
 	customTagSyntheticSuffix   = 68
 	customTagBlobReferences    = 69
+	// customTagBlobReferences2 contains BackingValueSize for each BlobReference.
+	customTagBlobReferences2 = 70
 )
 
 // DeletedTableEntry holds the state for a sstable deletion from a level. The
@@ -437,7 +439,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 							return err
 						}
 
-					case customTagBlobReferences:
+					case customTagBlobReferences, customTagBlobReferences2:
 						// The first varint encodes the 'blob reference depth'
 						// of the table.
 						v, err := d.readUvarint()
@@ -459,9 +461,17 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 							if err != nil {
 								return err
 							}
+							var backingValueSize uint64
+							if customTag == customTagBlobReferences2 {
+								backingValueSize, err = d.readUvarint()
+								if err != nil {
+									return err
+								}
+							}
 							blobReferences[i] = BlobReference{
-								FileID:    base.BlobFileID(fileID),
-								ValueSize: valueSize,
+								FileID:           base.BlobFileID(fileID),
+								ValueSize:        valueSize,
+								BackingValueSize: backingValueSize,
 							}
 						}
 						continue
@@ -893,12 +903,28 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 				e.writeBytes(x.Meta.SyntheticPrefixAndSuffix.Suffix())
 			}
 			if len(x.Meta.BlobReferences) > 0 {
-				e.writeUvarint(customTagBlobReferences)
+				writeBackingValueSize := false
+				if x.Meta.Virtual {
+					for _, ref := range x.Meta.BlobReferences {
+						if ref.BackingValueSize > 0 && ref.BackingValueSize != ref.ValueSize {
+							writeBackingValueSize = true
+							break
+						}
+					}
+				}
+				if writeBackingValueSize {
+					e.writeUvarint(customTagBlobReferences2)
+				} else {
+					e.writeUvarint(customTagBlobReferences)
+				}
 				e.writeUvarint(uint64(x.Meta.BlobReferenceDepth))
 				e.writeUvarint(uint64(len(x.Meta.BlobReferences)))
 				for _, ref := range x.Meta.BlobReferences {
 					e.writeUvarint(uint64(ref.FileID))
 					e.writeUvarint(ref.ValueSize)
+					if writeBackingValueSize {
+						e.writeUvarint(ref.BackingValueSize)
+					}
 				}
 			}
 			e.writeUvarint(customTagTerminate)
@@ -1313,7 +1339,7 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 				if ref.EstimatedPhysicalSize == 0 {
 					// We must call MakeBlobReference so that we compute the
 					// reference's physical estimated size.
-					f.BlobReferences[i] = MakeBlobReference(ref.FileID, ref.ValueSize, phys)
+					f.BlobReferences[i] = MakeBlobReference(ref.FileID, ref.ValueSize, ref.BackingValueSize, phys)
 				}
 			}
 

--- a/open_test.go
+++ b/open_test.go
@@ -503,7 +503,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000003",
-			"marker.format-version.000013.026",
+			"marker.format-version.000014.027",
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -71,6 +71,10 @@ create: db/marker.format-version.000013.026
 close: db/marker.format-version.000013.026
 remove: db/marker.format-version.000012.025
 sync: db
+create: db/marker.format-version.000014.027
+close: db/marker.format-version.000014.027
+remove: db/marker.format-version.000013.026
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -137,9 +141,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.026
-close: checkpoints/checkpoint1/marker.format-version.000001.026
+create: checkpoints/checkpoint1/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.027
+close: checkpoints/checkpoint1/marker.format-version.000001.027
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -181,9 +185,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.026
-close: checkpoints/checkpoint2/marker.format-version.000001.026
+create: checkpoints/checkpoint2/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.027
+close: checkpoints/checkpoint2/marker.format-version.000001.027
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -220,9 +224,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.026
-close: checkpoints/checkpoint3/marker.format-version.000001.026
+create: checkpoints/checkpoint3/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.027
+close: checkpoints/checkpoint3/marker.format-version.000001.027
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -306,7 +310,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -316,7 +320,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.026
+marker.format-version.000001.027
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -383,7 +387,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.026
+marker.format-version.000001.027
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -425,7 +429,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000001.026
+marker.format-version.000001.027
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -544,9 +548,9 @@ sync-data: checkpoints/checkpoint4/OPTIONS-000003
 close: checkpoints/checkpoint4/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.026
-close: checkpoints/checkpoint4/marker.format-version.000001.026
+create: checkpoints/checkpoint4/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.027
+close: checkpoints/checkpoint4/marker.format-version.000001.027
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -634,7 +638,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000003
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -653,9 +657,9 @@ sync-data: checkpoints/checkpoint5/OPTIONS-000003
 close: checkpoints/checkpoint5/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.026
-close: checkpoints/checkpoint5/marker.format-version.000001.026
+create: checkpoints/checkpoint5/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.027
+close: checkpoints/checkpoint5/marker.format-version.000001.027
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -755,9 +759,9 @@ sync-data: checkpoints/checkpoint6/OPTIONS-000003
 close: checkpoints/checkpoint6/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.026
-close: checkpoints/checkpoint6/marker.format-version.000001.026
+create: checkpoints/checkpoint6/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.027
+close: checkpoints/checkpoint6/marker.format-version.000001.027
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst
@@ -942,6 +946,10 @@ create: valsepdb/marker.format-version.000013.026
 close: valsepdb/marker.format-version.000013.026
 remove: valsepdb/marker.format-version.000012.025
 sync: valsepdb
+create: valsepdb/marker.format-version.000014.027
+close: valsepdb/marker.format-version.000014.027
+remove: valsepdb/marker.format-version.000013.026
+sync: valsepdb
 create: valsepdb/temporary.000003.dbtmp
 sync: valsepdb/temporary.000003.dbtmp
 close: valsepdb/temporary.000003.dbtmp
@@ -990,9 +998,9 @@ sync-data: checkpoints/checkpoint8/OPTIONS-000003
 close: checkpoints/checkpoint8/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint8
-create: checkpoints/checkpoint8/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint8/marker.format-version.000001.026
-close: checkpoints/checkpoint8/marker.format-version.000001.026
+create: checkpoints/checkpoint8/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint8/marker.format-version.000001.027
+close: checkpoints/checkpoint8/marker.format-version.000001.027
 sync: checkpoints/checkpoint8
 close: checkpoints/checkpoint8
 link: valsepdb/000006.blob -> checkpoints/checkpoint8/000006.blob
@@ -1104,9 +1112,9 @@ sync-data: checkpoints/checkpoint9/OPTIONS-000003
 close: checkpoints/checkpoint9/OPTIONS-000003
 close: valsepdb/OPTIONS-000003
 open-dir: checkpoints/checkpoint9
-create: checkpoints/checkpoint9/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint9/marker.format-version.000001.026
-close: checkpoints/checkpoint9/marker.format-version.000001.026
+create: checkpoints/checkpoint9/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint9/marker.format-version.000001.027
+close: checkpoints/checkpoint9/marker.format-version.000001.027
 sync: checkpoints/checkpoint9
 close: checkpoints/checkpoint9
 link: valsepdb/000006.blob -> checkpoints/checkpoint9/000006.blob

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -59,6 +59,10 @@ create: db/marker.format-version.000010.026
 close: db/marker.format-version.000010.026
 remove: db/marker.format-version.000009.025
 sync: db
+create: db/marker.format-version.000011.027
+close: db/marker.format-version.000011.027
+remove: db/marker.format-version.000010.026
+sync: db
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -125,9 +129,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000003
 close: checkpoints/checkpoint1/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.026
-close: checkpoints/checkpoint1/marker.format-version.000001.026
+create: checkpoints/checkpoint1/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.027
+close: checkpoints/checkpoint1/marker.format-version.000001.027
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -178,9 +182,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000003
 close: checkpoints/checkpoint2/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.026
-close: checkpoints/checkpoint2/marker.format-version.000001.026
+create: checkpoints/checkpoint2/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.027
+close: checkpoints/checkpoint2/marker.format-version.000001.027
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -227,9 +231,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000003
 close: checkpoints/checkpoint3/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.026
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.026
-close: checkpoints/checkpoint3/marker.format-version.000001.026
+create: checkpoints/checkpoint3/marker.format-version.000001.027
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.027
+close: checkpoints/checkpoint3/marker.format-version.000001.027
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -286,7 +290,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000010.026
+marker.format-version.000011.027
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -296,7 +300,7 @@ list checkpoints/checkpoint1
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.026
+marker.format-version.000001.027
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -348,7 +352,7 @@ list checkpoints/checkpoint2
 MANIFEST-000001
 OPTIONS-000003
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.026
+marker.format-version.000001.027
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 

--- a/testdata/compaction/backing_value_size
+++ b/testdata/compaction/backing_value_size
@@ -1,0 +1,36 @@
+# Test a blob file rewrite compaction with virtual sstable references that
+# track backing value sizes do not trigger unnecessary blob file rewrites.
+
+define value-separation=(true,1,10,0s,0.01)
+----
+
+batch
+set a apple
+set b banana
+set c coconut
+----
+
+compact a-b
+----
+L6:
+  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:767 blobrefs:[(B000006: 18); depth:1]
+Blob files:
+  B000006 physical:{000006 size:[194 (194B)] vals:[18 (18B)]}
+
+excise b ba
+----
+L6:
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(767) blobrefs:[(B000006: 2/18); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(767) blobrefs:[(B000006: 2/18); depth:1]
+Blob files:
+  B000006 physical:{000006 size:[194 (194B)] vals:[18 (18B)]}
+
+run-blob-rewrite-compaction
+----
+no blob file rewrite compaction
+
+validate-blob-reference-index-block
+000007.sst
+000008.sst
+----
+validated

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -92,6 +92,11 @@ close: db/marker.format-version.000013.026
 remove: db/marker.format-version.000012.025
 sync: db
 upgraded to format version: 026
+create: db/marker.format-version.000014.027
+close: db/marker.format-version.000014.027
+remove: db/marker.format-version.000013.026
+sync: db
+upgraded to format version: 027
 create: db/temporary.000003.dbtmp
 sync: db/temporary.000003.dbtmp
 close: db/temporary.000003.dbtmp
@@ -478,9 +483,9 @@ sync-data: checkpoint/OPTIONS-000003
 close: checkpoint/OPTIONS-000003
 close: db/OPTIONS-000003
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.026
-sync-data: checkpoint/marker.format-version.000001.026
-close: checkpoint/marker.format-version.000001.026
+create: checkpoint/marker.format-version.000001.027
+sync-data: checkpoint/marker.format-version.000001.027
+close: checkpoint/marker.format-version.000001.027
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -38,7 +38,7 @@ ext
 ext1
 ext2
 ext3
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 # Ingest can complete despite the flush being blocked.
@@ -62,7 +62,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 allowFlush
@@ -96,7 +96,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -117,7 +117,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -210,7 +210,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext5
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 allowFlush
@@ -440,7 +440,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -460,7 +460,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -493,7 +493,7 @@ MANIFEST-000001
 MANIFEST-000011
 OPTIONS-000014
 ext
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000002.MANIFEST-000011
 
 # Make sure that the new mutable memtable can accept writes.
@@ -636,7 +636,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000003
 ext
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -655,7 +655,7 @@ MANIFEST-000001
 OPTIONS-000003
 ext
 ext1
-marker.format-version.000013.026
+marker.format-version.000014.027
 marker.manifest.000001.MANIFEST-000001
 
 open

--- a/tool/testdata/db_upgrade
+++ b/tool/testdata/db_upgrade
@@ -27,7 +27,7 @@ db get foo yellow
 db upgrade foo
 ----
 ----
-Upgrading DB from internal version 16 to 26.
+Upgrading DB from internal version 16 to 27.
 WARNING!!!
 This DB will not be usable with older versions of Pebble!
 
@@ -43,7 +43,7 @@ Continue? [Y/N] Error: EOF
 
 db upgrade foo --yes
 ----
-Upgrading DB from internal version 16 to 26.
+Upgrading DB from internal version 16 to 27.
 Upgrade complete.
 
 db get foo blue
@@ -56,4 +56,4 @@ db get foo yellow
 
 db upgrade foo
 ----
-DB is already at internal version 26.
+DB is already at internal version 27.

--- a/value_separation.go
+++ b/value_separation.go
@@ -341,11 +341,9 @@ func (vs *writeNewBlobFiles) FinishOutput() (compact.ValueSeparationMetadata, er
 	vs.minimumSize = vs.globalMinimumSize
 
 	return compact.ValueSeparationMetadata{
-		BlobReferences: manifest.BlobReferences{manifest.MakeBlobReference(
-			base.BlobFileID(vs.objMeta.DiskFileNum),
-			stats.UncompressedValueBytes,
-			meta,
-		)},
+		BlobReferences: manifest.BlobReferences{
+			manifest.MakeBlobReference(base.BlobFileID(vs.objMeta.DiskFileNum), stats.UncompressedValueBytes, stats.UncompressedValueBytes, meta),
+		},
 		BlobReferenceSize:  stats.UncompressedValueBytes,
 		BlobReferenceDepth: 1,
 		BlobFileStats:      stats,
@@ -492,7 +490,7 @@ func (vs *preserveBlobReferences) FinishOutput() (compact.ValueSeparationMetadat
 			return compact.ValueSeparationMetadata{},
 				errors.AssertionFailedf("pebble: blob file %s not found among input sstables", ref.blobFileID)
 		}
-		references[i] = manifest.MakeBlobReference(ref.blobFileID, ref.valueSize, phys)
+		references[i] = manifest.MakeBlobReference(ref.blobFileID, ref.valueSize, ref.valueSize, phys)
 	}
 	referenceSize := vs.totalValueSize
 	vs.currReferences = vs.currReferences[:0]

--- a/value_separation_test.go
+++ b/value_separation_test.go
@@ -154,7 +154,11 @@ func TestValueSeparationPolicy(t *testing.T) {
 				} else {
 					fmt.Fprintln(&buf, "blobrefs:[")
 					for i, ref := range meta.BlobReferences {
-						fmt.Fprintf(&buf, " %d: %s %d\n", i, ref.FileID, ref.ValueSize)
+						fmt.Fprintf(&buf, " %d: %s %d", i, ref.FileID, ref.ValueSize)
+						if ref.ValueSize != ref.BackingValueSize && ref.BackingValueSize > 0 {
+							fmt.Fprintf(&buf, "/%d", ref.BackingValueSize)
+						}
+						fmt.Fprintf(&buf, "\n")
 					}
 					fmt.Fprintln(&buf, "]")
 				}


### PR DESCRIPTION
## pebble: add FMV for writing BackingValueSize to manifest
This field will be added for virtual tables with blob refs.

--------------------------------------------------------------

## manifest: add BackingValueSize field for blob refs

Track BackingValueSize for blob references, which is the uncompressed value
size in blob files referenced by the backing sstable. For non-virtual sstables,
this equals the existing ValueSize field. The BackingValueSize should only be
popualted for FMV >= FormatBackingValueSize, falling back to reading ValueSize
when the BackingValueSize is 0.

Use BackingValueSize in the estimation of referencedValueSize for the
CurrentBlobFileSet. This prevents wasteful blob file rewrite compactions when
virtual sstables are involved, as blob compactions currentlyr rewrite based
on value references tracked by the original table.

Part of: #4915