### PR TITLE
arenaskl: use pointer comparison to avoid key comparison

### DIFF
--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -387,8 +387,18 @@ func (s *Skiplist) findSplice(key base.InternalKey, ins *Inserter) (found bool) 
 	for level = level - 1; level >= 0; level-- {
 		for {
 			// Assume prev.key < key.
-			next = s.getNext(prev, level)
-			if next == s.tail {
+			nextInLevel := s.getNext(prev, level)
+			// next is currently set to the previous level's `next`, the first
+			// node whose key is ≥ `key` within the previous level. If
+			// nextInLevel's equals the last level's `next`, then `next` is also
+			// the first node whose is key ≥ `key` within this level as well.
+			//
+			// This pointer comparison avoids an extra key comparison.
+			if nextInLevel == next {
+				break
+			}
+			next = nextInLevel
+			if nextInLevel == s.tail {
 				// Tail node, so done.
 				break
 			} else if next == nil {


### PR DESCRIPTION
When inserting a new node into the memtable skiplist, we must determine which
nodes within the skiplist will be to the left and right of the new node. When
computing this "slice" we descend to each level, moving along the level until
we find a key greater than the one we're inserting.

Our skiplist implementation has a max height of 20, so we must consider at most
20 levels. With each additional level, the probability a node existing at that
level increases by the inverse of Euler's number (> 36%). It's not unlikely
that one node may point to the same node on consecutive levels of the skiplist.

This commit adapts the splice-finding code to take advantage of this porperty
by checking for pointer equality between next nodes of consecutive levels. If
we observe a pointer to a node at height h and we already recorded the node as
'next' within the splice at height h+1, we can elide the key comparison.

```
goos: linux
goarch: amd64
pkg: github.com/cockroachdb/pebble/internal/arenaskl
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                      │     a.txt     │               c.txt                │
                      │    sec/op     │    sec/op     vs base              │
ReadWrite/frac_0-24      247.1n ±  2%   236.6n ±  1%  -4.23% (p=0.002 n=6)
ReadWrite/frac_10-24     233.8n ±  1%   225.5n ±  1%  -3.53% (p=0.002 n=6)
ReadWrite/frac_20-24     219.7n ±  1%   211.9n ±  0%  -3.55% (p=0.002 n=6)
ReadWrite/frac_30-24     206.7n ±  1%   199.0n ±  1%  -3.70% (p=0.002 n=6)
ReadWrite/frac_40-24     192.2n ±  1%   183.8n ±  2%  -4.37% (p=0.002 n=6)
ReadWrite/frac_50-24     176.2n ±  1%   169.2n ±  2%  -3.97% (p=0.002 n=6)
ReadWrite/frac_60-24     163.0n ±  2%   157.1n ±  2%  -3.62% (p=0.002 n=6)
ReadWrite/frac_70-24     143.7n ±  3%   140.7n ±  4%  -2.09% (p=0.015 n=6)
ReadWrite/frac_80-24     124.6n ±  4%   121.7n ±  6%  -2.37% (p=0.048 n=6)
ReadWrite/frac_90-24    101.81n ±  6%   93.70n ±  4%  -7.97% (p=0.026 n=6)
ReadWrite/frac_100-24    10.41n ± 22%   10.45n ± 57%       ~ (p=0.818 n=6)
OrderedWrite-24          101.5n ±  0%   101.0n ±  0%  -0.54% (p=0.004 n=6)
geomean                  132.0n         127.6n        -3.32%
```