### PR TITLE
event: add a WALReplayed event

### DIFF
--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -25,6 +25,7 @@ sync: db
 [JOB 1] MANIFEST created 000001
 lock: wal/LOCK
 open-dir: wal
+Replayed WALs: none
 create: wal/000002.log
 sync: wal
 [JOB 1] WAL created 000002


### PR DESCRIPTION
We currently log some information about WALs which shows up more than
we'd like in verbose tests. This change adds a `WALReplayed` event to
`EventListener` and uses that instead.