### PR TITLE
deletepacer: don't use fifo.Queue

### DIFF
--- a/internal/deletepacer/delete_pacer_test.go
+++ b/internal/deletepacer/delete_pacer_test.go
@@ -248,7 +248,7 @@ func TestFallingBehind(t *testing.T) {
 	queueSize := func() int {
 		dp.mu.Lock()
 		defer dp.mu.Unlock()
-		return dp.mu.queue.Len()
+		return len(dp.mu.queue)
 	}
 	// At 1MB, each job will take 100ms each. Note that the rate increase based on
 	// history won't make much difference, since the enqueued size is averaged


### PR DESCRIPTION
There is a msan failure that goes away if we switch to using a slice
here. This isn't due to some bug in `fifo.Queue` but it looks like a
possible compiler bug; the problem will continue to be investigated as
part of https://github.com/golang/go/issues/76138

We don't really need the specialized `fifo.Queue` here, a slice is
just as good; we just make sure to allocate in reasonable chunks.

Fixes #5498