### PR TITLE
sstable: track value separation policy props used

### DIFF
--- a/replay/testdata/corpus/simple_val_sep
+++ b/replay/testdata/corpus/simple_val_sep
@@ -103,6 +103,6 @@ stat simple_val_sep/MANIFEST-000013 simple_val_sep/000015.sst simple_val_sep/000
 simple_val_sep/MANIFEST-000013:
   size: 250
 simple_val_sep/000015.sst:
-  size: 760
+  size: 802
 simple_val_sep/000016.blob:
   size: 97

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -5,14 +5,14 @@ tree
 ----
           /
             build/
-     787      000005.sst
+     829      000005.sst
      101      000006.blob
-     766      000008.sst
+     808      000008.sst
       97      000009.blob
       92      000011.log
-     660      000012.sst
+     707      000012.sst
       63      000014.log
-     760      000015.sst
+     802      000015.sst
       97      000016.blob
        0      LOCK
      152      MANIFEST-000010
@@ -21,16 +21,16 @@ tree
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
-     760      000015.sst
+     802      000015.sst
       97      000016.blob
      250      MANIFEST-000013
               checkpoint/
-     787        000005.sst
+     829        000005.sst
      101        000006.blob
-     766        000008.sst
+     808        000008.sst
       97        000009.blob
       11        000011.log
-     660        000012.sst
+     707        000012.sst
      187        MANIFEST-000013
     2947        OPTIONS-000003
        0        marker.format-version.000001.024

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -1272,6 +1272,12 @@ func (w *RawColumnWriter) copyProperties(props Properties) {
 	w.props.IndexType = 0
 }
 
