### PR TITLE
db: export SpanPolicy and ValueStoragePolicyAdjustment as public type aliases

### DIFF
--- a/options.go
+++ b/options.go
@@ -44,6 +44,11 @@ const (
 	defaultVirtualTableUnreferencedFraction = 0.3
 )
 
+// Type aliases for types moved to internal/base package.
+// These provide public access to internal types needed by external users.
+type SpanPolicy = base.SpanPolicy
+type ValueStoragePolicyAdjustment = base.ValueStoragePolicyAdjustment
+
 // FilterType exports the base.FilterType type.
 type FilterType = base.FilterType
 


### PR DESCRIPTION
These types were moved to internal/base but are needed by external users like CockroachDB. Add public type aliases to maintain API compatibility.