### PR TITLE
crl-release-25.4: db: add configurable latency tolerant minimum size

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3484,7 +3484,7 @@ func (d *DB) compactAndWrite(
 			// This span of keyspace is more tolerant of latency, so set a more
 			// aggressive value separation policy for this output.
 			vSep.SetNextOutputConfig(compact.ValueSeparationOutputConfig{
-				MinimumSize: latencyTolerantMinimumSize,
+				MinimumSize: d.opts.Experimental.ValueSeparationPolicy().MinimumLatencyTolerantSize,
 			})
 		}
 		objMeta, tw, err := d.newCompactionOutputTable(jobID, c, writerOpts)

--- a/data_test.go
+++ b/data_test.go
@@ -1868,6 +1868,11 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 						if err != nil {
 							return err
 						}
+					case "latency-tolerant-min-size":
+						policy.MinimumLatencyTolerantSize, err = strconv.Atoi(value)
+						if err != nil {
+							return err
+						}
 					default:
 						return errors.Newf("unrecognized value-separation argument %q", name)
 					}

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -633,9 +633,10 @@ func TestBlobCorruptionEvent(t *testing.T) {
 			}
 			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return ValueSeparationPolicy{
-					Enabled:               true,
-					MinimumSize:           1,
-					MaxBlobReferenceDepth: 10,
+					Enabled:                    true,
+					MinimumSize:                1,
+					MinimumLatencyTolerantSize: 10,
+					MaxBlobReferenceDepth:      10,
 				}
 			}
 			d, err := Open("", opts)

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -335,13 +335,12 @@ func (r *Runner) writeKeysToTable(
 		}
 
 		valueLen := kv.V.Len()
-		isLikelyMVCCGarbage := sstable.IsLikelyMVCCGarbage(kv.K.UserKey, prevKeyKind, kv.K.Kind(), valueLen, prefixEqual)
+		isLikelyMVCCGarbage := sstable.IsLikelyMVCCGarbage(kv.K.UserKey, prevKeyKind, kv.K.Kind(), prefixEqual)
 		// Add the value to the sstable, possibly separating its value into a
 		// blob file. The ValueSeparation implementation is responsible for
-		// writing the KV to the sstable.
-		// If the key might be garbage (all requirements of
-		// sstable.IsLikelyMVCCGarbage are met), we eagerly separate the value
-		// into a blob file.
+		// writing the KV to the sstable. If the key might be garbage (all
+		// requirements of sstable.IsLikelyMVCCGarbage are met), we eagerly
+		// separate the value into a blob file.
 		if err := valueSeparation.Add(tw, kv, r.iter.ForceObsoleteDueToRangeDel(), isLikelyMVCCGarbage); err != nil {
 			return nil, err
 		}

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -311,12 +311,13 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 
 	opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 		return pebble.ValueSeparationPolicy{
-			Enabled:                  true,
-			MinimumSize:              5,
-			MaxBlobReferenceDepth:    3,
-			RewriteMinimumAge:        50 * time.Millisecond,
-			GarbageRatioLowPriority:  0.10, // 10% garbage
-			GarbageRatioHighPriority: 0.30, // 30% garbage
+			Enabled:                    true,
+			MinimumSize:                5,
+			MinimumLatencyTolerantSize: 10,
+			MaxBlobReferenceDepth:      3,
+			RewriteMinimumAge:          50 * time.Millisecond,
+			GarbageRatioLowPriority:    0.10, // 10% garbage
+			GarbageRatioHighPriority:   0.30, // 30% garbage
 		}
 	}
 
