### PR TITLE
db: add min latency tolerant size, garbage size to val sep struct

### DIFF
--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -93,6 +93,7 @@ func TestBlobRewrite(t *testing.T) {
 						inputBlobPhysicalFiles,
 						0, /* outputBlobReferenceDepth */
 						0, /* minimumSize */
+						0, /* minimum MVCC garbage size */
 					)
 					vs = pbr
 				case "write-new-blob-files":
@@ -106,6 +107,7 @@ func TestBlobRewrite(t *testing.T) {
 						},
 						blob.FileWriterOptions{},
 						minimumSize,
+						0, /* minimum MVCC garbage size */
 						valsep.WriteNewBlobFilesOptions{},
 					)
 					vs = newSep

--- a/compaction.go
+++ b/compaction.go
@@ -3486,6 +3486,7 @@ func (d *DB) compactAndWrite(
 			vSep.SetNextOutputConfig(valsep.ValueSeparationOutputConfig{
 				MinimumSize:                    spanPolicy.ValueStoragePolicy.OverrideBlobSeparationMinimumSize,
 				DisableValueSeparationBySuffix: spanPolicy.ValueStoragePolicy.DisableSeparationBySuffix,
+				MinimumMVCCGarbageSize:         spanPolicy.ValueStoragePolicy.MinimumMVCCGarbageSize,
 			})
 		}
 		objMeta, tw, err := d.newCompactionOutputTable(jobID, c, writerOpts)

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1543,6 +1543,15 @@ func runCompactionTest(
 						if size == 0 {
 							policy.ValueStoragePolicy.DisableBlobSeparation = true
 						}
+					case "minimum-mvcc-garbage-size":
+						if len(parts) != 2 {
+							td.Fatalf(t, "expected minimum-mvcc-garbage-size=<size>, got: %s", arg)
+						}
+						size, err := strconv.ParseUint(parts[1], 10, 64)
+						if err != nil {
+							td.Fatalf(t, "parsing minimum-mvcc-garbage-size: %s", err)
+						}
+						policy.ValueStoragePolicy.MinimumMVCCGarbageSize = int(size)
 					default:
 						td.Fatalf(t, "unknown span policy arg: %s", arg)
 					}

--- a/compaction_value_separation.go
+++ b/compaction_value_separation.go
@@ -48,6 +48,7 @@ func (d *DB) determineCompactionValueSeparation(
 			blobFileSet,
 			outputBlobReferenceDepth,
 			policy.MinimumSize,
+			policy.MinimumMVCCGarbageSize,
 		)
 	}
 
@@ -60,6 +61,7 @@ func (d *DB) determineCompactionValueSeparation(
 		},
 		d.makeBlobWriterOptions(c.outputLevel.level),
 		policy.MinimumSize,
+		policy.MinimumMVCCGarbageSize,
 		valsep.WriteNewBlobFilesOptions{
 			InputBlobPhysicalFiles: blobFileSet,
 			ShortAttrExtractor:     d.opts.Experimental.ShortAttributeExtractor,

--- a/data_test.go
+++ b/data_test.go
@@ -919,6 +919,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		valueSeparator.metas,
 		0, /* outputreference depth */
 		d.opts.Experimental.ValueSeparationPolicy().MinimumSize,
+		d.opts.Experimental.ValueSeparationPolicy().MinimumMVCCGarbageSize,
 	)
 
 	var mem *memTable
@@ -1847,6 +1848,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 						value = arg[i+1:]
 					}
 					policy.MinimumLatencyTolerantSize = 10
+					policy.MinimumMVCCGarbageSize = 1
 					var err error
 					switch name {
 					case "enabled", "disabled":
@@ -1858,6 +1860,11 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 						}
 					case "min-latency-tolerant-size":
 						policy.MinimumLatencyTolerantSize, err = strconv.Atoi(value)
