### PR TITLE
db: deflake TestOpenRecovery

### DIFF
--- a/open_test.go
+++ b/open_test.go
@@ -325,7 +325,7 @@ func TestOpenRecovery(t *testing.T) {
 				return err.Error()
 			}
 			waitForCompactionsAndTableStats(d)
-			return runLSMCmd(td, d)
+			return "ok"
 		default:
 			return fmt.Sprintf("unrecognized command %q", td.Cmd)
 		}

--- a/testdata/open_recovery
+++ b/testdata/open_recovery
@@ -35,7 +35,11 @@ set e foo
 
 reopen auto-compactions=on inject-errors=((RandomLatency "5ms" 1 (And OpFileWrite (PathMatch "*.sst"))))
 ----
-L5:
-  000012:[b#3,SET-e#10,SET]
-L6:
-  000006:[c#0,SET-d#0,SET]
+ok
+
+# Ensure closing and re-opening again succeeds (and the previous reopen didn't
+# accidentally delete a necessary sstable).
+
+reopen
+----
+ok


### PR DESCRIPTION
The file numbers are non-deterministic.

Fix #5439.
Fix #5440.
Fix #5441.
Fix #5442.