### PR TITLE
base: reduce MakeFilename allocations

### DIFF
--- a/filenames_test.go
+++ b/filenames_test.go
@@ -110,3 +110,13 @@ func (l noFatalLogger) Errorf(format string, args ...interface{}) {
 func (l noFatalLogger) Fatalf(format string, args ...interface{}) {
 	l.t.Logf(format, args...)
 }
+
+func BenchmarkMakeFilename(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		typ := base.FileTypeTable
+		if i%2 == 0 {
+			typ = base.FileTypeBlob
+		}
+		var _ = base.MakeFilename(typ, base.DiskFileNum(i))
+	}
+}


### PR DESCRIPTION
Reduce allocations while constructing a filename from a disk file number. MakeFilename alocations made up ~1.5% of all allocations during a pebble ycsb/A run of the nightly benchmarks.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble
cpu: Apple M1 Pro
                │   old.txt    │               new.txt               │
                │    sec/op    │   sec/op     vs base                │
MakeFilename-10   167.10n ± 1%   67.38n ± 0%  -59.68% (p=0.000 n=25)

                │   old.txt   │              new.txt               │
                │    B/op     │    B/op     vs base                │
MakeFilename-10   40.000 ± 0%   8.000 ± 0%  -80.00% (p=0.000 n=25)

                │  old.txt   │              new.txt               │
                │ allocs/op  │ allocs/op   vs base                │
MakeFilename-10   4.000 ± 0%   1.000 ± 0%  -75.00% (p=0.000 n=25)
```