### PR TITLE
crl-release-25.3: compact: make TombstoneDenseCompactionThreshold dynamically reconfigurable

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1722,7 +1722,8 @@ func (p *compactionPickerByScore) pickBlobFileRewriteCompaction(
 func (p *compactionPickerByScore) pickTombstoneDensityCompaction(
 	env compactionEnv,
 ) (pc *pickedTableCompaction) {
-	if p.opts.Experimental.TombstoneDenseCompactionThreshold <= 0 {
+	threshold := p.opts.Experimental.TombstoneDenseCompactionThreshold()
+	if threshold <= 0 {
 		// Tombstone density compactions are disabled.
 		return nil
 	}
@@ -1745,7 +1746,7 @@ func (p *compactionPickerByScore) pickTombstoneDensityCompaction(
 			if f.IsCompacting() || !f.StatsValid() || f.Size == 0 {
 				continue
 			}
-			if f.Stats.TombstoneDenseBlocksRatio < p.opts.Experimental.TombstoneDenseCompactionThreshold {
+			if f.Stats.TombstoneDenseBlocksRatio < threshold {
 				continue
 			}
 			overlaps := p.vers.Overlaps(lastNonEmptyLevel, f.UserKeyBounds())

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3242,7 +3242,7 @@ func TestTombstoneDensityCompactionMoveOptimization(t *testing.T) {
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = 0.5 // Lower for test
+	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
 	opts.Experimental.NumDeletionsThreshold = 1
 	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
@@ -3340,7 +3340,7 @@ func TestTombstoneDensityCompactionMoveOptimization_NoMoveWithOverlap(t *testing
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = 0.5 // Lower for test
+	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
 	opts.Experimental.NumDeletionsThreshold = 1
 	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
@@ -3419,7 +3419,7 @@ func TestTombstoneDensityCompactionMoveOptimization_GrandparentOverlapTooLarge(t
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = 0.5
+	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
 	opts.Experimental.NumDeletionsThreshold = 1
 	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
@@ -3481,7 +3481,7 @@ func TestTombstoneDensityCompactionMoveOptimization_BelowDensityThreshold(t *tes
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = 0.9 // Set high threshold
+	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.9 } // Set high threshold
 	opts.Experimental.NumDeletionsThreshold = 1
 	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
@@ -3528,7 +3528,7 @@ func TestTombstoneDensityCompactionMoveOptimization_InvalidStats(t *testing.T) {
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = 0.5
+	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
 	opts.Experimental.NumDeletionsThreshold = 1
 	opts.Experimental.EnableColumnarBlocks = func() bool { return true }
 	opts.Experimental.CompactionScheduler = NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -85,6 +85,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"Experimental.RemoteStorage:",
 		"Experimental.SingleDeleteInvariantViolationCallback:",
 		"Experimental.EnableDeleteOnlyCompactionExcises:",
+		"Experimental.TombstoneDenseCompactionThreshold:",
 		"Experimental.ValueSeparationPolicy:",
 		"Levels[0].Compression:",
 		"Levels[1].Compression:",
@@ -115,6 +116,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		expectEqualFn(t, o.Opts.Experimental.DisableIngestAsFlushable, parsed.Opts.Experimental.DisableIngestAsFlushable)
 		expectEqualFn(t, o.Opts.Experimental.IngestSplit, parsed.Opts.Experimental.IngestSplit)
 		expectEqualFn(t, o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency, parsed.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency)
+		expectEqualFn(t, o.Opts.Experimental.TombstoneDenseCompactionThreshold, parsed.Opts.Experimental.TombstoneDenseCompactionThreshold)
 		expectEqualFn(t, o.Opts.Experimental.ValueSeparationPolicy, parsed.Opts.Experimental.ValueSeparationPolicy)
 		expectEqualFn(t, o.Opts.TargetByteDeletionRate, parsed.Opts.TargetByteDeletionRate)
 

--- a/options_test.go
+++ b/options_test.go
@@ -404,7 +404,7 @@ func TestOptionsParse(t *testing.T) {
 			opts.Experimental.ReadSamplingMultiplier = 400
 			opts.Experimental.NumDeletionsThreshold = 500
 			opts.Experimental.DeletionSizeRatioThreshold = 0.7
-			opts.Experimental.TombstoneDenseCompactionThreshold = 0.2
+			opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.2 }
 			opts.Experimental.FileCacheShards = 500
 			opts.Experimental.SecondaryCacheSizeBytes = 1024
 			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {


### PR DESCRIPTION
Previously, TombstoneDenseCompactionThreshold was a static float64 value
that could only be set at initialization time. This made it impossible to
dynamically adjust the threshold based on changing workload characteristics
or operational requirements.

This commit changes TombstoneDenseCompactionThreshold from a float64 to
a function returning float64, following the pattern used by other dynamic
options like CompactionGarbageFractionForMaxConcurrency and
VirtualTableRewriteUnreferencedFraction. The default value remains 0.10.

Benefits:
- Allows runtime adjustment of tombstone compaction behavior
- Enables workload-specific tuning without restarting the database
- Makes it easier to turn down or disable tombstone compactions when they
  lead to increased resource usage with no visible latency benefits

Changes:
- Updated Options.Experimental.TombstoneDenseCompactionThreshold to func() float64
- Modified EnsureDefaults to use function wrapper
- Updated String() and Parse() methods to handle function type
- Modified pickTombstoneDensityCompaction to call the function
- Updated all test files to use function syntax

Fixes #5457.