### PR TITLE
*: use (*sync.WaitGroup).Go

### DIFF
--- a/cmd/pebble/fsbench.go
+++ b/cmd/pebble/fsbench.go
@@ -612,13 +612,10 @@ func (bench *fsBench) init(wg *sync.WaitGroup) {
 	fmt.Println("Running benchmark:", bench.name)
 	fmt.Println("Description:", bench.description)
 
-	wg.Add(1)
-	go bench.execute(wg)
+	wg.Go(bench.execute)
 }
 
-func (bench *fsBench) execute(wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (bench *fsBench) execute() {
 	latencyHist := bench.reg.Register(bench.name)
 
 	for {

--- a/cmd/pebble/queue.go
+++ b/cmd/pebble/queue.go
@@ -62,10 +62,7 @@ func queueTest() (test, *atomic.Int64) {
 			}
 
 			limiter := maxOpsPerSec.newRateLimiter()
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
+			wg.Go(func() {
 				for i := queueConfig.size; ; i++ {
 					idx := i % queueConfig.size
 
@@ -94,7 +91,7 @@ func queueTest() (test, *atomic.Int64) {
 					wait(limiter)
 					ops.Add(1)
 				}
-			}()
+			})
 		},
 		tick: func(elapsed time.Duration, i int) {
 			if i%20 == 0 {

--- a/cmd/pebble/scan.go
+++ b/cmd/pebble/scan.go
@@ -90,11 +90,8 @@ func runScan(cmd *cobra.Command, args []string) {
 
 			limiter := maxOpsPerSec.newRateLimiter()
 
-			wg.Add(concurrency)
-			for i := 0; i < concurrency; i++ {
-				go func(i int) {
-					defer wg.Done()
-
+			for i := range concurrency {
+				wg.Go(func() {
 					rng := rand.New(rand.NewPCG(0, uint64(i)))
 					startKeyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 					endKeyBuf := append(make([]byte, 0, 64), []byte("key-")...)
@@ -123,7 +120,7 @@ func runScan(cmd *cobra.Command, args []string) {
 						bytes.Add(nbytes)
 						scanned.Add(int64(count))
 					}
-				}(i)
+				})
 			}
 		},
 

--- a/cmd/pebble/write_bench.go
+++ b/cmd/pebble/write_bench.go
@@ -224,11 +224,7 @@ func runWriteBenchmark(_ *cobra.Command, args []string) error {
 			// take a material amount of time. Instead, pause the
 			// writers in parallel in the background, and wait for all
 			// to complete before continuing.
-			wg.Add(1)
-			go func(writer *pauseWriter) {
-				writer.pause()
-				wg.Done()
-			}(w)
+			wg.Go(func() { w.pause() })
 		}
 		wg.Wait()
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3412,9 +3412,7 @@ func TestCompactionCorruption(t *testing.T) {
 	startWorkload := func(minKey, maxKey byte) (stop func()) {
 		var shouldStop atomic.Bool
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			var valSeed [32]byte
 			for i := range valSeed {
 				valSeed[i] = byte(rand.Uint32())
@@ -3443,7 +3441,7 @@ func TestCompactionCorruption(t *testing.T) {
 					panic(err)
 				}
 			}
-		}()
+		})
 		return func() {
 			shouldStop.Store(true)
 			wg.Wait()

--- a/db_test.go
+++ b/db_test.go
@@ -1161,10 +1161,8 @@ func TestDBConcurrentCommitCompactFlush(t *testing.T) {
 	// those operations.
 	const n = 1000
 	var wg sync.WaitGroup
-	wg.Add(n)
-	for i := 0; i < n; i++ {
-		go func(i int) {
-			defer wg.Done()
+	for i := range n {
+		wg.Go(func() {
 			_ = d.Set([]byte(fmt.Sprint(i)), nil, nil)
 			var err error
 			switch i % 3 {
@@ -1176,7 +1174,7 @@ func TestDBConcurrentCommitCompactFlush(t *testing.T) {
 				_, err = d.AsyncFlush()
 			}
 			require.NoError(t, err)
-		}(i)
+		})
 	}
 	wg.Wait()
 
@@ -2495,12 +2493,10 @@ type parallel []orderingNode
 
 func (p parallel) visit(fn func(int)) {
 	var wg sync.WaitGroup
-	wg.Add(len(p))
 	for i := range p {
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			p[i].visit(fn)
-		}(i)
+		})
 	}
 	wg.Wait()
 }
@@ -2617,7 +2613,7 @@ func TestLoadBlockSema(t *testing.T) {
 	}
 
 	// Read all regions to warm up the file cache.
-	for i := 0; i < numRegions; i++ {
+	for i := range numRegions {
 		val, closer, err := db.Get(key(i, 1))
 		require.NoError(t, err)
 		require.Equal(t, []byte("value"), val)
@@ -2633,12 +2629,10 @@ func TestLoadBlockSema(t *testing.T) {
 			var wg sync.WaitGroup
 			// Spin up workers that perform random reads.
 			const numWorkers = 20
-			for i := 0; i < numWorkers; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+			for range numWorkers {
+				wg.Go(func() {
 					const numQueries = 100
-					for i := 0; i < numQueries; i++ {
+					for range numQueries {
 						val, closer, err := db.Get(key(rand.IntN(numRegions), rand.IntN(numKeys)))
 						require.NoError(t, err)
 						require.Equal(t, []byte("value"), val)
@@ -2647,7 +2641,7 @@ func TestLoadBlockSema(t *testing.T) {
 						}
 						runtime.Gosched()
 					}
-				}()
+				})
 			}
 			wg.Wait()
 			// Verify the maximum read count did not exceed the limit.

--- a/excise_test.go
+++ b/excise_test.go
@@ -761,11 +761,9 @@ func TestConcurrentExcise(t *testing.T) {
 					return err.Error()
 				}
 			} else {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					_ = runCompactCmd(t, &tdClone, d)
-				}()
+				})
 				<-bc.startBlock
 				return "spun off in separate goroutine"
 			}

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -205,32 +205,26 @@ func TestConcurrentBasic(t *testing.T) {
 			l.testing = true
 
 			var wg sync.WaitGroup
-			for i := 0; i < n; i++ {
-				wg.Add(1)
-				go func(i int) {
-					defer wg.Done()
-
+			for i := range n {
+				wg.Go(func() {
 					if inserter {
 						var ins Inserter
 						ins.Add(l, makeIntKey(i), makeValue(i))
 					} else {
 						l.Add(makeIntKey(i), makeValue(i))
 					}
-				}(i)
+				})
 			}
 			wg.Wait()
 
 			// Check values. Concurrent reads.
-			for i := 0; i < n; i++ {
-				wg.Add(1)
-				go func(i int) {
-					defer wg.Done()
-
+			for i := range n {
+				wg.Go(func() {
 					it := l.NewIter(nil, nil)
 					kv := it.SeekGE(makeKey(fmt.Sprintf("%05d", i)), base.SeekGEFlagsNone)
 					require.NotNil(t, kv)
 					require.EqualValues(t, fmt.Sprintf("%05d", i), kv.K.UserKey)
-				}(i)
+				})
 			}
 			wg.Wait()
 			require.Equal(t, n, length(l))
@@ -253,11 +247,9 @@ func TestConcurrentOneKey(t *testing.T) {
 
 			var wg sync.WaitGroup
 			writeDone := make(chan struct{}, 1)
-			for i := 0; i < n; i++ {
-				wg.Add(1)
-				go func(i int) {
+			for i := range n {
+				wg.Go(func() {
 					defer func() {
-						wg.Done()
 						select {
 						case writeDone <- struct{}{}:
 						default:
@@ -270,16 +262,13 @@ func TestConcurrentOneKey(t *testing.T) {
 					} else {
 						l.Add(ikey, makeValue(i))
 					}
-				}(i)
+				})
 			}
 			// Wait until at least some write made it such that reads return a value.
 			<-writeDone
 			var sawValue atomic.Int32
-			for i := 0; i < n; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-
+			for range n {
+				wg.Go(func() {
 					it := l.NewIter(nil, nil)
 					kv := it.SeekGE(key, base.SeekGEFlagsNone)
 					require.NotNil(t, kv)
@@ -289,7 +278,7 @@ func TestConcurrentOneKey(t *testing.T) {
 					v, err := strconv.Atoi(string(mustGetValue(t, kv.V)[1:]))
 					require.NoError(t, err)
 					require.True(t, 0 <= v && v < n)
-				}()
+				})
 			}
 			wg.Wait()
 			require.Equal(t, int32(n), sawValue.Load())

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -274,15 +274,13 @@ func TestCacheStressSetExisting(t *testing.T) {
 	defer h.Close()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			for j := 0; j < 10000; j++ {
+	for i := range 10 {
+		wg.Go(func() {
+			for range 10000 {
 				setTestValue(h, 0, uint64(i), "a", 1)
 				runtime.Gosched()
 			}
-		}(i)
+		})
 	}
 	wg.Wait()
 }

--- a/internal/cache/read_shard_test.go
+++ b/internal/cache/read_shard_test.go
@@ -266,7 +266,7 @@ func TestReadShardConcurrent(t *testing.T) {
 
 	var differentReaders []*testSyncReaders
 	// 50 blocks are read.
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		valLen := rand.Intn(100) + 1
 		val := make([]byte, valLen)
 		crand.Read(val)

--- a/internal/genericcache/cache_test.go
+++ b/internal/genericcache/cache_test.go
@@ -205,17 +205,15 @@ func TestErrorHandling(t *testing.T) {
 		*v = -1
 	}
 	c := New[intKey, int](20, 4, initFn, releaseFn)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	fail.Store(1)
 	var wg sync.WaitGroup
-	wg.Add(3)
-	for i := 0; i < 3; i++ {
-		go func() {
-			defer wg.Done()
+	for range 3 {
+		wg.Go(func() {
 			_, err := c.FindOrCreate(ctx, 1, struct{}{})
 			require.ErrorContains(t, err, "1")
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -472,13 +472,11 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 	toRemove := want[cloneTestSize/2:]
 	for i := 0; i < len(trees)/2; i++ {
 		tree := trees[i]
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			for _, item := range toRemove {
 				tree.Delete(item, ignoreObsoleteFiles{})
 			}
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -610,10 +610,8 @@ func TestMetricsWALBytesWrittenMonotonicity(t *testing.T) {
 	ks := testkeys.Alpha(3)
 	var wg sync.WaitGroup
 	const concurrentWriters = 5
-	wg.Add(concurrentWriters)
-	for w := 0; w < concurrentWriters; w++ {
-		go func() {
-			defer wg.Done()
+	for range concurrentWriters {
+		wg.Go(func() {
 			data := make([]byte, 1<<10) // 1 KiB
 			rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
 			for i := range data {
@@ -630,7 +628,7 @@ func TestMetricsWALBytesWrittenMonotonicity(t *testing.T) {
 				n := testkeys.WriteKey(buf, ks, uint64(i)%ks.Count())
 				require.NoError(t, d.Set(buf[:n], data, NoSync))
 			}
-		}()
+		})
 	}
 
 	func() {

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -222,15 +222,13 @@ func TestFlushDelayStress(t *testing.T) {
 		now := time.Now().UnixNano()
 		writers := runtime.GOMAXPROCS(0)
 		var wg sync.WaitGroup
-		wg.Add(writers)
-		for i := 0; i < writers; i++ {
+		for i := range writers {
 			rng := rand.New(rand.NewPCG(0, uint64(now)+uint64(i)))
-			go func() {
+			wg.Go(func() {
 				const ops = 100
-				defer wg.Done()
 
 				var k1, k2 [32]byte
-				for j := 0; j < ops; j++ {
+				for range ops {
 					switch rng.IntN(3) {
 					case 0:
 						randStr(k1[:], rng)
@@ -248,7 +246,7 @@ func TestFlushDelayStress(t *testing.T) {
 						panic("unreachable")
 					}
 				}
-			}()
+			})
 		}
 		wg.Wait()
 		time.Sleep(time.Duration(rng.IntN(10)+1) * time.Millisecond)

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -179,8 +179,7 @@ func NewFileWriter(fn base.DiskFileNum, w objstorage.Writable, opts FileWriterOp
 	fw.physBlockMaker.Init(opts.Compression, opts.ChecksumType, opts.CompressionCounters)
 	fw.cpuMeasurer = opts.CpuMeasurer
 	fw.writeQueue.ch = make(chan compressedBlock)
-	fw.writeQueue.wg.Add(1)
-	go fw.drainWriteQueue()
+	fw.writeQueue.wg.Go(fw.drainWriteQueue)
 	return fw
 }
 
@@ -280,7 +279,6 @@ func (w *FileWriter) flush() {
 // finished, compressed data blocks to the writable. It reads from w.writeQueue
 // until the channel is closed. All value blocks are written by this goroutine.
 func (w *FileWriter) drainWriteQueue() {
-	defer w.writeQueue.wg.Done()
 	// Call once to initialize the CPU measurer.
 	w.cpuMeasurer.MeasureCPU(base.CompactionGoroutineBlobFileSecondary)
 	for cb := range w.writeQueue.ch {

--- a/sstable/colblk/index_block_test.go
+++ b/sstable/colblk/index_block_test.go
@@ -152,15 +152,13 @@ func TestIndexIterInitHandle(t *testing.T) {
 
 	const workers = 8
 	var wg sync.WaitGroup
-	wg.Add(workers)
 	for w := 0; w < workers; w++ {
-		go func() {
+		wg.Go(func() {
 			var iter IndexIter
-			defer wg.Done()
 			for i := 0; i < 10; i++ {
 				getBlockAndIterate(&iter)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/sstable/colblk/keyspan_test.go
+++ b/sstable/colblk/keyspan_test.go
@@ -113,14 +113,12 @@ func TestKeyspanBlockPooling(t *testing.T) {
 
 	const workers = 8
 	var wg sync.WaitGroup
-	wg.Add(workers)
-	for w := 0; w < workers; w++ {
-		go func() {
-			defer wg.Done()
-			for i := 0; i < 10; i++ {
+	for range workers {
+		wg.Go(func() {
+			for range 10 {
 				getBlockAndIterate()
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -190,9 +190,8 @@ func newColumnarWriter(
 	w.props.MergerName = o.MergerName
 
 	w.writeQueue.ch = make(chan block.OwnedPhysicalBlock)
-	w.writeQueue.wg.Add(1)
 	w.cpuMeasurer = cpuMeasurer
-	go w.drainWriteQueue()
+	w.writeQueue.wg.Go(w.drainWriteQueue)
 
 	return w
 }
@@ -877,7 +876,6 @@ func (w *RawColumnWriter) flushBufferedIndexBlocks() (rootIndex block.Handle, er
 // until the channel is closed. All data blocks are written by this goroutine.
 // Other blocks are written directly by the client goroutine. See Close.
 func (w *RawColumnWriter) drainWriteQueue() {
-	defer w.writeQueue.wg.Done()
 	// Call once to initialize the CPU measurer.
 	w.cpuMeasurer.MeasureCPU(base.CompactionGoroutineSSTableSecondary)
 	for pb := range w.writeQueue.ch {

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -311,21 +311,17 @@ func TestLazyLoadingConcurrentAccess(t *testing.T) {
 	const numGoroutines = 10
 	const operationsPerGoroutine = 50
 
-	var wg sync.WaitGroup
 	errorCh := make(chan error, numGoroutines)
 
 	// Launch concurrent goroutines performing iterator operations
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(goroutineID int) {
-			defer wg.Done()
-
+	var wg sync.WaitGroup
+	for goroutineID := range numGoroutines {
+		wg.Go(func() {
 			if err := performConcurrentOps(reader, keys, operationsPerGoroutine, goroutineID); err != nil {
 				errorCh <- err
 			}
-		}(i)
+		})
 	}
-
 	wg.Wait()
 	close(errorCh)
 

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -1087,16 +1087,14 @@ func TestWriterRace(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 16; i++ {
-		wg.Add(1)
-		go func() {
+	for range 16 {
+		wg.Go(func() {
 			val := make([]byte, rand.IntN(1000))
 			opts := WriterOptions{
 				Comparer:    testkeys.Comparer,
 				BlockSize:   rand.IntN(1 << 10),
 				Compression: block.NoCompression,
 			}
-			defer wg.Done()
 			f := &objstorage.MemObj{}
 			w := newRowWriter(f, opts)
 			for ki := 0; ki < len(keys); ki++ {
@@ -1122,7 +1120,7 @@ func TestWriterRace(t *testing.T) {
 				require.Equal(t, vBytes, val)
 				ki++
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/vfs/disk_full_test.go
+++ b/vfs/disk_full_test.go
@@ -118,14 +118,12 @@ func TestOnDiskFull_Concurrent(t *testing.T) {
 	})
 
 	var wg sync.WaitGroup
-	wg.Add(concurrentWriters)
 	for range concurrentWriters {
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, err := fs.Create("foo", WriteCategoryUnspecified)
 			// They all should succeed on retry.
 			require.NoError(t, err)
-		}()
+		})
 	}
 	wg.Wait()
 	// Since all operations should start before the first one returns an

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -847,11 +847,7 @@ func newStopper() *stopper {
 }
 
 func (s *stopper) runAsync(f func()) {
-	s.wg.Add(1)
-	go func() {
-		f()
-		s.wg.Done()
-	}()
+	s.wg.Go(f)
 }
 
 // shouldQuiesce returns a channel which will be closed when stop() has been


### PR DESCRIPTION
Update uses of WaitGroup to use the new (Go 1.25+) Go method to prevent accidental misuse and simplify call sites.