### PR TITLE
pebble: remove unnecessary set of  ReportCorruptionFn

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -310,9 +310,8 @@ func (d *DB) runBlobFileRewriteLocked(
 	bufferPool.Init(4, block.ForBlobFileRewrite)
 	defer bufferPool.Release()
 	env := block.ReadEnv{
-		Stats:              &c.internalIteratorStats,
-		BufferPool:         &bufferPool,
-		ReportCorruptionFn: d.reportCorruption,
+		Stats:      &c.internalIteratorStats,
+		BufferPool: &bufferPool,
 	}
 
 	// Create a new file for the rewritten blob file.


### PR DESCRIPTION
This param gets overwritten by the cached file reader. Remove setting this, as we also need to specify the corresponding argw henever this field is set.

Resolves: #5343