### PR TITLE
tests: use colon separator for KVs

### DIFF
--- a/replay/testdata/corpus/simple_ingest
+++ b/replay/testdata/corpus/simple_ingest
@@ -12,10 +12,10 @@ build:
   marker.manifest.000001.MANIFEST-000001
 
 build-sst foo.sst
-a#0,SET = a
-b#0,SET = byaya
-c#0,SET = cyuumi
-d#0,SET = d
+a#0,SET:a
+b#0,SET:byaya
+c#0,SET:cyuumi
+d#0,SET:d
 ----
 
 ingest foo.sst
@@ -23,8 +23,8 @@ ingest foo.sst
 ingested
 
 build-sst f.sst
-p#0,SET = p
-q#0,SET = q
+p#0,SET:p
+q#0,SET:q
 ----
 
 ingest-and-excise f.sst excise=a-d
@@ -64,8 +64,8 @@ simple_ingest/checkpoint:
   marker.manifest.000001.MANIFEST-000001
 
 build-sst loo.sst
-x#0,SET = x
-y#0,SET = y
+x#0,SET:x
+y#0,SET:y
 ----
 
 ingest loo.sst
@@ -73,7 +73,7 @@ ingest loo.sst
 ingested
 
 build-sst l.sst
-z#0,SET = z
+z#0,SET:z
 ----
 
 ingest-and-excise l.sst excise=d-p

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -130,23 +130,25 @@ func (kv ParsedKVOrSpan) String() string {
 	return fmt.Sprintf("%s%s = blob:%s attr=%d", prefix, kv.Key, kv.BlobHandle, kv.Attr)
 }
 
-// ParseTestKVsAndSpans parses a multi-line string that defines SSTable contents.
+// ParseTestKVsAndSpans parses a multi-line string that defines SSTable
+// contents.
 //
-// The blobtest.Values argument can be nil if there are no blob references in the input.
+// The blobtest.Values argument can be nil if there are no blob references in
+// the input.
 //
 // Each input line can be either a key-value pair or a key spans Sample input
 // showing the format:
 //
-//	a#1,SET = a
-//	force-obsolete: d#2,SET = d
-//	f#3,SET = blob{fileNum=1 blockNum=2 offset=110 valueLen=200}attr=7
+//	a#1,SET:a
+//	force-obsolete: d#2,SET:d
+//	f#3,SET:blob{fileNum=1 blockNum=2 offset=110 valueLen=200}attr=7
 //	Span: d-e:{(#4,RANGEDEL)}
 //	Span: a-d:{(#11,RANGEKEYSET,@10,foo)}
 //	Span: g-l:{(#5,RANGEDEL)}
 //	Span: y-z:{(#12,RANGEKEYSET,@11,foo)}
 //
