### PR TITLE
db: track and report long-standing iterators

### DIFF
--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -49,3 +49,34 @@ jobs:
       sha: ${{ github.sha }}
       file_issue_branch: 'master'
       go_version: ${{ matrix.go }}
+
+  linux-cockroach-go:
+    runs-on: ubuntu-latest
+    env:
+      GO_BRANCH: cockroach-go1.23.12
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Step 1: Fetch the branch tip SHA for cache key
+      - name: Get cockroachdb/go commit hash
+        id: go-sha
+        run: |
+          SHA=$(git ls-remote https://github.com/cockroachdb/go.git refs/heads/$GO_BRANCH | cut -f1)
+          echo "GO_SHA=$SHA" >> $GITHUB_ENV
+
+      # Step 2: Restore cache (per branch + commit SHA)
+      - name: Cache custom Go toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/cockroachdb-go/${{ env.GO_SHA }}
+          key: cockroachdb-${{ env.GO_SHA }}
+
+      # Step 3: Install bootstrap Go (needed to build fork)
+      - name: Install bootstrap Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.x"
+
+      # Step 4: Run tests with custom Go
+      - run: ./scripts/run-tests-with-custom-go.sh -tags invariants ./...

--- a/db.go
+++ b/db.go
@@ -1114,8 +1114,8 @@ func (d *DB) newIter(
 		dbi.batch.batch = batch
 		dbi.batch.batchSeqNum = batch.nextSeqNum()
 	}
-	if !dbi.batchOnlyIter {
-		dbi.tracker = d.iterTracker
+	dbi.tracker = d.iterTracker
+	if !dbi.batchOnlyIter && d.iterTracker != nil && !dbi.opts.ExemptFromTracking {
 		dbi.trackerHandle = d.iterTracker.Start()
 	}
 	return finishInitializingIter(ctx, buf)
@@ -1624,8 +1624,10 @@ func (d *DB) Close() error {
 		err = firstError(err, errors.Errorf("leaked snapshots: %d open snapshots on DB %p", v, d))
 	}
 
-	d.iterTracker.Close()
-	d.iterTracker = nil
+	if d.iterTracker != nil {
+		d.iterTracker.Close()
+		d.iterTracker = nil
+	}
 
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/RaduBerinde/axisds v0.0.0-20250419182453-5135a0650657
 	github.com/cespare/xxhash/v2 v2.2.0
-	github.com/cockroachdb/crlib v0.0.0-20250916151006-1094cb39adac
+	github.com/cockroachdb/crlib v0.0.0-20251001180057-2a49e1873587
 	github.com/cockroachdb/datadriven v1.0.3-0.20250911232732-d959cf14706c
 	github.com/cockroachdb/errors v1.11.3
 	github.com/cockroachdb/metamorphic v0.0.0-20231108215700-4ba948b56895
@@ -24,6 +24,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.3.0
+	github.com/puzpuzpuz/xsync/v3 v3.5.1
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cockroachdb/crlib v0.0.0-20250916151006-1094cb39adac h1:L+7nhSrQ9WzW91AJHP0LmjwMHEed2nl5b7PvN9eIw58=
-github.com/cockroachdb/crlib v0.0.0-20250916151006-1094cb39adac/go.mod h1:Gq51ZeKaFCXk6QwuGM0w1dnaOqc/F5zKT2zA9D6Xeac=
+github.com/cockroachdb/crlib v0.0.0-20251001180057-2a49e1873587 h1:qjG2TrBrPbGRVYp5obcAi8OSsuFJ8s1AElDImHLV9tY=
+github.com/cockroachdb/crlib v0.0.0-20251001180057-2a49e1873587/go.mod h1:ae57yNis2F1FThSNdPdoXfiPOVi8G1TLreCBQYPOdqo=
 github.com/cockroachdb/datadriven v1.0.3-0.20250911232732-d959cf14706c h1:a0m7gmtv2mzJQ4wP9BkxCmJAnjZ7fsvCi2IORGD1als=
 github.com/cockroachdb/datadriven v1.0.3-0.20250911232732-d959cf14706c/go.mod h1:jsaKMvD3RBCATk1/jbUZM8C9idWBJME9+VRZ5+Liq1g=
 github.com/cockroachdb/errors v1.11.3 h1:5bA+k2Y6r+oz/6Z/RFlNeVCesGARKuC6YymtcDrbC/I=
@@ -190,6 +190,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=
+github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/internal/inflight/in_flight.go
+++ b/internal/inflight/in_flight.go
@@ -72,6 +72,10 @@ type Tracker struct {
 // A zero Handle is not valid.
 type Handle uint64
 
+func (h Handle) IsValid() bool {
+	return h != 0
+}
+
 // ReportFn is called (typically periodically) with a formatted report that
 // describes entries older than some threshold. An empty string report is never
 // delivered by the polling tracker.

--- a/internal/inflight/in_flight.go
+++ b/internal/inflight/in_flight.go
@@ -1,0 +1,273 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package inflight provides a lightweight, sharded tracker for reporting
+// long-running operations.
+package inflight
+
+import (
+	"cmp"
+	"fmt"
+	"iter"
+	"maps"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/crlib/crsync"
+	"github.com/cockroachdb/crlib/crtime"
+	"github.com/puzpuzpuz/xsync/v3"
+)
+
+// Tracker is a lightweight, sharded tracker for detecting long-running
+// operations. Call Start() at the beginning of an operation and Stop() when it
+// completes; if an operation exceeds a configured age threshold, a formatted
+// report that includes the caller stack of Start() can be produced via Report,
+// or periodically via NewPollingTracker.
+//
+// The tracker is concurrency-safe and designed to have very low overhead in the
+// common path (Start/Stop). Observability work (capturing up to a small fixed
+// number of program counters and formatting stack frames) is deferred to when a
+// report is requested.
+//
+// Example:
+//
+//	 pollInterval := time.Minute
+//	 maxAge := 10 * time.Minute
+//		t := NewPollingTracker(pollInterval, maxAge, func(r string) {
+//		  log.Infof(ctx, "slow operations:\n%s", r)
+//		})
+//		defer t.Close()
+//
+//		h := t.Start()
+//		// ... do work ...
+//		t.Stop(h)
+//
+// If any operations have been running for more than 10 minutes, the report
+// function is called every 1 minute with a human‑readable dump that deduplicates
+// by Start() stack trace and shows the oldest occurrence per trace.
+type Tracker struct {
+	// The tracker has a fixed number of shards to reduce contention on
+	// Start/Stop. The first byte of Handle identifies the shard that was used
+	// during Start().
+
+	// Both maps and handleCounters have one entry per shard. We separate them
+	// because the map pointers don't change.
+	maps           []*xsync.MapOf[Handle, entry]
+	handleCounters []handleCounter
+
+	mu struct {
+		sync.Mutex
+		// timer is non-nil if this tracker was created with NewPollingTracker() and
+		// hasn't been closed yet.
+		timer *time.Timer
+	}
+}
+
+// Handle uniquely identifies a started operation. Treat it as an opaque token.
+// A zero Handle is not valid.
+type Handle uint64
+
+// ReportFn is called (typically periodically) with a formatted report that
+// describes entries older than some threshold. An empty string report is never
+// delivered by the polling tracker.
+//
+// See Tracker.Report() for details on the report format.
+type ReportFn func(report string)
+
+// NewTracker creates a new tracker that can be used to generate reports on
+// long-running operations. It does not start any background goroutines; callers
+// can invoke Report() on demand.
+func NewTracker() *Tracker {
+	return newTracker(crsync.NumShards())
+}
+
+// NewPollingTracker creates a new tracker that will periodically generate
+// reports on long-running operations.
+//
+// Specifically, every pollInterval, reportFn will be called if there are
+// operations that have been running for more than maxAge.
+//
+// The tracker must be closed with Close() when no longer needed.
+func NewPollingTracker(
+	pollInterval time.Duration, maxAge time.Duration, reportFn ReportFn,
+) *Tracker {
+	t := newTracker(crsync.NumShards())
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.mu.timer = time.AfterFunc(pollInterval, func() {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		if t.mu.timer == nil {
+			// Close was called.
+			return
+		}
+		if report := t.Report(maxAge); report != "" {
+			reportFn(report)
+		}
+		t.mu.timer.Reset(pollInterval)
+	})
+	return t
+}
+
+// Close stops background polling (if enabled).
+//
+// Note that Start, Stop, and Report can still be used during/after Close.
+func (t *Tracker) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.mu.timer != nil {
+		t.mu.timer.Stop()
+		// If the timer function is waiting for the mutex, it will notice that timer
+		// is nil and exit.
+		t.mu.timer = nil
+	}
+}
+
+// Start records the start of an operation and returns a handle that should be
+// used with Stop.
+func (t *Tracker) Start() Handle {
+	// We record a monotonic start time and capture program counters from the
+	// caller’s stack. We generate a handle that includes the shard index in its
+	// high byte, making Stop an O(1) operation on the right shard without a
+	// lookup.
+	var e entry
+	e.startTime = crtime.NowMono()
+	runtime.Callers(2, e.stack[:])
+	shardIdx := crsync.CPUBiasedInt() % len(t.maps)
+	h := Handle(t.handleCounters[shardIdx].Add(1))
+	t.maps[shardIdx].Store(h, e)
+	return h
+}
+
+// Stop records the end of an operation. Does nothing if the operation was
+// already stopped.
+func (t *Tracker) Stop(h Handle) {
+	// The high byte of h is the shard index; see newTracker.
+	t.maps[h>>56].Delete(h)
+}
+
+// Report returns a multi-line, human-readable summary of all entries that were
+// started before the given threshold (i.e., with age > threshold at the call
+// time). The result is suitable for logging or debugging. If no entries exceed
+// the threshold, Report returns "".
+//
+// The output is grouped by Start() stack trace: for each unique stack we show
+// the number of occurrences and the oldest start time among them. Groups are
+// ordered by age (oldest first), and for each group we print the resolved stack
+// frames.
+func (t *Tracker) Report(threshold time.Duration) string {
+	type infoForStackTrace struct {
+		oldestStartTime crtime.Mono
+		occurrences     int
+	}
+	now := crtime.NowMono()
+	cutoff := now - crtime.Mono(threshold)
+	// We deduplicate stack traces in the report. For each stack, we mention the
+	// number of long-running operations and the oldest operation time.
+	var m map[stack]infoForStackTrace
+	for e := range t.olderThan(cutoff) {
+		if m == nil {
+			m = make(map[stack]infoForStackTrace)
+		}
+		info, ok := m[e.stack]
+		if ok {
+			info.occurrences++
+			info.oldestStartTime = min(info.oldestStartTime, e.startTime)
+		} else {
+			info.occurrences = 1
+			info.oldestStartTime = e.startTime
+		}
+		m[e.stack] = info
+	}
+	if len(m) == 0 {
+		return ""
+	}
+	// Sort by oldest start time.
+	stacks := slices.Collect(maps.Keys(m))
+	slices.SortFunc(stacks, func(a, b stack) int {
+		return cmp.Compare(m[a].oldestStartTime, m[b].oldestStartTime)
+	})
+	var b strings.Builder
+	for _, stack := range stacks {
+		info := m[stack]
+		if info.occurrences == 1 {
+			fmt.Fprintf(&b, "started %s ago:\n", now.Sub(info.oldestStartTime))
+		} else {
+			fmt.Fprintf(&b, "%d occurrences, oldest started %s ago:\n", info.occurrences, now.Sub(info.oldestStartTime))
+		}
+		pcs := stack[:]
+		for i := range pcs {
+			if pcs[i] == 0 {
+				pcs = pcs[:i]
+				break
+			}
+		}
+		frames := runtime.CallersFrames(pcs)
+		for {
+			frame, more := frames.Next()
+			fmt.Fprintf(&b, "  %s\n   %s:%d\n", frame.Function, frame.File, frame.Line)
+			if !more {
+				break
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func (t *Tracker) olderThan(cutoff crtime.Mono) iter.Seq[entry] {
+	return func(yield func(entry) bool) {
+		for i := range t.maps {
+			for _, e := range t.maps[i].Range {
+				if e.startTime < cutoff && !yield(e) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// We use the high byte of Handle as a shard index. This limits us to 256 shards
+// (which is plenty).
+const maxShards = 256
+const mapPresize = 128
+
+// handleCounter is an atomic counter with padding to avoid false sharing.
+type handleCounter struct {
+	atomic.Uint64
+	_ [7]uint64
+}
+
+type entry struct {
+	startTime crtime.Mono
+	stack     stack
+}
+
+// stack contains program counters from Start()'s stack frame. Only the first 7
+// frames are recorded to keep Start() overhead low. Unused slots are zero.
+//
+// We chose 7 so that entry{} fits in a typical cache line. It should be
+// sufficient to identify the call path in most cases.
+type stack [7]uintptr
+
+func newTracker(numShards int) *Tracker {
+	numShards = min(numShards, maxShards)
+
+	maps := make([]*xsync.MapOf[Handle, entry], numShards)
+	handleCounters := make([]handleCounter, numShards)
+	for i := range numShards {
+		// All handles have the shard index in the high byte; see Start().
+		handleCounters[i].Store(uint64(i) << 56)
+		maps[i] = xsync.NewMapOf[Handle, entry](xsync.WithPresize(mapPresize))
+	}
+	return &Tracker{
+		maps:           maps,
+		handleCounters: handleCounters,
+	}
+}

--- a/internal/inflight/in_flight_bench_test.go
+++ b/internal/inflight/in_flight_bench_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package inflight
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// BenchmarkTracker benchmarks the overhead of Start/Stop under varying parallelism.
+//
+// Sample results on an Apple M1 Pro (10 core), without and with the cockroach
+// Go runtime:
+//
+//	name             vanilla-go time/op  crdb-go time/op  delta
+//	Tracker/p=1-10           231ns ± 1%       215ns ± 0%  -7.00%  (p=0.008 n=5+5)
+//	Tracker/p=5-10           325ns ± 1%       332ns ± 1%  +2.18%  (p=0.008 n=5+5)
+//	Tracker/p=10-10          540ns ±15%       527ns ± 4%    ~     (p=0.690 n=5+5)
+//	Tracker/p=20-10         1.05µs ± 8%      1.07µs ± 1%    ~     (p=0.135 n=5+5)
+func BenchmarkTracker(b *testing.B) {
+	procs := runtime.GOMAXPROCS(0)
+	for _, parallelism := range []int{1, procs / 2, procs, 2 * procs} {
+		b.Run(fmt.Sprintf("p=%d", parallelism), func(b *testing.B) {
+			const batchSize = 100
+			// Each element of ch corresponds to a batch of operations to be performed.
+			// The batch size is intended to amortize the overhead of channel operations.
+			ch := make(chan int, 1+b.N/batchSize)
+
+			tr := NewTracker()
+			var wg sync.WaitGroup
+			for range parallelism {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					for numOps := range ch {
+						for range numOps {
+							h := tr.Start()
+							tr.Stop(h)
+						}
+					}
+				}()
+			}
+
+			numOps := int64(b.N) * int64(parallelism)
+			for i := int64(0); i < numOps; i += batchSize {
+				ch <- int(min(batchSize, numOps-i))
+			}
+			close(ch)
+			wg.Wait()
+		})
+	}
+}

--- a/internal/inflight/in_flight_test.go
+++ b/internal/inflight/in_flight_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+//go:build go1.25
+
+package inflight
+
+import (
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackerBasic(t *testing.T) {
+	tr := NewTracker()
+	require.Empty(t, tr.Report(time.Minute))
+	h := tr.Start()
+	require.Empty(t, tr.Report(time.Minute))
+	time.Sleep(10 * time.Millisecond)
+	// Sample Report() output:
+	//
+	// started 11.123708ms ago:
+	//   github.com/cockroachdb/pebble/internal/inflight.TestTrackerBasic
+	//    /Users/radu/go/src/github.com/cockroachdb/pebble/internal/inflight/in_flight_test.go:17
+	//   testing.tRunner
+	//    /Users/radu/go/go1.24.2/src/testing/testing.go:1792
+	//   runtime.goexit
+	//    /Users/radu/go/go1.24.2/src/runtime/asm_arm64.s:1223
+	require.NotEmpty(t, tr.Report(time.Millisecond))
+	require.Empty(t, tr.Report(time.Minute))
+	tr.Stop(h)
+	require.Empty(t, tr.Report(time.Millisecond))
+}
+
+func TestPollingTracker(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var lastReport atomic.Value
+		lastReport.Store("")
+		reportFn := func(report string) {
+			lastReport.Store(report)
+		}
+
+		tr := NewPollingTracker(time.Millisecond, 10*time.Millisecond, reportFn)
+		time.Sleep(11 * time.Millisecond)
+		synctest.Wait()
+		require.Empty(t, lastReport.Load())
+		h := tr.Start()
+		time.Sleep(11 * time.Millisecond)
+		synctest.Wait()
+		require.NotEmpty(t, lastReport.Load())
+
+		tr.Stop(h)
+		synctest.Wait()
+		lastReport.Store("")
+		time.Sleep(11 * time.Millisecond)
+		require.Empty(t, lastReport.Load())
+
+		tr.Start()
+		time.Sleep(11 * time.Millisecond)
+		tr.Close()
+		// Make sure there are no further reports.
+		lastReport.Store("")
+		time.Sleep(11 * time.Millisecond)
+		synctest.Wait()
+		require.Empty(t, lastReport.Load())
+	})
+}

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -934,6 +934,11 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 		}
 	}
 
+	if rand.IntN(2) == 0 {
+		opts.Experimental.IteratorTracking.PollInterval = 100 * time.Millisecond
+		opts.Experimental.IteratorTracking.MaxAge = 10 * time.Second
+	}
+
 	testOpts.seedEFOS = rng.Uint64()
 	testOpts.ingestSplit = rng.IntN(2) == 0
 	opts.Experimental.IngestSplit = func() bool { return testOpts.ingestSplit }

--- a/options.go
+++ b/options.go
@@ -207,6 +207,13 @@ type IterOptions struct {
 	// changed by calling SetOptions.
 	Category block.Category
 
+	// ExemptFromTracking indicates that we should not track the lifetime of the
+	// iterator (used to log information about long-lived iterators). Useful for
+	// hot paths where we know the iterator will be short-lived.
+	ExemptFromTracking bool
+
+	// DebugRangeKeyStack enables additional logging of the range key stack
+	// iterator, via keyspan.InjectLogging. Only used for debugging.
 	DebugRangeKeyStack bool
 
 	// Internal options.
@@ -792,6 +799,22 @@ type Options struct {
 		// virtual table rewrite compactions entirely. The default value is 0.30
 		// (rewrite when >= 30% of backing data is unreferenced).
 		VirtualTableRewriteUnreferencedFraction func() float64
+
+		// IteratorTracking configures periodic logging of iterators held open for
+		// too long.
+		IteratorTracking struct {
+			// PollInterval is the interval at which to log a report of long-lived
+			// iterators. If zero, disables iterator tracking.
+			//
+			// The default value is 0 (disabled).
+			PollInterval time.Duration
+
+			// MaxAge is the age above which iterators are considered long-lived. If
+			// zero, disables iterator tracking.
+			//
+			// The default value is 0 (disabled).
+			MaxAge time.Duration
+		}
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for
@@ -1786,6 +1809,13 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  secondary_cache_size_bytes=%d\n", o.Experimental.SecondaryCacheSizeBytes)
 	fmt.Fprintf(&buf, "  create_on_shared=%d\n", o.Experimental.CreateOnShared)
 
+	if o.Experimental.IteratorTracking.PollInterval != 0 {
+		fmt.Fprintf(&buf, "  iterator_tracking_poll_interval=%s\n", o.Experimental.IteratorTracking.PollInterval)
+	}
+	if o.Experimental.IteratorTracking.MaxAge != 0 {
+		fmt.Fprintf(&buf, "  iterator_tracking_max_age=%s\n", o.Experimental.IteratorTracking.MaxAge)
+	}
+
 	// Private options.
 	//
 	// These options are only encoded if true, because we do not want them to
@@ -2228,6 +2258,10 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				var createOnSharedInt int64
 				createOnSharedInt, err = strconv.ParseInt(value, 10, 64)
 				o.Experimental.CreateOnShared = remote.CreateOnSharedStrategy(createOnSharedInt)
+			case "iterator_tracking_poll_interval":
+				o.Experimental.IteratorTracking.PollInterval, err = time.ParseDuration(value)
+			case "iterator_tracking_max_age":
+				o.Experimental.IteratorTracking.MaxAge, err = time.ParseDuration(value)
 			default:
 				if hooks != nil && hooks.SkipUnknown != nil && hooks.SkipUnknown(section+"."+key, value) {
 					return nil

--- a/options_test.go
+++ b/options_test.go
@@ -52,6 +52,10 @@ func (o *Options) randomizeForTesting(t testing.TB) {
 		}
 		o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy { return policy }
 	}
+	if rand.IntN(2) == 0 {
+		o.Experimental.IteratorTracking.PollInterval = 100 * time.Millisecond
+		o.Experimental.IteratorTracking.MaxAge = 10 * time.Second
+	}
 	o.EnsureDefaults()
 }
 

--- a/scripts/run-tests-with-custom-go.sh
+++ b/scripts/run-tests-with-custom-go.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# run-tests-with-custom-go.sh
+#
+# Downloads and builds a custom Go toolchain from cockcroachdb/go (specific
+# branch), caches it in ~/.cache/cockcroachdb-go/<branch>/<sha>, and runs
+# `go test`.
+#
+# Works in GitHub Actions or when run manually.
+# In CI: pass GO_SHA to pin an exact commit.
+# Locally: if GO_SHA is unset, script fetches the latest branch tip.
+
+set -euo pipefail
+
+GO_REPO="https://github.com/cockroachdb/go.git"
+GO_SHA="${GO_SHA:-}"
+
+if [ -z "$GO_SHA" ]; then
+  GO_BRANCH="${GO_BRANCH:-cockroach-go1.23.12}"
+  echo "==> Resolving latest SHA for branch $GO_BRANCH..."
+  GO_SHA=$(git ls-remote "$GO_REPO" "refs/heads/$GO_BRANCH" | cut -f1)
+fi
+
+# Use GITHUB_WORKSPACE if present (GitHub Actions), else current dir
+REPO_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+
+# Cache location (works locally and in CI)
+CACHE_BASE="${XDG_CACHE_HOME:-$HOME/.cache}/cockroachdb-go"
+CACHE_DIR="$CACHE_BASE/$GO_SHA"
+SRC_DIR="$CACHE_DIR/src"
+
+echo "==> Commit SHA: $GO_SHA"
+echo "==> Repository root: $REPO_ROOT"
+echo "==> Cache directory: $CACHE_DIR"
+
+if [ ! -x "$SRC_DIR/go/bin/go" ]; then
+  echo "==> Building new Go toolchain..."
+  mkdir -p "$SRC_DIR"
+  rm -rf "$SRC_DIR/go" # in case of partial/incomplete build
+
+  git clone "$GO_REPO" "$SRC_DIR/go"
+  cd "$SRC_DIR/go"
+  git checkout "$GO_SHA"
+
+  cd "$SRC_DIR/go/src"
+  ./make.bash
+else
+  echo "==> Reusing cached Go toolchain"
+fi
+
+# Point environment to new Go
+export GOROOT="$SRC_DIR/go"
+export PATH="$GOROOT/bin:$PATH"
+
+echo "==> Custom Go version:"
+go version
+
+echo "==> Running tests in $REPO_ROOT"
+cd "$REPO_ROOT"
+echo go test -tags cockroach_go "$@"
+go test -tags cockroach_go "$@"


### PR DESCRIPTION
I will try to figure out how to test this with CRDB. I also plan to run sysbench to see if there is any observable perf hit.

#### github: run tests against custom cockroach Go

Add a script and a nightly target that runs tests with the
custom Go runtime and the `cockroach_go` tag. The script is lifted
from crlib.

#### inflight: add data structure to detect long-running operations

This will be used to report long-lived iterators.

#### db: track and report long-standing iterators

We wire up iterators to an `inflight.Tracker`. Every 5 minutes we log
a report on iterators that have been open for more than 1 minute.

#### db: make iterator tracking configurable

We disable iterator tracking by default (since the overhead is
measurable). In addition, we allow disabling tracking for specific
iterators via `IterOptions`.

In CRDB we will enable iterator tracking but exempt those in the
hottest batch eval paths.
