### PR TITLE
cockroachkvs: avoid cockroachKeysSeeker.init allocation

### DIFF
--- a/cockroachkvs/cockroachkvs.go
+++ b/cockroachkvs/cockroachkvs.go
@@ -747,12 +747,20 @@ var _ uint = colblk.KeySeekerMetadataSize - uint(unsafe.Sizeof(cockroachKeySeeke
 
 var _ colblk.KeySeeker = (*cockroachKeySeeker)(nil)
 
-func (ks *cockroachKeySeeker) init(d *colblk.DataBlockDecoder, bd colblk.BlockDecoder) {
-	ks.roachKeys = bd.PrefixBytes(cockroachColRoachKey)
+func (ks *cockroachKeySeeker) init(
+	d *colblk.DataBlockDecoder,
+	//gcassert:noescape
+	bd colblk.BlockDecoder,
+) {
+	// Note that we call DecodeColumn directly rather than using the
+	// BlockDecoder's type-specific convenience methods (e.g. PrefixBytes,
+	// Uints, etc) to avoid bd from escaping to the heap.
+	rows := int(bd.Rows())
+	ks.roachKeys = colblk.DecodeColumn(&bd, cockroachColRoachKey, rows, colblk.DataTypePrefixBytes, colblk.DecodePrefixBytes)
 	ks.roachKeyChanged = d.PrefixChanged()
-	ks.mvccWallTimes = bd.Uints(cockroachColMVCCWallTime)
-	ks.mvccLogical = bd.Uints(cockroachColMVCCLogical)
-	ks.untypedVersions = bd.RawBytes(cockroachColUntypedVersion)
+	ks.mvccWallTimes = colblk.DecodeColumn(&bd, cockroachColMVCCWallTime, rows, colblk.DataTypeUint, colblk.DecodeUnsafeUints)
+	ks.mvccLogical = colblk.DecodeColumn(&bd, cockroachColMVCCLogical, rows, colblk.DataTypeUint, colblk.DecodeUnsafeUints)
+	ks.untypedVersions = colblk.DecodeColumn(&bd, cockroachColUntypedVersion, rows, colblk.DataTypeBytes, colblk.DecodeRawBytes)
 	header := bd.Header()
 	header = header[:len(header)-colblk.DataBlockCustomHeaderSize]
 	if len(header) != 1 {


### PR DESCRIPTION
The change in https://github.com/cockroachdb/pebble/pull/5345 prevented BlockDecoder from escaping to the heap when using
the testkeys.KeySchema, but with the cockroachkvs.KeySchema the key seeker init
func's local BlockDecoder still escaped. This commit updates the key seeker to
call colblk.DecodeColumn directly, which is enough for the Go compiler to avoid
moving the arg to the heap.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble/cockroachkvs
cpu: Apple M1 Pro
                         │   old.txt   │              new.txt               │
                         │   sec/op    │   sec/op     vs base               │
InitDataBlockMetadata-10   135.5n ± 1%   110.8n ± 0%  -18.20% (p=0.002 n=6)

                         │  old.txt   │              new.txt              │
                         │    B/op    │   B/op     vs base                │
InitDataBlockMetadata-10   48.00 ± 0%   0.00 ± 0%  -100.00% (p=0.002 n=6)

                         │  old.txt   │              new.txt               │
                         │ allocs/op  │ allocs/op   vs base                │
InitDataBlockMetadata-10   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
```