### PR TITLE
db: remove unused newFileMetrics

### DIFF
--- a/version_set_test.go
+++ b/version_set_test.go
@@ -563,18 +563,3 @@ func TestCrashDuringManifestWrite_LargeKeys(t *testing.T) {
 		}()
 	}
 }
-
-func newFileMetrics(newFiles []manifest.NewTableEntry) levelMetricsDelta {
-	var m levelMetricsDelta
-	for _, nf := range newFiles {
-		lm := m[nf.Level]
-		if lm == nil {
-			lm = &LevelMetrics{}
-			m[nf.Level] = lm
-		}
-		lm.TablesCount++
-		lm.TablesSize += int64(nf.Meta.Size)
-		lm.EstimatedReferencesSize += nf.Meta.EstimatedReferenceSize()
-	}
-	return m
-}


### PR DESCRIPTION
This func was unused and failing lint checking.

Fix #5473.
Fix #5472.
Fix #5471.
Fix #5470.
Fix #5469.
Fix #5468.