### PR TITLE
pebble: deflake  TestCompactionDeleteOnlyHints

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2603,6 +2603,7 @@ func (d *DB) compact(c compaction, errChannel chan error) {
 		func() {
 			d.mu.Lock()
 			defer d.mu.Unlock()
+			d.mu.compact.compactProcesses++
 			jobID := d.newJobIDLocked()
 
 			compactErr := c.Execute(jobID, d)
@@ -2655,6 +2656,7 @@ func (d *DB) compact(c compaction, errChannel chan error) {
 			d.mu.Lock()
 			defer d.mu.Unlock()
 			d.maybeScheduleCompaction()
+			d.mu.compact.compactProcesses--
 			d.mu.compact.cond.Broadcast()
 		}()
 	})

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1688,7 +1688,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 
 	compactInfo = nil
 	compactionString := func() string {
-		for d.mu.compact.compactingCount > 0 {
+		for d.mu.compact.compactingCount > 0 || d.mu.compact.compactProcesses > 0 {
 			d.mu.compact.cond.Wait()
 		}
 		slices.SortFunc(compactInfo, func(a, b CompactionInfo) int {

--- a/db.go
+++ b/db.go
@@ -418,6 +418,12 @@ type DB struct {
 			flushing bool
 			// The number of ongoing non-download compactions.
 			compactingCount int
+			// The number of calls to compact that have not yet finished. This is different
+			// from compactingCount, as calls to compact will attempt to schedule and run
+			// follow-up compactions after the current compaction finishes, dropping db.mu
+			// in between updating compactingCount and the scheduling operation. This value is
+			// used in tests in order to track when all compaction activity has finished.
+			compactProcesses int
 			// The number of download compactions.
 			downloadingCount int
 			// The list of deletion hints, suggesting ranges for delete-only


### PR DESCRIPTION
maybe-compact was previously waiting on compactingCount to be 0 before reading the collected compaction info. This observation was flaky, as compactingCount is updated just before another call to `maybeScheduleCompaction`, with the mutex being dropped in between.

Now, we observe both `compactingCount` and a new field, `compactProcesses`, which track the number of calls to compact which still need to perform the compaction scheduling step.

Fixes: #5351