### PR TITLE
db: make CompactionScheduler option a function

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1495,7 +1495,7 @@ func (d *DB) flush() {
 		d.maybeScheduleFlush()
 		// Let the CompactionScheduler know, so that it can react immediately to
 		// an increase in DB.GetAllowedWithoutPermission.
-		d.opts.Experimental.CompactionScheduler.UpdateGetAllowedWithoutPermission()
+		d.compactionScheduler.UpdateGetAllowedWithoutPermission()
 		// The flush may have produced too many files in a level, so schedule a
 		// compaction if needed.
 		d.maybeScheduleCompaction()
@@ -2004,7 +2004,7 @@ func (d *DB) maybeScheduleCompaction() {
 		if pc == nil {
 			return
 		}
-		success, grantHandle := d.opts.Experimental.CompactionScheduler.TrySchedule()
+		success, grantHandle := d.compactionScheduler.TrySchedule()
 		if !success {
 			// Can't run now, but remember this pickedCompaction in the cache.
 			d.mu.versions.pickedCompactionCache.add(pc)

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1325,7 +1325,9 @@ func TestCompactionPickerPickFile(t *testing.T) {
 		FS:                 fs,
 		Logger:             testutils.Logger{T: t},
 	}
-	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
+	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
+	}
 
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -1469,7 +1471,9 @@ func TestCompactionPickerScores(t *testing.T) {
 		FS:                          fs,
 		Logger:                      testutils.Logger{T: t},
 	}
-	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
+	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
+	}
 
 	d, err := Open("", opts)
 	require.NoError(t, err)
@@ -1491,7 +1495,9 @@ func TestCompactionPickerScores(t *testing.T) {
 			if td.HasArg("pause-cleaning") {
 				cleaner.pause()
 			}
-			opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
+			opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+				return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
+			}
 			d, err = runDBDefineCmd(td, opts)
 			if err != nil {
 				return err.Error()

--- a/compaction_scheduler.go
+++ b/compaction_scheduler.go
@@ -302,6 +302,9 @@ func (s *ConcurrencyLimitScheduler) Register(numGoroutinesPerCompaction int, db 
 	if s.stopPeriodicGranterCh != nil {
 		go s.periodicGranter()
 	}
+	if s.mu.unregistered {
+		panic("cannot reuse ConcurrencyLimitScheduler")
+	}
 }
 
 func (s *ConcurrencyLimitScheduler) Unregister() {
@@ -429,12 +432,6 @@ func (s *ConcurrencyLimitScheduler) adjustRunningCompactionsForTesting(delta int
 	} else {
 		s.mu.Unlock()
 	}
-}
-
-func (s *ConcurrencyLimitScheduler) isUnregisteredForTesting() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.mu.unregistered
 }
 
 // schedulerTimeSource is used to abstract time.NewTicker for

--- a/data_test.go
+++ b/data_test.go
@@ -853,15 +853,6 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 // runDBDefineCmdReuseFS is like runDBDefineCmd, but does not set opts.FS, expecting
 // the caller to have set an appropriate FS already.
 func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) {
-	// Some tests expect that opts is an in-out parameter in that the changes to
-	// opts made here are used later by the caller. But the
-	// ConcurrencyLimitScheduler cannot be reused after the DB is closed. So we
-	// replace it here.
-	scheduler, ok := opts.Experimental.CompactionScheduler.(*ConcurrencyLimitScheduler)
-	if ok && scheduler.isUnregisteredForTesting() {
-		opts.Experimental.CompactionScheduler =
-			NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
-	}
 	opts.EnsureDefaults()
 	if err := parseDBOptionsArgs(opts, td.CmdArgs); err != nil {
 		return nil, err

--- a/db.go
+++ b/db.go
@@ -311,6 +311,8 @@ type DB struct {
 
 	cleanupManager *cleanupManager
 
+	compactionScheduler CompactionScheduler
+
 	// During an iterator close, we may asynchronously schedule read compactions.
 	// We want to wait for those goroutines to finish, before closing the DB.
 	// compactionShedulers.Wait() should not be called while the DB.mu is held.
@@ -1657,7 +1659,7 @@ func (d *DB) Close() error {
 	// calling d.Schedule. When this Unregister returns, we know that the
 	// CompactionScheduler will never again call a method on the DB. Note that
 	// this must be called without holding d.mu.
-	d.opts.Experimental.CompactionScheduler.Unregister()
+	d.compactionScheduler.Unregister()
 	// Lock the commit pipeline for the duration of Close. This prevents a race
 	// with makeRoomForWrite. Rotating the WAL in makeRoomForWrite requires
 	// dropping d.mu several times for I/O. If Close only holds d.mu, an

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -267,8 +267,9 @@ func (t *Test) init(
 func (t *Test) finalizeOptions() pebble.Options {
 	o := *t.opts
 	// Give each DB its own CompactionScheduler.
-	o.Experimental.CompactionScheduler =
-		pebble.NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
+	o.Experimental.CompactionScheduler = func() pebble.CompactionScheduler {
+		return pebble.NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
+	}
 
 	// Set up external/shared storage. These directories are created inside the
 	// test's data dir and can be shared among multiple dbs.

--- a/options.go
+++ b/options.go
@@ -753,10 +753,10 @@ type Options struct {
 		// the excise phase of IngestAndExcise.
 		EnableDeleteOnlyCompactionExcises func() bool
 
-		// CompactionScheduler, if set, is used to limit concurrent compactions as
-		// well as to pace compactions already chosen. If nil, a default scheduler
-		// is created and used.
-		CompactionScheduler CompactionScheduler
+		// CompactionScheduler, if set, is used to create a scheduler to limit
+		// concurrent compactions as well as to pace compactions already chosen. If
+		// nil, a default scheduler is created and used.
+		CompactionScheduler func() CompactionScheduler
 
 		UserKeyCategories UserKeyCategories
 


### PR DESCRIPTION
The `CompactionScheduler` option is a foot-gun in tests: you can
accidentally reuse a scheduler over a reopen. When that happens, there
is no assertion that fires, but instead the scheduler does not
function.

Change `CompactionScheduler` to a factory function that constructs a
scheduler. Also add an assertion to disallow `Register()` after
`Unregister()`.