### PR TITLE
block: minor improvements to compression profiles

### DIFF
--- a/sstable/compressionanalyzer/buckets.go
+++ b/sstable/compressionanalyzer/buckets.go
@@ -112,15 +112,6 @@ var Profiles = [...]*block.CompressionProfile{
 		OtherBlocks:         compression.MinLZFastest,
 		MinReductionPercent: 0,
 	},
-
-	{
-		Name:                "MinLZ2",
-		DataBlocks:          compression.MinLZBalanced,
-		ValueBlocks:         compression.MinLZBalanced,
-		OtherBlocks:         compression.MinLZBalanced,
-		MinReductionPercent: 0,
-	},
-
 	{
 		Name:                "Zstd1",
 		DataBlocks:          compression.ZstdLevel1,
@@ -130,11 +121,20 @@ var Profiles = [...]*block.CompressionProfile{
 	},
 
 	{
-		Name:                           "Auto1",
+		Name:                           "Auto1/30",
 		DataBlocks:                     compression.ZstdLevel1,
 		ValueBlocks:                    compression.ZstdLevel1,
 		OtherBlocks:                    compression.MinLZFastest,
 		AdaptiveReductionCutoffPercent: 30,
+		MinReductionPercent:            0,
+	},
+
+	{
+		Name:                           "Auto1/15",
+		DataBlocks:                     compression.ZstdLevel1,
+		ValueBlocks:                    compression.ZstdLevel1,
+		OtherBlocks:                    compression.MinLZFastest,
+		AdaptiveReductionCutoffPercent: 15,
 		MinReductionPercent:            0,
 	},
 
@@ -146,14 +146,6 @@ var Profiles = [...]*block.CompressionProfile{
 		MinReductionPercent: 0,
 	},
 
-	{
-		Name:                           "Auto3",
-		DataBlocks:                     compression.ZstdLevel3,
-		ValueBlocks:                    compression.ZstdLevel3,
-		OtherBlocks:                    compression.MinLZFastest,
-		AdaptiveReductionCutoffPercent: 30,
-		MinReductionPercent:            0,
-	},
 	// Zstd levels 5+ are too slow (on the order of 15-20MB/s to compress) and
 	// don't usually offer a very large benefit in terms of size vs. level 3.
 }

--- a/sstable/compressionanalyzer/testdata/buckets
+++ b/sstable/compressionanalyzer/testdata/buckets
@@ -53,48 +53,55 @@ compressibility
 
 example-buckets-string
 ----
