### PR TITLE
github: run asan on ubuntu 22.04

### DIFF
--- a/.github/workflows/instrumented.yaml
+++ b/.github/workflows/instrumented.yaml
@@ -59,7 +59,9 @@ jobs:
 
   linux-asan:
     name: linux-asan
-    runs-on: ubuntu-latest
+    # We have seen crashes with 24.04 that don't reproduce with 22.04 and are
+    # likely some asan bug triggered by a specific kernel (#5342).
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We started seeing occasional crashes which only reproduce with the
current ubuntu 24.04 image. This is possibly a bug in the asan library
or in the Go/asan glue being triggered by a specific kernal.

Switch to ubuntu 22.04 for the asan nightlies.

Closes #5342