### PR TITLE
db: add backwards compatibility warnings

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -151,6 +151,13 @@ func (d DeferredBatchOp) Finish() error {
 //
 // # Internal representation
 //
+// WARNING: Do not remove the ability to handle older internal
+// representations, without thinking through the consequences in CockroachDB.
+// Specifically, CockroachDB can have unapplied raft log entries that contain
+// encoded Pebble batches, and without a CockroachDB-level below-Raft
+// migration they can correspond to arbitrarily old binary versions. Pebble
+// needs to be able to successfully apply such batches.
+//
 // The internal batch representation is a contiguous byte buffer with a fixed
 // 12-byte header, followed by a series of records.
 //

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -308,6 +308,13 @@ func (v FormatMajorVersion) MaxTableFormat() sstable.TableFormat {
 
 // MinTableFormat returns the minimum sstable.TableFormat that can be used at
 // this FormatMajorVersion.
+//
+// WARNING: Do not bump this to a higher value without thinking through the
+// consequences in CockroachDB. Specifically, CockroachDB can have unapplied
+// raft log entries that correspond to sstable ingestions, and without a
+// CockroachDB-level below-Raft migration they can correspond to arbitrarily
+// old binary versions. Pebble needs to be able to successfully ingest such
+// sstables.
 func (v FormatMajorVersion) MinTableFormat() sstable.TableFormat {
 	_ = v.resolveDefault()
 	return sstable.TableFormatPebblev1


### PR DESCRIPTION
Motivated by the discussion in
https://cockroachlabs.slack.com/archives/C02KHQMF2US/p1760454132816939?thread_ts=1760452441.114879&cid=C02KHQMF2US