### PR TITLE
Revert "db: add MinimumLatencyTolerantSize to ValueSeparationPolicy s…

### DIFF
--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -633,11 +633,10 @@ func TestBlobCorruptionEvent(t *testing.T) {
 			}
 			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return ValueSeparationPolicy{
-					Enabled:                    true,
-					MinimumSize:                1,
-					MinimumLatencyTolerantSize: 10,
-					MinimumMVCCGarbageSize:     10,
-					MaxBlobReferenceDepth:      10,
+					Enabled:                true,
+					MinimumSize:            1,
+					MinimumMVCCGarbageSize: 10,
+					MaxBlobReferenceDepth:  10,
 				}
 			}
 			d, err := Open("", opts)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1420,11 +1420,10 @@ func TestIteratorValueRetrievalProfile(t *testing.T) {
 	opts.FormatMajorVersion = internalFormatNewest
 	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
-			Enabled:                    true,
-			MinimumSize:                1,
-			MinimumLatencyTolerantSize: 10,
-			MinimumMVCCGarbageSize:     10,
-			MaxBlobReferenceDepth:      5,
+			Enabled:                true,
+			MinimumSize:            1,
+			MinimumMVCCGarbageSize: 10,
+			MaxBlobReferenceDepth:  5,
 		}
 	}
 	d := newTestkeysDatabase(t, opts, testkeys.Alpha(2), rand.New(rand.NewPCG(1, 1)))

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -311,14 +311,13 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 
 	opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 		return pebble.ValueSeparationPolicy{
-			Enabled:                    true,
-			MinimumSize:                5,
-			MinimumLatencyTolerantSize: 10,
-			MinimumMVCCGarbageSize:     10,
-			MaxBlobReferenceDepth:      3,
-			RewriteMinimumAge:          50 * time.Millisecond,
-			GarbageRatioLowPriority:    0.10, // 10% garbage
-			GarbageRatioHighPriority:   0.30, // 30% garbage
+			Enabled:                  true,
+			MinimumSize:              5,
+			MinimumMVCCGarbageSize:   10,
+			MaxBlobReferenceDepth:    3,
+			RewriteMinimumAge:        50 * time.Millisecond,
+			GarbageRatioLowPriority:  0.10, // 10% garbage
+			GarbageRatioHighPriority: 0.30, // 30% garbage
 		}
 	}
 
@@ -898,14 +897,13 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 		}
 		lowPri := max(rng.Float64(), 0.05)
 		policy := pebble.ValueSeparationPolicy{
-			Enabled:                    true,
-			MinimumSize:                1 + rng.IntN(maxValueSize),
-			MinimumLatencyTolerantSize: 5 + rng.IntN(11),                                  // [5, 15] bytes
-			MinimumMVCCGarbageSize:     5 + rng.IntN(11),                                  // [5, 15] bytes
-			MaxBlobReferenceDepth:      2 + rng.IntN(9),                                   // 2-10
-			RewriteMinimumAge:          time.Duration(rng.IntN(90)+10) * time.Millisecond, // [10ms, 100ms)
-			GarbageRatioLowPriority:    lowPri,
-			GarbageRatioHighPriority:   lowPri + rand.Float64()*(1.0-lowPri), // [lowPri, 1.0)
+			Enabled:                  true,
+			MinimumSize:              1 + rng.IntN(maxValueSize),
+			MinimumMVCCGarbageSize:   5 + rng.IntN(11),                                  // [5, 15] bytes
+			MaxBlobReferenceDepth:    2 + rng.IntN(9),                                   // 2-10
+			RewriteMinimumAge:        time.Duration(rng.IntN(90)+10) * time.Millisecond, // [10ms, 100ms)
+			GarbageRatioLowPriority:  lowPri,
+			GarbageRatioHighPriority: lowPri + rand.Float64()*(1.0-lowPri), // [lowPri, 1.0)
 		}
 		opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 			return policy

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -269,11 +269,10 @@ func TestMetrics(t *testing.T) {
 		opts.Experimental.EnableValueBlocks = func() bool { return true }
 		opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
 			return ValueSeparationPolicy{
-				Enabled:                    true,
-				MinimumSize:                3,
-				MinimumLatencyTolerantSize: 10,
-				MinimumMVCCGarbageSize:     10,
-				MaxBlobReferenceDepth:      5,
+				Enabled:                true,
+				MinimumSize:            3,
+				MinimumMVCCGarbageSize: 10,
+				MaxBlobReferenceDepth:  5,
 			}
 		}
 		opts.TargetFileSizes[0] = 50

