### PR TITLE
db: min size for mvcc separation should be configurable

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3476,14 +3476,15 @@ func (d *DB) compactAndWrite(
 			writerOpts.Compression = block.FastestCompression
 		}
 		vSep := valueSeparation
-		switch spanPolicy.ValueStoragePolicy {
-		case ValueStorageLowReadLatency:
+		switch spanPolicy.ValueStoragePolicy.PolicyAdjustment {
+		case NoValueSeparation:
 			vSep = compact.NeverSeparateValues{}
-		case ValueStorageLatencyTolerant:
+		case Override:
 			// This span of keyspace is more tolerant of latency, so set a more
 			// aggressive value separation policy for this output.
 			vSep.SetNextOutputConfig(compact.ValueSeparationOutputConfig{
-				MinimumSize: latencyTolerantMinimumSize,
+				MinimumSize:            spanPolicy.ValueStoragePolicy.MinimumSize,
+				MinimumMVCCGarbageSize: spanPolicy.ValueStoragePolicy.MinimumMVCCGarbageSize,
 			})
 		}
 		objMeta, tw, err := d.newCompactionOutputTable(jobID, c, writerOpts)

--- a/data_test.go
+++ b/data_test.go
@@ -1783,21 +1783,27 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 			}
 			policy := SpanPolicy{
 				DisableValueSeparationBySuffix: true,
-				ValueStoragePolicy:             ValueStorageLowReadLatency,
+				ValueStoragePolicy: ValueStoragePolicy{
+					PolicyAdjustment: NoValueSeparation,
+				},
 			}
 			spanPolicies = append(spanPolicies, SpanAndPolicy{
 				KeyRange: span,
 				Policy:   policy,
 			})
-		case "latency-tolerant-span":
+		case "override-span":
 			if len(cmdArg.Vals) != 2 {
-				return errors.New("latency-tolerant-span expects 2 arguments: <start-key> <end-key>")
+				return errors.New("override-span expects 2 arguments: <start-key> <end-key>")
 			}
 			span := KeyRange{
 				Start: []byte(cmdArg.Vals[0]),
 				End:   []byte(cmdArg.Vals[1]),
 			}
-			policy := SpanPolicy{ValueStoragePolicy: ValueStorageLatencyTolerant}
+			policy := SpanPolicy{ValueStoragePolicy: ValueStoragePolicy{
+				PolicyAdjustment:       Override,
+				MinimumSize:            latencyTolerantMinimumSize,
+				MinimumMVCCGarbageSize: 1,
+			}}
 			spanPolicies = append(spanPolicies, SpanAndPolicy{
 				KeyRange: span,
 				Policy:   policy,
@@ -1868,6 +1874,11 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 							return err
 						}
 						policy.GarbageRatioHighPriority, err = strconv.ParseFloat(value[i+1:], 64)
+						if err != nil {
+							return err
+						}
+					case "min-mvcc-garbage-size":
+						policy.MinimumMVCCGarbageSize, err = strconv.Atoi(value)
 						if err != nil {
 							return err
 						}

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -633,9 +633,10 @@ func TestBlobCorruptionEvent(t *testing.T) {
 			}
 			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return ValueSeparationPolicy{
-					Enabled:               true,
-					MinimumSize:           1,
-					MaxBlobReferenceDepth: 10,
+					Enabled:                true,
+					MinimumSize:            1,
+					MinimumMVCCGarbageSize: 1,
+					MaxBlobReferenceDepth:  10,
 				}
 			}
 			d, err := Open("", opts)

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -115,6 +115,9 @@ type ValueSeparationOutputConfig struct {
 	// MinimumSize is the minimum size of a value that will be separated into a
 	// blob file.
 	MinimumSize int
+	// MinimumMVCCGarbageSize is the minimum size of a value that will be
+	// separated into a blob file if the value is likely MVCC garbage.
+	MinimumMVCCGarbageSize int
 }
 
 // ValueSeparation defines an interface for writing some values to separate blob
@@ -344,7 +347,7 @@ func (r *Runner) writeKeysToTable(
 		}
 
 		valueLen := kv.V.Len()
