### PR TITLE
manifest: fix underflow in LevelMetadata

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -102,6 +102,10 @@ func NewVersionForTesting(
 		}
 		for _, f := range files[l] {
 			v.Levels[l].totalTableSize += f.Size
+			v.Levels[l].totalRefSize += f.EstimatedReferenceSize()
+			if f.Virtual {
+				v.Levels[l].virtualTables.Inc(f.Size)
+			}
 		}
 	}
 	l0Organizer.ResetForTesting(v)

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1358,7 +1358,11 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 			// counts.  However, because we cloned the previous level's B-Tree,
 			// this should never result in a file's reference count dropping to
 			// zero. The remove call will panic if this happens.
-			v.Levels[level].remove(f)
+			if !v.Levels[level].remove(f) {
+				if invariants.Enabled {
+					panic(errors.AssertionFailedf("deleted table %f not in level", f))
+				}
+			}
 			v.RangeKeyLevels[level].remove(f)
 			v.MarkedForCompaction.Delete(f, level)
 		}

--- a/version_set.go
+++ b/version_set.go
@@ -1082,8 +1082,8 @@ func setBasicLevelMetrics(m *Metrics, newVersion *manifest.Version) {
 		l := &m.Levels[i]
 		l.TablesCount = int64(newVersion.Levels[i].Len())
 		l.TablesSize = int64(newVersion.Levels[i].TableSize())
-		l.VirtualTablesCount = newVersion.Levels[i].NumVirtual
-		l.VirtualTablesSize = newVersion.Levels[i].VirtualTableSize
+		l.VirtualTablesCount = newVersion.Levels[i].VirtualTables().Count
+		l.VirtualTablesSize = newVersion.Levels[i].VirtualTables().Bytes
 		l.EstimatedReferencesSize = newVersion.Levels[i].EstimatedReferenceSize()
 		l.Sublevels = 0
 		if l.TablesCount > 0 {


### PR DESCRIPTION
We were underflowing when trying to maintain the metrics for a range
key level. We don't use the metrics for range key levels, so this is
not a visible bug.

We now handle the case where the element did not exist, and assert
that this never happens for the regular levels.

Fixes #5483