### PR TITLE
colblk: remove BlockDecoder allocation

### DIFF
--- a/cockroachkvs/cockroachkvs.go
+++ b/cockroachkvs/cockroachkvs.go
@@ -498,7 +498,7 @@ var KeySchema = colblk.KeySchema{
 	NewKeyWriter: func() colblk.KeyWriter {
 		return makeCockroachKeyWriter()
 	},
-	InitKeySeekerMetadata: func(meta *colblk.KeySeekerMetadata, d *colblk.DataBlockDecoder, bd *colblk.BlockDecoder) {
+	InitKeySeekerMetadata: func(meta *colblk.KeySeekerMetadata, d *colblk.DataBlockDecoder, bd colblk.BlockDecoder) {
 		ks := (*cockroachKeySeeker)(unsafe.Pointer(meta))
 		ks.init(d, bd)
 	},
@@ -747,7 +747,7 @@ var _ uint = colblk.KeySeekerMetadataSize - uint(unsafe.Sizeof(cockroachKeySeeke
 
 var _ colblk.KeySeeker = (*cockroachKeySeeker)(nil)
 
-func (ks *cockroachKeySeeker) init(d *colblk.DataBlockDecoder, bd *colblk.BlockDecoder) {
+func (ks *cockroachKeySeeker) init(d *colblk.DataBlockDecoder, bd colblk.BlockDecoder) {
 	ks.roachKeys = bd.PrefixBytes(cockroachColRoachKey)
 	ks.roachKeyChanged = d.PrefixChanged()
 	ks.mvccWallTimes = bd.Uints(cockroachColMVCCWallTime)

--- a/cockroachkvs/cockroachkvs_test.go
+++ b/cockroachkvs/cockroachkvs_test.go
@@ -204,7 +204,7 @@ func TestKeySchema_KeySeeker(t *testing.T) {
 	var buf bytes.Buffer
 	var enc colblk.DataBlockEncoder
 	var dec colblk.DataBlockDecoder
-	var bd *colblk.BlockDecoder
+	var bd colblk.BlockDecoder
 	var ks colblk.KeySeeker
 	var maxKeyLen int
 	enc.Init(&KeySchema)

--- a/sstable/colblk/data_block_test.go
+++ b/sstable/colblk/data_block_test.go
@@ -29,7 +29,7 @@ func TestDataBlock(t *testing.T) {
 	var buf bytes.Buffer
 	var w DataBlockEncoder
 	var r DataBlockDecoder
-	var bd *BlockDecoder
+	var bd BlockDecoder
 	var v DataBlockValidator
 	var it DataBlockIter
 	rw := NewDataBlockRewriter(&testKeysSchema, testkeys.Comparer.EnsureDefaults())


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble/sstable/colblk
cpu: Apple M1 Pro
                        │   old.txt   │               new.txt               │
                        │   sec/op    │   sec/op     vs base                │
DataBlockDecoderInit-10   94.53n ± 0%   82.12n ± 0%  -13.13% (p=0.000 n=25)

                        │  old.txt   │              new.txt               │
                        │    B/op    │   B/op     vs base                 │
DataBlockDecoderInit-10   48.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=25)

                        │  old.txt   │               new.txt               │
                        │ allocs/op  │ allocs/op   vs base                 │
DataBlockDecoderInit-10   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=25)
```

Fix https://github.com/cockroachdb/pebble/issues/5339.