### PR TITLE
compression: avoid msan crashes

### DIFF
--- a/internal/compression/msan_off.go
+++ b/internal/compression/msan_off.go
@@ -1,0 +1,11 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build !msan
+
+package compression
+
+// msanWrite is used to inform MemorySanitizer that the memory in p was written
+// to; this is necessary for some compression algorithms which use assembly code.
+func msanWrite(p []byte) {}

--- a/internal/compression/msan_on.go
+++ b/internal/compression/msan_on.go
@@ -1,0 +1,20 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build msan
+
+package compression
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+// msanWrite is used to inform MemorySanitizer that the memory in p was written
+// to; this is necessary for some compression algorithms which use assembly code.
+func msanWrite(p []byte) {
+	if len(p) > 0 {
+		runtime.MSanWrite(unsafe.Pointer(&p[0]), len(p))
+	}
+}

--- a/internal/compression/snappy.go
+++ b/internal/compression/snappy.go
@@ -17,8 +17,9 @@ var _ Compressor = snappyCompressor{}
 func (snappyCompressor) Algorithm() Algorithm { return Snappy }
 
 func (snappyCompressor) Compress(dst, src []byte) ([]byte, Setting) {
-	dst = dst[:cap(dst):cap(dst)]
-	return snappy.Encode(dst, src), SnappySetting
+	result := snappy.Encode(dst[:cap(dst):cap(dst)], src)
+	msanWrite(result)
+	return result, SnappySetting
 }
 
 func (snappyCompressor) Close() {}
@@ -36,6 +37,7 @@ func (snappyDecompressor) DecompressInto(buf, compressed []byte) error {
 		return base.CorruptionErrorf("pebble: decompressed into unexpected buffer: %p != %p",
 			errors.Safe(result), errors.Safe(buf))
 	}
+	msanWrite(buf)
 	return nil
 }
 

--- a/internal/compression/zstd_nocgo.go
+++ b/internal/compression/zstd_nocgo.go
@@ -43,6 +43,7 @@ func (z *zstdCompressor) Compress(compressedBuf, b []byte) ([]byte, Setting) {
 	}
 	varIntLen := binary.PutUvarint(compressedBuf, uint64(len(b)))
 	res := z.encoder.EncodeAll(b, compressedBuf[:varIntLen])
+	msanWrite(res)
 	return res, Setting{Algorithm: Zstd, Level: uint8(z.level)}
 }
 
@@ -84,6 +85,7 @@ func (zstdDecompressor) DecompressInto(dst, src []byte) error {
 		return base.CorruptionErrorf("pebble/table: decompressed into unexpected buffer: %p != %p",
 			errors.Safe(result), errors.Safe(dst))
 	}
+	msanWrite(result)
 	return nil
 }
 


### PR DESCRIPTION
Some of the compression algorithms use hand-written assembly code,
which is "invislble" to the memory sanitizer. Together with the recent
change to use `malloc` instead of `calloc` for the block cache, this
results in uninitialized memory failures with `msan`.

The fix is to call `runtime.MSanWrite()` to inform `msan` that the
memory was written to. Note that `runtime.MSanWrite()` exists only
in builds with the `msan` tag.

Fixes #5275