@@ -896,12 +897,13 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 		}
 		lowPri := max(rng.Float64(), 0.05)
 		policy := pebble.ValueSeparationPolicy{
-			Enabled:                  true,
-			MinimumSize:              1 + rng.IntN(maxValueSize),
-			MaxBlobReferenceDepth:    2 + rng.IntN(9),                                   // 2-10
-			RewriteMinimumAge:        time.Duration(rng.IntN(90)+10) * time.Millisecond, // [10ms, 100ms)
-			GarbageRatioLowPriority:  lowPri,
-			GarbageRatioHighPriority: lowPri + rand.Float64()*(1.0-lowPri), // [lowPri, 1.0)
+			Enabled:                    true,
+			MinimumSize:                1 + rng.IntN(maxValueSize),
+			MinimumLatencyTolerantSize: 5 + rng.IntN(11),                                  // [5, 15] bytes
+			MaxBlobReferenceDepth:      2 + rng.IntN(9),                                   // 2-10
+			RewriteMinimumAge:          time.Duration(rng.IntN(90)+10) * time.Millisecond, // [10ms, 100ms)
+			GarbageRatioLowPriority:    lowPri,
+			GarbageRatioHighPriority:   lowPri + rand.Float64()*(1.0-lowPri), // [lowPri, 1.0)
 		}
 		opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 			return policy

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -250,9 +250,10 @@ func TestMetrics(t *testing.T) {
 		opts.Experimental.EnableValueBlocks = func() bool { return true }
 		opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 			return ValueSeparationPolicy{
-				Enabled:               true,
-				MinimumSize:           3,
-				MaxBlobReferenceDepth: 5,
+				Enabled:                    true,
+				MinimumSize:                3,
+				MinimumLatencyTolerantSize: 10,
+				MaxBlobReferenceDepth:      5,
 			}
 		}
 		opts.TargetFileSizes[0] = 50