--- a/options_test.go
+++ b/options_test.go
@@ -42,11 +42,10 @@ func (o *Options) randomizeForTesting(t testing.TB) {
 	if o.FormatMajorVersion >= FormatValueSeparation && o.Experimental.ValueSeparationPolicy == nil && rand.Int64N(4) > 0 {
 		lowPri := 0.1 + rand.Float64()*0.9 // [0.1, 1.0)
 		policy := ValueSeparationPolicy{
-			Enabled:                    true,
-			MinimumSize:                1 << rand.IntN(10), // [1, 512]
-			MinimumLatencyTolerantSize: 5 + rand.IntN(11),  // [5, 15]
-			MinimumMVCCGarbageSize:     5 + rand.IntN(11),  // [5, 15]
-			MaxBlobReferenceDepth:      1 + rand.IntN(10),  // [1, 10]
+			Enabled:                true,
+			MinimumSize:            1 << rand.IntN(10), // [1, 512]
+			MinimumMVCCGarbageSize: 5 + rand.IntN(11),  // [5, 15]
+			MaxBlobReferenceDepth:  1 + rand.IntN(10),  // [1, 10]
 			// Constrain the rewrite minimum age to [0, 15s).
 			RewriteMinimumAge:        time.Duration(rand.IntN(15)) * time.Second,
 			GarbageRatioLowPriority:  lowPri,
@@ -660,9 +659,7 @@ func TestStaticSpanPolicyFunc(t *testing.T) {
 			case "lowlatency":
 				sap.Policy.ValueStoragePolicy = ValueStorageLowReadLatency
 			case "latencytolerant":
-				sap.Policy.ValueStoragePolicy = ValueStoragePolicyAdjustment{
-					OverrideBlobSeparationMinimumSize: 10,
-				}
+				sap.Policy.ValueStoragePolicy = ValueStorageLatencyTolerant
 			default:
 				t.Fatalf("unknown policy: %s", tok)
 			}

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -350,12 +350,11 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 			}
 			opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 				return pebble.ValueSeparationPolicy{
-					Enabled:                    true,
-					MinimumSize:                3,
-					MinimumLatencyTolerantSize: 10,
-					MinimumMVCCGarbageSize:     10,
-					MaxBlobReferenceDepth:      5,
-					RewriteMinimumAge:          15 * time.Minute,
+					Enabled:                true,
+					MinimumSize:            3,
+					MinimumMVCCGarbageSize: 10,
+					MaxBlobReferenceDepth:  5,
+					RewriteMinimumAge:      15 * time.Minute,
 				}
 			}
 			setDefaultExperimentalOpts(opts)

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -17,7 +17,7 @@ tree
        0      LOCK
      152      MANIFEST-000010
      250      MANIFEST-000013
-    2977      OPTIONS-000002
+    2942      OPTIONS-000002
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
@@ -32,7 +32,7 @@ tree
       11        000011.log
      687        000012.sst
      187        MANIFEST-000013
-    2977        OPTIONS-000002
+    2942        OPTIONS-000002
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013
 
@@ -92,7 +92,6 @@ cat build/OPTIONS-000002
 [Value Separation]
   enabled=true
   minimum_size=3
-  minimum_latency_tolerant_size=10
   minimum_mvcc_garbage_size=10
   max_blob_reference_depth=5
   rewrite_minimum_age=15m0s

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -236,7 +236,7 @@ Iter category stats:
 
 disk-usage
 ----
-3,719B
+3,684B
 
 batch
 set b 2
@@ -365,7 +365,7 @@ Iter category stats:
 
 disk-usage
 ----
-5,952B
+5,917B
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -584,7 +584,7 @@ Iter category stats:
 
 disk-usage
 ----
-5,265B
+5,230B
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -695,7 +695,7 @@ Iter category stats:
 
 disk-usage
 ----
-4,578B
+4,543B
 
 additional-metrics
 ----
@@ -2600,7 +2600,7 @@ Blob files:
 
 disk-usage
 ----
-7,640B
+7,605B
 
 init reopen
 ----
@@ -2608,4 +2608,4 @@ init reopen
 # The disk usage is expected to go down a bit because we remove the WALs.
 disk-usage
 ----
-7,123B
+7,088B


### PR DESCRIPTION
…truct"

This reverts commit d5052bfb553e0cb39eba123773a0f720988e7ce0.

We can actually just make this configurable on the cockroach side via a cluster setting/through the span policy.