### PR TITLE
db: clean up compaction test infrastructure

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1544,7 +1544,7 @@ func TestCompactionPickerScores(t *testing.T) {
 			if err := runBuildCmd(td, d, d.opts.FS); err != nil {
 				return err.Error()
 			}
-			if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			d.mu.Lock()

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1094,7 +1094,7 @@ func runCompactionTest(
 			return runGetCmd(t, td, d)
 
 		case "ingest":
-			if err := runIngestCmd(td, d, mem); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			d.mu.Lock()
@@ -1848,7 +1848,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				if err = runBuildCmd(td, d, d.opts.FS); err != nil {
 					return err.Error()
 				}
-				if err = runIngestCmd(td, d, d.opts.FS); err != nil {
+				if err = runIngestCmd(td, d); err != nil {
 					return err.Error()
 				}
 				return "OK"

--- a/data_test.go
+++ b/data_test.go
@@ -1553,7 +1553,7 @@ func runIngestAndExciseCmd(td *datadriven.TestData, d *DB) error {
 	return nil
 }
 
-func runIngestCmd(td *datadriven.TestData, d *DB, fs vfs.FS) error {
+func runIngestCmd(td *datadriven.TestData, d *DB) error {
 	paths := make([]string, 0, len(td.CmdArgs))
 	for _, arg := range td.CmdArgs {
 		if arg.Key == "no-wait" {

--- a/db_test.go
+++ b/db_test.go
@@ -2272,7 +2272,7 @@ func TestDeterminism(t *testing.T) {
 					}
 					opts.Experimental.IngestSplit = func() bool { return rand.IntN(2) == 1 }
 					var err error
-					if d, err = runDBDefineCmdReuseFS(td, opts); err != nil {
+					if d, err = runDBDefineCmd(td, opts); err != nil {
 						return err.Error()
 					}
 					return d.mu.versions.currentVersion().String()

--- a/disk_usage_test.go
+++ b/disk_usage_test.go
@@ -88,7 +88,7 @@ func TestEstimateDiskUsageDataDriven(t *testing.T) {
 			return ""
 
 		case "ingest":
-			if err := runIngestCmd(td, d, fs); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			return ""

--- a/excise_test.go
+++ b/excise_test.go
@@ -160,7 +160,7 @@ func TestExcise(t *testing.T) {
 			if !noWait {
 				clearFlushed()
 			}
-			if err := runIngestCmd(td, d, mem); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			if noWait {
@@ -519,7 +519,7 @@ func TestConcurrentExcise(t *testing.T) {
 			return ""
 
 		case "ingest":
-			if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			// Wait for a possible flush.

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1609,7 +1609,6 @@ func TestIngestTargetLevel(t *testing.T) {
 			opts := Options{
 				FormatMajorVersion: internalFormatNewest,
 			}
-			opts.WithFSDefaults()
 			if d, err = runDBDefineCmd(td, &opts); err != nil {
 				return err.Error()
 			}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -579,7 +579,7 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 			return ""
 
 		case "ingest":
-			if err := runIngestCmd(td, d, mem); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			if !blockFlush {
@@ -789,7 +789,7 @@ func testIngestSharedImpl(
 			return ""
 
 		case "ingest":
-			if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			// Wait for a possible flush.
@@ -1245,7 +1245,7 @@ func TestIngestExternal(t *testing.T) {
 
 		case "ingest":
 			flushed = false
-			if err := runIngestCmd(td, d, mem); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			// Wait for a possible flush.
@@ -1752,7 +1752,7 @@ func TestIngest(t *testing.T) {
 
 		case "ingest":
 			flushed = false
-			if err := runIngestCmd(td, d, mem); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			// Wait for a possible flush.

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -226,7 +226,7 @@ func TestIterHistories(t *testing.T) {
 				}
 				return ""
 			case "ingest-existing":
-				if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+				if err := runIngestCmd(td, d); err != nil {
 					return err.Error()
 				}
 				return ""
@@ -234,7 +234,7 @@ func TestIterHistories(t *testing.T) {
 				if err := runBuildCmd(td, d, d.opts.FS); err != nil {
 					return err.Error()
 				}
-				if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+				if err := runIngestCmd(td, d); err != nil {
 					return err.Error()
 				}
 				return ""

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -573,7 +573,7 @@ func TestIteratorNextPrev(t *testing.T) {
 			return ""
 
 		case "ingest":
-			if err := runIngestCmd(td, d, mem); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			return runLSMCmd(td, d)
@@ -633,7 +633,7 @@ func TestIteratorStats(t *testing.T) {
 			return ""
 
 		case "ingest":
-			if err := runIngestCmd(td, d, mem); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			return runLSMCmd(td, d)

--- a/lsm_view_test.go
+++ b/lsm_view_test.go
@@ -15,7 +15,7 @@ func TestLSMViewURL(t *testing.T) {
 		func(t *testing.T, td *datadriven.TestData) string {
 			switch td.Cmd {
 			case "define":
-				d, err := runDBDefineCmd(td, nil /* options */)
+				d, err := runDBDefineCmd(td, &Options{})
 				if err != nil {
 					td.Fatalf(t, "error: %s", err)
 				}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -362,7 +362,7 @@ func TestMetrics(t *testing.T) {
 			return s
 
 		case "ingest":
-			if err := runIngestCmd(td, d, d.opts.FS); err != nil {
+			if err := runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			return ""

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -35,10 +35,6 @@ func TestRangeDel(t *testing.T) {
 			require.NoError(t, d.Close())
 		}
 	}()
-	opts := &Options{
-		DisableAutomaticCompactions: true,
-		Logger:                      testutils.Logger{T: t},
-	}
 
 	datadriven.RunTest(t, "testdata/range_del", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
@@ -52,6 +48,10 @@ func TestRangeDel(t *testing.T) {
 				}
 			}
 
+			opts := &Options{
+				DisableAutomaticCompactions: true,
+				Logger:                      testutils.Logger{T: t},
+			}
 			var err error
 			if d, err = runDBDefineCmd(td, opts); err != nil {
 				return err.Error()

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -115,7 +115,7 @@ func TestTableStats(t *testing.T) {
 			if err = runBuildCmd(td, d, d.opts.FS); err != nil {
 				return err.Error()
 			}
-			if err = runIngestCmd(td, d, d.opts.FS); err != nil {
+			if err = runIngestCmd(td, d); err != nil {
 				return err.Error()
 			}
 			d.mu.Lock()

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -29,19 +29,22 @@ import (
 func TestTableStats(t *testing.T) {
 	// loadedInfo is protected by d.mu.
 	var loadedInfo *TableStatsInfo
-	opts := &Options{
-		Comparer:                    testkeys.Comparer,
-		DisableAutomaticCompactions: true,
-		FormatMajorVersion:          FormatMinSupported,
-		FS:                          vfs.NewMem(),
-		EventListener: &EventListener{
-			TableStatsLoaded: func(info TableStatsInfo) {
-				loadedInfo = &info
+	mkOpts := func() *Options {
+		return &Options{
+			Comparer:                    testkeys.Comparer,
+			DisableAutomaticCompactions: true,
+			FormatMajorVersion:          FormatMinSupported,
+			FS:                          vfs.NewMem(),
+			EventListener: &EventListener{
+				TableStatsLoaded: func(info TableStatsInfo) {
+					loadedInfo = &info
+				},
 			},
-		},
-		Logger: testutils.Logger{T: t},
+			Logger: testutils.Logger{T: t},
+		}
 	}
 
+	opts := mkOpts()
 	d, err := Open("", opts)
 	require.NoError(t, err)
 	defer func() {
@@ -71,6 +74,7 @@ func TestTableStats(t *testing.T) {
 			require.NoError(t, d.Close())
 			loadedInfo = nil
 
+			opts = mkOpts()
 			d, err = runDBDefineCmd(td, opts)
 			if err != nil {
 				return err.Error()

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -7,6 +7,7 @@ define l0-compaction-threshold=1 auto-compactions=off
 
 set-concurrent-compactions range=(3,3)
 ----
+concurrency set to [3, 3]
 
 
 populate keylen=4 timestamps=(1) vallen=1

--- a/testdata/compaction/multilevel
+++ b/testdata/compaction/multilevel
@@ -38,6 +38,7 @@ L4:
 # Set concurrent compactions to 2 for the remainder of the tests.
 set-concurrent-compactions max=2
 ----
+concurrency set to [1, 2]
 
 define level-max-bytes=(L2 : 5) auto-compactions=off
 L1

--- a/testdata/compaction/set_with_del_sstable_Pebblev4
+++ b/testdata/compaction/set_with_del_sstable_Pebblev4
@@ -644,6 +644,7 @@ add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 
 set-concurrent-compactions max=2
 ----
+concurrency set to [1, 2]
 
 compact a-b L3
 ----

--- a/testdata/compaction/set_with_del_sstable_Pebblev5
+++ b/testdata/compaction/set_with_del_sstable_Pebblev5
@@ -649,6 +649,7 @@ add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 
 set-concurrent-compactions max=2
 ----
+concurrency set to [1, 2]
 
 compact a-b L3
 ----

--- a/testdata/compaction/set_with_del_sstable_Pebblev6
+++ b/testdata/compaction/set_with_del_sstable_Pebblev6
@@ -649,6 +649,7 @@ add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 
 set-concurrent-compactions max=2
 ----
+concurrency set to [1, 2]
 
 compact a-b L3
 ----
@@ -672,6 +673,7 @@ L5:
 # Reset to default value of 1.
 set-concurrent-compactions max=1
 ----
+concurrency set to [1, 1]
 
 
 # Test of a scenario where consecutive elided range tombstones and grandparent

--- a/testdata/compaction/set_with_del_sstable_Pebblev7
+++ b/testdata/compaction/set_with_del_sstable_Pebblev7
@@ -649,6 +649,7 @@ add-ongoing-compaction startLevel=0 outputLevel=1 start=a end=z
 
 set-concurrent-compactions max=2
 ----
+concurrency set to [1, 2]
 
 compact a-b L3
 ----

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -262,7 +262,7 @@ range-deletions-bytes-estimate: 78
 
 # Test the interaction between point and range key deletions.
 
-define block-size=1 target-file-sizes=(100, 1)
+define block-size=1 target-file-sizes=(100, 1) flush-split-bytes=1000000
 ----
 
 # Start with a table that contains point and range keys, but no range dels or

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -262,7 +262,7 @@ range-deletions-bytes-estimate: 78
 
 # Test the interaction between point and range key deletions.
 
-define
+define block-size=1 target-file-sizes=(100, 1)
 ----
 
 # Start with a table that contains point and range keys, but no range dels or
@@ -393,7 +393,7 @@ range-deletions-bytes-estimate: 0
 # A hint for exclusively range key deletions that covers a table with point keys
 # should not contain an estimate for point keys.
 
-define
+define block-size=1 target-file-sizes=(100, 1)
 ----
 
 # A table with point keys.
@@ -451,7 +451,7 @@ range-deletions-bytes-estimate: 0
 # A hint from a range del that covers a table with only range keys should not
 # contain an estimate for the range keys.
 
-define
+define block-size=1 target-file-sizes=(100, 1)
 L4
   a.RANGEDEL.4:c
 L5
@@ -572,7 +572,7 @@ keys.missized-tombstones-count: 1
 
 # Virtual sstables tests. Note that these tests are just for sanity checking
 # purposes. Small sstables lead to inaccurate values during extrapolation.
-define format-major-version=16
+define format-major-version=16 block-size=32768 target-file-sizes=(100, 1)
 ----
 
 batch
@@ -980,7 +980,7 @@ range-deletions-bytes-estimate: 482
 
 # Create a database with value separation enabled.
 
-define format-major-version=24 value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=1m, garbage-ratios=0.1:0.3) target-file-sizes=(100000)
+define format-major-version=24 value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=1m, garbage-ratios=0.1:0.3) target-file-sizes=(100000) block-size=32768
 ----
 
 batch

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -374,19 +374,19 @@ func TestLargeKeys(t *testing.T) {
 		return c
 	}()
 
-	opts := &Options{
-		Comparer:                    &largeKeyComparer,
-		FormatMajorVersion:          internalFormatNewest,
-		FS:                          vfs.NewMem(),
-		Logger:                      testutils.Logger{T: t},
-		MemTableStopWritesThreshold: 4,
-		DisableTableStats:           true,
-	}
 	var d *DB
 	defer func() { require.NoError(t, d.Close()) }()
 	datadriven.RunTest(t, "testdata/large_keys", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "define":
+			opts := &Options{
+				Comparer:                    &largeKeyComparer,
+				FormatMajorVersion:          internalFormatNewest,
+				FS:                          vfs.NewMem(),
+				Logger:                      testutils.Logger{T: t},
+				MemTableStopWritesThreshold: 4,
+				DisableTableStats:           true,
+			}
 			var err error
 			d, err = runDBDefineCmd(td, opts)
 			require.NoError(t, err)

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -375,7 +375,11 @@ func TestLargeKeys(t *testing.T) {
 	}()
 
 	var d *DB
-	defer func() { require.NoError(t, d.Close()) }()
+	defer func() {
+		if d != nil {
+			require.NoError(t, d.Close())
+		}
+	}()
 	datadriven.RunTest(t, "testdata/large_keys", func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "define":


### PR DESCRIPTION
#### db: fix TestTableStats options reuse

In `TestTableStats` any options passed to `define` persist through to
the next `define`, which is very unexpected.

We fix this by re-initializing the options each time.

#### db: don't reuse options in TestMarkedForCompaction


#### db: don't reuse options in TestCompactionPickerPickFile


#### db: don't reuse options in TestCompactionPickerScores


#### db: don't reuse options in TestRangeDel


#### db: don't reuse options in TestLargeKeys


#### db: split up TestCompaction

We split off the main part of `TestCompaction`. Now each test file
initializes new state (which is less fragile and allows reproducing a
specific test file failure with a given seed).

#### db: remove unused runIngestCmd argument

In some tests (`TestCompaction`), the passed argument is incorrect
anyway (because `runDBDefineCmd` overwrites the FS we think we're
using).

#### db: clean up test code for set-concurrent-compactions

We no longer require copying `CompactionConcurrencyRange` from the old
options.

#### db: clean up runDBDefineCmd

Consolidate the two variants of this function: we create a new `MemFS`
only if `opts.FS` is not set (which is much more intuitive).

Note that we no longer call `EnsureDefaults()` before modifying the
options passed to the `define` directive. This changes certain values
that have defaults that depends on other values, like
`FlushSplitBytes`. We add a `flush-split-byte` argument to correct
this.