### PR TITLE
wal: clean up tests, fix leaked goroutine

### DIFF
--- a/wal/reader_test.go
+++ b/wal/reader_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"unicode"
 
+	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/batchrepr"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -98,6 +99,8 @@ func TestList(t *testing.T) {
 // TestReader tests the virtual WAL reader that merges across multiple physical
 // log files.
 func TestReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	rng := rand.New(rand.NewPCG(1, 1))
 	var buf bytes.Buffer
 	var fs vfs.FS


### PR DESCRIPTION
The TestFailoverManager_AllFilesDeletable unit test was leaking a goroutine through failing to Close the FailoverManager. This commit fixes the test to Close the manager. It also adds leaktest across the package's unit tests and adapts one test to use synctest.Test to reduce its execution time.