### PR TITLE
metamorphic: fix bug in suffix generation when prefix == startPrefix

### DIFF
--- a/metamorphic/cockroachkvs.go
+++ b/metamorphic/cockroachkvs.go
@@ -303,7 +303,7 @@ func (kg *cockroachKeyGenerator) randKey(
 		suffixIdx = kg.skewedSuffixInt(0.01)
 		if cockroachkvs.Equal(prefix, startPrefix) {
 			// We can't use a suffix which sorts before startSuffix.
-			for i := 0; suffixIdx > startSuffixIdx; i++ {
+			for i := 0; suffixIdx < startSuffixIdx; i++ {
 				if i > 10 {
 					suffixIdx = startSuffixIdx
 					break


### PR DESCRIPTION
While the suffixIdx < startSuffixIdx, generate a new suffixIdx - not the other way around.

Fixes: #5349