--- a/options.go
+++ b/options.go
@@ -1213,6 +1213,14 @@ type ValueSeparationPolicy struct {
 	//
 	// MinimumSize must be > 0.
 	MinimumSize int
+	// MinimumLatencyTolerantSize specifies the minimum size of a value that can
+	// be separated into a blob file if said value is a part of a latency tolerant
+	// span or likely MVCC garbage (see sstable.IsLikelyMVCCGarbage). This
+	// applies only to span policies that permit separation of MVCC garbage,
+	// which is also the default.
+	//
+	// MinimumLatencyTolerantSize must be > 0.
+	MinimumLatencyTolerantSize int
 	// MaxBlobReferenceDepth limits the number of potentially overlapping (in
 	// the keyspace) blob files that can be referenced by a single sstable. If a
 	// compaction may produce an output sstable referencing more than this many
@@ -1823,6 +1831,7 @@ func (o *Options) String() string {
 			fmt.Fprintln(&buf, "[Value Separation]")
 			fmt.Fprintf(&buf, "  enabled=%t\n", policy.Enabled)
 			fmt.Fprintf(&buf, "  minimum_size=%d\n", policy.MinimumSize)
+			fmt.Fprintf(&buf, "  minimum_latency_tolerant_size=%d\n", policy.MinimumLatencyTolerantSize)
 			fmt.Fprintf(&buf, "  max_blob_reference_depth=%d\n", policy.MaxBlobReferenceDepth)
 			fmt.Fprintf(&buf, "  rewrite_minimum_age=%s\n", policy.RewriteMinimumAge)
 			fmt.Fprintf(&buf, "  garbage_ratio_low_priority=%.2f\n", policy.GarbageRatioLowPriority)
@@ -2271,6 +2280,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				var minimumSize int
 				minimumSize, err = strconv.Atoi(value)
 				valSepPolicy.MinimumSize = minimumSize
+			case "minimum_latency_tolerant_size":
+				valSepPolicy.MinimumLatencyTolerantSize, err = strconv.Atoi(value)
 			case "max_blob_reference_depth":
 				valSepPolicy.MaxBlobReferenceDepth, err = strconv.Atoi(value)
 			case "rewrite_minimum_age":
@@ -2564,6 +2575,9 @@ func (o *Options) Validate() error {
 	if policy := o.Experimental.ValueSeparationPolicy(); policy.Enabled {
 		if policy.MinimumSize <= 0 {
 			fmt.Fprintf(&buf, "ValueSeparationPolicy.MinimumSize (%d) must be > 0\n", policy.MinimumSize)
+		}
+		if policy.MinimumLatencyTolerantSize <= 0 {
+			fmt.Fprintf(&buf, "ValueSeparationPolicy.MinimumLatencyTolerantSize (%d) must be > 0\n", policy.MinimumLatencyTolerantSize)
 		}
 		if policy.MaxBlobReferenceDepth <= 0 {
 			fmt.Fprintf(&buf, "ValueSeparationPolicy.MaxBlobReferenceDepth (%d) must be > 0\n", policy.MaxBlobReferenceDepth)

--- a/options_test.go
+++ b/options_test.go
@@ -45,9 +45,10 @@ func (o *Options) testingRandomized(t testing.TB) *Options {
 	if o.FormatMajorVersion >= FormatValueSeparation && o.Experimental.ValueSeparationPolicy == nil && rand.Int64N(4) > 0 {
 		lowPri := 0.1 + rand.Float64()*0.9 // [0.1, 1.0)
 		policy := ValueSeparationPolicy{
-			Enabled:               true,
-			MinimumSize:           1 << rand.IntN(10), // [1, 512]
-			MaxBlobReferenceDepth: rand.IntN(10) + 1,  // [1, 10)
+			Enabled:                    true,
+			MinimumSize:                1 << rand.IntN(10), // [1, 512]
+			MinimumLatencyTolerantSize: 5 + rand.IntN(11),  // [5, 15]
+			MaxBlobReferenceDepth:      rand.IntN(10) + 1,  // [1, 10]
 			// Constrain the rewrite minimum age to [0, 15s).
 			RewriteMinimumAge:        time.Duration(rand.IntN(15)) * time.Second,
 			GarbageRatioLowPriority:  lowPri,

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -350,10 +350,11 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 			}
 			opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 				return pebble.ValueSeparationPolicy{
-					Enabled:               true,
-					MinimumSize:           3,
-					MaxBlobReferenceDepth: 5,
-					RewriteMinimumAge:     15 * time.Minute,
+					Enabled:                    true,
+					MinimumSize:                3,
+					MinimumLatencyTolerantSize: 10,
+					MaxBlobReferenceDepth:      5,
+					RewriteMinimumAge:          15 * time.Minute,
 				}
 			}
 			setDefaultExperimentalOpts(opts)

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -17,7 +17,7 @@ tree
        0      LOCK
      152      MANIFEST-000010
      250      MANIFEST-000013
-    2947      OPTIONS-000003
+    2982      OPTIONS-000003
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
@@ -32,7 +32,7 @@ tree
       11        000011.log
      660        000012.sst
      187        MANIFEST-000013
-    2947        OPTIONS-000003
+    2982        OPTIONS-000003
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013
 
@@ -93,6 +93,7 @@ cat build/OPTIONS-000003
 [Value Separation]
   enabled=true
   minimum_size=3
+  minimum_latency_tolerant_size=10
   max_blob_reference_depth=5
   rewrite_minimum_age=15m0s
   garbage_ratio_low_priority=0.00

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -643,9 +643,17 @@ func (w *RawColumnWriter) evaluatePoint(
 	// We require:
 	//  . Value blocks to be enabled.
 	//  . IsLikelyMVCCGarbage to be true; see comment for MVCC garbage criteria.
+	//  . The value to be sufficiently large. (Currently we simply require a
+	//	  non-zero length, so all non-empty values are eligible for storage
+	//	  out-of-band in a value block.)
+	//
+	// Use of 0 here is somewhat arbitrary. Given the minimum 3 byte encoding of
+	// valueHandle, this should be > 3. But tiny values are common in test and
+	// unlikely in production, so we use 0 here for better test coverage.
 	useValueBlock := !w.opts.DisableValueBlocks &&
 		w.valueBlock != nil &&
-		IsLikelyMVCCGarbage(key.UserKey, prevKeyKind, keyKind, valueLen, prefixEqual)
+		valueLen > 0 &&
+		IsLikelyMVCCGarbage(key.UserKey, prevKeyKind, keyKind, prefixEqual)
 	if !useValueBlock {
 		return eval, nil
 	}
@@ -1279,26 +1287,14 @@ func (w *RawColumnWriter) copyProperties(props Properties) {
 //
 //	. The previous key to be a SET/SETWITHDEL.
 //	. The current key to be a SET/SETWITHDEL.
-//	. The value to be sufficiently large. (Currently we simply require a
-//	  non-zero length, so all non-empty values are eligible for storage
-//	  out-of-band in a value block.)
 //	. The current key to have the same prefix as the previous key.
-//
-// Use of 0 here is somewhat arbitrary. Given the minimum 3 byte encoding of
-// valueHandle, this should be > 3. But tiny values are common in test and
-// unlikely in production, so we use 0 here for better test coverage.
 func IsLikelyMVCCGarbage(
-	k []byte,
-	prevKeyKind, keyKind base.InternalKeyKind,
-	valueLen int,
-	prefixEqual func(k []byte) bool,
+	k []byte, prevKeyKind, keyKind base.InternalKeyKind, prefixEqual func(k []byte) bool,
 ) bool {
-	const tinyValueThreshold = 0
 	isSetStarKind := func(k base.InternalKeyKind) bool {
 		return k == InternalKeyKindSet || k == InternalKeyKindSetWithDelete
 	}
 	return isSetStarKind(prevKeyKind) &&
 		isSetStarKind(keyKind) &&
-		valueLen > tinyValueThreshold &&
 		prefixEqual(k)
 }

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -877,7 +877,7 @@ L6:
 # Create a new database with value separation enabled to test that blob files
 # are included in checkpoints.
 
-open valsepdb value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0)
+open valsepdb value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1)
 ----
 mkdir-all: valsepdb 0755
 open-dir: .

--- a/testdata/compaction/backing_value_size
+++ b/testdata/compaction/backing_value_size
@@ -1,7 +1,7 @@
 # Test a blob file rewrite compaction with virtual sstable references that
 # track backing value sizes do not trigger unnecessary blob file rewrites.
 
-define value-separation=(enabled=true, min-size=1, max-ref-depth=10, garbage-ratios=0.01:0.2)
+define value-separation=(enabled=true, min-size=1, max-ref-depth=10, garbage-ratios=0.01:0.2, latency-tolerant-min-size=1)
 ----
 
 batch

--- a/testdata/compaction/blob_rewrite
+++ b/testdata/compaction/blob_rewrite
@@ -1,6 +1,6 @@
 # Test blob rewrite compactions.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0, garbage-ratios=0.0:0.0)
+define value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0, garbage-ratios=0.0:0.0, latency-tolerant-min-size=1)
 ----
 
 batch

--- a/testdata/compaction/mvcc_garbage_blob
+++ b/testdata/compaction/mvcc_garbage_blob
@@ -1,6 +1,6 @@
 # Set the minimum size for a separated value to 5.
 
-define value-separation=(enabled, min-size=5, max-ref-depth=3, garbage-ratios=1.0:1.0)
+define value-separation=(enabled, min-size=5, max-ref-depth=3, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1)
 ----
 
 batch

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -1,7 +1,7 @@
 # Test a simple sequence of flushes and compactions where all values are
 # separated.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0, garbage-ratios=1.0:1.0)
+define value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1)
 ----
 
 batch
@@ -55,7 +55,7 @@ compact a-d
 # and the value separation policy is configured to limit the blob reference
 # depth to 3.
 
-define verbose value-separation=(enabled, min-size=3, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
+define verbose value-separation=(enabled, min-size=3, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1)
 L6 blob-depth=3
   a.SET.0:a
   b.SET.0:blob{fileNum=100002 value=bar}
@@ -197,7 +197,7 @@ COMPRESSION
 
 # Set the minimum size for a separated value to 5.
 
-define value-separation=(enabled, min-size=5, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
+define value-separation=(enabled, min-size=5, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1)
 ----
 
 batch
@@ -247,7 +247,7 @@ w:world
 
 # Configure the database to require keys in the range [a,m) to be in-place.
 
-define required-in-place=(a,m) value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0)
+define required-in-place=(a,m) value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1)
 ----
 
 batch
@@ -274,7 +274,7 @@ Blob files:
 # references. Because these files overlap and are in separate sublevels, a
 # compaction that preserves blob references should sum their depths.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=2
+define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1) l0-compaction-threshold=2
 L0 blob-depth=1
   a.SET.9:a
   d.SET.9:blob{fileNum=100001 value=d}
@@ -310,7 +310,7 @@ Blob files:
 # sublevel, a compaction that preserves blob references should take the MAX of
 # their depths.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=2
+define value-separation=(enabled, min-size=1, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1) l0-compaction-threshold=2
 L0 blob-depth=1
   a.SET.9:a
   d.SET.9:blob{fileNum=100001 value=d}
@@ -345,7 +345,7 @@ Blob files:
 # garbage ratio of 0.0 (no garbage). With this configuration, any blob file that
 # contains any unreferenced values should be immediately compacted.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=2, rw-min-age=0s, garbage-ratios=0.0:0.0) auto-compactions=off
+define value-separation=(enabled, min-size=1, max-ref-depth=2, rw-min-age=0s, garbage-ratios=0.0:0.0, latency-tolerant-min-size=1) auto-compactions=off
 ----
 
 batch
@@ -474,7 +474,7 @@ COMPRESSION
 
 # Test a blob file rewrite compaction with virtual sstable references.
 
-define value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=0s, garbage-ratios=0.01:0.01)
+define value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=0s, garbage-ratios=0.01:0.01, latency-tolerant-min-size=1)
 ----
 
 batch
@@ -512,7 +512,7 @@ validate-blob-reference-index-block
 ----
 validated
 
-define value-separation=(enabled, min-size=5, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0) l0-compaction-threshold=1 target-file-sizes=65536 memtable-size=10000000
+define value-separation=(enabled, min-size=5, max-ref-depth=5, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1) l0-compaction-threshold=1 target-file-sizes=65536 memtable-size=10000000
 ----
 
 # Test writing a non-trivial amount of data. With a key length of 4, we'll write
@@ -636,7 +636,7 @@ would excise 1 files.
 # 1024 bytes, but there's also a key span defined with the latency-tolerant
 # value storage policy.
 
-define value-separation=(enabled, min-size=1024, max-ref-depth=10, rw-min-age=0s, garbage-ratios=1.0:1.0) latency-tolerant-span=(f,o)
+define value-separation=(enabled, min-size=1024, max-ref-depth=10, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=10) latency-tolerant-span=(f,o)
 ----
 
 batch
@@ -744,7 +744,7 @@ w: (helloworld, .)
 x: (helloworld!, .)
 stats: seeked 1 times (1 internal); stepped 23 times (23 internal); blocks: 0B cached, 615B not cached (read time: 0s); points: 24 (24B keys, 157B values); separated: 6 (63B, 63B fetched)
 
-define value-separation=(enabled, min-size=8, max-ref-depth=10, rw-min-age=0s, garbage-ratios=1.0:1.0)
+define value-separation=(enabled, min-size=8, max-ref-depth=10, rw-min-age=0s, garbage-ratios=1.0:1.0, latency-tolerant-min-size=1)
 ----
 
 batch

--- a/testdata/compaction_picker_scores
+++ b/testdata/compaction_picker_scores
@@ -271,7 +271,7 @@ L6       898KB    0.00     0.97           0.97
 # it weren't for the high priority blob file rewrite compaction heuristic
 # triggering, we would pursue an automatic score compaction from L0 -> LBase.
 
-define l0-compaction-threshold=1 lbase-max-bytes=65536  enable-table-stats=true auto-compactions=off value-separation=(enabled, min-size=1, max-ref-depth=5, garbage-ratios=0.1:0.2)
+define l0-compaction-threshold=1 lbase-max-bytes=65536  enable-table-stats=true auto-compactions=off value-separation=(enabled, min-size=1, max-ref-depth=5, garbage-ratios=0.1:0.2, latency-tolerant-min-size=1)
 ----
 
 batch

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -454,7 +454,7 @@ Iter category stats:
 
 disk-usage
 ----
-5.0KB
+5.1KB
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -980,7 +980,7 @@ range-deletions-bytes-estimate: 482
 
 # Create a database with value separation enabled.
 
-define format-major-version=24 value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=1m, garbage-ratios=0.1:0.3) target-file-sizes=(100000) block-size=32768
+define format-major-version=24 value-separation=(enabled, min-size=1, max-ref-depth=10, rw-min-age=1m, garbage-ratios=0.1:0.3, latency-tolerant-min-size=1) target-file-sizes=(100000) block-size=32768
 ----
 
 batch


### PR DESCRIPTION
We'll allow both likely MVCC garbage and latency tolerant values to have their minimum size to be separated configurable via a field in our ValueSeparationPolicy.