### PR TITLE
cache: invariants: use Go allocated values half the time

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -122,7 +122,7 @@ func (c *shard) init(maxSize int64) {
 		maxSize:    maxSize,
 		coldTarget: maxSize,
 	}
-	if entriesGoAllocated {
+	if entriesCanBeGoAllocated && entriesGoAllocated {
 		c.entries = make(map[*entry]struct{})
 	}
 	c.blocks.Init(16)
@@ -396,7 +396,7 @@ func (c *shard) metaAdd(key key, e *entry) bool {
 	}
 
 	c.blocks.Put(key, e)
-	if entriesGoAllocated {
+	if entriesCanBeGoAllocated && entriesGoAllocated {
 		// Go allocated entries need to be referenced from Go memory. The entries
 		// map provides that reference.
 		c.entries[e] = struct{}{}
@@ -436,7 +436,7 @@ func (c *shard) metaDel(e *entry) (deletedValue *Value) {
 	e.val = nil
 
 	c.blocks.Delete(e.key)
-	if entriesGoAllocated {
+	if entriesCanBeGoAllocated && entriesGoAllocated {
 		// Go allocated entries need to be referenced from Go memory. The entries
 		// map provides that reference.
 		delete(c.entries, e)


### PR DESCRIPTION
Currently if the `invariants` tag is used (which is true for most of
our testing), the cache uses Go-backed memory. This reduces test
coverage on the production path of using "manual" memory via cgo.

This commit changes things so that we only use Go-backed memory half
the time in invariants mode. We do this while still allowing the
Go-backed code to be statically elided in production builds.