### PR TITLE
metrics: more granular block cache metrics

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -857,7 +857,7 @@ func TestMemTableReservation(t *testing.T) {
 		t.Fatalf("expected 2 refs, but found %d", refs)
 	}
 	// Verify the memtable reservation has caused our test block to be evicted.
-	if cv := tmpHandle.Get(base.DiskFileNum(0), 0); cv != nil {
+	if cv := tmpHandle.Get(base.DiskFileNum(0), 0, cache.CategoryBackground); cv != nil {
 		t.Fatalf("expected failure, but found success: %#v", cv)
 	}
 

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -42,7 +42,7 @@ func TestCache(t *testing.T) {
 		wantHit := fields[1][0] == 'h'
 
 		var hit bool
-		cv := h.Get(base.DiskFileNum(key), 0)
+		cv := h.Get(base.DiskFileNum(key), 0, CategorySSTableData)
 		if cv == nil {
 			cv = Alloc(1)
 			cv.RawBuffer()[0] = fields[0][0]
@@ -85,12 +85,12 @@ func TestCacheDelete(t *testing.T) {
 	if expected, size := int64(10), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	if v := h.Get(base.DiskFileNum(0), 0); v == nil {
+	if v := h.Get(base.DiskFileNum(0), 0, CategorySSTableData); v == nil {
 		t.Fatalf("expected to find block 0/0")
 	} else {
 		v.Release()
 	}
-	if v := h.Get(base.DiskFileNum(1), 0); v != nil {
+	if v := h.Get(base.DiskFileNum(1), 0, CategorySSTableData); v != nil {
 		t.Fatalf("expected to not find block 1/0")
 	}
 	// Deleting a non-existing block does nothing.
@@ -157,11 +157,11 @@ func TestMultipleDBs(t *testing.T) {
 	if expected, size := int64(5), cache.Size(); expected != size {
 		t.Fatalf("expected cache size %d, but found %d", expected, size)
 	}
-	v := h1.Get(base.DiskFileNum(0), 0)
+	v := h1.Get(base.DiskFileNum(0), 0, CategorySSTableData)
 	if v != nil {
 		t.Fatalf("expected not present, but found %#v", v)
 	}
-	v = h2.Get(base.DiskFileNum(0), 0)
+	v = h2.Get(base.DiskFileNum(0), 0, CategorySSTableData)
 	if v := v.RawBuffer(); string(v) != "bbbbb" {
 		t.Fatalf("expected bbbbb, but found %s", v)
 	}
@@ -266,7 +266,7 @@ func BenchmarkCacheGet(b *testing.B) {
 		rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
 
 		for pb.Next() {
-			v := h.Get(base.DiskFileNum(0), uint64(rng.IntN(size)))
+			v := h.Get(base.DiskFileNum(0), uint64(rng.IntN(size)), CategorySSTableData)
 			if v == nil {
 				b.Fatal("failed to lookup value")
 			}

--- a/internal/cache/metrics.go
+++ b/internal/cache/metrics.go
@@ -1,0 +1,121 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cache
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/crlib/crtime"
+)
+
+// Category is used to maintain granular cache hit/miss statistics.
+type Category uint8
+
+const (
+	// CategoryBackground is used for cache accesses made by compactions or
+	// downloads.
+	CategoryBackground           = 0
+	CategorySSTableData Category = iota
+	CategorySSTableValue
+	CategoryBlobValue
+	CategoryFilter
+	// CategoryIndex includes index blocks and other metadata blocks (for both
+	// sstables and blob files).
+	CategoryIndex
+
+	NumCategories
+)
+
+func (c Category) String() string {
+	switch c {
+	case CategoryBackground:
+		return "background"
+	case CategorySSTableData:
+		return "sstdata"
+	case CategorySSTableValue:
+		return "sstval"
+	case CategoryBlobValue:
+		return "blobval"
+	case CategoryFilter:
+		return "filter"
+	case CategoryIndex:
+		return "index"
+	default:
+		return fmt.Sprintf("invalid(%d)", c)
+	}
+}
+
+// Metrics holds metrics for the cache.
+type Metrics struct {
+	// Hits and misse since the cache was created.
+	HitsAndMisses HitsAndMisses
+	// The current number of bytes inuse by the cache.
+	Size int64
+	// The current count of objects (blocks or tables) in the cache.
+	Count int64
+	// Recent contains cache hit metrics covering two recent periods (last ~10
+	// minutes and last ~1 hour).
+	Recent [2]struct {
+		HitsAndMisses
+		Since crtime.Mono
+	}
+}
+
+// HitsAndMisses contains the number of cache hits and misses across a period of
+// time.
+type HitsAndMisses [NumCategories]struct {
+	Hits   int64
+	Misses int64
+}
+
+// Aggregate returns the total hits and misses across all categories.
+func (hm *HitsAndMisses) Aggregate() (hits, misses int64) {
+	for i := range *hm {
+		hits += hm[i].Hits
+		misses += hm[i].Misses
+	}
+	return hits, misses
+}
+
+// ToRecent changes the receiver to reflect recent hits and misses, given the
+// current metrics.
+// At a high level, hm.ToRecent(current) means hm = current - hm.
+func (hm *HitsAndMisses) ToRecent(current *HitsAndMisses) {
+	for i := range *hm {
+		hm[i].Hits = current[i].Hits - hm[i].Hits
+		hm[i].Misses = current[i].Misses - hm[i].Misses
+	}
+}
+
+// Metrics returns the current metrics for the cache.
+func (c *Cache) Metrics() Metrics {
+	var m Metrics
+	m.HitsAndMisses = c.hitsAndMisses()
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.mu.RLock()
+		m.Count += int64(s.blocks.Len())
+		m.Size += s.sizeHot + s.sizeCold
+		s.mu.RUnlock()
+	}
+	m.Recent[0].HitsAndMisses, m.Recent[0].Since = c.metricsWindow.TenMinutesAgo()
+	m.Recent[1].HitsAndMisses, m.Recent[1].Since = c.metricsWindow.OneHourAgo()
+	for i := range m.Recent {
+		m.Recent[i].ToRecent(&m.HitsAndMisses)
+	}
+	return m
+}
+
+func (c *Cache) hitsAndMisses() HitsAndMisses {
+	var hm HitsAndMisses
+	for i := range c.shards {
+		shardCounters := &c.shards[i].counters
+		for j := range hm {
+			hm[j].Hits += shardCounters[j].hits.Load()
+			hm[j].Misses += shardCounters[j].misses.Load()
+		}
+	}
+	return hm
+}

--- a/internal/cache/read_shard_test.go
+++ b/internal/cache/read_shard_test.go
@@ -50,7 +50,7 @@ func newTestReader(
 }
 
 func (r *testReader) getAsync(shard *shard) *string {
-	v, re := shard.getWithMaybeReadEntry(r.key, true /* desireReadEntry */)
+	v, re := shard.getWithMaybeReadEntry(r.key, CategorySSTableData, true /* desireReadEntry */)
 	if v != nil {
 		str := string(v.RawBuffer())
 		v.Release()
@@ -285,7 +285,7 @@ func TestReadShardConcurrent(t *testing.T) {
 	for _, r := range differentReaders {
 		for j := 0; j < r.numReaders; j++ {
 			go func(r *testSyncReaders, index int) {
-				v, rh, _, _, _, err := r.handle.GetWithReadHandle(context.Background(), r.fileNum, r.offset)
+				v, rh, _, _, _, err := r.handle.GetWithReadHandle(context.Background(), r.fileNum, r.offset, CategorySSTableData)
 				require.NoError(t, err)
 				if v != nil {
 					require.Equal(t, r.val, v.RawBuffer())

--- a/internal/metricsutil/window.go
+++ b/internal/metricsutil/window.go
@@ -1,0 +1,164 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metricsutil
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/crlib/crtime"
+)
+
+// NewWindow creates a new Window instance, which maintains a sliding window of
+// metrics collected at regular intervals. It collects metrics every minute.
+//
+// Sample usage:
+//
+//	w := NewWindow[MyMetricsType](func() MyMetricsType {
+//	  return retrieveCurrentMetrics()
+//	})
+//	w.Start()
+//	defer w.Stop()
+//	..
+//	currentMetrics := retrieveCurrentMetrics()
+//	prevMetrics, prevTime := w.TenMinutesAgo()
+//	fmt.Printf("statistics over last %s: %s\n", prevTime.Elapsed(), currentMetrics.Subtract(prevMetrics))
+func NewWindow[M any](collectFn CollectFn[M]) *Window[M] {
+	return &Window[M]{collectFn: collectFn}
+}
+
+// CollectFn is a function used to collect the current metrics.
+type CollectFn[M any] func() M
+
+// Window maintains a sliding window of metrics collected at regular intervals,
+// allowing the retrieval of metrics from approximately 10 minutes and 1 hour
+// ago. These metrics can be used against the current metrics to get statistics
+// for these recent timeframes.
+type Window[M any] struct {
+	collectFn CollectFn[M]
+	mu        struct {
+		sync.Mutex
+		running   bool
+		startTime crtime.Mono
+		nextA     crtime.Mono
+		ringA     ring[M]
+		nextB     crtime.Mono
+		ringB     ring[M]
+		timer     *time.Timer
+	}
+}
+
+// TenMinutesAgo returns the metrics from ~10 minutes ago (normally ±30s) and
+// the time when they were collected.
+//
+// If no metrics are available (less than 10m passed), the zero values are
+// returned.
+func (w *Window[M]) TenMinutesAgo() (_ M, collectedAt crtime.Mono) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.mu.ringA.Oldest()
+}
+
+// OneHourAgo returns the metrics from ~1h ago (normally ±3m) and the time when
+// they were collected.
+//
+// If no metrics are available (i.e. less than 1h passed), the zero values are
+// returned.
+func (w *Window[M]) OneHourAgo() (_ M, collectedAt crtime.Mono) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.mu.ringB.Oldest()
+}
+
+// Start background collection of metrics.
+func (w *Window[M]) Start() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.mu.running {
+		return
+	}
+	w.mu.ringA = ring[M]{}
+	w.mu.ringB = ring[M]{}
+	w.mu.running = true
+	// Initialize both rings. We do this in a separate goroutine in case the
+	// caller is holding a lock that the collect function uses as well.
+	go func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if !w.mu.running {
+			// We were stopped before we got here.
+			return
+		}
+		w.mu.startTime = crtime.NowMono()
+		w.mu.nextA = w.mu.startTime + crtime.Mono(tickA)
+		w.mu.nextB = w.mu.startTime + crtime.Mono(tickB)
+		m := w.collectFn()
+		w.mu.ringA.Add(m, w.mu.startTime)
+		w.mu.ringB.Add(m, w.mu.startTime)
+		// We prefer to use a timer instead of a ticker and goroutine to avoid yet
+		// another goroutine showing up in goroutine dumps.
+		w.mu.timer = time.AfterFunc(tickA, w.tick)
+	}()
+}
+
+// Stop background collection of metrics and wait for any in-progress collection
+// to finish.
+func (w *Window[M]) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.mu.running = false
+	if w.mu.timer != nil {
+		// If Stop fails, the timer function didn't reach the critical section yet;
+		// when it does it will notice running=false and exit.
+		w.mu.timer.Stop()
+		w.mu.timer = nil
+	}
+}
+
+func (w *Window[M]) tick() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.mu.running {
+		return
+	}
+	m := w.collectFn()
+	now := crtime.NowMono()
+	for w.mu.nextA <= now {
+		w.mu.ringA.Add(m, now)
+		w.mu.nextA += crtime.Mono(tickA)
+	}
+	for w.mu.nextB <= now {
+		w.mu.ringB.Add(m, now)
+		w.mu.nextB += crtime.Mono(tickB)
+	}
+	w.mu.timer.Reset(min(w.mu.nextA, w.mu.nextB).Sub(now))
+}
+
+// We scale down the timeframes by 5% so that the oldest sample is within ±5% of
+// the desired target.
+const timeframeA = 10 * time.Minute * 95 / 100
+const timeframeB = time.Hour * 95 / 100
+
+const resolution = 10
+const tickA = timeframeA / time.Duration(resolution)
+const tickB = timeframeB / time.Duration(resolution)
+
+type ring[M any] struct {
+	pos int
+	buf [resolution]struct {
+		m           M
+		collectedAt crtime.Mono
+	}
+}
+
+func (r *ring[M]) Add(value M, collectedAt crtime.Mono) {
+	r.buf[r.pos].m = value
+	r.buf[r.pos].collectedAt = collectedAt
+	r.pos = (r.pos + 1) % resolution
+}
+
+func (r *ring[M]) Oldest() (_ M, collectedAt crtime.Mono) {
+	return r.buf[r.pos].m, r.buf[r.pos].collectedAt
+}

--- a/internal/metricsutil/window_test.go
+++ b/internal/metricsutil/window_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build go1.25
+
+package metricsutil
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/cockroachdb/crlib/crtime"
+)
+
+func TestWindow(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		startTime := crtime.NowMono()
+		w := NewWindow[time.Duration](startTime.Elapsed)
+		w.Start()
+		defer w.Stop()
+		<-time.After(5 * time.Minute)
+		v, x := w.TenMinutesAgo()
+		if v != 0 || x != 0 {
+			t.Fatalf("expected empty, got %v %v", v, x)
+		}
+		<-time.After(5*time.Minute + time.Second)
+		v, x = w.TenMinutesAgo()
+		if x := x.Elapsed(); x < 9*time.Minute || x > 11*time.Minute {
+			t.Fatalf("expected ~10md, got %s", x)
+		}
+		if v < 0 || v > time.Minute {
+			t.Fatalf("expected ~0, got %s", v)
+		}
+
+		<-time.After(20*time.Minute + time.Second)
+		v, x = w.TenMinutesAgo()
+		if x := x.Elapsed(); x < 9*time.Minute || x > 11*time.Minute {
+			t.Fatalf("expected ~10m, got %s", x)
+		}
+		if v < 19*time.Minute || v > 21*time.Minute {
+			t.Fatalf("expected ~0, got %s", v)
+		}
+
+		<-time.After(30*time.Minute + time.Second)
+		v, x = w.OneHourAgo()
+		if x := x.Elapsed(); x < 50*time.Minute || x > 70*time.Minute {
+			t.Fatalf("expected ~1h, got %s", x)
+		}
+		if v < 0 || v > 10*time.Minute {
+			t.Fatalf("expected 0-10m, got %s", v)
+		}
+	})
+}

--- a/metrics.go
+++ b/metrics.go
@@ -719,22 +719,32 @@ var (
 		table.Div(),
 		table.String("flushable", 11, table.AlignRight, func(i commitPipelineInfo) string { return i.flushable }),
 	)
+	blockCacheInfoTableTopHeader = `BLOCK CACHE`
+	blockCacheInfoTable          = table.Define[blockCacheInfo](
+		func() []table.Element {
+			e := make([]table.Element, 1, 1+2*cache.NumCategories)
+			e[0] = table.String("all", 6, table.AlignRight, func(i blockCacheInfo) string { return i.hitRate })
+			for c := range cache.NumCategories {
+				e = append(e, table.Div())
+				e = append(e, table.String(c.String(), 11, table.AlignRight, func(i blockCacheInfo) string {
+					return i.perCategory[c]
+				}))
+			}
+			return e
+		}()...,
+	)
 	iteratorInfoTableTopHeader = `ITERATORS`
-	iteratorInfoTableSubHeader = `        block cache        |         file cache         |    filter    |  sst iters  |  snapshots`
+	iteratorInfoTableSubHeader = `        file cache        |    filter   |    open     |    open`
 	iteratorInfoTable          = table.Define[iteratorInfo](
-		table.String("entries", 12, table.AlignRight, func(i iteratorInfo) string { return i.bcEntries }),
-		table.Div(),
-		table.String("hit rate", 11, table.AlignRight, func(i iteratorInfo) string { return i.bcHitRate }),
-		table.Div(),
 		table.String("entries", 12, table.AlignRight, func(i iteratorInfo) string { return i.fcEntries }),
 		table.Div(),
-		table.String("hit rate", 11, table.AlignRight, func(i iteratorInfo) string { return i.fcHitRate }),
+		table.String("hit rate", 10, table.AlignRight, func(i iteratorInfo) string { return i.fcHitRate }),
 		table.Div(),
-		table.String("util", 12, table.AlignRight, func(i iteratorInfo) string { return i.bloomFilterUtil }),
+		table.String("utilization", 11, table.AlignRight, func(i iteratorInfo) string { return i.bloomFilterUtil }),
 		table.Div(),
-		table.String("open", 11, table.AlignRight, func(i iteratorInfo) string { return i.sstableItersOpen }),
+		table.String("sst iters ", 11, table.AlignRight, func(i iteratorInfo) string { return i.sstableItersOpen }),
 		table.Div(),
-		table.String("open", 11, table.AlignRight, func(i iteratorInfo) string { return i.snapshotsOpen }),
+		table.String("snapshots ", 11, table.AlignRight, func(i iteratorInfo) string { return i.snapshotsOpen }),
 	)
 	fileInfoTableHeader = `FILES                 tables                       |       blob files        |     blob values`
 	fileInfoTable       = table.Define[tableAndBlobInfo](
@@ -811,9 +821,30 @@ type commitPipelineInfo struct {
 	flushable string
 }
 
+type blockCacheInfo struct {
+	hitRate     string
+	perCategory [cache.NumCategories]string
+}
+
+func makeBlockCacheInfo(hm *cache.HitsAndMisses) blockCacheInfo {
+	hits, misses := hm.Aggregate()
+	var bci blockCacheInfo
+	bci.hitRate = fmt.Sprintf("%.1f%%", hitRate(hits, misses))
+	decimals := func(v float64) int {
+		if v >= 9.95 {
+			return 0
+		}
+		return 1
+	}
+	for i := range bci.perCategory {
+		mr := percent(hm[i].Misses, hm[i].Hits+hm[i].Misses)
+		p := percent(hm[i].Misses, misses)
+		bci.perCategory[i] = fmt.Sprintf("%.*f%% [%.*f%%]", decimals(mr), mr, decimals(p), p)
+	}
+	return bci
+}
+
 type iteratorInfo struct {
-	bcEntries        string
-	bcHitRate        string
 	fcEntries        string
 	fcHitRate        string
 	bloomFilterUtil  string
@@ -950,9 +981,27 @@ func (m *Metrics) String() string {
 	cur = commitPipelineInfoTable.Render(cur, table.RenderOptions{}, oneItemIter(commitPipelineInfoContents))
 	cur = cur.NewlineReturn()
 
+	cur = cur.WriteString(blockCacheInfoTableTopHeader)
+	cur = cur.Printf(": %s entries (%s)", humanizeCount(m.BlockCache.Count), humanizeBytes(m.BlockCache.Size))
+
+	cur = cur.WriteString("\n                 miss rate [percentage of total misses] since start\n")
+	bci := makeBlockCacheInfo(&m.BlockCache.HitsAndMisses)
+	cur = blockCacheInfoTable.Render(cur, table.RenderOptions{}, oneItemIter(bci))
+
+	if m.BlockCache.Recent[0].Since != 0 {
+		cur = cur.WriteString("\n                 miss rate [percentage of total misses] over last ~10m\n") // TODO(radu): print exact timeframe
+		bci = makeBlockCacheInfo(&m.BlockCache.Recent[0].HitsAndMisses)
+		cur = blockCacheInfoTable.Render(cur, table.RenderOptions{}, oneItemIter(bci))
+	}
+
+	if m.BlockCache.Recent[1].Since != 0 {
+		cur = cur.WriteString("\n                 miss rate [percentage of total misses] over last ~1h\n") // TODO(radu): print exact timeframe
+		bci = makeBlockCacheInfo(&m.BlockCache.Recent[1].HitsAndMisses)
+		cur = blockCacheInfoTable.Render(cur, table.RenderOptions{}, oneItemIter(bci))
+		cur = cur.NewlineReturn()
+	}
+
 	iteratorInfoContents := iteratorInfo{
-		bcEntries:        fmt.Sprintf("%s (%s)", humanizeCount(m.BlockCache.Count), humanizeBytes(m.BlockCache.Size)),
-		bcHitRate:        fmt.Sprintf("%.1f%%", hitRate(m.BlockCache.Hits, m.BlockCache.Misses)),
 		fcEntries:        fmt.Sprintf("%s (%s)", humanizeCount(m.FileCache.TableCount), humanizeBytes(m.FileCache.Size)),
 		fcHitRate:        fmt.Sprintf("%.1f%%", hitRate(m.FileCache.Hits, m.FileCache.Misses)),
 		bloomFilterUtil:  fmt.Sprintf("%.1f%%", hitRate(m.Filter.Hits, m.Filter.Misses)),
@@ -1098,6 +1147,12 @@ func (m *Metrics) StringForTests() string {
 	// Don't show cgo memory statistics as they can vary based on architecture,
 	// invariants tag, etc.
 	mCopy.manualMemory = manual.Metrics{}
+
+	// Clear the recent block cache stats as they can vary based on timing.
+	for i := range mCopy.BlockCache.Recent {
+		mCopy.BlockCache.Recent[i].HitsAndMisses = cache.HitsAndMisses{}
+		mCopy.BlockCache.Recent[i].Since = 0
+	}
 	return redact.StringWithoutMarkers(&mCopy)
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -39,8 +39,15 @@ func exampleMetrics() Metrics {
 	var m Metrics
 	m.BlockCache.Size = 1 * GB
 	m.BlockCache.Count = 100
-	m.BlockCache.Hits = 10000
-	m.BlockCache.Misses = 5000
+	for i := range m.BlockCache.HitsAndMisses {
+		x := int64(i) * 1000
+		m.BlockCache.HitsAndMisses[i].Hits = 10000 + x
+		m.BlockCache.HitsAndMisses[i].Misses = 1000 + x
+		m.BlockCache.Recent[0].HitsAndMisses[i].Hits = 20000 + x
+		m.BlockCache.Recent[0].HitsAndMisses[i].Misses = 4000 + x
+		m.BlockCache.Recent[1].HitsAndMisses[i].Hits = 30000 + x
+		m.BlockCache.Recent[1].HitsAndMisses[i].Misses = 9000 + x
+	}
 
 	m.Compact.Count = 1000
 	m.Compact.DefaultCount = 10

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -351,6 +351,19 @@ func (r *Reader) ChecksumType() ChecksumType {
 	return r.checksumType
 }
 
+var kindToCacheCategory = [blockkind.NumKinds]cache.Category{
+	blockkind.Unknown:                         cache.CategoryBackground,
+	blockkind.SSTableData:                     cache.CategorySSTableData,
+	blockkind.SSTableIndex:                    cache.CategoryIndex,
+	blockkind.SSTableValue:                    cache.CategorySSTableValue,
+	blockkind.BlobValue:                       cache.CategoryBlobValue,
+	blockkind.BlobReferenceValueLivenessIndex: cache.CategoryIndex,
+	blockkind.Filter:                          cache.CategoryFilter,
+	blockkind.RangeDel:                        cache.CategorySSTableData,
+	blockkind.RangeKey:                        cache.CategorySSTableData,
+	blockkind.Metadata:                        cache.CategoryIndex,
+}
+
 // Read reads the block referenced by the provided handle. The readHandle is
 // optional.
 func (r *Reader) Read(
@@ -366,7 +379,7 @@ func (r *Reader) Read(
 	// reading a block.
 	if r.opts.CacheOpts.CacheHandle == nil || env.BufferPool != nil {
 		if r.opts.CacheOpts.CacheHandle != nil {
-			if cv := r.opts.CacheOpts.CacheHandle.Get(r.opts.CacheOpts.FileNum, bh.Offset); cv != nil {
+			if cv := r.opts.CacheOpts.CacheHandle.Get(r.opts.CacheOpts.FileNum, bh.Offset, cache.CategoryBackground); cv != nil {
 				recordCacheHit(ctx, env, readHandle, bh, kind)
 				return CacheBufferHandle(cv), nil
 			}
@@ -379,7 +392,7 @@ func (r *Reader) Read(
 	}
 
 	cv, crh, errorDuration, waitDuration, hit, err := r.opts.CacheOpts.CacheHandle.GetWithReadHandle(
-		ctx, r.opts.CacheOpts.FileNum, bh.Offset)
+		ctx, r.opts.CacheOpts.FileNum, bh.Offset, kindToCacheCategory[kind])
 	const slowDur = 5 * time.Millisecond
 	if waitDuration > slowDur && r.opts.LoggerAndTracer.IsTracingEnabled(ctx) {
 		r.opts.LoggerAndTracer.Eventf(
@@ -533,7 +546,7 @@ func (r *Reader) Readable() objstorage.Readable {
 // Users should prefer using Read, which handles reading from object storage on
 // a cache miss.
 func (r *Reader) GetFromCache(bh Handle) *cache.Value {
-	return r.opts.CacheOpts.CacheHandle.Get(r.opts.CacheOpts.FileNum, bh.Offset)
+	return r.opts.CacheOpts.CacheHandle.Get(r.opts.CacheOpts.FileNum, bh.Offset, cache.CategoryBackground)
 }
 
 // UsePreallocatedReadHandle returns a ReadHandle that reads from the reader and

--- a/sstable/colblk/index_block_test.go
+++ b/sstable/colblk/index_block_test.go
@@ -132,7 +132,7 @@ func TestIndexIterInitHandle(t *testing.T) {
 	}
 
 	getBlockAndIterate := func(it *IndexIter) {
-		cv := ch.Get(base.DiskFileNum(1), 0)
+		cv := ch.Get(base.DiskFileNum(1), 0, cache.CategorySSTableData)
 		require.NotNil(t, cv)
 		require.NoError(t, it.InitHandle(testkeys.Comparer, block.CacheBufferHandle(cv), blockiter.NoTransforms))
 		defer it.Close()

--- a/sstable/colblk/keyspan_test.go
+++ b/sstable/colblk/keyspan_test.go
@@ -94,7 +94,7 @@ func TestKeyspanBlockPooling(t *testing.T) {
 	v.SetInCacheForTesting(ch, base.DiskFileNum(1), 0)
 
 	getBlockAndIterate := func() {
-		cv := ch.Get(base.DiskFileNum(1), 0)
+		cv := ch.Get(base.DiskFileNum(1), 0, cache.CategorySSTableData)
 		require.NotNil(t, cv)
 		it := NewKeyspanIter(testkeys.Comparer.Compare, block.CacheBufferHandle(cv), blockiter.NoFragmentTransforms)
 		defer it.Close()

--- a/sstable/rowblk/rowblk_fragment_iter_test.go
+++ b/sstable/rowblk/rowblk_fragment_iter_test.go
@@ -96,7 +96,7 @@ func TestBlockFragmentIterator(t *testing.T) {
 				return d.Expected
 			}
 
-			blockHandle := block.CacheBufferHandle(cacheHandle.Get(0, 0))
+			blockHandle := block.CacheBufferHandle(cacheHandle.Get(0, 0, cache.CategorySSTableData))
 			require.True(t, blockHandle.Valid())
 			i, err := NewFragmentIter(0, comparer, blockHandle, transforms)
 			defer i.Close()

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -835,7 +835,7 @@ func TestWriterClearCache(t *testing.T) {
 
 	// Verify that the written blocks have been cleared from the cache.
 	check := func(bh block.Handle) {
-		cv := cacheOpts.CacheHandle.Get(cacheOpts.FileNum, bh.Offset)
+		cv := cacheOpts.CacheHandle.Get(cacheOpts.FileNum, bh.Offset, cache.CategorySSTableData)
 		if cv != nil {
 			t.Fatalf("%d: expected cache to be cleared, but found %#v", bh.Offset, cv)
 		}

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -65,11 +65,16 @@ COMMIT PIPELINE
 ----------+--------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) | 4.5MB: 4.5MB |      0.0% |         2 |  1 (512KB) |  1 (512KB) |     9.5 M |      0 (0B)
 
+BLOCK CACHE: 1.5K entries (6.4MB)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 60.0% | 100% [0.2%] |   40% [99%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |  40% [0.6%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-1.5K (6.4MB) |       60.0% |     3 (840B) |       90.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    3 (840B) |      90.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -154,11 +154,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   30B: 41B |     36.7% |         1 |  1 (256KB) |  1 (256KB) |        71 |      0 (0B)
 
+BLOCK CACHE: 5 entries (1.6KB)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 81.8% |   33% [24%] |   11% [12%] | 0.0% [0.0%] |   19% [20%] | 0.0% [0.0%] |   17% [44%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-   5 (1.6KB) |       81.8% |     1 (392B) |       89.6% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    1 (392B) |      89.6% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -430,11 +435,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) | 126B: 156B |     23.8% |         2 |  1 (256KB) |  1 (256KB) |       282 |      0 (0B)
 
+BLOCK CACHE: 7 entries (2.3KB)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 59.6% |   46% [29%] |   30% [14%] | 0.0% [0.0%] |   43% [14%] | 0.0% [0.0%] |   41% [43%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-   7 (2.3KB) |       59.6% |     1 (504B) |       78.6% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    1 (504B) |      78.6% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -291,11 +291,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   48B: 97B |    102.1% |         3 |  1 (256KB) |  1 (256KB) |       145 |      0 (0B)
 
+BLOCK CACHE: 2 entries (672B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% |  100% [85%] | 100% [7.7%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 100% [7.7%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (672B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      50.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -432,11 +437,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |  82B: 132B |     61.0% |         6 |  1 (512KB) |  1 (512KB) |       214 |   1 (1.3KB)
 
+BLOCK CACHE: 6 entries (2KB)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% |  100% [74%] |  100% [13%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |  100% [13%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-     6 (2KB) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      50.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -65,11 +65,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |     0B: 0B |      0.0% |         0 |  1 (256KB) |     0 (0B) |         0 |      0 (0B)
 
+BLOCK CACHE: 3 entries (924B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 15.4% |  100% [73%] |  50% [9.1%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |   67% [18%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    3 (924B) |       15.4% |     1 (280B) |       50.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    1 (280B) |      50.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,11 +34,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
  22 (24B) |   25B: 26B |      4.0% |         8 |   12 (2GB) |   5 (13MB) |        51 |      4 (6B)
 
+BLOCK CACHE: 100 entries (1GB)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 78.1% | 9.1% [4.8%] |  15% [9.5%] |   20% [14%] |   24% [19%] |   26% [24%] |   29% [29%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-   100 (1GB) |       66.7% |    180 (1MB) |       48.7% |        47.4% |          21 |           4
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+   180 (1MB) |      48.7% |       47.4% |          21 |           4
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |        live |     zombie |  total |      refed
@@ -127,11 +132,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   17B: 28B |     64.7% |         1 |  1 (256KB) |  1 (256KB) |        45 |      0 (0B)
 
+BLOCK CACHE: 2 entries (683B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% |  100% [50%] |  100% [25%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |  100% [25%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (683B) |        0.0% |     1 (280B) |        0.0% |         0.0% |           1 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    1 (280B) |       0.0% |        0.0% |           1 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -229,11 +239,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |        98 |      0 (0B)
 
+BLOCK CACHE: 2 entries (683B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 33.3% |   75% [75%] |   50% [12%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |   50% [12%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (683B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    2 (560B) |      66.7% |        0.0% |           2 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -313,11 +328,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |        98 |      0 (0B)
 
+BLOCK CACHE: 2 entries (683B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 33.3% |   75% [75%] |   50% [12%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |   50% [12%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (683B) |       33.3% |     2 (560B) |       66.7% |         0.0% |           2 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    2 (560B) |      66.7% |        0.0% |           2 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -394,11 +414,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |        98 |      0 (0B)
 
+BLOCK CACHE: 2 entries (683B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 33.3% |   75% [75%] |   50% [12%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |   50% [12%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (683B) |       33.3% |     1 (280B) |       66.7% |         0.0% |           1 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    1 (280B) |      66.7% |        0.0% |           1 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -478,11 +503,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  1 (256KB) |        98 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 33.3% |   75% [75%] |   50% [12%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |   50% [12%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |       33.3% |       0 (0B) |       66.7% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      66.7% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -601,11 +631,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) | 116B: 165B |     42.2% |         3 |  1 (256KB) |  1 (256KB) |       281 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 33.3% |   75% [75%] |   50% [12%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |   50% [12%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |       33.3% |       0 (0B) |       66.7% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      66.7% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -710,11 +745,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) | 116B: 165B |     42.2% |         3 |  1 (256KB) |  1 (256KB) |       281 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+ 10.0% |   94% [94%] |  50% [2.8%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |  50% [2.8%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |       10.0% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      55.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -870,11 +910,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) | 176B: 211B |     19.9% |         8 |    1 (1MB) |    1 (1MB) |       387 |   2 (1.9KB)
 
+BLOCK CACHE: 6 entries (2KB)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  7.3% |   96% [84%] |  80% [7.8%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |  80% [7.8%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-     6 (2KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      55.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -992,11 +1037,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |       500 |   2 (1.9KB)
 
+BLOCK CACHE: 6 entries (2KB)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  7.3% |   96% [84%] |  80% [7.8%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] |  80% [7.8%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-     6 (2KB) |        7.3% |       0 (0B) |       55.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      55.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1126,11 +1176,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |       500 |   2 (1.9KB)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |        0.0% |       0 (0B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1304,11 +1359,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |       500 |   2 (1.9KB)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |        0.0% |       0 (0B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1399,11 +1459,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |        65 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |        0.0% |       0 (0B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1480,11 +1545,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |        65 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% | 100% [100%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      50.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1576,11 +1646,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |        65 |      0 (0B)
 
+BLOCK CACHE: 2 entries (675B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% |  100% [88%] | 100% [5.9%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 100% [5.9%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (675B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      50.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1664,11 +1739,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |   44B: 74B |     68.2% |         2 |  1 (256KB) |  1 (256KB) |       118 |      0 (0B)
 
+BLOCK CACHE: 2 entries (675B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% |  100% [88%] | 100% [5.9%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 100% [5.9%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (675B) |        0.0% |       0 (0B) |       50.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |      50.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1742,11 +1822,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |     0B: 0B |      0.0% |         1 |  1 (512KB) |  1 (256KB) |         0 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |        0.0% |       0 (0B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1823,11 +1908,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |     0B: 0B |      0.0% |         1 |  1 (512KB) |  1 (256KB) |         0 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |        0.0% |       0 (0B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -1941,11 +2031,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |  57B: 106B |     86.0% |         3 |  1 (256KB) |  1 (256KB) |       163 |      0 (0B)
 
+BLOCK CACHE: 2 entries (662B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% |  100% [67%] |  100% [33%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (662B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    2 (560B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -2019,11 +2114,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    1 (0B) |  57B: 106B |     86.0% |         3 |  1 (256KB) |  1 (256KB) |       163 |      0 (0B)
 
+BLOCK CACHE: 2 entries (662B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% |  100% [67%] |  100% [33%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-    2 (662B) |        0.0% |     2 (560B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+    2 (560B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -44,11 +44,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    0 (0B) |     0B: 0B |      0.0% |         0 |  1 (256KB) |     0 (0B) |         0 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |        0.0% |       0 (0B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -114,11 +119,16 @@ COMMIT PIPELINE
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
    0 (0B) |     0B: 0B |      0.0% |         0 |  1 (256KB) |     0 (0B) |         0 |      0 (0B)
 
+BLOCK CACHE: 0 entries (0B)
+                 miss rate [percentage of total misses] since start
+   all |  background |     sstdata |      sstval |     blobval |      filter |       index
+-------+-------------+-------------+-------------+-------------+-------------+------------
+  0.0% | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%] | 0.0% [0.0%]
 ITERATORS
-        block cache        |         file cache         |    filter    |  sst iters  |  snapshots
-     entries |    hit rate |      entries |    hit rate |         util |        open |        open
--------------+-------------+--------------+-------------+--------------+-------------+------------
-      0 (0B) |        0.0% |       0 (0B) |        0.0% |         0.0% |           0 |           0
+        file cache        |    filter   |    open     |    open
+     entries |   hit rate | utilization |  sst iters  |  snapshots
+-------------+------------+-------------+-------------+------------
+      0 (0B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed


### PR DESCRIPTION
#### metricsutil: add Window data structure

Window maintains instances of metric at regular intervals and is able
to return the metrics from ~10 minutes and ~1hr ago. This is useful to
provide statistics (e.g. cache hits) from these timeframes.

#### metrics: more granular block cache metrics

We improve the cache metrics in two ways:
 - we break down the misses by the type of block (for the most
   important block types)
 - we also show miss rates across the last 10 minutes and the last
   hour

In follow-up work, I will attempt to plumb the LSM level as well.