### PR TITLE
bytesprofile: bump stack depth

### DIFF
--- a/internal/bytesprofile/bytesprofile.go
+++ b/internal/bytesprofile/bytesprofile.go
@@ -28,7 +28,7 @@ func NewProfile() *Profile {
 	return &Profile{samples: make(map[stack]aggSamples)}
 }
 
-type stack [20]uintptr
+type stack [30]uintptr
 
 // trimmed returns the non-zero stack frames of stack.
 func (s stack) trimmed() []uintptr {


### PR DESCRIPTION
Bump the maximum stack depth sampled from 20 frames to 30. We've observed that we could use more depth in Cockroach stack traces, as we're unable to see where a batch evaluation originated even if it's run on the same node.