### PR TITLE
cache: don't update hit/miss metrics for compaction reads

### DIFF
--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -130,32 +130,47 @@ func (c *shard) init(maxSize int64) {
 	c.readShard.Init(c)
 }
 
-// getWithMaybeReadEntry is the internal helper for implementing
-// Cache.{Get,GetWithReadHandle}. When desireReadEntry is true, and the block
-// is not in the cache (nil Value), a non-nil readEntry is returned (in which
-// case the caller is responsible to dereference the entry, via one of
-// unrefAndTryRemoveFromMap(), setReadValue(), setReadError()).
-func (c *shard) getWithMaybeReadEntry(k key, desireReadEntry bool) (*Value, *readEntry) {
+// get is the internal helper for implementing Cache.Get. This is not used for
+// latency-sensitive paths and does *not* update cache hit metrics.
+func (c *shard) get(k key) *Value {
 	c.mu.RLock()
-	var value *Value
+	defer c.mu.RUnlock()
+	e, _ := c.blocks.Get(k)
+	if e == nil {
+		return nil
+	}
+	value := e.acquireValue()
+	// Note: we Load first to avoid an atomic XCHG when not necessary.
+	if value != nil && !e.referenced.Load() {
+		e.referenced.Store(true)
+	}
+	return value
+}
+
+// getWithReadEntry is the internal helper for implementing
+// Cache.GetWithReadHandle. When the block is not in the cache (nil Value), a
+// non-nil readEntry is returned (in which case the caller is responsible to
+// dereference the entry, via one of unrefAndTryRemoveFromMap(), setReadValue(),
+// setReadError()).
+//
+// This method updates cache hit/miss metrics.
+func (c *shard) getWithReadEntry(k key) (*Value, *readEntry) {
+	c.mu.RLock()
 	if e, _ := c.blocks.Get(k); e != nil {
-		value = e.acquireValue()
-		// Note: we Load first to avoid an atomic XCHG when not necessary.
-		if value != nil && !e.referenced.Load() {
-			e.referenced.Store(true)
+		if value := e.acquireValue(); value != nil {
+			// Note: we Load first to avoid an atomic XCHG when not necessary.
+			if !e.referenced.Load() {
+				e.referenced.Store(true)
+			}
+			c.mu.RUnlock()
+			c.hits.Add(1)
+			return value, nil
 		}
 	}
-	var re *readEntry
-	if value == nil && desireReadEntry {
-		re = c.readShard.acquireReadEntry(k)
-	}
+	re := c.readShard.acquireReadEntry(k)
 	c.mu.RUnlock()
-	if value == nil {
-		c.misses.Add(1)
-	} else {
-		c.hits.Add(1)
-	}
-	return value, re
+	c.misses.Add(1)
+	return nil, re
 }
 
 func (c *shard) set(k key, value *Value, markAccessed bool) {

--- a/internal/cache/read_shard_test.go
+++ b/internal/cache/read_shard_test.go
@@ -50,7 +50,7 @@ func newTestReader(
 }
 
 func (r *testReader) getAsync(shard *shard) *string {
-	v, re := shard.getWithMaybeReadEntry(r.key, true /* desireReadEntry */)
+	v, re := shard.getWithReadEntry(r.key)
 	if v != nil {
 		str := string(v.RawBuffer())
 		v.Release()

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -532,6 +532,9 @@ func (r *Reader) Readable() objstorage.Readable {
 //
 // Users should prefer using Read, which handles reading from object storage on
 // a cache miss.
+//
+// GetFromCache is not intended for latency-sensitive paths and does not update
+// cache hit metrics.
 func (r *Reader) GetFromCache(bh Handle) *cache.Value {
 	return r.opts.CacheOpts.CacheHandle.Get(r.opts.CacheOpts.FileNum, bh.Offset)
 }

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -158,7 +158,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   5 (1.6KB) |       81.8% |     1 (392B) |       89.6% |         0.0% |           0 |           0
+   5 (1.6KB) |       84.0% |     1 (392B) |       89.6% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -434,7 +434,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-   7 (2.3KB) |       59.6% |     1 (504B) |       78.6% |         0.0% |           0 |           0
+   7 (2.3KB) |       61.5% |     1 (504B) |       78.6% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -69,7 +69,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    3 (924B) |       15.4% |     1 (280B) |       50.0% |         0.0% |           0 |           0
+    3 (924B) |       40.0% |     1 (280B) |       50.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -233,7 +233,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (683B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+    2 (683B) |       50.0% |     2 (560B) |       66.7% |         0.0% |           2 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -317,7 +317,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (683B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+    2 (683B) |       50.0% |     2 (560B) |       66.7% |         0.0% |           2 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -398,7 +398,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (683B) |       33.3% |     1 (280B) |       66.7% |         0.0% |           1 |           0
+    2 (683B) |       50.0% |     1 (280B) |       66.7% |         0.0% |           1 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -482,7 +482,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |       33.3% |       0 (0B) |       66.7% |         0.0% |           0 |           0
+      0 (0B) |       50.0% |       0 (0B) |       66.7% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -605,7 +605,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |       33.3% |       0 (0B) |       66.7% |         0.0% |           0 |           0
+      0 (0B) |       50.0% |       0 (0B) |       66.7% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -714,7 +714,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |       10.0% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+      0 (0B) |       50.0% |       0 (0B) |       55.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -874,7 +874,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-     6 (2KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+     6 (2KB) |       20.0% |       0 (0B) |       55.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -996,7 +996,7 @@ ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-     6 (2KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+     6 (2KB) |       20.0% |       0 (0B) |       55.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed


### PR DESCRIPTION
To improve the usefulness of the cache hit metrics, we no longer
update them for compaction reads and CopySpan cache accesses (these
paths are not latency-sensitive).