### PR TITLE
github: remove labeled type from pr bot review triggering condition

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -2,7 +2,7 @@ name: Claude Code PR Review
 
 on:
   pull_request_target:
-    types: [synchronize, ready_for_review, reopened, labeled]
+    types: [synchronize, ready_for_review, reopened]
 
 jobs:
   claude-code-pr-review:


### PR DESCRIPTION
The `labeled` condition was required when the triggering is off by default so that we can trigger the review by hand. Now that we are in opt-out mode, this condition should be removed to avoid unnecessary runs.