-		isLikelyMVCCGarbage := sstable.IsLikelyMVCCGarbage(kv.K.UserKey, prevKeyKind, kv.K.Kind(), valueLen, prefixEqual)
+		isLikelyMVCCGarbage := sstable.IsLikelyMVCCGarbage(kv.K.UserKey, prevKeyKind, kv.K.Kind(), prefixEqual)
 		// Add the value to the sstable, possibly separating its value into a
 		// blob file. The ValueSeparation implementation is responsible for
 		// writing the KV to the sstable.

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -341,6 +341,7 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 		return pebble.ValueSeparationPolicy{
 			Enabled:                  true,
 			MinimumSize:              5,
+			MinimumMVCCGarbageSize:   1,
 			MaxBlobReferenceDepth:    3,
 			RewriteMinimumAge:        50 * time.Millisecond,
 			GarbageRatioLowPriority:  0.10, // 10% garbage
@@ -926,6 +927,7 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 		policy := pebble.ValueSeparationPolicy{
 			Enabled:                  true,
 			MinimumSize:              1 + rng.IntN(maxValueSize),
+			MinimumMVCCGarbageSize:   1 + rng.IntN(10),                                  // [1, 11)
 			MaxBlobReferenceDepth:    2 + rng.IntN(9),                                   // 2-10
 			RewriteMinimumAge:        time.Duration(rng.IntN(90)+10) * time.Millisecond, // [10ms, 100ms)
 			GarbageRatioLowPriority:  lowPri,

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -254,9 +254,10 @@ func TestMetrics(t *testing.T) {
 		opts.Experimental.EnableValueBlocks = func() bool { return true }
 		opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 			return ValueSeparationPolicy{
-				Enabled:               true,
-				MinimumSize:           3,
-				MaxBlobReferenceDepth: 5,
+				Enabled:                true,
+				MinimumSize:            3,
+				MinimumMVCCGarbageSize: 1,
+				MaxBlobReferenceDepth:  5,
 			}
 		}
 		opts.TargetFileSizes[0] = 50

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -350,10 +350,11 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 			}
 			opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 				return pebble.ValueSeparationPolicy{
-					Enabled:               true,
-					MinimumSize:           3,
-					MaxBlobReferenceDepth: 5,
-					RewriteMinimumAge:     15 * time.Minute,
+					Enabled:                true,
+					MinimumSize:            3,
+					MinimumMVCCGarbageSize: 1,
+					MaxBlobReferenceDepth:  5,
+					RewriteMinimumAge:      15 * time.Minute,
 				}
 			}
 			setDefaultExperimentalOpts(opts)

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -17,7 +17,7 @@ tree
        0      LOCK
      152      MANIFEST-000010
      250      MANIFEST-000013
-    2947      OPTIONS-000003
+    2977      OPTIONS-000003
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
@@ -32,7 +32,7 @@ tree
       11        000011.log
      707        000012.sst
      187        MANIFEST-000013
-    2947        OPTIONS-000003
+    2977        OPTIONS-000003
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013
 
@@ -93,6 +93,7 @@ cat build/OPTIONS-000003
 [Value Separation]
   enabled=true
   minimum_size=3
+  minimum_mvcc_garbage_size=1
   max_blob_reference_depth=5
   rewrite_minimum_age=15m0s
   garbage_ratio_low_priority=0.00

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -895,7 +895,7 @@ L6:
 # Create a new database with value separation enabled to test that blob files
 # are included in checkpoints.
 
-open valsepdb value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0)
+open valsepdb value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1)
 ----
 mkdir-all: valsepdb 0755
 open-dir: .

--- a/testdata/compaction/backing_value_size
+++ b/testdata/compaction/backing_value_size
@@ -1,7 +1,7 @@
 # Test a blob file rewrite compaction with virtual sstable references that
 # track backing value sizes do not trigger unnecessary blob file rewrites.
 
-define value-separation=(enabled=true, min-size=1, max-ref-depth=10, garbage-ratios=0.01:0.2)
+define value-separation=(enabled=true, min-size=1, max-ref-depth=10, garbage-ratios=0.01:0.2, min-mvcc-garbage-size=1)
 ----
 
 batch

--- a/testdata/compaction/mvcc_garbage_blob
+++ b/testdata/compaction/mvcc_garbage_blob
@@ -1,6 +1,6 @@
 # Set the minimum size for a separated value to 5.
 
-define value-separation=(enabled, min-size=5, max-ref-depth=3, garbage-ratios=1.0:1.0)
+define value-separation=(enabled, min-size=5, max-ref-depth=3, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1)
 ----
 
 batch

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -1,7 +1,7 @@
 # Test a simple sequence of flushes and compactions where all values are
 # separated.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0, garbage-ratios=1.0:1.0)
