### PR TITLE
crl-release-24.3: db: add fail-safe to the delete pacer

### DIFF
--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -52,6 +52,8 @@ type cleanupManager struct {
 
 // We can queue this many jobs before we have to block EnqueueJob.
 const jobsQueueDepth = 1000
+const jobsQueueHighThreshold = jobsQueueDepth * 3 / 4
+const jobsQueueLowThreshold = jobsQueueDepth / 10
 
 // deletableFile is used for non log files.
 type deletableFile struct {
@@ -207,7 +209,11 @@ func (cm *cleanupManager) maybePace(
 	if !cm.needsPacing(fileType, fileNum) {
 		return
 	}
-
+	if len(cm.jobsCh) >= jobsQueueHighThreshold {
+		// If there are many jobs queued up, disable pacing. In this state, we
+		// execute deletion jobs at the same rate as new jobs get queued.
+		return
+	}
 	tokens := cm.deletePacer.PacingDelay(time.Now(), fileSize)
 	if tokens == 0.0 {
 		// The token bucket might be in debt; it could make us wait even for 0
@@ -292,19 +298,17 @@ func (cm *cleanupManager) deleteObsoleteObject(
 //
 // Must be called with cm.mu locked.
 func (cm *cleanupManager) maybeLogLocked() {
-	const highThreshold = jobsQueueDepth * 3 / 4
-	const lowThreshold = jobsQueueDepth / 10
 
 	jobsInQueue := cm.mu.totalJobs - cm.mu.completedJobs
 
-	if !cm.mu.jobsQueueWarningIssued && jobsInQueue > highThreshold {
+	if !cm.mu.jobsQueueWarningIssued && jobsInQueue > jobsQueueHighThreshold {
 		cm.mu.jobsQueueWarningIssued = true
-		cm.opts.Logger.Infof("cleanup falling behind; job queue has over %d jobs", highThreshold)
+		cm.opts.Logger.Infof("cleanup falling behind; job queue has over %d jobs", jobsQueueHighThreshold)
 	}
 
-	if cm.mu.jobsQueueWarningIssued && jobsInQueue < lowThreshold {
+	if cm.mu.jobsQueueWarningIssued && jobsInQueue < jobsQueueLowThreshold {
 		cm.mu.jobsQueueWarningIssued = false
-		cm.opts.Logger.Infof("cleanup back to normal; job queue has under %d jobs", lowThreshold)
+		cm.opts.Logger.Infof("cleanup back to normal; job queue has under %d jobs", jobsQueueLowThreshold)
 	}
 }
 


### PR DESCRIPTION
When we reach 3/4 of the capacity of the deletion jobs channel, we
disable pacing. This should act as a catch-all if the delete pacing
logic fails to keep up.

Release justification: mitigation of serious condition encountered in
production.

Informs #5424