### PR TITLE
block: fix off-by-one bug in CompressionStats

### DIFF
--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -135,7 +135,7 @@ func (c *CompressionStats) add(
 			return
 		}
 	}
-	if c.n >= len(c.buf)-1 {
+	if c.n >= len(c.buf) {
 		panic("too many compression settings")
 	}
 	c.buf[c.n] = CompressionStatsForSetting{


### PR DESCRIPTION
CompressionStats is supposed to hold up to four settings but because of an off-by-one bug it only allows three. The "built-in" profiles use at most three, but it is possible for a user to define their own profile which might require four.

Fix and add a test.

Informs #5260