### PR TITLE
crl-release-25.4: db: fix BlobBytesCompacted accounting

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3535,16 +3535,15 @@ func (c *tableCompaction) makeVersionEdit(result compact.Result) (*manifest.Vers
 			outputMetrics.TableBytesRead += c.metrics.internalIterStats.BlockReads[i].BlockBytes
 		}
 	}
-	outputMetrics.BlobBytesCompacted = result.Stats.CumulativeBlobFileSize
-	if c.flush.flushables != nil {
-		outputMetrics.BlobBytesFlushed = result.Stats.CumulativeBlobFileSize
-	}
 	if len(c.extraLevels) > 0 {
 		outputMetrics.TableBytesIn += c.extraLevels[0].files.TableSizeSum()
 	}
 
 	if len(c.flush.flushables) == 0 {
 		c.metrics.perLevel.level(c.startLevel.level)
+		outputMetrics.BlobBytesCompacted = result.Stats.CumulativeBlobFileSize
+	} else {
+		outputMetrics.BlobBytesFlushed = result.Stats.CumulativeBlobFileSize
 	}
 	if len(c.extraLevels) > 0 {
 		c.metrics.perLevel.level(c.extraLevels[0].level)
@@ -3609,7 +3608,6 @@ func (c *tableCompaction) makeVersionEdit(result compact.Result) (*manifest.Vers
 			Level: c.outputLevel.level,
 			Meta:  fileMeta,
 		}
-
 		// Update metrics.
 		if c.flush.flushables == nil {
 			outputMetrics.TablesCompacted++

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -124,15 +124,15 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 23.24
+   L0         0B |      0    0B |      0     0 |     0B     0B |    41B |      0    0B |   0 20.80
    L6       916B |      1  804B |      0     0 |   112B     0B |   753B |      0    0B |   1  1.22
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       916B |      1  804B |      0     0 |   112B     0B |    41B |      0    0B |   1 46.59
+total       916B |      1  804B |      0     0 |   112B     0B |    41B |      0    0B |   1 44.15
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      1   753B   200B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      1   753B   100B
    L1 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
    L2 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
    L3 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
@@ -140,7 +140,7 @@ level | score    ff   cff | tables  size |   top    in  read | tables  blob | ta
    L5 |     -     0     0 |      1  753B |    0B    0B    0B |     0B    0B |      0     0B     0B
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   372B   84B |      1   804B   112B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      5 3.7KB |    0B    0B    0B |   372B   84B |      2  1.6KB   312B
+total |     -     -     - |      5 3.7KB |    0B    0B    0B |   372B   84B |      2  1.6KB   212B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     5     0     0        0     0      0     0       0
@@ -407,18 +407,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   156B |      0    0B |   0 13.33
+   L0         0B |      0    0B |      0     0 |     0B     0B |   156B |      0    0B |   0 11.72
    L6        1KB |      1  805B |      0     0 |   232B     0B |  1.5KB |      0    0B |   1  0.51
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total        1KB |      1  805B |      0     0 |   232B     0B |   156B |      0    0B |   1 19.49
+total        1KB |      1  805B |      0     0 |   232B     0B |   156B |      0    0B |   1 17.88
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.5KB   502B
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      2  1.5KB   251B
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   310B    0B |      1   805B     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   310B    0B |      3  2.5KB   502B
+total |     -     -     - |      0    0B |    0B    0B    0B |   310B    0B |      3  2.5KB   251B
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     1       0

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -591,18 +591,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      6.4KB |      7 5.2KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 55.05
+   L0      6.4KB |      7 5.2KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 47.54
    L6      1.3KB |      2 1.3KB |      0     0 |     0B     0B |  1.3KB |      0    0B |   1  0.99
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      7.7KB |      9 6.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   2 63.99
+total      7.7KB |      9 6.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   2 56.48
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.5KB  2.4KB
+   L0 |     -  0.25  0.25 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.5KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   691B    0B |      2  1.3KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |     11  7.9KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |   691B    0B |     11  7.9KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       1       0        0     0     0     0        0     0      0     0       0
@@ -701,18 +701,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 55.05
+   L0         0B |      0    0B |      0     0 |     0B     0B |   165B |      0    0B |   0 47.54
    L6      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |  6.5KB |      0    0B |   1  1.00
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 95.93
+total      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |   165B |      0    0B |   1 88.42
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.5KB  2.4KB
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |      9  6.5KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     18   13KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     18   13KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -862,18 +862,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      3.9KB |      6 3.9KB |      0     0 |     0B     0B |   211B |      3 1.9KB |   2 52.43
+   L0      3.9KB |      6 3.9KB |      0     0 |     0B     0B |   211B |      3 1.9KB |   2 46.56
    L6      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |  6.5KB |      0    0B |   1  1.00
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       11KB |     15  10KB |      0     0 |  1.2KB     0B |  2.1KB |      3 1.9KB |   3  9.11
+total       11KB |     15  10KB |      0     0 |  1.2KB     0B |  2.1KB |      3 1.9KB |   3  8.54
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     12  8.4KB  2.4KB
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     12  8.4KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     21   17KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     21   17KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -985,18 +985,18 @@ metrics
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      8.4KB |     13 8.4KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 56.62
+   L0      8.4KB |     13 8.4KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 52.14
    L6      7.6KB |      9 6.4KB |      0     0 |  1.2KB     0B |  6.5KB |      0    0B |   1  1.00
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       16KB |     22  15KB |      0     0 |  1.2KB     0B |  2.2KB |      3 1.9KB |   3 10.93
+total       16KB |     22  15KB |      0     0 |  1.2KB     0B |  2.2KB |      3 1.9KB |   3 10.38
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  2.4KB
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     28   22KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     28   22KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -1120,18 +1120,18 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0      7.1KB |     11 7.1KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 56.62
+   L0      7.1KB |     11 7.1KB |      0     0 |     0B     0B |   277B |      3 1.9KB |   2 52.14
    L6      8.3KB |     10 7.1KB |      0     0 |  1.2KB     0B |  6.5KB |      1  655B |   1  1.00
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       15KB |     21  14KB |      0     0 |  1.2KB     0B |  2.8KB |      4 2.6KB |   3  8.68
+total       15KB |     21  14KB |      0     0 |  1.2KB     0B |  2.8KB |      4 2.6KB |   3  8.26
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  2.4KB
+   L0 |     -  0.50  0.50 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |  5.1KB    0B |      9  6.4KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     28   22KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |  5.1KB    0B |     28   22KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       2       0        0     0     0     0        0     0      0     0       0
@@ -1296,18 +1296,18 @@ metrics zero-cache-hits-misses
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 1.9KB |   0 56.62
+   L0         0B |      0    0B |      0     0 |     0B     0B |   277B |      3 1.9KB |   0 52.14
    L6       13KB |     18  12KB |      0     0 |  1.2KB     0B |   13KB |      2 1.3KB |   1  0.85
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       13KB |     18  12KB |      0     0 |  1.2KB     0B |  3.5KB |      5 3.2KB |   1  8.56
+total       13KB |     18  12KB |      0     0 |  1.2KB     0B |  3.5KB |      5 3.2KB |   1  8.22
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
 ------+-------------------+--------------+-------------------+--------------+---------------------
-   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  2.4KB
+   L0 |     -     0     0 |      0    0B |    0B    0B    0B |     0B    0B |     19   13KB  1.2KB
    L6 |     -  0.00  0.00 |      0    0B |    0B    0B    0B |   11KB    0B |     16   11KB     0B
 ------+-------------------+--------------+-------------------+--------------+---------------------
-total |     -     -     - |      0    0B |    0B    0B    0B |   11KB    0B |     35   27KB  2.4KB
+total |     -     -     - |      0    0B |    0B    0B    0B |   11KB    0B |     35   27KB  1.2KB
 
  kind | default  delete  elision  move  read  tomb  rewrite  copy  multi  blob virtual
 count |       3       0        0     0     0     0        0     0      0     0       0


### PR DESCRIPTION
25.4 backport of #5445.

----

Previously flushes would contribute the size of written blob files to both BlobBytesFlushed and BlobBytesCompacted, artificially inflating the BytesCompacted total. This commit fixes the metric update to include the blob files in either the flushes total or the compacted total but not both.