### PR TITLE
db: don't store table fromat in compaction

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -320,7 +320,7 @@ func (d *DB) runBlobFileRewriteLocked(
 	if err != nil {
 		return objstorage.ObjectMetadata{}, nil, err
 	}
-	// Initialize a blob file rewriter. We pass L6 to MakeBlobWriterOptions.
+	// Initialize a blob file rewriter. We pass L6 to makeBlobWriterOptions.
 	// There's no single associated level with a blob file. A long-lived blob
 	// file that gets rewritten is likely to mostly be referenced from L6.
 	// TODO(jackson): Consider refactoring to remove the level association.
@@ -329,7 +329,7 @@ func (d *DB) runBlobFileRewriteLocked(
 		env,
 		objMeta.DiskFileNum,
 		writable,
-		d.opts.MakeBlobWriterOptions(6, d.BlobFileFormat()),
+		d.makeBlobWriterOptions(6),
 		c.referencingTables,
 		c.input,
 	)

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -248,7 +248,7 @@ func (pc *pickedTableCompaction) ConstructCompaction(
 		d.timeNow(),
 		d.ObjProvider(),
 		grantHandle,
-		d.TableFormat(),
+		d.shouldCreateShared(pc.outputLevel.level),
 		d.determineCompactionValueSeparation)
 }
 

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -671,7 +671,7 @@ func TestCompactionPickerL0(t *testing.T) {
 			var result strings.Builder
 			if ptc != nil {
 				checkClone(t, ptc)
-				c := newCompaction(ptc, opts, time.Now(), nil /* provider */, noopGrantHandle{}, sstable.TableFormatMinSupported, neverSeparateValues)
+				c := newCompaction(ptc, opts, time.Now(), nil /* provider */, noopGrantHandle{}, noSharedStorage, neverSeparateValues)
 				fmt.Fprintf(&result, "L%d -> L%d\n", ptc.startLevel.level, ptc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", ptc.startLevel.level, tableNums(ptc.startLevel.files))
 				if !ptc.outputLevel.files.Empty() {
@@ -712,6 +712,8 @@ func TestCompactionPickerL0(t *testing.T) {
 		return fmt.Sprintf("unrecognized command: %s", td.Cmd)
 	})
 }
+
+const noSharedStorage = false
 
 func TestCompactionPickerConcurrency(t *testing.T) {
 	opts := DefaultOptions()
@@ -803,7 +805,7 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 			var result strings.Builder
 			fmt.Fprintf(&result, "picker.getCompactionConcurrency: %d\n", allowedCompactions)
 			if pc != nil {
-				c := newCompaction(ptc, opts, time.Now(), nil /* provider */, noopGrantHandle{}, sstable.TableFormatMinSupported, neverSeparateValues)
+				c := newCompaction(ptc, opts, time.Now(), nil /* provider */, noopGrantHandle{}, noSharedStorage, neverSeparateValues)
 				fmt.Fprintf(&result, "L%d -> L%d\n", ptc.startLevel.level, ptc.outputLevel.level)
 				fmt.Fprintf(&result, "L%d: %s\n", ptc.startLevel.level, tableNums(ptc.startLevel.files))
 				if !ptc.outputLevel.files.Empty() {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -545,7 +545,7 @@ func TestPickCompaction(t *testing.T) {
 		pc, got := vs.picker.pickAutoScore(compactionEnv{diskAvailBytes: math.MaxUint64}), ""
 		if pc != nil {
 			tableCompaction := pc.(*pickedTableCompaction)
-			c := newCompaction(tableCompaction, opts, time.Now(), nil /* provider */, noopGrantHandle{}, sstable.TableFormatMinSupported, neverSeparateValues)
+			c := newCompaction(tableCompaction, opts, time.Now(), nil /* provider */, noopGrantHandle{}, noSharedStorage, neverSeparateValues)
 
 			gotStart := fileNums(c.startLevel.files)
 			gotML := ""
@@ -1609,7 +1609,7 @@ func TestCompactionOutputLevel(t *testing.T) {
 				d.ScanArgs(t, "start", &start)
 				d.ScanArgs(t, "base", &base)
 				pc := newPickedTableCompaction(opts, version, l0Organizer, start, defaultOutputLevel(start, base), base)
-				c := newCompaction(pc, opts, time.Now(), nil /* provider */, noopGrantHandle{}, sstable.TableFormatMinSupported, neverSeparateValues)
+				c := newCompaction(pc, opts, time.Now(), nil /* provider */, noopGrantHandle{}, noSharedStorage, neverSeparateValues)
 				return fmt.Sprintf("output=%d\nmax-output-file-size=%d\n",
 					c.outputLevel.level, c.maxOutputFileSize)
 
@@ -3551,7 +3551,7 @@ func TestTombstoneDensityCompactionMoveOptimization(t *testing.T) {
 
 	// Create the compaction.
 	tableCompaction := pc.(*pickedTableCompaction)
-	c := newCompaction(tableCompaction, opts, time.Now(), nil, noopGrantHandle{}, sstable.TableFormatMinSupported, neverSeparateValues)
+	c := newCompaction(tableCompaction, opts, time.Now(), nil, noopGrantHandle{}, noSharedStorage, neverSeparateValues)
 
 	// The compaction should be converted to a move.
 	require.Equal(t, compactionKindMove, c.kind, "expected compaction to be optimized to a move")
@@ -3667,7 +3667,7 @@ func TestTombstoneDensityCompactionMoveOptimization_NoMoveWithOverlap(t *testing
 
 	// Create the compaction.
 	tableCompaction := pc.(*pickedTableCompaction)
-	c := newCompaction(tableCompaction, opts, time.Now(), nil, noopGrantHandle{}, sstable.TableFormatMinSupported, neverSeparateValues)
+	c := newCompaction(tableCompaction, opts, time.Now(), nil, noopGrantHandle{}, noSharedStorage, neverSeparateValues)
 
 	// The compaction should NOT be converted to a move.
 	require.NotEqual(t, compactionKindMove, c.kind, "move optimization should NOT apply when there is overlap in output level")

--- a/download.go
+++ b/download.go
@@ -446,7 +446,7 @@ func (d *DB) tryLaunchDownloadForFile(
 
 	download.numLaunchedDownloads++
 	doneCh = make(chan error, 1)
-	c := newCompaction(pc, d.opts, d.timeNow(), d.objProvider, noopGrantHandle{}, d.TableFormat(), d.determineCompactionValueSeparation)
+	c := newCompaction(pc, d.opts, d.timeNow(), d.objProvider, noopGrantHandle{}, d.shouldCreateShared(pc.outputLevel.level), d.determineCompactionValueSeparation)
 	c.isDownload = true
 	d.mu.compact.downloadingCount++
 	c.AddInProgressLocked(d)

--- a/options.go
+++ b/options.go
@@ -2589,19 +2589,25 @@ func (o *Options) MakeWriterOptions(level int, format sstable.TableFormat) sstab
 	return writerOpts
 }
 
-// MakeBlobWriterOptions constructs blob.FileWriterOptions from the corresponding
-// options in the receiver.
-func (o *Options) MakeBlobWriterOptions(level int, format blob.FileFormat) blob.FileWriterOptions {
-	lo := o.Levels[level]
+// makeWriterOptions constructs sstable.WriterOptions for the specified level
+// using the current DB options and format.
+func (d *DB) makeWriterOptions(level int) sstable.WriterOptions {
+	return d.opts.MakeWriterOptions(level, d.TableFormat())
+}
+
+// makeBlobWriterOptions constructs blob.FileWriterOptions using the current DB
+// options and format.
+func (d *DB) makeBlobWriterOptions(level int) blob.FileWriterOptions {
+	lo := &d.opts.Levels[level]
 	return blob.FileWriterOptions{
-		Format:       format,
+		Format:       d.BlobFileFormat(),
 		Compression:  lo.Compression(),
 		ChecksumType: block.ChecksumTypeCRC32c,
 		FlushGovernor: block.MakeFlushGovernor(
 			lo.BlockSize,
 			lo.BlockSizeThreshold,
 			base.SizeClassAwareBlockSizeThreshold,
-			o.AllocatorSizeClasses,
+			d.opts.AllocatorSizeClasses,
 		),
 	}
 }


### PR DESCRIPTION
We currently store a table format in compaction. In practice, this is
always `d.TableFormat()`, and we don't even end up using it when we
write the output (we use `d.TableFormat()` again).

This change removes the table format from the compaction to simplify
things a bit. This allows adding a simpler `DB.makeWriterOptions()`
(which makes future extensions easier).