### PR TITLE
metrics: redesign disk usage metrics

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -259,8 +259,8 @@ func (c *blobFileRewriteCompaction) Execute(jobID JobID, d *DB) error {
 					// We don't know the size of the output blob file--it may have
 					// been half-written. We use the input blob file size as an
 					// approximation for deletion pacing.
-					FileSize: c.input.Physical.Size,
-					IsLocal:  true,
+					FileSize:  c.input.Physical.Size,
+					Placement: base.Local,
 				},
 			})
 		}

--- a/compaction.go
+++ b/compaction.go
@@ -2677,7 +2677,7 @@ func (d *DB) cleanupVersionEdit(ve *manifest.VersionEdit) {
 				FileNum:  ve.NewBlobFiles[i].Physical.FileNum,
 				FileSize: ve.NewBlobFiles[i].Physical.Size,
 			},
-			isLocal: objstorage.IsLocalBlobFile(d.objProvider, ve.NewBlobFiles[i].Physical.FileNum),
+			placement: objstorage.Placement(d.objProvider, base.FileTypeBlob, ve.NewBlobFiles[i].Physical.FileNum),
 		})
 	}
 	for i := range ve.NewTables {
@@ -2706,7 +2706,7 @@ func (d *DB) cleanupVersionEdit(ve *manifest.VersionEdit) {
 				FileNum:  of.DiskFileNum,
 				FileSize: of.Size,
 			},
-			isLocal: objstorage.IsLocalTable(d.objProvider, of.DiskFileNum),
+			placement: objstorage.Placement(d.objProvider, base.FileTypeTable, of.DiskFileNum),
 		})
 	}
 	d.mu.versions.addObsoleteLocked(obsoleteFiles)

--- a/internal/base/placement.go
+++ b/internal/base/placement.go
@@ -1,0 +1,44 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/redact"
+)
+
+// Placement identifies where a file/object is stored.
+//
+// The zero value is invalid (this is intentional to disambiguate accidentally
+// uninitialized fields).
+type Placement uint8
+
+const (
+	Local Placement = 1 + iota
+	Shared
+	External
+)
+
+func (p Placement) String() string {
+	switch p {
+	case Local:
+		return "local"
+	case Shared:
+		return "shared"
+	case External:
+		return "external"
+	default:
+		if invariants.Enabled {
+			panic(errors.AssertionFailedf("invalid placement type %d", p))
+		}
+		return "invalid"
+	}
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (p Placement) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Print(redact.SafeString(p.String()))
+}

