### PR TITLE
manifest: replace marked for compaction annotator with a set

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -690,9 +690,9 @@ func TestCompactionPickerL0(t *testing.T) {
 					if f.TableNum != base.TableNum(tableNum) {
 						continue
 					}
+					// This code should be identical to the one in DB.markFilesLocked().
 					f.MarkedForCompaction = true
-					picker.vers.Stats.MarkedForCompaction++
-					markedForCompactionAnnotator.InvalidateLevelAnnotation(picker.vers.Levels[l])
+					picker.vers.MarkedForCompaction.Insert(f, l)
 					return fmt.Sprintf("marked L%d.%s", l, f.TableNum)
 				}
 			}

--- a/db.go
+++ b/db.go
@@ -2061,7 +2061,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.Compact.InProgressBytes = d.mu.versions.atomicInProgressBytes.Load()
 	// TODO(radu): split this to separate the download compactions.
 	metrics.Compact.NumInProgress = int64(d.mu.compact.compactingCount + d.mu.compact.downloadingCount)
-	metrics.Compact.MarkedFiles = vers.Stats.MarkedForCompaction
+	metrics.Compact.MarkedFiles = vers.MarkedForCompaction.Count()
 	metrics.Compact.Duration = d.mu.compact.duration
 	for c := range d.mu.compact.inProgress {
 		if !c.IsFlush() {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06
 	github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9
 	github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e
+	github.com/google/btree v1.1.3
 	github.com/guptarohit/asciigraph v0.5.5
 	github.com/klauspost/compress v1.17.11
 	github.com/kr/pretty v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/gonum/internal v0.0.0-20181124074243-f884aa714029/go.mod h1:Pu4dmpkhS
 github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9/go.mod h1:XA3DeT6rxh2EAE789SSiSJNqxPaC0aE9J8NTOI0Jo/A=
 github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP0HCqCz+K4ts155PXIlUywf0wqN+GfPZw=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/manifest/annotator.go
+++ b/internal/manifest/annotator.go
@@ -258,18 +258,6 @@ func (a *TableAnnotator[T]) accumulateRangeAnnotation(
 	return dst
 }
 
-// InvalidateAnnotation removes any existing cached annotations from this
-// annotator from a node's subtree.
-func (a *TableAnnotator[T]) invalidateNodeAnnotation(n *node[*TableMetadata]) {
-	annot := a.findAnnotation(n)
-	annot.valid.Store(false)
-	if !n.isLeaf() {
-		for i := int16(0); i <= n.count; i++ {
-			a.invalidateNodeAnnotation(n.child(i))
-		}
-	}
-}
-
 // LevelAnnotation calculates the annotation defined by this TableAnnotator for all
 // files in the given LevelMetadata. A pointer to the TableAnnotator is used as the
 // key for pre-calculated values, so the same TableAnnotator must be used to avoid
@@ -335,20 +323,6 @@ func (a *TableAnnotator[T]) VersionRangeAnnotation(v *Version, bounds base.UserK
 		accumulateSlice(lm.Slice())
 	}
 	return dst
-}
-
-// InvalidateLevelAnnotation clears any cached annotations defined by TableAnnotator.
-// A pointer to the TableAnnotator is used as the key for pre-calculated values, so
-// the same TableAnnotator must be used to clear the appropriate cached annotation.
-// Calls to InvalidateLevelAnnotation are *not* concurrent-safe with any other
-// calls to TableAnnotator methods for the same TableAnnotator (concurrent calls from
-// other annotators are fine). Any calls to this function must have some
-// externally-guaranteed mutual exclusion.
-func (a *TableAnnotator[T]) InvalidateLevelAnnotation(lm LevelMetadata) {
-	if lm.Empty() {
-		return
-	}
-	a.invalidateNodeAnnotation(lm.tree.root)
 }
 
 // Annotation calculates the annotation defined by this BlobFileAnnotator for

--- a/internal/manifest/marked_for_compaction.go
+++ b/internal/manifest/marked_for_compaction.go
@@ -1,0 +1,89 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"iter"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	googlebtree "github.com/google/btree"
+)
+
+// MarkedForCompactionSet implements an ordered set of tables that are marked
+// for compaction. They are ordered by decreasing LSM level, and within each
+// level by increasing LargestSeqNum.
+//
+// Files can be marked for compaction when upgrading a DB to a specific version.
+type MarkedForCompactionSet struct {
+	tree *googlebtree.BTreeG[tableAndLevel]
+}
+
+type tableAndLevel struct {
+	meta  *TableMetadata
+	level int
+}
+
+func markedForCompactionLessFn(a, b tableAndLevel) bool {
+	if a.level != b.level {
+		return a.level > b.level
+	}
+	if a.meta.LargestSeqNum != b.meta.LargestSeqNum {
+		return a.meta.LargestSeqNum < b.meta.LargestSeqNum
+	}
+	return a.meta.TableNum < b.meta.TableNum
+}
+
+// Count returns the number of tables in the set.
+func (s *MarkedForCompactionSet) Count() int {
+	if s.tree == nil {
+		return 0
+	}
+	return s.tree.Len()
+}
+
+// Insert adds a table to the set. The table must not be in the set already.
+func (s *MarkedForCompactionSet) Insert(meta *TableMetadata, level int) {
+	if s.tree == nil {
+		s.tree = googlebtree.NewG[tableAndLevel](8, markedForCompactionLessFn)
+	}
+	_, existed := s.tree.ReplaceOrInsert(tableAndLevel{meta: meta, level: level})
+	if invariants.Enabled && existed {
+		panic(errors.AssertionFailedf("table %s already in MarkedForCompaction", meta.TableNum))
+	}
+}
+
+// Delete removes a table from the set. The table must be in the set.
+func (s *MarkedForCompactionSet) Delete(meta *TableMetadata, level int) {
+	ok := false
+	if s.tree != nil {
+		_, ok = s.tree.Delete(tableAndLevel{meta: meta, level: level})
+	}
+	if invariants.Enabled && !ok {
+		panic(errors.AssertionFailedf("table %s not in MarkedForCompaction", meta.TableNum))
+	}
+}
+
+// Clone the set. The resulting set can be independently modified.
+func (s *MarkedForCompactionSet) Clone() MarkedForCompactionSet {
+	if s.tree == nil {
+		return MarkedForCompactionSet{}
+	}
+	return MarkedForCompactionSet{tree: s.tree.Clone()}
+}
+
+// Ascending returns an iterator which produces the tables marked for compaction
+// (along with the level), ordered by decreasing level and within each level by
+// increasing LargestSeqNum.
+func (s *MarkedForCompactionSet) Ascending() iter.Seq2[*TableMetadata, int] {
+	return func(yield func(*TableMetadata, int) bool) {
+		if s.tree == nil {
+			return
+		}
+		s.tree.Ascend(func(t tableAndLevel) bool {
+			return yield(t.meta, t.level)
+		})
+	}
+}

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -148,17 +148,12 @@ type Version struct {
 	// longer referenced by any version.
 	BlobFiles BlobFileSet
 
+	// MarkedForCompaction holds the set of tables that are marked for compaction.
+	MarkedForCompaction MarkedForCompactionSet
+
 	// The callback to invoke when the last reference to a version is
 	// removed. Will be called with list.mu held.
 	Deleted func(obsolete ObsoleteFiles)
-
-	// Stats holds aggregated stats about the version maintained from
-	// version to version.
-	Stats struct {
-		// MarkedForCompaction records the count of files marked for
-		// compaction within the version.
-		MarkedForCompaction int
-	}
 
 	cmp *base.Comparer
 

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -20,9 +20,30 @@ marked L0.000004
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000005] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (665B), in 1.0s (2.0s total), output rate 665B/s
-[JOB 100] compacted(rewrite) L0 [000004] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (654B), in 1.0s (2.0s total), output rate 654B/s
+[JOB 100] compacted(rewrite) L1 [000005] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000008] (665B), in 1.0s (2.0s total), output rate 665B/s
+[JOB 100] compacted(rewrite) L0 [000004] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000009] (654B), in 1.0s (2.0s total), output rate 654B/s
 L0.0:
-  000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:654
+  000009:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:654
 L1:
-  000006:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:665
+  000008:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:665
+
+mark-for-compaction file=000008
+----
+marked L1.000008
+
+mark-for-compaction file=000009
+----
+marked L0.000009
+
+# Verify that we remember the files we marked for compaction across reopens.
+reopen
+----
+
+maybe-compact
+----
+[JOB 100] compacted(rewrite) L1 [000008] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000016] (665B), in 1.0s (2.0s total), output rate 665B/s
+[JOB 100] compacted(rewrite) L0 [000009] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000017] (654B), in 1.0s (2.0s total), output rate 654B/s
+L0.0:
+  000017:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:654
+L1:
+  000016:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:665


### PR DESCRIPTION
*This PR is just for the top commit.*

The marked-for-compaction annotator is an overcomplicated way to
implement an ordered set. It does not fit neatly in the annotator
pattern - unlike all other annotators, it can become invalidated. It
also requires separate logic to maintain a count of marked files.

We remove this annotator and replace it with an ordered set (using the
google btree) stored in the Version. This is a lot cleaner and also
addresses a limitation of the annotator: we were only able to obtain
one candidate per level (and thus only one rewrite compaction
per level at any time).
