### PR TITLE
metrics: fix TestMetrics flake

### DIFF
--- a/metrics_test.go
+++ b/metrics_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/crlib/crhumanize"
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -247,6 +248,9 @@ func TestMetrics(t *testing.T) {
 			// Large value for determinism.
 			MaxOpenFiles: 10000,
 		}
+		// Fix FileCacheShards to avoid non-determinism in disk usage (the option is
+		// written to the OPTIONS file).
+		opts.Experimental.FileCacheShards = 10
 		opts.Experimental.EnableValueBlocks = func() bool { return true }
 		opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 			return ValueSeparationPolicy{
@@ -508,7 +512,7 @@ func TestMetrics(t *testing.T) {
 			return buf.String()
 
 		case "disk-usage":
-			return humanize.Bytes.Uint64(d.Metrics().DiskSpaceUsage()).String()
+			return string(crhumanize.Bytes(d.Metrics().DiskSpaceUsage(), crhumanize.Compact, crhumanize.Exact))
 
 		case "additional-metrics":
 			// The asynchronous loading of table stats can change metrics, so

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -184,7 +184,7 @@ Iter category stats:
 
 disk-usage
 ----
-3.6KB
+3,709B
 
 batch
 set b 2
@@ -287,7 +287,7 @@ Iter category stats:
 
 disk-usage
 ----
-5.9KB
+6,002B
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -454,7 +454,7 @@ Iter category stats:
 
 disk-usage
 ----
-5.2KB
+5,295B
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -539,7 +539,7 @@ Iter category stats:
 
 disk-usage
 ----
-4.5KB
+4,588B
 
 additional-metrics
 ----


### PR DESCRIPTION
The disk usage counts the OPTIONS file as well. One of the values
`table_cache_shards` varies depending on machine and can lead to a 1
byte difference.

We fix this option in this test and show exact bytes values for disk
usage so this is easier to catch (it was caught with a separate change
where that 1 byte happened to make the difference between `4.5KB` and
`4.6KB`).