### PR TITLE
manual: use sync.Pool to help the GC when CGo is off

### DIFF
--- a/internal/manual/manual_nocgo.go
+++ b/internal/manual/manual_nocgo.go
@@ -7,6 +7,8 @@
 package manual
 
 import (
+	"math/bits"
+	"sync"
 	"unsafe"
 
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -21,9 +23,8 @@ func New(purpose Purpose, n uintptr) Buf {
 		return Buf{}
 	}
 	recordAlloc(purpose, n)
-	slice := make([]byte, n)
 	return Buf{
-		data: unsafe.Pointer(unsafe.SliceData(slice)),
+		data: pools[sizeClass(n)].Get().(unsafe.Pointer),
 		n:    n,
 	}
 }
@@ -32,5 +33,33 @@ func New(purpose Purpose, n uintptr) Buf {
 // returned by New.
 func Free(purpose Purpose, b Buf) {
 	invariants.MaybeMangle(b.Slice())
+	if b.data == nil {
+		return
+	}
+
+	// Clear the block for consistency with the cgo implementation (which uses calloc)
+	clear(unsafe.Slice((*byte)(b.data), b.n))
+
 	recordFree(purpose, b.n)
+	pools[sizeClass(b.n)].Put(b.data)
+}
+
+var pools [bits.UintSize]sync.Pool // pools[n] is for allocs of size 1 << n
+
+func init() {
+	for i := range pools {
+		allocSize := 1 << i
+		pools[i].New = func() any {
+			// Boxing an unsafe.Pointer into an interface does not require an allocation
+			return unsafe.Pointer(unsafe.SliceData(make([]byte, allocSize)))
+		}
+	}
+}
+
+// sizeClass determines the smallest n such that 1 << n >= size
+func sizeClass(size uintptr) int {
+	if invariants.Enabled && size == 0 {
+		panic("zero size should never get through New")
+	}
+	return bits.Len(uint(size - 1))
 }


### PR DESCRIPTION
When CGO_ENABLED=0, the manual cache memory management described at https://github.com/cockroachdb/pebble/blob/master/docs/memory.md is essentially stubbed out, because there is no access to C.free().

This was causing very large heap growth and GC churn in my application.

We can still get some of the benefit of manual memory management just by using a sync.Pool for each size class of cache allocation. This significantly reduces my application's heap usage.