### PR TITLE
db: add ability to collect a profile of separated value retrievals

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -3390,6 +3390,7 @@ func (d *DB) compactAndWrite(
 			uint64(uintptr(unsafe.Pointer(c))),
 			categoryCompaction,
 		),
+		ValueRetrievalProfile: d.valueRetrievalProfile.Load(),
 	}
 	if c.version != nil {
 		c.iterationState.valueFetcher.Init(&c.version.BlobFiles, d.fileCache, blockReadEnv, suggestedCacheReaders)

--- a/internal/bytesprofile/bytesprofile.go
+++ b/internal/bytesprofile/bytesprofile.go
@@ -1,0 +1,91 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package bytesprofile
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/pebble/internal/humanize"
+)
+
+// Profile is a profile mapping stack traces to a cumulative count and byte sum.
+type Profile struct {
+	mu      sync.Mutex
+	samples map[stack]aggSamples
+}
+
+// NewProfile creates a new profile.
+func NewProfile() *Profile {
+	return &Profile{samples: make(map[stack]aggSamples)}
+}
+
+type stack [20]uintptr
+
+// trimmed returns the non-zero stack frames of stack.
+func (s stack) trimmed() []uintptr {
+	for i := range s {
+		if s[i] == 0 {
+			return s[:i]
+		}
+	}
+	return s[:]
+}
+
+type aggSamples struct {
+	bytes int64
+	count int64
+}
+
+// Record records a sample of the given number of bytes with the calling stack trace.
+func (p *Profile) Record(bytes int64) {
+	var stack stack
+	runtime.Callers(2, stack[:])
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	curr := p.samples[stack]
+	curr.bytes += bytes
+	curr.count++
+	p.samples[stack] = curr
+}
+
+// TODO(jackson): We could add the ability to export the profile to a pprof file
+// (which internally is just a protocol buffer). Ideally the Go standard library
+// would provide facilities for this (e.g., golang/go#18454). The runtime/pprof
+// library comes close with its definition of custom profiles, but they only
+// support profiles tracking in-use resources.
+
+// String returns a string representation of the stacks captured by the profile.
+func (p *Profile) String() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Sort the stacks by bytes in descending order.
+	uniqueStacks := slices.SortedFunc(maps.Keys(p.samples), func(a, b stack) int {
+		return -cmp.Compare(p.samples[a].bytes, p.samples[b].bytes)
+	})
+	var sb strings.Builder
+	for i, stack := range uniqueStacks {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		fmt.Fprintf(&sb, "%d: Count: %d (%s), Bytes: %d (%s)\n", i,
+			p.samples[stack].count, humanize.Count.Int64(p.samples[stack].count),
+			p.samples[stack].bytes, humanize.Bytes.Int64(p.samples[stack].bytes))
+		frames := runtime.CallersFrames(stack.trimmed())
+		for {
+			frame, more := frames.Next()
+			fmt.Fprintf(&sb, "  %s\n   %s:%d\n", frame.Function, frame.File, frame.Line)
+			if !more {
+				break
+			}
+		}
+	}
+	return sb.String()
+}

--- a/internal/bytesprofile/bytesprofile_test.go
+++ b/internal/bytesprofile/bytesprofile_test.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package bytesprofile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytesProfile(t *testing.T) {
+	p := NewProfile()
+	for i := 0; i < 100; i++ {
+		p.Record(int64(i))
+	}
+	for i := 0; i < 10; i++ {
+		p.Record(11 * int64(i))
+	}
+	s := p.String()
+	require.Contains(t, s, "0: Count: 100 (100), Bytes: 4950 (4.8KB)")
+	require.Contains(t, s, "1: Count: 10 (10), Bytes: 495 (495B)")
+	t.Log(s)
+}

--- a/metrics/value_retrieval_profile.go
+++ b/metrics/value_retrieval_profile.go
@@ -1,0 +1,10 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package metrics
+
+import "github.com/cockroachdb/pebble/internal/bytesprofile"
+
+// ValueRetrievalProfile is a profile of separated value retrievals.
+type ValueRetrievalProfile = bytesprofile.Profile

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -201,7 +201,8 @@ func (d *DB) newInternalIter(
 	if d.iterTracker != nil {
 		dbi.trackerHandle = d.iterTracker.Start()
 	}
-	dbi.blobValueFetcher.Init(&vers.BlobFiles, d.fileCache, block.ReadEnv{},
+	dbi.blobValueFetcher.Init(&vers.BlobFiles, d.fileCache,
+		block.ReadEnv{ValueRetrievalProfile: d.valueRetrievalProfile.Load()},
 		blob.SuggestedCachedReaders(vers.MaxReadAmp()))
 
 	dbi.opts = *o

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -340,6 +340,14 @@ func (cr *cachedReader) GetUnsafeValue(
 		cr.currentValueBlock.loaded = true
 	}
 
+	// If the ReadEnv is configured with a value-retrieval profile, record the
+	// value retrieval to it. This is used to allow runtime profiling of value
+	// retrievals, providing observability into which codepaths are responsible
+	// for the comparatively expensive value retrievals.
+	if env.ValueRetrievalProfile != nil {
+		env.ValueRetrievalProfile.Record(int64(vh.ValueLen))
+	}
+
 	// Convert the ValueID to an index into the block's values. When a blob file
 	// is first constructed, the ValueID == the index. However when a blob file
 	// is rewritten, multiple blocks from the original blob file may be combined

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bitflip"
+	"github.com/cockroachdb/pebble/internal/bytesprofile"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/crc"
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -284,6 +285,10 @@ type ReadEnv struct {
 	// more details.
 	ReportCorruptionFn  func(base.ObjectInfo, error) error
 	ReportCorruptionArg base.ObjectInfo
+
+	// ValueRetrievalProfile, if non-nil, is used to record stack traces of
+	// retrievals of separated values. It's only used by the blob.ValueFetcher.
+	ValueRetrievalProfile *bytesprofile.Profile
 }
 
 // BlockServedFromCache updates the stats when a block was found in the cache.


### PR DESCRIPTION
With the introduction of value separation, retrievals of separated values are more expensive than retrievals of inlined values. Pebble exports an aggregate metric recording the total count of value retrievals that must load a value from an external blob file. This can be used to help attribute performance issues to excessive separated value retrievals, but it doesn't help with understanding what codepaths are performing the retrievals.

This commit adds support for collection of a 'separated value retrieval' profile, aggregating the count and byte-total of value retrievals per unique stack trace while profile collection is active. This additional instrumentation adds some overhead and is too expensive to perform by default.

Users may call DB.RecordSeparatedValueRetrievals to initiate collection of a profile. All subsequent opened iterators and compactions will record retrievals of separated values into the profile until the caller stops the collection with the invocation of a callback.

For now this profile can only be dumped to a text format through a String method. We could export it to a pprof file but it would require a fair bit of work.

Close #5535.
Informs cockroachdb/cockroach#144715.