-Kind      Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       MinLZ2       Zstd1        Auto1        Zstd3        Auto3
-sstval    24-48KB     1.1-1.5  5        44.7KB ± 53%  CR      1.34 ± 17%   2.57 ± 9%    3.64 ± 6%    4.29 ± 3%    5.48 ± 5%    6.21 ± 4%    7.15 ± 1%
-                                                      Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-sstval    24-48KB     >2.5     6        34.3KB ± 71%  CR      1.34 ± 22%   2.48 ± 6%    3.35 ± 8%    4.38 ± 6%    5.34 ± 3%    6.58 ± 4%    7.41 ± 4%
-                                                      Comp    92MBps ± 2%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-blobval   24-48KB     1.5-2.5  5        24.6KB ± 77%  CR      1.65 ± 10%   2.53 ± 13%   3.56 ± 4%    4.45 ± 6%    5.40 ± 6%    6.37 ± 3%    7.36 ± 4%
-                                                      Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-filter    >128KB      <1.1     22       34.4KB ± 59%  CR      1.49 ± 22%   2.34 ± 11%   3.31 ± 7%    4.46 ± 6%    5.52 ± 6%    6.37 ± 4%    7.50 ± 4%
-                                                      Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-rangedel  48-128KB    >2.5     12       36.6KB ± 49%  CR      1.34 ± 23%   2.64 ± 11%   3.56 ± 7%    4.26 ± 5%    5.52 ± 5%    6.35 ± 4%    7.45 ± 4%
-                                                      Comp    92MBps ± 3%  47MBps ± 2%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-rangekey  >128KB      >2.5     1        48.0KB ± 0%   CR      1.90 ± 0%    2.40 ± 0%    3.50 ± 0%    4.80 ± 0%    5.30 ± 0%    6.20 ± 0%    7.10 ± 0%
-                                                      Comp    87MBps ± 0%  47MBps ± 0%  31MBps ± 0%  24MBps ± 0%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+Kind        Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       Zstd1        Auto1/30     Auto1/15     Zstd3
+sstval      24-48KB     >2.5     6        46.5KB ± 41%  CR      1.64 ± 15%   2.37 ± 7%    3.58 ± 5%    4.40 ± 4%    5.44 ± 5%    6.28 ± 4%
+                                                        Comp    92MBps ± 3%  46MBps ± 2%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%
+                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+blobrefval  <24KB       <1.1     20       36.2KB ± 52%  CR      1.42 ± 19%   2.35 ± 12%   3.54 ± 8%    4.41 ± 6%    5.30 ± 4%    6.49 ± 4%
+                                                        Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 1%
+                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+blobrefval  24-48KB     <1.1     4        39.0KB ± 63%  CR      1.34 ± 10%   2.35 ± 6%    3.62 ± 6%    4.48 ± 7%    5.31 ± 6%    6.72 ± 3%
+                                                        Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 0%  19MBps ± 1%  16MBps ± 0%
+                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+filter      24-48KB     1.5-2.5  1        15.0KB ± 0%   CR      1.30 ± 0%    2.50 ± 0%    3.50 ± 0%    4.30 ± 0%    5.10 ± 0%    6.20 ± 0%
+                                                        Comp    89MBps ± 0%  46MBps ± 0%  31MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
+                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangedel    48-128KB    >2.5     6        39.8KB ± 34%  CR      1.38 ± 18%   2.57 ± 11%   3.44 ± 7%    4.54 ± 5%    5.41 ± 5%    6.45 ± 4%
+                                                        Comp    92MBps ± 2%  46MBps ± 1%  31MBps ± 1%  24MBps ± 0%  19MBps ± 1%  16MBps ± 0%
+                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangedel    >128KB      1.1-1.5  1        30.3KB ± 0%   CR      1.60 ± 0%    2.50 ± 0%    3.70 ± 0%    4.30 ± 0%    5.60 ± 0%    6.70 ± 0%
+                                                        Comp    89MBps ± 0%  47MBps ± 0%  32MBps ± 0%  24MBps ± 0%  19MBps ± 0%  16MBps ± 0%
+                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangekey    >128KB      1.5-2.5  8        29.9KB ± 54%  CR      1.42 ± 21%   2.54 ± 10%   3.48 ± 8%    4.61 ± 7%    5.58 ± 5%    6.36 ± 3%
+                                                        Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 1%
+                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+metadata    >128KB      1.1-1.5  5        35.4KB ± 33%  CR      1.41 ± 20%   2.35 ± 11%   3.33 ± 3%    4.71 ± 3%    5.49 ± 4%    6.59 ± 2%
+                                                        Comp    91MBps ± 3%  46MBps ± 1%  32MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
+                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
 
 example-buckets-string min-samples=5
 ----
-Kind      Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       MinLZ2       Zstd1        Auto1        Zstd3        Auto3
-sstval    24-48KB     1.1-1.5  5        44.7KB ± 53%  CR      1.34 ± 17%   2.57 ± 9%    3.64 ± 6%    4.29 ± 3%    5.48 ± 5%    6.21 ± 4%    7.15 ± 1%
-                                                      Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-sstval    24-48KB     >2.5     6        34.3KB ± 71%  CR      1.34 ± 22%   2.48 ± 6%    3.35 ± 8%    4.38 ± 6%    5.34 ± 3%    6.58 ± 4%    7.41 ± 4%
-                                                      Comp    92MBps ± 2%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-blobval   24-48KB     1.5-2.5  5        24.6KB ± 77%  CR      1.65 ± 10%   2.53 ± 13%   3.56 ± 4%    4.45 ± 6%    5.40 ± 6%    6.37 ± 3%    7.36 ± 4%
-                                                      Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-filter    >128KB      <1.1     22       34.4KB ± 59%  CR      1.49 ± 22%   2.34 ± 11%   3.31 ± 7%    4.46 ± 6%    5.52 ± 6%    6.37 ± 4%    7.50 ± 4%
-                                                      Comp    91MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
-rangedel  48-128KB    >2.5     12       36.6KB ± 49%  CR      1.34 ± 23%   2.64 ± 11%   3.56 ± 7%    4.26 ± 5%    5.52 ± 5%    6.35 ± 4%    7.45 ± 4%
-                                                      Comp    92MBps ± 3%  47MBps ± 2%  31MBps ± 1%  23MBps ± 1%  19MBps ± 1%  16MBps ± 0%  14MBps ± 0%
-                                                      Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%   1MBps ± 0%
+Kind        Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       Zstd1        Auto1/30     Auto1/15     Zstd3
+sstval      24-48KB     >2.5     6        46.5KB ± 41%  CR      1.64 ± 15%   2.37 ± 7%    3.58 ± 5%    4.40 ± 4%    5.44 ± 5%    6.28 ± 4%
+                                                        Comp    92MBps ± 3%  46MBps ± 2%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%
+                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+blobrefval  <24KB       <1.1     20       36.2KB ± 52%  CR      1.42 ± 19%   2.35 ± 12%   3.54 ± 8%    4.41 ± 6%    5.30 ± 4%    6.49 ± 4%
+                                                        Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 1%
+                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangedel    48-128KB    >2.5     6        39.8KB ± 34%  CR      1.38 ± 18%   2.57 ± 11%   3.44 ± 7%    4.54 ± 5%    5.41 ± 5%    6.45 ± 4%
+                                                        Comp    92MBps ± 2%  46MBps ± 1%  31MBps ± 1%  24MBps ± 0%  19MBps ± 1%  16MBps ± 0%
+                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangekey    >128KB      1.5-2.5  8        29.9KB ± 54%  CR      1.42 ± 21%   2.54 ± 10%   3.48 ± 8%    4.61 ± 7%    5.58 ± 5%    6.36 ± 3%
+                                                        Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 1%
+                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+metadata    >128KB      1.1-1.5  5        35.4KB ± 33%  CR      1.41 ± 20%   2.35 ± 11%   3.33 ± 3%    4.71 ± 3%    5.49 ± 4%    6.59 ± 2%
+                                                        Comp    91MBps ± 3%  46MBps ± 1%  32MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
+                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
 
 example-buckets-csv min-samples=6
 ----