-// Note that the older KV format "<user-key>.<kind>.<seq-num> : <value>" is also supported
-// (for now).
+// Note that the older key format "<user-key>.<kind>.<seq-num>" is also
+// supported (for now).
 func ParseTestKVsAndSpans(input string, bv *blobtest.Values) (_ []ParsedKVOrSpan, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -163,10 +165,10 @@ func ParseTestKVsAndSpans(input string, bv *blobtest.Values) (_ []ParsedKVOrSpan
 
 		var kv ParsedKVOrSpan
 		line, kv.ForceObsolete = strings.CutPrefix(line, "force-obsolete:")
-		// Cut the key at the first ":" or "=".
-		sepIdx := strings.IndexAny(line, "=:")
+		// Cut the key at the first ":".
+		sepIdx := strings.Index(line, ":")
 		if sepIdx == -1 {
-			return nil, errors.Newf("KV format is [force-obsolete:] <key>=<value> (or <key>:<value>): %q", line)
+			return nil, errors.Newf("KV format is \"[force-obsolete:] <key>:<value>\": %q", line)
 		}
 		keyStr := strings.TrimSpace(line[:sepIdx])
 		valStr := strings.TrimSpace(line[sepIdx+1:])

--- a/testdata/compaction_corruption
+++ b/testdata/compaction_corruption
@@ -1,7 +1,7 @@
 build-remote file-not-there
-d#0,SET = dvalue
-q#0,SET = qvalue
-w#0,SET = wvalue
+d#0,SET:dvalue
+q#0,SET:qvalue
+w#0,SET:wvalue
 ----
 
 ingest-external
@@ -31,9 +31,9 @@ wait-for-no-external-files workload=(d,w)
 ----
 
 build-remote file2-not-there
-a#0,SET = avalue
-u#0,SET = uvalue
-z#0,SET = zvalue
+a#0,SET:avalue
+u#0,SET:uvalue
+z#0,SET:zvalue
 ----
 
 ingest-external

--- a/testdata/disk_usage
+++ b/testdata/disk_usage
@@ -92,11 +92,11 @@ total: 1358, remote: 0, external: 0
 
 # Test with remote files and external files
 build-remote ext2 block-size=10 index-block-size=10
-k#0,SET = foo
-l#0,SET = foo
-m#0,SET = foo
-n#0,SET = foo
-o#0,SET = foo
+k#0,SET:foo
+l#0,SET:foo
+m#0,SET:foo
+n#0,SET:foo
+o#0,SET:foo
 ----
 
 estimate-disk-usage-by-backing-type a z

--- a/testdata/excise
+++ b/testdata/excise
@@ -737,9 +737,9 @@ L6:
 # We set the block size to prevent randomization of block sizes (which affects
 # the size).
 build-remote remote1 block-size=1024 index-block-size=1024
-g#0,SET = foo
-h#0,SET = bar
-i#0,SET = foobar
+g#0,SET:foo
+h#0,SET:bar
+i#0,SET:foobar
 ----
 
 ingest-external
@@ -776,9 +776,9 @@ L6:
 # Non-local tables are excised without data access.
 
 build-remote remote2
-u#0,SET = foo
-v#0,SET = bar
-w#0,SET = foobar
+u#0,SET:foo
+v#0,SET:bar
+w#0,SET:foobar
 ----
 
 ingest-external

--- a/testdata/excise_bounds
+++ b/testdata/excise_bounds
@@ -1,8 +1,8 @@
 build-sst
-b#1,SET = b
-c#1,SET = c
-d#1,SET = d
-e#1,SET = e
+b#1,SET:b
+c#1,SET:c
+d#1,SET:d
+e#1,SET:e
 ----
 Bounds:
   overall: b#1,SET - e#1,SET
@@ -135,9 +135,9 @@ Right table bounds (loose):
 
 # Test with a RANGEDEL.
 build-sst
-b#1,SET = b
-cc#1,SET = cc
-e#1,SET = e
+b#1,SET:b
+cc#1,SET:cc
+e#1,SET:e
 Span: c-d:{(#2,RANGEDEL)}
 ----
 Bounds:
@@ -198,9 +198,9 @@ Left table bounds (loose):
 # Test with range keys.
 
 build-sst
-b#1,SET = b
-cc#1,SET = cc
-e#1,SET = e
+b#1,SET:b
+cc#1,SET:cc
+e#1,SET:e
 Span: c-d:{(#2,RANGEKEYSET,@10,foo)}
 ----
 Bounds:

--- a/testdata/ingest_external
+++ b/testdata/ingest_external
@@ -2,9 +2,9 @@
 # Simple case.
 
 build-remote f1
-a#0,SET = foo
-b#0,SET = bar
-c#0,SET = foobar
+a#0,SET:foo
+b#0,SET:bar
+c#0,SET:foobar
 ----
 
 ingest-external
@@ -33,9 +33,9 @@ reset
 ----
 
 build-remote f2
-a#0,SET = foo
-b#0,SET = bar
-c#0,SET = foobar
+a#0,SET:foo
+b#0,SET:bar
+c#0,SET:foobar
 ----
 
 ingest-external
@@ -59,15 +59,15 @@ b: (bar, .)
 .
 
 build-remote f3
-c#0,SET = foobarbaz
-d#0,SET = haha
-e#0,SET = something
+c#0,SET:foobarbaz
+d#0,SET:haha
+e#0,SET:something
 ----
 
 build-remote f4
-f#0,SET = foo
-g#0,SET = foo
-h#0,SET = foo
+f#0,SET:foo
+g#0,SET:foo
+h#0,SET:foo
 ----
 
 # This ingestion should error out due to the overlap between file spans.
@@ -154,9 +154,9 @@ h: (foo, .)
 .
 
 build-remote f5
-f#0,SET = foo
-g#0,SET = foo
-h#0,SET = foo
+f#0,SET:foo
+g#0,SET:foo
+h#0,SET:foo
 ----
 
 ingest-external
@@ -164,9 +164,9 @@ f5 bounds=(ff,fi) synthetic-prefix=f
 ----
 
 build-remote f6
-bf#0,SET = foo
-bg#0,SET = foo
-bh#0,SET = foo
+bf#0,SET:foo
+bg#0,SET:foo
+bh#0,SET:foo
 ----
 
 # Test that ingestion with a synthetic prefix or suffix fails on older
@@ -176,9 +176,9 @@ reset format-major-version=16
 ----
 
 build-remote f5
-ef#0,SET = foo
-eg#0,SET = foo
-eh#0,SET = foo
+ef#0,SET:foo
+eg#0,SET:foo
+eh#0,SET:foo
 ----
 
 ingest-external
@@ -197,13 +197,13 @@ reset
 ----
 
 build-remote f1
-a@1#0,SET = foo
-b@2#0,SET = foo
-c@1#0,SET = foo
+a@1#0,SET:foo
+b@2#0,SET:foo
+c@1#0,SET:foo
 ----
 
 build-remote f6
-b#0,SET = foo
+b#0,SET:foo
 Span: f-u:{(#0,RANGEDEL)}
 ----
 
@@ -246,7 +246,7 @@ set i bar
 ----
 
 build-remote f6
-b#0,SET = foo
+b#0,SET:foo
 Span: f-u:{(#0,RANGEDEL)}
 ----
 
@@ -267,11 +267,11 @@ reset
 ----
 
 build-remote f7
-a#0,SET = foo
+a#0,SET:foo
 ----
 
 build-remote f8
-x#0,SET = bar
+x#0,SET:bar
 ----
 
 ingest-external
@@ -292,19 +292,19 @@ reset
 ----
 
 build-remote f7 block-size=5 index-block-size=5
-b#0,SET = ignored
-c#0,SET = foo
-d#0,SET = haha
-e#0,SET = something
-x#0,SET = ignored
+b#0,SET:ignored
+c#0,SET:foo
+d#0,SET:haha
+e#0,SET:something
+x#0,SET:ignored
 ----
 
 build-remote f8 block-size=100 index-block-size=100
-a#0,SET = ignored
-g#0,SET = foo
-h#0,SET = foo
-i#0,SET = foo
-z#0,SET = ignored
+a#0,SET:ignored
+g#0,SET:foo
+h#0,SET:foo
+i#0,SET:foo
+z#0,SET:ignored
 ----
 
 ingest-external
@@ -375,7 +375,7 @@ reset
 ----
 
 build-remote f9
-i#0,SET = foo
+i#0,SET:foo
 ----
 
 ingest-external
@@ -402,9 +402,9 @@ reset
 ----
 
 build-remote ext
-a#0,SET = a
-b#0,SET = b
-c#0,SET = c
+a#0,SET:a
+b#0,SET:b
+c#0,SET:c
 ----
 
 ingest-external
@@ -458,8 +458,8 @@ reset
 ----
 
 build-remote f11
-a#0,SET = foo
-b#0,SET = bar
+a#0,SET:foo
+b#0,SET:bar
 ----
 
 ingest-external
@@ -498,10 +498,10 @@ reset
 ----
 
 build-remote f12
-a#0,SET = d1-v1
-b#0,SET = d1-v1
-c#0,SET = d1-v1
-d#0,SET = d-1v1
+a#0,SET:d1-v1
+b#0,SET:d1-v1
+c#0,SET:d1-v1
+d#0,SET:d-1v1
 ----
 
 ingest-external
@@ -566,8 +566,8 @@ L6:
   000005:[d#10,SET-e#11,SET]
 
 build-remote f13
-a#0,SET = d1-v1
-b#0,SET = d1-v1
+a#0,SET:d1-v1
+b#0,SET:d1-v1
 ----
 
 ingest-external
@@ -612,8 +612,8 @@ reset
 ----
 
 build-remote trunctest
-a#0,SET = foo
-b#0,SET = bar
+a#0,SET:foo
+b#0,SET:bar
 ----
 
 ingest-external
@@ -628,9 +628,9 @@ reset
 ----
 
 build-remote inclusive_bounds_test
-a#0,SET = foo
-b#0,SET = bar
-c#0,SET = baz
+a#0,SET:foo
+b#0,SET:bar
+c#0,SET:baz
 ----
 
 ingest-external
@@ -660,18 +660,18 @@ reset
 ----
 
 build-remote reuse1
-ax#0,SET = ax
-ay#0,SET = ay
-da#0,SET = da
-db#0,SET = db
-dc#0,SET = dc
-uv#0,SET = uv
+ax#0,SET:ax
+ay#0,SET:ay
+da#0,SET:da
+db#0,SET:db
+dc#0,SET:dc
+uv#0,SET:uv
 ----
 
 build-remote reuse2
-f#0,SET = f
-h#0,SET = h
-j#0,SET = j
+f#0,SET:f
+h#0,SET:h
+j#0,SET:j
 ----
 
 # Test reuse of backings within a single ingestion. We should see only two
@@ -762,8 +762,8 @@ reset
 ----
 
 build-remote reuse
-a@10#0,SET = a
-b@11#0,SET = b
+a@10#0,SET:a
+b@11#0,SET:b
 ----
 
 ingest-external
@@ -786,8 +786,8 @@ reset
 ----
 
 build-remote ext3
-aa@10#0,SET = a
-b@11#0,SET = b
+aa@10#0,SET:a
+b@11#0,SET:b
 ----
 
 ingest-external
@@ -838,8 +838,8 @@ reset
 ----
 
 build-remote ext
-a@10#0,SET = a
-b@11#0,SET = b
+a@10#0,SET:a
+b@11#0,SET:b
 ----
 
 ingest-external
@@ -918,10 +918,10 @@ reset
 ----
 
 build-remote points.sst
-a@1#0,SET = va
-b@1#0,SET = vb
-c@1#0,SET = vc
-d@1#0,SET = vc
+a@1#0,SET:va
+b@1#0,SET:vb
+c@1#0,SET:vc
+d@1#0,SET:vc
 ----
 
 build-remote ranges.sst
@@ -1004,10 +1004,10 @@ reset
 ----
 
 build-remote points-and-ranges.sst
-a@1#0,SET = va
-b@1#0,SET = vb
-c@1#0,SET = vc
-d@1#0,SET = vc
+a@1#0,SET:va
+b@1#0,SET:vb
+c@1#0,SET:vc
+d@1#0,SET:vc
 Span: b-c1:{(#0,RANGEKEYSET,@2,vrange)}
 ----
 


### PR DESCRIPTION
The vast majority of tests that specify a KV use the `key:value`
format. The parsing code also supports using a `=` separator and a
handful of tests use that format.

For the sake of consistency, remove this alternate format and fix up
the relevant tests.