### PR TITLE
[tiered prototype] db: implementation of ValueSeparation for tiering

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3241,9 +3241,6 @@ func (d *DB) runCompaction(
 		return nil, compact.Stats{}, err
 	}
 	valueSeparation := c.getValueSeparation(jobID, c, c.tableFormat, &cttRetriever)
-	// TODO(sumeer): remove Init method, since getValueSeparation already has
-	// the cttRetriever.
-	valueSeparation.Init(&cttRetriever)
 
 	result := d.compactAndWrite(jobID, c, snapshots, c.tableFormat, valueSeparation, cttRetriever)
 	if result.Err == nil {
@@ -3428,7 +3425,7 @@ func (d *DB) compactAndWrite(
 		case ValueStorageLatencyTolerant:
 			// This span of keyspace is more tolerant of latency, so set a more
 			// aggressive value separation policy for this output.
-			vSep.SetNextOutputConfig(compact.ValueSeparationOutputConfig{
+			vSep.OverrideNextOutputConfig(compact.ValueSeparationOverrideConfig{
 				MinimumSize: latencyTolerantMinimumSize,
 			})
 		}

--- a/data_test.go
+++ b/data_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/block/blockkind"
+	"github.com/cockroachdb/pebble/sstable/tieredmeta"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/cockroachdb/pebble/wal"
@@ -952,7 +953,9 @@ func runDBDefineCmdReuseFS(td *datadriven.TestData, opts *Options) (*DB, error) 
 		if err != nil {
 			return err
 		}
-		c.getValueSeparation = func(JobID, *tableCompaction, sstable.TableFormat) compact.ValueSeparation {
+		c.getValueSeparation = func(
+			JobID, *tableCompaction, sstable.TableFormat, tieredmeta.ColdTierThresholdRetriever,
+		) compact.ValueSeparation {
 			return valueSeparator
 		}
 		// NB: define allows the test to exactly specify which keys go

--- a/download.go
+++ b/download.go
@@ -446,7 +446,9 @@ func (d *DB) tryLaunchDownloadForFile(
 
 	download.numLaunchedDownloads++
 	doneCh = make(chan error, 1)
-	c := newCompaction(pc, d.opts, d.timeNow(), d.objProvider, noopGrantHandle{}, d.TableFormat(), d.determineCompactionValueSeparation)
+	c := newCompaction(
+		pc, d.opts, d.timeNow(), d.objProvider, noopGrantHandle{}, d.TableFormat(),
+		d.determineCompactionValueSeparation)
 	c.isDownload = true
 	d.mu.compact.downloadingCount++
 	c.AddInProgressLocked(d)

--- a/excise.go
+++ b/excise.go
@@ -461,6 +461,9 @@ func determineExcisedTableBlobReferences(
 	}
 	newBlobReferences := make(manifest.BlobReferences, len(originalBlobReferences))
 	for i, bf := range originalBlobReferences {
+		if bf == (manifest.BlobReference{}) {
+			continue
+		}
 		bf.ValueSize = max(bf.ValueSize*excisedTable.Size/originalSize, 1)
 		newBlobReferences[i] = bf
 	}

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -44,7 +44,8 @@ func PhysicalTableFileNum(f DiskFileNum) TableNum {
 	return TableNum(f)
 }
 
-// BlobFileID is an internal identifier for a blob file.
+// BlobFileID is an internal identifier for a blob file. Zero is not a valid
+// BlobFileID.
 //
 // Initially there exists a physical blob file with a DiskFileNum that equals
 // the value of the BlobFileID. However, if the blob file is replaced, the

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -309,6 +309,11 @@ type BlobReferenceDepth int
 // significant and should be maintained. In practice, a sstable's BlobReferences
 // are ordered by earliest appearance within the sstable. The ordering is
 // persisted to the manifest.
+//
+// Some BlobReference fields may be zero, since while writing a sstable that
+// will preserve some references and write some new references, the writer
+// cannot foretell the future and needs to reserve some slots for new
+// references.
 type BlobReferences []BlobReference
 
 // Assert that *BlobReferences implements sstable.BlobReferences.


### PR DESCRIPTION
generalizedValueSeparation subsumes the functionality of
preserveBlobReferences and writeNewBlobFiles, and can additionally
preserve cold references or write new cold blob files.

There are some changes to the ValueSeparation interface to go with this
change.