### PR TITLE
crl-release-25.2: db: fix Options.Clone()

### DIFF
--- a/options.go
+++ b/options.go
@@ -1391,11 +1391,15 @@ func (o *Options) Level(level int) LevelOptions {
 
 // Clone creates a shallow-copy of the supplied options.
 func (o *Options) Clone() *Options {
-	n := &Options{}
-	if o != nil {
-		*n = *o
+	if o == nil {
+		return &Options{}
 	}
-	return n
+	n := *o
+	if o.WALFailover != nil {
+		c := *o.WALFailover
+		n.WALFailover = &c
+	}
+	return &n
 }
 
 func filterPolicyName(p FilterPolicy) string {


### PR DESCRIPTION
`Clone()` was allowing a shallow copy of `*WALFailover`. This caused a lot of time debugging a test which unwittingly aliased the WAL failover FS and dir of two stores.

This commit fixes this and adds a test that would have caught it.

We should probably make `WALFailover` a non-pointer (with an `Enabled` field); even if we do, the new test is still valuable.


Fixes: #5538