### PR TITLE
crl-release-25.3: wal: clean up all segment files

### DIFF
--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -440,6 +440,10 @@ type segmentWithSizeEtc struct {
 	synchronouslyClosed bool
 }
 
+func cmpSegmentWithSizeEtc(a, b segmentWithSizeEtc) int {
+	return cmp.Compare(a.segment.logNameIndex, b.segment.logNameIndex)
+}
+
 type failoverManager struct {
 	opts Options
 	// initialObsolete holds the set of DeletableLogs that formed the logs
@@ -661,41 +665,41 @@ func (wm *failoverManager) ElevateWriteStallThresholdForFailover() bool {
 	return wm.monitor.elevateWriteStallThresholdForFailover()
 }
 
+// writerClosed is called by the failoverWriter; see
+// failoverWriterOpts.writerClosed.
 func (wm *failoverManager) writerClosed(llse logicalLogWithSizesEtc) {
 	wm.monitor.noWriter()
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
-	wm.mu.closedWALs = append(wm.mu.closedWALs, llse)
+	wm.recordClosedWALLocked(llse)
 	wm.mu.ww = nil
 }
 
 // segmentClosed is called by the failoverWriter; see
 // failoverWriterOpts.segmentClosed.
-func (wm *failoverManager) segmentClosed(num NumWAL, s segmentWithSizeEtc) {
+func (wm *failoverManager) segmentClosed(llse logicalLogWithSizesEtc) {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
+	wm.recordClosedWALLocked(llse)
+}
+
+func (wm *failoverManager) recordClosedWALLocked(llse logicalLogWithSizesEtc) {
 	// Find the closed WAL matching the logical WAL num, if one exists. If we
-	// find one, we append the segment to the list of segments if it's not
-	// already there.
-	i, found := slices.BinarySearchFunc(wm.mu.closedWALs, num, func(llse logicalLogWithSizesEtc, num NumWAL) int {
-		return cmp.Compare(llse.num, num)
-	})
-	if found {
-		segmentIndex, segmentFound := slices.BinarySearchFunc(wm.mu.closedWALs[i].segments, s.segment.logNameIndex,
-			func(s segmentWithSizeEtc, logNameIndex LogNameIndex) int {
-				return cmp.Compare(s.segment.logNameIndex, logNameIndex)
-			})
-		if !segmentFound {
-			wm.mu.closedWALs[i].segments = slices.Insert(wm.mu.closedWALs[i].segments, segmentIndex, s)
-		}
+	// find one, we merge the segments into the existing list.
+	i, found := slices.BinarySearchFunc(wm.mu.closedWALs, llse.num,
+		func(llse logicalLogWithSizesEtc, num NumWAL) int {
+			return cmp.Compare(llse.num, num)
+		})
+	if !found {
+		// If we didn't find an existing entry in closedWALs for the provided
+		// NumWAL, append a new entry.
+		wm.mu.closedWALs = slices.Insert(wm.mu.closedWALs, i, llse)
 		return
 	}
-	// If we didn't find an existing entry in closedWALs for the provided
-	// NumWAL, append a new entry.
-	wm.mu.closedWALs = slices.Insert(wm.mu.closedWALs, i, logicalLogWithSizesEtc{
-		num:      num,
-		segments: []segmentWithSizeEtc{s},
-	})
+	wm.mu.closedWALs[i].segments = append(wm.mu.closedWALs[i].segments, llse.segments...)
+	slices.SortFunc(wm.mu.closedWALs[i].segments, cmpSegmentWithSizeEtc)
+	wm.mu.closedWALs[i].segments = slices.CompactFunc(wm.mu.closedWALs[i].segments,
+		func(a, b segmentWithSizeEtc) bool { return a.logNameIndex == b.logNameIndex })
 }
 
 // Stats implements Manager.

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -5,6 +5,7 @@
 package wal
 
 import (
+	"cmp"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -537,26 +538,22 @@ func (wm *failoverManager) init(o Options, initial Logs) error {
 func (wm *failoverManager) List() Logs {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
-	n := len(wm.mu.closedWALs)
-	if wm.mu.ww != nil {
-		n++
-	}
-	wals := make(Logs, n)
-	setLogicalLog := func(index int, llse logicalLogWithSizesEtc) {
+	wals := make(Logs, 0, len(wm.mu.closedWALs)+1)
+	setLogicalLog := func(llse logicalLogWithSizesEtc) {
 		segments := make([]segment, len(llse.segments))
 		for j := range llse.segments {
 			segments[j] = llse.segments[j].segment
 		}
-		wals[index] = LogicalLog{
+		wals = append(wals, LogicalLog{
 			Num:      llse.num,
 			segments: segments,
-		}
+		})
 	}
-	for i, llse := range wm.mu.closedWALs {
-		setLogicalLog(i, llse)
+	for _, llse := range wm.mu.closedWALs {
+		setLogicalLog(llse)
 	}
 	if wm.mu.ww != nil {
-		setLogicalLog(n-1, wm.mu.ww.getLog())
+		setLogicalLog(wm.mu.ww.getLog())
 	}
 	return wals
 }
@@ -637,6 +634,7 @@ func (wm *failoverManager) Create(wn NumWAL, jobID int) (Writer, error) {
 		stopper:                     wm.stopper,
 		failoverWriteAndSyncLatency: wm.opts.FailoverWriteAndSyncLatency,
 		writerClosed:                wm.writerClosed,
+		segmentClosed:               wm.segmentClosed,
 		writerCreatedForTest:        wm.opts.logWriterCreatedForTesting,
 		writeWALSyncOffsets:         wm.opts.WriteWALSyncOffsets,
 	}
@@ -669,6 +667,35 @@ func (wm *failoverManager) writerClosed(llse logicalLogWithSizesEtc) {
 	defer wm.mu.Unlock()
 	wm.mu.closedWALs = append(wm.mu.closedWALs, llse)
 	wm.mu.ww = nil
+}
+
+// segmentClosed is called by the failoverWriter; see
+// failoverWriterOpts.segmentClosed.
+func (wm *failoverManager) segmentClosed(num NumWAL, s segmentWithSizeEtc) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	// Find the closed WAL matching the logical WAL num, if one exists. If we
+	// find one, we append the segment to the list of segments if it's not
+	// already there.
+	i, found := slices.BinarySearchFunc(wm.mu.closedWALs, num, func(llse logicalLogWithSizesEtc, num NumWAL) int {
+		return cmp.Compare(llse.num, num)
+	})
+	if found {
+		segmentIndex, segmentFound := slices.BinarySearchFunc(wm.mu.closedWALs[i].segments, s.segment.logNameIndex,
+			func(s segmentWithSizeEtc, logNameIndex LogNameIndex) int {
+				return cmp.Compare(s.segment.logNameIndex, logNameIndex)
+			})
+		if !segmentFound {
+			wm.mu.closedWALs[i].segments = slices.Insert(wm.mu.closedWALs[i].segments, segmentIndex, s)
+		}
+		return
+	}
+	// If we didn't find an existing entry in closedWALs for the provided
+	// NumWAL, append a new entry.
+	wm.mu.closedWALs = slices.Insert(wm.mu.closedWALs, i, logicalLogWithSizesEtc{
+		num:      num,
+		segments: []segmentWithSizeEtc{s},
+	})
 }
 
 // Stats implements Manager.
@@ -883,8 +910,3 @@ func (t *defaultTicker) stop() {
 func (t *defaultTicker) ch() <-chan time.Time {
 	return (*time.Ticker)(t).C
 }
-
-// Make lint happy.
-var _ = (*failoverMonitor).noWriter
-var _ = (*failoverManager).writerClosed
-var _ = (&stopper{}).shouldQuiesce

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -428,27 +428,29 @@ func TestManagerFailover(t *testing.T) {
 				return b.String()
 
 			case "list-and-stats":
-				logs := fm.List()
-				stats := fm.Stats()
-				var b strings.Builder
-				if len(logs) > 0 {
-					fmt.Fprintf(&b, "logs:\n")
-					for _, f := range logs {
-						fmt.Fprintf(&b, "  %s\n", f.String())
+				return td.Retry(t, func() string {
+					logs := fm.List()
+					stats := fm.Stats()
+					var b strings.Builder
+					if len(logs) > 0 {
+						fmt.Fprintf(&b, "logs:\n")
+						for _, f := range logs {
+							fmt.Fprintf(&b, "  %s\n", f.String())
+						}
 					}
-				}
-				fmt.Fprintf(&b, "stats:\n")
-				fmt.Fprintf(&b, "  obsolete: count %d size %d\n", stats.ObsoleteFileCount, stats.ObsoleteFileSize)
-				fmt.Fprintf(&b, "  live: count %d size %d\n", stats.LiveFileCount, stats.LiveFileSize)
-				fmt.Fprintf(&b, "  failover: switches %d pri-dur %s sec-dur %s\n", stats.Failover.DirSwitchCount,
-					stats.Failover.PrimaryWriteDuration.String(), stats.Failover.SecondaryWriteDuration.String())
-				var latencyProto io_prometheus_client.Metric
-				stats.Failover.FailoverWriteAndSyncLatency.Write(&latencyProto)
-				latencySampleCount := *latencyProto.Histogram.SampleCount
-				if latencySampleCount > 0 {
-					fmt.Fprintf(&b, "  latency sample count: %d\n", latencySampleCount)
-				}
-				return b.String()
+					fmt.Fprintf(&b, "stats:\n")
+					fmt.Fprintf(&b, "  obsolete: count %d size %d\n", stats.ObsoleteFileCount, stats.ObsoleteFileSize)
+					fmt.Fprintf(&b, "  live: count %d size %d\n", stats.LiveFileCount, stats.LiveFileSize)
+					fmt.Fprintf(&b, "  failover: switches %d pri-dur %s sec-dur %s\n", stats.Failover.DirSwitchCount,
+						stats.Failover.PrimaryWriteDuration.String(), stats.Failover.SecondaryWriteDuration.String())
+					var latencyProto io_prometheus_client.Metric
+					stats.Failover.FailoverWriteAndSyncLatency.Write(&latencyProto)
+					latencySampleCount := *latencyProto.Histogram.SampleCount
+					if latencySampleCount > 0 {
+						fmt.Fprintf(&b, "  latency sample count: %d\n", latencySampleCount)
+					}
+					return b.String()
+				})
 
 			case "write-record":
 				var value string

--- a/wal/failover_writer.go
+++ b/wal/failover_writer.go
@@ -476,7 +476,7 @@ type failoverWriterOpts struct {
 	// invoked. It's used to ensure that we reclaim all physical segment files,
 	// including ones that did not complete creation before the Writer was
 	// closed.
-	segmentClosed func(NumWAL, segmentWithSizeEtc)
+	segmentClosed func(logicalLogWithSizesEtc)
 
 	writerCreatedForTest chan<- struct{}
 
@@ -704,13 +704,18 @@ func (ww *failoverWriter) switchToNewDir(dir dirAndFileHandle) error {
 				// there's an obsolete segment file we should clean up. Note
 				// that the file may be occupying non-negligible disk space even
 				// though we never wrote to it due to preallocation.
-				ww.opts.segmentClosed(ww.opts.wn, segmentWithSizeEtc{
-					segment: segment{
-						logNameIndex: LogNameIndex(writerIndex),
-						dir:          dir.Dir,
+				ww.opts.segmentClosed(logicalLogWithSizesEtc{
+					num: ww.opts.wn,
+					segments: []segmentWithSizeEtc{
+						{
+							segment: segment{
+								logNameIndex: LogNameIndex(writerIndex),
+								dir:          dir.Dir,
+							},
+							approxFileSize:      initialFileSize,
+							synchronouslyClosed: false,
+						},
 					},
-					approxFileSize:      initialFileSize,
-					synchronouslyClosed: false,
 				})
 			})
 		}

--- a/wal/failover_writer_test.go
+++ b/wal/failover_writer_test.go
@@ -285,7 +285,7 @@ func TestFailoverWriter(t *testing.T) {
 						stopper:                     stopper,
 						failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 						writerClosed:                func(_ logicalLogWithSizesEtc) {},
-						segmentClosed:               func(_ NumWAL, _ segmentWithSizeEtc) {},
+						segmentClosed:               func(_ logicalLogWithSizesEtc) {},
 						writerCreatedForTest:        logWriterCreated,
 						writeWALSyncOffsets:         func() bool { return false },
 					}, testDirs[dirIndex])
@@ -651,7 +651,7 @@ func TestConcurrentWritersWithManyRecords(t *testing.T) {
 		stopper:                     stopper,
 		failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		writerClosed:                func(_ logicalLogWithSizesEtc) {},
-		segmentClosed:               func(_ NumWAL, _ segmentWithSizeEtc) {},
+		segmentClosed:               func(_ logicalLogWithSizesEtc) {},
 		writerCreatedForTest:        logWriterCreated,
 		writeWALSyncOffsets:         func() bool { return false },
 	}, dirs[dirIndex])
@@ -755,7 +755,7 @@ func TestFailoverWriterManyRecords(t *testing.T) {
 		stopper:                     stopper,
 		failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		writerClosed:                func(_ logicalLogWithSizesEtc) {},
-		segmentClosed:               func(_ NumWAL, _ segmentWithSizeEtc) {},
+		segmentClosed:               func(_ logicalLogWithSizesEtc) {},
 		writeWALSyncOffsets:         func() bool { return false },
 	}, dir)
 	require.NoError(t, err)

--- a/wal/failover_writer_test.go
+++ b/wal/failover_writer_test.go
@@ -285,6 +285,7 @@ func TestFailoverWriter(t *testing.T) {
 						stopper:                     stopper,
 						failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 						writerClosed:                func(_ logicalLogWithSizesEtc) {},
+						segmentClosed:               func(_ NumWAL, _ segmentWithSizeEtc) {},
 						writerCreatedForTest:        logWriterCreated,
 						writeWALSyncOffsets:         func() bool { return false },
 					}, testDirs[dirIndex])
@@ -650,6 +651,7 @@ func TestConcurrentWritersWithManyRecords(t *testing.T) {
 		stopper:                     stopper,
 		failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		writerClosed:                func(_ logicalLogWithSizesEtc) {},
+		segmentClosed:               func(_ NumWAL, _ segmentWithSizeEtc) {},
 		writerCreatedForTest:        logWriterCreated,
 		writeWALSyncOffsets:         func() bool { return false },
 	}, dirs[dirIndex])
@@ -753,6 +755,7 @@ func TestFailoverWriterManyRecords(t *testing.T) {
 		stopper:                     stopper,
 		failoverWriteAndSyncLatency: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		writerClosed:                func(_ logicalLogWithSizesEtc) {},
+		segmentClosed:               func(_ NumWAL, _ segmentWithSizeEtc) {},
 		writeWALSyncOffsets:         func() bool { return false },
 	}, dir)
 	require.NoError(t, err)

--- a/wal/testdata/manager_failover
+++ b/wal/testdata/manager_failover
@@ -290,10 +290,11 @@ ok
 list-and-stats
 ----
 logs:
+  000001: {(sec,001)}
   000001: {(pri,002)}
 stats:
   obsolete: count 0 size 0
-  live: count 1 size 18
+  live: count 2 size 18
   failover: switches 2 pri-dur 77ms sec-dur 80ms
 
 advance-time dur=1s
@@ -318,6 +319,7 @@ obsolete min-unflushed=2
 ok
 recycler empty
 to delete:
+  wal 1: path: sec/000001-001.log size: 0
   wal 1: path: pri/000001-002.log size: 18
 
 create-writer wal-num=2

--- a/wal/testdata/manager_failover
+++ b/wal/testdata/manager_failover
@@ -290,8 +290,7 @@ ok
 list-and-stats
 ----
 logs:
-  000001: {(sec,001)}
-  000001: {(pri,002)}
+  000001: {(sec,001), (pri,002)}
 stats:
   obsolete: count 0 size 0
   live: count 2 size 18


### PR DESCRIPTION
25.3 backport of https://github.com/cockroachdb/pebble/pull/5388 and https://github.com/cockroachdb/pebble/pull/5403.

When WAL failover is configured, a single logical WAL may be composed of
multiple physical segment files. The creation of these physical segment files
occurs asynchronously. This asynchronous creation may race with the closing of
the failover writer.

Specifically, an outstanding attempt to create a segment file may block.
Meanwhile, writes persisting all the necessary records may complete on the
other device. If the logical WAL is now finished, the failover writer may be
closed by higher-level code while the outstanding attempt to create a file
remains. The system progresses, accumulating a list of obsolete files based on
the set that existed at the time that the writer was closed. Eventually, the
outstanding file creation may complete, creating a new file.

Previously this race resulted in leaking the straggling file. Because we
preallocate disk space for WAL files, this logically empty file could still
consume significant disk space. This leaked file could not be discovered and
deleted until process restart.

This commit adjusts the FailoverWriter to invoke a callback on the
FailoverManager, propagating information about these abandoned segment files.
This allows the FailoverManager to propagate these obsolete files to higher
levels for deletion.