+define value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1)
 ----
 
 batch
@@ -81,7 +81,7 @@ compact a-d
 # and the value separation policy is configured to limit the blob reference
 # depth to 3.
 
-define verbose value-separation=(enabled, min-size=3, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
+define verbose value-separation=(enabled, min-size=3, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1)
 L6 blob-depth=3
   a.SET.0:a
   b.SET.0:blob{fileNum=100002 value=bar}
@@ -223,7 +223,7 @@ COMPRESSION
 
 # Set the minimum size for a separated value to 5.
 
-define value-separation=(enabled, min-size=5, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
+define value-separation=(enabled, min-size=5, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1)
 ----
 
 batch
@@ -273,7 +273,7 @@ w:world
 
 # Configure the database to require keys in the range [a,m) to be in-place.
 
-define required-in-place=(a,m) value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
+define required-in-place=(a,m) value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1)
 ----
 
 batch
@@ -300,7 +300,7 @@ Blob files:
 # references. Because these files overlap and are in separate sublevels, a
 # compaction that preserves blob references should sum their depths.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=2
+define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1) l0-compaction-threshold=2
 L0 blob-depth=1
   a.SET.9:a
   d.SET.9:blob{fileNum=100001 value=d}
@@ -362,7 +362,7 @@ obsolete-key: hex:00
 # sublevel, a compaction that preserves blob references should take the MAX of
 # their depths.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=2
+define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1) l0-compaction-threshold=2
 L0 blob-depth=1
   a.SET.9:a
   d.SET.9:blob{fileNum=100001 value=d}
@@ -397,7 +397,7 @@ Blob files:
 # garbage ratio of 0.0 (no garbage). With this configuration, any blob file that
 # contains any unreferenced values should be immediately compacted.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=2, rw-min-age=0s, garbage-ratios=0.0:0.0) auto-compactions=off
+define value-separation=(enabled, min-size=1, max-ref-depth=2, rw-min-age=0s, garbage-ratios=0.0:0.0, min-mvcc-garbage-size=1) auto-compactions=off
 ----
 
 batch
@@ -526,7 +526,7 @@ COMPRESSION
 
 # Test a blob file rewrite compaction with virtual sstable references.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=0s, garbage-ratios=0.01:0.01)
+define value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=0s, garbage-ratios=0.01:0.01, min-mvcc-garbage-size=1)
 ----
 
 batch
@@ -564,7 +564,7 @@ validate-blob-reference-index-block
 ----
 validated
 
