### PR TITLE
cockroachkvs: add functions for MaximumSuffixProperty interface to cockroachkvs

### DIFF
--- a/metamorphic/cockroachkvs.go
+++ b/metamorphic/cockroachkvs.go
@@ -162,6 +162,11 @@ func (kg *cockroachKeyGenerator) IncMaxSuffix() []byte {
 	return kg.suffixSpace.ToMaterializedSuffix(s)
 }
 
+// MaximumSuffixProperty returns the maximum suffix property.
+func (kg *cockroachKeyGenerator) MaximumSuffixProperty() pebble.MaximumSuffixProperty {
+	return cockroachkvs.MaxMVCCTimestampProperty{}
+}
+
 // SuffixRange generates a new uniformly random range of suffixes (low, high]
 // such that high is guaranteed to be strictly greater (as defined by
 // ComparePointSuffixes) than low.

--- a/metamorphic/config.go
+++ b/metamorphic/config.go
@@ -440,4 +440,7 @@ type KeyGenerator interface {
 	//
 	// May return a nil suffix.
 	UniformSuffix() []byte
+	// MaximumSuffixProperty returns the maximum suffix property used during
+	// the lazy position of SeekPrefixGE optimization.
+	MaximumSuffixProperty() pebble.MaximumSuffixProperty
 }

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -93,9 +93,9 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *newIndexedBatchOp:
 		return &t.dbID, &t.batchID, nil
 	case *newIterOp:
-		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix}
+		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.maximumSuffixProperty}
 	case *newIterUsingCloneOp:
-		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix}
+		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.maximumSuffixProperty}
 	case *newSnapshotOp:
 		return &t.dbID, &t.snapID, []interface{}{&t.bounds}
 	case *newExternalObjOp:
@@ -119,7 +119,7 @@ func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
 	case *iterSetBoundsOp:
 		return &t.iterID, nil, []interface{}{&t.lower, &t.upper}
 	case *iterSetOptionsOp:
-		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix}
+		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.maximumSuffixProperty}
 	case *singleDeleteOp:
 		return &t.writerID, nil, []interface{}{&t.key, &t.maybeReplaceDelete}
 	case *rangeKeyDeleteOp:
@@ -407,6 +407,14 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
 			}
 			*t = pebble.FormatMajorVersion(val)
+
+		case *pebble.MaximumSuffixProperty:
+			elem.expectToken(p, token.STRING)
+			s, err := strconv.Unquote(elem.lit)
+			if err != nil {
+				panic(p.errorf(elem.pos, "error parsing %q: %s", elem.lit, err))
+			}
+			*t = deserializeMaximumSuffixProperty(s)
 
 		default:
 			panic(p.errorf(pos, "%s: unsupported arg[%d] type: %T", methodName, i, args[i]))

--- a/metamorphic/testkeys.go
+++ b/metamorphic/testkeys.go
@@ -156,6 +156,11 @@ func (kg *testkeyKeyGenerator) IncMaxSuffix() []byte {
 	return testkeys.Suffix(int64(kg.cfg.writeSuffixDist.Max()))
 }
 
+// MaximumSuffixProperty returns the maximum suffix property.
+func (kg *testkeyKeyGenerator) MaximumSuffixProperty() pebble.MaximumSuffixProperty {
+	return sstable.MaxTestKeysSuffixProperty{}
+}
+
 // SuffixRange generates a new uniformly random range of suffixes (low, high]
 // such that high is guaranteed to be strictly greater (as defined by
 // ComparePointSuffixes) than low.

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -863,7 +863,8 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 		// table's max suffix, return a synthetic key with that max suffix.
 		// We'll only actually perform the seek if the synthetic key rises to
 		// the top of the iterator's heap, and the iterator is Nexted.
-		if ok && maxSuffix != nil && i.cmp(key[len(prefix):], maxSuffix) < 0 {
+		// During a RangeDelIter, the prefix passed and the prefix in the key might not be the same.
+		if ok && maxSuffix != nil && i.reader.Comparer.ComparePointSuffixes(key[len(i.reader.Comparer.Split.Prefix(key)):], maxSuffix) < 0 {
 			smallest := i.readEnv.InternalBounds.SmallestUserKey()
 			smallest = i.reader.Comparer.Split.Prefix(smallest)
 			largest := i.readEnv.InternalBounds.LargestUserKey()

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -466,7 +466,8 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 		// table's max suffix, return a synthetic key with that max suffix.
 		// We'll only actually perform the seek if the synthetic key rises to
 		// the top of the iterator's heap, and the iterator is Nexted.
-		if ok && maxSuffix != nil && i.secondLevel.cmp(key[len(prefix):], maxSuffix) < 0 {
+		// During a RangeDelIter, the prefix passed and the prefix in the key might not be the same.
+		if ok && maxSuffix != nil && i.secondLevel.reader.Comparer.ComparePointSuffixes(key[len(i.secondLevel.reader.Comparer.Split.Prefix(key)):], maxSuffix) < 0 {
 			smallest := i.secondLevel.readEnv.InternalBounds.SmallestUserKey()
 			smallest = i.secondLevel.reader.Comparer.Split.Prefix(smallest)
 			largest := i.secondLevel.readEnv.InternalBounds.LargestUserKey()


### PR DESCRIPTION
**cockroachkvs: add functions for MaximumSuffixProperty interface to cockroachkvs**
 
**sstable: fix issue with comparing suffix during SeekPrefixGE lazy positioning**

During a RangeDelIter the prefix passed might not be the same the prefix of the key
therefore we need to split the prefix fromt the given key.

**metamorphic: add changes to iterOpts in metamorphic settings for new SeekPrefix lazy positioning**

Added metamorphic changes with 20% probability to add new lazy positioning optimization in iterator opts

**sstable: fix i.synthetic.atSyntheticKey check in Next**

we should check if key is synthetic before invalidation check
