### PR TITLE
pebble-release-2.1: feat: add pebblegozstd build tag to allow to configure zstdlib

### DIFF
--- a/internal/compression/zstd_cgo.go
+++ b/internal/compression/zstd_cgo.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build cgo
+//go:build cgo && !pebblegozstd
 
 package compression
 

--- a/internal/compression/zstd_nocgo.go
+++ b/internal/compression/zstd_nocgo.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build !cgo
+//go:build !cgo || pebblegozstd
 
 package compression
 


### PR DESCRIPTION
Add a build tag that lets developers choose the zstd library. The current cgo implementation dramatically slows down builds and tests, and it blocks non‑cgo projects from running tests with the race detector unless they also switch the underlying library.