### PR TITLE
db: tolerate unknown options

### DIFF
--- a/tool/db.go
+++ b/tool/db.go
@@ -362,9 +362,6 @@ func (d *dbT) loadOptions(dir string) error {
 			}
 			return nil, errors.Errorf("unknown merger %q", errors.Safe(name))
 		},
-		SkipUnknown: func(name, value string) bool {
-			return true
-		},
 	}
 
 	// TODO(peter): RocksDB sometimes leaves multiple OPTIONS files in


### PR DESCRIPTION
Instead of throwing an error when we encounter unfamiliar options, we will instead tolerate it and log a message. This will allow us to be more lenient about options handling (backporting, renaming, etc.). It also addresses the case in which a user could revert before a major upgrade finalization and have some new option written that the lesser version doesn't recognize and error out at.