### PR TITLE
crl-release-25.4: options: make TargetByteDeletionRate dynamically configurable

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3108,7 +3108,7 @@ func TestSharedObjectDeletePacing(t *testing.T) {
 		"": remote.NewInMem(),
 	})
 	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
-	opts.TargetByteDeletionRate = 1
+	opts.TargetByteDeletionRate = func() int { return 1 }
 	opts.Logger = testutils.Logger{T: t}
 
 	d, err := Open("", &opts)

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -689,7 +689,8 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	opts.FormatMajorVersion += pebble.FormatMajorVersion(rng.IntN(n + 1))
 	opts.Experimental.L0CompactionConcurrency = 1 + rng.IntN(4) // 1-4
 	opts.Experimental.LevelMultiplier = 5 << rng.IntN(7)        // 5 - 320
-	opts.TargetByteDeletionRate = 1 << uint(20+rng.IntN(10))    // 1MB - 1GB
+	targetByteDeletionRate := 1 << uint(20+rng.IntN(10))        // 1MB - 1GB
+	opts.TargetByteDeletionRate = func() int { return targetByteDeletionRate }
 	opts.Experimental.ValidateOnIngest = rng.IntN(2) != 0
 	opts.L0CompactionThreshold = 1 + rng.IntN(100)     // 1 - 100
 	opts.L0CompactionFileThreshold = 1 << rng.IntN(11) // 1 - 1024

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -75,6 +75,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"EventListener:",
 		"CompactionConcurrencyRange:",
 		"MaxConcurrentDownloads:",
+		"TargetByteDeletionRate:",
 		"Experimental.CompactionGarbageFractionForMaxConcurrency:",
 		"Experimental.DisableIngestAsFlushable:",
 		"Experimental.EnableColumnarBlocks:",
@@ -116,6 +117,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		expectEqualFn(t, o.Opts.Experimental.IngestSplit, parsed.Opts.Experimental.IngestSplit)
 		expectEqualFn(t, o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency, parsed.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency)
 		expectEqualFn(t, o.Opts.Experimental.ValueSeparationPolicy, parsed.Opts.Experimental.ValueSeparationPolicy)
+		expectEqualFn(t, o.Opts.TargetByteDeletionRate, parsed.Opts.TargetByteDeletionRate)
 
 		expBaseline, expUpper := o.Opts.CompactionConcurrencyRange()
 		parsedBaseline, parsedUpper := parsed.Opts.CompactionConcurrencyRange()

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -98,7 +98,7 @@ func openCleanupManager(
 		deletePacer: newDeletionPacer(
 			crtime.NowMono(),
 			opts.FreeSpaceThresholdBytes,
-			int64(opts.TargetByteDeletionRate),
+			opts.TargetByteDeletionRate,
 			opts.FreeSpaceTimeframe,
 			opts.ObsoleteBytesMaxRatio,
 			opts.ObsoleteBytesTimeframe,

--- a/obsolete_files_test.go
+++ b/obsolete_files_test.go
@@ -146,7 +146,7 @@ func TestCleanupManagerCloseWithPacing(t *testing.T) {
 	mem := vfs.NewMem()
 	opts := &Options{
 		FS:                     mem,
-		TargetByteDeletionRate: 1024, // 1 KB/s - slow pacing
+		TargetByteDeletionRate: func() int { return 1024 }, // 1 KB/s - slow pacing
 	}
 	opts.EnsureDefaults()
 

--- a/options.go
+++ b/options.go
@@ -1129,8 +1129,8 @@ type Options struct {
 	// This value is only a best-effort target; the effective rate can be
 	// higher if deletions are falling behind or disk space is running low.
 	//
-	// Setting this to 0 disables deletion pacing, which is also the default.
-	TargetByteDeletionRate int
+	// A returned value of 0 disables deletion pacing (this is also the default).
+	TargetByteDeletionRate func() int
 
 	// FreeSpaceThresholdBytes specifies the minimum amount of free disk space that Pebble
 	// attempts to maintain. If free disk space drops below this threshold, deletions
@@ -1484,6 +1484,10 @@ func (o *Options) EnsureDefaults() {
 		o.Cleaner = DeleteCleaner{}
 	}
 
+	if o.TargetByteDeletionRate == nil {
+		o.TargetByteDeletionRate = func() int { return 0 }
+	}
+
 	if o.FreeSpaceThresholdBytes == 0 {
 		o.FreeSpaceThresholdBytes = 16 << 30 // 16 GB
 	}
@@ -1770,7 +1774,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  max_open_files=%d\n", o.MaxOpenFiles)
 	fmt.Fprintf(&buf, "  mem_table_size=%d\n", o.MemTableSize)
 	fmt.Fprintf(&buf, "  mem_table_stop_writes_threshold=%d\n", o.MemTableStopWritesThreshold)
-	fmt.Fprintf(&buf, "  min_deletion_rate=%d\n", o.TargetByteDeletionRate)
+	fmt.Fprintf(&buf, "  min_deletion_rate=%d\n", o.TargetByteDeletionRate())
 	fmt.Fprintf(&buf, "  free_space_threshold_bytes=%d\n", o.FreeSpaceThresholdBytes)
 	fmt.Fprintf(&buf, "  free_space_timeframe=%s\n", o.FreeSpaceTimeframe.String())
 	fmt.Fprintf(&buf, "  obsolete_bytes_max_ratio=%f\n", o.ObsoleteBytesMaxRatio)
@@ -2134,7 +2138,11 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				// Do nothing; option existed in older versions of pebble, and
 				// may be meaningful again eventually.
 			case "min_deletion_rate":
-				o.TargetByteDeletionRate, err = strconv.Atoi(value)
+				var rate int
+				rate, err = strconv.Atoi(value)
+				if err == nil {
+					o.TargetByteDeletionRate = func() int { return rate }
+				}
 			case "free_space_threshold_bytes":
 				o.FreeSpaceThresholdBytes, err = strconv.ParseUint(value, 10, 64)
 			case "free_space_timeframe":

--- a/options_test.go
+++ b/options_test.go
@@ -398,7 +398,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.FlushDelayDeleteRange = 10 * time.Second
 			opts.FlushDelayRangeKey = 11 * time.Second
 			opts.Experimental.LevelMultiplier = 5
-			opts.TargetByteDeletionRate = 200
+			opts.TargetByteDeletionRate = func() int { return 200 }
 			opts.WALFailover = &WALFailoverOptions{
 				Secondary: wal.Dir{Dirname: "wal_secondary", FS: vfs.Default},
 			}


### PR DESCRIPTION
Change this setting to a function. This change will be backported to
older releases, as it provides an important "escape hatch" if delete
pacing goes wrong.

Informs #5424