### PR TITLE
github: enable claude code review bot as an opt-in GH action

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -1,0 +1,250 @@
+name: Claude Code PR Review
+
+on:
+  pull_request_target:
+    types: [synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-code-pr-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: contains(github.event.pull_request.labels.*.name, 'O-AI-Review')
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 1
+
+      - name: Authenticate to Google Cloud
+        uses: 'google-github-actions/auth@v3'
+        with:
+          project_id: 'vertex-model-runners'
+          service_account: 'ai-review@dev-inf-prod.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/72497726731/locations/global/workloadIdentityPools/ai-review/providers/ai-review'
+
+      - name: Stage 1 - Initial Bug Screening
+        id: stage1
+        uses: cockroachdb/claude-code-action@v1
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
+          CLOUD_ML_REGION: global
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_vertex: "true"
+          claude_args: |
+            --model claude-sonnet-4-5@20250929
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Examine each line of code in this PR for potential bugs that could negatively impact
+            CockroachDB and Pebble users. Focus on:
+            - Basic logic errors
+            - Obvious security vulnerabilities
+            - Clear error handling problems
+            - Type safety issues
+
+            When performing your analysis, be conservative but thorough. You should think:
+            "would I be willing to go to jail if my analysis is incorrect?"
+
+            **CRITICAL**: You must respond with EXACTLY one of these formats:
+            1. 'POTENTIAL_BUG_DETECTED - [brief description]' if you find a definite bug
+            2. 'NO_BUG_FOUND' if no obvious bugs are found
+
+            If you detect bugs, clearly explain what you found and why it's problematic.
+
+            **OUTPUT REQUIREMENT**: End your response with a single line containing only:
+            - `STAGE1_RESULT - POTENTIAL_BUG_DETECTED` or
+            - `STAGE1_RESULT - NO_BUG_FOUND`
+
+      - name: Extract Stage 1 Result
+        id: stage1_result
+        if: steps.stage1.conclusion == 'success'
+        run: |
+          RESULT=$(jq -r '.[] | select(.type == "result") | .result' "${{ steps.stage1.outputs.execution_file }}")
+          {
+            echo 'result<<EOF'
+            echo "$RESULT"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "Stage 1 result extracted (${#RESULT} characters)"
+
+      - name: Stage 2 - Database Expert Review
+        id: stage2
+        if: contains(steps.stage1_result.outputs.result, 'STAGE1_RESULT - POTENTIAL_BUG_DETECTED')
+        uses: cockroachdb/claude-code-action@v1
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
+          CLOUD_ML_REGION: global
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_vertex: "true"
+          claude_args: |
+            --model claude-sonnet-4-5@20250929
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are a database systems expert providing a second opinion. Stage 1 analysis
+            found potential issues. Your job is to confirm or reject those findings.
+
+            **Stage 1 Results**:
+            ${{ steps.stage1_result.outputs.result }}
+
+            Review the Stage 1 findings and perform your own analysis. Do not identify
+            new bugs unless they're glaringly obvious.
+
+            Be very thorough and conservative. Ask yourself: "would I risk losing my job
+            over falsely identifying a bug?" If there's doubt, err on the side of
+            NO_BUG_DETECTED.
+
+            **CRITICAL**: You must respond with EXACTLY one of these formats:
+            1. 'POTENTIAL_BUG_DETECTED - [detailed description of confirmed bugs]'
+            2. 'NO_BUG_FOUND' if bugs are not confirmed
+
+            **OUTPUT REQUIREMENT**: End your response with a single line containing only:
+            - `STAGE2_RESULT - POTENTIAL_BUG_DETECTED [detailed description of confirmed bugs]` or
+            - `STAGE2_RESULT - NO_BUG_FOUND`
+
+      - name: Extract Stage 2 Result
+        id: stage2_result
+        if: steps.stage2.conclusion == 'success'
+        run: |
+          RESULT=$(jq -r '.[] | select(.type == "result") | .result' "${{ steps.stage2.outputs.execution_file }}")
+          {
+            echo 'result<<EOF'
+            echo "$RESULT"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "Stage 2 result extracted (${#RESULT} characters)"
+
+      - name: Stage 3 - Principal Engineer Final Review
+        id: stage3
+        if: contains(steps.stage2_result.outputs.result, 'STAGE2_RESULT - POTENTIAL_BUG_DETECTED')
+        uses: cockroachdb/claude-code-action@v1
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
+          CLOUD_ML_REGION: global
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_vertex: "true"
+          claude_args: |
+            --model claude-sonnet-4-5@20250929
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are a principal engineer performing the final, most critical analysis.
+            Two previous stages have found potential issues that need final validation.
+
+            **Stage 1 Results**:
+            ${{ steps.stage1_result.outputs.result }}
+
+            **Stage 2 Results**:
+            ${{ steps.stage2_result.outputs.result }}
+
+            This is the final gate before flagging this PR as having critical bugs.
+            Only confirm bugs that could cause:
+            - Data loss or corruption
+            - Performance degradation
+            - Memory leaks
+            - Race conditions
+            - Incorrect errors, traps or panics
+            - Security breaches
+            - Cluster instability
+            - Production outages
+
+            Be extremely conservative - only flag truly critical issues. If you're wrong,
+            it could mean serious consequences for the project.
+
+            Use conservative language and minimize superlatives. Assume the reader has
+            a heart condition - just articulate facts without emotion.
+
+            **CRITICAL**: You must respond with EXACTLY one of these formats:
+            1. 'BUG_DETECTED: [description, line numbers and suggested fix]'
+            2. 'NO_BUG_DETECTED' if issues are not critical enough
+
+            For each issue found, provide:
+            1. The specific line(s) where the issue occurs
+            2. A clear description of what is wrong
+            3. A suggested fix
+
+            **OUTPUT REQUIREMENT**: End your response with a single line containing only:
+            - `STAGE3_RESULT - POTENTIAL_BUG_CONFIRMED` or
+            - `STAGE3_RESULT - NO_BUG_FOUND`
+
+      - name: Extract Stage 3 Result
+        id: stage3_result
+        if: steps.stage3.conclusion == 'success'
+        run: |
+          RESULT=$(jq -r '.[] | select(.type == "result") | .result' "${{ steps.stage3.outputs.execution_file }}")
+          {
+            echo 'result<<EOF'
+            echo "$RESULT"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "Stage 3 result extracted (${#RESULT} characters)"
+
+      - name: Final Analysis Report
+        if: always()
+        uses: cockroachdb/claude-code-action@v1
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
+          CLOUD_ML_REGION: global
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_vertex: "true"
+          claude_args: |
+            --model claude-sonnet-4-5@20250929
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            ## Three-Stage Analysis Summary
+
+            Generate a final summary report based on the completed analysis stages:
+
+            **Stage 1 Result**: ${{ steps.stage1_result.outputs.result || 'Not completed' }}
+            **Stage 2 Result**: ${{ steps.stage2_result.outputs.result || 'Skipped - Stage 1 found no bugs' }}
+            **Stage 3 Result**: ${{ steps.stage3_result.outputs.result || 'Skipped - Stage 2 did not confirm bugs' }}
+
+            **Analysis Process**:
+            - Stage 1 (Initial Screening): ${{ steps.stage1.conclusion }}
+            - Stage 2 (Database Expert): ${{ steps.stage2.conclusion || 'Skipped' }}
+            - Stage 3 (Principal Engineer): ${{ steps.stage3.conclusion || 'Skipped' }}
+
+            Provide a clear, concise summary of:
+            1. How many stages were executed
+            2. The final determination (critical bug found or no critical bugs)
+            3. If bugs were found, what actions are recommended
+
+            **If all three stages detected bugs**, this indicates a potential issue that warrants investigation.
+
+      - name: Comment on PR if bugs confirmed
+        if: contains(steps.stage3_result.outputs.result, 'STAGE3_RESULT - POTENTIAL_BUG_CONFIRMED')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "## Potential Bug(s) Detected
+
+          The three-stage Claude Code analysis has identified potential bug(s) in this PR that may warrant investigation.
+
+          **Next Steps:**
+          Please review the detailed findings in the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+          **Note:** When viewing the workflow output, scroll to the bottom to find the Final Analysis Summary.
+
+          After you review the findings, please tag the issue as follows:
+          - If the detected issue is real or was helpful in any way, please tag the issue with \`O-AI-Review-Real-Issue-Found\`
+          - If the detected issue was not helpful in any way, please tag the issue with \`O-AI-Review-Not-Helpful\`"
+
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "O-AI-Review-Potential-Issue-Detected"


### PR DESCRIPTION
The action is largely copied from https://github.com/cockroachdb/cockroach/blob/master/.github/workflows/pr-analyzer-threestage.yml

Infra support: https://github.com/cockroachlabs/crl-infrastructure/pull/4307

We will start with opt-in mode. Only PRs with `O-AI-Review` label would get AI review (line 11).

