### PR TITLE
arenaskl: optimize TrySeekUsingNext with skiplist tower traversal

### DIFF
--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -49,12 +49,9 @@ type node struct {
 	keySize    uint32
 	keyTrailer base.InternalKeyTrailer
 	valueSize  uint32
-
-	// Padding to align tower on an 8-byte boundary, so that 32-bit and 64-bit
-	// architectures use the same memory layout for node. Needed for tests which
-	// expect a certain struct size. The padding can be removed if we add or
-	// remove a field from the node.
-	_ [4]byte
+	// Height of this node's tower (1-based, so height 1 means only level 0 exists).
+	// This allows us to know which levels are valid for this node.
+	height uint32
 
 	// Most nodes do not need to use the full height of the tower, since the
 	// probability of each successive level decreases exponentially. Because
@@ -109,6 +106,7 @@ func newRawNode(arena *Arena, height uint32, keySize, valueSize uint32) (nd *nod
 	nd.keyOffset = nodeOffset + nodeSize
 	nd.keySize = keySize
 	nd.valueSize = valueSize
+	nd.height = height
 	return
 }
 


### PR DESCRIPTION
Previously, TrySeekUsingNext would perform up to 5 simple Next() operations
at level 0. If the target key wasn't found, all that work was abandoned and
the iterator fell back to a full seek from the top of the skiplist. This
wasted both the forward progress made and the information gained during those
Next operations.

The new implementation leverages the skiplist tower structure to make seeking
more efficient. Instead of advancing only at level 0, it attempts to climb to
higher levels when possible, allowing it to skip over many nodes efficiently.
When a node >= target is found at a higher level, it descends through
progressively lower levels to find the exact first node >= target at level 0.
This approach better utilizes the skiplist's hierarchical structure for
workloads with sequential access patterns.

The optimization shows a modest improvement in the SeekPrefixGE benchmark,
particularly as the skip distance between seeks increases. With `use-next=true`,
performance improves by up to 5.5% for larger skips (`skip=16`), while
shorter skips show smaller gains.

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/pebble/internal/arenaskl
cpu: Apple M2 Pro
                                       │ ./bench_master.txt │       ./bench_optimized.txt       │
                                       │       sec/op       │   sec/op     vs base              │
SeekPrefixGE/skip=1/use-next=false-12          180.8n ±  2%   186.8n ± 2%  +3.32% (p=0.015 n=6)
SeekPrefixGE/skip=1/use-next=true-12           88.26n ± 10%   89.05n ± 3%       ~ (p=0.699 n=6)
SeekPrefixGE/skip=2/use-next=false-12          183.0n ±  5%   184.9n ± 2%       ~ (p=1.000 n=6)
SeekPrefixGE/skip=2/use-next=true-12           94.73n ±  2%   93.31n ± 0%  -1.49% (p=0.002 n=6)
SeekPrefixGE/skip=4/use-next=false-12          175.9n ±  4%   178.1n ± 1%       ~ (p=0.065 n=6)
SeekPrefixGE/skip=4/use-next=true-12           114.5n ±  1%   111.0n ± 3%  -3.01% (p=0.006 n=6)
SeekPrefixGE/skip=8/use-next-false-12          177.2n ±  5%   177.6n ± 3%       ~ (p=0.615 n=6)
SeekPrefixGE/skip=8/use-next=true-12           219.1n ±  1%   216.4n ± 3%       ~ (p=0.485 n=6)
SeekPrefixGE/skip=16/use-next-false-12         180.2n ±  2%   179.2n ± 3%       ~ (p=0.288 n=6)
SeekPrefixGE/skip=16/use-next=true-12          208.3n ±  3%   196.8n ± 6%  -5.50% (p=0.009 n=6)
geomean                                        155.2n         154.4n       -0.53%

                                       │ ./bench_master.txt │       ./bench_optimized.txt        │
                                       │        B/op        │    B/op     vs base                │
SeekPrefixGE/skip=1/use-next=false-12            22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=1/use-next=true-12             22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=2/use-next=false-12            22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=2/use-next=true-12             22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=4/use-next=false-12            22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=4/use-next=true-12             22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=8/use-next-false-12            22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=8/use-next=true-12             22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=16/use-next-false-12           22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=16/use-next=true-12            22.00 ± 0%   22.00 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                          22.00        22.00       +0.00%
¹ all samples are equal

                                       │ ./bench_master.txt │       ./bench_optimized.txt        │
                                       │     allocs/op      │ allocs/op   vs base                │
SeekPrefixGE/skip=1/use-next=false-12            2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=1/use-next=true-12             2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=2/use-next=false-12            2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=2/use-next=true-12             2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=4/use-next=false-12            2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=4/use-next=true-12             2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=8/use-next-false-12            2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=8/use-next=true-12             2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=16/use-next-false-12           2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
SeekPrefixGE/skip=16/use-next=true-12            2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                          2.000        2.000       +0.00%
¹ all samples are equal
```

Fixes https://github.com/cockroachdb/pebble/issues/5358