-define value-separation=(enabled, min-size=5, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=1 target-file-sizes=65536 memtable-size=10000000
+define value-separation=(enabled, min-size=5, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1) l0-compaction-threshold=1 target-file-sizes=65536 memtable-size=10000000
 ----
 
 # Test writing a non-trivial amount of data. With a key length of 4, we'll write
@@ -685,10 +685,10 @@ would excise 1 files.
 
 
 # Test a value separation policy that is configured to only separate values ≥
-# 1024 bytes, but there's also a key span defined with the latency-tolerant
+# 1024 bytes, but there's also a key span defined with the overrride 
 # value storage policy.
 
-define value-separation=(enabled, min-size=1024, max-ref-depth=10, rw-min-age=0s, garbage-ratios=1.0:1.0) latency-tolerant-span=(f,o)
+define value-separation=(enabled, min-size=1024, max-ref-depth=10, rw-min-age=0s, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=1) override-span=(f,o)
 ----
 
 batch

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -271,7 +271,7 @@ L6       898KB    0.00     0.97           0.97
 # it weren't for the high priority blob file rewrite compaction heuristic
 # triggering, we would pursue an automatic score compaction from L0 -> LBase.
 
-define l0-compaction-threshold=1 lbase-max-bytes=65536  enable-table-stats=true auto-compactions=off value-separation=(enabled, min-size=1, max-ref-depth=5, garbage-ratios=0.1:0.2)
+define l0-compaction-threshold=1 lbase-max-bytes=65536  enable-table-stats=true auto-compactions=off value-separation=(enabled, min-size=1, max-ref-depth=5, garbage-ratios=0.1:0.2, min-mvcc-garbage-size=1)
 ----
 
 batch

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -184,7 +184,7 @@ Iter category stats:
 
 disk-usage
 ----
-3,709B
+3,739B
 
 batch
 set b 2
@@ -287,7 +287,7 @@ Iter category stats:
 
 disk-usage
 ----
-6,002B
+6,032B
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -454,7 +454,7 @@ Iter category stats:
 
 disk-usage
 ----
-5,295B
+5,325B
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -539,7 +539,7 @@ Iter category stats:
 
 disk-usage
 ----
-4,588B
+4,618B
 
 additional-metrics
 ----

--- a/testdata/static_span_policy_func
+++ b/testdata/static_span_policy_func
@@ -1,59 +1,59 @@
 # A single policy.
 
-test d-f:lowlatency
+test d-f:novalueseparation
 a b c d e f g
 ----
 a ->  until d
 b ->  until d
 c ->  until d
-d -> low-read-latency until f
-e -> low-read-latency until f
+d -> no-value-separation until f
+e -> no-value-separation until f
 f -> none
 g -> none
 
 
 # A single encompassing policy.
 
-test a-z:lowlatency
+test a-z:novalueseparation
 a b c d e z
 ----
-a -> low-read-latency until z
-b -> low-read-latency until z
-c -> low-read-latency until z
-d -> low-read-latency until z
-e -> low-read-latency until z
+a -> no-value-separation until z
+b -> no-value-separation until z
+c -> no-value-separation until z
+d -> no-value-separation until z
+e -> no-value-separation until z
 z -> none
 
 # Abutting policies.
 
-test b-d:lowlatency d-f:latencytolerant f-h:lowlatency
+test b-d:novalueseparation d-f:override f-h:novalueseparation
 a b c d e f g h i z
 ----
 a ->  until b
-b -> low-read-latency until d
-c -> low-read-latency until d
-d -> latency-tolerant until f
-e -> latency-tolerant until f
-f -> low-read-latency until h
-g -> low-read-latency until h
+b -> no-value-separation until d
+c -> no-value-separation until d
+d -> override until f
+e -> override until f
+f -> no-value-separation until h
+g -> no-value-separation until h
 h -> none
 i -> none
 z -> none
 
 # Gaps between policies.
 
-test b-d:lowlatency h-j:latencytolerant
+test b-d:novalueseparation h-j:override
 a b c d e f g h i j k l
 ----
 a ->  until b
-b -> low-read-latency until d
-c -> low-read-latency until d
+b -> no-value-separation until d
+c -> no-value-separation until d
 d ->  until h
 e ->  until h
 f ->  until h
 g ->  until h
-h -> latency-tolerant until j
-i -> latency-tolerant until j
+h -> override until j
+i -> override until j
 j -> none
 k -> none
 l -> none

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -980,7 +980,7 @@ range-deletions-bytes-estimate: 482
 
 # Create a database with value separation enabled.
 
-define format-major-version=24 value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=1m, garbage-ratios=0.1:0.3) target-file-sizes=(100000) block-size=32768
+define format-major-version=24 value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=1m, garbage-ratios=0.1:0.3, min-mvcc-garbage-size=1) target-file-sizes=(100000) block-size=32768
 ----
 
 batch

