### PR TITLE
Makefile: disable asan leak check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ all:
 	@echo "  make generate"
 	@echo "  make generate-test-data"
 	@echo "  make clean"
-
 override testflags :=
 .PHONY: test
 test:
@@ -35,10 +34,13 @@ testcoverage:
 testrace: testflags += -race -timeout 20m
 testrace: test
 
+.PHONY: testasan
 testasan: testflags += -asan -timeout 20m
 testasan: TAGS += slowbuild
-testasan: test
+testasan:
+	ASAN_OPTIONS=detect_leaks=0 ${GO} test -tags '$(TAGS)' ${testflags} -run ${TESTS} ${PKG}
 
+.PHONY: testmsan
 testmsan: export CC=clang
 testmsan: testflags += -msan -timeout 20m
 testmsan: TAGS += slowbuild


### PR DESCRIPTION
As of go 1.25, the asan build checks for leaks at program exit by
default. We expect leaks since we store some of our allocated buffers
into pools (and use finalizers that are not guaranteed to run before
exit).

Fixes #5303