### PR TITLE
pebble-release-2.0: block: add pebblegozstd build tag to allow to configure zstd lib

### DIFF
--- a/sstable/block/compression_cgo.go
+++ b/sstable/block/compression_cgo.go
@@ -2,8 +2,8 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build cgo
-// +build cgo
+//go:build cgo && !pebblegozstd
+// +build cgo,!pebblegozstd
 
 package block
 

--- a/sstable/block/compression_nocgo.go
+++ b/sstable/block/compression_nocgo.go
@@ -2,8 +2,8 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-//go:build !cgo
-// +build !cgo
+//go:build !cgo || pebblegozstd
+// +build !cgo pebblegozstd
 
 package block
 


### PR DESCRIPTION
Add a build tag that lets developers choose the zstd library. The current cgo implementation dramatically slows down builds and tests, and it blocks non‑cgo projects from running tests with the race detector unless they also switch the underlying library.