--- a/value_separation.go
+++ b/value_separation.go
@@ -21,7 +21,7 @@ import (
 
 // latencyTolerantMinimumSize is the minimum size, in bytes, of a value that
 // will be separated into a blob file when the value storage policy is
-// ValueStorageLatencyTolerant.
+// Override.
 const latencyTolerantMinimumSize = 10
 
 var neverSeparateValues getValueSeparation = func(JobID, *tableCompaction, ValueStoragePolicy) compact.ValueSeparation {
@@ -41,7 +41,7 @@ func (d *DB) determineCompactionValueSeparation(
 		return compact.NeverSeparateValues{}
 	}
 	policy := d.opts.Experimental.ValueSeparationPolicy()
-	if !policy.Enabled || valueStorage == ValueStorageLowReadLatency {
+	if !policy.Enabled || valueStorage.PolicyAdjustment == NoValueSeparation {
 		return compact.NeverSeparateValues{}
 	}
 
@@ -51,9 +51,9 @@ func (d *DB) determineCompactionValueSeparation(
 		// This compaction should preserve existing blob references.
 		kind := sstable.ValueSeparationDefault
 		minSize := policy.MinimumSize
-		if valueStorage != ValueStorageDefault {
+		if valueStorage.PolicyAdjustment == Override {
 			kind = sstable.ValueSeparationSpanPolicy
-			minSize = latencyTolerantMinimumSize
+			minSize = valueStorage.MinimumSize
 		}
 		return &preserveBlobReferences{
 			inputBlobPhysicalFiles:      uniqueInputBlobMetadatas(&c.version.BlobFiles, c.inputs),
@@ -64,6 +64,12 @@ func (d *DB) determineCompactionValueSeparation(
 	}
 
 	// This compaction should write values to new blob files.
+	minSize := policy.MinimumSize
+	mvccMinimumSize := policy.MinimumMVCCGarbageSize
+	if valueStorage.PolicyAdjustment == Override {
+		minSize = valueStorage.MinimumSize
+		mvccMinimumSize = valueStorage.MinimumMVCCGarbageSize
+	}
 	return &writeNewBlobFiles{
 		comparer: d.opts.Comparer,
 		newBlobObject: func() (objstorage.Writable, objstorage.ObjectMetadata, error) {
@@ -72,8 +78,9 @@ func (d *DB) determineCompactionValueSeparation(
 		},
 		shortAttrExtractor: d.opts.Experimental.ShortAttributeExtractor,
 		writerOpts:         d.makeBlobWriterOptions(c.outputLevel.level),
-		minimumSize:        policy.MinimumSize,
+		minimumSize:        minSize,
 		globalMinimumSize:  policy.MinimumSize,
+		mvccMinimumSize:    mvccMinimumSize,
 		invalidValueCallback: func(userKey []byte, value []byte, err error) {
 			// The value may not be safe, so it will be redacted when redaction
 			// is enabled.
@@ -131,13 +138,13 @@ func shouldWriteBlobFiles(
 			if !backingPropsValid {
 				continue
 			}
-			switch valueStorage {
-			case ValueStorageLowReadLatency:
+			switch valueStorage.PolicyAdjustment {
+			case NoValueSeparation:
 				// This case should be handled prior to calling this function,
 				// but include it here for completeness.
 				return false, inputReferenceDepth
-			case ValueStorageLatencyTolerant:
-				if backingProps.ValueSeparationMinSize != latencyTolerantMinimumSize {
+			case Override:
+				if backingProps.ValueSeparationMinSize != uint64(valueStorage.MinimumSize) {
 					return true, 0
 				}
 			default:
@@ -240,8 +247,12 @@ type writeNewBlobFiles struct {
 	minimumSize int
 	// globalMinimumSize is the size threshold for separating values into blob
 	// files globally across the keyspace. It may be overridden per-output by
-	// SetNextOutputConfig.
+	// SetNextOutputConfig if minimumSize is different.
 	globalMinimumSize int
+	// mvccMinimumSize is the minimum size of a value that will be separated into
+	// a blob file when the value is likely MVCC garbage; see comments in
+	// sstable.IsLikelyMVCCGarbage for the exact criteria we use.
+	mvccMinimumSize int
 	// invalidValueCallback is called when a value is encountered for which the
 	// short attribute extractor returns an error.
 	invalidValueCallback func(userKey []byte, value []byte, err error)
@@ -259,6 +270,7 @@ var _ compact.ValueSeparation = (*writeNewBlobFiles)(nil)
 // SetNextOutputConfig implements the ValueSeparation interface.
 func (vs *writeNewBlobFiles) SetNextOutputConfig(config compact.ValueSeparationOutputConfig) {
 	vs.minimumSize = config.MinimumSize
+	vs.mvccMinimumSize = config.MinimumMVCCGarbageSize
 }
 
 // Kind implements the ValueSeparation interface.
@@ -306,8 +318,10 @@ func (vs *writeNewBlobFiles) Add(
 		vs.buf = v[:0]
 	}
 
+	isLikelyMVCCGarbage = len(v) >= vs.mvccMinimumSize && isLikelyMVCCGarbage
 	// Values that are too small are never separated; however, MVCC keys are
-	// separated if they are a SET key kind, as long as the value is not empty.
+	// separated if they are a SET key kind, as long as the value meets the
+	// mvccMinimumSize constraint.
 	if len(v) < vs.minimumSize && !isLikelyMVCCGarbage {
 		return tw.Add(kv.K, v, forceObsolete)
 	}


### PR DESCRIPTION
We will add a configurable option, `LatencyTolerantSpanPolicy`, that
specifies the minimum value size required for latency tolerant spans
and likely MVCC garbage to be separated into a blob file.

Fixes: #5377