### PR TITLE
cache: don't mark blocks as accessed for background work

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -858,7 +858,7 @@ func TestMemTableReservation(t *testing.T) {
 		t.Fatalf("expected 2 refs, but found %d", refs)
 	}
 	// Verify the memtable reservation has caused our test block to be evicted.
-	if cv := tmpHandle.Get(base.DiskFileNum(0), 0); cv != nil {
+	if cv := tmpHandle.Peek(base.DiskFileNum(0), 0); cv != nil {
 		t.Fatalf("expected failure, but found success: %#v", cv)
 	}
 

--- a/internal/cache/read_shard_test.go
+++ b/internal/cache/read_shard_test.go
@@ -50,7 +50,7 @@ func newTestReader(
 }
 
 func (r *testReader) getAsync(shard *shard) *string {
-	v, re := shard.getWithMaybeReadEntry(r.key, true /* desireReadEntry */)
+	v, re := shard.getWithReadEntry(r.key)
 	if v != nil {
 		str := string(v.RawBuffer())
 		v.Release()

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -366,7 +366,7 @@ func (r *Reader) Read(
 	// reading a block.
 	if r.opts.CacheOpts.CacheHandle == nil || env.BufferPool != nil {
 		if r.opts.CacheOpts.CacheHandle != nil {
-			if cv := r.opts.CacheOpts.CacheHandle.Get(r.opts.CacheOpts.FileNum, bh.Offset); cv != nil {
+			if cv := r.opts.CacheOpts.CacheHandle.Peek(r.opts.CacheOpts.FileNum, bh.Offset); cv != nil {
 				recordCacheHit(ctx, env, readHandle, bh, kind)
 				return CacheBufferHandle(cv), nil
 			}
@@ -528,12 +528,13 @@ func (r *Reader) Readable() objstorage.Readable {
 	return r.readable
 }
 
-// GetFromCache retrieves the block from the cache, if it is present.
+// GetFromCache retrieves the block from the cache, if it is present. It does
+// not mark the block as recently used.
 //
 // Users should prefer using Read, which handles reading from object storage on
 // a cache miss.
 func (r *Reader) GetFromCache(bh Handle) *cache.Value {
-	return r.opts.CacheOpts.CacheHandle.Get(r.opts.CacheOpts.FileNum, bh.Offset)
+	return r.opts.CacheOpts.CacheHandle.Peek(r.opts.CacheOpts.FileNum, bh.Offset)
 }
 
 // UsePreallocatedReadHandle returns a ReadHandle that reads from the reader and


### PR DESCRIPTION
We don't want block cache hits for compactions to cause the respective
block to stay in the cache longer (in fact, it is about to become
obsolete). This change adds a `Peek()` method to the block cache which
is like `Get()` but does not mark the block as recently accessed.