### PR TITLE
db: unify wait-for-stats helpers

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1593,7 +1593,7 @@ func TestCompactionPickerScores(t *testing.T) {
 			return buf.String()
 
 		case "wait-pending-table-stats":
-			return runTableStatsCmd(td, d)
+			return runWaitForTableStatsCmd(td, d)
 
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)

--- a/data_test.go
+++ b/data_test.go
@@ -1211,7 +1211,7 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 	return d, nil
 }
 
-func runTableStatsCmd(td *datadriven.TestData, d *DB) string {
+func runWaitForTableStatsCmd(td *datadriven.TestData, d *DB) string {
 	// In the original test file, parse the command args first
 	var forceTombstoneDensityRatio float64 = -1.0
 	for _, arg := range td.CmdArgs {
@@ -1231,8 +1231,8 @@ func runTableStatsCmd(td *datadriven.TestData, d *DB) string {
 	tableNum := base.TableNum(u)
 
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	v := d.mu.versions.currentVersion()
+	d.mu.Unlock()
 
 	for _, levelMetadata := range v.Levels {
 		for f := range levelMetadata.All() {
@@ -1461,23 +1461,22 @@ func runPopulateCmd(t *testing.T, td *datadriven.TestData, b *Batch) {
 	}
 }
 
-// waitTableStatsInitialLoad waits until the statistics for all files that
-// existed during Open have been loaded; used in tests.
-// The d.mu mutex must be locked while calling this method.
-//
-// TODO(jackson): Consolidate waitTableStatsInitialLoad and waitTableStats. It
-// seems to be possible for loadedInitial to remain indefinitely false in some
-// tests that use waitTableStats today.
-func (d *DB) waitTableStatsInitialLoad() {
-	for !d.mu.tableStats.loadedInitial {
-		d.mu.tableStats.cond.Wait()
-	}
+// waitTableStats waits for all table statistics to be loaded; used in tests.
+func (d *DB) waitTableStats() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.waitTableStatsLocked()
 }
 
-// waitTableStats waits until all new files' statistics have been loaded. It's
-// used in tests. The d.mu mutex must be locked while calling this method.
-func (d *DB) waitTableStats() {
-	for d.mu.tableStats.loading || len(d.mu.tableStats.pending) > 0 {
+// waitTableStatsLocked waits for all table statistics to be loaded; used in tests.
+//
+// The d.mu mutex must be held while calling this variant. It can get released
+// and reaquired as part of the call.
+func (d *DB) waitTableStatsLocked() {
+	if d.opts.DisableTableStats {
+		return
+	}
+	for d.mu.tableStats.loading || !d.mu.tableStats.loadedInitial || len(d.mu.tableStats.pending) > 0 {
 		d.mu.tableStats.cond.Wait()
 	}
 }

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -220,9 +220,7 @@ func TestEventListener(t *testing.T) {
 		case "metrics":
 			// The asynchronous loading of table stats can change metrics, so
 			// wait for all the tables' stats to be loaded.
-			d.mu.Lock()
 			d.waitTableStats()
-			d.mu.Unlock()
 
 			return d.Metrics().StringForTests()
 

--- a/excise_test.go
+++ b/excise_test.go
@@ -270,13 +270,11 @@ func TestExcise(t *testing.T) {
 		case "metrics":
 			// The asynchronous loading of table stats can change metrics, so
 			// wait for all the tables' stats to be loaded.
-			d.mu.Lock()
 			d.waitTableStats()
-			d.mu.Unlock()
 
 			return d.Metrics().StringForTests()
 		case "wait-pending-table-stats":
-			return runTableStatsCmd(td, d)
+			return runWaitForTableStatsCmd(td, d)
 		case "excise":
 			if err := runExciseCmd(td, d); err != nil {
 				return err.Error()
@@ -655,14 +653,12 @@ func TestConcurrentExcise(t *testing.T) {
 		case "metrics":
 			// The asynchronous loading of table stats can change metrics, so
 			// wait for all the tables' stats to be loaded.
-			d.mu.Lock()
 			d.waitTableStats()
-			d.mu.Unlock()
 
 			return d.Metrics().StringForTests()
 
 		case "wait-pending-table-stats":
-			return runTableStatsCmd(td, d)
+			return runWaitForTableStatsCmd(td, d)
 
 		case "excise":
 			ve := &manifest.VersionEdit{

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -916,14 +916,12 @@ func testIngestSharedImpl(
 		case "metrics":
 			// The asynchronous loading of table stats can change metrics, so
 			// wait for all the tables' stats to be loaded.
-			d.mu.Lock()
 			d.waitTableStats()
-			d.mu.Unlock()
 
 			return d.Metrics().StringForTests()
 
 		case "wait-pending-table-stats":
-			return runTableStatsCmd(td, d)
+			return runWaitForTableStatsCmd(td, d)
 
 		case "excise":
 			ve := &manifest.VersionEdit{
@@ -1316,14 +1314,12 @@ func TestIngestExternal(t *testing.T) {
 		case "metrics":
 			// The asynchronous loading of table stats can change metrics, so
 			// wait for all the tables' stats to be loaded.
-			d.mu.Lock()
 			d.waitTableStats()
-			d.mu.Unlock()
 
 			return d.Metrics().StringForTests()
 
 		case "wait-pending-table-stats":
-			return runTableStatsCmd(td, d)
+			return runWaitForTableStatsCmd(td, d)
 
 		case "compact":
 			if len(td.CmdArgs) != 2 {
@@ -1785,15 +1781,12 @@ func TestIngest(t *testing.T) {
 		case "metrics":
 			// The asynchronous loading of table stats can change metrics, so
 			// wait for all the tables' stats to be loaded.
-			d.mu.Lock()
-			d.waitTableStatsInitialLoad()
 			d.waitTableStats()
-			d.mu.Unlock()
 
 			return d.Metrics().StringForTests()
 
 		case "wait-pending-table-stats":
-			return runTableStatsCmd(td, d)
+			return runWaitForTableStatsCmd(td, d)
 
 		case "compact":
 			if len(td.CmdArgs) != 2 {

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -243,9 +243,7 @@ func TestIterHistories(t *testing.T) {
 			case "lsm":
 				return runLSMCmd(td, d)
 			case "metrics":
-				d.mu.Lock()
 				d.waitTableStats()
-				d.mu.Unlock()
 				m := d.Metrics()
 				return fmt.Sprintf("Metrics.Keys.RangeKeySetsCount = %d\n", m.Keys.RangeKeySetsCount)
 			case "mutate":
@@ -398,9 +396,7 @@ func TestIterHistories(t *testing.T) {
 				td.ScanArgs(t, "iter", &name)
 				return runIterCmd(td, iters[name], false /* close iter */)
 			case "wait-table-stats":
-				d.mu.Lock()
 				d.waitTableStats()
-				d.mu.Unlock()
 				return ""
 			default:
 				return fmt.Sprintf("unknown command %q", td.Cmd)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2798,10 +2798,10 @@ func waitForCompactionsAndTableStats(d *DB) {
 	d.mu.Lock()
 	// NB: Wait for table stats because some compaction types rely
 	// on table stats to be collected.
-	d.waitTableStats()
+	d.waitTableStatsLocked()
 	for d.mu.compact.compactingCount > 0 {
 		d.mu.compact.cond.Wait()
-		d.waitTableStats()
+		d.waitTableStatsLocked()
 	}
 	d.mu.Unlock()
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -416,10 +416,7 @@ func TestMetrics(t *testing.T) {
 		case "metrics":
 			// The asynchronous loading of table stats can change metrics, so
 			// wait for all the tables' stats to be loaded.
-			d.mu.Lock()
-			d.waitTableStatsInitialLoad()
 			d.waitTableStats()
-			d.mu.Unlock()
 
 			m := d.Metrics()
 			// Some subset of cases show non-determinism in cache hits/misses.
@@ -497,9 +494,7 @@ func TestMetrics(t *testing.T) {
 		case "additional-metrics":
 			// The asynchronous loading of table stats can change metrics, so
 			// wait for all the tables' stats to be loaded.
-			d.mu.Lock()
 			d.waitTableStats()
-			d.mu.Unlock()
 
 			m := d.Metrics()
 			var b strings.Builder

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -65,7 +65,7 @@ func TestRangeDel(t *testing.T) {
 			return s
 
 		case "wait-pending-table-stats":
-			return runTableStatsCmd(td, d)
+			return runWaitForTableStatsCmd(td, d)
 
 		case "compact":
 			if err := runCompactCmd(td, d); err != nil {

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -157,7 +157,7 @@ func TestTableStats(t *testing.T) {
 			return ""
 
 		case "wait-pending-table-stats":
-			return runTableStatsCmd(td, d)
+			return runWaitForTableStatsCmd(td, d)
 
 		case "wait-loaded-initial":
 			d.mu.Lock()


### PR DESCRIPTION
We have two separate variants of helpers for waiting for table stats.
This change unifies them; in the past we hit some problems when trying
this, the issue was that in some tests the table stats are disabled.