### PR TITLE
db: fix grandparents for intra-L0 compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -605,7 +605,7 @@ func newCompaction(
 	// Compute the set of outputLevel+1 files that overlap this compaction (these
 	// are the grandparent sstables).
 	if c.outputLevel.level+1 < numLevels {
-		c.grandparents = c.version.Overlaps(c.outputLevel.level+1, c.bounds)
+		c.grandparents = c.version.Overlaps(max(c.outputLevel.level+1, pc.baseLevel), c.bounds)
 	}
 	c.delElision, c.rangeKeyElision = compact.SetupTombstoneElision(
 		c.comparer.Compare, c.version, pc.l0Organizer, c.outputLevel.level, c.bounds,

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -258,6 +258,7 @@ pick-auto
 ----
 L0 -> L0
 L0: 000100,000110,000130,000140
+grandparents: 000200
 
 max-output-file-size
 ----
@@ -436,3 +437,4 @@ pick-auto non-score l0_compaction_threshold=1000
 ----
 L0 -> L0
 L0: 000049
+grandparents: 000045


### PR DESCRIPTION
For intra-L0 compactions, use Lbase instead of L1 to determine
grandparents.