### PR TITLE
objstorageprovider: propagate errIsNotExist fn in remoteReadable

### DIFF
--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -264,7 +264,7 @@ func openExternalObj(
 	opts := t.opts.MakeReaderOptions()
 	reader, err = sstable.NewReader(
 		context.Background(),
-		objstorageprovider.NewRemoteReadable(objReader, objSize),
+		objstorageprovider.NewRemoteReadable(objReader, objSize, t.externalStorage.IsNotExistError),
 		opts,
 	)
 	if err != nil {

--- a/objstorage/objstorageprovider/remote_readable.go
+++ b/objstorage/objstorageprovider/remote_readable.go
@@ -16,10 +16,13 @@ import (
 )
 
 // NewRemoteReadable creates an objstorage.Readable out of a remote.ObjectReader.
-func NewRemoteReadable(objReader remote.ObjectReader, size int64) objstorage.Readable {
+func NewRemoteReadable(
+	objReader remote.ObjectReader, size int64, errIsNotExist func(error) bool,
+) objstorage.Readable {
 	return &remoteReadable{
-		objReader: objReader,
-		size:      size,
+		objReader:     objReader,
+		size:          size,
+		errIsNotExist: errIsNotExist,
 	}
 }
 

--- a/tool/db_analyze_data.go
+++ b/tool/db_analyze_data.go
@@ -259,7 +259,7 @@ func (r *remoteStorage) Open(name string) (objstorage.Readable, error) {
 	if err != nil {
 		return nil, err
 	}
-	return objstorageprovider.NewRemoteReadable(objReader, size), nil
+	return objstorageprovider.NewRemoteReadable(objReader, size, r.storage.IsNotExistError), nil
 }
 
 // We avoid files that are very large to prevent excessive memory usage. Note


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/154032