### PR TITLE
db: remove unnecessary metric updates

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -1190,7 +1190,6 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		return versionUpdate{
 			VE:                      ve,
 			JobID:                   jobID,
-			Metrics:                 newFileMetrics(ve.NewTables),
 			InProgressCompactionsFn: func() []compactionInfo { return nil },
 		}, nil
 	})

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -393,27 +393,11 @@ func TestVirtualReadsWiring(t *testing.T) {
 	d.checkVirtualBounds(v2)
 
 	// Write the version edit.
-	fileMetrics := func(ve *manifest.VersionEdit) levelMetricsDelta {
-		metrics := newFileMetrics(ve.NewTables)
-		for de, f := range ve.DeletedTables {
-			lm := metrics[de.Level]
-			if lm == nil {
-				lm = &LevelMetrics{}
-				metrics[de.Level] = lm
-			}
-			metrics[de.Level].TablesCount--
-			metrics[de.Level].TablesSize -= int64(f.Size)
-			metrics[de.Level].EstimatedReferencesSize -= f.EstimatedReferenceSize()
-		}
-		return metrics
-	}
-
 	applyVE := func(ve *manifest.VersionEdit) error {
 		_, err := d.mu.versions.UpdateVersionLocked(func() (versionUpdate, error) {
 			return versionUpdate{
 				VE:                      ve,
 				JobID:                   d.newJobIDLocked(),
-				Metrics:                 fileMetrics(ve),
 				InProgressCompactionsFn: func() []compactionInfo { return d.getInProgressCompactionInfoLocked(nil) },
 			}, nil
 		})

--- a/version_set.go
+++ b/version_set.go
@@ -1133,18 +1133,3 @@ func findCurrentManifest(
 	}
 	return marker, manifestNum, true, nil
 }
-
-func newFileMetrics(newFiles []manifest.NewTableEntry) levelMetricsDelta {
-	var m levelMetricsDelta
-	for _, nf := range newFiles {
-		lm := m[nf.Level]
-		if lm == nil {
-			lm = &LevelMetrics{}
-			m[nf.Level] = lm
-		}
-		lm.TablesCount++
-		lm.TablesSize += int64(nf.Meta.Size)
-		lm.EstimatedReferencesSize += nf.Meta.EstimatedReferenceSize()
-	}
-	return m
-}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -147,23 +147,10 @@ func TestVersionSet(t *testing.T) {
 				createFile(ve.CreatedBackingTables[i].DiskFileNum)
 			}
 
-			fileMetrics := newFileMetrics(ve.NewTables)
-			for de, f := range ve.DeletedTables {
-				lm := fileMetrics[de.Level]
-				if lm == nil {
-					lm = &LevelMetrics{}
-					fileMetrics[de.Level] = lm
-				}
-				lm.TablesCount--
-				lm.TablesSize -= int64(f.Size)
-				lm.EstimatedReferencesSize -= f.EstimatedReferenceSize()
-			}
-
 			mu.Lock()
 			_, err = vs.UpdateVersionLocked(func() (versionUpdate, error) {
 				return versionUpdate{
 					VE:                      ve,
-					Metrics:                 fileMetrics,
 					ForceManifestRotation:   rand.IntN(3) == 0,
 					InProgressCompactionsFn: func() []compactionInfo { return nil },
 				}, nil


### PR DESCRIPTION
When we apply a new version, we also pass "delta metrics" that are
added to the current `LevelMetrics`.

Some of `LevelMetrics` fields (like table counts/sizes, estimated
ref size) are reset from the `LevelMetadata` from the new version.
These fields don't require maintenance through the delta metrics.

This change removes the ineffectual code which attempts to keep these
fields updated through the delta metrics.