### PR TITLE
internal: add concurrentset

### DIFF
--- a/internal/concurrentset/bench_test.go
+++ b/internal/concurrentset/bench_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package concurrentset
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// Sample benchmark results.
+//
+// On Apple M1 (10 core):
+//   Set/1-10            59.3ns ± 4%
+//   Set/4-10            67.1ns ± 2%
+//   Set/10-10           66.9ns ± 1%
+//   Set/40-10           67.3ns ± 1%
+//   MapWithMutex/1-10   91.8ns ± 2%
+//   MapWithMutex/4-10    194ns ± 1%
+//   MapWithMutex/10-10   294ns ± 1%
+//   MapWithMutex/40-10   278ns ± 2%
+//
+// On Intel(R) Xeon(R) CPU @ 2.80GHz (GCP n2-custom-24-32768):
+//   Set/1-24            132ns ± 3%
+//   Set/4-24            154ns ± 3%
+//   Set/24-24           155ns ± 1%
+//   Set/96-24           156ns ± 2%
+//   MapWithMutex/1-24   168ns ± 6%
+//   MapWithMutex/4-24   244ns ± 3%
+//   MapWithMutex/24-24  331ns ± 1%
+//   MapWithMutex/96-24  348ns ± 2%
+
+func BenchmarkSet(b *testing.B) {
+	for _, p := range []int{1, 4, runtime.GOMAXPROCS(0), 4 * runtime.GOMAXPROCS(0)} {
+		b.Run(fmt.Sprint(p), func(b *testing.B) {
+			runBenchmark(b, p, New[uint64](), nil)
+		})
+	}
+}
+
+func BenchmarkMapWithMutex(b *testing.B) {
+	for _, p := range []int{1, 4, runtime.GOMAXPROCS(0), 4 * runtime.GOMAXPROCS(0)} {
+		b.Run(fmt.Sprint(p), func(b *testing.B) {
+			runBenchmark(b, p, nil, newRefSet[uint64]())
+		})
+	}
+}
+
+func runBenchmark(b *testing.B, parallelism int, set *Set[uint64], refSet *refSet[uint64]) {
+	b.SetParallelism(parallelism)
+
+	var wg sync.WaitGroup
+
+	for range parallelism {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
+			// Maintain a random set of recent handles.
+			handles := make([]Handle, 0, 128)
+			randHandle := func() Handle {
+				i := rng.IntN(len(handles))
+				h := handles[i]
+				handles[i] = handles[len(handles)-1]
+				handles = handles[:len(handles)-1]
+				return h
+			}
+			for range b.N / parallelism {
+				if len(handles) == 0 || rng.IntN(100) < 60 { // 60% adds, 40% removes
+					if len(handles) == cap(handles) {
+						randHandle()
+					}
+					value := rng.Uint64()
+					if set != nil {
+						handles = append(handles, set.Add(value))
+					} else {
+						h := Handle(value)
+						refSet.Add(h, value)
+						handles = append(handles, Handle(value))
+					}
+				} else {
+					h := randHandle()
+					if set != nil {
+						set.Remove(h)
+					} else {
+						refSet.Remove(h)
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/concurrentset/concurent_set_test.go
+++ b/internal/concurrentset/concurent_set_test.go
@@ -1,0 +1,165 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package concurrentset
+
+import (
+	"math/rand/v2"
+	"reflect"
+	"runtime"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetBasic(t *testing.T) {
+	s := New[int]()
+	expect := func(vals ...int) {
+		t.Helper()
+		a := s.AppendAll(nil)
+		slices.Sort(a)
+		require.Equal(t, vals, a)
+	}
+	expect()
+	h1 := s.Add(1)
+	expect(1)
+	h1000 := s.Add(1000)
+	expect(1, 1000)
+	s.Remove(h1)
+	expect(1000)
+	s.Remove(h1000)
+	expect()
+	h := make([]Handle, rand.IntN(10000))
+	for i := range h {
+		h[i] = s.Add(i)
+	}
+	for i := range h {
+		if i%2 == 0 {
+			s.Remove(h[i])
+		}
+	}
+	var exp []int
+	for i := range h {
+		if i%2 == 1 {
+			exp = append(exp, i)
+		}
+	}
+	expect(exp...)
+}
+
+type refSet[T any] struct {
+	mu sync.Mutex
+	m  map[Handle]T
+}
+
+func newRefSet[T any]() *refSet[T] {
+	return &refSet[T]{m: make(map[Handle]T)}
+}
+func (r *refSet[T]) Add(h Handle, v T) {
+	r.mu.Lock()
+	r.m[h] = v
+	r.mu.Unlock()
+}
+func (r *refSet[T]) Remove(h Handle) {
+	r.mu.Lock()
+	delete(r.m, h)
+	r.mu.Unlock()
+}
+func (r *refSet[T]) Snapshot() map[Handle]T {
+	r.mu.Lock()
+	cp := make(map[Handle]T, len(r.m))
+	for k, v := range r.m {
+		cp[k] = v
+	}
+	r.mu.Unlock()
+	return cp
+}
+
+// handleBag tracks handles available for deletion; used to bias the op mix.
+type handleBag struct {
+	mu sync.Mutex
+	hs []Handle
+}
+
+func (b *handleBag) add(h Handle) {
+	b.mu.Lock()
+	b.hs = append(b.hs, h)
+	b.mu.Unlock()
+}
+
+// maybePop removes and returns a random handle, or false if empty.
+func (b *handleBag) maybePop(r *rand.Rand) (Handle, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.hs) == 0 {
+		return 0, false
+	}
+	i := r.IntN(len(b.hs))
+	h := b.hs[i]
+	// swap-delete
+	b.hs[i] = b.hs[len(b.hs)-1]
+	b.hs = b.hs[:len(b.hs)-1]
+	return h, true
+}
+
+// compareMultiset compares the multiset of values in the Set (via Append) with the reference.
+func compareMultiset(t *testing.T, gotVals []int, ref map[Handle]int) {
+	gotCount := make(map[int]int, len(gotVals))
+	for _, v := range gotVals {
+		gotCount[v]++
+	}
+	wantCount := make(map[int]int, len(ref))
+	for _, v := range ref {
+		wantCount[v]++
+	}
+	if !reflect.DeepEqual(gotCount, wantCount) {
+		t.Fatalf("multiset mismatch\n got:  %+v\n want: %+v", gotCount, wantCount)
+	}
+}
+
+func TestSetConcurrentAddRemove(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
+
+	workers := 1 + rng.IntN(2*runtime.GOMAXPROCS(0))
+	opsPerWorker := rand.IntN(100000)
+
+	s := New[int]()
+	ref := newRefSet[int]()
+	var bag handleBag
+	var wg sync.WaitGroup
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
+			for i := 0; i < opsPerWorker; i++ {
+				if r.IntN(100) < 60 { // 60% adds, 40% removes
+					v := r.Int()
+					h := s.Add(v)
+					ref.Add(h, v)
+					bag.add(h)
+				} else {
+					if h, ok := bag.maybePop(r); ok {
+						s.Remove(h)
+						ref.Remove(h)
+					}
+				}
+				// Occasionally yield to stir the scheduler.
+				if i%257 == 0 {
+					runtime.Gosched()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Quiescent: take a snapshot and compare.
+	got := s.AppendAll(nil)
+	compareMultiset(t, got, ref.Snapshot())
+}

--- a/internal/concurrentset/concurrent_set.go
+++ b/internal/concurrentset/concurrent_set.go
@@ -1,0 +1,292 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package concurrentset
+
+import (
+	"runtime"
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
+
+// Set is a high-throughput, low-contention container that supports lock-free
+// fast paths for Add/Remove and a locked, consistent snapshot via Append.
+//
+// Supports addition of elements, removal of elements by Handle returned by Add,
+// and listing of elements in the set.
+//
+// Semantics:
+//   - Add returns the Handle for the inserted element.
+//   - Remove removes by Handle.
+//   - Append runs under a lock and visits the consolidated map; very recent
+//     adds that haven’t been reloaded yet won’t be visible until the next reload.
+//
+// Implementation:
+//   - Producers record operations (adds/dels) into a fixed-size "magazine" using
+//     atomics (no mutex).
+//   - A slow path ("reload") swaps in a fresh magazine and folds the completed
+//     one into a centralized map.
+//   - Append forces a reload under a lock to iterate a consistent snapshot.
+type Set[T any] struct {
+	mu struct {
+		sync.Mutex
+		m               map[Handle]T
+		recent          atomic.Pointer[magazine[T]]
+		nextStartHandle Handle
+		magAlloc        []magazine[T]
+	}
+}
+
+// Handle is a stable identifier for an element in the Set. It is monotonically
+// increasing with each Add; two different Add operations on the same set will
+// never return the same Handle.
+type Handle uint64
+
+// New creates a new empty Set.
+func New[T any]() *Set[T] {
+	s := &Set[T]{}
+	s.mu.m = make(map[Handle]T)
+
+	s.mu.magAlloc = make([]magazine[T], magAllocBatch)
+
+	mag := &s.mu.magAlloc[0]
+	mag.addsStartHandle = 1
+	s.mu.magAlloc = s.mu.magAlloc[1:]
+	s.mu.recent.Store(mag)
+
+	s.mu.nextStartHandle = 1 + magazineSize
+	return s
+}
+
+// Add inserts t and returns a Handle.
+func (s *Set[T]) Add(t T) Handle {
+	mag := s.mu.recent.Load()
+	if idx := mag.TryAdd(t); idx != -1 {
+		// Fast path.
+		return mag.addsStartHandle + Handle(idx)
+	}
+	// Slow path.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for {
+		mag = s.mu.recent.Load()
+		if idx := mag.TryAdd(t); idx != -1 {
+			return mag.addsStartHandle + Handle(idx)
+		}
+		s.reloadLocked()
+	}
+}
+
+// Remove removes the element identified by h. The element must exist in the
+// set.
+func (s *Set[T]) Remove(h Handle) {
+	if mag := s.mu.recent.Load(); mag.TryDel(h) {
+		// Fast path.
+		return
+	}
+	// Slow path.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for {
+		if mag := s.mu.recent.Load(); mag.TryDel(h) {
+			return
+		}
+		s.reloadLocked()
+	}
+}
+
+const magAllocBatch = 16
+
+// reloadLocked installs a fresh magazine and folds the finished magazine into
+// the centralized map, applying deletes before adds.
+func (s *Set[T]) reloadLocked() {
+	if len(s.mu.magAlloc) == 0 {
+		s.mu.magAlloc = make([]magazine[T], magAllocBatch)
+	}
+	newMag := &s.mu.magAlloc[0]
+	s.mu.magAlloc = s.mu.magAlloc[1:]
+	newMag.addsStartHandle = s.mu.nextStartHandle
+	s.mu.nextStartHandle += magazineSize
+
+	// Note: as soon as we swap in the new magazine, other goroutines can start
+	// adding to it immediately.
+	mag := s.mu.recent.Swap(newMag)
+	nAdds, nDels := mag.Finish()
+
+	for _, h := range mag.dels[:nDels] {
+		if invariants.Enabled {
+			if _, ok := s.mu.m[h]; !ok {
+				panic("delete of unknown handle")
+			}
+		}
+		delete(s.mu.m, h)
+	}
+
+	for i := range mag.adds[:nAdds] {
+		if mag.adds[i].deleted.Load() {
+			continue
+		}
+		h := mag.addsStartHandle + Handle(i)
+		if invariants.Enabled {
+			if _, ok := s.mu.m[h]; ok {
+				panic("add of existing handle")
+			}
+		}
+		s.mu.m[h] = mag.adds[i].t
+	}
+}
+
+// AppendAll appends all elements in the set to the given slice, in arbitrary
+// order.
+func (s *Set[T]) AppendAll(dest []T) []T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Swap in a new magazine. This will give us the latest "view"  in s.mu.m and
+	// also allow other goroutines to make as much progress as possible without
+	// locking.
+	s.reloadLocked()
+	dest = slices.Grow(dest, len(s.mu.m))
+	for _, t := range s.mu.m {
+		dest = append(dest, t)
+	}
+	return dest
+}
+
+// AppendFiltered runs the filter over a consistent snapshot of the set and
+// appends matching elements to dest (in arbitrary order). The filter must be
+// very fast; the mutex is held for the entire iteration.
+func (s *Set[T]) AppendFiltered(filter func(t T) bool, dest []T) []T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Swap in a new magazine. This will give us the latest "view"  in s.mu.m and
+	// also allow other goroutines to make as much progress as possible without
+	// locking.
+	s.reloadLocked()
+	for _, t := range s.mu.m {
+		if filter(t) {
+			dest = append(dest, t)
+		}
+	}
+	return dest
+}
+
+// --- Magazine internals ---
+
+const magazineSize = 128
+
+// A magazine can hold up to magazineSize new elements. These elements map to a
+// contiguous range of Handles. A magazine can also hold up to magazineSize
+// Handles for deletions of objects that correspond to previous magazines.
+//
+// A magazine can be Finish()ed, at which point no further adds or deletes are
+// possible.
+type magazine[T any] struct {
+	// adds[0] through adds[min(addsReserved,magazineSize)-1] store added elements.
+	// Only addsInitialized elements out of these have actually been set, the rest
+	// are in the process of being written.
+	// Note that instead of using CAS to reserve a slot, we simply do an atomic
+	// add; as such, addsReserved can exceed magazineSize in which case it should
+	// be interpreted as equal to magazineSize.
+	addsReserved    atomic.Uint32
+	addsInitialized atomic.Uint32
+	addsStartHandle Handle
+	adds            [magazineSize]struct {
+		t       T
+		deleted atomic.Bool
+	}
+	// inMagDeletes counts the number of deletes of handles in this magazine.
+	inMagDeletes atomic.Uint32
+
+	// dels[0] through dels[min(delsReserved,magazineSize)-1] store deleted
+	// out-of-magazine handles.
+	delsReserved    atomic.Uint32
+	delsInitialized atomic.Uint32
+	dels            [magazineSize]Handle
+}
+
+func (m *magazine[T]) TryAdd(t T) int {
+	idx := m.addsReserved.Add(1) - 1
+	if idx >= magazineSize {
+		return -1
+	}
+	m.adds[idx].t = t
+	m.addsInitialized.Add(1)
+	return int(idx)
+}
+
+func (m *magazine[T]) TryDel(h Handle) bool {
+	if h >= m.addsStartHandle {
+		if invariants.Enabled && h >= m.addsStartHandle+magazineSize {
+			// This cannot happen. The only way for the user to pass us a handle from a
+			// newer magazine implies the add operation loaded a newer magazine than we
+			// did now.
+			panic("delete newer than magazine")
+		}
+		if m.inMagDeletes.Add(1) > magazineSize {
+			// Magazine has been finished.
+			return false
+		}
+		wasDeleted := m.adds[h-m.addsStartHandle].deleted.Swap(true)
+		if wasDeleted {
+			// It's important to check this even in non-invariant builds; if we don't,
+			// Finish() will hang waiting for the correct count of set flags.
+			panic("handle deleted twice")
+		}
+		return true
+	}
+	idx := m.delsReserved.Add(1) - 1
+	if idx >= magazineSize {
+		return false
+	}
+	m.dels[idx] = h
+	m.delsInitialized.Add(1)
+	return true
+}
+
+// Finish causes any subsequent TryAdd/TryDel calls to fail and waits until any
+// concurrent TryAdd/TryDel calls complete. Returns the adds and dels in the
+// magazine.
+func (m *magazine[T]) Finish() (nAdds, nDels uint32) {
+	// We block further operations by swapping in recentSize. The old value
+	// contains the number of elements that were inserted (or are in the process
+	// of being inserted right now).
+	nAdds = m.addsReserved.Swap(magazineSize)
+	nDels = m.delsReserved.Swap(magazineSize)
+	nInMagDels := m.inMagDeletes.Swap(magazineSize)
+	// The previous reserved value can exceed recentSize if multiple goroutines
+	// were trying (and failing) to add.
+	nAdds = min(nAdds, magazineSize)
+	nDels = min(nDels, magazineSize)
+	nInMagDels = min(nInMagDels, magazineSize)
+	// Make sure all adds finished writing.
+	for m.addsInitialized.Load() < nAdds {
+		runtime.Gosched()
+	}
+	// Make sure all out-of-magazine dels finished writing.
+	for m.delsInitialized.Load() < nDels {
+		runtime.Gosched()
+	}
+	// Make sure all inside-magazine dels finished writing.
+	for {
+		n := uint32(0)
+		for i := range m.adds {
+			if m.adds[i].deleted.Load() {
+				n++
+			}
+		}
+		if n >= nInMagDels {
+			if invariants.Enabled && n > nInMagDels {
+				panic("more in-magazine deletes than recorded")
+			}
+			break
+		}
+		runtime.Gosched()
+	}
+	return nAdds, nDels
+}


### PR DESCRIPTION
Add a set data structure that supports adding/removing elements
with high concurrency.

This data structure will be used to keep track of iterators, so we can
periodically check for long-lived iterators. In that case the value
type will contain a timestamp and a few PCs from the creation caller
stack.

See bench_test.go for benchmark results.