### PR TITLE
Revert "cache: use malloc instead of calloc"

### DIFF
--- a/internal/cache/value.go
+++ b/internal/cache/value.go
@@ -59,7 +59,7 @@ func Alloc(n int) *Value {
 
 	if valueEntryCanBeGoAllocated && valueEntryGoAllocated {
 		// Note: if cgo is not enabled, manual.New will do a regular Go allocation.
-		b := manual.NewUninitialized(manual.BlockCacheData, uintptr(n))
+		b := manual.New(manual.BlockCacheData, uintptr(n))
 		v := &Value{buf: b.Slice()}
 		v.ref.init(1)
 		// Note: this is a no-op if invariants and tracing are disabled or race is
@@ -77,10 +77,7 @@ func Alloc(n int) *Value {
 	// When we're not performing leak detection, the lifetime of the returned
 	// Value is exactly the lifetime of the backing buffer and we can manually
 	// allocate both.
-	b := manual.NewUninitialized(manual.BlockCacheData, ValueMetadataSize+uintptr(n))
-	// We must clear the slice because Value contains pointers. See
-	// manual.NewUninitialized.
-	clear(b.Slice()[:ValueMetadataSize])
+	b := manual.New(manual.BlockCacheData, ValueMetadataSize+uintptr(n))
 	v := (*Value)(b.Data())
 	v.buf = b.Slice()[ValueMetadataSize:]
 	v.ref.init(1)

--- a/internal/manual/manual_nocgo.go
+++ b/internal/manual/manual_nocgo.go
@@ -15,9 +15,7 @@ import (
 // Provides versions of New and Free when cgo is not available (e.g. cross
 // compilation).
 
-// New allocates a slice of size n. The returned slice is from manually managed
-// memory and MUST be released by calling Free. Failure to do so will result in
-// a memory leak.
+// New allocates a slice of size n.
 func New(purpose Purpose, n uintptr) Buf {
 	if n == 0 {
 		return Buf{}
@@ -28,17 +26,6 @@ func New(purpose Purpose, n uintptr) Buf {
 		data: unsafe.Pointer(unsafe.SliceData(slice)),
 		n:    n,
 	}
-}
-
-// NewUninitialized allocates a slice of size n without zeroing it out. The
-// returned slice is from manually managed memory and MUST be released by
-// calling Free. Failure to do so will result in a memory leak (see
-// https://github.com/golang/go/issues/19928).
-//
-// If the caller does an unsafe cast from the slice to any type containing
-// pointers, the relevant part of the slice *must* be zeroed out.
-func NewUninitialized(purpose Purpose, n uintptr) Buf {
-	return New(purpose, n)
 }
 
 // Free frees the specified slice. It has to be exactly the slice that was


### PR DESCRIPTION
This reverts commit dd58b8432fe899bfeeb55feb3ee76cf9d129b0e0.

The pebble ycsb benchmarks show a regression around the time this commit was merged. A comparison of the CPU profiles before and after show ~5.32% time in _Cfunc_calloc before and ~12.10% time in _cgo_cmalloc after.