### PR TITLE
manifest: remove btree memory abuse

### DIFF
--- a/internal/manifest/annotator.go
+++ b/internal/manifest/annotator.go
@@ -126,8 +126,8 @@ func (a *Annotator[T]) nodeAnnotation(n *node[*TableMetadata]) (t *T, cacheOK bo
 	valid := true
 
 	for i := int16(0); i <= n.count; i++ {
-		if !n.leaf {
-			v, ok := a.nodeAnnotation(n.children[i])
+		if !n.isLeaf() {
+			v, ok := a.nodeAnnotation(n.child(i))
 			t = a.Aggregator.Merge(v, t)
 			valid = valid && ok
 		}
@@ -202,7 +202,7 @@ func (a *Annotator[T]) accumulateRangeAnnotation(
 		dst = v
 	}
 
-	if !n.leaf {
+	if !n.isLeaf() {
 		// We will accumulate annotations from each child in the end-inclusive
 		// range [leftChild, rightChild].
 		leftChild, rightChild := leftItem, rightItem
@@ -219,7 +219,7 @@ func (a *Annotator[T]) accumulateRangeAnnotation(
 
 		for i := leftChild; i <= rightChild; i++ {
 			dst = a.accumulateRangeAnnotation(
-				n.children[i],
+				n.child(int16(i)),
 				cmp,
 				bounds,
 				// If this child is to the right of leftItem, then its entire
@@ -240,9 +240,9 @@ func (a *Annotator[T]) accumulateRangeAnnotation(
 func (a *Annotator[T]) invalidateNodeAnnotation(n *node[*TableMetadata]) {
 	annot := a.findAnnotation(n)
 	annot.valid.Store(false)
-	if !n.leaf {
+	if !n.isLeaf() {
 		for i := int16(0); i <= n.count; i++ {
-			a.invalidateNodeAnnotation(n.children[i])
+			a.invalidateNodeAnnotation(n.child(i))
 		}
 	}
 }

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -387,10 +387,10 @@ func (s *BlobFileSet) LookupPhysical(fileID base.BlobFileID) (*PhysicalBlobFile,
 		}
 		// If we've reached a lead node without finding fileID, the file is not
 		// present.
-		if n.leaf {
+		if n.isLeaf() {
 			return nil, false
 		}
-		n = n.children[i]
+		n = n.child(int16(i))
 	}
 	return nil, false
 }

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -211,7 +211,7 @@ func NewLevelSliceSpecificOrder(files []*TableMetadata) LevelSlice {
 func newLevelSlice(iter iterator[*TableMetadata]) LevelSlice {
 	s := LevelSlice{iter: iter}
 	if iter.r != nil {
-		s.length = iter.r.subtreeCount
+		s.length = iter.r.subtreeCount()
 	}
 	s.verifyInvariants()
 	return s
@@ -616,7 +616,7 @@ func (i *LevelIterator) SeekGE(cmp Compare, userKey []byte) *TableMetadata {
 			}
 		}
 		i.iter.pos = int16(j)
-		if i.iter.n.leaf {
+		if i.iter.n.isLeaf() {
 			if i.iter.pos == i.iter.n.count {
 				// next, which will ascend and descend to move to the next node.
 				i.iter.next()
@@ -678,7 +678,7 @@ func (i *LevelIterator) SeekLT(cmp Compare, userKey []byte) *TableMetadata {
 			}
 		}
 		i.iter.pos = int16(j)
-		if i.iter.n.leaf {
+		if i.iter.n.isLeaf() {
 			if i.iter.pos == i.iter.n.count {
 				i.iter.next()
 			}


### PR DESCRIPTION
We currently allocate either a `leafNode` or a `node` and cast between
them. This is potentially unsafe, since at times we are holding a
`*node`, part of which is outside a `leafNode` object.

We remove this hack by moving the children list to a separate object
and having a pointer to it inside `node`. We also move the
`subtreeCount` to save space, since it is not useful in the leaves
(this offsets the size of the extra pointer for leaves, which are the
vast majority).

The separate object is still allocated together with the inner node,
so this does not increase the number of allocations.

Fixes #5200