### PR TITLE
db: narrow down versionSet.metrics

### DIFF
--- a/db.go
+++ b/db.go
@@ -1888,7 +1888,12 @@ func (d *DB) Metrics() *Metrics {
 	vers.Ref()
 	defer vers.Unref()
 
-	*metrics = d.mu.versions.metrics
+	metrics.Levels = d.mu.versions.metrics.Levels
+	metrics.Compact = d.mu.versions.metrics.Compact
+	metrics.Ingest = d.mu.versions.metrics.Ingest
+	metrics.Flush = d.mu.versions.metrics.Flush
+	metrics.Keys = d.mu.versions.metrics.Keys
+
 	metrics.Compact.EstimatedDebt = d.mu.versions.picker.estimatedCompactionDebt()
 	metrics.Compact.InProgressBytes = d.mu.versions.atomicInProgressBytes.Load()
 	// TODO(radu): split this to separate the download compactions.

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -221,7 +221,7 @@ func TestVersionSet(t *testing.T) {
 			}
 
 		case "metrics":
-			return vs.metrics.LevelMetricsString()
+			return vs.metrics.Levels.String()
 
 		default:
 			td.Fatalf(t, "unknown command: %s", td.Cmd)


### PR DESCRIPTION
We now store in `versionSet` only the subset of metrics that are
actually maintained by the version set, reducing confusion.