### PR TITLE
db: fix BlobBytesCompacted accounting

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3534,16 +3534,15 @@ func (c *tableCompaction) makeVersionEdit(result compact.Result) (*manifest.Vers
 			outputMetrics.TableBytesRead += c.metrics.internalIterStats.BlockReads[i].BlockBytes
 		}
 	}
-	outputMetrics.BlobBytesCompacted = result.Stats.CumulativeBlobFileSize
-	if c.flush.flushables != nil {
-		outputMetrics.BlobBytesFlushed = result.Stats.CumulativeBlobFileSize
-	}
 	if len(c.extraLevels) > 0 {
 		outputMetrics.TableBytesIn += c.extraLevels[0].files.TableSizeSum()
 	}
 
 	if len(c.flush.flushables) == 0 {
 		c.metrics.perLevel.level(c.startLevel.level)
+		outputMetrics.BlobBytesCompacted = result.Stats.CumulativeBlobFileSize
+	} else {
+		outputMetrics.BlobBytesFlushed = result.Stats.CumulativeBlobFileSize
 	}
 	if len(c.extraLevels) > 0 {
 		c.metrics.perLevel.level(c.extraLevels[0].level)
@@ -3608,7 +3607,6 @@ func (c *tableCompaction) makeVersionEdit(result compact.Result) (*manifest.Vers
 			Level: c.outputLevel.level,
 			Meta:  fileMeta,
 		}
-
 		// Update metrics.
 		if c.flush.flushables == nil {
 			outputMetrics.TablesCompacted++

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -150,15 +150,15 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 24.27
+   L0         0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 21.83
    L6       966B |      1  854B |      0     0 |   112B     0B |   795B |      0    0B |   1  1.22
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       966B |      1  854B |      0     0 |   112B     0B |    41B |      0    0B |   1 48.83
+total       966B |      1  854B |      0     0 |   112B     0B |    41B |      0    0B |   1 46.39
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      1   795B   200B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      1   795B   100B
    L1 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
    L2 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
    L3 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
@@ -166,7 +166,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
    L5 |     -     0     0 |      1  795B |    0B    0B    0B |     0B    0B |      0     0B     0B
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   372B   84B |      1   854B   112B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      5 3.9KB |    0B    0B    0B |   372B   84B |      2  1.7KB   312B
+total |     -     -     - |      5 3.9KB |    0B    0B    0B |   372B   84B |      2  1.7KB   212B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     5     0     0        0     0      0     0       0
@@ -459,18 +459,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   156B |      0    0B |   0 13.92
+   L0         0B |      0    0B |      0     0 |     0B     0B |   156B |      0    0B |   0 12.31
    L6      1.1KB |      1  855B |      0     0 |   232B     0B |  1.6KB |      0    0B |   1  0.51
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      1.1KB |      1  855B |      0     0 |   232B     0B |   156B |      0    0B |   1 20.40
+total      1.1KB |      1  855B |      0     0 |   232B     0B |   156B |      0    0B |   1 18.79
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.6KB   502B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.6KB   251B
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   310B    0B |      1   855B     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   310B    0B |      3  2.6KB   502B
+total |     -     -     - |      0    0B |    0B    0B    0B |   310B    0B |      3  2.6KB   251B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     1       0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -591,18 +591,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      6.7KB |      7 5.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 57.40
+   L0      6.7KB |      7 5.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 49.89
    L6      1.4KB |      2 1.4KB |      0     0 |     0B     0B |  1.4KB |      0    0B |   1  0.99
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total        8KB |      9 6.8KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   2 66.91
+total        8KB |      9 6.8KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   2 59.40
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.8KB  2.4KB
+   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.8KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   738B    0B |      2  1.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   738B    0B |     11  8.4KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |   738B    0B |     11  8.4KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -701,18 +701,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 57.40
+   L0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 49.89
    L6        8KB |      9 6.8KB |      0     0 |  1.2KB     0B |  6.8KB |      0    0B |   1  1.00
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total        8KB |      9 6.8KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 100.6
+total        8KB |      9 6.8KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 93.12
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.8KB  2.4KB
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.8KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.4KB    0B |      9  6.8KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     18   14KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     18   14KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -862,18 +862,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0        4KB |      6   4KB |      0     0 |     0B     0B |   211B |      3 1.9KB |   2 54.94
+   L0        4KB |      6   4KB |      0     0 |     0B     0B |   211B |      3 1.9KB |   2 49.07
    L6        8KB |      9 6.8KB |      0     0 |  1.2KB     0B |  6.8KB |      0    0B |   1  1.00
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       12KB |     15  11KB |      0     0 |  1.2KB     0B |  2.1KB |      3 1.9KB |   3  9.53
+total       12KB |     15  11KB |      0     0 |  1.2KB     0B |  2.1KB |      3 1.9KB |   3  8.96
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     12  8.9KB  2.4KB
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     12  8.9KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.4KB    0B |      9  6.8KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     21   18KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     21   18KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -985,18 +985,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      8.8KB |     13 8.8KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 59.71
+   L0      8.8KB |     13 8.8KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 55.24
    L6        8KB |      9 6.8KB |      0     0 |  1.2KB     0B |  6.8KB |      0    0B |   1  1.00
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       17KB |     22  16KB |      0     0 |  1.2KB     0B |  2.2KB |      3 1.9KB |   3 11.49
+total       17KB |     22  16KB |      0     0 |  1.2KB     0B |  2.2KB |      3 1.9KB |   3 10.93
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  2.4KB
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.4KB    0B |      9  6.8KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     28   23KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     28   23KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -1120,18 +1120,18 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      7.4KB |     11 7.4KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 59.71
+   L0      7.4KB |     11 7.4KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 55.24
    L6      8.7KB |     10 7.4KB |      0     0 |  1.2KB     0B |  6.8KB |      1  655B |   1  1.00
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       16KB |     21  15KB |      0     0 |  1.2KB     0B |  2.8KB |      4 2.6KB |   3  9.11
+total       16KB |     21  15KB |      0     0 |  1.2KB     0B |  2.8KB |      4 2.6KB |   3  8.69
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  2.4KB
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.4KB    0B |      9  6.8KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     28   23KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.4KB    0B |     28   23KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -1296,18 +1296,18 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 1.9KB |   0 59.71
+   L0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 1.9KB |   0 55.24
    L6       14KB |     18  13KB |      0     0 |  1.2KB     0B |   14KB |      2 1.3KB |   1  0.85
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       14KB |     18  13KB |      0     0 |  1.2KB     0B |  3.5KB |      5 3.2KB |   1  9.01
+total       14KB |     18  13KB |      0     0 |  1.2KB     0B |  3.5KB |      5 3.2KB |   1  8.66
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  2.4KB
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |     19   14KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   11KB    0B |     16   12KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   11KB    0B |     35   29KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |   11KB    0B |     35   29KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       3       0        0     0     0     0        0     0      0     0       0


### PR DESCRIPTION
Previously flushes would contribute the size of written blob files to both BlobBytesFlushed and BlobBytesCompacted, artificially inflating the BytesCompacted total. This commit fixes the metric update to include the blob files in either the flushes total or the compacted total but not both.