+						if err != nil {
+							return err
+						}
+					case "min-mvcc-garbage-size":
+						policy.MinimumMVCCGarbageSize, err = strconv.Atoi(value)
 						if err != nil {
 							return err
 						}

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -636,6 +636,7 @@ func TestBlobCorruptionEvent(t *testing.T) {
 					Enabled:                    true,
 					MinimumSize:                1,
 					MinimumLatencyTolerantSize: 10,
+					MinimumMVCCGarbageSize:     10,
 					MaxBlobReferenceDepth:      10,
 				}
 			}

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -301,7 +301,8 @@ func (r *Runner) writeKeysToTable(
 		}
 
 		valueLen := kv.V.Len()
-		isLikelyMVCCGarbage := sstable.IsLikelyMVCCGarbage(kv.K.UserKey, prevKeyKind, kv.K.Kind(), valueLen, prefixEqual)
+		isLikelyMVCCGarbage := valueLen > valueSeparation.OutputConfig().MinimumMVCCGarbageSize &&
+			sstable.IsLikelyMVCCGarbage(kv.K.UserKey, prevKeyKind, kv.K.Kind(), valueLen, prefixEqual)
 		// Add the value to the sstable, possibly separating its value into a
 		// blob file. The ValueSeparation implementation is responsible for
 		// writing the KV to the sstable.

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1423,6 +1423,7 @@ func TestIteratorValueRetrievalProfile(t *testing.T) {
 			Enabled:                    true,
 			MinimumSize:                1,
 			MinimumLatencyTolerantSize: 10,
+			MinimumMVCCGarbageSize:     10,
 			MaxBlobReferenceDepth:      5,
 		}
 	}

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -314,6 +314,7 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 			Enabled:                    true,
 			MinimumSize:                5,
 			MinimumLatencyTolerantSize: 10,
+			MinimumMVCCGarbageSize:     10,
 			MaxBlobReferenceDepth:      3,
 			RewriteMinimumAge:          50 * time.Millisecond,
 			GarbageRatioLowPriority:    0.10, // 10% garbage
@@ -900,6 +901,7 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 			Enabled:                    true,
 			MinimumSize:                1 + rng.IntN(maxValueSize),
 			MinimumLatencyTolerantSize: 5 + rng.IntN(11),                                  // [5, 15] bytes
+			MinimumMVCCGarbageSize:     5 + rng.IntN(11),                                  // [5, 15] bytes
 			MaxBlobReferenceDepth:      2 + rng.IntN(9),                                   // 2-10
 			RewriteMinimumAge:          time.Duration(rng.IntN(90)+10) * time.Millisecond, // [10ms, 100ms)
 			GarbageRatioLowPriority:    lowPri,

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -272,6 +272,7 @@ func TestMetrics(t *testing.T) {
 				Enabled:                    true,
 				MinimumSize:                3,
 				MinimumLatencyTolerantSize: 10,
+				MinimumMVCCGarbageSize:     10,
 				MaxBlobReferenceDepth:      5,
 			}
 		}

--- a/options.go
+++ b/options.go
@@ -1239,6 +1239,13 @@ type ValueSeparationPolicy struct {
 	//
 	// MinimumLatencyTolerantSize must be > 0.
 	MinimumLatencyTolerantSize int
+	// MinimumMVCCGarbageSize specifies the minimum size of a value that can be
+	// separated into a blob file if said value is likely to be MVCC garbage.
+	// See sstable.IsLikelyMVCCGarbage for the exact criteria we use to
+	// determine whether a value is likely MVCC garbage.
+	//
+	// MinimumMVCCGarbageSize must be > 0.
+	MinimumMVCCGarbageSize int
 	// MaxBlobReferenceDepth limits the number of potentially overlapping (in
 	// the keyspace) blob files that can be referenced by a single sstable. If a
 	// compaction may produce an output sstable referencing more than this many
@@ -1306,7 +1313,10 @@ func (p SpanPolicy) String() string {
 		sb.WriteString("no-blob-value-separation,")
 	}
 	if p.ValueStoragePolicy.OverrideBlobSeparationMinimumSize > 0 {
-		sb.WriteString("override-value-separation-min-size")
+		sb.WriteString("override-value-separation-min-size,")
+	}
+	if p.ValueStoragePolicy.MinimumMVCCGarbageSize > 0 {
+		sb.WriteString("minimum-mvcc-garbage-size")
 	}
 	return strings.TrimSuffix(sb.String(), ",")
 }