-Kind,Size Range,Test CR,Samples,Size,Size±,Snappy CR,Snappy CR±,Snappy Comp ns/b,Snappy Comp±,Snappy Decomp ns/b,Snappy Decomp±,MinLZ1 CR,MinLZ1 CR±,MinLZ1 Comp ns/b,MinLZ1 Comp±,MinLZ1 Decomp ns/b,MinLZ1 Decomp±,MinLZ2 CR,MinLZ2 CR±,MinLZ2 Comp ns/b,MinLZ2 Comp±,MinLZ2 Decomp ns/b,MinLZ2 Decomp±,Zstd1 CR,Zstd1 CR±,Zstd1 Comp ns/b,Zstd1 Comp±,Zstd1 Decomp ns/b,Zstd1 Decomp±,Auto1 CR,Auto1 CR±,Auto1 Comp ns/b,Auto1 Comp±,Auto1 Decomp ns/b,Auto1 Decomp±,Zstd3 CR,Zstd3 CR±,Zstd3 Comp ns/b,Zstd3 Comp±,Zstd3 Decomp ns/b,Zstd3 Decomp±,Auto3 CR,Auto3 CR±,Auto3 Comp ns/b,Auto3 Comp±,Auto3 Decomp ns/b,Auto3 Decomp±
-sstval,24-48KB,>2.5,6,35074,24930,1.337,0.289,10.348,0.191,100.419,0.268,2.483,0.157,20.422,0.270,200.394,0.223,3.347,0.276,30.423,0.254,300.431,0.084,4.384,0.251,40.392,0.226,400.273,0.278,5.341,0.182,50.513,0.218,500.538,0.152,6.583,0.274,60.574,0.173,600.736,0.254,7.408,0.300,70.489,0.264,700.386,0.291
-filter,>128KB,<1.1,22,35247,20784,1.489,0.325,10.447,0.281,100.478,0.320,2.343,0.261,20.326,0.249,200.506,0.250,3.306,0.229,30.519,0.239,300.492,0.285,4.462,0.253,40.420,0.215,400.380,0.244,5.520,0.329,50.422,0.301,500.354,0.269,6.368,0.270,60.446,0.289,600.340,0.261,7.504,0.311,70.457,0.293,700.497,0.274
-rangedel,48-128KB,>2.5,12,37516,18543,1.336,0.308,10.419,0.275,100.429,0.305,2.635,0.282,20.423,0.351,200.391,0.336,3.559,0.248,30.453,0.319,300.496,0.267,4.262,0.210,40.597,0.290,400.442,0.233,5.525,0.250,50.441,0.295,500.490,0.281,6.353,0.226,60.591,0.281,600.367,0.240,7.450,0.301,70.278,0.145,700.416,0.313
+Kind,Size Range,Test CR,Samples,Size,Size±,Snappy CR,Snappy CR±,Snappy Comp ns/b,Snappy Comp±,Snappy Decomp ns/b,Snappy Decomp±,MinLZ1 CR,MinLZ1 CR±,MinLZ1 Comp ns/b,MinLZ1 Comp±,MinLZ1 Decomp ns/b,MinLZ1 Decomp±,Zstd1 CR,Zstd1 CR±,Zstd1 Comp ns/b,Zstd1 Comp±,Zstd1 Decomp ns/b,Zstd1 Decomp±,Auto1/30 CR,Auto1/30 CR±,Auto1/30 Comp ns/b,Auto1/30 Comp±,Auto1/30 Decomp ns/b,Auto1/30 Decomp±,Auto1/15 CR,Auto1/15 CR±,Auto1/15 Comp ns/b,Auto1/15 Comp±,Auto1/15 Decomp ns/b,Auto1/15 Decomp±,Zstd3 CR,Zstd3 CR±,Zstd3 Comp ns/b,Zstd3 Comp±,Zstd3 Decomp ns/b,Zstd3 Decomp±
+sstval,24-48KB,>2.5,6,47579,19300,1.640,0.252,10.376,0.288,100.403,0.236,2.367,0.173,20.517,0.322,200.543,0.241,3.576,0.188,30.577,0.178,300.182,0.215,4.404,0.188,40.482,0.308,400.396,0.105,5.439,0.248,50.383,0.303,500.222,0.169,6.282,0.264,60.394,0.141,600.513,0.233
+blobrefval,<24KB,<1.1,20,37081,19435,1.416,0.271,10.331,0.272,100.335,0.280,2.349,0.275,20.430,0.304,200.565,0.252,3.538,0.297,30.488,0.245,300.514,0.259,4.409,0.253,40.509,0.225,400.566,0.234,5.295,0.232,50.430,0.305,500.411,0.333,6.492,0.251,60.395,0.312,600.378,0.293
+rangedel,48-128KB,>2.5,6,40738,13854,1.378,0.243,10.373,0.177,100.283,0.197,2.571,0.290,20.588,0.306,200.599,0.308,3.444,0.256,30.451,0.320,300.384,0.236,4.536,0.240,40.309,0.129,400.200,0.264,5.409,0.268,50.541,0.328,500.355,0.252,6.450,0.244,60.407,0.202,600.624,0.242
+rangekey,>128KB,1.5-2.5,8,30567,16391,1.421,0.304,10.373,0.332,100.577,0.261,2.538,0.241,20.263,0.208,200.289,0.215,3.479,0.282,30.575,0.253,300.612,0.210,4.605,0.302,40.420,0.265,400.473,0.187,5.583,0.285,50.347,0.245,500.596,0.330,6.355,0.217,60.364,0.361,600.632,0.203

