### PR TITLE
sstable: clean up logic for copying filter blocks

### DIFF
--- a/sstable/copier.go
+++ b/sstable/copier.go
@@ -7,7 +7,6 @@ package sstable
 import (
 	"context"
 	"slices"
-	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -100,37 +99,24 @@ func CopySpan(
 		return 0, errors.Wrap(err, "reading properties")
 	}
 
-	// Copy the filter block if it exists. We iterate over the metaindex to find
-	// the appropriate filter block so that we copy the filter block even if the
-	// reader wasn't configured with the same filter policy.
-	var filterBlockHandle block.Handle
-	var filterBlockName string
-	for name, bh := range metaIndex {
-		if !strings.HasPrefix(name, "fullfilter.") {
-			continue
+	// Copy the filter block if it exists. Note that we don't rely on the reader
+	// having been configured with a matching filter decoder.
+	if props.FilterPolicyName != "" {
+		bh, ok := metaIndex[filterPolicyToBlockName(props.FilterPolicyName)]
+		if !ok {
+			return 0, errors.Newf("table has filter policy %q but no corresponding filter block", props.FilterPolicyName)
 		}
-		filterBlockHandle = bh
-		filterBlockName = name
-		break
-	}
-	if filterBlockName != "" {
-		err = func() error {
-			filterBlock, err := r.readFilterBlock(ctx, block.NoReadEnv, rh, filterBlockHandle)
-			if err != nil {
-				return errors.Wrap(err, "reading filter")
-			}
-			defer filterBlock.Release()
-
-			w.setFilter(copyFilterWriter{
-				origMetaName:   filterBlockName,
-				origPolicyName: props.FilterPolicyName,
-				data:           slices.Clone(filterBlock.BlockData()),
-			})
-			return nil
-		}()
+		filterBlock, err := r.readFilterBlock(ctx, block.NoReadEnv, rh, bh)
 		if err != nil {
-			return 0, err
+			return 0, errors.Wrap(err, "reading filter")
 		}
+		filterData := slices.Clone(filterBlock.BlockData())
+		filterBlock.Release()
+
+		w.setFilter(copyFilterWriter{
+			origPolicyName: props.FilterPolicyName,
+			data:           filterData,
+		})
 	}
 
 	indexH, err := r.readTopLevelIndexBlock(ctx, block.NoReadEnv, rh)

--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -39,7 +39,6 @@ func (m *FilterMetricsTracker) Load() FilterMetrics {
 type filterWriter interface {
 	addKey(key []byte)
 	finish() ([]byte, error)
-	metaName() string
 	policyName() string
 }
 
@@ -91,10 +90,6 @@ func (f *tableFilterWriter) finish() ([]byte, error) {
 		return nil, nil
 	}
 	return f.writer.Finish(nil), nil
-}
-
-func (f *tableFilterWriter) metaName() string {
-	return "fullfilter." + f.policy.Name()
 }
 
 func (f *tableFilterWriter) policyName() string {

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/cockroachdb/errors"
@@ -540,7 +539,7 @@ func (r *Reader) initMetaindexBlocks(
 	}
 
 	for name, fp := range filters {
-		if bh, ok := meta["fullfilter."+name]; ok {
+		if bh, ok := meta[filterPolicyToBlockName(name)]; ok {
 			r.filterBH = bh
 			r.tableFilter = newTableFilterReader(fp, r.filterMetricsTracker)
 			break
@@ -636,7 +635,7 @@ func (r *Reader) Layout() (*Layout, error) {
 		return nil, err
 	}
 	for name, bh := range meta {
-		if strings.HasPrefix(name, "fullfilter.") {
+		if _, ok := filterPolicyFromBlockName(name); ok {
 			l.Filter = append(l.Filter, NamedBlockHandle{Name: name, Handle: bh})
 		}
 	}

--- a/sstable/testdata/rewriter_v5
+++ b/sstable/testdata/rewriter_v5
@@ -6,7 +6,7 @@ c@xyz#1,SET:c
 point:    [a@xyz#1,SET-c@xyz#1,SET]
 seqnums:  [1-1]
 
-rewrite from=@xyz to=@123 block-size=1 index-block-size=1 filter comparer=split-4b-suffix
+rewrite from=@xyz to=@123 block-size=1 index-block-size=1 comparer=split-4b-suffix
 ----
 rewrite failed: mismatched Comparer pebble.internal.testkeys vs comparer-split-4b-suffix, replacement requires same splitter to copy filters
 
@@ -18,11 +18,11 @@ ca@xyz#1,SET:c
 point:    [aa@xyz#1,SET-ca@xyz#1,SET]
 seqnums:  [1-1]
 
-rewrite from=yz to=23 block-size=1 index-block-size=1 filter
+rewrite from=yz to=23 block-size=1 index-block-size=1
 ----
 rewrite failed: rewriting data blocks: key aa@xyz#1,SET has suffix 0x4078797a; require 0x797a
 
-rewrite from=a@xyz to=a@123 block-size=1 index-block-size=1 filter
+rewrite from=a@xyz to=a@123 block-size=1 index-block-size=1
 ----
 rewrite failed: rewriting data blocks: key aa@xyz#1,SET has suffix 0x4078797a; require 0x614078797a
 
@@ -64,7 +64,7 @@ b
 get f@0: pebble: not found
 c
 
-rewrite from=@0 to=@123 block-size=1 index-block-size=1 filter
+rewrite from=@0 to=@123 block-size=1 index-block-size=1
 ----
 point:    [a@123#1,SET-c@123#1,SET]
 seqnums:  [1-1]
@@ -99,7 +99,7 @@ b
 get f@123: pebble: not found
 c
 
-rewrite from=@123 to=@456 block-size=1 index-block-size=1 filter concurrency=2
+rewrite from=@123 to=@456 block-size=1 index-block-size=1 concurrency=2
 ----
 point:    [a@456#1,SET-c@456#1,SET]
 seqnums:  [1-1]
@@ -134,7 +134,7 @@ b
 get f@456: pebble: not found
 c
 
-rewrite from=@456 to=@123 block-size=1 index-block-size=1 filter concurrency=3
+rewrite from=@456 to=@123 block-size=1 index-block-size=1 concurrency=3
 ----
 point:    [a@123#1,SET-c@123#1,SET]
 seqnums:  [1-1]
@@ -170,7 +170,7 @@ get f@123: pebble: not found
 c
 
 
-rewrite from=@123 to=@0 block-size=1 index-block-size=1 filter concurrency=4
+rewrite from=@123 to=@0 block-size=1 index-block-size=1 concurrency=4
 ----
 point:    [a@0#1,SET-c@0#1,SET]
 seqnums:  [1-1]
@@ -221,7 +221,7 @@ a-b:{(#1,RANGEKEYSET,@0)}
 b-c:{(#1,RANGEKEYSET,@0)}
 c-d:{(#1,RANGEKEYSET,@0)}
 
-rewrite from=@0 to=@123 block-size=1 index-block-size=1 filter
+rewrite from=@0 to=@123 block-size=1 index-block-size=1
 ----
 rangekey: [a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 seqnums:  [1-1]
@@ -240,7 +240,7 @@ c#1,SET:c
 point:    [a#1,SET-c#1,SET]
 seqnums:  [1-1]
 
-rewrite from= to=@123 block-size=1 index-block-size=1 filter
+rewrite from= to=@123 block-size=1 index-block-size=1
 ----
 point:    [a@123#1,SET-c@123#1,SET]
 seqnums:  [1-1]

--- a/sstable/testdata/rewriter_v6
+++ b/sstable/testdata/rewriter_v6
@@ -18,7 +18,7 @@ ca@xyz#1,SET:c
 point:    [aa@xyz#1,SET-ca@xyz#1,SET]
 seqnums:  [1-1]
 
-rewrite from=yz to=23 block-size=1 index-block-size=1 filter
+rewrite from=yz to=23 block-size=1 index-block-size=1
 ----
 rewrite failed: rewriting data blocks: key aa@xyz#1,SET has suffix 0x4078797a; require 0x797a
 
@@ -64,7 +64,7 @@ b
 get f@0: pebble: not found
 c
 
-rewrite from=@0 to=@123 block-size=1 index-block-size=1 filter
+rewrite from=@0 to=@123 block-size=1 index-block-size=1
 ----
 point:    [a@123#1,SET-c@123#1,SET]
 seqnums:  [1-1]
@@ -134,7 +134,7 @@ b
 get f@456: pebble: not found
 c
 
-rewrite from=@456 to=@123 block-size=1 index-block-size=1 filter concurrency=3
+rewrite from=@456 to=@123 block-size=1 index-block-size=1 concurrency=3
 ----
 point:    [a@123#1,SET-c@123#1,SET]
 seqnums:  [1-1]

--- a/sstable/testdata/rewriter_v7
+++ b/sstable/testdata/rewriter_v7
@@ -18,7 +18,7 @@ ca@xyz#1,SET:c
 point:    [aa@xyz#1,SET-ca@xyz#1,SET]
 seqnums:  [1-1]
 
-rewrite from=yz to=23 block-size=1 index-block-size=1 filter
+rewrite from=yz to=23 block-size=1 index-block-size=1
 ----
 rewrite failed: rewriting data blocks: key aa@xyz#1,SET has suffix 0x4078797a; require 0x797a
 
@@ -99,7 +99,7 @@ b
 get f@123: pebble: not found
 c
 
-rewrite from=@123 to=@456 block-size=1 index-block-size=1 filter concurrency=2
+rewrite from=@123 to=@456 block-size=1 index-block-size=1 concurrency=2
 ----
 point:    [a@456#1,SET-c@456#1,SET]
 seqnums:  [1-1]
@@ -170,7 +170,7 @@ get f@123: pebble: not found
 c
 
 
-rewrite from=@123 to=@0 block-size=1 index-block-size=1 filter concurrency=4
+rewrite from=@123 to=@0 block-size=1 index-block-size=1 concurrency=4
 ----
 point:    [a@0#1,SET-c@0#1,SET]
 seqnums:  [1-1]


### PR DESCRIPTION
The current logic for copying filter blocks when rewriting suffixes
relies on the `WriterOptions` having a matching filter policy. This is
unnecessary and makes it harder to add more complex filter builders
(which might decide the family dynamically).

The new code simply copies over whatever filter exists, deducing the
filter policy name from the filter block name (similar to how
`CopySpan()` does it).

In `TestRewriter`, the `filter` argument to `rewrite` no longer
matters; we remove it for some of the testcases to ensure the output
remains unchanged.