### PR TITLE
db: fix TestCleanupManagerCloseWithPacing

### DIFF
--- a/obsolete_files_test.go
+++ b/obsolete_files_test.go
@@ -145,8 +145,9 @@ func TestCleaner(t *testing.T) {
 func TestCleanupManagerCloseWithPacing(t *testing.T) {
 	mem := vfs.NewMem()
 	opts := &Options{
-		FS:                     mem,
-		TargetByteDeletionRate: 1024, // 1 KB/s - slow pacing
+		FS:                      mem,
+		FreeSpaceThresholdBytes: 1,
+		TargetByteDeletionRate:  1024, // 1 KB/s - slow pacing
 	}
 	opts.EnsureDefaults()
 
@@ -160,6 +161,7 @@ func TestCleanupManagerCloseWithPacing(t *testing.T) {
 	getDeletePacerInfo := func() deletionPacerInfo {
 		return deletionPacerInfo{
 			freeBytes: 10 << 30,
+			liveBytes: 10 << 30,
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #5348.

This test is ineffective because the `FreeSpaceThresholdBytes` option disables pacing. Fix by setting that option to 1 byte.

We also remove the extra checking of `stopCh` - if it is closed, we will exit the pacing loop right away so there's no need for this special check.