--- a/internal/deletepacer/delete_pacer_test.go
+++ b/internal/deletepacer/delete_pacer_test.go
@@ -100,9 +100,9 @@ func executeTest(t *testing.T, td *datadriven.TestData, ts *testState) {
 			fileSize, err := crhumanize.ParseBytes[uint64](words[1])
 			require.NoErrorf(t, err, "%s: %q", td.Pos, l)
 			ts.dp.Enqueue(0, ObsoleteFile{
-				FileType: base.FileTypeTable,
-				FileSize: fileSize,
-				IsLocal:  true,
+				FileType:  base.FileTypeTable,
+				FileSize:  fileSize,
+				Placement: base.Local,
 			})
 			ts.adds = append(ts.adds, logEntry{
 				timestamp: time.Now(),
@@ -194,9 +194,9 @@ func TestCloseWithPacing(t *testing.T) {
 	largeFiles := make([]ObsoleteFile, 100)
 	for i := range largeFiles {
 		largeFiles[i] = ObsoleteFile{
-			FileType: base.FileTypeTable,
-			FileSize: 10 * 1024,
-			IsLocal:  true,
+			FileType:  base.FileTypeTable,
+			FileSize:  10 * 1024,
+			Placement: base.Local,
 		}
 	}
 
@@ -235,9 +235,9 @@ func TestFallingBehind(t *testing.T) {
 	addJob := func(fileSize int) {
 		x++
 		dp.Enqueue(1, ObsoleteFile{
-			FileType: base.FileTypeTable,
-			FileSize: uint64(fileSize),
-			IsLocal:  true,
+			FileType:  base.FileTypeTable,
+			FileSize:  uint64(fileSize),
+			Placement: base.Local,
 		})
 	}
 

--- a/internal/deletepacer/obsolete_file.go
+++ b/internal/deletepacer/obsolete_file.go
@@ -11,19 +11,19 @@ import (
 
 // ObsoleteFile describes a file that is to be deleted.
 type ObsoleteFile struct {
-	FileType base.FileType
-	FS       vfs.FS
-	Path     string
-	FileNum  base.DiskFileNum
-	FileSize uint64 // approx for log files
-	IsLocal  bool
+	FileType  base.FileType
+	FS        vfs.FS
+	Path      string
+	FileNum   base.DiskFileNum
+	FileSize  uint64 // approx for log files
+	Placement base.Placement
 }
 
 // pacingBytes returns the size of the file, or 0 if deleting the file does not
 // require pacing.
 func (of ObsoleteFile) pacingBytes() uint64 {
 	// We only need to pace local objects--sstables and blob files.
-	if of.IsLocal && (of.FileType == base.FileTypeTable || of.FileType == base.FileTypeBlob) {
+	if of.Placement == base.Local && (of.FileType == base.FileTypeTable || of.FileType == base.FileTypeBlob) {
 		return of.FileSize
 	}
 	return 0

--- a/internal/manifest/virtual_backings_test.go
+++ b/internal/manifest/virtual_backings_test.go
@@ -37,7 +37,7 @@ func TestVirtualBackings(t *testing.T) {
 					DiskFileNum:                  n,
 					Size:                         size,
 					ReferencedBlobValueSizeTotal: blobValueSize,
-				}, true /* local */)
+				}, base.Local)
 
 			case "remove":
 				bv.Remove(n)

--- a/metrics/by_placement.go
+++ b/metrics/by_placement.go
@@ -1,0 +1,202 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metrics
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/redact"
+)
+
+// CountAndSizeByPlacement contains space usage information for a set of files
+// (e.g. blob files, table backings), broken down by where they are stored.
+type CountAndSizeByPlacement struct {
+	ByPlacement[CountAndSize]
+}
+
+func (csp *CountAndSizeByPlacement) Inc(fileSize uint64, placement base.Placement) {
+	csp.Ptr(placement).Inc(fileSize)
+}
+
+func (csp *CountAndSizeByPlacement) Dec(fileSize uint64, placement base.Placement) {
+	csp.Ptr(placement).Dec(fileSize)
+}
+
+func (csp *CountAndSizeByPlacement) Accumulate(rhs CountAndSizeByPlacement) {
+	csp.Local.Accumulate(rhs.Local)
+	csp.Shared.Accumulate(rhs.Shared)
+	csp.External.Accumulate(rhs.External)
+}
+
+func (csp *CountAndSizeByPlacement) Deduct(rhs CountAndSizeByPlacement) {
+	csp.Local.Deduct(rhs.Local)
+	csp.Shared.Deduct(rhs.Shared)
+	csp.External.Deduct(rhs.External)
+}
+
+func (csp CountAndSizeByPlacement) Total() CountAndSize {
+	return csp.Local.Sum(csp.Shared).Sum(csp.External)
+}
+
+func (csp CountAndSizeByPlacement) String() string {
+	return redact.StringWithoutMarkers(csp)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (csp CountAndSizeByPlacement) SafeFormat(w redact.SafePrinter, verb rune) {
+	if csp.Shared.IsZero() && csp.External.IsZero() {
+		w.Printf("%s", csp.Local)
+		return
+	}
+	w.Printf("%s [local: %s]", csp.Total(), csp.Local)
+}
+
+// ByPlacement contains multiple instances of a struct T, one for each possible
+// Placement.
+type ByPlacement[T any] struct {
+	Local    T
+	Shared   T
+	External T
+}
+
+func (bp *ByPlacement[T]) Get(placement base.Placement) T {
+	switch placement {
+	case base.Local:
+		return bp.Local
+	case base.Shared:
+		return bp.Shared
+	case base.External:
+		return bp.External
+	default:
+		if invariants.Enabled {
+			panic(errors.AssertionFailedf("invalid placement %d", placement))
+		}
+		return bp.Local
+	}
+}
+
+func (bp *ByPlacement[T]) Set(placement base.Placement, value T) {
+	switch placement {
+	case base.Local:
+		bp.Local = value
+	case base.Shared:
+		bp.Shared = value
+	case base.External:
+		bp.External = value
+	default:
+		if invariants.Enabled {
+			panic(errors.AssertionFailedf("invalid placement %d", placement))
+		}
+		bp.Local = value
+	}
+}
+
+func (bp *ByPlacement[T]) Ptr(placement base.Placement) *T {
+	switch placement {
+	case base.Local:
+		return &bp.Local
+	case base.Shared:
+		return &bp.Shared
+	case base.External:
+		return &bp.External
+	default:
+		if invariants.Enabled {
+			panic(errors.AssertionFailedf("invalid placement %d", placement))
+		}
+		return &bp.Local
+	}
+}
+
+// FileCountsAndSizes contains counts and sizes for all file types.
+type FileCountsAndSizes struct {
+	// Tables contains counts and sizes for tables.
+	Tables CountAndSizeByPlacement
+
+	// BlobFiles contains counts and sizes for blob files.
+	BlobFiles CountAndSizeByPlacement
+
+	// Other contains counts and sizes for other file types (log, manifest, etc).
+	// These files are all local.
+	Other CountAndSize
+}
+
+// Total returns the total count and size of files.
+func (cs *FileCountsAndSizes) Total() CountAndSize {
+	return cs.Tables.Total().Sum(cs.BlobFiles.Total()).Sum(cs.Other)
+}
+
+// Inc increases the relevant count and size for a single file.
+func (cs *FileCountsAndSizes) Inc(
+	fileType base.FileType, fileSize uint64, placement base.Placement,
+) {
+	switch fileType {
+	case base.FileTypeTable:
+		cs.Tables.Inc(fileSize, placement)
+	case base.FileTypeBlob:
+		cs.BlobFiles.Inc(fileSize, placement)
+	default:
+		cs.Other.Inc(fileSize)
+	}
+}
+
+// Dec decreases the relevant count and size for a single file.
+func (cs *FileCountsAndSizes) Dec(
+	fileType base.FileType, fileSize uint64, placement base.Placement,
+) {
+	switch fileType {
+	case base.FileTypeTable:
+		cs.Tables.Dec(fileSize, placement)
+	case base.FileTypeBlob:
+		cs.BlobFiles.Dec(fileSize, placement)
+	default:
+		cs.Other.Dec(fileSize)
+	}
+}
+
+// Accumulate increases the counts and sizes by the given amounts.
+func (cs *FileCountsAndSizes) Accumulate(other FileCountsAndSizes) {
+	cs.Tables.Accumulate(other.Tables)
+	cs.BlobFiles.Accumulate(other.BlobFiles)
+	cs.Other.Accumulate(other.Other)
+}
+
+// Deduct decreases the counts and sizes by the given amounts.
+func (cs *FileCountsAndSizes) Deduct(other FileCountsAndSizes) {
+	cs.Tables.Deduct(other.Tables)
+	cs.BlobFiles.Deduct(other.BlobFiles)
+	cs.Other.Deduct(other.Other)
+}
+
+func (cs FileCountsAndSizes) String() string {
+	return redact.StringWithoutMarkers(cs)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (cs FileCountsAndSizes) SafeFormat(w redact.SafePrinter, verb rune) {
+	if cs == (FileCountsAndSizes{}) {
+		w.Printf("no files")
+		return
+	}
+	first := true
+	if cs.Tables != (CountAndSizeByPlacement{}) {
+		first = false
+		w.Printf("tables: %s", cs.Tables)
+	}
+	if cs.BlobFiles != (CountAndSizeByPlacement{}) {
+		if !first {
+			w.Printf("; ")
+		}
+		first = false
+		w.Printf("blob files: %s", cs.BlobFiles)
+	}
+	if cs.Other != (CountAndSize{}) {
+		if !first {
+			w.Printf("; ")
+		}
+		first = false
+		w.Printf("other: %s", cs.Other)
+	}
+}

--- a/metrics/by_placement_test.go
+++ b/metrics/by_placement_test.go
@@ -1,0 +1,296 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestByPlacement_GetPtr(t *testing.T) {
+	var bp CountAndSizeByPlacement
+	bp.Local = CountAndSize{Count: 10, Bytes: 1000}
+	bp.Shared = CountAndSize{Count: 20, Bytes: 2000}
+	bp.External = CountAndSize{Count: 30, Bytes: 3000}
+
+	require.Equal(t, CountAndSize{Count: 10, Bytes: 1000}, bp.Get(base.Local))
+	require.Equal(t, CountAndSize{Count: 20, Bytes: 2000}, bp.Get(base.Shared))
+	require.Equal(t, CountAndSize{Count: 30, Bytes: 3000}, bp.Get(base.External))
+
+	// Verify we get pointers to the actual fields
+	require.Equal(t, &bp.Local, bp.Ptr(base.Local))
+	require.Equal(t, &bp.Shared, bp.Ptr(base.Shared))
+	require.Equal(t, &bp.External, bp.Ptr(base.External))
+
+	// Verify modifications through pointer affect the original
+	bp.Ptr(base.Local).Inc(500)
+	require.Equal(t, CountAndSize{Count: 11, Bytes: 1500}, bp.Get(base.Local))
+}
+
+func TestByPlacement_Accumulate(t *testing.T) {
+	var bp1, bp2 CountAndSizeByPlacement
+
+	bp1.Local = CountAndSize{Count: 10, Bytes: 1000}
+	bp1.Shared = CountAndSize{Count: 20, Bytes: 2000}
+	bp1.External = CountAndSize{Count: 30, Bytes: 3000}
+
+	bp2.Local = CountAndSize{Count: 5, Bytes: 500}
+	bp2.Shared = CountAndSize{Count: 15, Bytes: 1500}
+	bp2.External = CountAndSize{Count: 25, Bytes: 2500}
+
+	bp1.Accumulate(bp2)
+
+	require.Equal(t, CountAndSize{Count: 15, Bytes: 1500}, bp1.Local)
+	require.Equal(t, CountAndSize{Count: 35, Bytes: 3500}, bp1.Shared)
+	require.Equal(t, CountAndSize{Count: 55, Bytes: 5500}, bp1.External)
+}
+
+func TestByPlacement_Inc_Dec(t *testing.T) {
+	var bp CountAndSizeByPlacement
+
+	// Test Inc
+	bp.Inc(1000, base.Local)
+	bp.Inc(2000, base.Shared)
+	bp.Inc(3000, base.External)
+
+	require.Equal(t, CountAndSize{Count: 1, Bytes: 1000}, bp.Local)
+	require.Equal(t, CountAndSize{Count: 1, Bytes: 2000}, bp.Shared)
+	require.Equal(t, CountAndSize{Count: 1, Bytes: 3000}, bp.External)
+
+	// Test Dec
+	bp.Dec(500, base.Local)
+	bp.Dec(1000, base.Shared)
+
+	require.Equal(t, CountAndSize{Count: 0, Bytes: 500}, bp.Local)
+	require.Equal(t, CountAndSize{Count: 0, Bytes: 1000}, bp.Shared)
+	require.Equal(t, CountAndSize{Count: 1, Bytes: 3000}, bp.External)
+}
+
+func TestByPlacement_Deduct(t *testing.T) {
+	bp1 := CountAndSizeByPlacement{
+		ByPlacement: ByPlacement[CountAndSize]{
+			Local:    CountAndSize{Count: 10, Bytes: 1000},
+			Shared:   CountAndSize{Count: 20, Bytes: 2000},
+			External: CountAndSize{Count: 30, Bytes: 3000},
+		},
+	}
+
+	bp2 := CountAndSizeByPlacement{
+		ByPlacement: ByPlacement[CountAndSize]{
+			Local:    CountAndSize{Count: 3, Bytes: 300},
+			Shared:   CountAndSize{Count: 5, Bytes: 500},
+			External: CountAndSize{Count: 10, Bytes: 1000},
+		},
+	}
+
+	bp1.Deduct(bp2)
+
+	require.Equal(t, CountAndSize{Count: 7, Bytes: 700}, bp1.Local)
+	require.Equal(t, CountAndSize{Count: 15, Bytes: 1500}, bp1.Shared)
+	require.Equal(t, CountAndSize{Count: 20, Bytes: 2000}, bp1.External)
+}
+
+func TestByPlacement_Total(t *testing.T) {
+	bp := CountAndSizeByPlacement{
+		ByPlacement: ByPlacement[CountAndSize]{
+			Local:    CountAndSize{Count: 10, Bytes: 1000},
+			Shared:   CountAndSize{Count: 20, Bytes: 2000},
+			External: CountAndSize{Count: 30, Bytes: 3000},
+		},
+	}
+
+	total := bp.Total()
+	require.Equal(t, CountAndSize{Count: 60, Bytes: 6000}, total)
+}
+
+func TestFileCountsAndSizes_Inc_Dec(t *testing.T) {
+	var cs FileCountsAndSizes
+
+	// Add files at different placements
+	cs.Inc(base.FileTypeTable, 1000, base.Local)
+	cs.Inc(base.FileTypeTable, 2000, base.Shared)
+	cs.Inc(base.FileTypeBlob, 3000, base.External)
+	cs.Inc(base.FileTypeLog, 500, base.Local)
+
+	require.Equal(t, CountAndSize{Count: 1, Bytes: 1000}, cs.Tables.Local)
+	require.Equal(t, CountAndSize{Count: 1, Bytes: 2000}, cs.Tables.Shared)
+	require.Equal(t, CountAndSize{Count: 0, Bytes: 0}, cs.Tables.External)
+	require.Equal(t, CountAndSize{Count: 0, Bytes: 0}, cs.BlobFiles.Local)
+	require.Equal(t, CountAndSize{Count: 1, Bytes: 3000}, cs.BlobFiles.External)
+	require.Equal(t, CountAndSize{Count: 1, Bytes: 500}, cs.Other)
+
+	// Subtract files
+	cs.Dec(base.FileTypeTable, 1000, base.Local)
+	cs.Dec(base.FileTypeLog, 500, base.Local)
+
+	require.Equal(t, CountAndSize{Count: 0, Bytes: 0}, cs.Tables.Local)
+	require.Equal(t, CountAndSize{Count: 0, Bytes: 0}, cs.Other)
+}
+
+func TestFileCountsAndSizes_Accumulate_Deduct(t *testing.T) {
+	cs1 := FileCountsAndSizes{
+		Tables: CountAndSizeByPlacement{
+			ByPlacement: ByPlacement[CountAndSize]{
+				Local:  CountAndSize{Count: 10, Bytes: 2000},
+				Shared: CountAndSize{Count: 5, Bytes: 1000},
+			},
+		},
+		BlobFiles: CountAndSizeByPlacement{
+			ByPlacement: ByPlacement[CountAndSize]{
+				External: CountAndSize{Count: 3, Bytes: 600},
+			},
+		},
+		Other: CountAndSize{Count: 2, Bytes: 300},
+	}
+
+	cs2 := FileCountsAndSizes{
+		Tables: CountAndSizeByPlacement{
+			ByPlacement: ByPlacement[CountAndSize]{
+				Local:  CountAndSize{Count: 3, Bytes: 500},
+				Shared: CountAndSize{Count: 2, Bytes: 400},
+			},
+		},
+		BlobFiles: CountAndSizeByPlacement{
+			ByPlacement: ByPlacement[CountAndSize]{
+				External: CountAndSize{Count: 1, Bytes: 200},
+			},
+		},
+		Other: CountAndSize{Count: 1, Bytes: 100},
+	}
+
+	// Test Accumulate
+	sum := cs1
+	sum.Accumulate(cs2)
+
+	require.Equal(t, CountAndSize{Count: 13, Bytes: 2500}, sum.Tables.Local)
+	require.Equal(t, CountAndSize{Count: 7, Bytes: 1400}, sum.Tables.Shared)
+	require.Equal(t, CountAndSize{Count: 4, Bytes: 800}, sum.BlobFiles.External)
+	require.Equal(t, CountAndSize{Count: 3, Bytes: 400}, sum.Other)
+
+	// Test Deduct
+	sum.Deduct(cs2)
+	require.Equal(t, cs1, sum)
+}
+
+func TestFileCountsAndSizes_Total(t *testing.T) {
+	cs := FileCountsAndSizes{
+		Tables: CountAndSizeByPlacement{
+			ByPlacement: ByPlacement[CountAndSize]{
+				Local:  CountAndSize{Count: 10, Bytes: 2000},
+				Shared: CountAndSize{Count: 5, Bytes: 1000},
+			},
+		},
+		BlobFiles: CountAndSizeByPlacement{
+			ByPlacement: ByPlacement[CountAndSize]{
+				External: CountAndSize{Count: 3, Bytes: 600},
+			},
+		},
+		Other: CountAndSize{Count: 2, Bytes: 300},
+	}
+
+	total := cs.Total()
+	require.Equal(t, CountAndSize{Count: 20, Bytes: 3900}, total)
+}
+
+func TestFileCountsAndSizes_String(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cs       FileCountsAndSizes
+		expected string
+	}{
+		{
+			name:     "empty",
+			cs:       FileCountsAndSizes{},
+			expected: "no files",
+		},
+		{
+			name: "only local tables",
+			cs: FileCountsAndSizes{
+				Tables: CountAndSizeByPlacement{
+					ByPlacement: ByPlacement[CountAndSize]{
+						Local: CountAndSize{Count: 5, Bytes: 1024},
+					},
+				},
+			},
+			expected: "tables: 5 (1KB)",
+		},
+		{
+			name: "tables with shared placement",
+			cs: FileCountsAndSizes{
+				Tables: CountAndSizeByPlacement{
+					ByPlacement: ByPlacement[CountAndSize]{
+						Local:  CountAndSize{Count: 3, Bytes: 512},
+						Shared: CountAndSize{Count: 2, Bytes: 512},
+					},
+				},
+			},
+			expected: "tables: 5 (1KB) [local: 3 (512B)]",
+		},
+		{
+			name: "tables and blob files",
+			cs: FileCountsAndSizes{
+				Tables: CountAndSizeByPlacement{
+					ByPlacement: ByPlacement[CountAndSize]{
+						Local: CountAndSize{Count: 10, Bytes: 2000},
+					},
+				},
+				BlobFiles: CountAndSizeByPlacement{
+					ByPlacement: ByPlacement[CountAndSize]{
+						External: CountAndSize{Count: 3, Bytes: 600},
+					},
+				},
+			},
+			expected: "tables: 10 (2KB); blob files: 3 (600B) [local: 0 (0B)]",
+		},
+		{
+			name: "just blob files",
+			cs: FileCountsAndSizes{
+				BlobFiles: CountAndSizeByPlacement{
+					ByPlacement: ByPlacement[CountAndSize]{
+						External: CountAndSize{Count: 3, Bytes: 600},
+					},
+				},
+			},
+			expected: "blob files: 3 (600B) [local: 0 (0B)]",
+		},
+		{
+			name: "blob files and other",
+			cs: FileCountsAndSizes{
+				BlobFiles: CountAndSizeByPlacement{
+					ByPlacement: ByPlacement[CountAndSize]{
+						External: CountAndSize{Count: 3, Bytes: 600},
+					},
+				},
+				Other: CountAndSize{Count: 1, Bytes: 100},
+			},
+			expected: "blob files: 3 (600B) [local: 0 (0B)]; other: 1 (100B)",
+		},
+		{
+			name: "all file types",
+			cs: FileCountsAndSizes{
+				Tables: CountAndSizeByPlacement{
+					ByPlacement: ByPlacement[CountAndSize]{
+						Local: CountAndSize{Count: 5, Bytes: 1000},
+					},
+				},
+				BlobFiles: CountAndSizeByPlacement{
+					ByPlacement: ByPlacement[CountAndSize]{
+						Local: CountAndSize{Count: 2, Bytes: 400},
+					},
+				},
+				Other: CountAndSize{Count: 1, Bytes: 100},
+			},
+			expected: "tables: 5 (1KB); blob files: 2 (400B); other: 1 (100B)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.cs.String())
+		})
+	}
+}

--- a/metrics/count_and_size.go
+++ b/metrics/count_and_size.go
@@ -6,7 +6,6 @@ package metrics
 
 import (
 	"github.com/cockroachdb/crlib/crhumanize"
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/redact"
 )
@@ -44,6 +43,18 @@ func (cs *CountAndSize) Deduct(other CountAndSize) {
 	cs.Bytes = invariants.SafeSub(cs.Bytes, other.Bytes)
 }
 
+func (cs CountAndSize) IsZero() bool {
+	return cs.Count == 0 && cs.Bytes == 0
+}
+
+// Sum returns the sums of the counts and sizes.
+func (cs CountAndSize) Sum(other CountAndSize) CountAndSize {
+	return CountAndSize{
+		Count: cs.Count + other.Count,
+		Bytes: cs.Bytes + other.Bytes,
+	}
+}
+
 func (cs CountAndSize) String() string {
 	return redact.StringWithoutMarkers(cs)
 }
@@ -51,194 +62,4 @@ func (cs CountAndSize) String() string {
 // SafeFormat implements redact.SafeFormatter.
 func (cs CountAndSize) SafeFormat(w redact.SafePrinter, verb rune) {
 	w.Printf("%s (%s)", crhumanize.Count(cs.Count, crhumanize.Compact), crhumanize.Bytes(cs.Bytes, crhumanize.Compact, crhumanize.OmitI))
-}
-
-// TableCountsAndSizes contains counts and sizes for tables, broken down by
-// locality.
-type TableCountsAndSizes struct {
-	// All contains counts for all tables (local and remote).
-	All CountAndSize
-	// Local contains counts for local tables only.
-	Local CountAndSize
-}
-
-// Inc increases the count and size for a single table.
-func (cs *TableCountsAndSizes) Inc(tableSize uint64, isLocal bool) {
-	cs.All.Inc(tableSize)
-	if isLocal {
-		cs.Local.Inc(tableSize)
-	}
-}
-
-// Dec decreases the count and size for a single table.
-func (cs *TableCountsAndSizes) Dec(tableSize uint64, isLocal bool) {
-	cs.All.Dec(tableSize)
-	if isLocal {
-		cs.Local.Dec(tableSize)
-	}
-}
-
-// Accumulate increases the counts and sizes by the given amounts.
-func (cs *TableCountsAndSizes) Accumulate(other TableCountsAndSizes) {
-	cs.All.Accumulate(other.All)
-	cs.Local.Accumulate(other.Local)
-}
-
-// Deduct decreases the counts and sizes by the given amounts.
-func (cs *TableCountsAndSizes) Deduct(other TableCountsAndSizes) {
-	cs.All.Deduct(other.All)
-	cs.Local.Deduct(other.Local)
-}
-
-func (cs TableCountsAndSizes) String() string {
-	return redact.StringWithoutMarkers(cs)
-}
-
-// SafeFormat implements redact.SafeFormatter.
-func (cs TableCountsAndSizes) SafeFormat(w redact.SafePrinter, verb rune) {
-	cs.All.SafeFormat(w, verb)
-	if cs.All != cs.Local {
-		w.Printf(" [local: ")
-		cs.Local.SafeFormat(w, verb)
-		w.Printf("]")
-	}
-}
-
-// BlobFileCountsAndSizes contains counts and sizes for blob files, broken down
-// by locality.
-type BlobFileCountsAndSizes struct {
-	// All contains counts for all blob files (local and remote).
-	All CountAndSize
-	// Local contains counts for local blob files only.
-	Local CountAndSize
-}
-
-// Inc increases the count and size for a single blob file.
-func (cs *BlobFileCountsAndSizes) Inc(fileSize uint64, isLocal bool) {
-	cs.All.Inc(fileSize)
-	if isLocal {
-		cs.Local.Inc(fileSize)
-	}
-}
-
-// Dec decreases the count and size for a single blob file.
-func (cs *BlobFileCountsAndSizes) Dec(fileSize uint64, isLocal bool) {
-	cs.All.Dec(fileSize)
-	if isLocal {
-		cs.Local.Dec(fileSize)
-	}
-}
-
-// Accumulate increases the counts and sizes by the given amounts.
-func (cs *BlobFileCountsAndSizes) Accumulate(other BlobFileCountsAndSizes) {
-	cs.All.Accumulate(other.All)
-	cs.Local.Accumulate(other.Local)
-}
-
-// Deduct decreases the counts and sizes by the given amounts.
-func (cs *BlobFileCountsAndSizes) Deduct(other BlobFileCountsAndSizes) {
-	cs.All.Deduct(other.All)
-	cs.Local.Deduct(other.Local)
-}
-
-func (cs BlobFileCountsAndSizes) String() string {
-	return redact.StringWithoutMarkers(cs)
-}
-
-// SafeFormat implements redact.SafeFormatter.
-func (cs BlobFileCountsAndSizes) SafeFormat(w redact.SafePrinter, verb rune) {
-	cs.All.SafeFormat(w, verb)
-	if cs.All != cs.Local {
-		w.Printf(" [local: %s]", cs.Local)
-	}
-}
-
-// FileCountsAndSizes contains counts and sizes for all file types.
-type FileCountsAndSizes struct {
-	// Tables contains counts and sizes for tables.
-	Tables TableCountsAndSizes
-
-	// BlobFiles contains counts and sizes for blob files.
-	BlobFiles BlobFileCountsAndSizes
-
-	// Other contains counts and sizes for other file types (log, manifest, etc).
-	// These are not separated by locality.
-	Other CountAndSize
-}
-
-// TotalCount returns the total
-func (cs *FileCountsAndSizes) Totals() CountAndSize {
-	res := cs.Tables.All
-	res.Accumulate(cs.BlobFiles.All)
-	res.Accumulate(cs.Other)
-	return res
-}
-
-// Inc increases the relevant count and size for a single file.
-func (cs *FileCountsAndSizes) Inc(fileType base.FileType, fileSize uint64, isLocal bool) {
-	switch fileType {
-	case base.FileTypeTable:
-		cs.Tables.Inc(fileSize, isLocal)
-	case base.FileTypeBlob:
-		cs.BlobFiles.Inc(fileSize, isLocal)
-	default:
-		cs.Other.Inc(fileSize)
-	}
-}
-
-// Dec decreases the relevant count and size for a single file.
-func (cs *FileCountsAndSizes) Dec(fileType base.FileType, fileSize uint64, isLocal bool) {
-	switch fileType {
-	case base.FileTypeTable:
-		cs.Tables.Dec(fileSize, isLocal)
-	case base.FileTypeBlob:
-		cs.BlobFiles.Dec(fileSize, isLocal)
-	default:
-		cs.Other.Dec(fileSize)
-	}
-}
-
-// Accumulate increases the counts and sizes by the given amounts.
-func (cs *FileCountsAndSizes) Accumulate(other FileCountsAndSizes) {
-	cs.Tables.Accumulate(other.Tables)
-	cs.BlobFiles.Accumulate(other.BlobFiles)
-	cs.Other.Accumulate(other.Other)
-}
-
-// Deduct decreases the counts and sizes by the given amounts.
-func (cs *FileCountsAndSizes) Deduct(other FileCountsAndSizes) {
-	cs.Tables.Deduct(other.Tables)
-	cs.BlobFiles.Deduct(other.BlobFiles)
-	cs.Other.Deduct(other.Other)
-}
-
-func (cs FileCountsAndSizes) String() string {
-	return redact.StringWithoutMarkers(cs)
-}
-
-// SafeFormat implements redact.SafeFormatter.
-func (cs FileCountsAndSizes) SafeFormat(w redact.SafePrinter, verb rune) {
-	if cs == (FileCountsAndSizes{}) {
-		w.Printf("no files")
-		return
-	}
-	first := true
-	if cs.Tables != (TableCountsAndSizes{}) {
-		first = false
-		w.Printf("tables: %s", cs.Tables)
-	}
-	if cs.BlobFiles != (BlobFileCountsAndSizes{}) {
-		if !first {
-			w.Printf("; ")
-			first = false
-		}
-		w.Printf("blob files: %s", cs.BlobFiles)
-	}
-	if cs.Other != (CountAndSize{}) {
-		if !first {
-			w.Printf("; ")
-			first = false
-		}
-		w.Printf("other: %s", cs.Other)
-	}
 }

--- a/metrics/count_and_size_test.go
+++ b/metrics/count_and_size_test.go
@@ -7,7 +7,6 @@ package metrics
 import (
 	"testing"
 
-	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,203 +16,61 @@ func expect(t *testing.T, cs CountAndSize, expCount uint64, expBytes uint64) {
 	require.Equal(t, expBytes, cs.Bytes)
 }
 
-func TestTableCountsAndSizes(t *testing.T) {
-	var cs TableCountsAndSizes
+func TestCountAndSize_Inc(t *testing.T) {
+	var cs CountAndSize
 
-	// Add local table
-	cs.Inc(1000, true)
-	expect(t, cs.All, 1, 1000)
-	expect(t, cs.Local, 1, 1000)
+	cs.Inc(1000)
+	expect(t, cs, 1, 1000)
 
-	// Add remote table
-	cs.Inc(2000, false)
-	expect(t, cs.All, 2, 3000)
-	expect(t, cs.Local, 1, 1000)
-
-	// Subtract local table
-	cs.Dec(500, true)
-	expect(t, cs.All, 1, 2500)
-	expect(t, cs.Local, 0, 500)
-
-	// Subtract remote table
-	cs.Dec(1000, false)
-	expect(t, cs.All, 0, 1500)
-	expect(t, cs.Local, 0, 500)
-
-	// Test Accumulate method
-	cs2 := TableCountsAndSizes{
-		All:   CountAndSize{Count: 5, Bytes: 5000},
-		Local: CountAndSize{Count: 3, Bytes: 3000},
-	}
-	cs.Accumulate(cs2)
-	expect(t, cs.All, 5, 6500)
-	expect(t, cs.Local, 3, 3500)
-
-	// Test Deduct method
-	cs.Deduct(cs2)
-	expect(t, cs.All, 0, 1500)
-	expect(t, cs.Local, 0, 500)
+	cs.Inc(2000)
+	expect(t, cs, 2, 3000)
 }
 
-func TestBlobFileCountsAndSizes(t *testing.T) {
-	var cs BlobFileCountsAndSizes
+func TestCountAndSize_Dec(t *testing.T) {
+	cs := CountAndSize{Count: 5, Bytes: 5000}
 
-	// Add local blob
-	cs.Inc(5000, true)
-	expect(t, cs.All, 1, 5000)
-	expect(t, cs.Local, 1, 5000)
+	cs.Dec(1000)
+	expect(t, cs, 4, 4000)
 
-	// Add remote blob
-	cs.Inc(3000, false)
-	expect(t, cs.All, 2, 8000)
-	expect(t, cs.Local, 1, 5000)
-
-	// Subtract local blob
-	cs.Dec(2000, true)
-	expect(t, cs.All, 1, 6000)
-	expect(t, cs.Local, 0, 3000)
-
-	// Subtract remote blob
-	cs.Dec(3000, false)
-	expect(t, cs.All, 0, 3000)
-	expect(t, cs.Local, 0, 3000)
-
-	// Test Accumulate method
-	cs2 := BlobFileCountsAndSizes{
-		All:   CountAndSize{Count: 4, Bytes: 8000},
-		Local: CountAndSize{Count: 2, Bytes: 4000},
-	}
-	cs.Accumulate(cs2)
-	expect(t, cs.All, 4, 11000)
-	expect(t, cs.Local, 2, 7000)
-
-	// Test Deduct method
-	cs.Deduct(cs2)
-	expect(t, cs.All, 0, 3000)
-	expect(t, cs.Local, 0, 3000)
+	cs.Dec(2000)
+	expect(t, cs, 3, 2000)
 }
 
-func TestFileCountsAndSizes(t *testing.T) {
-	cs1 := FileCountsAndSizes{}
-	cs1.Tables.All = CountAndSize{Count: 5, Bytes: 1000}
-	cs1.Tables.Local = CountAndSize{Count: 3, Bytes: 600}
-	cs1.BlobFiles.All = CountAndSize{Count: 2, Bytes: 500}
-	cs1.BlobFiles.Local = CountAndSize{Count: 1, Bytes: 250}
+func TestCountAndSize_Accumulate(t *testing.T) {
+	cs1 := CountAndSize{Count: 10, Bytes: 1000}
+	cs2 := CountAndSize{Count: 5, Bytes: 500}
 
-	cs2 := FileCountsAndSizes{}
-	cs2.Tables.All = CountAndSize{Count: 3, Bytes: 400}
-	cs2.Tables.Local = CountAndSize{Count: 2, Bytes: 300}
-	cs2.BlobFiles.All = CountAndSize{Count: 1, Bytes: 200}
-	cs2.BlobFiles.Local = CountAndSize{Count: 1, Bytes: 200}
-
-	sum := cs1
-	sum.Accumulate(cs2)
-
-	x := sum
-	x.Deduct(cs2)
-	require.Equal(t, cs1, x)
-
-	expect(t, sum.Tables.All, 8, 1400)
-	expect(t, sum.Tables.Local, 5, 900)
-	expect(t, sum.BlobFiles.All, 3, 700)
-	expect(t, sum.BlobFiles.Local, 2, 450)
-
-	sum.Inc(base.FileTypeTable, 10000, true /* isLocal */)
-	sum.Dec(base.FileTypeBlob, 250, false)
-
-	expect(t, sum.Tables.All, 9, 11400)
-	expect(t, sum.Tables.Local, 6, 10900)
-	expect(t, sum.BlobFiles.All, 2, 450)
-	expect(t, sum.BlobFiles.Local, 2, 450)
+	cs1.Accumulate(cs2)
+	expect(t, cs1, 15, 1500)
 }
 
-func TestFileCountsAndSizes_Inc_OtherTypes(t *testing.T) {
-	var cs FileCountsAndSizes
+func TestCountAndSize_Deduct(t *testing.T) {
+	cs1 := CountAndSize{Count: 10, Bytes: 1000}
+	cs2 := CountAndSize{Count: 3, Bytes: 300}
 
-	// Add log file
-	cs.Inc(base.FileTypeLog, 1000, true)
-	expect(t, cs.Other, 1, 1000)
-	expect(t, cs.Tables.All, 0, 0)
-	expect(t, cs.BlobFiles.All, 0, 0)
-
-	// Add manifest file
-	cs.Inc(base.FileTypeManifest, 2000, false)
-	expect(t, cs.Other, 2, 3000)
-
-	// Add options file
-	cs.Inc(base.FileTypeOptions, 100, true)
-	expect(t, cs.Other, 3, 3100)
-
-	// Subtract log file
-	cs.Dec(base.FileTypeLog, 500, false)
-	expect(t, cs.Other, 2, 2600)
+	cs1.Deduct(cs2)
+	expect(t, cs1, 7, 700)
 }
 
-func TestFileCountsAndSizes_Mixed(t *testing.T) {
-	var cs FileCountsAndSizes
+func TestCountAndSize_Sum(t *testing.T) {
+	cs1 := CountAndSize{Count: 10, Bytes: 1000}
+	cs2 := CountAndSize{Count: 5, Bytes: 500}
 
-	// Add various files
-	cs.Inc(base.FileTypeTable, 1000, true)    // local table
-	cs.Inc(base.FileTypeTable, 2000, false)   // remote table
-	cs.Inc(base.FileTypeBlob, 3000, true)     // local blob
-	cs.Inc(base.FileTypeBlob, 4000, false)    // remote blob
-	cs.Inc(base.FileTypeLog, 500, true)       // log file
-	cs.Inc(base.FileTypeManifest, 200, false) // manifest file
+	result := cs1.Sum(cs2)
+	expect(t, result, 15, 1500)
 
-	expect(t, cs.Tables.All, 2, 3000)
-	expect(t, cs.Tables.Local, 1, 1000)
-	expect(t, cs.BlobFiles.All, 2, 7000)
-	expect(t, cs.BlobFiles.Local, 1, 3000)
-	expect(t, cs.Other, 2, 700)
-
-	// Subtract some files
-	cs.Dec(base.FileTypeTable, 1000, true)
-	cs.Dec(base.FileTypeBlob, 3000, true)
-	cs.Dec(base.FileTypeLog, 500, true)
-
-	expect(t, cs.Tables.All, 1, 2000)
-	expect(t, cs.Tables.Local, 0, 0)
-	expect(t, cs.BlobFiles.All, 1, 4000)
-	expect(t, cs.BlobFiles.Local, 0, 0)
-	expect(t, cs.Other, 1, 200)
+	// Original should be unchanged
+	expect(t, cs1, 10, 1000)
+	expect(t, cs2, 5, 500)
 }
 
-func TestFileCountsAndSizes_AccumulateDeduct(t *testing.T) {
-	cs1 := FileCountsAndSizes{
-		Tables: TableCountsAndSizes{
-			All:   CountAndSize{Count: 10, Bytes: 2000},
-			Local: CountAndSize{Count: 6, Bytes: 1200},
-		},
-		BlobFiles: BlobFileCountsAndSizes{
-			All:   CountAndSize{Count: 5, Bytes: 1000},
-			Local: CountAndSize{Count: 3, Bytes: 600},
-		},
-		Other: CountAndSize{Count: 2, Bytes: 300},
-	}
+func TestCountAndSize_IsZero(t *testing.T) {
+	var cs CountAndSize
+	require.True(t, cs.IsZero())
 
-	cs2 := FileCountsAndSizes{
-		Tables: TableCountsAndSizes{
-			All:   CountAndSize{Count: 3, Bytes: 500},
-			Local: CountAndSize{Count: 2, Bytes: 400},
-		},
-		BlobFiles: BlobFileCountsAndSizes{
-			All:   CountAndSize{Count: 2, Bytes: 300},
-			Local: CountAndSize{Count: 1, Bytes: 200},
-		},
-		Other: CountAndSize{Count: 1, Bytes: 100},
-	}
+	cs.Inc(100)
+	require.False(t, cs.IsZero())
 
-	// Test Accumulate
-	sum := cs1
-	sum.Accumulate(cs2)
-
-	expect(t, sum.Tables.All, 13, 2500)
-	expect(t, sum.Tables.Local, 8, 1600)
-	expect(t, sum.BlobFiles.All, 7, 1300)
-	expect(t, sum.BlobFiles.Local, 4, 800)
-	expect(t, sum.Other, 3, 400)
-
-	// Test Deduct
-	sum.Deduct(cs2)
-	require.Equal(t, cs1, sum)
+	cs.Dec(100)
+	require.True(t, cs.IsZero())
 }

--- a/open.go
+++ b/open.go
@@ -335,7 +335,8 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	d.newIters = d.fileCache.newIters
 	d.tableNewRangeKeyIter = tableNewRangeKeyIter(d.newIters)
 
-	d.fileSizeAnnotator = d.makeFileSizeAnnotator()
+	d.tableDiskUsageAnnotator = d.makeTableDiskSpaceUsageAnnotator()
+	d.blobFileDiskUsageAnnotator = d.makeBlobFileDiskSpaceUsageAnnotator()
 
 	d.mu.versions.markFileNumUsed(rs.maxFilenumUsed)
 	if n := len(wals); n > 0 {

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -74,10 +74,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
    4 (1.1KB) |      90.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   4 (236KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -193,10 +193,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     1 (392B) |      89.6% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |   1 (112B) |     0 (0B) |    19B | 100% (19B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (854B)       0 (0B)        0 (0B)     |   1 (112B)       0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 19B
+  refed         | 19B (100%)
+  backing-refed | 19B (100%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -502,10 +515,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     1 (504B) |      78.6% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |   2 (245B) |     0 (0B) |    59B | 100% (59B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (855B)       0 (0B)        0 (0B)     |   2 (245B)       0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 59B
+  refed         | 59B (100%)
+  backing-refed | 59B (100%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot

--- a/testdata/compaction/virtual_rewrite
+++ b/testdata/compaction/virtual_rewrite
@@ -177,10 +177,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
    4 (1.1KB) |      91.9% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |   1 (732B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   4 (2.7KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -324,10 +324,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      50.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-      loading |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   3 (1.9KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+--------
+table stats     | loading
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -475,10 +488,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      50.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-      loading |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   6 (3.8KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+--------
+table stats     | loading
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -69,10 +69,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     1 (280B) |      50.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (463B)       0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -57,10 +57,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
    180 (1MB) |      48.7% |       47.4% |          21 |           4
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |        live |     zombie |  total |      refed
---------------+------------+-----------------------+-------------+------------+--------+-----------
-   31 pending |    1 (2MB) |  18 (17MB local:30MB) | 1.2K (15GB) |  14 (30MB) |   14GB | 79% (11GB)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live | 1.2K (1.2GB)   240 (240MB)   120 (120MB)  | 2.4K (2.3GB)   480 (480MB)   240 (240MB)
+   zombie |  100 (100MB)    20 (20MB)     10 (10MB)   |   30 (30MB)      6 (6MB)       3 (3MB)
+ obsolete |   20 (20MB)      4 (4MB)       2 (2MB)    |  140 (140MB)    28 (28MB)     14 (14MB)
+
+MISC            |
+----------------+-----------
+table stats     | 31 pending
+table garbage   |
+  point del     | 1MB
+  range del     | 2MB
+blob values     |
+  total         | 14GB
+  refed         | 11GB (79%)
+  backing-refed | 12GB (86%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -86,11 +99,11 @@ COMPRESSION
          zstd |   10GB (CR=5) |  100GB (CR=5)
       unknown |         500MB |          50MB
 
-DELETE PACER   |             in queue             |            deleted
----------------+----------------------------------+------------------------------
-        tables |  100 (100MB) [local: 50 (50MB)]  | 1K (1GB) [local: 500 (500MB)]
-    blob files | 200 (200MB) [local: 100 (100MB)] |  2K (2GB) [local: 1K (1GB)]
-   other files |            10 (10MB)             |          100 (100MB)
+DELETE PACER   |            in queue            |             deleted
+---------------+--------------------------------+--------------------------------
+        tables | 1.3K (1.3GB) [local: 1K (1GB)] | 13K (13GB) [local: 10K (9.8GB)]
+    blob files | 2.6K (2.5GB) [local: 2K (2GB)] | 26K (25GB) [local: 20K (20GB)]
+   other files |           10 (10MB)            |           100 (100MB)
 ----
 ----
 
@@ -155,10 +168,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     1 (280B) |       0.0% |        0.0% |           1 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (707B)       0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -264,10 +290,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     2 (560B) |      66.7% |        0.0% |           2 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) | 2 (1.4KB local:1.4KB) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   2 (1.4KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |   2 (1.4KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -355,10 +394,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     2 (560B) |      66.7% |        0.0% |           2 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) | 2 (1.4KB local:1.4KB) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   2 (1.4KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |   2 (1.4KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -443,10 +495,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     1 (280B) |      66.7% |        0.0% |           1 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |   1 (707B local:707B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   2 (1.4KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |   1 (707B)       0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -534,10 +599,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      66.7% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   2 (1.4KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -664,10 +742,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      66.7% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   9 (6.8KB)      0 (0B)        0 (0B)     |   7 (1.2KB)      0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 21B
+  refed         | 21B (100%)
+  backing-refed | 21B (100%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -780,10 +871,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      55.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   9 (6.8KB)      0 (0B)        0 (0B)     |   7 (1.2KB)      0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 21B
+  refed         | 21B (100%)
+  backing-refed | 21B (100%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -947,10 +1051,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      55.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   15 (11KB)      0 (0B)        0 (0B)     |   7 (1.2KB)      0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 21B
+  refed         | 21B (100%)
+  backing-refed | 21B (100%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1076,10 +1193,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      55.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   22 (16KB)      0 (0B)        0 (0B)     |   7 (1.2KB)      0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 21B
+  refed         | 21B (100%)
+  backing-refed | 21B (100%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1162,14 +1292,10 @@ Blob files:
 # There should be 2 backing tables. Note that tiny sstables have inaccurate
 # virtual sstable sizes.
 metrics-value
-num-backing
-backing-size
 num-virtual
 num-virtual 0
 virtual-size
 ----
-0
-0B
 0
 0
 0B
@@ -1214,10 +1340,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   21 (15KB)      0 (0B)        0 (0B)     |   7 (1.2KB)      0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 21B
+  refed         | 21B (100%)
+  backing-refed | 21B (100%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1300,14 +1439,10 @@ Blob files:
   B000024 physical:{000024 size:[177 (177B)] vals:[3 (3B)]}
 
 metrics-value
-num-backing
-backing-size
 num-virtual
 num-virtual 0
 virtual-size
 ----
-0
-0B
 0
 0
 0B
@@ -1344,14 +1479,10 @@ Blob files:
 
 # Virtual sstables metrics should be gone after the compaction.
 metrics-value
-num-backing
-backing-size
 num-virtual
 num-virtual 0
 virtual-size
 ----
-0
-0B
 0
 0
 0B
@@ -1396,10 +1527,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |  7 (1.2KB) |     0 (0B) |    21B | 100% (21B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   18 (13KB)      0 (0B)        0 (0B)     |   7 (1.2KB)      0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 21B
+  refed         | 21B (100%)
+  backing-refed | 21B (100%)
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1493,10 +1637,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   3 (2.1KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1581,10 +1738,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      50.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |    0 (0B)       3 (1.9KB)      0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1684,10 +1854,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      50.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |    0 (0B)       4 (2.6KB)      0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1779,10 +1962,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |      50.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (707B)      4 (2.6KB)      0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1861,10 +2057,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (707B)      4 (2.6KB)      0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -1944,10 +2153,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (702B)      2 (1.3KB)      0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -2069,10 +2291,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     2 (560B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   5 (3.5KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 502B
+  range del     | 1.4KB
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -2154,10 +2389,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
     2 (560B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-   all loaded |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   5 (3.5KB)      0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+-----------
+table stats     | all loaded
+table garbage   |
+  point del     | 502B
+  range del     | 1.4KB
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -46,10 +46,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-      loading |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (709B)       0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+--------
+table stats     | loading
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot
@@ -118,10 +131,23 @@ ITERATORS
 -------------+------------+-------------+-------------+------------
       0 (0B) |       0.0% |        0.0% |           0 |           0
 
-FILES                 tables                       |       blob files        |     blob values
-   stats prog |    backing |                zombie |       live |     zombie |  total |      refed
---------------+------------+-----------------------+------------+------------+--------+-----------
-      loading |     0 (0B) |       0 (0B local:0B) |     0 (0B) |     0 (0B) |     0B |    0% (0B)
+FILES                 physical tables                 |                blob files
+          |     local        shared        remote     |     local        shared        remote
+----------+-------------------------------------------+------------------------------------------
+     live |   1 (709B)       0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+   zombie |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+ obsolete |    0 (0B)        0 (0B)        0 (0B)     |    0 (0B)        0 (0B)        0 (0B)
+
+MISC            |
+----------------+--------
+table stats     | loading
+table garbage   |
+  point del     | 0B
+  range del     | 0B
+blob values     |
+  total         | 0B
+  refed         | 0B
+  backing-refed | 0B
 
 CGO MEMORY    |          block cache           |                     memtables
           tot |           tot |           data |            maps |            ents |           tot


### PR DESCRIPTION
The way we maintain the metrics that are used for disk usage
calculations are very messy. They are updated incrementally with
special code paths which can be fragile. And they are not consistent
with sibling metrics (for example: `Tables.Live.All` uses virtual table
sizes, whereas `Tables.Live.Local` uses backing sizes)

This change redesigns these metrics. We specialize the metrics to
focus on disk usage, and thus only include physical tables and
physical backings. We now use the (improved) disk space aggregator and
new blob size aggregator on demand, only when metrics are needed.