### PR TITLE
db: clean up some nil Options paths

### DIFF
--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -38,7 +38,7 @@ func loadVersion(
 ) (*manifest.Version, *latestVersionState, *Options, string) {
 	var sizes [numLevels]int64
 	opts := &Options{}
-	opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 	opts.EnsureDefaults()
 	d.ScanArgs(t, "l-base-max-bytes", &opts.LBaseMaxBytes)
 	var files [numLevels][]*manifest.TableMetadata

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -585,7 +585,7 @@ func TestAutomaticFlush(t *testing.T) {
 		Logger:                testutils.Logger{T: t},
 		MemTableSize:          memTableSize,
 	}
-	opts = opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 	opts.WithFSDefaults()
 	d, err := Open("", opts)
 	if err != nil {
@@ -2478,7 +2478,7 @@ func TestCompactionErrorCleanup(t *testing.T) {
 	for i := range opts.TargetFileSizes {
 		opts.TargetFileSizes[i] = 1
 	}
-	opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 	d, err := Open("", opts)
 	require.NoError(t, err)
 
@@ -3227,7 +3227,7 @@ func TestCompactionErrorStats(t *testing.T) {
 	for i := range opts.TargetFileSizes {
 		opts.TargetFileSizes[i] = 1
 	}
-	opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 	d, err := Open("", opts)
 	require.NoError(t, err)
 

--- a/db_test.go
+++ b/db_test.go
@@ -830,7 +830,7 @@ func TestMemTableReservation(t *testing.T) {
 		FS:                vfs.NewMem(),
 	}
 	defer opts.Cache.Unref()
-	opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 	opts.EnsureDefaults()
 
 	// Add a block to the cache. Note that the memtable size is larger than the
@@ -974,7 +974,7 @@ func TestRollManifest(t *testing.T) {
 		NumPrevManifest:       int(toPreserve),
 	}
 	opts.DisableAutomaticCompactions = true
-	opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 	d, err := Open("", opts)
 	require.NoError(t, err)
 

--- a/external_iterator_test.go
+++ b/external_iterator_test.go
@@ -28,7 +28,7 @@ func TestExternalIterator(t *testing.T) {
 		FormatMajorVersion: internalFormatNewest,
 		Comparer:           testkeys.Comparer,
 	}
-	o.testingRandomized(t)
+	o.randomizeForTesting(t)
 	o.EnsureDefaults()
 	d, err := Open("", o)
 	require.NoError(t, err)

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -2179,7 +2179,7 @@ func TestIngestFlushQueuedMemTable(t *testing.T) {
 
 	mem := vfs.NewMem()
 	o := &Options{FS: mem}
-	o.testingRandomized(t)
+	o.randomizeForTesting(t)
 	d, err := Open("", o)
 	require.NoError(t, err)
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1577,7 +1577,7 @@ func newTestkeysDatabase(t *testing.T, ks testkeys.Keyspace, rng *rand.Rand) *DB
 		FS:       vfs.NewMem(),
 		Logger:   panicLogger{},
 	}
-	dbOpts.testingRandomized(t)
+	dbOpts.randomizeForTesting(t)
 	d, err := Open("", dbOpts)
 	require.NoError(t, err)
 
@@ -1627,7 +1627,7 @@ func newPointTestkeysDatabase(t *testing.T, ks testkeys.Keyspace) *DB {
 		Comparer: testkeys.Comparer,
 		FS:       vfs.NewMem(),
 	}
-	dbOpts.testingRandomized(t)
+	dbOpts.randomizeForTesting(t)
 	d, err := Open("", dbOpts)
 	require.NoError(t, err)
 

--- a/open_test.go
+++ b/open_test.go
@@ -1342,7 +1342,7 @@ func TestOpenWALReplayMemtableGrowth(t *testing.T) {
 		MemTableSize: memTableSize,
 		FS:           mem,
 	}
-	opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 	func() {
 		db, err := Open("", opts)
 		require.NoError(t, err)
@@ -1385,7 +1385,7 @@ func TestGetVersion(t *testing.T) {
 	opts := &Options{
 		FS: mem,
 	}
-	opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 
 	// Case 1: No options file.
 	version, err := GetVersion("", mem)

--- a/options_test.go
+++ b/options_test.go
@@ -25,12 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testingRandomized randomizes some default options. Currently, it's
+// randomizeForTesting randomizes some default options. Currently, it's
 // used for testing under a random format major version in some tests.
-func (o *Options) testingRandomized(t testing.TB) *Options {
-	if o == nil {
-		o = &Options{}
-	}
+func (o *Options) randomizeForTesting(t testing.TB) {
 	if o.Logger == nil {
 		o.Logger = testutils.Logger{T: t}
 	}
@@ -56,11 +53,10 @@ func (o *Options) testingRandomized(t testing.TB) *Options {
 		o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy { return policy }
 	}
 	o.EnsureDefaults()
-	return o
 }
 
 func testingRandomized(t testing.TB, o *Options) *Options {
-	o.testingRandomized(t)
+	o.randomizeForTesting(t)
 	return o
 }
 
@@ -614,7 +610,7 @@ func TestKeyCategories(t *testing.T) {
 
 func TestApplyDBCompressionSettings(t *testing.T) {
 	var o Options
-	o.testingRandomized(t)
+	o.randomizeForTesting(t)
 
 	var profile DBCompressionSettings
 	o.ApplyCompressionSettings(func() DBCompressionSettings {

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -294,7 +294,7 @@ func TestStatsAfterReopen(t *testing.T) {
 	}
 	opts.Levels[0].BlockSize = 50
 	opts.TargetFileSizes[0] = 100
-	opts.testingRandomized(t)
+	opts.randomizeForTesting(t)
 	// We need at least FormatV2BlobFiles to retrieve blob file compression
 	// statistics.
 	opts.FormatMajorVersion = max(opts.FormatMajorVersion, FormatV2BlobFiles)


### PR DESCRIPTION
We no longer use nil Options; clean up some paths that tolerated it.