### PR TITLE
blob: pool []cachedReader slices separately

### DIFF
--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -166,7 +166,7 @@ func TestValueFetcher(t *testing.T) {
 
 func writeValueFetcherState(w *bytes.Buffer, f *ValueFetcher) {
 	fmt.Fprintf(w, "ValueFetcher{\n")
-	for _, cr := range f.readers {
+	for _, cr := range f.cached.readers {
 		if cr.r == nil {
 			fmt.Fprintln(w, "  empty")
 			continue


### PR DESCRIPTION
Previously a blob.ValueFetcher's cached readers were implicitly pooled through the pooling of a pebble.Iterator. This commit updates the ValueFetcher to explicitly pool cached reader slices separately. The fetcher's cached readers are only retrieved if an external value is actually retrieved.