### PR TITLE
db: fix Metrics.String ingestion count

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -974,7 +974,7 @@ func (m *Metrics) String() string {
 		live:    fmt.Sprintf("%s (%s)", humanizeCount(m.MemTable.Count), humanizeBytes(m.MemTable.Size)),
 		zombie:  fmt.Sprintf("%s (%s)", humanizeCount(m.MemTable.ZombieCount), humanizeBytes(m.MemTable.ZombieSize)),
 		// ingestions.
-		total:     crhumanize.Count(m.WAL.BytesIn + m.WAL.BytesWritten).String(),
+		total:     crhumanize.Count(m.Ingest.Count).String(),
 		flushable: fmt.Sprintf("%s (%s)", humanizeCount(m.Flush.AsIngestCount), humanizeBytes(m.Flush.AsIngestBytes)),
 	}
 	cur = cur.WriteString(commitPipelineInfoTableTopHeader).NewlineReturn()

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -58,7 +58,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |      written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+--------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 160KB: 160KB |      0.0% |         1 |  1 (512KB) |  1 (512KB) |     328 K |      0 (0B)
+   1 (0B) | 160KB: 160KB |      0.0% |         1 |  1 (512KB) |  1 (512KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -175,7 +175,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   30B: 41B |     36.7% |         1 |  1 (256KB) |  1 (256KB) |        71 |      0 (0B)
+   1 (0B) |   30B: 41B |     36.7% |         1 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 4 entries (1.3KB)
                  miss rate [percentage of total misses] since start
@@ -485,7 +485,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 126B: 156B |     23.8% |         2 |  1 (256KB) |  1 (256KB) |       282 |      0 (0B)
+   1 (0B) | 126B: 156B |     23.8% |         2 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start

--- a/testdata/compaction/virtual_rewrite
+++ b/testdata/compaction/virtual_rewrite
@@ -160,7 +160,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 259B: 289B |     11.6% |         2 |  1 (256KB) |  1 (256KB) |       548 |      0 (0B)
+   1 (0B) | 259B: 289B |     11.6% |         2 |  1 (256KB) |  1 (256KB) |         2 |      0 (0B)
 
 BLOCK CACHE: 2 entries (797B)
                  miss rate [percentage of total misses] since start

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -302,7 +302,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   48B: 97B |    102.1% |         3 |  1 (256KB) |  1 (256KB) |       145 |      0 (0B)
+   1 (0B) |   48B: 97B |    102.1% |         3 |  1 (256KB) |  1 (256KB) |         1 |      0 (0B)
 
 BLOCK CACHE: 2 entries (672B)
                  miss rate [percentage of total misses] since start
@@ -451,7 +451,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |  82B: 132B |     61.0% |         6 |  1 (512KB) |  1 (512KB) |       214 |   1 (1.3KB)
+   1 (0B) |  82B: 132B |     61.0% |         6 |  1 (512KB) |  1 (512KB) |         2 |   1 (1.3KB)
 
 BLOCK CACHE: 6 entries (2KB)
                  miss rate [percentage of total misses] since start

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -53,7 +53,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |     0B: 0B |      0.0% |         0 |  1 (256KB) |     0 (0B) |         0 |      0 (0B)
+   1 (0B) |     0B: 0B |      0.0% |         0 |  1 (256KB) |     0 (0B) |         1 |      0 (0B)
 
 BLOCK CACHE: 3 entries (924B)
                  miss rate [percentage of total misses] since start

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -34,7 +34,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
- 22 (24B) |   25B: 26B |      4.0% |         8 |   12 (2GB) |   5 (13MB) |        51 |      4 (6B)
+ 22 (24B) |   25B: 26B |      4.0% |         8 |   12 (2GB) |   5 (13MB) |        12 |      4 (6B)
 
 BLOCK CACHE: 100 entries (1GB)
                  miss rate [percentage of total misses] since start
@@ -138,7 +138,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   17B: 28B |     64.7% |         1 |  1 (256KB) |  1 (256KB) |        45 |      0 (0B)
+   1 (0B) |   17B: 28B |     64.7% |         1 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 2 entries (683B)
                  miss rate [percentage of total misses] since start
@@ -247,7 +247,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |        98 |      0 (0B)
+   1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 2 entries (683B)
                  miss rate [percentage of total misses] since start
@@ -338,7 +338,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |        98 |      0 (0B)
+   1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 2 entries (683B)
                  miss rate [percentage of total misses] since start
@@ -426,7 +426,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |        98 |      0 (0B)
+   1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  2 (512KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 2 entries (683B)
                  miss rate [percentage of total misses] since start
@@ -517,7 +517,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  1 (256KB) |        98 |      0 (0B)
+   1 (0B) |   34B: 64B |     88.2% |         2 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start
@@ -647,7 +647,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 116B: 165B |     42.2% |         3 |  1 (256KB) |  1 (256KB) |       281 |      0 (0B)
+   1 (0B) | 116B: 165B |     42.2% |         3 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start
@@ -763,7 +763,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 116B: 165B |     42.2% |         3 |  1 (256KB) |  1 (256KB) |       281 |      0 (0B)
+   1 (0B) | 116B: 165B |     42.2% |         3 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start
@@ -930,7 +930,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 176B: 211B |     19.9% |         8 |    1 (1MB) |    1 (1MB) |       387 |   2 (1.9KB)
+   1 (0B) | 176B: 211B |     19.9% |         8 |    1 (1MB) |    1 (1MB) |         2 |   2 (1.9KB)
 
 BLOCK CACHE: 6 entries (2KB)
                  miss rate [percentage of total misses] since start
@@ -1059,7 +1059,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |       500 |   2 (1.9KB)
+   1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |         2 |   2 (1.9KB)
 
 BLOCK CACHE: 6 entries (2KB)
                  miss rate [percentage of total misses] since start
@@ -1200,7 +1200,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |       500 |   2 (1.9KB)
+   1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |         3 |   2 (1.9KB)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start
@@ -1382,7 +1382,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |       500 |   2 (1.9KB)
+   1 (0B) | 223B: 277B |     24.2% |         9 |    1 (1MB) |    1 (1MB) |         4 |   2 (1.9KB)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start
@@ -1479,7 +1479,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |        65 |      0 (0B)
+   1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start
@@ -1564,7 +1564,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |        65 |      0 (0B)
+   1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 0 entries (0B)
                  miss rate [percentage of total misses] since start
@@ -1667,7 +1667,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |        65 |      0 (0B)
+   1 (0B) |   27B: 38B |     40.7% |         1 |  1 (256KB) |  1 (256KB) |         1 |      0 (0B)
 
 BLOCK CACHE: 2 entries (675B)
                  miss rate [percentage of total misses] since start
@@ -1762,7 +1762,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |   44B: 74B |     68.2% |         2 |  1 (256KB) |  1 (256KB) |       118 |      0 (0B)
+   1 (0B) |   44B: 74B |     68.2% |         2 |  1 (256KB) |  1 (256KB) |         1 |      0 (0B)
 
 BLOCK CACHE: 2 entries (675B)
                  miss rate [percentage of total misses] since start
@@ -2052,7 +2052,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |  57B: 106B |     86.0% |         3 |  1 (256KB) |  1 (256KB) |       163 |      0 (0B)
+   1 (0B) |  57B: 106B |     86.0% |         3 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 2 entries (662B)
                  miss rate [percentage of total misses] since start
@@ -2137,7 +2137,7 @@ COMMIT PIPELINE
                wals                |              memtables              |       ingestions
     files |    written |  overhead |   flushes |       live |     zombie |     total |   flushable
 ----------+------------+-----------+-----------+------------+------------+-----------+------------
-   1 (0B) |  57B: 106B |     86.0% |         3 |  1 (256KB) |  1 (256KB) |       163 |      0 (0B)
+   1 (0B) |  57B: 106B |     86.0% |         3 |  1 (256KB) |  1 (256KB) |         0 |      0 (0B)
 
 BLOCK CACHE: 2 entries (662B)
                  miss rate [percentage of total misses] since start


### PR DESCRIPTION
The Metrics.String output was printing the WAL.BytesIn+WAL.BytesWritten as the ingestion count.