### PR TITLE
db: initialize more LevelMetrics fields on recovery

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -300,13 +300,7 @@ func recoverVersion(
 		MinimumAge:  opts.Experimental.ValueSeparationPolicy().RewriteMinimumAge,
 	})
 	vs.version = newVersion
-
-	for i := range vs.metrics.Levels {
-		l := &vs.metrics.Levels[i]
-		l.TablesCount = int64(newVersion.Levels[i].Len())
-		files := newVersion.Levels[i].Slice()
-		l.TablesSize = int64(files.TableSizeSum())
-	}
+	setBasicLevelMetrics(&vs.metrics, newVersion)
 	for _, l := range newVersion.Levels {
 		for f := range l.All() {
 			if !f.Virtual {

--- a/testdata/version_set
+++ b/testdata/version_set
@@ -423,6 +423,16 @@ obsolete tables: 000102
 no zombie blob files
 no obsolete blob files
 
+metrics
+----
+LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
+level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+-----------------+--------------+--------------+---------------+--------+--------------+----------
+   L2       100B |      1  100B |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+   L3       23KB |      3 2.9KB |      0     0 |   20KB     0B |     0B |      0    0B |   1     0
+-----------------+--------------+--------------+---------------+--------+--------------+----------
+total       23KB |      4   3KB |      0     0 |   20KB     0B |     0B |      0    0B |   2     0
+
 reopen
 ----
 current version:
@@ -439,6 +449,16 @@ no zombie tables
 no obsolete tables
 no zombie blob files
 no obsolete blob files
+
+metrics
+----
+LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
+level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
+-----------------+--------------+--------------+---------------+--------+--------------+----------
+   L2       100B |      1  100B |      0     0 |     0B     0B |     0B |      0    0B |   1     0
+   L3       23KB |      3 2.9KB |      0     0 |   20KB     0B |     0B |      0    0B |   1     0
+-----------------+--------------+--------------+---------------+--------+--------------+----------
+total       23KB |      4   3KB |      0     0 |   20KB     0B |     0B |      0    0B |   2     0
 
 # Delete the referencing table and the blob file. There is no reference to the
 # previous Version, so the files should all be immediately obsolete.

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -14,9 +14,9 @@ db lsm
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0       709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+   L0       709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   1     0
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+total       709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   1     0
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz
@@ -80,9 +80,9 @@ db lsm --url
 LSM                             |    vtables   |   value sep   |        |   ingested   |    amp
 level       size | tables  size |  count  size |  refsz valblk |     in | tables  size |   r     w
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-   L0       709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+   L0       709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   1     0
 -----------------+--------------+--------------+---------------+--------+--------------+----------
-total       709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   0     0
+total       709B |      1  709B |      0     0 |     0B     0B |     0B |      0    0B |   1     0
 
 COMPACTIONS               |     moved    |     multilevel    |     read     |       written
 level | score    ff   cff | tables  size |   top    in  read | tables  blob | tables  sstsz blobsz

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -232,6 +232,9 @@ func TestVersionSet(t *testing.T) {
 				}
 			}
 
+		case "metrics":
+			return vs.metrics.LevelMetricsString()
+
 		default:
 			td.Fatalf(t, "unknown command: %s", td.Cmd)
 		}
@@ -572,4 +575,19 @@ func TestCrashDuringManifestWrite_LargeKeys(t *testing.T) {
 			require.NoError(t, d.Close())
 		}()
 	}
+}
+
+func newFileMetrics(newFiles []manifest.NewTableEntry) levelMetricsDelta {
+	var m levelMetricsDelta
+	for _, nf := range newFiles {
+		lm := m[nf.Level]
+		if lm == nil {
+			lm = &LevelMetrics{}
+			m[nf.Level] = lm
+		}
+		lm.TablesCount++
+		lm.TablesSize += int64(nf.Meta.Size)
+		lm.EstimatedReferencesSize += nf.Meta.EstimatedReferenceSize()
+	}
+	return m
 }


### PR DESCRIPTION
We weren't initializing all `LevelMetrics` fields when reading a
manifest. This isn't a big deal in practice because on the first
version change, we will reinitialize these fields.

This change reuses the code that normally sets these fields when
updating the version.