@@ -1341,10 +1351,17 @@ type ValueStoragePolicyAdjustment struct {
 	// for value separation into a blob file. Note that value separation must
 	// be enabled globally for this to take effect.
 	OverrideBlobSeparationMinimumSize int
+
+	// MinimumMVCCGarbageSize, when non-zero, imposes a new minimum size required
+	// for value separation into a blob file only if the value is likely MVCC
+	// garbage. Note that value separation must be enabled globally for this to
+	// take effect.
+	MinimumMVCCGarbageSize int
 }
 
 func (vsp *ValueStoragePolicyAdjustment) ContainsOverrides() bool {
-	return vsp.OverrideBlobSeparationMinimumSize > 0 || vsp.DisableSeparationBySuffix
+	return vsp.OverrideBlobSeparationMinimumSize > 0 || vsp.DisableSeparationBySuffix ||
+		vsp.MinimumMVCCGarbageSize > 0
 }
 
 // ValueStorageLowReadLatency is the suggested ValueStoragePolicyAdjustment
@@ -1857,6 +1874,7 @@ func (o *Options) String() string {
 			fmt.Fprintf(&buf, "  enabled=%t\n", policy.Enabled)
 			fmt.Fprintf(&buf, "  minimum_size=%d\n", policy.MinimumSize)
 			fmt.Fprintf(&buf, "  minimum_latency_tolerant_size=%d\n", policy.MinimumLatencyTolerantSize)
+			fmt.Fprintf(&buf, "  minimum_mvcc_garbage_size=%d\n", policy.MinimumMVCCGarbageSize)
 			fmt.Fprintf(&buf, "  max_blob_reference_depth=%d\n", policy.MaxBlobReferenceDepth)
 			fmt.Fprintf(&buf, "  rewrite_minimum_age=%s\n", policy.RewriteMinimumAge)
 			fmt.Fprintf(&buf, "  garbage_ratio_low_priority=%.2f\n", policy.GarbageRatioLowPriority)
@@ -2311,6 +2329,10 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				var minimumLatencyTolerantSize int
 				minimumLatencyTolerantSize, err = strconv.Atoi(value)
 				valSepPolicy.MinimumLatencyTolerantSize = minimumLatencyTolerantSize
+			case "minimum_mvcc_garbage_size":
+				var minimumMVCCGarbageSize int
+				minimumMVCCGarbageSize, err = strconv.Atoi(value)
+				valSepPolicy.MinimumMVCCGarbageSize = minimumMVCCGarbageSize
 			case "max_blob_reference_depth":
 				valSepPolicy.MaxBlobReferenceDepth, err = strconv.Atoi(value)
 			case "rewrite_minimum_age":
@@ -2613,6 +2635,9 @@ func (o *Options) Validate() error {
 		}
 		if policy.MinimumLatencyTolerantSize <= 0 {
 			fmt.Fprintf(&buf, "ValueSeparationPolicy.MinimumLatencyTolerantSize (%d) must be > 0\n", policy.MinimumLatencyTolerantSize)
+		}
+		if policy.MinimumMVCCGarbageSize <= 0 {
+			fmt.Fprintf(&buf, "ValueSeparationPolicy.MinimumMVCCGarbageSize (%d) must be > 0\n", policy.MinimumMVCCGarbageSize)
 		}
 		if policy.MaxBlobReferenceDepth <= 0 {
 			fmt.Fprintf(&buf, "ValueSeparationPolicy.MaxBlobReferenceDepth (%d) must be > 0\n", policy.MaxBlobReferenceDepth)

--- a/options_test.go
+++ b/options_test.go
@@ -45,6 +45,7 @@ func (o *Options) randomizeForTesting(t testing.TB) {
 			Enabled:                    true,
 			MinimumSize:                1 << rand.IntN(10), // [1, 512]
 			MinimumLatencyTolerantSize: 5 + rand.IntN(11),  // [5, 15]
+			MinimumMVCCGarbageSize:     5 + rand.IntN(11),  // [5, 15]
 			MaxBlobReferenceDepth:      1 + rand.IntN(10),  // [1, 10]
 			// Constrain the rewrite minimum age to [0, 15s).
 			RewriteMinimumAge:        time.Duration(rand.IntN(15)) * time.Second,

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -353,6 +353,7 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 					Enabled:                    true,
 					MinimumSize:                3,
 					MinimumLatencyTolerantSize: 10,
+					MinimumMVCCGarbageSize:     10,
 					MaxBlobReferenceDepth:      5,
 					RewriteMinimumAge:          15 * time.Minute,
 				}

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -17,7 +17,7 @@ tree
        0      LOCK
      152      MANIFEST-000010
      250      MANIFEST-000013
-    2946      OPTIONS-000002
+    2977      OPTIONS-000002
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
@@ -32,7 +32,7 @@ tree
       11        000011.log
      687        000012.sst
      187        MANIFEST-000013
-    2946        OPTIONS-000002
+    2977        OPTIONS-000002
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013
 
@@ -93,6 +93,7 @@ cat build/OPTIONS-000002
   enabled=true
   minimum_size=3
   minimum_latency_tolerant_size=10
+  minimum_mvcc_garbage_size=10
   max_blob_reference_depth=5
   rewrite_minimum_age=15m0s
   garbage_ratio_low_priority=0.00

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -641,9 +641,17 @@ func (w *RawColumnWriter) evaluatePoint(
 	//
 	// We require:
 	//  . Value blocks to be enabled.
+	//	. The value to be sufficiently large. (Currently we simply require a
+	//	  non-zero length, so all non-empty values are eligible for storage
+	//	  out-of-band in a value block.)
 	//  . IsLikelyMVCCGarbage to be true; see comment for MVCC garbage criteria.
+	//
+	// Use of 0 here is somewhat arbitrary. Given the minimum 3 byte encoding of
+	// valueHandle, this should be > 3. But tiny values are common in test and
+	// unlikely in production, so we use 0 here for better test coverage.
 	useValueBlock := !w.opts.DisableValueBlocks &&
 		w.valueBlock != nil &&
+		valueLen > 0 &&
 		IsLikelyMVCCGarbage(key.UserKey, prevKeyKind, keyKind, valueLen, prefixEqual)
 	if !useValueBlock {
 		return eval, nil
@@ -1285,26 +1293,17 @@ func (w *RawColumnWriter) SetValueSeparationProps(
 //
 //	. The previous key to be a SET/SETWITHDEL.
 //	. The current key to be a SET/SETWITHDEL.
-//	. The value to be sufficiently large. (Currently we simply require a
-//	  non-zero length, so all non-empty values are eligible for storage
-//	  out-of-band in a value block.)
 //	. The current key to have the same prefix as the previous key.
-//
-// Use of 0 here is somewhat arbitrary. Given the minimum 3 byte encoding of
-// valueHandle, this should be > 3. But tiny values are common in test and
-// unlikely in production, so we use 0 here for better test coverage.
 func IsLikelyMVCCGarbage(
 	k []byte,
 	prevKeyKind, keyKind base.InternalKeyKind,
 	valueLen int,
 	prefixEqual func(k []byte) bool,
 ) bool {
-	const tinyValueThreshold = 0
 	isSetStarKind := func(k base.InternalKeyKind) bool {
 		return k == InternalKeyKindSet || k == InternalKeyKindSetWithDelete
 	}
 	return isSetStarKind(prevKeyKind) &&
 		isSetStarKind(keyKind) &&
-		valueLen > tinyValueThreshold &&
 		prefixEqual(k)
 }

--- a/testdata/compaction/mvcc_garbage_blob
+++ b/testdata/compaction/mvcc_garbage_blob
@@ -223,3 +223,22 @@ rocksdb.property.collectors: [obsolete-key]
 rocksdb.compression: Snappy
 pebble.compression_stats: None:188
 obsolete-key: hex:00
+
+define value-separation=(enabled, min-size=5, max-ref-depth=3, garbage-ratios=1.0:1.0, min-mvcc-garbage-size=5)
+----
+
+batch
+set yay@3 a
+set yay@2 ab
+set zoo@4 b
+set zoo@3 ba
+del zoo@2
+set zoo@2 bag
+set zoo@1 bah
+----
+
+# This flush should *not* write any blob files because the values are too small.
+flush
+----
+L0.0:
+  000005:[yay@3#10,SET-zoo@1#16,SET] seqnums:[10-16] points:[yay@3#10,SET-zoo@1#16,SET] size:870

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -236,7 +236,7 @@ Iter category stats:
 
 disk-usage
 ----
-3,688B
+3,719B
 
 batch
 set b 2
@@ -365,7 +365,7 @@ Iter category stats:
 
 disk-usage
 ----
-5,921B
+5,952B
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -584,7 +584,7 @@ Iter category stats:
 
 disk-usage
 ----
-5,234B
+5,265B
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -695,7 +695,7 @@ Iter category stats:
 
 disk-usage
 ----
-4,547B
+4,578B
 
 additional-metrics
 ----
@@ -2600,7 +2600,7 @@ Blob files:
 
 disk-usage
 ----
-7,609B
+7,640B
 
 init reopen
 ----
@@ -2608,4 +2608,4 @@ init reopen
 # The disk usage is expected to go down a bit because we remove the WALs.
 disk-usage
 ----
-7,092B
+7,123B

--- a/valsep/value_separation.go
+++ b/valsep/value_separation.go
@@ -24,6 +24,12 @@ type ValueSeparationOutputConfig struct {
 	// KV suffix when separating values (e.g. for MVCC garbage). See
 	// pebble.ValueStoragePolicyAdjustment for details.
 	DisableValueSeparationBySuffix bool
+	// MinimumMVCCGarbageSize imposes a new minimum size required for value
+	// separation into a blob file only if the value is likely MVCC garbage.
+	// See sstable.IsLikelyMVCCGarbage for the exact criteria we use to
+	// determine whether a value is likely MVCC garbage. If 0, all MVCC garbage
+	// values are separated.
+	MinimumMVCCGarbageSize int
 }
 
 // ValueSeparation defines an interface for writing some values to separate blob

--- a/valsep/value_separation_test.go
+++ b/valsep/value_separation_test.go
@@ -87,6 +87,7 @@ func TestValueSeparationPolicy(t *testing.T) {
 						inputBlobPhysicalFiles, /* blob file set */
 						manifest.BlobReferenceDepth(0),
 						0, /* minimum size */
+						0, /* minimum MVCC garbage size */
 					)
 					vs = pbr
 				case "write-new-blob-files":
@@ -109,6 +110,7 @@ func TestValueSeparationPolicy(t *testing.T) {
 						},
 						blob.FileWriterOptions{},
 						minimumSize,
+						0, /* minimum MVCC garbage size */
 						WriteNewBlobFilesOptions{
 							ShortAttrExtractor: shortAttrExtractor,
 							InvalidValueCallback: func(userKey []byte, value []byte, err error) {


### PR DESCRIPTION
### db: add MinimumLatencyTolerantSize to ValueSeparationPolicy struct

This patch adds a globally configurable MinimumLatencyTolerant size
to the ValueSeparationPolicy struct.

Informs: https://github.com/cockroachdb/pebble/issues/5377

### db: add MinimumMVCCGarbageSize to ValueSeparationPolicy struct

This patch adds a globally configurable MinimumMVCCGarbageSize to our
ValueSeparationPolicy, along with some modifications around
ValueStoragePolicyAdjustment that allows our setting to be persisted
via a span policy.

Fixes: https://github.com/cockroachdb/pebble/issues/5377