### PR TITLE
internal/manifest: document relationship between LastSeqNum and WAL seqnums

### DIFF
--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -150,7 +150,8 @@ type VersionEdit struct {
 
 	// LastSeqNum is an upper bound on the sequence numbers that have been
 	// assigned in flushed WALs. Unflushed WALs (that will be replayed during
-	// recovery) may contain sequence numbers greater than this value.
+	// recovery) may contain sequence numbers greater than this value. They're
+	// also allowed to contain sequence numbers less than or equal to this value.
 	LastSeqNum base.SeqNum
 
 	// A file num may be present in both deleted files and new files when it

--- a/version_set.go
+++ b/version_set.go
@@ -34,6 +34,12 @@ const manifestMarkerName = `manifest`
 // to the MANIFEST file, which is replayed at startup.
 type versionSet struct {
 	// Next seqNum to use for WAL writes.
+	//
+	// Note that unflushed WALs may contain sequence numbers less than, equal
+	// to, or greater than logSeqNum. This is because every version edit
+	// includes the current logSeqNum, so any version edits applied after a
+	// write and before the flush of the write to a sstable will update
+	// logSeqNum beyond the write's sequence number.
 	logSeqNum base.AtomicSeqNum
 
 	// The upper bound on sequence numbers that have been assigned so far. A


### PR DESCRIPTION
Clarify commentary around logSeqNum/LastSeqNum. Unflushed WALs may contain sequence numbers less than the most recently persisted LastSeqNum.