### PR TITLE
db: assert that iterAlloc has been zeroed under invariants

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -2454,6 +2454,7 @@ func (i *Iterator) Close() error {
 	}
 	alloc.dbi = Iterator{}
 	alloc.merging = mergingIter{}
+	clear(mergingIterHeapItems[:cap(mergingIterHeapItems)])
 	alloc.merging.heap.items = mergingIterHeapItems
 	clear(alloc.mlevels[:])
 	clear(alloc.levels[:])
@@ -2861,7 +2862,7 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 	}
 	// Bundle various structures under a single umbrella in order to allocate
 	// them together.
-	buf := iterAllocPool.Get().(*iterAlloc)
+	buf := newIterAlloc()
 	dbi := &buf.dbi
 	*dbi = Iterator{
 		ctx:                 ctx,

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -181,7 +181,7 @@ func (d *DB) newInternalIter(
 
 	// Bundle various structures under a single umbrella in order to allocate
 	// them together.
-	buf := iterAllocPool.Get().(*iterAlloc)
+	buf := newIterAlloc()
 	dbi := &scanInternalIterator{
 		ctx:             ctx,
 		db:              d,


### PR DESCRIPTION
Under invariants builds, assert that the iterAlloc struct has been zeroed out. We allow some fields that deliberately recycle fields to be exempted. Additionally we allow pointers to zeroed structs and slices with len()=0 and underlying capacity that is all zeroed.