### PR TITLE
blob: vary max cached readers by read amplification

### DIFF
--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -410,7 +410,8 @@ func TestBlobRewriteRandomized(t *testing.T) {
 		// Verify that the rewritten blob file contains the correct values, and
 		// that they may still be accessed using the original handles.
 		var valueFetcher blob.ValueFetcher
-		valueFetcher.Init(constantFileMapping(newBlobFileNum), fch, readEnv)
+		valueFetcher.Init(constantFileMapping(newBlobFileNum), fch, readEnv,
+			blob.SuggestedCachedReaders(1))
 		func() {
 			defer func() { _ = valueFetcher.Close() }()
 			for _, valueIndex := range newFile.valueIndices {

--- a/compaction.go
+++ b/compaction.go
@@ -3321,7 +3321,8 @@ func (d *DB) compactAndWrite(
 		),
 	}
 	if c.version != nil {
-		c.iterationState.valueFetcher.Init(&c.version.BlobFiles, d.fileCache, blockReadEnv)
+		c.iterationState.valueFetcher.Init(&c.version.BlobFiles, d.fileCache, blockReadEnv,
+			blob.SuggestedCachedReaders(len(c.inputs)))
 	}
 	iiopts := internalIterOpts{
 		compaction:       true,

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1175,7 +1175,8 @@ func TestCompaction(t *testing.T) {
 					}
 				}
 				vf := &blob.ValueFetcher{}
-				vf.Init(&d.mu.versions.currentVersion().BlobFiles, d.fileCache, block.ReadEnv{})
+				vf.Init(&d.mu.versions.currentVersion().BlobFiles, d.fileCache, block.ReadEnv{},
+					blob.SuggestedCachedReaders(d.mu.versions.currentVersion().MaxReadAmp()))
 				defer func() { _ = vf.Close() }()
 				err := validateBlobValueLiveness(inputTables, d.fileCache, block.ReadEnv{}, vf)
 				if err != nil {

--- a/get.go
+++ b/get.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
+	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
 )
 
@@ -120,7 +121,8 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 		keyBuf:    buf.keyBuf,
 	}
 	// Set up a blob value fetcher to use for retrieving values from blob files.
-	i.blobValueFetcher.Init(&readState.current.BlobFiles, d.fileCache, block.NoReadEnv)
+	i.blobValueFetcher.Init(&readState.current.BlobFiles, d.fileCache, block.NoReadEnv,
+		blob.SuggestedCachedReaders(readState.current.MaxReadAmp()))
 	get.iiopts.blobValueFetcher = &i.blobValueFetcher
 
 	if !i.First() {

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -308,6 +308,19 @@ func (v *Version) unrefFiles() ObsoleteFiles {
 	return obsoleteFiles
 }
 
+// MaxReadAmp returns the number of non-empty sublevels and levels in the
+// Version. This is the maximum number of sstables that a point read must
+// consult.
+func (v *Version) MaxReadAmp() int {
+	readAmp := len(v.L0SublevelFiles)
+	for i := 1; i < len(v.Levels); i++ {
+		if !v.Levels[i].Empty() {
+			readAmp++
+		}
+	}
+	return readAmp
+}
+
 // ObsoleteFiles holds a set of files that are no longer referenced by any
 // referenced Version.
 type ObsoleteFiles struct {

--- a/level_checker.go
+++ b/level_checker.go
@@ -554,7 +554,11 @@ func (d *DB) CheckLevels(stats *CheckLevelsStats) error {
 		},
 		fileCache: d.fileCache,
 	}
-	checkConfig.blobValueFetcher.Init(&readState.current.BlobFiles, checkConfig.fileCache, checkConfig.readEnv)
+	checkConfig.blobValueFetcher.Init(
+		&readState.current.BlobFiles,
+		checkConfig.fileCache,
+		checkConfig.readEnv,
+		blob.SuggestedCachedReaders(readState.current.MaxReadAmp()))
 	defer func() { _ = checkConfig.blobValueFetcher.Close() }()
 	return checkLevelsInternal(checkConfig)
 }

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -195,7 +195,8 @@ func (d *DB) newInternalIter(
 		seqNum:          seqNum,
 		mergingIter:     &buf.merging,
 	}
-	dbi.blobValueFetcher.Init(&vers.BlobFiles, d.fileCache, block.ReadEnv{})
+	dbi.blobValueFetcher.Init(&vers.BlobFiles, d.fileCache, block.ReadEnv{},
+		blob.SuggestedCachedReaders(vers.MaxReadAmp()))
 
 	dbi.opts = *o
 	dbi.opts.logger = d.opts.Logger

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -123,8 +123,10 @@ func TestValueFetcher(t *testing.T) {
 		case "new-fetcher":
 			var name string
 			td.ScanArgs(t, "name", &name)
+			maxCachedReaders := 5
+			td.MaybeScanArgs(t, "maxCachedReaders", &maxCachedReaders)
 			fetchers[name] = &ValueFetcher{}
-			fetchers[name].Init(identityFileMapping{}, rp, block.ReadEnv{})
+			fetchers[name].Init(identityFileMapping{}, rp, block.ReadEnv{}, maxCachedReaders)
 			return ""
 		case "fetch":
 			var (
@@ -209,7 +211,7 @@ func TestValueFetcherRetrieveRandomized(t *testing.T) {
 
 	t.Run("sequential", func(t *testing.T) {
 		var fetcher ValueFetcher
-		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{}, 5)
 		defer fetcher.Close()
 		for i := 0; i < len(handles); i++ {
 			val, err := fetcher.retrieve(ctx, handles[i])
@@ -219,7 +221,7 @@ func TestValueFetcherRetrieveRandomized(t *testing.T) {
 	})
 	t.Run("random", func(t *testing.T) {
 		var fetcher ValueFetcher
-		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{}, 5)
 		defer fetcher.Close()
 		for _, i := range rng.Perm(len(handles)) {
 			val, err := fetcher.retrieve(ctx, handles[i])
@@ -281,7 +283,7 @@ func benchmarkValueFetcherRetrieve(b *testing.B, valueSize int, cacheSize int64)
 		rp := makeMockReaderProvider(b, obj, cacheSize, handles)
 		defer rp.Close()
 		var fetcher ValueFetcher
-		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{}, 5)
 		defer fetcher.Close()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -301,7 +303,7 @@ func benchmarkValueFetcherRetrieve(b *testing.B, valueSize int, cacheSize int64)
 			indices[i] = testutils.RandIntInRange(rng, 0, len(handles))
 		}
 		var fetcher ValueFetcher
-		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{}, 5)
 		defer fetcher.Close()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -339,7 +341,7 @@ func makeMockReaderProvider(
 	// blocks.
 	if cacheSize > 0 {
 		var fetcher ValueFetcher
-		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{})
+		fetcher.Init(identityFileMapping{}, rp, block.ReadEnv{}, 5)
 		defer fetcher.Close()
 		for i, h := range handles {
 			if i > 0 && handles[i-1].BlockID == h.BlockID {

--- a/sstable/blob/rewrite.go
+++ b/sstable/blob/rewrite.go
@@ -39,7 +39,7 @@ func NewFileRewriter(
 		fileID: fileID,
 		w:      NewFileWriter(outputFileNum, w, opts),
 	}
-	rw.f.Init(inputFileMapping{info: inputFile}, rp, readEnv)
+	rw.f.Init(inputFileMapping{info: inputFile}, rp, readEnv, 1)
 	return rw
 }
 

--- a/sstable/values.go
+++ b/sstable/values.go
@@ -55,7 +55,7 @@ func LoadValBlobContext(
 	fm base.BlobFileMapping, rp blob.ReaderProvider, blobRefs BlobReferences,
 ) (*blob.ValueFetcher, TableBlobContext) {
 	vf := &blob.ValueFetcher{}
-	vf.Init(fm, rp, block.ReadEnv{})
+	vf.Init(fm, rp, block.ReadEnv{}, 1)
 	return vf, TableBlobContext{
 		ValueFetcher: vf,
 		References:   blobRefs,

--- a/tool/blob_files.go
+++ b/tool/blob_files.go
@@ -92,7 +92,11 @@ func newBlobFileMappings(
 		physicalFiles: make(map[base.BlobFileID][]base.DiskFileNum),
 		provider:      debugReaderProvider{objProvider: provider},
 	}
-	mappings.fetcher.Init(mappings, &mappings.provider, block.ReadEnv{})
+	mappings.fetcher.Init(mappings, &mappings.provider, block.ReadEnv{},
+		// The choice of 5 is arbitrary. We could base this off the manifest's
+		// final LSM's read-amp, but there's no need in the context of the debug
+		// tool.
+		blob.SuggestedCachedReaders(5))
 	for _, fl := range manifests {
 		err := func() error {
 			mf, err := fs.Open(fl.path)


### PR DESCRIPTION
The blob.ValueFetcher maintains a small cache of open blob file readers. This allows a scan that's retrieving values to avoid repeatedly re-opening the same blob file and re-retrieving the index block from the block cache. This cache previously used a fixed size of 5 in all contexts. This commit updates the fetcher to configure the size of the cache dynamically. Iterator construction now sets a cache size of 5 times the number of non-empty levels in the LSM, capturing the fact that deeper LSMs will reference more blob files over a span.

Close #5181.

```
                   │   all.txt    │
                   │   ops/sec    │
ycsb/A/values=1024   383.6k ± ∞ ¹
ycsb/B/values=1024   619.7k ± ∞ ¹
ycsb/C/values=1024   1.005M ± ∞ ¹
ycsb/D/values=1024   232.8k ± ∞ ¹
ycsb/E/values=1024   96.19k ± ∞ ¹
ycsb/F/values=1024   82.91k ± ∞ ¹
geomean              276.2k
```