### PR TITLE
internal/base: set ComparePointSuffixes in EnsureDefaults

### DIFF
--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -261,7 +261,7 @@ func (c *Comparer) EnsureDefaults() *Comparer {
 	if c.AbbreviatedKey == nil || c.Separator == nil || c.Successor == nil || c.Name == "" {
 		panic("invalid Comparer: mandatory field not set")
 	}
-	if c.CompareRangeSuffixes != nil && c.Compare != nil && c.Equal != nil && c.Split != nil && c.FormatKey != nil {
+	if c.CompareRangeSuffixes != nil && c.ComparePointSuffixes != nil && c.Compare != nil && c.Equal != nil && c.Split != nil && c.FormatKey != nil {
 		return c
 	}
 	n := &Comparer{}
@@ -270,13 +270,17 @@ func (c *Comparer) EnsureDefaults() *Comparer {
 	if n.Split == nil {
 		n.Split = DefaultSplit
 	}
-	if n.CompareRangeSuffixes == nil && n.Compare == nil && n.Equal == nil {
+	if n.CompareRangeSuffixes == nil && n.ComparePointSuffixes == nil && n.Compare == nil && n.Equal == nil {
 		n.CompareRangeSuffixes = bytes.Compare
+		n.ComparePointSuffixes = bytes.Compare
 		n.Compare = bytes.Compare
 		n.Equal = bytes.Equal
 	} else {
 		if n.CompareRangeSuffixes == nil {
 			n.CompareRangeSuffixes = bytes.Compare
+		}
+		if n.ComparePointSuffixes == nil {
+			n.ComparePointSuffixes = bytes.Compare
 		}
 		if n.Compare == nil {
 			n.Compare = func(a, b []byte) int {

--- a/internal/base/comparer_test.go
+++ b/internal/base/comparer_test.go
@@ -71,6 +71,36 @@ func TestDefaultComparer(t *testing.T) {
 	}
 }
 
+func TestEnsureDefaults(t *testing.T) {
+	cases := []struct {
+		comparer *Comparer
+	}{
+		{
+			comparer: &Comparer{
+				AbbreviatedKey: DefaultComparer.AbbreviatedKey,
+				Separator:      DefaultComparer.Separator,
+				Successor:      DefaultComparer.Successor,
+				Name:           "test",
+			},
+		},
+		{
+			comparer: &Comparer{
+				AbbreviatedKey: DefaultComparer.AbbreviatedKey,
+				Separator:      DefaultComparer.Separator,
+				Successor:      DefaultComparer.Successor,
+				Compare:        DefaultComparer.Compare,
+				Name:           "test",
+			},
+		},
+	}
+	for _, tc := range cases {
+		comparer := tc.comparer.EnsureDefaults()
+		if err := CheckComparer(comparer, [][]byte{{}, []byte("abc"), []byte("d"), []byte("ef")}, [][]byte{{}}); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
 func TestAbbreviatedKey(t *testing.T) {
 	rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
 	randBytes := func(size int) []byte {


### PR DESCRIPTION
Previously this was not set, although its documentation says it is. Add tests for both branches of EnsureDefaults where it is set.