### PR TITLE
db: delete obsolete files before scheduling flushes, compactions

### DIFF
--- a/open.go
+++ b/open.go
@@ -512,49 +512,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	}
 	d.mu.versions.visibleSeqNum.Store(d.mu.versions.logSeqNum.Load())
 
-	// Register with the CompactionScheduler before calling
-	// d.maybeScheduleFlush, since completion of the flush can trigger
-	// compactions.
-	d.compactionScheduler.Register(2, d)
 	if !d.opts.ReadOnly {
-		d.maybeScheduleFlush()
-		for d.mu.compact.flushing {
-			d.mu.compact.cond.Wait()
-		}
-
-		// Create an empty .log file for the mutable memtable.
-		newLogNum := d.mu.versions.getNextDiskFileNum()
-		d.mu.log.writer, err = d.mu.log.manager.Create(wal.NumWAL(newLogNum), int(jobID))
-		if err != nil {
-			return nil, err
-		}
-
-		// This isn't strictly necessary as we don't use the log number for
-		// memtables being flushed, only for the next unflushed memtable.
-		d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum = newLogNum
-	}
-	d.updateReadStateLocked(d.opts.DebugCheck)
-
-	if !d.opts.ReadOnly {
-		// If the Options specify a format major version higher than the
-		// loaded database's, upgrade it. If this is a new database, this
-		// code path also performs an initial upgrade from the starting
-		// implicit MinSupported version.
-		//
-		// We ratchet the version this far into Open so that migrations have a read
-		// state available. Note that this also results in creating/updating the
-		// format version marker file.
-		if opts.FormatMajorVersion > d.FormatMajorVersion() {
-			if err := d.ratchetFormatMajorVersionLocked(opts.FormatMajorVersion); err != nil {
-				return nil, err
-			}
-		} else if noFormatVersionMarker {
-			// We are creating a new store. Create the format version marker file.
-			if err := d.writeFormatVersionMarker(d.FormatMajorVersion()); err != nil {
-				return nil, err
-			}
-		}
-
 		// Write the current options to disk.
 		d.optionsFileNum = d.mu.versions.getNextDiskFileNum()
 		tmpPath := base.MakeFilepath(opts.FS, dirname, base.FileTypeTemp, d.optionsFileNum)
@@ -587,19 +545,54 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		if err := d.dataDir.Sync(); err != nil {
 			return nil, err
 		}
+
+		// Delete any obsolete files.
+		d.scanObsoleteFiles(rs.ls, flushableIngests)
+		d.deleteObsoleteFiles(jobID)
 	}
 
+	// Register with the CompactionScheduler before calling
+	// d.maybeScheduleFlush, since completion of the flush can trigger
+	// compactions.
+	d.compactionScheduler.Register(2, d)
 	if !d.opts.ReadOnly {
-		// Get a fresh list of files, in case some of the earlier flushes/compactions
-		// have deleted some files.
-		ls, err := opts.FS.List(dirname)
+		d.maybeScheduleFlush()
+		for d.mu.compact.flushing {
+			d.mu.compact.cond.Wait()
+		}
+
+		// Create an empty .log file for the mutable memtable.
+		newLogNum := d.mu.versions.getNextDiskFileNum()
+		d.mu.log.writer, err = d.mu.log.manager.Create(wal.NumWAL(newLogNum), int(jobID))
 		if err != nil {
 			return nil, err
 		}
-		d.scanObsoleteFiles(ls, flushableIngests)
-		d.deleteObsoleteFiles(jobID)
+
+		// This isn't strictly necessary as we don't use the log number for
+		// memtables being flushed, only for the next unflushed memtable.
+		d.mu.mem.queue[len(d.mu.mem.queue)-1].logNum = newLogNum
 	}
