### PR TITLE
docs: add annotation for variable blob reader count

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,6 +44,8 @@
           blocks</div>
         <div class="annotation" data-date="20250509">Enabled value
           separation (values=1024 variant)</div>
+        <div class="annotation" data-date="20250827">Vary count of
+          cached blob file readers</div>
       </div>
       <div class="section rows">
         <div>


### PR DESCRIPTION
Add an annotation for #5248, increasing the size of a blob.ValueFetcher's cache of readers to a variable count dependent on the read amplification. This change had a perceptible impact on write-only workloads by avoiding duplicate reads during compactions that write new blob files.