### PR TITLE
db: make tests faster

### DIFF
--- a/internal/genericcache/cache_test.go
+++ b/internal/genericcache/cache_test.go
@@ -71,7 +71,7 @@ func TestBasic(t *testing.T) {
 	c.Close()
 }
 
-func TestFileCacheClockPro(t *testing.T) {
+func TestClockPro(t *testing.T) {
 	// Reuse the data from the block cache. See
 	// internal/cache/clockpro_test.go:TestCache.
 	f, err := os.Open("../cache/testdata/cache")

--- a/open_test.go
+++ b/open_test.go
@@ -541,7 +541,7 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 	useStoreRelativeWALPath := rand.IntN(2) == 0
 	for _, startFromEmpty := range []bool{false, true} {
 		for _, walDirname := range []string{"", "wal"} {
-			for _, length := range []int{-1, 0, 1, 1000, 10000, 100000} {
+			for _, length := range []int{-1, 0, 1, 1000, 100000} {
 				dirname := "sharedDatabase" + walDirname
 				if startFromEmpty {
 					dirname = "startFromEmpty" + walDirname + strconv.Itoa(length)
@@ -566,7 +566,6 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 				if err != nil {
 					t.Fatalf("sfe=%t, length=%d: Open #0: %v",
 						startFromEmpty, length, err)
-					continue
 				}
 				if length >= 0 {
 					err = d0.Set([]byte("key"), []byte(xxx), nil)

--- a/open_test.go
+++ b/open_test.go
@@ -1993,7 +1993,7 @@ func TestWALHardCrashRandomized(t *testing.T) {
 				maxValueSize:        1 << (prng.IntN(19)), // [1, 256 KiB]
 				unsyncedDataPercent: prng.IntN(101),       // [0, 100]
 				seed:                seed,
-				numOps:              250,
+				numOps:              int(prng.ExpFloat64() * 100),
 				opCrashWeight:       1,
 				opBatchWeight:       20 << prng.IntN(3),
 			})

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -1,7 +1,7 @@
 # Generate sstables with sequential, non-overlapping keys. When we trigger a compaction
 # from L0 to Lbase, we expect all the compactions to be moves, since there are no
 # overlapping keys being written.
-define l0-compaction-threshold=1 auto-compactions=off
+define l0-compaction-threshold=1 auto-compactions=off target-file-sizes=65536
 ----
 
 
@@ -10,25 +10,27 @@ set-concurrent-compactions range=(3,3)
 concurrency set to [3, 3]
 
 
-populate keylen=4 timestamps=(1) vallen=1
+populate keylen=3 timestamps=(1) vallen=1
 ----
-wrote 475254 keys
+wrote 18278 keys
 
 
 flush
 ----
 L0.0:
-  000005:[a@1#10,SET-itbq@1#159645,SET]
-  000006:[itbr@1#159646,SET-rmbh@1#319226,SET]
-  000007:[rmbi@1#319227,SET-zzzz@1#475263,SET]
+  000006:[a@1#10,SET-hci@1#4995,SET]
+  000007:[hcj@1#4996,SET-oex@1#9985,SET]
+  000008:[oey@1#9986,SET-vhm@1#14976,SET]
+  000009:[vhn@1#14977,SET-zzz@1#18287,SET]
 
 
 auto-compact count=3
 ----
 L6:
-  000005:[a@1#10,SET-itbq@1#159645,SET]
-  000006:[itbr@1#159646,SET-rmbh@1#319226,SET]
-  000007:[rmbi@1#319227,SET-zzzz@1#475263,SET]
+  000006:[a@1#10,SET-hci@1#4995,SET]
+  000007:[hcj@1#4996,SET-oex@1#9985,SET]
+  000008:[oey@1#9986,SET-vhm@1#14976,SET]
+  000009:[vhn@1#14977,SET-zzz@1#18287,SET]
 
 metrics
 ----
@@ -36,33 +38,33 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |  4.5MB |      0    0B |   0  1.32
-   L6        6MB |      3   6MB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+   L0         0B |      0    0B |      0     0 |     0B     0B |  160KB |      0    0B |   0  1.47
+   L6      236KB |      4 236KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total        6MB |      3   6MB |      0     0 |     0B     0B |  4.5MB |      0    0B |   1  2.32
+total      236KB |      4 236KB |      0     0 |     0B     0B |  160KB |      0    0B |   1  2.47
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      3    6MB     0B
-   L6 |     -  0.09  0.09 |      3   6MB |    0B    0B    0B |     0B    0B |      0     0B     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      4  236KB     0B
+   L6 |     -  0.00  0.00 |      4 236KB |    0B    0B    0B |     0B    0B |      0     0B     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      3   6MB |    0B    0B    0B |     0B    0B |      3   10MB     0B
+total |     -     -     - |      4 236KB |    0B    0B    0B |     0B    0B |      4  396KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob
-count |       0       0        0     3     0     0        0     0      0     0
+count |       0       0        0     4     0     0        0     0      0     0
 
 COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |      written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+--------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 4.5MB: 4.5MB |      0.0% |         2 |  1 (512KB) |  1 (512KB) |     9.5 M |      0 (0B)
+   1 (0B) | 160KB: 160KB |      0.0% |         1 |  1 (512KB) |  1 (512KB) |     328 K |      0 (0B)
 
 ITERATORS
         block cache        |         file cache         |    filter    |  sst iters  |  snapshots
      entries |    hit rate |      entries |    hit rate |         util |        open |        open
 -------------+-------------+--------------+-------------+--------------+-------------+------------
-1.5K (6.4MB) |       60.0% |     3 (840B) |       90.0% |         0.0% |           0 |           0
+  63 (251KB) |       78.0% |    4 (1.1KB) |       90.0% |         0.0% |           0 |           0
 
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
@@ -87,6 +89,6 @@ KEYS
 COMPRESSION
     algorithm |        tables |    blob files
 --------------+---------------+--------------
-         none |         5.9MB |
+         none |         234KB |
 ----
 ----

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -493,62 +493,70 @@ validate-blob-reference-index-block
 ----
 validated
 
-define value-separation=(enabled, min-size=5, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=1
+define value-separation=(enabled, min-size=5, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=1 target-file-sizes=65536
 ----
 
 # Test writing a non-trivial amount of data. With a key length of 4, we'll write
-# 475254 keys each with a 64-byte value, totalling ~30MB of value data.
+# 18278 keys each with a 64-byte value, totalling ~1MB of value data.
 
-populate keylen=4 timestamps=(1) vallen=64
+populate keylen=3 timestamps=(1) vallen=64
 ----
-wrote 475254 keys
+wrote 18278 keys
 
 # Flush the memtable. The resulting L0 sstables should be relatively small, but
 # when their sizes are summed with their corresponding blob files, the sum
-# should be around the target file size of 2MB.
+# should be around the target file size of 64KB.
 
 flush
 ----
 L0.0:
-  000005:[a@1#10,SET-bkmx@1#25669,SET] seqnums:[10-25669] points:[a@1#10,SET-bkmx@1#25669,SET] size:396512 blobrefs:[(B000006: 1642240); depth:1]
-  000007:[bkmy@1#25670,SET-cv@1#51332,SET] seqnums:[25670-51332] points:[bkmy@1#25670,SET-cv@1#51332,SET] size:396339 blobrefs:[(B000008: 1642432); depth:1]
-  000009:[cva@1#51333,SET-efnh@1#77002,SET] seqnums:[51333-77002] points:[cva@1#51333,SET-efnh@1#77002,SET] size:395823 blobrefs:[(B000010: 1642880); depth:1]
-  000011:[efni@1#77003,SET-fqaj@1#102665,SET] seqnums:[77003-102665] points:[efni@1#77003,SET-fqaj@1#102665,SET] size:396255 blobrefs:[(B000012: 1642432); depth:1]
-  000013:[fqak@1#102666,SET-hamh@1#128297,SET] seqnums:[102666-128297] points:[fqak@1#102666,SET-hamh@1#128297,SET] size:398335 blobrefs:[(B000014: 1640448); depth:1]
-  000015:[hami@1#128298,SET-ikzi@1#153958,SET] seqnums:[128298-153958] points:[hami@1#128298,SET-ikzi@1#153958,SET] size:396458 blobrefs:[(B000016: 1642304); depth:1]
-  000017:[ikzj@1#153959,SET-jvoe@1#179669,SET] seqnums:[153959-179669] points:[ikzj@1#153959,SET-jvoe@1#179669,SET] size:393037 blobrefs:[(B000018: 1645504); depth:1]
-  000019:[jvof@1#179670,SET-lgaf@1#205305,SET] seqnums:[179670-205305] points:[jvof@1#179670,SET-lgaf@1#205305,SET] size:397560 blobrefs:[(B000020: 1640704); depth:1]
-  000021:[lgag@1#205306,SET-mqno@1#230974,SET] seqnums:[205306-230974] points:[lgag@1#205306,SET-mqno@1#230974,SET] size:395902 blobrefs:[(B000022: 1642816); depth:1]
-  000023:[mqnp@1#230975,SET-obac@1#256624,SET] seqnums:[230975-256624] points:[mqnp@1#230975,SET-obac@1#256624,SET] size:397156 blobrefs:[(B000024: 1641600); depth:1]
-  000025:[obad@1#256625,SET-plml@1#282266,SET] seqnums:[256625-282266] points:[obad@1#256625,SET-plml@1#282266,SET] size:397706 blobrefs:[(B000026: 1641088); depth:1]
-  000027:[plmm@1#282267,SET-qvzf@1#307920,SET] seqnums:[282267-307920] points:[plmm@1#282267,SET-qvzf@1#307920,SET] size:396854 blobrefs:[(B000028: 1641856); depth:1]
-  000029:[qvzg@1#307921,SET-sgld@1#333553,SET] seqnums:[307921-333553] points:[qvzg@1#307921,SET-sgld@1#333553,SET] size:398265 blobrefs:[(B000030: 1640512); depth:1]
-  000031:[sgle@1#333554,SET-tqxr@1#359200,SET] seqnums:[333554-359200] points:[sgle@1#333554,SET-tqxr@1#359200,SET] size:397369 blobrefs:[(B000032: 1641408); depth:1]
-  000033:[tqxs@1#359201,SET-vbls@1#384890,SET] seqnums:[359201-384890] points:[tqxs@1#359201,SET-vbls@1#384890,SET] size:394445 blobrefs:[(B000034: 1644160); depth:1]
-  000035:[vblt@1#384891,SET-wlyf@1#410537,SET] seqnums:[384891-410537] points:[vblt@1#384891,SET-wlyf@1#410537,SET] size:397367 blobrefs:[(B000036: 1641408); depth:1]
-  000037:[wlyg@1#410538,SET-xwmc@1#436222,SET] seqnums:[410538-436222] points:[wlyg@1#410538,SET-xwmc@1#436222,SET] size:394815 blobrefs:[(B000038: 1643840); depth:1]
-  000039:[xwmd@1#436223,SET-zhar@1#461926,SET] seqnums:[436223-461926] points:[xwmd@1#436223,SET-zhar@1#461926,SET] size:393481 blobrefs:[(B000040: 1645056); depth:1]
-  000041:[zhas@1#461927,SET-zzzz@1#475263,SET] seqnums:[461927-475263] points:[zhas@1#461927,SET-zzzz@1#475263,SET] size:208147 blobrefs:[(B000042: 853568); depth:1]
+  000005:[a@1#10,SET-bdm@1#808,SET] seqnums:[10-808] points:[a@1#10,SET-bdm@1#808,SET] size:13082 blobrefs:[(B000007: 51136); depth:1]
+  000008:[bdn@1#809,SET-cha@1#1607,SET] seqnums:[809-1607] points:[bdn@1#809,SET-cha@1#1607,SET] size:13082 blobrefs:[(B000009: 51136); depth:1]
+  000010:[chb@1#1608,SET-dkp@1#2406,SET] seqnums:[1608-2406] points:[chb@1#1608,SET-dkp@1#2406,SET] size:13066 blobrefs:[(B000011: 51136); depth:1]
+  000012:[dkq@1#2407,SET-eod@1#3205,SET] seqnums:[2407-3205] points:[dkq@1#2407,SET-eod@1#3205,SET] size:13090 blobrefs:[(B000013: 51136); depth:1]
+  000014:[eoe@1#3206,SET-frs@1#4004,SET] seqnums:[3206-4004] points:[eoe@1#3206,SET-frs@1#4004,SET] size:13066 blobrefs:[(B000015: 51136); depth:1]
+  000016:[frt@1#4005,SET-gvg@1#4803,SET] seqnums:[4005-4803] points:[frt@1#4005,SET-gvg@1#4803,SET] size:13082 blobrefs:[(B000017: 51136); depth:1]
+  000018:[gvh@1#4804,SET-hyv@1#5602,SET] seqnums:[4804-5602] points:[gvh@1#4804,SET-hyv@1#5602,SET] size:13074 blobrefs:[(B000019: 51136); depth:1]
+  000020:[hyw@1#5603,SET-jci@1#6401,SET] seqnums:[5603-6401] points:[hyw@1#5603,SET-jci@1#6401,SET] size:13106 blobrefs:[(B000021: 51136); depth:1]
+  000022:[jcj@1#6402,SET-kfy@1#7201,SET] seqnums:[6402-7201] points:[jcj@1#6402,SET-kfy@1#7201,SET] size:13066 blobrefs:[(B000023: 51200); depth:1]
+  000024:[kfz@1#7202,SET-ljm@1#8000,SET] seqnums:[7202-8000] points:[kfz@1#7202,SET-ljm@1#8000,SET] size:13066 blobrefs:[(B000025: 51136); depth:1]
+  000026:[ljn@1#8001,SET-mnb@1#8800,SET] seqnums:[8001-8800] points:[ljn@1#8001,SET-mnb@1#8800,SET] size:13074 blobrefs:[(B000027: 51200); depth:1]
+  000028:[mnc@1#8801,SET-nqr@1#9600,SET] seqnums:[8801-9600] points:[mnc@1#8801,SET-nqr@1#9600,SET] size:13058 blobrefs:[(B000029: 51200); depth:1]
+  000030:[nqs@1#9601,SET-ouf@1#10399,SET] seqnums:[9601-10399] points:[nqs@1#9601,SET-ouf@1#10399,SET] size:13066 blobrefs:[(B000031: 51136); depth:1]
+  000032:[oug@1#10400,SET-pxv@1#11199,SET] seqnums:[10400-11199] points:[oug@1#10400,SET-pxv@1#11199,SET] size:13066 blobrefs:[(B000033: 51200); depth:1]
+  000034:[pxw@1#11200,SET-rbi@1#11998,SET] seqnums:[11200-11998] points:[pxw@1#11200,SET-rbi@1#11998,SET] size:13106 blobrefs:[(B000035: 51136); depth:1]
+  000036:[rbj@1#11999,SET-sey@1#12798,SET] seqnums:[11999-12798] points:[rbj@1#11999,SET-sey@1#12798,SET] size:13066 blobrefs:[(B000037: 51200); depth:1]
+  000038:[sez@1#12799,SET-tim@1#13597,SET] seqnums:[12799-13597] points:[sez@1#12799,SET-tim@1#13597,SET] size:13066 blobrefs:[(B000039: 51136); depth:1]
+  000040:[tin@1#13598,SET-umb@1#14397,SET] seqnums:[13598-14397] points:[tin@1#13598,SET-umb@1#14397,SET] size:13074 blobrefs:[(B000041: 51200); depth:1]
+  000042:[umc@1#14398,SET-vpr@1#15197,SET] seqnums:[14398-15197] points:[umc@1#14398,SET-vpr@1#15197,SET] size:13058 blobrefs:[(B000043: 51200); depth:1]
+  000044:[vps@1#15198,SET-wtf@1#15996,SET] seqnums:[15198-15996] points:[vps@1#15198,SET-wtf@1#15996,SET] size:13074 blobrefs:[(B000045: 51136); depth:1]
+  000046:[wtg@1#15997,SET-xwv@1#16796,SET] seqnums:[15997-16796] points:[wtg@1#15997,SET-xwv@1#16796,SET] size:13066 blobrefs:[(B000047: 51200); depth:1]
+  000048:[xww@1#16797,SET-zai@1#17595,SET] seqnums:[16797-17595] points:[xww@1#16797,SET-zai@1#17595,SET] size:13090 blobrefs:[(B000049: 51136); depth:1]
+  000050:[zaj@1#17596,SET-zzz@1#18287,SET] seqnums:[17596-18287] points:[zaj@1#17596,SET-zzz@1#18287,SET] size:11391 blobrefs:[(B000051: 44288); depth:1]
 Blob files:
-  B000006 physical:{000006 size:[1704578 (1.6MB)] vals:[1642240 (1.6MB)]}
-  B000008 physical:{000008 size:[1704776 (1.6MB)] vals:[1642432 (1.6MB)]}
-  B000010 physical:{000010 size:[1705238 (1.6MB)] vals:[1642880 (1.6MB)]}
-  B000012 physical:{000012 size:[1704776 (1.6MB)] vals:[1642432 (1.6MB)]}
-  B000014 physical:{000014 size:[1702730 (1.6MB)] vals:[1640448 (1.6MB)]}
-  B000016 physical:{000016 size:[1704644 (1.6MB)] vals:[1642304 (1.6MB)]}
-  B000018 physical:{000018 size:[1707970 (1.6MB)] vals:[1645504 (1.6MB)]}
-  B000020 physical:{000020 size:[1702994 (1.6MB)] vals:[1640704 (1.6MB)]}
-  B000022 physical:{000022 size:[1705172 (1.6MB)] vals:[1642816 (1.6MB)]}
-  B000024 physical:{000024 size:[1703918 (1.6MB)] vals:[1641600 (1.6MB)]}
-  B000026 physical:{000026 size:[1703390 (1.6MB)] vals:[1641088 (1.6MB)]}
-  B000028 physical:{000028 size:[1704182 (1.6MB)] vals:[1641856 (1.6MB)]}
-  B000030 physical:{000030 size:[1702796 (1.6MB)] vals:[1640512 (1.6MB)]}
-  B000032 physical:{000032 size:[1703720 (1.6MB)] vals:[1641408 (1.6MB)]}
-  B000034 physical:{000034 size:[1706584 (1.6MB)] vals:[1644160 (1.6MB)]}
-  B000036 physical:{000036 size:[1703720 (1.6MB)] vals:[1641408 (1.6MB)]}
-  B000038 physical:{000038 size:[1706254 (1.6MB)] vals:[1643840 (1.6MB)]}
-  B000040 physical:{000040 size:[1707508 (1.6MB)] vals:[1645056 (1.6MB)]}
-  B000042 physical:{000042 size:[886008 (865KB)] vals:[853568 (834KB)]}
+  B000007 physical:{000007 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000009 physical:{000009 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000011 physical:{000011 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000013 physical:{000013 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000015 physical:{000015 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000017 physical:{000017 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000019 physical:{000019 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000021 physical:{000021 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000023 physical:{000023 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000025 physical:{000025 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000027 physical:{000027 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000029 physical:{000029 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000031 physical:{000031 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000033 physical:{000033 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000035 physical:{000035 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000037 physical:{000037 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000039 physical:{000039 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000041 physical:{000041 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000043 physical:{000043 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000045 physical:{000045 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000047 physical:{000047 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000049 physical:{000049 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000051 physical:{000051 size:[46028 (45KB)] vals:[44288 (43KB)]}
 
 # Manual compaction of key range so we merge files instead of moving.
 # This compaction should write data to L6. The resulting sstables will
@@ -559,44 +567,50 @@ Blob files:
 compact a-zzzz
 ----
 L6:
-  000044:[a@1#0,SET-czms@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-czms@1#0,SET] size:715164 blobrefs:[(B000006: 1642240), (B000008: 1642432), (B000010: 201984); depth:1]
-  000045:[czmt@1#0,SET-fyxn@1#0,SET] seqnums:[0-0] points:[czmt@1#0,SET-fyxn@1#0,SET] size:718513 blobrefs:[(B000010: 1440896), (B000012: 1642432), (B000014: 399936); depth:1]
-  000046:[fyxo@1#0,SET-iykr@1#0,SET] seqnums:[0-0] points:[fyxo@1#0,SET-iykr@1#0,SET] size:714466 blobrefs:[(B000014: 1240512), (B000016: 1642304), (B000018: 604544); depth:1]
-  000047:[iyks@1#0,SET-lxxi@1#0,SET] seqnums:[0-0] points:[iyks@1#0,SET-lxxi@1#0,SET] size:715380 blobrefs:[(B000018: 1040960), (B000020: 1640704), (B000022: 804800); depth:1]
-  000048:[lxxj@1#0,SET-oxiv@1#0,SET] seqnums:[0-0] points:[lxxj@1#0,SET-oxiv@1#0,SET] size:716841 blobrefs:[(B000022: 838016), (B000024: 1641600), (B000026: 1004864); depth:1]
-  000049:[oxiw@1#0,SET-rwta@1#0,SET] seqnums:[0-0] points:[oxiw@1#0,SET-rwta@1#0,SET] size:719227 blobrefs:[(B000026: 636224), (B000028: 1641856), (B000030: 1204160); depth:1]
-  000050:[rwtb@1#0,SET-uwen@1#0,SET] seqnums:[0-0] points:[rwtb@1#0,SET-uwen@1#0,SET] size:717372 blobrefs:[(B000030: 436352), (B000032: 1641408), (B000034: 1406720); depth:1]
-  000051:[uweo@1#0,SET-xvqm@1#0,SET] seqnums:[0-0] points:[uweo@1#0,SET-xvqm@1#0,SET] size:716617 blobrefs:[(B000034: 237440), (B000036: 1641408), (B000038: 1606400); depth:1]
-  000052:[xvqn@1#0,SET-zzzz@1#0,SET] seqnums:[0-0] points:[xvqn@1#0,SET-zzzz@1#0,SET] size:521015 blobrefs:[(B000038: 37440), (B000040: 1645056), (B000042: 853568); depth:1]
+  000052:[a@1#0,SET-ckw@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-ckw@1#0,SET] size:23075 blobrefs:[(B000007: 51136), (B000009: 51136), (B000011: 6592); depth:1]
+  000053:[ckx@1#0,SET-ewd@1#0,SET] seqnums:[0-0] points:[ckx@1#0,SET-ewd@1#0,SET] size:22411 blobrefs:[(B000011: 44544), (B000013: 51136), (B000015: 13824); depth:1]
+  000054:[ewe@1#0,SET-hgu@1#0,SET] seqnums:[0-0] points:[ewe@1#0,SET-hgu@1#0,SET] size:23198 blobrefs:[(B000015: 37312), (B000017: 51136), (B000019: 19968); depth:1]
+  000055:[hgv@1#0,SET-js@1#0,SET] seqnums:[0-0] points:[hgv@1#0,SET-js@1#0,SET] size:22537 blobrefs:[(B000019: 31168), (B000021: 51136), (B000023: 27072); depth:1]
+  000056:[jsa@1#0,SET-mcx@1#0,SET] seqnums:[0-0] points:[jsa@1#0,SET-mcx@1#0,SET] size:23069 blobrefs:[(B000023: 24128), (B000025: 51136), (B000027: 33600); depth:1]
+  000057:[mcy@1#0,SET-onw@1#0,SET] seqnums:[0-0] points:[mcy@1#0,SET-onw@1#0,SET] size:23016 blobrefs:[(B000027: 17600), (B000029: 51200), (B000031: 40128); depth:1]
+  000058:[onx@1#0,SET-qyv@1#0,SET] seqnums:[0-0] points:[onx@1#0,SET-qyv@1#0,SET] size:22975 blobrefs:[(B000031: 11008), (B000033: 51200), (B000035: 46720); depth:1]
+  000059:[qyw@1#0,SET-tjs@1#0,SET] seqnums:[0-0] points:[qyw@1#0,SET-tjs@1#0,SET] size:23087 blobrefs:[(B000035: 4416), (B000037: 51200), (B000039: 51136), (B000041: 2112); depth:1]
+  000060:[tjt@1#0,SET-vuj@1#0,SET] seqnums:[0-0] points:[tjt@1#0,SET-vuj@1#0,SET] size:23493 blobrefs:[(B000041: 49088), (B000043: 51200), (B000045: 8128); depth:1]
+  000061:[vuk@1#0,SET-yez@1#0,SET] seqnums:[0-0] points:[vuk@1#0,SET-yez@1#0,SET] size:23510 blobrefs:[(B000045: 43008), (B000047: 51200), (B000049: 14144); depth:1]
+  000062:[yf@1#0,SET-zzz@1#0,SET] seqnums:[0-0] points:[yf@1#0,SET-zzz@1#0,SET] size:17753 blobrefs:[(B000049: 36992), (B000051: 44288); depth:1]
 Blob files:
-  B000006 physical:{000006 size:[1704578 (1.6MB)] vals:[1642240 (1.6MB)]}
-  B000008 physical:{000008 size:[1704776 (1.6MB)] vals:[1642432 (1.6MB)]}
-  B000010 physical:{000010 size:[1705238 (1.6MB)] vals:[1642880 (1.6MB)]}
-  B000012 physical:{000012 size:[1704776 (1.6MB)] vals:[1642432 (1.6MB)]}
-  B000014 physical:{000014 size:[1702730 (1.6MB)] vals:[1640448 (1.6MB)]}
-  B000016 physical:{000016 size:[1704644 (1.6MB)] vals:[1642304 (1.6MB)]}
-  B000018 physical:{000018 size:[1707970 (1.6MB)] vals:[1645504 (1.6MB)]}
-  B000020 physical:{000020 size:[1702994 (1.6MB)] vals:[1640704 (1.6MB)]}
-  B000022 physical:{000022 size:[1705172 (1.6MB)] vals:[1642816 (1.6MB)]}
-  B000024 physical:{000024 size:[1703918 (1.6MB)] vals:[1641600 (1.6MB)]}
-  B000026 physical:{000026 size:[1703390 (1.6MB)] vals:[1641088 (1.6MB)]}
-  B000028 physical:{000028 size:[1704182 (1.6MB)] vals:[1641856 (1.6MB)]}
-  B000030 physical:{000030 size:[1702796 (1.6MB)] vals:[1640512 (1.6MB)]}
-  B000032 physical:{000032 size:[1703720 (1.6MB)] vals:[1641408 (1.6MB)]}
-  B000034 physical:{000034 size:[1706584 (1.6MB)] vals:[1644160 (1.6MB)]}
-  B000036 physical:{000036 size:[1703720 (1.6MB)] vals:[1641408 (1.6MB)]}
-  B000038 physical:{000038 size:[1706254 (1.6MB)] vals:[1643840 (1.6MB)]}
-  B000040 physical:{000040 size:[1707508 (1.6MB)] vals:[1645056 (1.6MB)]}
-  B000042 physical:{000042 size:[886008 (865KB)] vals:[853568 (834KB)]}
+  B000007 physical:{000007 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000009 physical:{000009 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000011 physical:{000011 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000013 physical:{000013 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000015 physical:{000015 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000017 physical:{000017 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000019 physical:{000019 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000021 physical:{000021 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000023 physical:{000023 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000025 physical:{000025 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000027 physical:{000027 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000029 physical:{000029 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000031 physical:{000031 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000033 physical:{000033 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000035 physical:{000035 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000037 physical:{000037 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000039 physical:{000039 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000041 physical:{000041 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000043 physical:{000043 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000045 physical:{000045 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000047 physical:{000047 size:[53204 (52KB)] vals:[51200 (50KB)]}
+  B000049 physical:{000049 size:[53138 (52KB)] vals:[51136 (50KB)]}
+  B000051 physical:{000051 size:[46028 (45KB)] vals:[44288 (43KB)]}
 
 
 excise-dryrun b c
 ----
 would excise 1 files.
-  del-table:     L6 000044
-  add-table:     L6 000053(000044):[a@1#0,SET-azzz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azzz@1#0,SET] size:242560(715164) blobrefs:[(B000006: 556993), (B000008: 557058), (B000010: 68506); depth:1]
-  add-table:     L6 000054(000044):[c@1#0,SET-czms@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-czms@1#0,SET] size:230320(715164) blobrefs:[(B000006: 528886), (B000008: 528948), (B000010: 65049); depth:1]
-  add-backing:   000044
+  del-table:     L6 000052
+  add-table:     L6 000063(000052):[a@1#0,SET-azz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azz@1#0,SET] size:11748(23075) blobrefs:[(B000007: 26034), (B000009: 26034), (B000011: 3356); depth:1]
+  add-table:     L6 000064(000052):[c@1#0,SET-ckw@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-ckw@1#0,SET] size:6302(23075) blobrefs:[(B000007: 13965), (B000009: 13965), (B000011: 1800); depth:1]
+  add-backing:   000052
 
 
 # Test a value separation policy that is configured to only separate values ≥


### PR DESCRIPTION
The runtime for the top-level package tests has been creeping up. This is an assorted set of small adjustments to improve the running time.

#### db: make TestCompaction/l0_to_lbase_compaction faster

This test took ~1s, now it takes 0.06s.

#### db: make TestCompaction/value_separation faster

This test was taking ~1s, now it's under 0.1s.

#### db: reduce TestOpenCloseOpenClose configurations

This saves about 0.5s.

#### db: remove duplicate TestFileCacheClockPro

The genericcache code already has this test.

#### db: reduce numOps in TestWALFailoverRandomized

This reduces run time from 4s to ~1.5s on average.

#### db: reduce numOps in TestWALHardCrashRandomized

This reduces the average run time from ~4s to ~0.5s.