### PR TITLE
db: add metric encapsulating blob file rewrite bytes read, written

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -426,6 +426,20 @@ type CompactMetrics struct {
 	// Duration records the cumulative duration of all compactions since the
 	// database was opened.
 	Duration time.Duration
+	// BlobFileRewrite contains metrics for blob file rewrite compactions.
+	BlobFileRewrite struct {
+		// The total number of bytes read during blob file rewrite compactions.
+		// This only counts blob value blocks (data blocks) that are read from
+		// the input blob file. The index block is read but tracked as
+		// blockkind.Metadata, not blockkind.BlobValue. As a result, BytesRead
+		// can be smaller than BytesWritten.
+		BytesRead int64
+		// The total number of bytes written during blob file rewrite compactions.
+		// This counts all bytes written to the output blob file, including blob
+		// value blocks, index block, properties block, and footer. As a result,
+		// BytesWritten can be larger than BytesRead.
+		BytesWritten int64
+	}
 }
 
 // IngestMetrics contains metrics related to ingestions.
@@ -767,16 +781,21 @@ var (
 		table.String("tot", 13, table.AlignRight, func(i cgoMemInfo) string { return i.memtablesTot }),
 	)
 	compactionInfoTableTopHeader = `COMPACTIONS`
+	compactionInfoTableSubHeader = `                                                                         |      blob rewrites`
 	compactionInfoTable          = table.Define[compactionMetricsInfo](
-		table.String("estimated debt", 17, table.AlignRight, func(i compactionMetricsInfo) string { return i.estimatedDebt }),
+		table.String("est. debt", 13, table.AlignRight, func(i compactionMetricsInfo) string { return i.estimatedDebt }),
 		table.Div(),
-		table.String("in progress", 17, table.AlignRight, func(i compactionMetricsInfo) string { return i.inProgress }),
+		table.String("in progress", 13, table.AlignRight, func(i compactionMetricsInfo) string { return i.inProgress }),
 		table.Div(),
-		table.String("cancelled", 17, table.AlignRight, func(i compactionMetricsInfo) string { return i.cancelled }),
+		table.String("cancelled", 10, table.AlignRight, func(i compactionMetricsInfo) string { return i.cancelled }),
 		table.Div(),
-		table.String("failed", 17, table.AlignRight, func(i compactionMetricsInfo) string { return fmt.Sprint(i.failed) }),
+		table.String("failed", 8, table.AlignRight, func(i compactionMetricsInfo) string { return fmt.Sprint(i.failed) }),
 		table.Div(),
-		table.String("problem spans", 18, table.AlignRight, func(i compactionMetricsInfo) string { return i.problemSpans }),
+		table.String("problem spans", 16, table.AlignRight, func(i compactionMetricsInfo) string { return i.problemSpans }),
+		table.Div(),
+		table.String("read", 10, table.AlignRight, func(i compactionMetricsInfo) string { return i.blobFileRewriteBytesRead }),
+		table.Div(),
+		table.String("written", 10, table.AlignRight, func(i compactionMetricsInfo) string { return i.blobFileRewriteBytesWritten }),
 	)
 	keysInfoTableTopHeader = `KEYS`
 	keysInfoTable          = table.Define[keysInfo](
@@ -902,11 +921,13 @@ type cgoMemInfo struct {
 }
 
 type compactionMetricsInfo struct {
-	estimatedDebt string
-	inProgress    string
-	cancelled     string
-	failed        int64
-	problemSpans  string
+	estimatedDebt               string
+	inProgress                  string
+	cancelled                   string
+	failed                      int64
+	problemSpans                string
+	blobFileRewriteBytesRead    string
+	blobFileRewriteBytesWritten string
 }
 
 type keysInfo struct {
@@ -1119,10 +1140,13 @@ func (m *Metrics) String() string {
 			humanizeBytes(m.Compact.InProgressBytes)),
 		cancelled: fmt.Sprintf("%s (%s)", humanizeCount(m.Compact.CancelledCount),
 			humanizeBytes(m.Compact.CancelledBytes)),
-		failed:       m.Compact.FailedCount,
-		problemSpans: fmt.Sprintf("%d%s", m.Compact.NumProblemSpans, ifNonZero(m.Compact.NumProblemSpans, "!!")),
+		failed:                      m.Compact.FailedCount,
+		problemSpans:                fmt.Sprintf("%d%s", m.Compact.NumProblemSpans, ifNonZero(m.Compact.NumProblemSpans, "!!")),
+		blobFileRewriteBytesRead:    humanizeBytes(m.Compact.BlobFileRewrite.BytesRead),
+		blobFileRewriteBytesWritten: humanizeBytes(m.Compact.BlobFileRewrite.BytesWritten),
 	}
 	cur = cur.WriteString(compactionInfoTableTopHeader).NewlineReturn()
+	cur = cur.WriteString(compactionInfoTableSubHeader).NewlineReturn()
 	cur = compactionInfoTable.Render(cur, table.RenderOptions{}, compactionMetricsInfoContents)
 	cur = cur.NewlineReturn()
 

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -98,9 +98,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -216,9 +216,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -544,9 +545,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |        83B |       150B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels

--- a/testdata/compaction/virtual_rewrite
+++ b/testdata/compaction/virtual_rewrite
@@ -201,9 +201,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -348,9 +348,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-            1.9KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+        1.9KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -518,9 +519,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-            3.8KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+        3.8KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -93,9 +93,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -81,9 +81,10 @@ CGO MEMORY    |          block cache           |                     memtables
          15KB |           9KB |            4KB |             2KB |             3KB |           5KB
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-              6GB |           2 (1MB) |           3 (3KB) |                 4 |                5!!
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+          6GB |       2 (1MB) |    3 (3KB) |        4 |              5!! |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -199,9 +200,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -326,9 +328,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -436,9 +439,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -543,9 +547,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -653,9 +658,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -802,9 +808,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-            7.9KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+        7.9KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -937,9 +944,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1123,9 +1131,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-             12KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+         12KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1271,9 +1280,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-             17KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+         17KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1424,9 +1434,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-             16KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+         16KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1617,9 +1628,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1733,9 +1745,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1839,9 +1852,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -1961,9 +1975,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-            2.6KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+        2.6KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -2075,9 +2090,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-            3.2KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+        3.2KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -2176,9 +2192,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-            3.2KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+        3.2KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -2277,9 +2294,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -2421,9 +2439,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-            3.4KB |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+        3.4KB |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -2524,9 +2543,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-            3.4KB |            0 (0B) |            0 (0B) |                 0 |                2!!
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+        3.4KB |        0 (0B) |     0 (0B) |        0 |              2!! |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels

--- a/tool/testdata/db_lsm
+++ b/tool/testdata/db_lsm
@@ -70,9 +70,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels
@@ -158,9 +159,10 @@ CGO MEMORY    |          block cache           |                     memtables
            0B |            0B |             0B |              0B |              0B |            0B
 
 COMPACTIONS
-   estimated debt |       in progress |         cancelled |            failed |      problem spans
-------------------+-------------------+-------------------+-------------------+-------------------
-               0B |            0 (0B) |            0 (0B) |                 0 |                  0
+                                                                         |      blob rewrites
+    est. debt |   in progress |  cancelled |   failed |    problem spans |       read |    written
+--------------+---------------+------------+----------+------------------+------------+-----------
+           0B |        0 (0B) |     0 (0B) |        0 |                0 |         0B |         0B
 
 KEYS
       range keys |       tombstones |      missized tombstones |      point dels |      range dels


### PR DESCRIPTION
Blob file rewrite compactions happen independent of LSM levels, and so don't
contribute to the per-level 'compacted bytes' total. This patch adds separate
metrics recording the bytes read and bytes written during these compactions.

Fixes: #5444