-	// Else, nothing is obsolete.
+	d.updateReadStateLocked(d.opts.DebugCheck)
+	if !d.opts.ReadOnly {
+		// If the Options specify a format major version higher than the
+		// loaded database's, upgrade it. If this is a new database, this
+		// code path also performs an initial upgrade from the starting
+		// implicit MinSupported version.
+		//
+		// We ratchet the version this far into Open so that migrations have a read
+		// state available. Note that this also results in creating/updating the
+		// format version marker file.
+		if opts.FormatMajorVersion > d.FormatMajorVersion() {
+			if err := d.ratchetFormatMajorVersionLocked(opts.FormatMajorVersion); err != nil {
+				return nil, err
+			}
+		} else if noFormatVersionMarker {
+			// We are creating a new store. Create the format version marker file.
+			if err := d.writeFormatVersionMarker(d.FormatMajorVersion()); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	d.mu.tableStats.cond.L = &d.mu.Mutex
 	d.mu.tableValidation.cond.L = &d.mu.Mutex

--- a/replay/testdata/corpus/findManifestStart
+++ b/replay/testdata/corpus/findManifestStart
@@ -37,10 +37,10 @@ open
 list-files build
 ----
 build:
-  000002.log
+  000003.log
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000001
 
@@ -56,12 +56,12 @@ flush
 list-files build
 ----
 build:
-  000002.log
+  000003.log
   000004.log
   000005.sst
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000001
 
@@ -76,20 +76,20 @@ list-files build
 ----
 build:
   000005.sst
-  000008.log
+  000009.log
   LOCK
   MANIFEST-000001
-  MANIFEST-000007
-  OPTIONS-000009
+  MANIFEST-000008
+  OPTIONS-000007
   marker.format-version.000001.013
-  marker.manifest.000002.MANIFEST-000007
+  marker.manifest.000002.MANIFEST-000008
 
 delete-all build/MANIFEST-000007
 ----
 
 find-manifest-start build
 ----
-index: 0, offset: 0, error: nil
+index: 1, offset: 87, error: nil
 
 make-file build manifest 7
 bf13d7161a00010114636f636b726f6163685f636f6d70617261746f7203
@@ -122,4 +122,4 @@ created
 
 find-manifest-start build
 ----
-index: 1, offset: 739, error: nil
+index: 2, offset: 87, error: nil

--- a/replay/testdata/corpus/high_read_amp
+++ b/replay/testdata/corpus/high_read_amp
@@ -4,10 +4,10 @@ open
 list-files build
 ----
 build:
-  000002.log
+  000003.log
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000001
 
@@ -75,7 +75,7 @@ build:
   LOCK
   MANIFEST-000001
   MANIFEST-000010
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000002.MANIFEST-000010
 
@@ -91,7 +91,7 @@ high_read_amp/checkpoint:
   000008.log
   000009.sst
   MANIFEST-000010
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000010
 

--- a/replay/testdata/corpus/simple
+++ b/replay/testdata/corpus/simple
@@ -4,10 +4,10 @@ open
 list-files build
 ----
 build:
-  000002.log
+  000003.log
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000001
 
@@ -23,12 +23,12 @@ flush
 list-files build
 ----
 build:
-  000002.log
+  000003.log
   000004.log
   000005.sst
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000001
 
@@ -47,7 +47,7 @@ simple/checkpoint:
   000004.log
   000005.sst
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000001
 

--- a/replay/testdata/corpus/simple_ingest
+++ b/replay/testdata/corpus/simple_ingest
@@ -4,10 +4,10 @@ open-ingest-excise
 list-files build
 ----
 build:
-  000002.log
+  000003.log
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000012.025
   marker.manifest.000001.MANIFEST-000001
 
@@ -34,12 +34,12 @@ ingest-and-excised
 list-files build
 ----
 build:
-  000002.log
+  000003.log
   000004.sst
   000005.sst
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000012.025
   marker.manifest.000001.MANIFEST-000001
 
@@ -55,11 +55,11 @@ simple_ingest:
 list-files simple_ingest/checkpoint
 ----
 simple_ingest/checkpoint:
-  000002.log
+  000003.log
   000004.sst
   000005.sst
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.025
   marker.manifest.000001.MANIFEST-000001
 

--- a/replay/testdata/corpus/simple_val_sep
+++ b/replay/testdata/corpus/simple_val_sep
@@ -4,10 +4,10 @@ open-val-sep
 list-files build
 ----
 build:
-  000002.log
+  000003.log
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000011.024
   marker.manifest.000001.MANIFEST-000001
 
@@ -51,7 +51,7 @@ build:
   LOCK
   MANIFEST-000010
   MANIFEST-000013
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000011.024
   marker.manifest.000003.MANIFEST-000013
 
@@ -74,7 +74,7 @@ simple_val_sep/checkpoint:
   000011.log
   000012.sst
   MANIFEST-000013
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.024
   marker.manifest.000001.MANIFEST-000013
 

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -11,7 +11,7 @@ tree
      508      000007.sst
        0      LOCK
      133      MANIFEST-000001
-    2769      OPTIONS-000003
+    2769      OPTIONS-000002
        0      marker.format-version.000001.013
        0      marker.manifest.000001.MANIFEST-000001
             simple/
@@ -21,11 +21,11 @@ tree
       11        000004.log
      480        000005.sst
       85        MANIFEST-000001
-    2769        OPTIONS-000003
+    2769        OPTIONS-000002
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000001
 
-cat build/OPTIONS-000003
+cat build/OPTIONS-000002
 ----
 ----
 [Version]

--- a/replay/testdata/replay_ingest
+++ b/replay/testdata/replay_ingest
@@ -5,14 +5,14 @@ tree
 ----
           /
             build/
-      36      000002.log
+      36      000003.log
      661      000005.sst
      661      000007.sst
      655      000009.sst
        0      LOCK
      172      MANIFEST-000001
      209      MANIFEST-000008
-    2770      OPTIONS-000003
+    2770      OPTIONS-000002
        0      marker.format-version.000012.025
        0      marker.manifest.000002.MANIFEST-000008
             simple_ingest/
@@ -21,15 +21,15 @@ tree
      172      MANIFEST-000001
      209      MANIFEST-000008
               checkpoint/
-      11        000002.log
+      11        000003.log
      678        000004.sst
      661        000005.sst
      172        MANIFEST-000001
-    2770        OPTIONS-000003
+    2770        OPTIONS-000002
        0        marker.format-version.000001.025
        0        marker.manifest.000001.MANIFEST-000001
 
-cat build/OPTIONS-000003
+cat build/OPTIONS-000002
 ----
 ----
 [Version]

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -14,7 +14,7 @@ tree
        0      LOCK
      133      MANIFEST-000001
      205      MANIFEST-000010
-    2769      OPTIONS-000003
+    2769      OPTIONS-000002
        0      marker.format-version.000001.013
        0      marker.manifest.000002.MANIFEST-000010
             high_read_amp/
@@ -26,7 +26,7 @@ tree
       11        000008.log
      454        000009.sst
      157        MANIFEST-000010
-    2769        OPTIONS-000003
+    2769        OPTIONS-000002
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000010
 

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -17,7 +17,7 @@ tree
        0      LOCK
      152      MANIFEST-000010
      250      MANIFEST-000013
-    2947      OPTIONS-000003
+    2947      OPTIONS-000002
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
@@ -32,14 +32,14 @@ tree
       11        000011.log
      707        000012.sst
      187        MANIFEST-000013
-    2947        OPTIONS-000003
+    2947        OPTIONS-000002
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013
 
 replay simple_val_sep unpaced
 ----
 
-cat build/OPTIONS-000003
+cat build/OPTIONS-000002
 ----
 ----
 [Version]

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -19,7 +19,12 @@ sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 open-dir: db
-create: db/000002.log
+create: db/temporary.000002.dbtmp
+sync: db/temporary.000002.dbtmp
+close: db/temporary.000002.dbtmp
+rename: db/temporary.000002.dbtmp -> db/OPTIONS-000002
+sync: db
+create: db/000003.log
 sync: db
 create: db/marker.format-version.000001.014
 sync: db/marker.format-version.000001.014
@@ -95,23 +100,18 @@ sync: db/marker.format-version.000015.028
 close: db/marker.format-version.000015.028
 remove: db/marker.format-version.000014.027
 sync: db
-create: db/temporary.000003.dbtmp
-sync: db/temporary.000003.dbtmp
-close: db/temporary.000003.dbtmp
-rename: db/temporary.000003.dbtmp -> db/OPTIONS-000003
-sync: db
 
 batch db
 set a 1
 set b 2
 set c 3
 ----
-sync-data: db/000002.log
+sync-data: db/000003.log
 
 flush db
 ----
-sync-data: db/000002.log
-close: db/000002.log
+sync-data: db/000003.log
+close: db/000003.log
 create: db/000004.log
 sync: db
 create: db/000005.sst
@@ -131,7 +131,7 @@ flush db
 ----
 sync-data: db/000004.log
 close: db/000004.log
-reuseForWrite: db/000002.log -> db/000006.log
+reuseForWrite: db/000003.log -> db/000006.log
 sync: db
 create: db/000007.sst
 sync-data: db/000007.sst
@@ -155,11 +155,11 @@ open-dir: .
 sync: .
 close: .
 open-dir: checkpoints/checkpoint1
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint1/OPTIONS-000003
-sync-data: checkpoints/checkpoint1/OPTIONS-000003
-close: checkpoints/checkpoint1/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint1/OPTIONS-000002
+sync-data: checkpoints/checkpoint1/OPTIONS-000002
+close: checkpoints/checkpoint1/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint1/marker.format-version.000001.028
@@ -199,11 +199,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint2
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint2/OPTIONS-000003
-sync-data: checkpoints/checkpoint2/OPTIONS-000003
-close: checkpoints/checkpoint2/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint2/OPTIONS-000002
+sync-data: checkpoints/checkpoint2/OPTIONS-000002
+close: checkpoints/checkpoint2/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint2/marker.format-version.000001.028
@@ -238,11 +238,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint3
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint3/OPTIONS-000003
-sync-data: checkpoints/checkpoint3/OPTIONS-000003
-close: checkpoints/checkpoint3/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint3/OPTIONS-000002
+sync-data: checkpoints/checkpoint3/OPTIONS-000002
+close: checkpoints/checkpoint3/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint3/marker.format-version.000001.028
@@ -329,7 +329,7 @@ list db
 000010.sst
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 marker.format-version.000015.028
 marker.manifest.000001.MANIFEST-000001
 
@@ -339,7 +339,7 @@ list checkpoints/checkpoint1
 000006.log
 000007.sst
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 marker.format-version.000001.028
 marker.manifest.000001.MANIFEST-000001
 
@@ -354,8 +354,8 @@ open-dir: checkpoints/checkpoint1
 open: checkpoints/checkpoint1/MANIFEST-000001
 close: checkpoints/checkpoint1/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
-open: checkpoints/checkpoint1/OPTIONS-000003
-close: checkpoints/checkpoint1/OPTIONS-000003
+open: checkpoints/checkpoint1/OPTIONS-000002
+close: checkpoints/checkpoint1/OPTIONS-000002
 open: checkpoints/checkpoint1/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint1/000006.log
 
@@ -406,7 +406,7 @@ list checkpoints/checkpoint2
 000006.log
 000007.sst
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 marker.format-version.000001.028
 marker.manifest.000001.MANIFEST-000001
 
@@ -421,8 +421,8 @@ open-dir: checkpoints/checkpoint2
 open: checkpoints/checkpoint2/MANIFEST-000001
 close: checkpoints/checkpoint2/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
-open: checkpoints/checkpoint2/OPTIONS-000003
-close: checkpoints/checkpoint2/OPTIONS-000003
+open: checkpoints/checkpoint2/OPTIONS-000002
+close: checkpoints/checkpoint2/OPTIONS-000002
 open: checkpoints/checkpoint2/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint2/000006.log
 
@@ -448,7 +448,7 @@ list checkpoints/checkpoint3
 000006.log
 000007.sst
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 marker.format-version.000001.028
 marker.manifest.000001.MANIFEST-000001
 
@@ -463,8 +463,8 @@ open-dir: checkpoints/checkpoint3
 open: checkpoints/checkpoint3/MANIFEST-000001
 close: checkpoints/checkpoint3/MANIFEST-000001
 open-dir: checkpoints/checkpoint3
-open: checkpoints/checkpoint3/OPTIONS-000003
-close: checkpoints/checkpoint3/OPTIONS-000003
+open: checkpoints/checkpoint3/OPTIONS-000002
+close: checkpoints/checkpoint3/OPTIONS-000002
 open: checkpoints/checkpoint3/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint3/000006.log
 
@@ -562,11 +562,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint4
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint4/OPTIONS-000003
-sync-data: checkpoints/checkpoint4/OPTIONS-000003
-close: checkpoints/checkpoint4/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint4/OPTIONS-000002
+sync-data: checkpoints/checkpoint4/OPTIONS-000002
+close: checkpoints/checkpoint4/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint4
 create: checkpoints/checkpoint4/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint4/marker.format-version.000001.028
@@ -606,8 +606,8 @@ open-dir: checkpoints/checkpoint4
 open: checkpoints/checkpoint4/MANIFEST-000001
 close: checkpoints/checkpoint4/MANIFEST-000001
 open-dir: checkpoints/checkpoint4
-open: checkpoints/checkpoint4/OPTIONS-000003
-close: checkpoints/checkpoint4/OPTIONS-000003
+open: checkpoints/checkpoint4/OPTIONS-000002
+close: checkpoints/checkpoint4/OPTIONS-000002
 open: checkpoints/checkpoint4/000008.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint4/000008.log
 
@@ -657,7 +657,7 @@ list db
 000014.sst
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 marker.format-version.000015.028
 marker.manifest.000001.MANIFEST-000001
 
@@ -671,11 +671,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint5
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint5/OPTIONS-000003
-sync-data: checkpoints/checkpoint5/OPTIONS-000003
-close: checkpoints/checkpoint5/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint5/OPTIONS-000002
+sync-data: checkpoints/checkpoint5/OPTIONS-000002
+close: checkpoints/checkpoint5/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint5
 create: checkpoints/checkpoint5/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint5/marker.format-version.000001.028
@@ -721,30 +721,30 @@ open-dir: checkpoints/checkpoint5
 open: checkpoints/checkpoint5/MANIFEST-000001
 close: checkpoints/checkpoint5/MANIFEST-000001
 open-dir: checkpoints/checkpoint5
-open: checkpoints/checkpoint5/OPTIONS-000003
-close: checkpoints/checkpoint5/OPTIONS-000003
+open: checkpoints/checkpoint5/OPTIONS-000002
+close: checkpoints/checkpoint5/OPTIONS-000002
 open: checkpoints/checkpoint5/000008.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint5/000008.log
-create: checkpoints/checkpoint5/000018.sst
-sync-data: checkpoints/checkpoint5/000018.sst
-close: checkpoints/checkpoint5/000018.sst
+create: checkpoints/checkpoint5/temporary.000018.dbtmp
+sync: checkpoints/checkpoint5/temporary.000018.dbtmp
+close: checkpoints/checkpoint5/temporary.000018.dbtmp
+rename: checkpoints/checkpoint5/temporary.000018.dbtmp -> checkpoints/checkpoint5/OPTIONS-000018
 sync: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/MANIFEST-000019
-sync: checkpoints/checkpoint5/MANIFEST-000019
-create: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000019
-sync: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000019
-close: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000019
+remove: checkpoints/checkpoint5/OPTIONS-000002
+create: checkpoints/checkpoint5/000019.sst
+sync-data: checkpoints/checkpoint5/000019.sst
+close: checkpoints/checkpoint5/000019.sst
+sync: checkpoints/checkpoint5
+create: checkpoints/checkpoint5/MANIFEST-000020
+sync: checkpoints/checkpoint5/MANIFEST-000020
+create: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000020
+sync: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000020
+close: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000020
 remove: checkpoints/checkpoint5/marker.manifest.000001.MANIFEST-000001
 sync: checkpoints/checkpoint5
 remove: checkpoints/checkpoint5/000008.log
-create: checkpoints/checkpoint5/000020.log
+create: checkpoints/checkpoint5/000021.log
 sync: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/temporary.000021.dbtmp
-sync: checkpoints/checkpoint5/temporary.000021.dbtmp
-close: checkpoints/checkpoint5/temporary.000021.dbtmp
-rename: checkpoints/checkpoint5/temporary.000021.dbtmp -> checkpoints/checkpoint5/OPTIONS-000021
-sync: checkpoints/checkpoint5
-remove: checkpoints/checkpoint5/OPTIONS-000003
 
 print-backing checkpoints/checkpoint5
 ----
@@ -755,7 +755,7 @@ print-backing checkpoints/checkpoint5
 lsm checkpoints/checkpoint5
 ----
 L0.0:
-  000018:[h#18,SET-h#18,SET]
+  000019:[h#18,SET-h#18,SET]
 L6:
   000013(000010):[d#0,SET-g#0,SET]
   000015(000011):[i#20,SET-i#20,SET]
@@ -774,11 +774,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint6
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint6/OPTIONS-000003
-sync-data: checkpoints/checkpoint6/OPTIONS-000003
-close: checkpoints/checkpoint6/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint6/OPTIONS-000002
+sync-data: checkpoints/checkpoint6/OPTIONS-000002
+close: checkpoints/checkpoint6/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint6
 create: checkpoints/checkpoint6/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint6/marker.format-version.000001.028
@@ -823,30 +823,30 @@ open-dir: checkpoints/checkpoint6
 open: checkpoints/checkpoint6/MANIFEST-000001
 close: checkpoints/checkpoint6/MANIFEST-000001
 open-dir: checkpoints/checkpoint6
-open: checkpoints/checkpoint6/OPTIONS-000003
-close: checkpoints/checkpoint6/OPTIONS-000003
+open: checkpoints/checkpoint6/OPTIONS-000002
+close: checkpoints/checkpoint6/OPTIONS-000002
 open: checkpoints/checkpoint6/000008.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint6/000008.log
-create: checkpoints/checkpoint6/000018.sst
-sync-data: checkpoints/checkpoint6/000018.sst
-close: checkpoints/checkpoint6/000018.sst
+create: checkpoints/checkpoint6/temporary.000018.dbtmp
+sync: checkpoints/checkpoint6/temporary.000018.dbtmp
+close: checkpoints/checkpoint6/temporary.000018.dbtmp
+rename: checkpoints/checkpoint6/temporary.000018.dbtmp -> checkpoints/checkpoint6/OPTIONS-000018
 sync: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/MANIFEST-000019
-sync: checkpoints/checkpoint6/MANIFEST-000019
-create: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000019
-sync: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000019
-close: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000019
+remove: checkpoints/checkpoint6/OPTIONS-000002
+create: checkpoints/checkpoint6/000019.sst
+sync-data: checkpoints/checkpoint6/000019.sst
+close: checkpoints/checkpoint6/000019.sst
+sync: checkpoints/checkpoint6
+create: checkpoints/checkpoint6/MANIFEST-000020
+sync: checkpoints/checkpoint6/MANIFEST-000020
+create: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000020
+sync: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000020
+close: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000020
 remove: checkpoints/checkpoint6/marker.manifest.000001.MANIFEST-000001
 sync: checkpoints/checkpoint6
 remove: checkpoints/checkpoint6/000008.log
-create: checkpoints/checkpoint6/000020.log
+create: checkpoints/checkpoint6/000021.log
 sync: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/temporary.000021.dbtmp
-sync: checkpoints/checkpoint6/temporary.000021.dbtmp
-close: checkpoints/checkpoint6/temporary.000021.dbtmp
-rename: checkpoints/checkpoint6/temporary.000021.dbtmp -> checkpoints/checkpoint6/OPTIONS-000021
-sync: checkpoints/checkpoint6
-remove: checkpoints/checkpoint6/OPTIONS-000003
 
 print-backing checkpoints/checkpoint6
 ----
@@ -855,7 +855,7 @@ print-backing checkpoints/checkpoint6
 lsm checkpoints/checkpoint6
 ----
 L0.0:
-  000018:[h#18,SET-h#18,SET]
+  000019:[h#18,SET-h#18,SET]
 L6:
   000015(000011):[i#20,SET-i#20,SET]
   000016(000011):[k#20,SET-k#20,SET]
@@ -884,7 +884,7 @@ open checkpoints/checkpoint7 readonly nondeterministic
 lsm checkpoints/checkpoint7
 ----
 L0.0:
-  000018:[h#18,SET-h#18,SET]
+  000019:[h#18,SET-h#18,SET]
 L6:
   000012(000010):[a#0,SET-b#0,SET]
   000013(000010):[d#0,SET-g#0,SET]
@@ -916,7 +916,12 @@ sync: valsepdb/marker.manifest.000001.MANIFEST-000001
 close: valsepdb/marker.manifest.000001.MANIFEST-000001
 sync: valsepdb
 open-dir: valsepdb
-create: valsepdb/000002.log
+create: valsepdb/temporary.000002.dbtmp
+sync: valsepdb/temporary.000002.dbtmp
+close: valsepdb/temporary.000002.dbtmp
+rename: valsepdb/temporary.000002.dbtmp -> valsepdb/OPTIONS-000002
+sync: valsepdb
+create: valsepdb/000003.log
 sync: valsepdb
 create: valsepdb/marker.format-version.000001.014
 sync: valsepdb/marker.format-version.000001.014
@@ -992,11 +997,6 @@ sync: valsepdb/marker.format-version.000015.028
 close: valsepdb/marker.format-version.000015.028
 remove: valsepdb/marker.format-version.000014.027
 sync: valsepdb
-create: valsepdb/temporary.000003.dbtmp
-sync: valsepdb/temporary.000003.dbtmp
-close: valsepdb/temporary.000003.dbtmp
-rename: valsepdb/temporary.000003.dbtmp -> valsepdb/OPTIONS-000003
-sync: valsepdb
 
 batch valsepdb
 set a a
@@ -1006,14 +1006,14 @@ set d d
 set e e
 set f f
 ----
-sync-data: valsepdb/000002.log
+sync-data: valsepdb/000003.log
 
 # The flush creates a blob file.
 
 flush valsepdb
 ----
-sync-data: valsepdb/000002.log
-close: valsepdb/000002.log
+sync-data: valsepdb/000003.log
+close: valsepdb/000003.log
 create: valsepdb/000004.log
 sync: valsepdb
 create: valsepdb/000005.sst
@@ -1034,11 +1034,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint8
-open: valsepdb/OPTIONS-000003
-create: checkpoints/checkpoint8/OPTIONS-000003
-sync-data: checkpoints/checkpoint8/OPTIONS-000003
-close: checkpoints/checkpoint8/OPTIONS-000003
-close: valsepdb/OPTIONS-000003
+open: valsepdb/OPTIONS-000002
+create: checkpoints/checkpoint8/OPTIONS-000002
+sync-data: checkpoints/checkpoint8/OPTIONS-000002
+close: checkpoints/checkpoint8/OPTIONS-000002
+close: valsepdb/OPTIONS-000002
 open-dir: checkpoints/checkpoint8
 create: checkpoints/checkpoint8/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint8/marker.format-version.000001.028
@@ -1079,8 +1079,8 @@ open-dir: checkpoints/checkpoint8
 open: checkpoints/checkpoint8/MANIFEST-000001
 close: checkpoints/checkpoint8/MANIFEST-000001
 open-dir: checkpoints/checkpoint8
-open: checkpoints/checkpoint8/OPTIONS-000003
-close: checkpoints/checkpoint8/OPTIONS-000003
+open: checkpoints/checkpoint8/OPTIONS-000002
+close: checkpoints/checkpoint8/OPTIONS-000002
 open: checkpoints/checkpoint8/000004.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint8/000004.log
 
@@ -1125,7 +1125,7 @@ flush valsepdb
 ----
 sync-data: valsepdb/000004.log
 close: valsepdb/000004.log
-reuseForWrite: valsepdb/000002.log -> valsepdb/000007.log
+reuseForWrite: valsepdb/000003.log -> valsepdb/000007.log
 sync: valsepdb
 create: valsepdb/000008.sst
 create: valsepdb/000009.blob
@@ -1148,11 +1148,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint9
-open: valsepdb/OPTIONS-000003
-create: checkpoints/checkpoint9/OPTIONS-000003
-sync-data: checkpoints/checkpoint9/OPTIONS-000003
-close: checkpoints/checkpoint9/OPTIONS-000003
-close: valsepdb/OPTIONS-000003
+open: valsepdb/OPTIONS-000002
+create: checkpoints/checkpoint9/OPTIONS-000002
+sync-data: checkpoints/checkpoint9/OPTIONS-000002
+close: checkpoints/checkpoint9/OPTIONS-000002
+close: valsepdb/OPTIONS-000002
 open-dir: checkpoints/checkpoint9
 create: checkpoints/checkpoint9/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint9/marker.format-version.000001.028
@@ -1191,8 +1191,8 @@ open-dir: checkpoints/checkpoint9
 open: checkpoints/checkpoint9/MANIFEST-000001
 close: checkpoints/checkpoint9/MANIFEST-000001
 open-dir: checkpoints/checkpoint9
-open: checkpoints/checkpoint9/OPTIONS-000003
-close: checkpoints/checkpoint9/OPTIONS-000003
+open: checkpoints/checkpoint9/OPTIONS-000002
+close: checkpoints/checkpoint9/OPTIONS-000002
 open: checkpoints/checkpoint9/000007.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint9/000007.log
 

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -19,7 +19,12 @@ sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 open-dir: db
-create: db/000002.log
+create: db/temporary.000002.dbtmp
+sync: db/temporary.000002.dbtmp
+close: db/temporary.000002.dbtmp
+rename: db/temporary.000002.dbtmp -> db/OPTIONS-000002
+sync: db
+create: db/000003.log
 sync: db
 create: db/marker.format-version.000001.017
 sync: db/marker.format-version.000001.017
@@ -80,11 +85,6 @@ sync: db/marker.format-version.000012.028
 close: db/marker.format-version.000012.028
 remove: db/marker.format-version.000011.027
 sync: db
-create: db/temporary.000003.dbtmp
-sync: db/temporary.000003.dbtmp
-close: db/temporary.000003.dbtmp
-rename: db/temporary.000003.dbtmp -> db/OPTIONS-000003
-sync: db
 create: db/REMOTE-OBJ-CATALOG-000001
 sync: db/REMOTE-OBJ-CATALOG-000001
 create: db/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -98,12 +98,12 @@ set a 1
 set b 2
 set c 3
 ----
-sync-data: db/000002.log
+sync-data: db/000003.log
 
 flush db
 ----
-sync-data: db/000002.log
-close: db/000002.log
+sync-data: db/000003.log
+close: db/000003.log
 create: db/000004.log
 sync: db
 sync: db/REMOTE-OBJ-CATALOG-000001
@@ -120,7 +120,7 @@ flush db
 ----
 sync-data: db/000004.log
 close: db/000004.log
-reuseForWrite: db/000002.log -> db/000006.log
+reuseForWrite: db/000003.log -> db/000006.log
 sync: db
 sync: db/REMOTE-OBJ-CATALOG-000001
 sync: db/MANIFEST-000001
@@ -141,11 +141,11 @@ open-dir: .
 sync: .
 close: .
 open-dir: checkpoints/checkpoint1
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint1/OPTIONS-000003
-sync-data: checkpoints/checkpoint1/OPTIONS-000003
-close: checkpoints/checkpoint1/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint1/OPTIONS-000002
+sync-data: checkpoints/checkpoint1/OPTIONS-000002
+close: checkpoints/checkpoint1/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint1/marker.format-version.000001.028
@@ -194,11 +194,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint2
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint2/OPTIONS-000003
-sync-data: checkpoints/checkpoint2/OPTIONS-000003
-close: checkpoints/checkpoint2/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint2/OPTIONS-000002
+sync-data: checkpoints/checkpoint2/OPTIONS-000002
+close: checkpoints/checkpoint2/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint2/marker.format-version.000001.028
@@ -243,11 +243,11 @@ open-dir: checkpoints
 sync: checkpoints
 close: checkpoints
 open-dir: checkpoints/checkpoint3
-open: db/OPTIONS-000003
-create: checkpoints/checkpoint3/OPTIONS-000003
-sync-data: checkpoints/checkpoint3/OPTIONS-000003
-close: checkpoints/checkpoint3/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoints/checkpoint3/OPTIONS-000002
+sync-data: checkpoints/checkpoint3/OPTIONS-000002
+close: checkpoints/checkpoint3/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.format-version.000001.028
 sync-data: checkpoints/checkpoint3/marker.format-version.000001.028
@@ -306,7 +306,7 @@ list db
 000008.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 REMOTE-OBJ-CATALOG-000001
 marker.format-version.000012.028
 marker.manifest.000001.MANIFEST-000001
@@ -316,7 +316,7 @@ list checkpoints/checkpoint1
 ----
 000006.log
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 REMOTE-OBJ-CATALOG-000001
 marker.format-version.000001.028
 marker.manifest.000001.MANIFEST-000001
@@ -335,8 +335,8 @@ close: checkpoints/checkpoint1/REMOTE-OBJ-CATALOG-000001
 open: checkpoints/checkpoint1/MANIFEST-000001
 close: checkpoints/checkpoint1/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
-open: checkpoints/checkpoint1/OPTIONS-000003
-close: checkpoints/checkpoint1/OPTIONS-000003
+open: checkpoints/checkpoint1/OPTIONS-000002
+close: checkpoints/checkpoint1/OPTIONS-000002
 open: checkpoints/checkpoint1/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint1/000006.log
 
@@ -368,7 +368,7 @@ list checkpoints/checkpoint2
 ----
 000006.log
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 REMOTE-OBJ-CATALOG-000001
 marker.format-version.000001.028
 marker.manifest.000001.MANIFEST-000001
@@ -387,8 +387,8 @@ close: checkpoints/checkpoint2/REMOTE-OBJ-CATALOG-000001
 open: checkpoints/checkpoint2/MANIFEST-000001
 close: checkpoints/checkpoint2/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
-open: checkpoints/checkpoint2/OPTIONS-000003
-close: checkpoints/checkpoint2/OPTIONS-000003
+open: checkpoints/checkpoint2/OPTIONS-000002
+close: checkpoints/checkpoint2/OPTIONS-000002
 open: checkpoints/checkpoint2/000006.log (options: *vfs.sequentialReadsOption)
 close: checkpoints/checkpoint2/000006.log
 

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -26,16 +26,16 @@ close: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 lock: db_wal/LOCK
 open-dir: db_wal
-create: db_wal/000002.log
+create: db/temporary.000002.dbtmp
+sync: db/temporary.000002.dbtmp
+close: db/temporary.000002.dbtmp
+rename: db/temporary.000002.dbtmp -> db/OPTIONS-000002
+sync: db
+create: db_wal/000003.log
 sync: db_wal
 create: db/marker.format-version.000001.013
 sync: db/marker.format-version.000001.013
 close: db/marker.format-version.000001.013
-sync: db
-create: db/temporary.000003.dbtmp
-sync: db/temporary.000003.dbtmp
-close: db/temporary.000003.dbtmp
-rename: db/temporary.000003.dbtmp -> db/OPTIONS-000003
 sync: db
 
 batch db
@@ -43,12 +43,12 @@ set a 1
 set b 2
 set c 3
 ----
-sync-data: db_wal/000002.log
+sync-data: db_wal/000003.log
 
 flush db
 ----
-sync-data: db_wal/000002.log
-close: db_wal/000002.log
+sync-data: db_wal/000003.log
+close: db_wal/000003.log
 create: db_wal/000004.log
 sync: db_wal
 create: db/000005.sst
@@ -57,7 +57,7 @@ close: db/000005.sst
 sync: db
 sync: db/MANIFEST-000001
 mkdir-all: db_wal/archive 0755
-rename: db_wal/000002.log -> db_wal/archive/000002.log
+rename: db_wal/000003.log -> db_wal/archive/000003.log
 
 batch db
 set d 4
@@ -110,7 +110,7 @@ list db
 000008.sst
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 archive
 marker.format-version.000001.013
 marker.manifest.000001.MANIFEST-000001
@@ -128,7 +128,7 @@ list db/archive
 
 list db_wal/archive
 ----
-000002.log
+000003.log
 000004.log
 
 # Test cleanup of extra sstables on open.
@@ -159,16 +159,16 @@ close: db1/marker.manifest.000001.MANIFEST-000001
 sync: db1
 lock: db1_wal/LOCK
 open-dir: db1_wal
-create: db1_wal/000002.log
+create: db1/temporary.000002.dbtmp
+sync: db1/temporary.000002.dbtmp
+close: db1/temporary.000002.dbtmp
+rename: db1/temporary.000002.dbtmp -> db1/OPTIONS-000002
+sync: db1
+create: db1_wal/000003.log
 sync: db1_wal
 create: db1/marker.format-version.000001.013
 sync: db1/marker.format-version.000001.013
 close: db1/marker.format-version.000001.013
-sync: db1
-create: db1/temporary.000003.dbtmp
-sync: db1/temporary.000003.dbtmp
-close: db1/temporary.000003.dbtmp
-rename: db1/temporary.000003.dbtmp -> db1/OPTIONS-000003
 sync: db1
 
 batch db1
@@ -176,12 +176,12 @@ set a 1
 set b 2
 set c 3
 ----
-sync-data: db1_wal/000002.log
+sync-data: db1_wal/000003.log
 
 flush db1
 ----
-sync-data: db1_wal/000002.log
-close: db1_wal/000002.log
+sync-data: db1_wal/000003.log
+close: db1_wal/000003.log
 create: db1_wal/000004.log
 sync: db1_wal
 create: db1/000005.sst
@@ -248,39 +248,40 @@ open-dir: db1
 open: db1/MANIFEST-000001
 close: db1/MANIFEST-000001
 lock: db1_wal/LOCK
-remove: db1_wal/000002.log
+remove: db1_wal/000003.log
 open-dir: db1_wal
-open: db1/OPTIONS-000003
-close: db1/OPTIONS-000003
+open: db1/OPTIONS-000002
+close: db1/OPTIONS-000002
 open: db1_wal/000004.log (options: *vfs.sequentialReadsOption)
 close: db1_wal/000004.log
-create: db1/MANIFEST-000458
-sync: db1/MANIFEST-000458
-create: db1/marker.manifest.000002.MANIFEST-000458
-sync: db1/marker.manifest.000002.MANIFEST-000458
-close: db1/marker.manifest.000002.MANIFEST-000458
-remove: db1/marker.manifest.000001.MANIFEST-000001
+create: db1/temporary.000458.dbtmp
+sync: db1/temporary.000458.dbtmp
+close: db1/temporary.000458.dbtmp
+rename: db1/temporary.000458.dbtmp -> db1/OPTIONS-000458
 sync: db1
-remove: db1_wal/000004.log
-create: db1_wal/000459.log
-sync: db1_wal
-create: db1/temporary.000460.dbtmp
-sync: db1/temporary.000460.dbtmp
-close: db1/temporary.000460.dbtmp
-rename: db1/temporary.000460.dbtmp -> db1/OPTIONS-000460
-sync: db1
-remove: db1/OPTIONS-000003
+remove: db1/OPTIONS-000002
 remove: db1/000123.sst
 remove: db1/000456.sst
 remove: db1/000234.blob
 remove: db1/000345.blob
+sync: db1
+create: db1/MANIFEST-000459
+sync: db1/MANIFEST-000459
+create: db1/marker.manifest.000002.MANIFEST-000459
+sync: db1/marker.manifest.000002.MANIFEST-000459
+close: db1/marker.manifest.000002.MANIFEST-000459
+remove: db1/marker.manifest.000001.MANIFEST-000001
+sync: db1
+remove: db1_wal/000004.log
+create: db1_wal/000460.log
+sync: db1_wal
 
 list db1
 ----
 000005.sst
 LOCK
 MANIFEST-000001
-MANIFEST-000458
-OPTIONS-000460
+MANIFEST-000459
+OPTIONS-000458
 marker.format-version.000001.013
-marker.manifest.000002.MANIFEST-000458
+marker.manifest.000002.MANIFEST-000459

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -26,9 +26,14 @@ sync: db
 [JOB 1] MANIFEST created 000001
 lock: wal/LOCK
 open-dir: wal
-create: wal/000002.log
+create: db/temporary.000002.dbtmp
+sync: db/temporary.000002.dbtmp
+close: db/temporary.000002.dbtmp
+rename: db/temporary.000002.dbtmp -> db/OPTIONS-000002
+sync: db
+create: wal/000003.log
 sync: wal
-[JOB 1] WAL created 000002
+[JOB 1] WAL created 000003
 create: db/marker.format-version.000001.014
 sync: db/marker.format-version.000001.014
 close: db/marker.format-version.000001.014
@@ -118,17 +123,12 @@ close: db/marker.format-version.000015.028
 remove: db/marker.format-version.000014.027
 sync: db
 upgraded to format version: 028
-create: db/temporary.000003.dbtmp
-sync: db/temporary.000003.dbtmp
-close: db/temporary.000003.dbtmp
-rename: db/temporary.000003.dbtmp -> db/OPTIONS-000003
-sync: db
 
 flush
 ----
-sync-data: wal/000002.log
-sync-data: wal/000002.log
-close: wal/000002.log
+sync-data: wal/000003.log
+sync-data: wal/000003.log
+close: wal/000003.log
 create: wal/000004.log
 sync: wal
 [JOB 2] WAL created 000004
@@ -154,9 +154,9 @@ compact
 sync-data: wal/000004.log
 sync-data: wal/000004.log
 close: wal/000004.log
-reuseForWrite: wal/000002.log -> wal/000007.log
+reuseForWrite: wal/000003.log -> wal/000007.log
 sync: wal
-[JOB 4] WAL created 000007 (recycled 000002)
+[JOB 4] WAL created 000007 (recycled 000003)
 [JOB 5] flushing 1 memtable (100B) to L0
 create: db/000008.sst
 [JOB 5] flushing: sstable created 000008
@@ -508,11 +508,11 @@ open-dir: .
 sync: .
 close: .
 open-dir: checkpoint
-open: db/OPTIONS-000003
-create: checkpoint/OPTIONS-000003
-sync-data: checkpoint/OPTIONS-000003
-close: checkpoint/OPTIONS-000003
-close: db/OPTIONS-000003
+open: db/OPTIONS-000002
+create: checkpoint/OPTIONS-000002
+sync-data: checkpoint/OPTIONS-000002
+close: checkpoint/OPTIONS-000002
+close: db/OPTIONS-000002
 open-dir: checkpoint
 create: checkpoint/marker.format-version.000001.028
 sync-data: checkpoint/marker.format-version.000001.028

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -30,10 +30,10 @@ blockFlush
 # One WAL, corresponding to the mutable memtable containing the set.
 ls
 ----
-000002.log
+000003.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 ext1
 ext2
@@ -52,7 +52,7 @@ lsm
 # memtable.
 ls
 ----
-000002.log
+000003.log
 000004.sst
 000005.sst
 000006.sst
@@ -60,7 +60,7 @@ ls
 000008.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 marker.format-version.000015.028
 marker.manifest.000001.MANIFEST-000001
@@ -86,7 +86,7 @@ d:1
 # flush completes.
 ls
 ----
-000002.log
+000003.log
 000004.sst
 000005.sst
 000006.sst
@@ -94,7 +94,7 @@ ls
 000008.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 marker.format-version.000015.028
 marker.manifest.000001.MANIFEST-000001
@@ -107,7 +107,7 @@ close
 # after the DB is closed, those sstables should still be hanging around.
 ls
 ----
-000002.log
+000003.log
 000004.sst
 000005.sst
 000006.sst
@@ -115,7 +115,7 @@ ls
 000008.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 marker.format-version.000015.028
 marker.manifest.000001.MANIFEST-000001
@@ -129,7 +129,7 @@ lsm
 L0.1:
   000004:[a#11,SET-a#11,SET]
 L0.0:
-  000010:[a#10,SET-a#10,SET]
+  000011:[a#10,SET-a#10,SET]
 L6:
   000005:[b#12,SET-b#12,SET]
   000006:[d#13,SET-d#13,SET]
@@ -201,13 +201,13 @@ ingest ext4
 
 ls
 ----
-000002.log
+000003.log
 000004.sst
 000005.log
 000006.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 ext5
 marker.format-version.000015.028
@@ -430,7 +430,7 @@ f:1
 # ingested files.
 ls
 ----
-000002.log
+000003.log
 000004.sst
 000005.sst
 000006.sst
@@ -438,7 +438,7 @@ ls
 000008.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 marker.format-version.000015.028
 marker.manifest.000001.MANIFEST-000001
@@ -450,7 +450,7 @@ close
 # after the DB is closed, those memtables should still be hanging around.
 ls
 ----
-000002.log
+000003.log
 000004.sst
 000005.sst
 000006.sst
@@ -458,7 +458,7 @@ ls
 000008.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 marker.format-version.000015.028
 marker.manifest.000001.MANIFEST-000001
@@ -472,8 +472,8 @@ lsm
 L0.1:
   000004:[a#11,SET-a#11,SET]
 L0.0:
-  000010:[a#10,SET-a#10,SET]
-  000012:[f#14,SET-f#14,SET]
+  000011:[a#10,SET-a#10,SET]
+  000013:[f#14,SET-f#14,SET]
 L6:
   000005:[b#12,SET-b#12,SET]
   000006:[d#13,SET-d#13,SET]
@@ -485,16 +485,16 @@ ls
 000004.sst
 000005.sst
 000006.sst
-000010.sst
-000012.sst
-000013.log
+000011.sst
+000013.sst
+000014.log
 LOCK
 MANIFEST-000001
-MANIFEST-000011
-OPTIONS-000014
+MANIFEST-000012
+OPTIONS-000010
 ext
 marker.format-version.000015.028
-marker.manifest.000002.MANIFEST-000011
+marker.manifest.000002.MANIFEST-000012
 
 # Make sure that the new mutable memtable can accept writes.
 batch
@@ -627,14 +627,14 @@ L0.0:
 
 ls
 ----
-000002.log
+000003.log
 000004.sst
 000005.log
 000006.log
 000007.sst
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 marker.format-version.000015.028
 marker.manifest.000001.MANIFEST-000001
@@ -646,13 +646,13 @@ close
 # is gone because that file was never synced.
 reset-to-crash-clone
 ----
-000002.log
+000003.log
 000004.sst
 000005.log
 000006.log
 LOCK
 MANIFEST-000001
-OPTIONS-000003
+OPTIONS-000002
 ext
 ext1
 marker.format-version.000015.028

--- a/testdata/iter_histories/errors
+++ b/testdata/iter_histories/errors
@@ -51,7 +51,7 @@ next
 next
 next
 ----
-err=pebble: backing file 000005 error: injected error
+err=pebble: backing file 000006 error: injected error
 a: (a, .)
 b: (b, .)
 c: (c, .)

--- a/testdata/open_recovery
+++ b/testdata/open_recovery
@@ -1,0 +1,41 @@
+# Construct a database with a file in L0.
+
+define auto-compactions=off
+L0
+  e.SET.7:boo
+L5
+  b.SET.3:foo
+  c.SET.4:foo
+  d.SET.5:foo
+  e.SET.6:foo
+L6
+  c.SET.0:foo
+  d.SET.0:foo
+----
+L0.0:
+  000004:[e#7,SET-e#7,SET]
+L5:
+  000005:[b#3,SET-e#6,SET]
+L6:
+  000006:[c#0,SET-d#0,SET]
+
+# Commit a batch to the WAL; On recovery the WAL will be replayed and a flush
+# initiated.
+
+batch
+set e foo
+----
+
+# Close and re-open the database with automatic compactions enabled, and
+# injecting artifical latency into writes into sstables. During Open the replay
+# of the WAL and subsequent memtable flush will create sufficient L0 sublevels
+# to cause the scheduling of a compaction. This test helps guard against races
+# during Open that might mistake the in-flight compaction's outputs as obsolete
+# files.
+
+reopen auto-compactions=on inject-errors=((RandomLatency "5ms" 1 (And OpFileWrite (PathMatch "*.sst"))))
+----
+L5:
+  000012:[b#3,SET-e#10,SET]
+L6:
+  000006:[c#0,SET-d#0,SET]

--- a/testdata/open_wal_failover
+++ b/testdata/open_wal_failover
@@ -6,16 +6,16 @@ ok
 
 list path=(a,data)
 ----
-  000002.log
+  000003.log
   LOCK
   MANIFEST-000001
-  OPTIONS-000003
+  OPTIONS-000002
   marker.format-version.000001.013
   marker.manifest.000001.MANIFEST-000001
 
 # The OPTIONS file should not include a [WAL Failover] stanza.
 
-grep-between path=(a,data/OPTIONS-000003) start=(\[WAL Failover\]) end=^$
+grep-between path=(a,data/OPTIONS-000002) start=(\[WAL Failover\]) end=^$
 ----
 
 # Open the same database with WAL failover configured, but pointing to a
@@ -33,17 +33,17 @@ list path=(b,)
 
 list path=(a,data)
 ----
-  000006.log
+  000007.log
   LOCK
   MANIFEST-000001
-  MANIFEST-000005
-  OPTIONS-000007
+  MANIFEST-000006
+  OPTIONS-000005
   marker.format-version.000001.013
-  marker.manifest.000002.MANIFEST-000005
+  marker.manifest.000002.MANIFEST-000006
 
 # The new OPTIONS file should declare the secondary WAL path.
 
-grep-between path=(a,data/OPTIONS-000007) start=(\[WAL Failover\]) end=^$
+grep-between path=(a,data/OPTIONS-000005) start=(\[WAL Failover\]) end=^$
 ----
   secondary_dir=secondary-wals
   primary_dir_probe_interval=1s

--- a/vfs/errorfs/dsl.go
+++ b/vfs/errorfs/dsl.go
@@ -58,6 +58,11 @@ var (
 	Writes Predicate = opKindPred{kind: OpIsWrite}
 )
 
+type opFileWrite struct{}
+
+func (o opFileWrite) String() string      { return "OpFileWrite" }
+func (o opFileWrite) Evaluate(op Op) bool { return op.Kind == OpFileWrite }
+
 type opFileReadAt struct {
 	// offset configures the predicate to evaluate to true only if the
 	// operation's offset exactly matches offset.
@@ -167,6 +172,7 @@ func NewParser() *Parser {
 	}
 	p.predicates.DefineConstant("Reads", func() dsl.Predicate[Op] { return Reads })
 	p.predicates.DefineConstant("Writes", func() dsl.Predicate[Op] { return Writes })
+	p.predicates.DefineConstant("OpFileWrite", func() dsl.Predicate[Op] { return opFileWrite{} })
 	p.predicates.DefineFunc("PathMatch",
 		func(p *dsl.Parser[dsl.Predicate[Op]], s *dsl.Scanner) dsl.Predicate[Op] {
 			pattern := s.ConsumeString()


### PR DESCRIPTION
During Open, scan the directory listing for obsolete files before scheduling a memtable flush or compaction. Previously, contrary to its documentation, DB.scanObsoleteFiles could run in parallel to compactions. Subtly, scanObsoleteFiles would block, waiting for compactions to queisce before proceeding. This ensured that once it proceeded it had a consistent view of the set of live files. This structure was subtle, less-deterministic and blocked Open from proceeding until compactions quiesced.

This commit moves the scanning of the directory listing before the scheduling of flushes or compactions and adds an assertion that no flushes or compactions are running during scanObsoleteFiles.

Fix #5420.