### PR TITLE
scripts: improve stress.sh

### DIFF
--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+# The GitHub Action runner has 4 cores. Use 3 processes to get good utilization
+# but not slow down things too much.
+# TODO(radu): replace with a percentage when stress supports it.
+PARALLEL="3"
+
 # Stress all packages, one at a time. This allows for a more useful output.
 for p in $(go list ./... | sed 's#github.com/cockroachdb/pebble#.#'); do
 echo
@@ -9,5 +14,18 @@ echo
   echo ""
   echo "Stressing $p"
   echo ""
-  make stress STRESSFLAGS='-maxtime 5m -maxruns 100' "PKG=$p"
+  case "$p" in
+    .|./internal/manifest|./sstable|./wal)
+      # These packages have a lot of state space to cover, so we give them more
+      # time.
+      MAX_TIME=30m
+      MAX_RUNS=100
+      ;;
+    *)
+      MAX_TIME=5m
+      MAX_RUNS=100
+      ;;
+  esac
+  echo "make stress STRESSFLAGS=\"-maxtime $MAX_TIME -maxruns $MAX_RUNS -p $PARALLEL\" PKG=\"$p\""
+  make stress STRESSFLAGS="-maxtime $MAX_TIME -maxruns $MAX_RUNS -p $PARALLEL" PKG="$p"
 done


### PR DESCRIPTION
We extend the stress time for certain packages that are more important
and have more/slower tests.

Fixes #5172