### PR TITLE
cache: split filter and index cache when sharing cache

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -57,9 +57,12 @@ func newPebbleDB(dir string) DB {
 	defer cache.Unref()
 	filterCache := pebble.NewCache(cacheSize)
 	defer filterCache.Unref()
+	indexCache := pebble.NewCache(cacheSize)
+	defer indexCache.Unref()
 	opts := &pebble.Options{
 		Cache:                       cache,
 		FilterCache:                 filterCache,
+		IndexCache:                  indexCache,
 		Comparer:                    mvccComparer,
 		DisableWAL:                  disableWAL,
 		FormatMajorVersion:          pebble.FormatNewest,

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -55,8 +55,11 @@ type pebbleDB struct {
 func newPebbleDB(dir string) DB {
 	cache := pebble.NewCache(cacheSize)
 	defer cache.Unref()
+	filterCache := pebble.NewCache(cacheSize)
+	defer filterCache.Unref()
 	opts := &pebble.Options{
 		Cache:                       cache,
+		FilterCache:                 filterCache,
 		Comparer:                    mvccComparer,
 		DisableWAL:                  disableWAL,
 		FormatMajorVersion:          pebble.FormatNewest,

--- a/db.go
+++ b/db.go
@@ -1584,7 +1584,7 @@ func (d *DB) Close() error {
 	close(d.closedCh)
 
 	defer d.opts.Cache.Unref()
-
+	defer d.opts.FilterCache.Unref()
 	for d.mu.compact.compactingCount > 0 || d.mu.compact.flushing {
 		d.mu.compact.cond.Wait()
 	}

--- a/db.go
+++ b/db.go
@@ -1585,6 +1585,7 @@ func (d *DB) Close() error {
 
 	defer d.opts.Cache.Unref()
 	defer d.opts.FilterCache.Unref()
+	defer d.opts.IndexCache.Unref()
 	for d.mu.compact.compactingCount > 0 || d.mu.compact.flushing {
 		d.mu.compact.cond.Wait()
 	}

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -458,8 +458,9 @@ func randomOptions(
 		}
 	}
 
-	opts.BytesPerSync = 1 << uint(rng.Intn(28))     // 1B - 256MB
-	opts.Cache = cache.New(1 << uint(rng.Intn(30))) // 1B - 1GB
+	opts.BytesPerSync = 1 << uint(rng.Intn(28))           // 1B - 256MB
+	opts.Cache = cache.New(1 << uint(rng.Intn(30)))       // 1B - 1GB
+	opts.FilterCache = cache.New(1 << uint(rng.Intn(30))) // 1B - 1GB
 	opts.DisableWAL = rng.Intn(2) == 0
 	opts.FlushDelayDeleteRange = time.Millisecond * time.Duration(5*rng.Intn(245)) // 5-250ms
 	opts.FlushDelayRangeKey = time.Millisecond * time.Duration(5*rng.Intn(245))    // 5-250ms

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -461,6 +461,7 @@ func randomOptions(
 	opts.BytesPerSync = 1 << uint(rng.Intn(28))           // 1B - 256MB
 	opts.Cache = cache.New(1 << uint(rng.Intn(30)))       // 1B - 1GB
 	opts.FilterCache = cache.New(1 << uint(rng.Intn(30))) // 1B - 1GB
+	opts.IndexCache = cache.New(1 << uint(rng.Intn(30)))  // 1B - 1GB
 	opts.DisableWAL = rng.Intn(2) == 0
 	opts.FlushDelayDeleteRange = time.Millisecond * time.Duration(5*rng.Intn(245)) // 5-250ms
 	opts.FlushDelayRangeKey = time.Millisecond * time.Duration(5*rng.Intn(245))    // 5-250ms

--- a/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
+++ b/objstorage/objstorageprovider/objiotracing/obj_io_tracing_off.go
@@ -52,7 +52,10 @@ func WithReason(ctx context.Context, reason Reason) context.Context { return ctx
 
 // WithBlockType creates a context that has an associated BlockType (which ends up in
 // traces created under that context).
-func WithBlockType(ctx context.Context, blockType BlockType) context.Context { return ctx }
+func WithBlockType(ctx context.Context, blockType BlockType) context.Context {
+	ctx = context.WithValue(ctx, "blockType", blockType)
+	return ctx
+}
 
 // WithLevel creates a context that has an associated level (which ends up in
 // traces created under that context).

--- a/open.go
+++ b/open.go
@@ -167,6 +167,11 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	} else {
 		opts.FilterCache.Ref()
 	}
+	if opts.IndexCache == nil {
+		opts.IndexCache = cache.New(cacheDefaultSize)
+	} else {
+		opts.IndexCache.Ref()
+	}
 
 	d := &DB{
 		cacheID:             opts.Cache.NewID(),
@@ -201,6 +206,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			// reference to the cache.
 			opts.Cache.Unref()
 			opts.FilterCache.Unref()
+			opts.IndexCache.Unref()
 
 			if d.tableCache != nil {
 				_ = d.tableCache.close()

--- a/open.go
+++ b/open.go
@@ -162,6 +162,11 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	} else {
 		opts.Cache.Ref()
 	}
+	if opts.FilterCache == nil {
+		opts.FilterCache = cache.New(cacheDefaultSize)
+	} else {
+		opts.FilterCache.Ref()
+	}
 
 	d := &DB{
 		cacheID:             opts.Cache.NewID(),
@@ -195,6 +200,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 			// the tableCache, then the tableCache will also release its
 			// reference to the cache.
 			opts.Cache.Unref()
+			opts.FilterCache.Unref()
 
 			if d.tableCache != nil {
 				_ = d.tableCache.close()

--- a/options.go
+++ b/options.go
@@ -481,7 +481,8 @@ type Options struct {
 	// Cache is used to cache uncompressed blocks from sstables.
 	//
 	// The default cache size is 8 MB.
-	Cache *cache.Cache
+	Cache       *cache.Cache
+	FilterCache *cache.Cache
 
 	// LoadBlockSema, if set, is used to limit the number of blocks that can be
 	// loaded (i.e. read from the filesystem) in parallel. Each load acquires one
@@ -1732,6 +1733,7 @@ func (o *Options) MakeReaderOptions() sstable.ReaderOptions {
 	var readerOpts sstable.ReaderOptions
 	if o != nil {
 		readerOpts.Cache = o.Cache
+		readerOpts.FilterCache = o.FilterCache
 		readerOpts.LoadBlockSema = o.LoadBlockSema
 		readerOpts.Comparer = o.Comparer
 		readerOpts.Filters = o.Filters
@@ -1751,6 +1753,7 @@ func (o *Options) MakeWriterOptions(level int, format sstable.TableFormat) sstab
 	writerOpts.TableFormat = format
 	if o != nil {
 		writerOpts.Cache = o.Cache
+		writerOpts.FilterCache = o.FilterCache
 		writerOpts.Comparer = o.Comparer
 		if o.Merger != nil {
 			writerOpts.MergerName = o.Merger.Name

--- a/options.go
+++ b/options.go
@@ -483,6 +483,7 @@ type Options struct {
 	// The default cache size is 8 MB.
 	Cache       *cache.Cache
 	FilterCache *cache.Cache
+	IndexCache  *cache.Cache
 
 	// LoadBlockSema, if set, is used to limit the number of blocks that can be
 	// loaded (i.e. read from the filesystem) in parallel. Each load acquires one
@@ -1734,6 +1735,7 @@ func (o *Options) MakeReaderOptions() sstable.ReaderOptions {
 	if o != nil {
 		readerOpts.Cache = o.Cache
 		readerOpts.FilterCache = o.FilterCache
+		readerOpts.IndexCache = o.IndexCache
 		readerOpts.LoadBlockSema = o.LoadBlockSema
 		readerOpts.Comparer = o.Comparer
 		readerOpts.Filters = o.Filters
@@ -1754,6 +1756,7 @@ func (o *Options) MakeWriterOptions(level int, format sstable.TableFormat) sstab
 	if o != nil {
 		writerOpts.Cache = o.Cache
 		writerOpts.FilterCache = o.FilterCache
+		writerOpts.IndexCache = o.IndexCache
 		writerOpts.Comparer = o.Comparer
 		if o.Merger != nil {
 			writerOpts.MergerName = o.Merger.Name

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -110,7 +110,8 @@ type ReaderOptions struct {
 	// Cache is used to cache uncompressed blocks from sstables.
 	//
 	// The default cache size is a zero-size cache.
-	Cache *cache.Cache
+	Cache       *cache.Cache
+	FilterCache *cache.Cache
 
 	// LoadBlockSema, if set, is used to limit the number of blocks that can be
 	// loaded (i.e. read from the filesystem) in parallel. Each load acquires one
@@ -187,7 +188,8 @@ type WriterOptions struct {
 	// Cache is used to cache uncompressed blocks from sstables.
 	//
 	// The default is a nil cache.
-	Cache *cache.Cache
+	Cache       *cache.Cache
+	FilterCache *cache.Cache
 
 	// Comparer defines a total ordering over the space of []byte keys: a 'less
 	// than' relationship. The same comparison algorithm must be used for reads

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -112,6 +112,7 @@ type ReaderOptions struct {
 	// The default cache size is a zero-size cache.
 	Cache       *cache.Cache
 	FilterCache *cache.Cache
+	IndexCache  *cache.Cache
 
 	// LoadBlockSema, if set, is used to limit the number of blocks that can be
 	// loaded (i.e. read from the filesystem) in parallel. Each load acquires one
@@ -190,6 +191,7 @@ type WriterOptions struct {
 	// The default is a nil cache.
 	Cache       *cache.Cache
 	FilterCache *cache.Cache
+	IndexCache  *cache.Cache
 
 	// Comparer defines a total ordering over the space of []byte keys: a 'less
 	// than' relationship. The same comparison algorithm must be used for reads

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -236,6 +236,7 @@ type Reader struct {
 // Close implements DB.Close, as documented in the pebble package.
 func (r *Reader) Close() error {
 	r.opts.Cache.Unref()
+	r.opts.FilterCache.Unref()
 
 	if r.readable != nil {
 		r.err = firstError(r.err, r.readable.Close())
@@ -524,7 +525,12 @@ func (r *Reader) readBlock(
 	stats *base.InternalIteratorStats,
 	bufferPool *BufferPool,
 ) (handle bufferHandle, _ error) {
-	if h := r.opts.Cache.Get(r.cacheID, r.fileNum, bh.Offset); h.Get() != nil {
+	dbCache := r.opts.Cache
+	if ctx.Value("blockType") == objiotracing.FilterBlock {
+		dbCache = r.opts.FilterCache
+	}
+
+	if h := dbCache.Get(r.cacheID, r.fileNum, bh.Offset); h.Get() != nil {
 		// Cache hit.
 		if readHandle != nil {
 			readHandle.RecordCacheHit(ctx, int64(bh.Offset), int64(bh.Length+blockTrailerLen))
@@ -641,7 +647,7 @@ func (r *Reader) readBlock(
 	if decompressed.buf.Valid() {
 		return bufferHandle{b: decompressed.buf}, nil
 	}
-	h := r.opts.Cache.Set(r.cacheID, r.fileNum, bh.Offset, decompressed.v)
+	h := dbCache.Set(r.cacheID, r.fileNum, bh.Offset, decompressed.v)
 	return bufferHandle{h: h}, nil
 }
 
@@ -1113,6 +1119,11 @@ func NewReader(f objstorage.Readable, o ReaderOptions, extraOpts ...ReaderOption
 		r.opts.Cache = cache.New(0)
 	} else {
 		r.opts.Cache.Ref()
+	}
+	if r.opts.FilterCache == nil {
+		r.opts.FilterCache = cache.New(0)
+	} else {
+		r.opts.FilterCache.Ref()
 	}
 
 	if f == nil {

--- a/table_cache.go
+++ b/table_cache.go
@@ -985,6 +985,7 @@ func (c *tableCacheShard) evict(fileNum base.DiskFileNum, dbOpts *tableCacheOpts
 	}
 
 	dbOpts.opts.Cache.EvictFile(dbOpts.cacheID, fileNum)
+	dbOpts.opts.FilterCache.EvictFile(dbOpts.cacheID, fileNum)
 }
 
 // removeDB evicts any nodes which have a reference to the DB

--- a/table_cache.go
+++ b/table_cache.go
@@ -986,6 +986,7 @@ func (c *tableCacheShard) evict(fileNum base.DiskFileNum, dbOpts *tableCacheOpts
 
 	dbOpts.opts.Cache.EvictFile(dbOpts.cacheID, fileNum)
 	dbOpts.opts.FilterCache.EvictFile(dbOpts.cacheID, fileNum)
+	dbOpts.opts.IndexCache.EvictFile(dbOpts.cacheID, fileNum)
 }
 
 // removeDB evicts any nodes which have a reference to the DB

--- a/tool/find.go
+++ b/tool/find.go
@@ -428,9 +428,10 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			}()
 
 			opts := sstable.ReaderOptions{
-				Cache:    cache,
-				Comparer: f.opts.Comparer,
-				Filters:  f.opts.Filters,
+				Cache:       cache,
+				FilterCache: cache,
+				Comparer:    f.opts.Comparer,
+				Filters:     f.opts.Filters,
 			}
 			readable, err := sstable.NewSimpleReadable(tf)
 			if err != nil {

--- a/tool/find.go
+++ b/tool/find.go
@@ -430,6 +430,7 @@ func (f *findT) searchTables(stdout io.Writer, searchKey []byte, refs []findRef)
 			opts := sstable.ReaderOptions{
 				Cache:       cache,
 				FilterCache: cache,
+				IndexCache:  cache,
 				Comparer:    f.opts.Comparer,
 				Filters:     f.opts.Filters,
 			}

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -145,10 +145,12 @@ func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
+	cache := pebble.NewCache(128 << 20 /* 128 MB */)
 	o := sstable.ReaderOptions{
-		Cache:    pebble.NewCache(128 << 20 /* 128 MB */),
-		Comparer: s.opts.Comparer,
-		Filters:  s.opts.Filters,
+		Cache:       cache,
+		FilterCache: cache,
+		Comparer:    s.opts.Comparer,
+		Filters:     s.opts.Filters,
 	}
 	defer o.Cache.Unref()
 	return sstable.NewReader(readable, o, s.comparers, s.mergers,

--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -149,6 +149,7 @@ func (s *sstableT) newReader(f vfs.File) (*sstable.Reader, error) {
 	o := sstable.ReaderOptions{
 		Cache:       cache,
 		FilterCache: cache,
+		IndexCache:  cache,
 		Comparer:    s.opts.Comparer,
 		Filters:     s.opts.Filters,
 	}


### PR DESCRIPTION
Hi guys, while using Pebble, we've discovered that sharing the cache across multiple instances can be a better solution. However, we're based on Pebble 1.0, and the current pull request is a proof-of-concept. If you agree on the changes, I'll continue optimizing it to meet the merge requirements.

In our scenario, we've been using a single database, accumulating around 1.5TB of data. To reduce the pressure on the single database, we've used parallel commits and other methods. We plan to run on shards in the future, so we'll split the single database into eight shards, which will of course reduce the cache size and handles proportionally.

Although parallel commits work well, read performance and cache hit rate have decreased slightly. We've tried using a shared cache across eight shards.

Version 1:
<img width="1184" height="213" alt="image" src="https://github.com/user-attachments/assets/f7736dff-7d9f-47a7-96ce-6e81971f0645" />

<img width="3454" height="1122" alt="image" src="https://github.com/user-attachments/assets/5de0f16f-e661-45a2-ac2e-897d5429f15e" />

The performance has deteriorated significantly. The flame graph shows a significant drop in the cache hit rate for readFilter. Analysis suggests this may be due to frequent evicts of the filter cache when using a shared cache.  see https://github.com/cockroachdb/pebble/issues/5242

Version 2:
<img width="1212" height="456" alt="image" src="https://github.com/user-attachments/assets/ebd24dd0-93af-45ce-a4b8-25bd455bcf54" />

<img width="1722" height="617" alt="image" src="https://github.com/user-attachments/assets/51941fdd-ed63-465d-965d-c1ab22db5974" />

We forked the Pebble code to isolate the filter and index caches. The performance difference is minimal compared to a single-DB cache.

Thank you for your review.