### PR TITLE
crl-release-25.1: db: add fail-safe to the delete pacer

### DIFF
--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -54,6 +54,8 @@ type cleanupManager struct {
 
 // We can queue this many jobs before we have to block EnqueueJob.
 const jobsQueueDepth = 1000
+const jobsQueueHighThreshold = jobsQueueDepth * 3 / 4
+const jobsQueueLowThreshold = jobsQueueDepth / 10
 
 // deletableFile is used for non log files.
 type deletableFile struct {
@@ -217,7 +219,11 @@ func (cm *cleanupManager) maybePace(
 	if !cm.needsPacing(fileType, fileNum) {
 		return
 	}
-
+	if len(cm.jobsCh) >= jobsQueueHighThreshold {
+		// If there are many jobs queued up, disable pacing. In this state, we
+		// execute deletion jobs at the same rate as new jobs get queued.
+		return
+	}
 	tokens := cm.deletePacer.PacingDelay(crtime.NowMono(), fileSize)
 	if tokens == 0.0 {
 		// The token bucket might be in debt; it could make us wait even for 0
@@ -302,19 +308,17 @@ func (cm *cleanupManager) deleteObsoleteObject(
 //
 // Must be called with cm.mu locked.
 func (cm *cleanupManager) maybeLogLocked() {
-	const highThreshold = jobsQueueDepth * 3 / 4
-	const lowThreshold = jobsQueueDepth / 10
 
 	jobsInQueue := cm.mu.totalJobs - cm.mu.completedJobs
 
-	if !cm.mu.jobsQueueWarningIssued && jobsInQueue > highThreshold {
+	if !cm.mu.jobsQueueWarningIssued && jobsInQueue > jobsQueueHighThreshold {
 		cm.mu.jobsQueueWarningIssued = true
-		cm.opts.Logger.Infof("cleanup falling behind; job queue has over %d jobs", highThreshold)
+		cm.opts.Logger.Infof("cleanup falling behind; job queue has over %d jobs", jobsQueueHighThreshold)
 	}
 
-	if cm.mu.jobsQueueWarningIssued && jobsInQueue < lowThreshold {
+	if cm.mu.jobsQueueWarningIssued && jobsInQueue < jobsQueueLowThreshold {
 		cm.mu.jobsQueueWarningIssued = false
-		cm.opts.Logger.Infof("cleanup back to normal; job queue has under %d jobs", lowThreshold)
+		cm.opts.Logger.Infof("cleanup back to normal; job queue has under %d jobs", jobsQueueLowThreshold)
 	}
 }
 

--- a/obsolete_files_test.go
+++ b/obsolete_files_test.go
@@ -5,13 +5,17 @@
 package pebble
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -135,4 +139,82 @@ func TestCleaner(t *testing.T) {
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}
 	})
+}
+
+// TestCleanupManagerFallingBehind verifies that we disable pacing when the jobs
+// channel reaches the high threshold.
+func TestCleanupManagerFallingBehind(t *testing.T) {
+	const MB = 1024 * 1024
+	const GB = 1024 * MB
+	mem := vfs.NewMem()
+	opts := &Options{
+		FS:                     mem,
+		TargetByteDeletionRate: 10 * MB,
+	}
+	opts.EnsureDefaults()
+
+	objProvider, err := objstorageprovider.Open(objstorageprovider.Settings{
+		FS:        mem,
+		FSDirName: "/",
+		FSCleaner: opts.Cleaner,
+	})
+	require.NoError(t, err)
+	defer objProvider.Close()
+
+	getDeletePacerInfo := func() deletionPacerInfo {
+		return deletionPacerInfo{
+			freeBytes: 100 * GB,
+			liveBytes: 100 * GB,
+		}
+	}
+
+	cm := openCleanupManager(opts, objProvider, getDeletePacerInfo)
+
+	x := 0
+	addJob := func(fileSize int) {
+		x++
+		fileNum := base.DiskFileNum(x)
+		w, _, err := objProvider.Create(context.Background(), base.FileTypeTable, fileNum, objstorage.CreateOptions{})
+		require.NoError(t, err)
+		require.NoError(t, w.Finish())
+
+		cm.EnqueueJob(1, []obsoleteFile{{
+			fileType: base.FileTypeTable,
+			nonLogFile: deletableFile{
+				fileNum:  fileNum,
+				fileSize: uint64(fileSize),
+				isLocal:  true,
+			},
+		}}, obsoleteTableStats{})
+	}
+
+	for range jobsQueueLowThreshold {
+		addJob(1 * MB)
+	}
+	// At 1MB, each job will take 100ms each. Note that the rate increase based on
+	// history won't make much difference, since the enqueued size is averaged
+	// over 5 minutes.
+	time.Sleep(50 * time.Millisecond)
+	require.Greater(t, len(cm.jobsCh), jobsQueueLowThreshold/2)
+	t.Logf("%d", len(cm.jobsCh))
+
+	// Add enough jobs to exceed the high threshold. We add small jobs so that the
+	// historic rate doesn't grow significantly.
+	require.Greater(t, jobsQueueDepth, jobsQueueHighThreshold+jobsQueueLowThreshold)
+	t.Logf("B")
+	for range jobsQueueHighThreshold {
+		addJob(1)
+	}
+
+	for i := 0; ; i++ {
+		time.Sleep(10 * time.Millisecond)
+		if len(cm.jobsCh) <= jobsQueueHighThreshold {
+			break
+		}
+		if i == 1000 {
+			t.Fatalf("jobs channel length never dropped below high threshold (%d vs %d)", len(cm.jobsCh), jobsQueueHighThreshold)
+		}
+	}
+	// Set a high rate so the rest of the jobs finish quickly.
+	close(cm.jobsCh)
 }


### PR DESCRIPTION
When we reach 3/4 of the capacity of the deletion jobs channel, we
disable pacing. This should act as a catch-all if the delete pacing
logic fails to keep up.

Release justification: mitigation of serious condition encountered in
production.

Informs #5424