### PR TITLE
db: add high-priority blob file rewrite compactions

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -81,11 +81,12 @@ func newPebbleDB(dir string) DB {
 	// value separation.
 	opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 		return pebble.ValueSeparationPolicy{
-			Enabled:               true,
-			MinimumSize:           512,
-			MaxBlobReferenceDepth: 10,
-			RewriteMinimumAge:     5 * time.Minute,
-			TargetGarbageRatio:    0.1,
+			Enabled:                  true,
+			MinimumSize:              512,
+			MaxBlobReferenceDepth:    10,
+			RewriteMinimumAge:        5 * time.Minute,
+			GarbageRatioLowPriority:  0.10, // 10% garbage
+			GarbageRatioHighPriority: 0.30, // 30% garbage
 		}
 	}
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -98,6 +98,12 @@ func (p *compactionPickerForTesting) estimatedCompactionDebt() uint64 {
 
 func (p *compactionPickerForTesting) forceBaseLevel1() {}
 
+func (p *compactionPickerForTesting) pickHighPrioritySpaceCompaction(
+	env compactionEnv,
+) pickedCompaction {
+	return nil
+}
+
 func (p *compactionPickerForTesting) pickAutoScore(env compactionEnv) (pc pickedCompaction) {
 	if p.score < 1 {
 		return nil
@@ -1128,7 +1134,7 @@ func TestCompaction(t *testing.T) {
 					env := d.makeCompactionEnvLocked()
 					require.NotNil(t, env)
 					picker := d.mu.versions.picker.(*compactionPickerByScore)
-					pc := picker.pickBlobFileRewriteCompaction(*env)
+					pc := picker.pickBlobFileRewriteCompactionLowPriority(*env)
 					if pc == nil {
 						d.mu.versions.logUnlock()
 						return errors.New("no blob file rewrite compaction")

--- a/options.go
+++ b/options.go
@@ -1199,23 +1199,33 @@ type ValueSeparationPolicy struct {
 	// to be eligible for a rewrite that reclaims disk space. Lower values
 	// reduce space amplification at the cost of write amplification
 	RewriteMinimumAge time.Duration
-	// TargetGarbageRatio is a value in the range [0, 1.0] and configures how
+	// GarbageRatioLowPriority is a value in the range [0, 1.0] configuring how
 	// aggressively blob files should be written in order to reduce space
-	// amplification induced by value separation. As compactions rewrite blob
-	// files, data may be duplicated.  Older blob files containing the
-	// duplicated data may need to remain because other sstables are referencing
-	// other values contained in the same file.
+	// amplification induced by value separation. As sstable compactions rewrite
+	// references to blob files, data may be duplicated.  Older blob files
+	// containing the duplicated data may need to remain because other sstables
+	// are referencing other values contained in the same file.
 	//
 	// The DB can rewrite these blob files in place in order to reduce this
 	// space amplification, but this incurs write amplification. This option
 	// configures how much garbage may accrue before the DB will attempt to
-	// rewrite blob files to reduce it. A value of 0.20 indicates that once 20%
-	// of values in blob files are unreferenced, the DB should attempt to
-	// rewrite blob files to reclaim disk space.
+	// rewrite blob files to reduce it if there is no other higher priority
+	// compaction work available. A value of 0.20 indicates that once 20% of
+	// values in blob files are unreferenced, the DB should attempt to rewrite
+	// blob files to reclaim disk space.
 	//
 	// A value of 1.0 indicates that the DB should never attempt to rewrite blob
 	// files.
-	TargetGarbageRatio float64
+	GarbageRatioLowPriority float64
+	// GarbageRatioHighPriority is a value in the range [0, 1.0] configuring how
+	// much garbage must be present before the DB will schedule blob file
+	// rewrite compactions at a high priority (including above default
+	// compactions necessary to keep up with incoming writes). At most 1 blob file
+	// rewrite compaction will be scheduled at a time.
+	//
+	// See GarbageRatioLowPriority for more details. Must be >=
+	// GarbageRatioLowPriority.
+	GarbageRatioHighPriority float64
 }
 
 // SpanPolicy contains policies that can vary by key range. The zero value is
@@ -1774,7 +1784,8 @@ func (o *Options) String() string {
 			fmt.Fprintf(&buf, "  minimum_size=%d\n", policy.MinimumSize)
 			fmt.Fprintf(&buf, "  max_blob_reference_depth=%d\n", policy.MaxBlobReferenceDepth)
 			fmt.Fprintf(&buf, "  rewrite_minimum_age=%s\n", policy.RewriteMinimumAge)
-			fmt.Fprintf(&buf, "  target_garbage_ratio=%.2f\n", policy.TargetGarbageRatio)
+			fmt.Fprintf(&buf, "  garbage_ratio_low_priority=%.2f\n", policy.GarbageRatioLowPriority)
+			fmt.Fprintf(&buf, "  garbage_ratio_high_priority=%.2f\n", policy.GarbageRatioHighPriority)
 		}
 	}
 
@@ -2212,8 +2223,11 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				valSepPolicy.MaxBlobReferenceDepth, err = strconv.Atoi(value)
 			case "rewrite_minimum_age":
 				valSepPolicy.RewriteMinimumAge, err = time.ParseDuration(value)
-			case "target_garbage_ratio":
-				valSepPolicy.TargetGarbageRatio, err = strconv.ParseFloat(value, 64)
+			case "target_garbage_ratio", "garbage_ratio_low_priority":
+				// NB: "target_garbage_ratio" is a deprecated name for the same field.
+				valSepPolicy.GarbageRatioLowPriority, err = strconv.ParseFloat(value, 64)
+			case "garbage_ratio_high_priority":
+				valSepPolicy.GarbageRatioHighPriority, err = strconv.ParseFloat(value, 64)
 			default:
 				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil
@@ -2476,6 +2490,10 @@ func (o *Options) Validate() error {
 		}
 		if policy.MaxBlobReferenceDepth <= 0 {
 			fmt.Fprintf(&buf, "ValueSeparationPolicy.MaxBlobReferenceDepth (%d) must be > 0\n", policy.MaxBlobReferenceDepth)
+		}
+		if policy.GarbageRatioHighPriority < policy.GarbageRatioLowPriority {
+			fmt.Fprintf(&buf, "ValueSeparationPolicy.GarbageRatioHighPriority (%f) must be >= ValueSeparationPolicy.GarbageRatioLowPriority (%f)\n",
+				policy.GarbageRatioHighPriority, policy.GarbageRatioLowPriority)
 		}
 	}
 

--- a/options_test.go
+++ b/options_test.go
@@ -43,13 +43,15 @@ func (o *Options) testingRandomized(t testing.TB) *Options {
 	}
 	// Enable value separation if using a format major version that supports it.
 	if o.FormatMajorVersion >= FormatValueSeparation && o.Experimental.ValueSeparationPolicy == nil && rand.Int64N(4) > 0 {
+		lowPri := 0.1 + rand.Float64()*0.9 // [0.1, 1.0)
 		policy := ValueSeparationPolicy{
 			Enabled:               true,
 			MinimumSize:           1 << rand.IntN(10), // [1, 512]
 			MaxBlobReferenceDepth: rand.IntN(10) + 1,  // [1, 10)
 			// Constrain the rewrite minimum age to [0, 15s).
-			RewriteMinimumAge:  time.Duration(rand.IntN(15)) * time.Second,
-			TargetGarbageRatio: 0.1 + rand.Float64()*0.9, // [0.1, 1.0)
+			RewriteMinimumAge:        time.Duration(rand.IntN(15)) * time.Second,
+			GarbageRatioLowPriority:  lowPri,
+			GarbageRatioHighPriority: lowPri + rand.Float64()*(1.0-lowPri), // [lowPri, 1.0)
 		}
 		o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy { return policy }
 	}

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -17,7 +17,7 @@ tree
        0      LOCK
      152      MANIFEST-000010
      250      MANIFEST-000013
-    2906      OPTIONS-000003
+    2947      OPTIONS-000003
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
@@ -32,7 +32,7 @@ tree
       11        000011.log
      660        000012.sst
      187        MANIFEST-000013
-    2906        OPTIONS-000003
+    2947        OPTIONS-000003
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013
 
@@ -95,7 +95,8 @@ cat build/OPTIONS-000003
   minimum_size=3
   max_blob_reference_depth=5
   rewrite_minimum_age=15m0s
-  target_garbage_ratio=0.00
+  garbage_ratio_low_priority=0.00
+  garbage_ratio_high_priority=0.00
 
 [Level "0"]
   block_restart_interval=16

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -877,7 +877,7 @@ L6:
 # Create a new database with value separation enabled to test that blob files
 # are included in checkpoints.
 
-open valsepdb value-separation=(true,1,5,0s,1.0)
+open valsepdb value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0)
 ----
 mkdir-all: valsepdb 0755
 open-dir: .

--- a/testdata/compaction/backing_value_size
+++ b/testdata/compaction/backing_value_size
@@ -1,7 +1,7 @@
 # Test a blob file rewrite compaction with virtual sstable references that
 # track backing value sizes do not trigger unnecessary blob file rewrites.
 
-define value-separation=(true,1,10,0s,0.01)
+define value-separation=(enabled=true, min-size=1, max-ref-depth=10, garbage-ratios=0.01:0.2)
 ----
 
 batch

--- a/testdata/compaction/mvcc_garbage_blob
+++ b/testdata/compaction/mvcc_garbage_blob
@@ -1,6 +1,6 @@
 # Set the minimum size for a separated value to 5.
 
-define value-separation=(true, 5, 3, 0s, 1.0)
+define value-separation=(enabled, min-size=5, max-ref-depth=3, garbage-ratios=1.0:1.0)
 ----
 
 batch

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -1,7 +1,7 @@
 # Test a simple sequence of flushes and compactions where all values are
 # separated.
 
-define value-separation=(true, 1, 3, 0, 1.0)
+define value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0, garbage-ratios=1.0:1.0)
 ----
 
 batch
@@ -55,7 +55,7 @@ compact a-d
 # and the value separation policy is configured to limit the blob reference
 # depth to 3.
 
-define verbose value-separation=(true, 3, 3, 0s, 1.0)
+define verbose value-separation=(enabled, min-size=3, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
 L6 blob-depth=3
   a.SET.0:a
   b.SET.0:blob{fileNum=100002 value=bar}
@@ -190,7 +190,7 @@ COMPRESSION
 
 # Set the minimum size for a separated value to 5.
 
-define value-separation=(true, 5, 3, 0s, 1.0)
+define value-separation=(enabled, min-size=5, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
 ----
 
 batch
@@ -240,7 +240,7 @@ w:world
 
 # Configure the database to require keys in the range [a,m) to be in-place.
 
-define required-in-place=(a,m) value-separation=(true,1,3,0s,1.0)
+define required-in-place=(a,m) value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
 ----
 
 batch
@@ -267,7 +267,7 @@ Blob files:
 # references. Because these files overlap and are in separate sublevels, a
 # compaction that preserves blob references should sum their depths.
 
-define value-separation=(true,1,5,0s,1.0) l0-compaction-threshold=2
+define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=2
 L0 blob-depth=1
   a.SET.9:a
   d.SET.9:blob{fileNum=100001 value=d}
@@ -303,7 +303,7 @@ Blob files:
 # sublevel, a compaction that preserves blob references should take the MAX of
 # their depths.
 
-define value-separation=(true,1,5,0s,1.0) l0-compaction-threshold=2
+define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=2
 L0 blob-depth=1
   a.SET.9:a
   d.SET.9:blob{fileNum=100001 value=d}
@@ -338,7 +338,7 @@ Blob files:
 # garbage ratio of 0.0 (no garbage). With this configuration, any blob file that
 # contains any unreferenced values should be immediately compacted.
 
-define value-separation=(true,1,2,0s,0.0) auto-compactions=off
+define value-separation=(enabled, min-size=1, max-ref-depth=2, rw-min-age=0s, garbage-ratios=0.0:0.0) auto-compactions=off
 ----
 
 batch
@@ -466,7 +466,7 @@ COMPRESSION
 
 # Test a blob file rewrite compaction with virtual sstable references.
 
-define value-separation=(true,1,10,0s,0.01)
+define value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=0s, garbage-ratios=0.01:0.01)
 ----
 
 batch
@@ -509,7 +509,7 @@ validate-blob-reference-index-block
 ----
 validated
 
-define value-separation=(true,5,5,0s,1.0) l0-compaction-threshold=1
+define value-separation=(enabled, min-size=5, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=1
 ----
 
 # Test writing a non-trivial amount of data. With a key length of 4, we'll write
@@ -619,7 +619,7 @@ would excise 1 files.
 # 1024 bytes, but there's also a key span defined with the latency-tolerant
 # value storage policy.
 
-define value-separation=(true,1024,10,0s,1.0) latency-tolerant-span=(f,o)
+define value-separation=(enabled, min-size=1024, max-ref-depth=10, rw-min-age=0s, garbage-ratios=1.0:1.0) latency-tolerant-span=(f,o)
 ----
 
 batch

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -265,3 +265,85 @@ L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
 L5       129KB    0.00     0.53           0.53
 L6       898KB    0.00     0.97           0.97
+
+# Test high priority blob file rewrite space reclamation compactions.  We set
+# l0-compaction-threshold=1 to ensure that post-flush, L0 has a score ≥ 1.0.  If
+# it weren't for the high priority blob file rewrite compaction heuristic
+# triggering, we would pursue an automatic score compaction from L0 -> LBase.
+
+define l0-compaction-threshold=1 lbase-max-bytes=65536  enable-table-stats=true auto-compactions=off value-separation=(enabled, min-size=1, max-ref-depth=5, garbage-ratios=0.1:0.2)
+----
+
+batch
+set a apple
+set b banana
+set c coconut
+set d dragonfruit
+----
+
+flush
+----
+L0.0:
+  000005:[a#10,SET-d#13,SET]
+Blob files:
+  B000006 physical:{000006 size:[206 (206B)] vals:[29 (29B)]}
+
+batch
+del b
+del d
+----
+
+flush
+----
+L0.1:
+  000008:[b#14,DEL-d#15,DEL]
+L0.0:
+  000005:[a#10,SET-d#13,SET]
+Blob files:
+  B000006 physical:{000006 size:[206 (206B)] vals:[29 (29B)]}
+
+maybe-compact
+----
+1 compactions in progress:
+0: 000005:a#10,SET-d#13,SET 000008:b#14,DEL-d#15,DEL
+6:
+
+batch
+set e elderberry
+set f fraise
+set g grapefruit
+set h huckleberry
+----
+
+wait-compactions
+----
+
+flush
+----
+L0.0:
+  000011:[e#16,SET-h#19,SET]
+L6:
+  000009:[a#0,SET-c#0,SET]
+Blob files:
+  B000006 physical:{000006 size:[206 (206B)] vals:[29 (29B)]}
+  B000012 physical:{000012 size:[214 (214B)] vals:[37 (37B)]}
+
+scores wait-for-compaction=completion
+----
+Level    Size    Score     Fill factor    Compensated fill factor
+L0       988B    156.97    2.00           2.00
+L1       0B      0.00      0.00           0.00
+L2       0B      0.00      0.00           0.00
+L3       0B      0.00      0.00           0.00
+L4       0B      0.00      0.00           0.00
+L5       0B      0.00      0.00           0.00
+L6       835B    0.00      0.01           0.01
+
+# This attempt to compact should chose to rewrite the blob file B000006 *AND*
+# compact out of L0.
+
+maybe-compact
+----
+1 burst concurrency active
+1 compactions in progress:
+blob file (ID: B000006) 000006 (206B) being rewritten (high priority)

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -168,7 +168,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.5KB
+3.6KB
 
 batch
 set b 2
@@ -270,7 +270,7 @@ Iter category stats:
 
 disk-usage
 ----
-5.6KB
+5.7KB
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -519,7 +519,7 @@ Iter category stats:
 
 disk-usage
 ----
-4.3KB
+4.4KB
 
 additional-metrics
 ----

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -980,7 +980,7 @@ range-deletions-bytes-estimate: 482
 
 # Create a database with value separation enabled.
 
-define format-major-version=24 value-separation=(true,1,10,1m,1.0) target-file-sizes=(100000)
+define format-major-version=24 value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=1m, garbage-ratios=0.1:0.3) target-file-sizes=(100000)
 ----
 
 batch
@@ -1043,7 +1043,7 @@ compression: None:36,Snappy:73/84
 
 # Use a small block-size so that excising the table results in virtual tables
 # which cover significantly fewer blocks.
-define format-major-version=25 block-size=100 value-separation=off
+define format-major-version=25 block-size=100 value-separation=disabled
 ----
 
 batch


### PR DESCRIPTION
This commit introduces a new trigger for blob-file rewrite compactions. Previously blob-file rewrite compactions were triggered when
  a) no default score-based compactions were available to run
  b) no tombstone density or elision-only compaction were available to run
  c) total unreferenced blob values exceeded the 'garbage ratio' threshold
  d) a blob file meets the criteria for rewrite (including the minimum age)

We've observed that score-based compactions can starve blob-file rewrite compactions, leaving blob-file—induced space amplification unbounded. This commit renames the old 'garbage ratio' threshold to GarbageRatioLowPriority and introduces a new GarbageRatioHighPriority setting. When the ratio of unreferenced values reaches the high priority setting, Pebble will schedule up to 1 blob file rewrite compaction at a time as long as eligible blob files exist. To avoid reducing the concurrency available for default compactions, compaction concurrency is temporarily inflated for the duration of the blob file rewrite compaction.

Informs #112.