### PR TITLE
scripts: more improvements to stress.sh

### DIFF
--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -2,11 +2,6 @@
 
 set -euo pipefail
 
-# The GitHub Action runner has 4 cores. Use 3 processes to get good utilization
-# but not slow down things too much.
-# TODO(radu): replace with a percentage when stress supports it.
-PARALLEL="3"
-
 # Stress all packages, one at a time. This allows for a more useful output.
 for p in $(go list ./... | sed 's#github.com/cockroachdb/pebble#.#'); do
 echo
@@ -15,15 +10,18 @@ echo
   echo "Stressing $p"
   echo ""
   case "$p" in
-    .|./internal/manifest|./sstable|./wal)
+    .|./internal/manifest|./internal/metamorphic|./sstable|./wal)
       # These packages have a lot of state space to cover, so we give them more
-      # time.
+      # time. We also reduce the number of processes to avoid slowing down each
+      # individual run too much.
       MAX_TIME=30m
-      MAX_RUNS=100
+      MAX_RUNS=1000
+      PARALLEL="75%"
       ;;
     *)
       MAX_TIME=5m
-      MAX_RUNS=100
+      MAX_RUNS=1000
+      PARALLEL="100%"
       ;;
   esac
   echo "make stress STRESSFLAGS=\"-maxtime $MAX_TIME -maxruns $MAX_RUNS -p $PARALLEL\" PKG=\"$p\""


### PR DESCRIPTION
Increase the number of runs as many packages have very fast tests.
Also, use reduced parallelism only for the bigger packages.

Informs #5172