### PR TITLE
db,compact: change sstable splitting behavior derived from SpanPolicy

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3241,9 +3241,6 @@ func (d *DB) runCompaction(
 		return nil, compact.Stats{}, err
 	}
 	valueSeparation := c.getValueSeparation(jobID, c, c.tableFormat, &cttRetriever)
-	// TODO(sumeer): remove Init method, since getValueSeparation already has
-	// the cttRetriever.
-	valueSeparation.Init(&cttRetriever)
 
 	result := d.compactAndWrite(jobID, c, snapshots, c.tableFormat, valueSeparation, cttRetriever)
 	if result.Err == nil {
@@ -3428,7 +3425,7 @@ func (d *DB) compactAndWrite(
 		case ValueStorageLatencyTolerant:
 			// This span of keyspace is more tolerant of latency, so set a more
 			// aggressive value separation policy for this output.
-			vSep.SetNextOutputConfig(compact.ValueSeparationOutputConfig{
+			vSep.OverrideNextOutputConfig(compact.ValueSeparationOverrideConfig{
 				MinimumSize: latencyTolerantMinimumSize,
 			})
 		}

--- a/compaction.go
+++ b/compaction.go
@@ -3382,33 +3382,112 @@ func (d *DB) compactAndWrite(
 	}
 	runner := compact.NewRunner(runnerCfg, iter)
 
+	mayWriteColdBlobFiles := valueSeparation.MayWriteColdBlobFiles()
 	// If spanPolicyValid is true and spanPolicy.KeyRange.End is empty, then
 	// spanPolicy applies for the rest of the keyspace.
+	//
+	// spanPolicyValid transitions once from false to true, in the first
+	// iteration.
 	var spanPolicyValid bool
-	var spanPolicy SpanPolicy
-
+	// spanPolicy is always valid once initialized and is the current extracted
+	// policy.
+	var spanPolicy ExtractedSpanPolicy
+	// tieringAndEndKeys goes together with spanPolicy. When multiple
+	// SpanPolicies have been encountered without a change in the
+	// ExtractedSpanPolicy, the corresponding end keys and the tiering policies
+	// are in this slice. This is always non-empty after initialization.
+	var tieringAndEndKeys []compact.TieringPolicyAndEndKey
+	// When mayWriteColdBlobFiles is true, tieringPolicyForNewColdBlob, if
+	// populated, specifies the single tiering policy that will be used for
+	// writing a new cold blob file in the context of this sstable. This
+	// restriction of one policy is due to the fact that a sstable cannot refer
+	// to multiple new cold blob files, while writing.
+	//
+	// We considered a cruder approach where maybeWriteColdBlobFiles always
+	// results in a single element in tieringAndEndKeys, but we are concerned
+	// that many compactions may encounter multiple tiering policies, with at
+	// most one having enough cold data to justify movement from hot to cold,
+	// and we don't want to unnecessarily create small sstables in such cases.
+	// Consider the following case where the TieringSpanIDs observed by the
+	// compaction are 1, 2, 3, 4, and only 3 has enough cold data that a cold
+	// blob file should be written. That is, only the call to
+	// ValueSeparation.MayWriteColdBlobFilesForTieringSpanID(3) will return
+	// true. In this case, the compaction may only create 2 sstables, one with
+	// the TieringSpanIDs {1, 2, 3} and one with {4}. If there are multiple
+	// shard boundaries for span 3, there will be more sstables. The main thing
+	// to note is that {1, 2, 3} can share a sstable.
+	var tieringPolicyForNewColdBlob base.TieringPolicy
 	for runner.MoreDataToWrite() {
 		if c.cancel.Load() {
 			return runner.Finish().WithError(ErrCancelledCompaction)
 		}
 		// Create a new table.
 		firstKey := runner.FirstKey()
-		if !spanPolicyValid ||
-			(len(spanPolicy.KeyRange.End) > 0 && d.cmp(firstKey, spanPolicy.KeyRange.End) >= 0) {
-			var err error
-			if d.opts.Experimental.SpanPolicyFunc != nil {
-				spanPolicy, err = d.opts.Experimental.SpanPolicyFunc(base.UserKeyBounds{
-					Start: firstKey,
-					End:   c.bounds.End,
-				})
-				if err != nil {
-					return runner.Finish().WithError(err)
-				}
-			}
-			// Else SpanPolicyFunc is nil, so use the empty policy which already has
-			// an empty KeyRange.End.
 
+		// Figure out the policy to use.
+		n := len(tieringAndEndKeys)
+		if !spanPolicyValid ||
+			(len(tieringAndEndKeys[n-1].EndKey) > 0 && d.cmp(firstKey, tieringAndEndKeys[n-1].EndKey) >= 0) {
+			// Need to get new policies to use.
+			spanPolicy = ExtractedSpanPolicy{}
+			tieringAndEndKeys = tieringAndEndKeys[:0]
+			tieringPolicyForNewColdBlob = TieringPolicy{}
+			if d.opts.Experimental.SpanPolicyFunc != nil {
+				first := true
+				for {
+					nextSpanPolicy, err := d.opts.Experimental.SpanPolicyFunc(base.UserKeyBounds{
+						Start: firstKey,
+						End:   c.bounds.End,
+					}, mayWriteColdBlobFiles)
+					if err != nil {
+						return runner.Finish().WithError(err)
+					}
+					tieringPolicyAppliesForNewBlobs := mayWriteColdBlobFiles &&
+						nextSpanPolicy.TieringPolicy.Policy != TieringPolicy{} &&
+						valueSeparation.MayWriteColdBlobFilesForTieringSpanID(
+							nextSpanPolicy.TieringPolicy.Policy.SpanID)
+					if first {
+						spanPolicy = nextSpanPolicy.ExtractCorePolicy()
+						first = false
+					} else if nextSpanPolicy.ExtractCorePolicy() != spanPolicy {
+						// Policy changed. Don't include it.
+						break
+					}
+					// Either the first, or the extracted policy is the same, and we
+					// either don't care about multiple tiering policies
+					// (mayWriteColdBlobFiles is false), or we haven't initialized
+					// singletonTieringPolicyForNewBlobs.
+					tieringAndEndKeys = append(tieringAndEndKeys, compact.TieringPolicyAndEndKey{
+						TieringPolicy: nextSpanPolicy.TieringPolicy,
+						EndKey:        nextSpanPolicy.KeyRange.End,
+					})
+					if tieringPolicyAppliesForNewBlobs {
+						// We are initializing singletonTieringPolicyForNewBlobs, so we
+						// stop here. The next SpanPolicy may have the same TieringPolicy,
+						// but note that we are splitting at shard boundaries in this
+						// case.
+						tieringPolicyForNewColdBlob = nextSpanPolicy.TieringPolicy.Policy
+						break
+					}
+					firstKey = nextSpanPolicy.KeyRange.End
+					if len(firstKey) == 0 {
+						// No more SpanPolicies.
+						break
+					}
+				}
+			} else {
+				// Else SpanPolicyFunc is nil, so use the empty policy, and initialize
+				// tieringAndEndKeys to have one empty entry, which has an empty
+				// EndKey.
+				tieringAndEndKeys = append(tieringAndEndKeys, compact.TieringPolicyAndEndKey{})
+			}
 			spanPolicyValid = true
+		} else {
+			// The existing policy is still relevant. Pop from tieringAndEndKeys if
+			// it is longer than 1.
+			for len(tieringAndEndKeys) > 1 && d.cmp(firstKey, tieringAndEndKeys[0].EndKey) >= 0 {
+				tieringAndEndKeys = tieringAndEndKeys[1:]
+			}
 		}
 
 		writerOpts := d.opts.MakeWriterOptions(c.outputLevel.level, tableFormat)
@@ -3433,7 +3512,8 @@ func (d *DB) compactAndWrite(
 		if err != nil {
 			return runner.Finish().WithError(err)
 		}
-		runner.WriteTable(objMeta, tw, spanPolicy.KeyRange.End, vSep, spanPolicy.TieringPolicy)
+		runner.WriteTable(
+			objMeta, tw, tieringPolicyForNewColdBlob, tieringAndEndKeys, vSep)
 	}
 	result = runner.Finish()
 	if result.Err == nil {
@@ -3720,12 +3800,12 @@ func (c *coldTierThresholdRetriever) init(
 	}
 	// Iterate over the compaction bounds, retrieving the SpanPolicys.
 	for {
-		policy, err := f(bounds)
+		policy, err := f(bounds, false)
 		if err != nil {
 			return err
 		}
-		if policy.TieringPolicy != nil {
-			p := policy.TieringPolicy.Policy()
+		if !policy.TieringPolicy.IsEmpty() {
+			p := policy.TieringPolicy.Policy
 			if c.m == nil {
 				c.m = make(map[base.TieringSpanID]base.TieringAttribute)
 			}

--- a/excise.go
+++ b/excise.go
@@ -461,6 +461,9 @@ func determineExcisedTableBlobReferences(
 	}
 	newBlobReferences := make(manifest.BlobReferences, len(originalBlobReferences))
 	for i, bf := range originalBlobReferences {
+		if bf == (manifest.BlobReference{}) {
+			continue
+		}
 		bf.ValueSize = max(bf.ValueSize*excisedTable.Size/originalSize, 1)
 		newBlobReferences[i] = bf
 	}

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -44,7 +44,8 @@ func PhysicalTableFileNum(f DiskFileNum) TableNum {
 	return TableNum(f)
 }
 
-// BlobFileID is an internal identifier for a blob file.
+// BlobFileID is an internal identifier for a blob file. Zero is not a valid
+// BlobFileID.
 //
 // Initially there exists a physical blob file with a DiskFileNum that equals
 // the value of the BlobFileID. However, if the blob file is replaced, the

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -786,9 +786,9 @@ type TieringPolicy struct {
 // over 100s of policies for CockroachDB tenants that have no ranges on this
 // DB. One way to mitigate this is by adding an interface to lookup the
 // TieringPolicy by SpanID.
-type TieringPolicyAndExtractor interface {
+type TieringPolicyAndExtractor struct {
 	// Policy returns the tiering policy.
-	Policy() TieringPolicy
+	Policy TieringPolicy
 	// ExtractAttribute extracts the tiering attribute from the key-value pair.
 	// Once extracted, the attribute can be remembered since it must never
 	// change for this key-value pair during the lifetime of the DB.
@@ -797,8 +797,13 @@ type TieringPolicyAndExtractor interface {
 	// 0 attribute (with a non-zero SpanID) to represent an extraction error,
 	// and stats are maintained for this so that users can enquire about the
 	// bytes in the system that have such errors.
-	ExtractAttribute(userKey []byte, value []byte) (TieringAttribute, error)
+	ExtractAttribute func(userKey []byte, value []byte) (TieringAttribute, error)
 }
+
+func (tpe TieringPolicyAndExtractor) IsEmpty() bool {
+	return tpe.Policy == (TieringPolicy{})
+}
+
 type StorageTier uint8
 
 const (

--- a/internal/compact/splitting.go
+++ b/internal/compact/splitting.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -145,7 +146,7 @@ func NewOutputSplitter(
 	}
 	if len(limit) > 0 {
 		if invariants.Enabled && cmp(startKey, limit) >= 0 {
-			panic("limit <= startKey")
+			panic(errors.AssertionFailedf("limit %x <= startKey %x", limit, startKey))
 		}
 		s.limit = slices.Clone(limit)
 	}

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -309,6 +309,11 @@ type BlobReferenceDepth int
 // significant and should be maintained. In practice, a sstable's BlobReferences
 // are ordered by earliest appearance within the sstable. The ordering is
 // persisted to the manifest.
+//
+// Some BlobReference fields may be zero, since while writing a sstable that
+// will preserve some references and write some new references, the writer
+// cannot foretell the future and needs to reserve some slots for new
+// references.
 type BlobReferences []BlobReference
 
 // Assert that *BlobReferences implements sstable.BlobReferences.

--- a/options_test.go
+++ b/options_test.go
@@ -628,7 +628,7 @@ func TestStaticSpanPolicyFunc(t *testing.T) {
 
 		spf := MakeStaticSpanPolicyFunc(testkeys.Comparer.Compare, inputSpanPolicies...)
 		for _, key := range strings.Fields(td.Input) {
-			policy, err := spf(UserKeyBounds{Start: []byte(key)})
+			policy, err := spf(UserKeyBounds{Start: []byte(key)}, false)
 			require.NoError(t, err)
 			// TODO(sumeer): also output KeyRange.Start.
 			if policy.KeyRange.End == nil {

--- a/value_separation_test.go
+++ b/value_separation_test.go
@@ -220,6 +220,16 @@ type defineDBValueSeparator struct {
 // Assert that *defineDBValueSeparator implements the compact.ValueSeparation interface.
 var _ compact.ValueSeparation = (*defineDBValueSeparator)(nil)
 
+// MayWriteColdBlobFiles implements the ValueSeparation interface.
+func (vs *defineDBValueSeparator) MayWriteColdBlobFiles() bool {
+	return false
+}
+
+// MayWriteColdBlobFilesForTieringSpanID implements the ValueSeparation interface.
+func (vs *defineDBValueSeparator) MayWriteColdBlobFilesForTieringSpanID(_ base.TieringSpanID) bool {
+	return false
+}
+
 // OverrideNextOutputConfig implements the compact.ValueSeparation interface.
 func (vs *defineDBValueSeparator) OverrideNextOutputConfig(
 	config compact.ValueSeparationOverrideConfig,


### PR DESCRIPTION
We had two deficiencies in how SpanPolicy was causing sstable splitting:
- When not writing new cold blob files, which is always the case for
  higher levels, and will often be the case for lower levels (since
  data will be moved from hot => cold in large chunks), we were splitting
  sstables when the TieringPolicy changed. This is a result of splits
  always occurring at SpanPolicy boundaries (in addition to other causes
  of splits).
  For this case, we now extract the attributes needed to switch sstables,
  into ExtractedSpanPolicy, and walk the SpanPolicys until the extracted
  attributes change, and then split.

- When writing cold blob files, we did not have a notion of a shard
  boundary (e.g. CockroachDB ranges), which can be deleted as a whole
  by the upper layer (e.g. CockroachDB). This shard boundary is needed
  to prevent cold blob files from spanning shards (best-effort, since
  such boundaries can change), so they can be deleted as a whole.
  For this case, the SpanPolicyFunc accepts a breakAtShardEndBoundary
  parameter that causes SpanPolicys to be broken at these boundaries.

These changes are accompanied with some reworking of the compact.Runner
and ValueSeparation interfaces.
