### PR TITLE
crl-release-25.4: db: add DBCompressionFast

### DIFF
--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -827,6 +827,7 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	if rng.IntN(2) == 0 {
 		csList := []pebble.DBCompressionSettings{
 			pebble.DBCompressionNone,
+			pebble.DBCompressionFast,
 			pebble.DBCompressionFastest,
 			pebble.DBCompressionBalanced,
 			pebble.DBCompressionGood,

--- a/options.go
+++ b/options.go
@@ -1418,15 +1418,23 @@ type DBCompressionSettings struct {
 
 // Predefined compression settings.
 var (
-	DBCompressionNone     = UniformDBCompressionSettings(block.NoCompression)
-	DBCompressionFastest  = UniformDBCompressionSettings(block.FastestCompression)
+	DBCompressionNone    = UniformDBCompressionSettings(block.NoCompression)
+	DBCompressionFastest = UniformDBCompressionSettings(block.FastestCompression)
+	DBCompressionFast    = func() DBCompressionSettings {
+		cs := DBCompressionSettings{Name: "Fast"}
+		for i := 0; i < manifest.NumLevels-1; i++ {
+			cs.Levels[i] = block.FastestCompression
+		}
+		cs.Levels[manifest.NumLevels-1] = block.FastCompression
+		return cs
+	}()
 	DBCompressionBalanced = func() DBCompressionSettings {
 		cs := DBCompressionSettings{Name: "Balanced"}
 		for i := 0; i < manifest.NumLevels-2; i++ {
 			cs.Levels[i] = block.FastestCompression
 		}
-		cs.Levels[manifest.NumLevels-2] = block.FastCompression     // Zstd1 for value blocks.
-		cs.Levels[manifest.NumLevels-1] = block.BalancedCompression // Zstd1 for data and value blocks.
+		cs.Levels[manifest.NumLevels-2] = block.FastCompression
+		cs.Levels[manifest.NumLevels-1] = block.BalancedCompression
 		return cs
 	}()
 	DBCompressionGood = func() DBCompressionSettings {
@@ -1434,8 +1442,8 @@ var (
 		for i := 0; i < manifest.NumLevels-2; i++ {
 			cs.Levels[i] = block.FastestCompression
 		}
-		cs.Levels[manifest.NumLevels-2] = block.BalancedCompression // Zstd1 for data and value blocks.
-		cs.Levels[manifest.NumLevels-1] = block.GoodCompression     // Zstd3 for data and value blocks.
+		cs.Levels[manifest.NumLevels-2] = block.BalancedCompression
+		cs.Levels[manifest.NumLevels-1] = block.GoodCompression
 		return cs
 	}()
 )


### PR DESCRIPTION
Add `DBCompressionSettings` that uses `FastCompression` on L6 (which
automatically chooses between MinLZ or Zstd1 for value blocks).