--- a/sstable/compressionanalyzer/testdata/file_analyzer
+++ b/sstable/compressionanalyzer/testdata/file_analyzer
@@ -1,13 +1,13 @@
 sst
 ../testdata/hamlet-sst/000002.sst
 ----
-Kind      Size Range  Test CR  Samples  Size                 Snappy      MinLZ1      MinLZ2      Zstd1       Auto1       Zstd3       Auto3
-data      <24KB       1.5-2.5  14       1.9KB ± 25%  CR      1.93 ± 3%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
-                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-index     <24KB       1.1-1.5  1        0.3KB ± 0%   CR      1.31 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
-                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-rangedel  <24KB       1.1-1.5  1        0.4KB ± 0%   CR      1.28 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
-                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
-                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+Kind      Size Range  Test CR  Samples  Size                 Snappy      MinLZ1      Zstd1       Auto1/30    Auto1/15    Zstd3
+data      <24KB       1.5-2.5  14       1.9KB ± 25%  CR      1.93 ± 3%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+index     <24KB       1.1-1.5  1        0.3KB ± 0%   CR      1.31 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+rangedel  <24KB       1.1-1.5  1        0.4KB ± 0%   CR      1.28 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%   0.00 ± 0%
+                                                     Comp    0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%
+                                                     Decomp  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%  0MBps ± 0%


### PR DESCRIPTION
We change the "good" profile to use Zstd1 instead of adaptively
choosing between MinLZ1 and Zstd3. We also reduce some of the
thresholds and improve comments.

We also update the compression analyzer profiles. We no longer measure
MinLZ2 since it's almost as slow as Zstd1 with much smaller size
benefit over MinLZ1.