### PR TITLE
pebble: use ReferencedValueSize to trigger  blob rewrite compactions

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1691,7 +1691,10 @@ func (p *compactionPickerByScore) pickBlobFileRewriteCompaction(
 		return nil
 	}
 
-	garbagePct := float64(aggregateStats.ValueSize-aggregateStats.ReferencedBackingValueSize) /
+	// We want to use ReferencedValueSize here instead of ReferencedBackingValueSize
+	// to get the estimate of live data in blob files. We'll check below to see if there
+	// are actually any candidates with garbage to reclaim.
+	garbagePct := float64(aggregateStats.ValueSize-aggregateStats.ReferencedValueSize) /
 		float64(aggregateStats.ValueSize)
 	if garbagePct <= policy.TargetGarbageRatio {
 		// Not enough garbage to warrant a rewrite compaction.

--- a/db.go
+++ b/db.go
@@ -1946,6 +1946,7 @@ func (d *DB) Metrics() *Metrics {
 	metrics.BlobFiles.LiveSize = blobStats.PhysicalSize
 	metrics.BlobFiles.ValueSize = blobStats.ValueSize
 	metrics.BlobFiles.ReferencedValueSize = blobStats.ReferencedValueSize
+	metrics.BlobFiles.ReferencedBackingValueSize = blobStats.ReferencedBackingValueSize
 
 	metrics.LogWriter.FsyncLatency = d.mu.log.metrics.fsyncLatency
 	if err := metrics.LogWriter.Merge(&d.mu.log.metrics.LogWriterMetrics); err != nil {

--- a/metrics.go
+++ b/metrics.go
@@ -416,6 +416,12 @@ type Metrics struct {
 		// blob files were rewritten, discarding values that are no longer
 		// referenced by any keys in any sstables within the current version.
 		ReferencedValueSize uint64
+		// ReferencedBackingValueSize is the sum of the length of the uncompressed
+		// values (in all live blob files) that are still referenced by keys
+		// within backing tables. Note that this value is an overestimate because
+		// each virtual table will contribute their backing table's referenced
+		// value sizes.
+		ReferencedBackingValueSize uint64
 		// The count of all obsolete blob files.
 		ObsoleteCount uint64
 		// The physical size of all obsolete blob files.

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -153,6 +153,7 @@ func exampleMetrics() Metrics {
 	m.BlobFiles.LiveSize = 15 * GB
 	m.BlobFiles.ValueSize = 14 * GB
 	m.BlobFiles.ReferencedValueSize = 11 * GB
+	m.BlobFiles.ReferencedValueSize = 12 * GB
 	m.BlobFiles.ObsoleteCount = 13
 	m.BlobFiles.ObsoleteSize = 29 * MB
 	m.BlobFiles.ZombieCount = 14


### PR DESCRIPTION
We should use ReferencedValueSize for the blob compaction heuristic, as using ReferencedBackingValueSize might be too restrictive.