### PR TITLE
cmd/pebble: ensure minimum mvcc is set for newPebbleDB

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -83,6 +83,7 @@ func newPebbleDB(dir string) DB {
 		return pebble.ValueSeparationPolicy{
 			Enabled:                  true,
 			MinimumSize:              512,
+			MinimumMVCCGarbageSize:   32,
 			MaxBlobReferenceDepth:    10,
 			RewriteMinimumAge:        5 * time.Minute,
 			GarbageRatioLowPriority:  0.10, // 10% garbage


### PR DESCRIPTION
This patch ensures that pebble commands that ultimately call `newPebbleDB` get their MinimumMCCGarbageSize set.