### PR TITLE
[tiered prototype] db: read and aggregate tiering histograms

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3529,7 +3529,7 @@ func (c *tableCompaction) makeVersionEdit(result compact.Result) (*manifest.Vers
 		// If the file didn't contain any range deletions, we can fill its
 		// table stats now, avoiding unnecessarily loading the table later.
 		maybeSetStatsFromProperties(
-			fileMeta.PhysicalMeta(), &t.WriterMeta.Properties, c.logger,
+			fileMeta.PhysicalMeta(), &t.WriterMeta.Properties, t.WriterMeta.TieringHistograms, c.logger,
 		)
 
 		if t.WriterMeta.HasPointKeys {

--- a/db.go
+++ b/db.go
@@ -2171,6 +2171,10 @@ func (d *DB) Metrics() *Metrics {
 		metrics.Table.Compression.MergeWith(compressionMetrics)
 	}
 
+	for i := 0; i < numLevels; i++ {
+		metrics.Levels[i].Additional.TieringHistograms =
+			*tieringHistogramsAnnotator.LevelAnnotation(vers.Levels[i]).Clone()
+	}
 	metrics.Table.PendingStatsCollectionCount = int64(len(d.mu.tableStats.pending))
 	metrics.Table.InitialStatsCollectionComplete = d.mu.tableStats.loadedInitial
 

--- a/ingest.go
+++ b/ingest.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/tieredmeta"
 )
 
 func sstableKeyCompare(userCmp Compare, a, b InternalKey) int {
@@ -322,7 +323,11 @@ func ingestLoad1(
 	// disallowing removal of an open file. Under MemFS, if we don't populate
 	// meta.Stats here, the file will be loaded into the file cache for
 	// calculating stats before we can remove the original link.
-	maybeSetStatsFromProperties(meta.PhysicalMeta(), &props, opts.Logger)
+	//
+	// Assume for now that ingested files have no tiering histograms.
+	// TODO(sumeer): fix this by reading the histogram block above.
+	maybeSetStatsFromProperties(
+		meta.PhysicalMeta(), &props, tieredmeta.TieringHistogramBlockContents{}, opts.Logger)
 
 	var iterStats base.InternalIteratorStats
 	env := sstable.ReadEnv{

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/strparse"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/tieredmeta"
 	"github.com/cockroachdb/pebble/sstable/virtual"
 )
 
@@ -1187,6 +1188,7 @@ type TableStats struct {
 	TombstoneDenseBlocksRatio float64
 	RawKeySize                uint64
 	RawValueSize              uint64
+	TieringHistograms         tieredmeta.TieringHistogramBlockContents
 }
 
 // CompactionState is the compaction state of a file.

--- a/internal/manifest/table_metadata_test.go
+++ b/internal/manifest/table_metadata_test.go
@@ -148,7 +148,7 @@ func TestTableMetadataSize(t *testing.T) {
 	}
 	structSize := unsafe.Sizeof(TableMetadata{})
 
-	const tableMetadataSize = 344
+	const tableMetadataSize = 352
 	if structSize != tableMetadataSize {
 		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableMetadataSize)

--- a/metrics.go
+++ b/metrics.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/sstable/tieredmeta"
 	"github.com/cockroachdb/pebble/wal"
 	"github.com/cockroachdb/redact"
 	"github.com/prometheus/client_golang/prometheus"
@@ -143,6 +144,10 @@ type LevelMetrics struct {
 		// LevelMetrics.format, but are available to sophisticated clients.
 		BytesWrittenDataBlocks  uint64
 		BytesWrittenValueBlocks uint64
+
+		// TODO(sumeer): the raw info is fine for prototyping, but this will need
+		// to be refined.
+		TieringHistograms tieredmeta.TieringHistogramBlockContents
 	}
 }
 
@@ -1060,7 +1065,7 @@ func (m *Metrics) StringForTests() string {
 
 	// We recalculate the file cache size using the 64-bit sizes, and we ignore
 	// the genericcache metadata size which is harder to adjust.
-	const sstableReaderSize64bit = 280
+	const sstableReaderSize64bit = 296
 	const blobFileReaderSize64bit = 128
 	mCopy.FileCache.Size = mCopy.FileCache.TableCount*sstableReaderSize64bit + mCopy.FileCache.BlobFileCount*blobFileReaderSize64bit
 	if math.MaxInt == math.MaxInt64 {

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -347,8 +347,9 @@ func (w *FileWriter) Close() (FileWriterStats, error) {
 		// Write the tiering histogram block if the file format is >= v3.
 		var tieringHistogramBlockHandle block.Handle
 		if w.format >= FileFormatV3 {
+			encoded, _ := w.tieringHistogramBlock.Flush()
 			tieringHistogramBlockHandle, err =
-				w.writeMetadataBlock(w.tieringHistogramBlock.Flush(), block.NoFlags)
+				w.writeMetadataBlock(encoded, block.NoFlags)
 			if err != nil {
 				return err
 			}

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1042,8 +1042,10 @@ func (w *RawColumnWriter) Close() (err error) {
 		}
 	}
 
+	var tieringHistograms tieredmeta.TieringHistogramBlockContents
 	if w.opts.TableFormat >= TableFormatPebblev8 {
-		toWrite := w.tieringHistogramBlock.Flush()
+		var toWrite []byte
+		toWrite, tieringHistograms = w.tieringHistogramBlock.Flush()
 		if _, err = w.layout.WriteTieringHistogramBlock(toWrite); err != nil {
 			return err
 		}
@@ -1111,6 +1113,7 @@ func (w *RawColumnWriter) Close() (err error) {
 		return err
 	}
 	w.meta.Properties = w.props
+	w.meta.TieringHistograms = tieringHistograms
 	// Release any held memory and make any future calls error.
 	*w = RawColumnWriter{meta: w.meta, err: errWriterClosed}
 	return nil

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -409,6 +409,8 @@ type WriterMetadata struct {
 	SmallestSeqNum   base.SeqNum
 	LargestSeqNum    base.SeqNum
 	Properties       Properties
+
+	TieringHistograms tieredmeta.TieringHistogramBlockContents
 }
 
 // SetSmallestPointKey sets the smallest point key to the given key.

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -70,7 +70,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-1.5K (6.5MB) |       60.0% |     3 (840B) |       90.0% |         0.0% |           0 |           0
+1.5K (6.5MB) |       60.0% |     3 (888B) |       90.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -158,7 +158,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-     5 (2KB) |       81.8% |     1 (408B) |       89.2% |         0.0% |           0 |           0
+     5 (2KB) |       81.8% |     1 (424B) |       89.2% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -433,7 +433,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   7 (2.8KB) |       59.6% |     1 (536B) |       78.6% |         0.0% |           0 |           0
+   7 (2.8KB) |       59.6% |     1 (552B) |       78.6% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -69,7 +69,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   3 (1.1KB) |       15.4% |     1 (280B) |       50.0% |         0.0% |           0 |           0
+   3 (1.1KB) |       15.4% |     1 (296B) |       50.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -127,7 +127,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (843B) |        0.0% |     1 (280B) |        0.0% |         0.0% |           1 |           0
+    2 (843B) |        0.0% |     1 (296B) |        0.0% |         0.0% |           1 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -228,7 +228,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (843B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+    2 (843B) |       33.3% |     2 (592B) |       66.7% |         0.0% |           2 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -312,7 +312,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (843B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+    2 (843B) |       33.3% |     2 (592B) |       66.7% |         0.0% |           2 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -393,7 +393,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (843B) |       33.3% |     1 (280B) |       66.7% |         0.0% |           1 |           0
+    2 (843B) |       33.3% |     1 (296B) |       66.7% |         0.0% |           1 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1931,7 +1931,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (822B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
+    2 (822B) |        0.0% |     2 (592B) |        0.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -2008,7 +2008,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (822B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
+    2 (822B) |        0.0% |     2 (592B) |        0.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed


### PR DESCRIPTION
As a temporary step, we read the histograms into TableStats and then use an AnnotationAggregator to aggregate them per level, so they can seen in metrics.

We will use the per sstable TableStats to make tiering decisions for compactions in future PRs.