+// SetValueSeparationProps implements RawWriter.
+func (w *RawColumnWriter) SetValueSeparationProps(kind ValueSeparationKind, minValueSize uint64) {
+	w.props.ValueSeparationKind = uint8(kind)
+	w.props.ValueSeparationMinSize = minValueSize
+}
+
 // IsLikelyMVCCGarbage determines whether the given user key is likely MVCC
 // garbage.
 //

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -122,6 +122,13 @@ type Properties struct {
 	// The compression statistics encoded as a string. The format is:
 	// "<setting1>:<compressed1>/<uncompressed1>,<setting2>:<compressed2>/<uncompressed2>,..."
 	CompressionStats string `prop:"pebble.compression_stats"`
+	// The value separation policy that was used when writing this sstable.
+	// This indicates how values were handled during writing (separated into
+	// blob files, preserved references, or kept in-place). See ValueSeparationKind type
+	// for possible values.
+	ValueSeparationKind uint8 `prop:"pebble.value-separation.kind"`
+	// The minimum size a value must be to be separated into a blob file during writing.
+	ValueSeparationMinSize uint64 `prop:"pebble.value-separation.min-size"`
 	// User collected properties. Currently, we only use them to store block
 	// properties aggregated at the table level.
 	UserProperties map[string]string
@@ -223,6 +230,28 @@ func (p *Properties) toAttributes() Attributes {
 
 	return attributes
 }
+
+// ValueSeparationKind indicates the value separation policy that was used
+// when writing an sstable.
+type ValueSeparationKind uint8
+
+const (
+	// ValueSeparationNone indicates that no value separation was used.
+	// All values are stored in-place within the sstable.
+	ValueSeparationNone ValueSeparationKind = iota
+
+	// ValueSeparationDefault indicates that values were separated into
+	// new blob files during writing.
+	ValueSeparationDefault
+
+	// ValueSeparationSpanPolicy indicates that values were separated
+	// based on a span policy during writing.
+	ValueSeparationSpanPolicy
+
+	// ValueSeparationPreservedRefs indicates that existing blob references
+	// were preserved without creating new blob files.
+	ValueSeparationPreservedRefs
+)
 
 var (
 	singleZeroSlice = []byte{0x00}

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -1966,6 +1966,11 @@ func (w *RawRowWriter) setFilter(fw filterWriter) {
 	w.filter = fw
 }
 
+// SetValueSeparationProps implements RawWriter.
+func (w *RawRowWriter) SetValueSeparationProps(_kind ValueSeparationKind, _minValueSize uint64) {
+	// Value separation requires TableFormatPebblev7+ which uses column writers.
+}
+
 // SetSnapshotPinnedProperties sets the properties for pinned keys. Should only
 // be used internally by Pebble.
 func (w *RawRowWriter) SetSnapshotPinnedProperties(

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -362,6 +362,10 @@ type RawWriter interface {
 	// Must not be called after Writer is closed.
 	IsPrefixEqualPrev(k []byte) bool
 
+	// SetValueSeparationProps sets the value separation props that were used when
+	// writing this sstable. This is recorded in the sstable properties.
+	SetValueSeparationProps(kind ValueSeparationKind, minValueSize uint64)
+
 	// rewriteSuffixes rewrites the table's data blocks to all contain the
 	// provided suffix. It's specifically used for the implementation of
 	// RewriteKeySuffixesAndReturnFormat. See that function's documentation for

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -1055,9 +1055,9 @@ close: checkpoints/checkpoint8/000004.log
 scan checkpoints/checkpoint8
 ----
 open: checkpoints/checkpoint8/000005.sst (options: *vfs.randomReadsOption)
-read-at(735, 61): checkpoints/checkpoint8/000005.sst
-read-at(658, 77): checkpoints/checkpoint8/000005.sst
-read-at(197, 461): checkpoints/checkpoint8/000005.sst
+read-at(785, 61): checkpoints/checkpoint8/000005.sst
+read-at(708, 77): checkpoints/checkpoint8/000005.sst
+read-at(197, 511): checkpoints/checkpoint8/000005.sst
 read-at(131, 41): checkpoints/checkpoint8/000005.sst
 read-at(0, 131): checkpoints/checkpoint8/000005.sst
 open: checkpoints/checkpoint8/000006.blob (options: *vfs.randomReadsOption)
@@ -1165,9 +1165,9 @@ close: checkpoints/checkpoint9/000007.log
 scan checkpoints/checkpoint9
 ----
 open: checkpoints/checkpoint9/000005.sst (options: *vfs.randomReadsOption)
-read-at(735, 61): checkpoints/checkpoint9/000005.sst
-read-at(658, 77): checkpoints/checkpoint9/000005.sst
-read-at(197, 461): checkpoints/checkpoint9/000005.sst
+read-at(785, 61): checkpoints/checkpoint9/000005.sst
+read-at(708, 77): checkpoints/checkpoint9/000005.sst
+read-at(197, 511): checkpoints/checkpoint9/000005.sst
 read-at(131, 41): checkpoints/checkpoint9/000005.sst
 read-at(0, 131): checkpoints/checkpoint9/000005.sst
 open: checkpoints/checkpoint9/000006.blob (options: *vfs.randomReadsOption)

--- a/testdata/compaction/backing_value_size
+++ b/testdata/compaction/backing_value_size
@@ -13,15 +13,15 @@ set c coconut
 compact a-b
 ----
 L6:
-  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:767 blobrefs:[(B000006: 18); depth:1]
+  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:809 blobrefs:[(B000006: 18); depth:1]
 Blob files:
   B000006 physical:{000006 size:[194 (194B)] vals:[18 (18B)]}
 
 excise b ba
 ----
 L6:
-  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(767) blobrefs:[(B000006: 2/18); depth:1]
-  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(767) blobrefs:[(B000006: 2/18); depth:1]
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(809) blobrefs:[(B000006: 2/18); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(809) blobrefs:[(B000006: 2/18); depth:1]
 Blob files:
   B000006 physical:{000006 size:[194 (194B)] vals:[18 (18B)]}
 

--- a/testdata/compaction/compaction_cancellation
+++ b/testdata/compaction/compaction_cancellation
@@ -34,7 +34,7 @@ manual compaction cancelled: context canceled, current queued compactions: 0
 # One compaction was done.
 compaction-log
 ----
-[JOB 1] compacted(move) L2 [000004] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L2 [000004] (705B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000004] (705B), in 1.0s (1.0s total), output rate 705B/s
 
 compact a-z L2 parallel
 ----
@@ -45,8 +45,8 @@ L3:
 
 compaction-log sort
 ----
-[JOB 1] compacted(move) L2 [000005] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000005] (680B), in 1.0s (1.0s total), output rate 680B/s
-[JOB 1] compacted(move) L2 [000006] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000006] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L2 [000005] (705B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000005] (705B), in 1.0s (1.0s total), output rate 705B/s
+[JOB 1] compacted(move) L2 [000006] (705B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000006] (705B), in 1.0s (1.0s total), output rate 705B/s
 
 # Repeat with only blocking the last of the three manual compactions.
 add-ongoing-compaction startLevel=3 outputLevel=4 start=g end=h
@@ -59,5 +59,5 @@ manual compaction cancelled: context canceled, current queued compactions: 0
 # Two compactions were done.
 compaction-log
 ----
-[JOB 1] compacted(move) L3 [000004] (680B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
-[JOB 1] compacted(move) L3 [000005] (680B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000005] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L3 [000004] (705B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000004] (705B), in 1.0s (1.0s total), output rate 705B/s
+[JOB 1] compacted(move) L3 [000005] (705B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000005] (705B), in 1.0s (1.0s total), output rate 705B/s

--- a/testdata/compaction/mvcc_garbage_blob
+++ b/testdata/compaction/mvcc_garbage_blob
@@ -19,7 +19,7 @@ set zoo@1 bah
 flush
 ----
 L0.0:
-  000005:[yay@3#10,SET-zoo@1#16,SET] seqnums:[10-16] points:[yay@3#10,SET-zoo@1#16,SET] size:827 blobrefs:[(B000006: 10); depth:1]
+  000005:[yay@3#10,SET-zoo@1#16,SET] seqnums:[10-16] points:[yay@3#10,SET-zoo@1#16,SET] size:869 blobrefs:[(B000006: 10); depth:1]
 Blob files:
   B000006 physical:{000006 size:[102 (102B)] vals:[10 (10B)]}
 
@@ -31,16 +31,16 @@ set yuumi@1 ba
 flush
 ----
 L0.1:
-  000008:[yuumi@2#17,DEL-yuumi@1#18,SET] seqnums:[17-18] points:[yuumi@2#17,DEL-yuumi@1#18,SET] size:707
+  000008:[yuumi@2#17,DEL-yuumi@1#18,SET] seqnums:[17-18] points:[yuumi@2#17,DEL-yuumi@1#18,SET] size:745
 L0.0:
-  000005:[yay@3#10,SET-zoo@1#16,SET] seqnums:[10-16] points:[yay@3#10,SET-zoo@1#16,SET] size:827 blobrefs:[(B000006: 10); depth:1]
+  000005:[yay@3#10,SET-zoo@1#16,SET] seqnums:[10-16] points:[yay@3#10,SET-zoo@1#16,SET] size:869 blobrefs:[(B000006: 10); depth:1]
 Blob files:
   B000006 physical:{000006 size:[102 (102B)] vals:[10 (10B)]}
 
 flush-log
 ----
-[JOB 1] flushed 1 memtable (100B) to L0 [000005] (827B) blob [000006 (MVCCGarbage: 100%)] (102B), in 1.0s (1.0s total), output rate 827B/s
-[JOB 1] flushed 1 memtable (100B) to L0 [000008] (707B), in 1.0s (1.0s total), output rate 707B/s
+[JOB 1] flushed 1 memtable (100B) to L0 [000005] (869B) blob [000006 (MVCCGarbage: 100%)] (102B), in 1.0s (1.0s total), output rate 869B/s
+[JOB 1] flushed 1 memtable (100B) to L0 [000008] (745B), in 1.0s (1.0s total), output rate 745B/s
 
 batch
 set yay@3 a
@@ -51,15 +51,15 @@ set yuumi@1 poiandyaya
 flush
 ----
 L0.2:
-  000010:[yay@3#19,SET-yuumi@1#21,SET] seqnums:[19-21] points:[yay@3#19,SET-yuumi@1#21,SET] size:795 blobrefs:[(B000011: 12); depth:1]
+  000010:[yay@3#19,SET-yuumi@1#21,SET] seqnums:[19-21] points:[yay@3#19,SET-yuumi@1#21,SET] size:837 blobrefs:[(B000011: 12); depth:1]
 L0.1:
-  000008:[yuumi@2#17,DEL-yuumi@1#18,SET] seqnums:[17-18] points:[yuumi@2#17,DEL-yuumi@1#18,SET] size:707
+  000008:[yuumi@2#17,DEL-yuumi@1#18,SET] seqnums:[17-18] points:[yuumi@2#17,DEL-yuumi@1#18,SET] size:745
 L0.0:
-  000005:[yay@3#10,SET-zoo@1#16,SET] seqnums:[10-16] points:[yay@3#10,SET-zoo@1#16,SET] size:827 blobrefs:[(B000006: 10); depth:1]
+  000005:[yay@3#10,SET-zoo@1#16,SET] seqnums:[10-16] points:[yay@3#10,SET-zoo@1#16,SET] size:869 blobrefs:[(B000006: 10); depth:1]
 Blob files:
   B000006 physical:{000006 size:[102 (102B)] vals:[10 (10B)]}
   B000011 physical:{000011 size:[102 (102B)] vals:[12 (12B)]}
 
 flush-log
 ----
-[JOB 1] flushed 1 memtable (100B) to L0 [000010] (795B) blob [000011 (MVCCGarbage: 17%)] (102B), in 1.0s (1.0s total), output rate 795B/s
+[JOB 1] flushed 1 memtable (100B) to L0 [000010] (837B) blob [000011 (MVCCGarbage: 17%)] (102B), in 1.0s (1.0s total), output rate 837B/s

--- a/testdata/compaction/score_compaction_picked_before_manual
+++ b/testdata/compaction/score_compaction_picked_before_manual
@@ -15,7 +15,7 @@ L6:
 # compaction.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (680B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L5 [000004] (705B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (705B), in 1.0s (1.0s total), output rate 705B/s
 
 # Do an auto score-based compaction with the same LSM as the previous test.
 define disable-multi-level lbase-max-bytes=1 auto-compactions=off
@@ -33,7 +33,7 @@ L6:
 # Note the score is > 1.0 since these is a score-based compaction.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (680B) Score=944.44 + L6 [] (0B) Score=0.00 -> L6 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L5 [000004] (705B) Score=952.70 + L6 [] (0B) Score=0.00 -> L6 [000004] (705B), in 1.0s (1.0s total), output rate 705B/s
 
 # With the same LSM as the previous test, try to do both a manual and
 # score-based compaction. The score-based compaction runs first.
@@ -64,4 +64,4 @@ set-disable-auto-compact v=true
 # The score-based compaction ran first.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (680B) Score=944.44 + L6 [] (0B) Score=0.00 -> L6 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L5 [000004] (705B) Score=952.70 + L6 [] (0B) Score=0.00 -> L6 [000004] (705B), in 1.0s (1.0s total), output rate 705B/s

--- a/testdata/compaction/set_with_del_sstable_Pebblev5
+++ b/testdata/compaction/set_with_del_sstable_Pebblev5
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1324
+range-deletions-bytes-estimate: 1374
 compression: None:79
 
 compact a-e L1
@@ -107,7 +107,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 662
+range-deletions-bytes-estimate: 687
 compression: None:87,Snappy:76/87
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.

--- a/testdata/compaction/set_with_del_sstable_Pebblev6
+++ b/testdata/compaction/set_with_del_sstable_Pebblev6
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1358
+range-deletions-bytes-estimate: 1408
 compression: None:79
 
 compact a-e L1
@@ -107,7 +107,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 679
+range-deletions-bytes-estimate: 704
 compression: None:87,Snappy:76/87
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.

--- a/testdata/compaction/set_with_del_sstable_Pebblev7
+++ b/testdata/compaction/set_with_del_sstable_Pebblev7
@@ -88,7 +88,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 1322
+range-deletions-bytes-estimate: 1376
 compression: None:79
 
 compact a-e L1
@@ -107,7 +107,7 @@ num-entries: 2
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 661
+range-deletions-bytes-estimate: 688
 compression: None:87,Snappy:76/87
 
 # Same as above, except range tombstone covers multiple grandparent file boundaries.

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -12,7 +12,7 @@ set b 2
 compact a-b
 ----
 L6:
-  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:754 blobrefs:[(B000006: 2); depth:1]
+  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:796 blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
 
@@ -24,11 +24,37 @@ set d 4
 compact c-d
 ----
 L6:
-  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:754 blobrefs:[(B000006: 2); depth:1]
-  000008:[c#12,SET-d#13,SET] seqnums:[12-13] points:[c#12,SET-d#13,SET] size:754 blobrefs:[(B000009: 2); depth:1]
+  000005:[a#10,SET-b#11,SET] seqnums:[10-11] points:[a#10,SET-b#11,SET] size:796 blobrefs:[(B000006: 2); depth:1]
+  000008:[c#12,SET-d#13,SET] seqnums:[12-13] points:[c#12,SET-d#13,SET] size:796 blobrefs:[(B000009: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
   B000009 physical:{000009 size:[92 (92B)] vals:[2 (2B)]}
+
+
+sstable-properties file=000005
+----
+rocksdb.num.entries: 2
+rocksdb.raw.key.size: 18
+rocksdb.raw.value.size: 2
+rocksdb.deleted.keys: 0
+rocksdb.num.range-deletions: 0
+rocksdb.num.data.blocks: 1
+rocksdb.comparator: leveldb.BytewiseComparator
+rocksdb.data.size: 91
+rocksdb.filter.size: 0
+rocksdb.index.size: 36
+rocksdb.block.based.table.index.type: 0
+pebble.colblk.schema: DefaultKeySchema(leveldb.BytewiseComparator,16)
+rocksdb.merge.operator: pebble.concatenate
+rocksdb.merge.operands: 0
+pebble.num.values.in.blob-files: 2
+rocksdb.property.collectors: [obsolete-key]
+rocksdb.compression: Snappy
+pebble.compression_stats: None:56,Snappy:86/114
+pebble.value-separation.kind: 1
+pebble.value-separation.min-size: 1
+obsolete-key: hex:00
+
 
 batch
 set b 5
@@ -38,7 +64,7 @@ set c 6
 compact a-d
 ----
 L6:
-  000013:[a#0,SET-d#0,SET] seqnums:[0-0] points:[a#0,SET-d#0,SET] size:792 blobrefs:[(B000006: 1), (B000012: 2), (B000009: 1); depth:2]
+  000013:[a#0,SET-d#0,SET] seqnums:[0-0] points:[a#0,SET-d#0,SET] size:819 blobrefs:[(B000006: 1), (B000012: 2), (B000009: 1); depth:2]
 Blob files:
   B000006 physical:{000006 size:[92 (92B)] vals:[2 (2B)]}
   B000009 physical:{000009 size:[92 (92B)] vals:[2 (2B)]}
@@ -64,7 +90,7 @@ L6 blob-depth=3
   z.SET.0:blob{fileNum=100004 value=zoo}
 ----
 L6:
-  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:794 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:821 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
   B100003 physical:{100003 size:[92 (92B)] vals:[3 (3B)]}
@@ -80,9 +106,9 @@ set e world
 flush
 ----
 L0.0:
-  000006:[d#10,SET-e#11,SET] seqnums:[10-11] points:[d#10,SET-e#11,SET] size:753 blobrefs:[(B000007: 10); depth:1]
+  000006:[d#10,SET-e#11,SET] seqnums:[10-11] points:[d#10,SET-e#11,SET] size:795 blobrefs:[(B000007: 10); depth:1]
 L6:
-  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:794 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:821 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B000007 physical:{000007 size:[100 (100B)] vals:[10 (10B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -95,7 +121,7 @@ Blob files:
 compact a-z
 ----
 L6:
-  000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:804 blobrefs:[(B000009: 19); depth:1]
+  000008:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:854 blobrefs:[(B000009: 19); depth:1]
 Blob files:
   B000009 physical:{000009 size:[112 (112B)] vals:[19 (19B)]}
 
@@ -124,23 +150,23 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 23.24
-   L6       916B |      1  804B |      0     0 |   112B     0B |   753B |      0    0B |   1  1.22
+   L0         0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 24.27
+   L6       966B |      1  854B |      0     0 |   112B     0B |   795B |      0    0B |   1  1.22
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       916B |      1  804B |      0     0 |   112B     0B |    41B |      0    0B |   1 46.59
+total       966B |      1  854B |      0     0 |   112B     0B |    41B |      0    0B |   1 48.83
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      1   753B   200B
-   L1 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
-   L2 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
-   L3 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
-   L4 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
-   L5 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   372B   84B |      1   804B   112B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      1   795B   200B
+   L1 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
+   L2 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
+   L3 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
+   L4 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
+   L5 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   372B   84B |      1   854B   112B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      5 3.7KB |    0B    0B    0B |   372B   84B |      2  1.6KB   312B
+total |     -     -     - |      5 3.9KB |    0B    0B    0B |   372B   84B |      2  1.7KB   312B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     5     0     0        0     0      0     0       0
@@ -213,7 +239,7 @@ set yaya yaya
 flush
 ----
 L0.0:
-  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:683
+  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:730
 
 batch
 set a a
@@ -228,9 +254,9 @@ set w world
 flush
 ----
 L0.1:
-  000007:[a#14,SET-w#17,SET] seqnums:[14-17] points:[a#14,SET-w#17,SET] size:782 blobrefs:[(B000008: 10); depth:1]
+  000007:[a#14,SET-w#17,SET] seqnums:[14-17] points:[a#14,SET-w#17,SET] size:824 blobrefs:[(B000008: 10); depth:1]
 L0.0:
-  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:683
+  000005:[bar#10,SET-yaya#13,SET] seqnums:[10-13] points:[bar#10,SET-yaya#13,SET] size:730
 Blob files:
   B000008 physical:{000008 size:[100 (100B)] vals:[10 (10B)]}
 
@@ -266,7 +292,7 @@ flush
 ----
 L0.0:
   000005:[a#10,SET-d#13,SET] seqnums:[10-13] points:[a#10,SET-d#13,SET] size:704
-  000006:[m#14,SET-m#14,SET] seqnums:[14-14] points:[m#14,SET-m#14,SET] size:750 blobrefs:[(B000007: 5); depth:1]
+  000006:[m#14,SET-m#14,SET] seqnums:[14-14] points:[m#14,SET-m#14,SET] size:792 blobrefs:[(B000007: 5); depth:1]
 Blob files:
   B000007 physical:{000007 size:[94 (94B)] vals:[5 (5B)]}
 
@@ -286,9 +312,9 @@ L0 blob-depth=3
   z.SET.1:blob{fileNum=100004 value=zoo}
 ----
 L0.1:
-  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:763 blobrefs:[(B100001: 1); depth:1]
+  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:790 blobrefs:[(B100001: 1); depth:1]
 L0.0:
-  000005:[a#1,SET-z#1,SET] seqnums:[1-1] points:[a#1,SET-z#1,SET] size:794 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000005:[a#1,SET-z#1,SET] seqnums:[1-1] points:[a#1,SET-z#1,SET] size:821 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -298,12 +324,35 @@ Blob files:
 compact a-z
 ----
 L1:
-  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:813 blobrefs:[(B100002: 3), (B100001: 1), (B100003: 3), (B100004: 3); depth:4]
+  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:840 blobrefs:[(B100002: 3), (B100001: 1), (B100003: 3), (B100004: 3); depth:4]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
   B100003 physical:{100003 size:[92 (92B)] vals:[3 (3B)]}
   B100004 physical:{100004 size:[92 (92B)] vals:[3 (3B)]}
+
+sstable-properties file=000006
+----
+rocksdb.num.entries: 6
+rocksdb.raw.key.size: 54
+rocksdb.raw.value.size: 12
+rocksdb.deleted.keys: 0
+rocksdb.num.range-deletions: 0
+rocksdb.num.data.blocks: 1
+rocksdb.comparator: leveldb.BytewiseComparator
+rocksdb.data.size: 143
+rocksdb.filter.size: 0
+rocksdb.index.size: 36
+rocksdb.block.based.table.index.type: 0
+pebble.colblk.schema: DefaultKeySchema(leveldb.BytewiseComparator,16)
+rocksdb.merge.operator: pebble.concatenate
+rocksdb.merge.operands: 0
+pebble.num.values.in.blob-files: 4
+rocksdb.property.collectors: [obsolete-key]
+rocksdb.compression: Snappy
+pebble.compression_stats: None:209
+pebble.value-separation.kind: 3
+obsolete-key: hex:00
 
 # Construct an initial state with two non-overlapping files in L0, both with
 # blob references. Because these files do NOT overlap and are in the same
@@ -322,8 +371,8 @@ L0 blob-depth=3
   z.SET.1:blob{fileNum=100004 value=zoo}
 ----
 L0.0:
-  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:763 blobrefs:[(B100001: 1); depth:1]
-  000005:[e#1,SET-z#1,SET] seqnums:[1-1] points:[e#1,SET-z#1,SET] size:794 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000004:[a#9,SET-d#9,SET] seqnums:[9-9] points:[a#9,SET-d#9,SET] size:790 blobrefs:[(B100001: 1); depth:1]
+  000005:[e#1,SET-z#1,SET] seqnums:[1-1] points:[e#1,SET-z#1,SET] size:821 blobrefs:[(B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -333,7 +382,7 @@ Blob files:
 compact a-z
 ----
 L1:
-  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:817 blobrefs:[(B100001: 1), (B100002: 3), (B100003: 3), (B100004: 3); depth:3]
+  000006:[a#0,SET-z#0,SET] seqnums:[0-0] points:[a#0,SET-z#0,SET] size:844 blobrefs:[(B100001: 1), (B100002: 3), (B100003: 3), (B100004: 3); depth:3]
 Blob files:
   B100001 physical:{100001 size:[90 (90B)] vals:[1 (1B)]}
   B100002 physical:{100002 size:[92 (92B)] vals:[3 (3B)]}
@@ -362,7 +411,7 @@ set h honeydew
 flush
 ----
 L0.0:
-  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:827 blobrefs:[(B000006: 60); depth:1]
+  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:877 blobrefs:[(B000006: 60); depth:1]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
 
@@ -375,9 +424,9 @@ set c cherry
 flush
 ----
 L0.1:
-  000008:[c#18,SET-c#18,SET] seqnums:[18-18] points:[c#18,SET-c#18,SET] size:750 blobrefs:[(B000009: 6); depth:1]
+  000008:[c#18,SET-c#18,SET] seqnums:[18-18] points:[c#18,SET-c#18,SET] size:792 blobrefs:[(B000009: 6); depth:1]
 L0.0:
-  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:827 blobrefs:[(B000006: 60); depth:1]
+  000005:[a#10,SET-h#17,SET] seqnums:[10-17] points:[a#10,SET-h#17,SET] size:877 blobrefs:[(B000006: 60); depth:1]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -388,7 +437,7 @@ Blob files:
 compact a-b
 ----
 L6:
-  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:805 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
+  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:832 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
 Blob files:
   B000006 physical:{000006 size:[156 (156B)] vals:[60 (60B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -396,7 +445,7 @@ Blob files:
 auto-compact
 ----
 L6:
-  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:805 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
+  000010:[a#0,SET-h#0,SET] seqnums:[0-0] points:[a#0,SET-h#0,SET] size:832 blobrefs:[(B000006: 53), (B000009: 6); depth:2]
 Blob files:
   B000006 physical:{000011 size:[150 (150B)] vals:[53 (53B)]}
   B000009 physical:{000009 size:[95 (95B)] vals:[6 (6B)]}
@@ -407,18 +456,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   156B |      0    0B |   0 13.33
-   L6        1KB |      1  805B |      0     0 |   232B     0B |  1.5KB |      0    0B |   1  0.51
+   L0         0B |      0    0B |      0     0 |     0B     0B |   156B |      0    0B |   0 13.92
+   L6        1KB |      1  832B |      0     0 |   232B     0B |  1.6KB |      0    0B |   1  0.50
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total        1KB |      1  805B |      0     0 |   232B     0B |   156B |      0    0B |   1 19.49
+total        1KB |      1  832B |      0     0 |   232B     0B |   156B |      0    0B |   1 20.25
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.5KB   502B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   310B    0B |      1   805B     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.6KB   502B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   310B    0B |      1   832B     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   310B    0B |      3  2.5KB   502B
+total |     -     -     - |      0    0B |    0B    0B    0B |   310B    0B |      3  2.6KB   502B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     1       0
@@ -486,15 +535,15 @@ set c coconut
 compact a-b
 ----
 L6:
-  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:767 blobrefs:[(B000006: 18); depth:1]
+  000005:[a#10,SET-c#12,SET] seqnums:[10-12] points:[a#10,SET-c#12,SET] size:809 blobrefs:[(B000006: 18); depth:1]
 Blob files:
   B000006 physical:{000006 size:[109 (109B)] vals:[18 (18B)]}
 
 excise b ba
 ----
 L6:
-  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(767) blobrefs:[(B000006: 2); depth:1]
-  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(767) blobrefs:[(B000006: 2); depth:1]
+  000007(000005):[a#10,SET-a#10,SET] seqnums:[10-12] points:[a#10,SET-a#10,SET] size:104(809) blobrefs:[(B000006: 2); depth:1]
+  000008(000005):[c#12,SET-c#12,SET] seqnums:[10-12] points:[c#12,SET-c#12,SET] size:104(809) blobrefs:[(B000006: 2); depth:1]
 Blob files:
   B000006 physical:{000006 size:[109 (109B)] vals:[18 (18B)]}
 
@@ -529,29 +578,29 @@ wrote 18278 keys
 flush
 ----
 L0.0:
-  000006:[a@1#10,SET-bdm@1#808,SET] seqnums:[10-808] points:[a@1#10,SET-bdm@1#808,SET] size:13082 blobrefs:[(B000007: 51136); depth:1]
-  000008:[bdn@1#809,SET-cha@1#1607,SET] seqnums:[809-1607] points:[bdn@1#809,SET-cha@1#1607,SET] size:13082 blobrefs:[(B000009: 51136); depth:1]
-  000010:[chb@1#1608,SET-dkp@1#2406,SET] seqnums:[1608-2406] points:[chb@1#1608,SET-dkp@1#2406,SET] size:13066 blobrefs:[(B000011: 51136); depth:1]
-  000012:[dkq@1#2407,SET-eod@1#3205,SET] seqnums:[2407-3205] points:[dkq@1#2407,SET-eod@1#3205,SET] size:13090 blobrefs:[(B000013: 51136); depth:1]
-  000014:[eoe@1#3206,SET-frs@1#4004,SET] seqnums:[3206-4004] points:[eoe@1#3206,SET-frs@1#4004,SET] size:13066 blobrefs:[(B000015: 51136); depth:1]
-  000016:[frt@1#4005,SET-gvg@1#4803,SET] seqnums:[4005-4803] points:[frt@1#4005,SET-gvg@1#4803,SET] size:13082 blobrefs:[(B000017: 51136); depth:1]
-  000018:[gvh@1#4804,SET-hyv@1#5602,SET] seqnums:[4804-5602] points:[gvh@1#4804,SET-hyv@1#5602,SET] size:13074 blobrefs:[(B000019: 51136); depth:1]
-  000020:[hyw@1#5603,SET-jci@1#6401,SET] seqnums:[5603-6401] points:[hyw@1#5603,SET-jci@1#6401,SET] size:13106 blobrefs:[(B000021: 51136); depth:1]
-  000022:[jcj@1#6402,SET-kfy@1#7201,SET] seqnums:[6402-7201] points:[jcj@1#6402,SET-kfy@1#7201,SET] size:13066 blobrefs:[(B000023: 51200); depth:1]
-  000024:[kfz@1#7202,SET-ljm@1#8000,SET] seqnums:[7202-8000] points:[kfz@1#7202,SET-ljm@1#8000,SET] size:13066 blobrefs:[(B000025: 51136); depth:1]
-  000026:[ljn@1#8001,SET-mnb@1#8800,SET] seqnums:[8001-8800] points:[ljn@1#8001,SET-mnb@1#8800,SET] size:13074 blobrefs:[(B000027: 51200); depth:1]
-  000028:[mnc@1#8801,SET-nqr@1#9600,SET] seqnums:[8801-9600] points:[mnc@1#8801,SET-nqr@1#9600,SET] size:13058 blobrefs:[(B000029: 51200); depth:1]
-  000030:[nqs@1#9601,SET-ouf@1#10399,SET] seqnums:[9601-10399] points:[nqs@1#9601,SET-ouf@1#10399,SET] size:13066 blobrefs:[(B000031: 51136); depth:1]
-  000032:[oug@1#10400,SET-pxv@1#11199,SET] seqnums:[10400-11199] points:[oug@1#10400,SET-pxv@1#11199,SET] size:13066 blobrefs:[(B000033: 51200); depth:1]
-  000034:[pxw@1#11200,SET-rbi@1#11998,SET] seqnums:[11200-11998] points:[pxw@1#11200,SET-rbi@1#11998,SET] size:13106 blobrefs:[(B000035: 51136); depth:1]
-  000036:[rbj@1#11999,SET-sey@1#12798,SET] seqnums:[11999-12798] points:[rbj@1#11999,SET-sey@1#12798,SET] size:13066 blobrefs:[(B000037: 51200); depth:1]
-  000038:[sez@1#12799,SET-tim@1#13597,SET] seqnums:[12799-13597] points:[sez@1#12799,SET-tim@1#13597,SET] size:13066 blobrefs:[(B000039: 51136); depth:1]
-  000040:[tin@1#13598,SET-umb@1#14397,SET] seqnums:[13598-14397] points:[tin@1#13598,SET-umb@1#14397,SET] size:13074 blobrefs:[(B000041: 51200); depth:1]
-  000042:[umc@1#14398,SET-vpr@1#15197,SET] seqnums:[14398-15197] points:[umc@1#14398,SET-vpr@1#15197,SET] size:13058 blobrefs:[(B000043: 51200); depth:1]
-  000044:[vps@1#15198,SET-wtf@1#15996,SET] seqnums:[15198-15996] points:[vps@1#15198,SET-wtf@1#15996,SET] size:13074 blobrefs:[(B000045: 51136); depth:1]
-  000046:[wtg@1#15997,SET-xwv@1#16796,SET] seqnums:[15997-16796] points:[wtg@1#15997,SET-xwv@1#16796,SET] size:13066 blobrefs:[(B000047: 51200); depth:1]
-  000048:[xww@1#16797,SET-zai@1#17595,SET] seqnums:[16797-17595] points:[xww@1#16797,SET-zai@1#17595,SET] size:13090 blobrefs:[(B000049: 51136); depth:1]
-  000050:[zaj@1#17596,SET-zzz@1#18287,SET] seqnums:[17596-18287] points:[zaj@1#17596,SET-zzz@1#18287,SET] size:11391 blobrefs:[(B000051: 44288); depth:1]
+  000006:[a@1#10,SET-bdm@1#808,SET] seqnums:[10-808] points:[a@1#10,SET-bdm@1#808,SET] size:13124 blobrefs:[(B000007: 51136); depth:1]
+  000008:[bdn@1#809,SET-cha@1#1607,SET] seqnums:[809-1607] points:[bdn@1#809,SET-cha@1#1607,SET] size:13124 blobrefs:[(B000009: 51136); depth:1]
+  000010:[chb@1#1608,SET-dkp@1#2406,SET] seqnums:[1608-2406] points:[chb@1#1608,SET-dkp@1#2406,SET] size:13108 blobrefs:[(B000011: 51136); depth:1]
+  000012:[dkq@1#2407,SET-eod@1#3205,SET] seqnums:[2407-3205] points:[dkq@1#2407,SET-eod@1#3205,SET] size:13132 blobrefs:[(B000013: 51136); depth:1]
+  000014:[eoe@1#3206,SET-frs@1#4004,SET] seqnums:[3206-4004] points:[eoe@1#3206,SET-frs@1#4004,SET] size:13108 blobrefs:[(B000015: 51136); depth:1]
+  000016:[frt@1#4005,SET-gvg@1#4803,SET] seqnums:[4005-4803] points:[frt@1#4005,SET-gvg@1#4803,SET] size:13124 blobrefs:[(B000017: 51136); depth:1]
+  000018:[gvh@1#4804,SET-hyv@1#5602,SET] seqnums:[4804-5602] points:[gvh@1#4804,SET-hyv@1#5602,SET] size:13116 blobrefs:[(B000019: 51136); depth:1]
+  000020:[hyw@1#5603,SET-jci@1#6401,SET] seqnums:[5603-6401] points:[hyw@1#5603,SET-jci@1#6401,SET] size:13148 blobrefs:[(B000021: 51136); depth:1]
+  000022:[jcj@1#6402,SET-kfy@1#7201,SET] seqnums:[6402-7201] points:[jcj@1#6402,SET-kfy@1#7201,SET] size:13108 blobrefs:[(B000023: 51200); depth:1]
+  000024:[kfz@1#7202,SET-ljm@1#8000,SET] seqnums:[7202-8000] points:[kfz@1#7202,SET-ljm@1#8000,SET] size:13108 blobrefs:[(B000025: 51136); depth:1]
+  000026:[ljn@1#8001,SET-mnb@1#8800,SET] seqnums:[8001-8800] points:[ljn@1#8001,SET-mnb@1#8800,SET] size:13116 blobrefs:[(B000027: 51200); depth:1]
+  000028:[mnc@1#8801,SET-nqr@1#9600,SET] seqnums:[8801-9600] points:[mnc@1#8801,SET-nqr@1#9600,SET] size:13100 blobrefs:[(B000029: 51200); depth:1]
+  000030:[nqs@1#9601,SET-ouf@1#10399,SET] seqnums:[9601-10399] points:[nqs@1#9601,SET-ouf@1#10399,SET] size:13108 blobrefs:[(B000031: 51136); depth:1]
+  000032:[oug@1#10400,SET-pxv@1#11199,SET] seqnums:[10400-11199] points:[oug@1#10400,SET-pxv@1#11199,SET] size:13108 blobrefs:[(B000033: 51200); depth:1]
+  000034:[pxw@1#11200,SET-rbi@1#11998,SET] seqnums:[11200-11998] points:[pxw@1#11200,SET-rbi@1#11998,SET] size:13148 blobrefs:[(B000035: 51136); depth:1]
+  000036:[rbj@1#11999,SET-sey@1#12798,SET] seqnums:[11999-12798] points:[rbj@1#11999,SET-sey@1#12798,SET] size:13108 blobrefs:[(B000037: 51200); depth:1]
+  000038:[sez@1#12799,SET-tim@1#13597,SET] seqnums:[12799-13597] points:[sez@1#12799,SET-tim@1#13597,SET] size:13108 blobrefs:[(B000039: 51136); depth:1]
+  000040:[tin@1#13598,SET-umb@1#14397,SET] seqnums:[13598-14397] points:[tin@1#13598,SET-umb@1#14397,SET] size:13116 blobrefs:[(B000041: 51200); depth:1]
+  000042:[umc@1#14398,SET-vpr@1#15197,SET] seqnums:[14398-15197] points:[umc@1#14398,SET-vpr@1#15197,SET] size:13100 blobrefs:[(B000043: 51200); depth:1]
+  000044:[vps@1#15198,SET-wtf@1#15996,SET] seqnums:[15198-15996] points:[vps@1#15198,SET-wtf@1#15996,SET] size:13116 blobrefs:[(B000045: 51136); depth:1]
+  000046:[wtg@1#15997,SET-xwv@1#16796,SET] seqnums:[15997-16796] points:[wtg@1#15997,SET-xwv@1#16796,SET] size:13108 blobrefs:[(B000047: 51200); depth:1]
+  000048:[xww@1#16797,SET-zai@1#17595,SET] seqnums:[16797-17595] points:[xww@1#16797,SET-zai@1#17595,SET] size:13132 blobrefs:[(B000049: 51136); depth:1]
+  000050:[zaj@1#17596,SET-zzz@1#18287,SET] seqnums:[17596-18287] points:[zaj@1#17596,SET-zzz@1#18287,SET] size:11433 blobrefs:[(B000051: 44288); depth:1]
 Blob files:
   B000007 physical:{000007 size:[53138 (52KB)] vals:[51136 (50KB)]}
   B000009 physical:{000009 size:[53138 (52KB)] vals:[51136 (50KB)]}
@@ -586,17 +635,17 @@ Blob files:
 compact a-zzzz
 ----
 L6:
-  000052:[a@1#0,SET-ckw@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-ckw@1#0,SET] size:23075 blobrefs:[(B000007: 51136), (B000009: 51136), (B000011: 6592); depth:1]
-  000053:[ckx@1#0,SET-ewd@1#0,SET] seqnums:[0-0] points:[ckx@1#0,SET-ewd@1#0,SET] size:22411 blobrefs:[(B000011: 44544), (B000013: 51136), (B000015: 13824); depth:1]
-  000054:[ewe@1#0,SET-hgu@1#0,SET] seqnums:[0-0] points:[ewe@1#0,SET-hgu@1#0,SET] size:23198 blobrefs:[(B000015: 37312), (B000017: 51136), (B000019: 19968); depth:1]
-  000055:[hgv@1#0,SET-js@1#0,SET] seqnums:[0-0] points:[hgv@1#0,SET-js@1#0,SET] size:22537 blobrefs:[(B000019: 31168), (B000021: 51136), (B000023: 27072); depth:1]
-  000056:[jsa@1#0,SET-mcx@1#0,SET] seqnums:[0-0] points:[jsa@1#0,SET-mcx@1#0,SET] size:23069 blobrefs:[(B000023: 24128), (B000025: 51136), (B000027: 33600); depth:1]
-  000057:[mcy@1#0,SET-onw@1#0,SET] seqnums:[0-0] points:[mcy@1#0,SET-onw@1#0,SET] size:23016 blobrefs:[(B000027: 17600), (B000029: 51200), (B000031: 40128); depth:1]
-  000058:[onx@1#0,SET-qyv@1#0,SET] seqnums:[0-0] points:[onx@1#0,SET-qyv@1#0,SET] size:22975 blobrefs:[(B000031: 11008), (B000033: 51200), (B000035: 46720); depth:1]
-  000059:[qyw@1#0,SET-tjs@1#0,SET] seqnums:[0-0] points:[qyw@1#0,SET-tjs@1#0,SET] size:23087 blobrefs:[(B000035: 4416), (B000037: 51200), (B000039: 51136), (B000041: 2112); depth:1]
-  000060:[tjt@1#0,SET-vuj@1#0,SET] seqnums:[0-0] points:[tjt@1#0,SET-vuj@1#0,SET] size:23493 blobrefs:[(B000041: 49088), (B000043: 51200), (B000045: 8128); depth:1]
-  000061:[vuk@1#0,SET-yez@1#0,SET] seqnums:[0-0] points:[vuk@1#0,SET-yez@1#0,SET] size:23510 blobrefs:[(B000045: 43008), (B000047: 51200), (B000049: 14144); depth:1]
-  000062:[yf@1#0,SET-zzz@1#0,SET] seqnums:[0-0] points:[yf@1#0,SET-zzz@1#0,SET] size:17753 blobrefs:[(B000049: 36992), (B000051: 44288); depth:1]
+  000052:[a@1#0,SET-ckw@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-ckw@1#0,SET] size:23100 blobrefs:[(B000007: 51136), (B000009: 51136), (B000011: 6592); depth:1]
+  000053:[ckx@1#0,SET-ewd@1#0,SET] seqnums:[0-0] points:[ckx@1#0,SET-ewd@1#0,SET] size:22436 blobrefs:[(B000011: 44544), (B000013: 51136), (B000015: 13824); depth:1]
+  000054:[ewe@1#0,SET-hgu@1#0,SET] seqnums:[0-0] points:[ewe@1#0,SET-hgu@1#0,SET] size:23223 blobrefs:[(B000015: 37312), (B000017: 51136), (B000019: 19968); depth:1]
+  000055:[hgv@1#0,SET-js@1#0,SET] seqnums:[0-0] points:[hgv@1#0,SET-js@1#0,SET] size:22562 blobrefs:[(B000019: 31168), (B000021: 51136), (B000023: 27072); depth:1]
+  000056:[jsa@1#0,SET-mcx@1#0,SET] seqnums:[0-0] points:[jsa@1#0,SET-mcx@1#0,SET] size:23094 blobrefs:[(B000023: 24128), (B000025: 51136), (B000027: 33600); depth:1]
+  000057:[mcy@1#0,SET-onw@1#0,SET] seqnums:[0-0] points:[mcy@1#0,SET-onw@1#0,SET] size:23041 blobrefs:[(B000027: 17600), (B000029: 51200), (B000031: 40128); depth:1]
+  000058:[onx@1#0,SET-qyv@1#0,SET] seqnums:[0-0] points:[onx@1#0,SET-qyv@1#0,SET] size:23000 blobrefs:[(B000031: 11008), (B000033: 51200), (B000035: 46720); depth:1]
+  000059:[qyw@1#0,SET-tjs@1#0,SET] seqnums:[0-0] points:[qyw@1#0,SET-tjs@1#0,SET] size:23112 blobrefs:[(B000035: 4416), (B000037: 51200), (B000039: 51136), (B000041: 2112); depth:1]
+  000060:[tjt@1#0,SET-vuj@1#0,SET] seqnums:[0-0] points:[tjt@1#0,SET-vuj@1#0,SET] size:23520 blobrefs:[(B000041: 49088), (B000043: 51200), (B000045: 8128); depth:1]
+  000061:[vuk@1#0,SET-yez@1#0,SET] seqnums:[0-0] points:[vuk@1#0,SET-yez@1#0,SET] size:23537 blobrefs:[(B000045: 43008), (B000047: 51200), (B000049: 14144); depth:1]
+  000062:[yf@1#0,SET-zzz@1#0,SET] seqnums:[0-0] points:[yf@1#0,SET-zzz@1#0,SET] size:17780 blobrefs:[(B000049: 36992), (B000051: 44288); depth:1]
 Blob files:
   B000007 physical:{000007 size:[53138 (52KB)] vals:[51136 (50KB)]}
   B000009 physical:{000009 size:[53138 (52KB)] vals:[51136 (50KB)]}
@@ -627,8 +676,8 @@ excise-dryrun b c
 ----
 would excise 1 files.
   del-table:     L6 000052
-  add-table:     L6 000063(000052):[a@1#0,SET-azz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azz@1#0,SET] size:11748(23075) blobrefs:[(B000007: 26034), (B000009: 26034), (B000011: 3356); depth:1]
-  add-table:     L6 000064(000052):[c@1#0,SET-ckw@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-ckw@1#0,SET] size:6302(23075) blobrefs:[(B000007: 13965), (B000009: 13965), (B000011: 1800); depth:1]
+  add-table:     L6 000063(000052):[a@1#0,SET-azz@1#0,SET] seqnums:[0-0] points:[a@1#0,SET-azz@1#0,SET] size:11748(23100) blobrefs:[(B000007: 26006), (B000009: 26006), (B000011: 3352); depth:1]
+  add-table:     L6 000064(000052):[c@1#0,SET-ckw@1#0,SET] seqnums:[0-0] points:[c@1#0,SET-ckw@1#0,SET] size:6302(23100) blobrefs:[(B000007: 13950), (B000009: 13950), (B000011: 1798); depth:1]
   add-backing:   000052
 
 
@@ -671,9 +720,9 @@ set z helloworld
 flush
 ----
 L0.0:
-  000005:[a#10,SET-e#14,SET] seqnums:[10-14] points:[a#10,SET-e#14,SET] size:709
-  000006:[f#15,SET-n#23,SET] seqnums:[15-23] points:[f#15,SET-n#23,SET] size:830 blobrefs:[(B000007: 63); depth:1]
-  000008:[o#24,SET-z#35,SET] seqnums:[24-35] points:[o#24,SET-z#35,SET] size:746
+  000005:[a#10,SET-e#14,SET] seqnums:[10-14] points:[a#10,SET-e#14,SET] size:773
+  000006:[f#15,SET-n#23,SET] seqnums:[15-23] points:[f#15,SET-n#23,SET] size:880 blobrefs:[(B000007: 63); depth:1]
+  000008:[o#24,SET-z#35,SET] seqnums:[24-35] points:[o#24,SET-z#35,SET] size:818
 Blob files:
   B000007 physical:{000007 size:[115 (115B)] vals:[63 (63B)]}
 
@@ -743,3 +792,28 @@ v: (hello, .)
 w: (helloworld, .)
 x: (helloworld!, .)
 stats: seeked 1 times (1 internal); stepped 23 times (23 internal); blocks: 0B cached, 615B not cached (read time: 0s); points: 24 (24B keys, 157B values); separated: 6 (63B, 63B fetched)
+
+# Value separation kind=2 for span policy based value separation.
+sstable-properties file=000006
+----
+rocksdb.num.entries: 9
+rocksdb.raw.key.size: 81
+rocksdb.raw.value.size: 78
+rocksdb.deleted.keys: 0
+rocksdb.num.range-deletions: 0
+rocksdb.num.data.blocks: 1
+rocksdb.comparator: leveldb.BytewiseComparator
+rocksdb.data.size: 165
+rocksdb.filter.size: 0
+rocksdb.index.size: 36
+rocksdb.block.based.table.index.type: 0
+pebble.colblk.schema: DefaultKeySchema(leveldb.BytewiseComparator,16)
+rocksdb.merge.operator: pebble.concatenate
+rocksdb.merge.operands: 0
+pebble.num.values.in.blob-files: 6
+rocksdb.property.collectors: [obsolete-key]
+rocksdb.compression: Snappy
+pebble.compression_stats: None:56,Snappy:160/194
+pebble.value-separation.kind: 2
+pebble.value-separation.min-size: 10
+obsolete-key: hex:00

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -127,7 +127,7 @@ maybe-compact
 Deletion hints:
   L1.000005 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) (excised: 000005) L1 [000005] (649B) Score=0.00 + L2 [000006] (666B) Score=0.00 -> L6 [000009] (1B), in 1.0s (2.0s total), output rate 1B/s
+  [JOB 100] compacted(delete-only) (excised: 000005) L1 [000005] (674B) Score=0.00 + L2 [000006] (693B) Score=0.00 -> L6 [000009] (1B), in 1.0s (2.0s total), output rate 1B/s
 [JOB 100] compacted(virtual-sst-rewrite) L1 [000009] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000010] (643B), in 1.0s (2.0s total), output rate 643B/s
 
 # Test a range tombstone that is already compacted into L6.
@@ -207,7 +207,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (666B) Score=0.00 + L3 [000006] (666B) Score=0.00 + L4 [000007] (666B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (693B) Score=0.00 + L3 [000006] (693B) Score=0.00 + L4 [000007] (693B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
 [JOB 100] compacted(virtual-sst-rewrite) L4 [000009] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000010] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 # A deletion hint present on an sstable in a higher level should NOT result in a
@@ -257,7 +257,7 @@ L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
 close-snapshot
 10
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (739B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (655B), in 1.0s (2.0s total), output rate 655B/s
+[JOB 100] compacted(elision-only) L6 [000004] (766B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 # In previous versions of the code, the deletion hint was removed by the
 # elision-only compaction because it zeroed sequence numbers of keys with
@@ -476,7 +476,7 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (649B) Score=0.00 + L2 [000006] (666B) Score=0.00 + L3 [000007] (666B) Score=0.00 + L4 [000008] (666B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (674B) Score=0.00 + L2 [000006] (693B) Score=0.00 + L3 [000007] (693B) Score=0.00 + L4 [000008] (693B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
 [JOB 100] compacted(virtual-sst-rewrite) L1 [000009] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 [JOB 100] compacted(virtual-sst-rewrite) L4 [000010] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000011] (655B), in 1.0s (2.0s total), output rate 655B/s
 

--- a/testdata/compaction_picker_pick_file
+++ b/testdata/compaction_picker_pick_file
@@ -16,9 +16,9 @@ L2:
 file-sizes
 ----
 L1:
-  000004:[b#11,SET-c#11,SET]: 670 bytes (670B)
+  000004:[b#11,SET-c#11,SET]: 694 bytes (694B)
 L2:
-  000005:[c#0,SET-d#0,SET]: 665 bytes (665B)
+  000005:[c#0,SET-d#0,SET]: 689 bytes (689B)
 
 pick-file L1
 ----
@@ -131,12 +131,12 @@ L6:
 file-sizes
 ----
 L5:
-  000004:[c#11,SET-e#11,SET]: 99298 bytes (97KB)
-  000005:[f#11,SET-f#11,SET]: 58019 bytes (57KB)
+  000004:[c#11,SET-e#11,SET]: 99322 bytes (97KB)
+  000005:[f#11,SET-f#11,SET]: 58043 bytes (57KB)
 L6:
-  000006:[c#0,SET-c#0,SET]: 66213 bytes (65KB)
-  000007:[e#0,SET-e#0,SET]: 66213 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66213 bytes (65KB)
+  000006:[c#0,SET-c#0,SET]: 66237 bytes (65KB)
+  000007:[e#0,SET-e#0,SET]: 66237 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66237 bytes (65KB)
 
 # Sst 5 is picked since 65KB/57KB is less than 130KB/97KB.
 pick-file L5
@@ -168,12 +168,12 @@ file-sizes
 L5:
   000010:[c#11,SET-c#11,SET]: 32862 bytes (32KB)
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
-  000005:[f#11,SET-f#11,SET]: 58019 bytes (57KB)
+  000005:[f#11,SET-f#11,SET]: 58043 bytes (57KB)
 L6:
-  000006:[c#0,SET-c#0,SET]: 66213 bytes (65KB)
+  000006:[c#0,SET-c#0,SET]: 66237 bytes (65KB)
   000009:[d#13,SET-d#13,SET]: 655 bytes (655B)
-  000007:[e#0,SET-e#0,SET]: 66213 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66213 bytes (65KB)
+  000007:[e#0,SET-e#0,SET]: 66237 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66237 bytes (65KB)
 
 # Superficially, sst 10 causes write amp of 65KB/32KB which is worse than sst
 # 5. But the garbage of ~64KB in the backing sst 4 is equally distributed
@@ -207,12 +207,12 @@ file-sizes
 ----
 L5:
   000011:[e#11,SET-e#11,SET]: 191 bytes (191B)
-  000005:[f#11,SET-f#11,SET]: 58019 bytes (57KB)
+  000005:[f#11,SET-f#11,SET]: 58043 bytes (57KB)
 L6:
   000012:[c#15,SET-c#15,SET]: 655 bytes (655B)
   000009:[d#13,SET-d#13,SET]: 655 bytes (655B)
-  000007:[e#0,SET-e#0,SET]: 66213 bytes (65KB)
-  000008:[f#0,SET-f#0,SET]: 66213 bytes (65KB)
+  000007:[e#0,SET-e#0,SET]: 66237 bytes (65KB)
+  000008:[f#0,SET-f#0,SET]: 66237 bytes (65KB)
 
 # Even though picking sst 11 seems to cause poor write amp of 65KB/126B, it is
 # picked because it is blamed for all the garbage in backing sst 4 (~96KB),

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -24,7 +24,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       642B     0.00     0.01           0.01
+L5       672B     0.00     0.01           0.01
 L6       321KB    1.11     1.11           1.11
 
 enable-table-stats
@@ -37,7 +37,7 @@ num-entries: 1
 num-deletions: 1
 num-range-key-sets: 0
 point-deletions-bytes-estimate: 0
-range-deletions-bytes-estimate: 328795
+range-deletions-bytes-estimate: 328819
 compression: None:79
 
 scores
@@ -48,7 +48,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       642B     0.01     0.01           5.03
+L5       672B     0.01     0.01           5.03
 L6       321KB    1.11     1.11           1.11
 
 # Ensure that point deletions in a higher level result in a compensated level
@@ -81,7 +81,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       709B     0.00     0.01           0.01
+L5       731B     0.00     0.01           0.01
 L6       321KB    1.11     1.11           1.11
 
 enable-table-stats
@@ -105,7 +105,7 @@ L1       0B       0.00     0.00           0.00
 L2       0B       0.00     0.00           0.00
 L3       0B       0.00     0.00           0.00
 L4       0B       0.00     0.00           0.00
-L5       709B     0.01     0.01           5.01
+L5       731B     0.01     0.01           5.01
 L6       321KB    1.11     1.11           1.11
 
 # Run a similar test as above, but this time the table containing the DELs is
@@ -215,11 +215,11 @@ L6       386KB    0.00     0.42           0.42
 lsm verbose
 ----
 L5:
-  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET] size:525303
-  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET] size:131758
+  000004:[aa#2,SET-dd#2,SET] seqnums:[2-2] points:[aa#2,SET-dd#2,SET] size:525327
+  000005:[e#2,SET-e#2,SET] seqnums:[2-2] points:[e#2,SET-e#2,SET] size:131782
 L6:
-  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET] size:263155
-  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET] size:131758
+  000006:[a#1,SET-d#1,SET] seqnums:[1-1] points:[a#1,SET-d#1,SET] size:263179
+  000007:[e#1,SET-e#1,SET] seqnums:[1-1] points:[e#1,SET-e#1,SET] size:131782
 
 # Attempting to schedule a compaction should begin a L5->L6 compaction.
 
@@ -330,14 +330,14 @@ Blob files:
 
 scores wait-for-compaction=completion
 ----
-Level    Size    Score     Fill factor    Compensated fill factor
-L0       988B    156.97    2.00           2.00
-L1       0B      0.00      0.00           0.00
-L2       0B      0.00      0.00           0.00
-L3       0B      0.00      0.00           0.00
-L4       0B      0.00      0.00           0.00
-L5       0B      0.00      0.00           0.00
-L6       835B    0.00      0.01           0.01
+Level    Size     Score     Fill factor    Compensated fill factor
+L0       1.0KB    151.53    2.00           2.00
+L1       0B       0.00      0.00           0.00
+L2       0B       0.00      0.00           0.00
+L3       0B       0.00      0.00           0.00
+L4       0B       0.00      0.00           0.00
+L5       0B       0.00      0.00           0.00
+L6       865B     0.00      0.01           0.01
 
 # This attempt to compact should chose to rewrite the blob file B000006 *AND*
 # compact out of L0.

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -43,7 +43,7 @@ compression: None:85
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (649B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (674B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that straddles a snapshot. It should not be compacted.
 define snapshots=(50) auto-compactions=off
@@ -89,7 +89,7 @@ compression: None:124
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (700B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (655B), in 1.0s (2.0s total), output rate 655B/s
+[JOB 100] compacted(elision-only) L6 [000004] (725B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 version
 ----
@@ -139,7 +139,7 @@ close-snapshot
 close-snapshot
 103
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (861B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (879B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that contains both deletions and non-deletions, but whose
 # non-deletions well outnumber its deletions. The table should not be
@@ -215,7 +215,7 @@ compression: None:16929
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=88.39 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
+[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=88.58 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
 
 define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
@@ -251,7 +251,7 @@ compression: None:128
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (704B) Score=5.95 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(default) L5 [000004] (729B) Score=6.01 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -335,7 +335,7 @@ compression: None:227
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (859B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (661B), in 1.0s (2.0s total), output rate 661B/s
+[JOB 100] compacted(elision-only) L6 [000004] (891B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (661B), in 1.0s (2.0s total), output rate 661B/s
 
 # Close the DB, asserting that the reference counts balance.
 close
@@ -391,7 +391,7 @@ maybe-compact
 ----
 [JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
 [JOB 101] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 102] compacted(default) L5 [000004] (696B) Score=2.72 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 102] compacted(default) L5 [000004] (721B) Score=2.82 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -440,7 +440,7 @@ maybe-compact
 ----
 [JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
 [JOB 101] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 102] compacted(default) L5 [000004] (696B) Score=2.72 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 102] compacted(default) L5 [000004] (721B) Score=2.82 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 
 # These tests demonstrate the behavior of the tombstone density compaction feature
@@ -518,8 +518,8 @@ compression: None:36,Snappy:95/108
 # should indicate "move" as the compaction type.
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L5 [000004] (716B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (661B), in 1.0s (2.0s total), output rate 661B/s
-[JOB 101] compacted(move) L4 [000004] (716B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (716B), in 1.0s (2.0s total), output rate 716B/s
+[JOB 100] compacted(tombstone-density) L5 [000004] (741B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (661B), in 1.0s (2.0s total), output rate 661B/s
+[JOB 101] compacted(move) L4 [000004] (741B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (741B), in 1.0s (2.0s total), output rate 741B/s
 
 # Verify the result - the file should now be in L5
 # The file should maintain its original content since it was just moved rather than recompacted
@@ -579,7 +579,7 @@ compression: None:36,Snappy:95/108
 # because there are overlapping files in L5 that prevent the optimization
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L4 [000004] (716B) Score=0.00 + L5 [000005] (666B) Score=0.00 -> L5 [000007] (661B), in 1.0s (2.0s total), output rate 661B/s
+[JOB 100] compacted(tombstone-density) L4 [000004] (741B) Score=0.00 + L5 [000005] (693B) Score=0.00 -> L5 [000007] (661B), in 1.0s (2.0s total), output rate 661B/s
 
 # Verify the result - the file was recompacted with the overlapping L5 file
 # The output file should be different from the input files

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -12,9 +12,9 @@ L6
   d@2.SET.2:v
 ----
 L5:
-  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:817 blobrefs:[(B000921: 10); depth:1]
+  000004:[b@9#9,SET-d@9#9,SET] seqnums:[9-9] points:[b@9#9,SET-d@9#9,SET] size:836 blobrefs:[(B000921: 10); depth:1]
 L6:
-  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:812 blobrefs:[(B000921: 6); depth:1]
+  000005:[b@2#2,SET-d@2#2,SET] seqnums:[2-2] points:[b@2#2,SET-d@2#2,SET] size:831 blobrefs:[(B000921: 6); depth:1]
 Blob files:
   B000921 physical:{000921 size:[106 (106B)] vals:[16 (16B)]}
 
@@ -35,7 +35,7 @@ c@2: (foobar, .)
 d@9: (v, .)
 d@2: (v, .)
 .
-stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 1.4KB not cached (read time: 0s); points: 6 (18B keys, 8B values); separated: 2 (16B, 16B fetched)
+stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 6 (18B keys, 8B values); separated: 2 (16B, 16B fetched)
 
 # Try the same but avoid fetching one of the values (by using NextPrefix to step
 # over it).
@@ -72,9 +72,9 @@ L6
   f@2.SETWITHDEL.3:blob{fileNum=000039 value=grapes}
 ----
 L5:
-  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:818 blobrefs:[(B000039: 14), (B000921: 20); depth:2]
+  000004:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] seqnums:[9-9] points:[b@9#9,SETWITHDEL-e@1#9,SETWITHDEL] size:837 blobrefs:[(B000039: 14), (B000921: 20); depth:2]
 L6:
-  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:826 blobrefs:[(B000039: 11), (B000921: 13); depth:2]
+  000005:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] seqnums:[2-9] points:[b@2#9,SETWITHDEL-f@2#3,SETWITHDEL] size:845 blobrefs:[(B000039: 11), (B000921: 13); depth:2]
 Blob files:
   B000039 physical:{000039 size:[117 (117B)] vals:[25 (25B)]}
   B000921 physical:{000921 size:[125 (125B)] vals:[33 (33B)]}
@@ -108,15 +108,15 @@ stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cac
 b@2: (lemon, .)
 stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 2 (6B keys, 4B values); separated: 3 (21B, 11B fetched)
 c@9: (canteloupe, .)
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 3 (9B keys, 6B values); separated: 4 (25B, 21B fetched)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 1.6KB not cached (read time: 0s); points: 3 (9B keys, 6B values); separated: 4 (25B, 21B fetched)
 c@2: (kiwi, .)
 d@9: (honeydew, .)
 d@2: (tangerine, .)
-stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 6 (18B keys, 12B values); separated: 7 (52B, 42B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 1.6KB not cached (read time: 0s); points: 6 (18B keys, 12B values); separated: 7 (52B, 42B fetched)
 e@1: (watermelon, .)
 f@2: (grapes, .)
 .
-stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 1.5KB not cached (read time: 0s); points: 8 (24B keys, 16B values); separated: 8 (58B, 58B fetched)
+stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 1.6KB not cached (read time: 0s); points: 8 (24B keys, 16B values); separated: 8 (58B, 58B fetched)
 
 # Test scanning a table, stepping into new blocks of the blob file. The stats
 # should reflect that a block is only loaded when stepping into a new block.
@@ -137,7 +137,7 @@ L6
   l.SETWITHDEL.2:blob{fileNum=000009 value=peach blockID=6 valueID=0}
 ----
 L6:
-  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:912 blobrefs:[(B000009: 96); depth:1]
+  000004:[a#2,SETWITHDEL-l#2,SETWITHDEL] seqnums:[2-2] points:[a#2,SETWITHDEL-l#2,SETWITHDEL] size:929 blobrefs:[(B000009: 96); depth:1]
 Blob files:
   B000009 physical:{000009 size:[322 (322B)] vals:[96 (96B)]}
 
@@ -170,27 +170,27 @@ next
 stats
 ----
 a: (lemonmeringue, .)
-stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 850B not cached (read time: 0s); points: 1 (1B keys, 2B values); separated: 1 (13B, 13B fetched)
+stats: seeked 1 times (1 internal); stepped 0 times (0 internal); blocks: 0B cached, 867B not cached (read time: 0s); points: 1 (1B keys, 2B values); separated: 1 (13B, 13B fetched)
 b: (keylime, .)
-stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 850B not cached (read time: 0s); points: 2 (2B keys, 4B values); separated: 2 (20B, 20B fetched)
+stats: seeked 1 times (1 internal); stepped 1 times (1 internal); blocks: 0B cached, 867B not cached (read time: 0s); points: 2 (2B keys, 4B values); separated: 2 (20B, 20B fetched)
 c: (pecan, .)
-stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 884B not cached (read time: 0s); points: 3 (3B keys, 6B values); separated: 3 (25B, 25B fetched)
+stats: seeked 1 times (1 internal); stepped 2 times (2 internal); blocks: 0B cached, 901B not cached (read time: 0s); points: 3 (3B keys, 6B values); separated: 3 (25B, 25B fetched)
 d: (cherry, .)
-stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 0B cached, 884B not cached (read time: 0s); points: 4 (4B keys, 8B values); separated: 4 (31B, 31B fetched)
+stats: seeked 1 times (1 internal); stepped 3 times (3 internal); blocks: 0B cached, 901B not cached (read time: 0s); points: 4 (4B keys, 8B values); separated: 4 (31B, 31B fetched)
 e: (apple, .)
-stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 0B cached, 884B not cached (read time: 0s); points: 5 (5B keys, 10B values); separated: 5 (36B, 36B fetched)
+stats: seeked 1 times (1 internal); stepped 4 times (4 internal); blocks: 0B cached, 901B not cached (read time: 0s); points: 5 (5B keys, 10B values); separated: 5 (36B, 36B fetched)
 f: (bananacream, .)
-stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 921B not cached (read time: 0s); points: 6 (6B keys, 12B values); separated: 6 (47B, 47B fetched)
+stats: seeked 1 times (1 internal); stepped 5 times (5 internal); blocks: 0B cached, 938B not cached (read time: 0s); points: 6 (6B keys, 12B values); separated: 6 (47B, 47B fetched)
 g: (chocolate, .)
-stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 921B not cached (read time: 0s); points: 7 (7B keys, 14B values); separated: 7 (56B, 56B fetched)
+stats: seeked 1 times (1 internal); stepped 6 times (6 internal); blocks: 0B cached, 938B not cached (read time: 0s); points: 7 (7B keys, 14B values); separated: 7 (56B, 56B fetched)
 h: (strawberry, .)
-stats: seeked 1 times (1 internal); stepped 7 times (7 internal); blocks: 0B cached, 955B not cached (read time: 0s); points: 8 (8B keys, 16B values); separated: 8 (66B, 66B fetched)
+stats: seeked 1 times (1 internal); stepped 7 times (7 internal); blocks: 0B cached, 972B not cached (read time: 0s); points: 8 (8B keys, 16B values); separated: 8 (66B, 66B fetched)
 i: (custard, .)
-stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 955B not cached (read time: 0s); points: 9 (9B keys, 18B values); separated: 9 (73B, 73B fetched)
+stats: seeked 1 times (1 internal); stepped 8 times (8 internal); blocks: 0B cached, 972B not cached (read time: 0s); points: 9 (9B keys, 18B values); separated: 9 (73B, 73B fetched)
 j: (blueberry, .)
-stats: seeked 1 times (1 internal); stepped 9 times (9 internal); blocks: 0B cached, 980B not cached (read time: 0s); points: 10 (10B keys, 20B values); separated: 10 (82B, 82B fetched)
+stats: seeked 1 times (1 internal); stepped 9 times (9 internal); blocks: 0B cached, 997B not cached (read time: 0s); points: 10 (10B keys, 20B values); separated: 10 (82B, 82B fetched)
 k: (raspberry, .)
-stats: seeked 1 times (1 internal); stepped 10 times (10 internal); blocks: 0B cached, 1005B not cached (read time: 0s); points: 11 (11B keys, 22B values); separated: 11 (91B, 91B fetched)
+stats: seeked 1 times (1 internal); stepped 10 times (10 internal); blocks: 0B cached, 1022B not cached (read time: 0s); points: 11 (11B keys, 22B values); separated: 11 (91B, 91B fetched)
 l: (peach, .)
 stats: seeked 1 times (1 internal); stepped 11 times (11 internal); blocks: 0B cached, 1.0KB not cached (read time: 0s); points: 12 (12B keys, 24B values); separated: 12 (96B, 96B fetched)
 .
@@ -210,7 +210,7 @@ L6
   b.SETWITHDEL.2:blob{fileNum=000009 value=keylime}
 ----
 L6:
-  000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:931 blobrefs:[(B000009: 7); depth:1]
+  000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[2-5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:960 blobrefs:[(B000009: 7); depth:1]
 Blob files:
   B000009 physical:{000009 size:[96 (96B)] vals:[7 (7B)]}
 

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -6,9 +6,9 @@ L1
   d.SET.0:foo
 ----
 L0.0:
-  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:654
+  000004:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:681
 L1:
-  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:665
+  000005:[c#0,SET-d#0,SET] seqnums:[0-0] points:[c#0,SET-d#0,SET] size:692
 
 mark-for-compaction file=000005
 ----
@@ -20,8 +20,8 @@ marked L0.000004
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000005] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (665B), in 1.0s (2.0s total), output rate 665B/s
-[JOB 100] compacted(rewrite) L0 [000004] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (654B), in 1.0s (2.0s total), output rate 654B/s
+[JOB 100] compacted(rewrite) L1 [000005] (692B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (665B), in 1.0s (2.0s total), output rate 665B/s
+[JOB 100] compacted(rewrite) L0 [000004] (681B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (654B), in 1.0s (2.0s total), output rate 654B/s
 L0.0:
   000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:654
 L1:

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -114,16 +114,16 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0       660B |      1  660B |      0     0 |     0B     0B |    28B |      0    0B |   1 23.57
+   L0       707B |      1  707B |      0     0 |     0B     0B |    28B |      0    0B |   1 25.25
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       660B |      1  660B |      0     0 |     0B     0B |    28B |      0    0B |   1 24.57
+total       707B |      1  707B |      0     0 |     0B     0B |    28B |      0    0B |   1 26.25
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      1   660B     0B
+   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      1   707B     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      1   688B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      1   735B     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       0       0        0     0     0     0        0     0      0     0       0
@@ -178,7 +178,7 @@ COMPRESSION
 Iter category stats:
    pebble-compaction, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
 ----
 ----
 
@@ -215,18 +215,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 20.62
-   L6      1.3KB |      2 1.3KB |      0     0 |     0B     0B |  1.3KB |      0    0B |   1  0.99
+   L0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 22.09
+   L6      1.4KB |      2 1.4KB |      0     0 |     0B     0B |  1.4KB |      0    0B |   1  0.99
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      1.3KB |      2 1.3KB |      0     0 |     0B     0B |    64B |      0    0B |   1 42.09
+total      1.4KB |      2 1.4KB |      0     0 |     0B     0B |    64B |      0    0B |   1 45.03
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.3KB     0B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.4KB     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   738B    0B |      2  1.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |      4  2.6KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   738B    0B |      4  2.8KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -255,7 +255,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) | 2 (1.3KB local:1.3KB) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+   all loaded |     0 (0B) | 2 (1.4KB local:1.4KB) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -278,16 +278,16 @@ COMPRESSION
          none |          230B |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
+   pebble-compaction, non-latency: {BlockBytes:738 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
 
 disk-usage
 ----
-5.7KB
+5.9KB
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -300,18 +300,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 20.62
-   L6      1.3KB |      2 1.3KB |      0     0 |     0B     0B |  1.3KB |      0    0B |   1  0.99
+   L0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 22.09
+   L6      1.4KB |      2 1.4KB |      0     0 |     0B     0B |  1.4KB |      0    0B |   1  0.99
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      1.3KB |      2 1.3KB |      0     0 |     0B     0B |    64B |      0    0B |   1 42.09
+total      1.4KB |      2 1.4KB |      0     0 |     0B     0B |    64B |      0    0B |   1 45.03
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.3KB     0B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.4KB     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   738B    0B |      2  1.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |      4  2.6KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   738B    0B |      4  2.8KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -340,7 +340,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) | 2 (1.3KB local:1.3KB) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+   all loaded |     0 (0B) | 2 (1.4KB local:1.4KB) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -363,9 +363,9 @@ COMPRESSION
          none |          230B |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
+   pebble-compaction, non-latency: {BlockBytes:738 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -382,18 +382,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 20.62
-   L6      1.3KB |      2 1.3KB |      0     0 |     0B     0B |  1.3KB |      0    0B |   1  0.99
+   L0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 22.09
+   L6      1.4KB |      2 1.4KB |      0     0 |     0B     0B |  1.4KB |      0    0B |   1  0.99
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      1.3KB |      2 1.3KB |      0     0 |     0B     0B |    64B |      0    0B |   1 42.09
+total      1.4KB |      2 1.4KB |      0     0 |     0B     0B |    64B |      0    0B |   1 45.03
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.3KB     0B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.4KB     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   738B    0B |      2  1.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |      4  2.6KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   738B    0B |      4  2.8KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -422,7 +422,7 @@ ITERATORS
 FILES                 tables                       |       blob files        |     blob values
    stats prog |    backing |                zombie |       live |     zombie |  total |      refed
 --------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |   1 (660B local:660B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+   all loaded |     0 (0B) |   1 (707B local:707B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -445,16 +445,16 @@ COMPRESSION
          none |          230B |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
+   pebble-compaction, non-latency: {BlockBytes:738 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
 
 disk-usage
 ----
-5.0KB
+5.2KB
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -467,18 +467,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 20.62
-   L6      1.3KB |      2 1.3KB |      0     0 |     0B     0B |  1.3KB |      0    0B |   1  0.99
+   L0         0B |      0    0B |      0     0 |     0B     0B |    64B |      0    0B |   0 22.09
+   L6      1.4KB |      2 1.4KB |      0     0 |     0B     0B |  1.4KB |      0    0B |   1  0.99
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      1.3KB |      2 1.3KB |      0     0 |     0B     0B |    64B |      0    0B |   1 42.09
+total      1.4KB |      2 1.4KB |      0     0 |     0B     0B |    64B |      0    0B |   1 45.03
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.3KB     0B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.4KB     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   738B    0B |      2  1.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |      4  2.6KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   738B    0B |      4  2.8KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -530,16 +530,16 @@ COMPRESSION
          none |          230B |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
+   pebble-compaction, non-latency: {BlockBytes:738 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
 
 disk-usage
 ----
-4.4KB
+4.5KB
 
 additional-metrics
 ----
@@ -591,18 +591,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      6.4KB |      7 5.2KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 55.05
-   L6      1.3KB |      2 1.3KB |      0     0 |     0B     0B |  1.3KB |      0    0B |   1  0.99
+   L0      6.7KB |      7 5.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 57.40
+   L6      1.4KB |      2 1.4KB |      0     0 |     0B     0B |  1.4KB |      0    0B |   1  0.99
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      7.7KB |      9 6.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   2 63.99
+total        8KB |      9 6.8KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   2 66.91
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.5KB  2.4KB
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
+   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.8KB  2.4KB
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   738B    0B |      2  1.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |     11  7.9KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |   738B    0B |     11  8.4KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -641,7 +641,7 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-            7.7KB |            0 (0B) |            0 (0B) |                 0 |                  0
+              8KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -655,9 +655,9 @@ COMPRESSION
        snappy | 630B (CR=1.27) |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:691 BlockBytesInCache:112 BlockReadDuration:20ms}
+   pebble-compaction, non-latency: {BlockBytes:738 BlockBytesInCache:112 BlockReadDuration:20ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -701,18 +701,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 55.05
-   L6      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |  6.5KB |      0    0B |   1  1.00
+   L0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 57.40
+   L6      7.9KB |      9 6.7KB |      0     0 |  1.2KB     0B |  6.8KB |      0    0B |   1  0.98
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 95.93
+total      7.9KB |      9 6.7KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 100.1
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.5KB  2.4KB
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.8KB  2.4KB
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.4KB    0B |      9  6.7KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     18   13KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     18   14KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -765,9 +765,9 @@ COMPRESSION
        snappy | 615B (CR=1.3) |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:5234 BlockBytesInCache:112 BlockReadDuration:160ms}
+   pebble-compaction, non-latency: {BlockBytes:5575 BlockBytesInCache:112 BlockReadDuration:160ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -862,18 +862,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      3.9KB |      6 3.9KB |      0     0 |     0B     0B |   211B |      3 1.9KB |   2 52.43
-   L6      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |  6.5KB |      0    0B |   1  1.00
+   L0        4KB |      6   4KB |      0     0 |     0B     0B |   211B |      3 1.9KB |   2 54.94
+   L6      7.9KB |      9 6.7KB |      0     0 |  1.2KB     0B |  6.8KB |      0    0B |   1  0.98
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       11KB |     15  10KB |      0     0 |  1.2KB     0B |  2.1KB |      3 1.9KB |   3  9.11
+total       12KB |     15  11KB |      0     0 |  1.2KB     0B |  2.1KB |      3 1.9KB |   3  9.49
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     12  8.4KB  2.4KB
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     12  8.9KB  2.4KB
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.4KB    0B |      9  6.7KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     21   17KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     21   18KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -912,7 +912,7 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-             11KB |            0 (0B) |            0 (0B) |                 0 |                  0
+             12KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -926,9 +926,9 @@ COMPRESSION
        snappy | 843B (CR=1.26) |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:5234 BlockBytesInCache:112 BlockReadDuration:160ms}
+   pebble-compaction, non-latency: {BlockBytes:5575 BlockBytesInCache:112 BlockReadDuration:160ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -985,18 +985,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      8.4KB |     13 8.4KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 56.62
-   L6      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |  6.5KB |      0    0B |   1  1.00
+   L0      8.8KB |     13 8.8KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 59.71
+   L6      7.9KB |      9 6.7KB |      0     0 |  1.2KB     0B |  6.8KB |      0    0B |   1  0.98
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       16KB |     22  15KB |      0     0 |  1.2KB     0B |  2.2KB |      3 1.9KB |   3 10.93
+total       17KB |     22  16KB |      0     0 |  1.2KB     0B |  2.2KB |      3 1.9KB |   3 11.45
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  2.4KB
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  2.4KB
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.4KB    0B |      9  6.7KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     28   22KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     28   23KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -1035,7 +1035,7 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-             16KB |            0 (0B) |            0 (0B) |                 0 |                  0
+             17KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1049,9 +1049,9 @@ COMPRESSION
        snappy | 1.3KB (CR=1.21) |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:5234 BlockBytesInCache:112 BlockReadDuration:160ms}
+   pebble-compaction, non-latency: {BlockBytes:5575 BlockBytesInCache:112 BlockReadDuration:160ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1120,18 +1120,18 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      7.1KB |     11 7.1KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 56.62
-   L6      8.3KB |     10 7.1KB |      0     0 |  1.2KB     0B |  6.5KB |      1  655B |   1  1.00
+   L0      7.4KB |     11 7.4KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 59.71
+   L6      8.6KB |     10 7.4KB |      0     0 |  1.2KB     0B |  6.8KB |      1  655B |   1  0.98
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       15KB |     21  14KB |      0     0 |  1.2KB     0B |  2.8KB |      4 2.6KB |   3  8.68
+total       16KB |     21  15KB |      0     0 |  1.2KB     0B |  2.8KB |      4 2.6KB |   3  9.09
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  2.4KB
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  2.4KB
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.4KB    0B |      9  6.7KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     28   22KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     28   23KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -1167,7 +1167,7 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-             15KB |            0 (0B) |            0 (0B) |                 0 |                  0
+             16KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1181,9 +1181,9 @@ COMPRESSION
        snappy | 1.2KB (CR=1.22) |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:5234 BlockBytesInCache:112 BlockReadDuration:160ms}
+   pebble-compaction, non-latency: {BlockBytes:5575 BlockBytesInCache:112 BlockReadDuration:160ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1296,18 +1296,18 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 1.9KB |   0 56.62
-   L6       13KB |     18  12KB |      0     0 |  1.2KB     0B |   13KB |      2 1.3KB |   1  0.85
+   L0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 1.9KB |   0 59.71
+   L6       14KB |     18  13KB |      0     0 |  1.2KB     0B |   14KB |      2 1.3KB |   1  0.85
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       13KB |     18  12KB |      0     0 |  1.2KB     0B |  3.5KB |      5 3.2KB |   1  8.56
+total       14KB |     18  13KB |      0     0 |  1.2KB     0B |  3.5KB |      5 3.2KB |   1  8.99
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  2.4KB
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   11KB    0B |     16   11KB     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  2.4KB
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   11KB    0B |     16   12KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   11KB    0B |     35   27KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |   11KB    0B |     35   29KB  2.4KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       3       0        0     0     0     0        0     0      0     0       0
@@ -1357,9 +1357,9 @@ COMPRESSION
        snappy | 682B (CR=1.3) |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:11009 BlockBytesInCache:457 BlockReadDuration:330ms}
+   pebble-compaction, non-latency: {BlockBytes:11679 BlockBytesInCache:457 BlockReadDuration:330ms}
                    a, non-latency: {BlockBytes:0 BlockBytesInCache:0 BlockReadDuration:0s}
-                   b,     latency: {BlockBytes:579 BlockBytesInCache:0 BlockReadDuration:30ms}
+                   b,     latency: {BlockBytes:626 BlockBytesInCache:0 BlockReadDuration:30ms}
                    c, non-latency: {BlockBytes:112 BlockBytesInCache:112 BlockReadDuration:0s}
 ----
 ----
@@ -1389,16 +1389,16 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      1.9KB |      3 1.9KB |      0     0 |     0B     0B |    38B |      0    0B |   1 52.11
+   L0      2.1KB |      3 2.1KB |      0     0 |     0B     0B |    38B |      0    0B |   1 55.82
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      1.9KB |      3 1.9KB |      0     0 |     0B     0B |    38B |      0    0B |   1 53.11
+total      2.1KB |      3 2.1KB |      0     0 |     0B     0B |    38B |      0    0B |   1 56.82
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  1.9KB     0B
+   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.1KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      3    2KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |     0B    0B |      3  2.1KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       0       0        0     0     0     0        0     0      0     0       0
@@ -1466,18 +1466,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |    38B |      0    0B |   0 52.11
-   L6      1.9KB |      3 1.9KB |      0     0 |     0B     0B |  1.9KB |      0    0B |   1  0.99
+   L0         0B |      0    0B |      0     0 |     0B     0B |    38B |      0    0B |   0 55.82
+   L6      1.9KB |      3 1.9KB |      0     0 |     0B     0B |  2.1KB |      0    0B |   1  0.93
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      1.9KB |      3 1.9KB |      0     0 |     0B     0B |    38B |      0    0B |   1 104.8
+total      1.9KB |      3 1.9KB |      0     0 |     0B     0B |    38B |      0    0B |   1 108.5
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      3  1.9KB     0B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.7KB    0B |      3  1.9KB     0B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.1KB     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.8KB    0B |      3  1.9KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.7KB    0B |      6  3.9KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.8KB    0B |      6    4KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -1529,7 +1529,7 @@ COMPRESSION
          none |          345B |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:1737 BlockBytesInCache:0 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:1878 BlockBytesInCache:0 BlockReadDuration:60ms}
 ----
 ----
 
@@ -1563,18 +1563,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0       655B |      1  655B |      0     0 |     0B     0B |    38B |      1  655B |   1 52.11
-   L6      1.9KB |      3 1.9KB |      0     0 |     0B     0B |  1.9KB |      0    0B |   1  0.99
+   L0       655B |      1  655B |      0     0 |     0B     0B |    38B |      1  655B |   1 55.82
+   L6      1.9KB |      3 1.9KB |      0     0 |     0B     0B |  2.1KB |      0    0B |   1  0.93
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      2.6KB |      4 2.6KB |      0     0 |     0B     0B |   693B |      1  655B |   2  6.69
+total      2.6KB |      4 2.6KB |      0     0 |     0B     0B |   693B |      1  655B |   2  6.90
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  1.9KB     0B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.7KB    0B |      3  1.9KB     0B
+   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      3  2.1KB     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.8KB    0B |      3  1.9KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.7KB    0B |      6  4.5KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.8KB    0B |      6  4.7KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -1626,7 +1626,7 @@ COMPRESSION
          none |          460B |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:1737 BlockBytesInCache:0 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:1878 BlockBytesInCache:0 BlockReadDuration:60ms}
 ----
 ----
 
@@ -1652,18 +1652,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      1.3KB |      2 1.3KB |      0     0 |     0B     0B |    74B |      1  655B |   2 35.68
-   L6      1.9KB |      3 1.9KB |      0     0 |     0B     0B |  1.9KB |      0    0B |   1  0.99
+   L0      1.3KB |      2 1.3KB |      0     0 |     0B     0B |    74B |      1  655B |   2 38.22
+   L6      1.9KB |      3 1.9KB |      0     0 |     0B     0B |  2.1KB |      0    0B |   1  0.93
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      3.2KB |      5 3.2KB |      0     0 |     0B     0B |   729B |      1  655B |   3  7.32
+total      3.2KB |      5 3.2KB |      0     0 |     0B     0B |   729B |      1  655B |   3  7.57
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |      4  2.6KB     0B
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.7KB    0B |      3  1.9KB     0B
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |      4  2.8KB     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  1.8KB    0B |      3  1.9KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  1.7KB    0B |      7  5.2KB     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |  1.8KB    0B |      7  5.4KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -1716,7 +1716,7 @@ COMPRESSION
        snappy | 76B (CR=1.14) |
 
 Iter category stats:
-   pebble-compaction, non-latency: {BlockBytes:1737 BlockBytesInCache:0 BlockReadDuration:60ms}
+   pebble-compaction, non-latency: {BlockBytes:1878 BlockBytesInCache:0 BlockReadDuration:60ms}
 ----
 ----
 
@@ -1810,16 +1810,16 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L6      1.9KB |      3 1.9KB |      0     0 |     0B     0B |  1.3KB |      0    0B |   1  0.50
+   L6        2KB |      3   2KB |      0     0 |     0B     0B |  1.3KB |      0    0B |   1  0.52
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      1.9KB |      3 1.9KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+total        2KB |      3   2KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   342B    0B |      1   655B     0B
+   L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   342B    0B |      1   702B     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   342B    0B |      1   655B     0B
+total |     -     -     - |      0    0B |    0B    0B    0B |   342B    0B |      1   702B     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -1924,18 +1924,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      1.3KB |      2 1.3KB |      0     0 |     0B     0B |   106B |      0    0B |   1 31.35
-   L6        2KB |      3   2KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+   L0      1.3KB |      2 1.3KB |      0     0 |     0B     0B |   106B |      0    0B |   1 33.37
+   L6      2.1KB |      3 2.1KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      3.2KB |      5 3.2KB |      0     0 |     0B     0B |   106B |      0    0B |   2 32.35
+total      3.5KB |      5 3.5KB |      0     0 |     0B     0B |   106B |      0    0B |   2 34.37
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      5  3.2KB     0B
-   L6 |     -  0.00  0.00 |      3   2KB |    0B    0B    0B |     0B    0B |      0     0B     0B
+   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      5  3.5KB     0B
+   L6 |     -  0.00  0.00 |      3 2.1KB |    0B    0B    0B |     0B    0B |      0     0B     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      3   2KB |    0B    0B    0B |     0B    0B |      5  3.3KB     0B
+total |     -     -     - |      3 2.1KB |    0B    0B    0B |     0B    0B |      5  3.6KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       0       0        0     3     0     0        0     0      0     0       0
@@ -1974,12 +1974,12 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-            3.2KB |            0 (0B) |            0 (0B) |                 0 |                  0
+            3.5KB |            0 (0B) |            0 (0B) |                 0 |                  0
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
 -----------------+------------------+--------------------------+-----------------+----------------
-               0 |                3 |                        0 |            502B |           1.3KB
+               0 |                3 |                        0 |            502B |           1.4KB
 
 COMPRESSION
     algorithm |         tables |    blob files
@@ -2003,18 +2003,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      1.3KB |      2 1.3KB |      0     0 |     0B     0B |   106B |      0    0B |   1 31.35
-   L6        2KB |      3   2KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+   L0      1.3KB |      2 1.3KB |      0     0 |     0B     0B |   106B |      0    0B |   1 33.37
+   L6      2.1KB |      3 2.1KB |      0     0 |     0B     0B |     0B |      0    0B |   1     0
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      3.2KB |      5 3.2KB |      0     0 |     0B     0B |   106B |      0    0B |   2 32.35
+total      3.5KB |      5 3.5KB |      0     0 |     0B     0B |   106B |      0    0B |   2 34.37
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      5  3.2KB     0B
-   L6 |     -  0.00  0.00 |      3   2KB |    0B    0B    0B |     0B    0B |      0     0B     0B
+   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      5  3.5KB     0B
+   L6 |     -  0.00  0.00 |      3 2.1KB |    0B    0B    0B |     0B    0B |      0     0B     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      3   2KB |    0B    0B    0B |     0B    0B |      5  3.3KB     0B
+total |     -     -     - |      3 2.1KB |    0B    0B    0B |     0B    0B |      5  3.6KB     0B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       0       0        0     3     0     0        0     0      0     0       0
@@ -2053,12 +2053,12 @@ CGO MEMORY    |          block cache           |                     memtables
 COMPACTIONS
    estimated debt |       in progress |         cancelled |            failed |      problem spans
 ------------------+-------------------+-------------------+-------------------+-------------------
-            3.2KB |            0 (0B) |            0 (0B) |                 0 |                2!!
+            3.5KB |            0 (0B) |            0 (0B) |                 0 |                2!!
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
 -----------------+------------------+--------------------------+-----------------+----------------
-               0 |                3 |                        0 |            502B |           1.3KB
+               0 |                3 |                        0 |            502B |           1.4KB
 
 COMPRESSION
     algorithm |         tables |    blob files

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -1037,7 +1037,7 @@ wait-pending-table-stats
 num-entries: 3
 num-deletions: 3
 num-range-key-sets: 0
-point-deletions-bytes-estimate: 4641
+point-deletions-bytes-estimate: 4649
 range-deletions-bytes-estimate: 0
 compression: None:36,Snappy:73/84
 

--- a/value_separation.go
+++ b/value_separation.go
@@ -224,6 +224,17 @@ func (vs *writeNewBlobFiles) SetNextOutputConfig(config compact.ValueSeparationO
 	vs.minimumSize = config.MinimumSize
 }
 
+// Kind implements the ValueSeparation interface.
+func (vs *writeNewBlobFiles) Kind() sstable.ValueSeparationKind {
+	if vs.minimumSize != vs.globalMinimumSize {
+		return sstable.ValueSeparationSpanPolicy
+	}
+	return sstable.ValueSeparationDefault
+}
+
+// MinimumSize implements the ValueSeparation interface.
+func (vs *writeNewBlobFiles) MinimumSize() int { return vs.minimumSize }
+
 // EstimatedFileSize returns an estimate of the disk space consumed by the current
 // blob file if it were closed now.
 func (vs *writeNewBlobFiles) EstimatedFileSize() uint64 {
@@ -396,6 +407,14 @@ var _ compact.ValueSeparation = (*preserveBlobReferences)(nil)
 
 // SetNextOutputConfig implements the ValueSeparation interface.
 func (vs *preserveBlobReferences) SetNextOutputConfig(config compact.ValueSeparationOutputConfig) {}
+
+// Kind implements the ValueSeparation interface.
+func (vs *preserveBlobReferences) Kind() sstable.ValueSeparationKind {
+	return sstable.ValueSeparationPreservedRefs
+}
+
+// MinimumSize implements the ValueSeparation interface.
+func (vs *preserveBlobReferences) MinimumSize() int { return 0 }
 
 // EstimatedFileSize returns an estimate of the disk space consumed by the current
 // blob file if it were closed now.

--- a/value_separation_test.go
+++ b/value_separation_test.go
@@ -214,6 +214,14 @@ var _ compact.ValueSeparation = (*defineDBValueSeparator)(nil)
 // SetNextOutputConfig implements the compact.ValueSeparation interface.
 func (vs *defineDBValueSeparator) SetNextOutputConfig(config compact.ValueSeparationOutputConfig) {}
 
+// Kind implements the ValueSeparation interface.
+func (vs *defineDBValueSeparator) Kind() sstable.ValueSeparationKind {
+	return vs.pbr.Kind()
+}
+
+// MinimumSize implements the ValueSeparation interface.
+func (vs *defineDBValueSeparator) MinimumSize() int { return 0 }
+
 // EstimatedFileSize returns an estimate of the disk space consumed by the current
 // blob file if it were closed now.
 func (vs *defineDBValueSeparator) EstimatedFileSize() uint64 {


### PR DESCRIPTION
Add ValueSeparationKind and ValueSeparationMinSize to sstable properties to
track the value separation policy used when writing the table.