### PR TITLE
wal: validate recovery directory through a stable identifier

### DIFF
--- a/open_test.go
+++ b/open_test.go
@@ -256,6 +256,9 @@ func TestOpen_WALFailover(t *testing.T) {
 			if o.FS == nil {
 				return "no path"
 			}
+			// Set a constant identifier for testing to avoid flaky tests
+			wal.SetGenerateStableIdentifierForTesting("9f69f2c3ffb3c247767290a9b3215fc5")
+			defer wal.ResetGenerateStableIdentifierForTesting()
 			d, err := Open(dataDir, o)
 			if err != nil {
 				return err.Error()

--- a/testdata/open_wal_failover
+++ b/testdata/open_wal_failover
@@ -46,6 +46,7 @@ list path=(a,data)
 grep-between path=(a,data/OPTIONS-000007) start=(\[WAL Failover\]) end=^$
 ----
   secondary_dir=secondary-wals
+  secondary_identifier=9f69f2c3ffb3c247767290a9b3215fc5
   primary_dir_probe_interval=1s
   healthy_probe_latency_threshold=25ms
   healthy_interval=15s

--- a/wal/standalone_manager.go
+++ b/wal/standalone_manager.go
@@ -257,6 +257,11 @@ func (m *StandaloneManager) Close() error {
 	return err
 }
 
+// Opts implements Manager.
+func (m *StandaloneManager) Opts() Options {
+	return m.o
+}
+
 // RecyclerForTesting implements Manager.
 func (m *StandaloneManager) RecyclerForTesting() *LogRecycler {
 	return &m.recycler

--- a/wal/testdata/manager_failover
+++ b/wal/testdata/manager_failover
@@ -42,6 +42,7 @@ ok
 list-fs
 ----
 pri/000001.log
+sec/failover_identifier
 sec/failover_source
 
 create-writer wal-num=2
@@ -60,6 +61,7 @@ list-fs
 ----
 pri/000001.log
 pri/000002.log
+sec/failover_identifier
 sec/failover_source
 
 close-manager
@@ -359,6 +361,7 @@ list-fs
 pri/000001-002.log
 pri/000002.log
 sec/000001-001.log
+sec/failover_identifier
 sec/failover_source
 
 # Test with dampening of switching based on latency and secondary errors.
@@ -424,6 +427,7 @@ now: 77ms
 
 list-fs
 ----
+sec/failover_identifier
 sec/failover_source
 
 # Wait until monitor sees the error and switches back to primary.
@@ -550,6 +554,7 @@ list-fs
 pri/000001-002.log
 pri/000001-004.log
 pri/000001.log
+sec/failover_identifier
 sec/failover_source
 
 # Test failback after primary is healthy.
@@ -673,6 +678,7 @@ list-fs
 pri/000001-002.log
 pri/probe-file
 sec/000001-001.log
+sec/failover_identifier
 sec/failover_source
 
 # Test that if UnhealthyOperationLatencyThreshold says not to allow failovers
@@ -714,4 +720,5 @@ ok
 
 list-fs
 ----
+sec/failover_identifier
 sec/failover_source

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -101,6 +101,11 @@ type Options struct {
 	// Secondary is used for failover. Optional. It must already be created and
 	// synced up to the root.
 	Secondary Dir
+	// SecondaryIdentifier is a stable UUID that uniquely identifies the secondary
+	// directory. This identifier is persisted both in the OPTIONS file and in a
+	// file within the secondary directory to detect when the wrong disk has been
+	// mounted at the expected path during recovery.
+	SecondaryIdentifier string
 
 	// MinUnflushedLogNum is the smallest WAL number corresponding to
 	// mutations that have not been flushed to a sstable.
@@ -365,6 +370,8 @@ type Manager interface {
 	// Close the manager.
 	// REQUIRES: Writers and Readers have already been closed.
 	Close() error
+	// Opts returns the Options used to initialize the Manager.
+	Opts() Options
 
 	// RecyclerForTesting exposes the internal LogRecycler.
 	RecyclerForTesting() *LogRecycler

--- a/wal_failover_identifier_test.go
+++ b/wal_failover_identifier_test.go
@@ -1,0 +1,185 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/pebble/wal"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWALFailoverIdentifier tests the WAL failover identifier mechanism, which
+// ensures that the correct secondary WAL directory is being used during database
+// recovery. The identifier is a unique string stored in a "failover_identifier"
+// file in the secondary WAL directory that helps prevent accidental use of the
+// wrong secondary directory (e.g., when the wrong disk is mounted).
+//
+// The test covers three scenarios:
+//  1. first_time_generation: when opening a database with WAL failover for the
+//     first time, a new identifier should be generated and written to both the
+//     secondary directory and the OPTIONS file
+//  2. identifier_mismatch_error: when the secondary directory contains a
+//     different identifier than what's expected in the options, the database
+//     should fail to open with an error indicating the wrong disk may be mounted
+//  3. no_primary_has_secondary: when no identifier is specified in options but
+//     the secondary directory already contains an identifier, the database should
+//     adopt the existing identifier and write it to the OPTIONS file
+func TestWALFailoverIdentifier(t *testing.T) {
+	t.Run("first_time_generation", func(t *testing.T) {
+		mem := vfs.NewMem()
+
+		// First time opening with WAL failover should generate an identifier.
+		opts := &Options{
+			FS: mem,
+			WALFailover: &WALFailoverOptions{
+				Secondary: wal.Dir{Dirname: "secondary", FS: mem},
+			},
+		}
+
+		db, err := Open("testdb", opts)
+		require.NoError(t, err, "failed to open database")
+		defer db.Close()
+
+		// Check that identifier file exists in secondary directory.
+		identifierFile := mem.PathJoin("secondary", "failover_identifier")
+		failoverId, err := mem.Open(identifierFile)
+		require.NoError(t, err)
+
+		// Read the identifier from the file.
+		defer failoverId.Close()
+		data := make([]byte, 100)
+		n, err := failoverId.Read(data)
+		if err != nil && err != io.EOF {
+			t.Fatalf("failed to read identifier file: %v", err)
+		}
+
+		identifier := strings.TrimSpace(string(data[:n]))
+		require.True(t, identifier != "", "expected identifier to be written to file")
+		t.Logf("identifier from failover_identifier file: %q", identifier)
+
+		// Check that the identifier is written to the OPTIONS file.
+		entries, err := mem.List("testdb")
+		require.NoError(t, err, "failed to list testdb directory")
+		var optionsFile string
+		for _, entry := range entries {
+			if strings.HasPrefix(entry, "OPTIONS-") {
+				optionsFile = mem.PathJoin("testdb", entry)
+				break
+			}
+		}
+		require.NotEmpty(t, optionsFile, "OPTIONS file should exist")
+
+		optionsF, err := mem.Open(optionsFile)
+		require.NoError(t, err, "failed to open OPTIONS file")
+		defer optionsF.Close()
+
+		optionsData, err := io.ReadAll(optionsF)
+		require.NoError(t, err, "failed to read OPTIONS file")
+
+		optionsContent := string(optionsData)
+		// Verify the OPTIONS file contains the [WAL Failover] section with the
+		// identifier we found in the failover_identifier above.
+		require.Contains(t, optionsContent, "[WAL Failover]",
+			"OPTIONS file should contain WAL Failover section")
+		require.Contains(t, optionsContent, "secondary_identifier="+identifier,
+			"OPTIONS file should contain the generated identifier")
+	})
+
+	t.Run("identifier_mismatch_error", func(t *testing.T) {
+		mem := vfs.NewMem()
+		secondaryDir := "secondary"
+		err := mem.MkdirAll(secondaryDir, 0755)
+		require.NoError(t, err)
+
+		// Create a secondary directory with a different identifier.
+		identifierFile := mem.PathJoin("secondary", "failover_identifier")
+		existingIdentifier := "44444444444444444444444444444444"
+		err = writeTestIdentifier(mem, identifierFile, existingIdentifier)
+		require.NoError(t, err)
+
+		// Try to open with a different identifier in options.
+		opts := &Options{
+			FS: mem,
+			WALFailover: &WALFailoverOptions{
+				Secondary:           wal.Dir{Dirname: "secondary", FS: mem},
+				SecondaryIdentifier: "7f495fb4914ecfc04deeafa41de42b78",
+			},
+		}
+
+		_, err = Open("testdb", opts)
+		require.Error(t, err, "expected error due to identifier mismatch")
+		require.Contains(t, err.Error(), "wrong disk may be mounted")
+	})
+
+	t.Run("no_primary_has_secondary", func(t *testing.T) {
+		// Test case: no identifier in primary options, secondary has identifier
+		// The system should adopt the existing identifier from the secondary directory.
+		mem := vfs.NewMem()
+		identifierFile := mem.PathJoin("secondary", "failover_identifier")
+		err := mem.MkdirAll("secondary", 0755)
+		require.NoError(t, err)
+
+		// Write an existing identifier to the secondary directory.
+		existingIdentifier := "44444444444444444444444444444444"
+		err = writeTestIdentifier(mem, identifierFile, existingIdentifier)
+		require.NoError(t, err)
+
+		// Open without specifying SecondaryIdentifier in options.
+		opts := &Options{
+			FS: mem,
+			WALFailover: &WALFailoverOptions{
+				Secondary: wal.Dir{Dirname: "secondary", FS: mem},
+			},
+		}
+
+		db, err := Open("testdb", opts)
+		require.NoError(t, err, "should succeed and adopt the existing identifier")
+		defer db.Close()
+
+		// Verify that the OPTIONS file now contains the adopted identifier.
+		entries, err := mem.List("testdb")
+		require.NoError(t, err, "failed to list testdb directory")
+		var optionsFile string
+		for _, entry := range entries {
+			if strings.HasPrefix(entry, "OPTIONS-") {
+				optionsFile = mem.PathJoin("testdb", entry)
+				break
+			}
+		}
+		require.NotEmpty(t, optionsFile, "OPTIONS file should exist")
+
+		optionsF, err := mem.Open(optionsFile)
+		require.NoError(t, err, "failed to open OPTIONS file")
+		defer optionsF.Close()
+
+		optionsData, err := io.ReadAll(optionsF)
+		require.NoError(t, err, "failed to read OPTIONS file")
+
+		optionsContent := string(optionsData)
+		require.Contains(t, optionsContent, "[WAL Failover]",
+			"OPTIONS file should contain WAL Failover section")
+		require.Contains(t, optionsContent, "secondary_identifier="+existingIdentifier,
+			"OPTIONS file should contain the adopted identifier")
+	})
+}
+
+func writeTestIdentifier(fs vfs.FS, filename, identifier string) error {
+	f, err := fs.Create(filename, "pebble-wal")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.WriteString(f, identifier)
+	if err != nil {
+		return err
+	}
+
+	return f.Sync()
+}


### PR DESCRIPTION
We now persist a stable identifier to both the OPTIONS file and a file within the secondary directory (failover_identifier). If recovery finds that the secondary directory does not contain a matching identifier, we abort recovery indicating that the secondary seems incorrect / corrupt.

Fixes: #4416