### PR TITLE
tool: add `db inspect manifest` subcommand

### DIFF
--- a/tool/testdata/db_inspect
+++ b/tool/testdata/db_inspect
@@ -1,0 +1,29 @@
+db inspect
+----
+----
+
+Inspect the DB internals without opening the DB.
+
+Usage:
+   db inspect [command]
+
+Available Commands:
+  manifest    Return the manifest filename
+
+Flags:
+  -h, --help   help for inspect
+
+Global Flags:
+  -v, --verbose   verbose output
+
+Use " db inspect [command] --help" for more information about a command.
+----
+----
+
+db inspect manifest
+----
+accepts 1 arg(s), received 0
+
+db inspect manifest ../testdata/db-stage-4
+----
+db-stage-4/MANIFEST-000006


### PR DESCRIPTION
Add a subcommand that finds the active manifest's filename (according to the atomic marker) and returns it. This can be composed with the `manifest` subcommands to examine the current manifest without manually finding the manifest files and determining which is current.

Informs #5353.