### PR TITLE
sstable/tieredmeta: add tiering histogram using t-digest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/DataDog/zstd v1.5.7
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/RaduBerinde/axisds v0.0.0-20260105221726-1be486564c85
+	github.com/RaduBerinde/tdigest v0.0.0-20251022152254-90e030c3a314
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cockroachdb/crlib v0.0.0-20251122031428-fe658a2dbda1
 	github.com/cockroachdb/datadriven v1.0.3-0.20251123150250-ddff6747b112

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/RaduBerinde/axisds v0.0.0-20260105221726-1be486564c85 h1:OjUilXBeTEMa
 github.com/RaduBerinde/axisds v0.0.0-20260105221726-1be486564c85/go.mod h1:gAhfbTwNsV064J6aon3TDJLzeh5IxfptXalQVnjjnWQ=
 github.com/RaduBerinde/btreemap v0.0.0-20260105202824-d3184786f603 h1:fSdiBlO4Bad28mJOPlAynvfgdDC9v+yRlzSFHvvjKYI=
 github.com/RaduBerinde/btreemap v0.0.0-20260105202824-d3184786f603/go.mod h1:0tr7FllbE9gJkHq7CVeeDDFAFKQVy5RnCSSNBOvdqbc=
+github.com/RaduBerinde/tdigest v0.0.0-20251022152254-90e030c3a314 h1:RcSNrxDZ1ZyEfpGwrpWqd3YWfMjQbKOtT+p3Wht6XN0=
+github.com/RaduBerinde/tdigest v0.0.0-20251022152254-90e030c3a314/go.mod h1:RClmoWh7JPAzCuExyOvKDCRVYGz3D11DcpzEkq4N3RA=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f h1:JjxwchlOepwsUWcQwD2mLUAGE9aCp0/ehy6yCHFBOvo=

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -672,6 +672,11 @@ type InternalKV struct {
 // The zero value is reserved to mean "no attribute" or "unknown".
 type TieringAttribute uint64
 
+// TieringSpanID is an identifier that provides a context for interpreting a
+// TieringAttribute value. At any point in time, the span policies determine
+// a set of non-overlapping key regions with distinct TieringSpanIDs.
+type TieringSpanID uint64
+
 // KVMeta describes optional metadata associated with an `InternalKV`.
 // It's currently produced only by sstable-backed iterators and is not embedded
 // within `InternalKV` to avoid overhead on the common iteration path.
@@ -683,7 +688,7 @@ type TieringAttribute uint64
 // These methods exist to support compaction-only logic (eg, `compaction.Iter`).
 // Regular iteration should use the standard methods that do not surface metadata.
 type KVMeta struct {
-	TieringSpanID    uint64
+	TieringSpanID    TieringSpanID
 	TieringAttribute TieringAttribute
 }
 

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -555,7 +555,7 @@ func ExtractKVMeta(value []byte) base.KVMeta {
 	if e != nil {
 		panic(fmt.Sprintf("invalid tiering span in KV metadata in %q", value))
 	}
-	res.TieringSpanID = v
+	res.TieringSpanID = base.TieringSpanID(v)
 	v, e = strconv.ParseUint(m[2], 10, 64)
 	if e != nil {
 		panic(fmt.Sprintf("invalid tiering attr in KV metadata in %q", value))

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -708,7 +708,7 @@ func (w *DataBlockEncoder) Add(
 		w.values.Put(value)
 	}
 	if w.columnConfig.SupportsTiering() && meta != (base.KVMeta{}) {
-		w.tieringSpanIDs.Set(w.rows, meta.TieringSpanID)
+		w.tieringSpanIDs.Set(w.rows, uint64(meta.TieringSpanID))
 		w.tieringAttributes.Set(w.rows, uint64(meta.TieringAttribute))
 	}
 	if len(ikey.UserKey) > int(w.maximumKeyLength) {
@@ -1518,7 +1518,7 @@ func (i *DataBlockIter) decodeMeta() base.KVMeta {
 		return base.KVMeta{}
 	}
 	return base.KVMeta{
-		TieringSpanID:    i.tieringSpanIDs.At(i.row),
+		TieringSpanID:    base.TieringSpanID(i.tieringSpanIDs.At(i.row)),
 		TieringAttribute: base.TieringAttribute(i.tieringAttributes.At(i.row)),
 	}
 }

--- a/sstable/tieredmeta/histogram.go
+++ b/sstable/tieredmeta/histogram.go
@@ -1,0 +1,200 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package tieredmeta
+
+import (
+	"encoding/binary"
+
+	"github.com/RaduBerinde/tdigest"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/pkg/errors"
+)
+
+// digestDelta is the compression argument for t-digest, used to specify the
+// tradeoff between accuracy and memory consumption: meaning higher values give
+// more accuracy, but use more memory/space. Specifically, the digest has at most
+// 2*compression centroids, with ~1.3*compression in practice.
+//
+// A value of 100 is a common default for t-digest implementations, which should
+// provide at least ±1% quantile accuracy (and much better at the tails).
+const digestDelta = 100
+
+// StatsHistogram is a quantile sketch using t-digest to track the distribution
+// of a bytes value (with a caller-determined meaning) by TieringAttribute. It
+// can efficiently answer questions like:
+//   - What fraction of bytes have attribute <= threshold? (CDF)
+//   - What attribute value covers q% of bytes? (Quantile)
+//   - How many bytes are "cold" vs "hot"?
+//
+// The sketch is mergeable, making it easy to combine statistics from
+// multiple files without bucket alignment issues.
+type StatsHistogram struct {
+	// TotalBytes is the sum of all bytes recorded (including BytesNoAttr).
+	TotalBytes uint64
+	// TotalCount is the number of records added.
+	TotalCount uint64
+	// BytesNoAttr tracks bytes with attribute=0 separately, as this typically
+	// indicates unset/special values that shouldn't be tiered.
+	BytesNoAttr uint64
+	// digest is the t-digest for non-zero attributes (read-only).
+	digest tdigest.TDigest
+}
+
+// CDF returns the fraction of non-zero bytes with attribute <= threshold.
+// Returns a value in [0, 1].
+// Example: CDF(coldThreshold) tells you what fraction of bytes are "cold".
+func (s *StatsHistogram) CDF(threshold base.TieringAttribute) float64 {
+	if s.BytesWithAttr() == 0 {
+		return 0
+	}
+	return s.digest.CDF(float64(threshold))
+}
+
+// Quantile returns the attribute value at quantile ~q (where q is in [0, 1]) of
+// bytes with a tiering attribute set.
+// Example: Quantile(0.5) returns a value close to the median value.
+func (s *StatsHistogram) Quantile(q float64) base.TieringAttribute {
+	return base.TieringAttribute(s.digest.Quantile(q))
+}
+
+// BytesWithAttr returns bytes that have a tiering attribute set, excluding
+// bytes with attr=0 (which typically indicates unset/special values).
+func (s *StatsHistogram) BytesWithAttr() uint64 {
+	return s.TotalBytes - s.BytesNoAttr
+}
+
+// BytesBelowThreshold estimates how many bytes (excluding NoAttrBytes) have
+// attribute <= threshold. This is useful for tiering decisions.
+func (s *StatsHistogram) BytesBelowThreshold(threshold base.TieringAttribute) uint64 {
+	return uint64(s.CDF(threshold) * float64(s.BytesWithAttr()))
+}
+
+// BytesAboveThreshold estimates how many non-zero bytes have attribute > threshold.
+// This is useful for tiering decisions.
+func (s *StatsHistogram) BytesAboveThreshold(threshold base.TieringAttribute) uint64 {
+	return s.BytesWithAttr() - s.BytesBelowThreshold(threshold)
+}
+
+// encode serializes the histogram to bytes. The encoding format is:
+//
+//	<total bytes> <total count> <zero count> <digest size> <digest data>
+func (s *StatsHistogram) encode() []byte {
+	// Calculate the size needed for the t-digest.
+	digestSize := s.digest.SerializedSize()
+
+	// Pre-allocate with estimated capacity (4 uvarints + digest).
+	// Each uvarint is at most 10 bytes for uint64.
+	buf := make([]byte, 0, 4*binary.MaxVarintLen64+digestSize)
+
+	buf = binary.AppendUvarint(buf, s.TotalBytes)
+	buf = binary.AppendUvarint(buf, s.TotalCount)
+	buf = binary.AppendUvarint(buf, s.BytesNoAttr)
+	buf = binary.AppendUvarint(buf, uint64(digestSize))
+	buf = s.digest.Serialize(buf)
+
+	return buf
+}
+
+// DecodeStatsHistogram decodes a StatsHistogram from the provided buffer.
+// The encoding format is:
+//
+//	<total bytes> <total count> <zero bytes> <digest size> <digest data>
+func DecodeStatsHistogram(buf []byte) (StatsHistogram, error) {
+	var h StatsHistogram
+	var n int
+
+	h.TotalBytes, n = binary.Uvarint(buf)
+	if n <= 0 {
+		return StatsHistogram{}, base.CorruptionErrorf("cannot decode TotalBytes from buf %x", buf)
+	}
+	buf = buf[n:]
+
+	h.TotalCount, n = binary.Uvarint(buf)
+	if n <= 0 {
+		return StatsHistogram{}, base.CorruptionErrorf("cannot decode TotalCount from buf %x", buf)
+	}
+	buf = buf[n:]
+
+	h.BytesNoAttr, n = binary.Uvarint(buf)
+	if n <= 0 {
+		return StatsHistogram{}, base.CorruptionErrorf("cannot decode BytesNoAttr from buf %x", buf)
+	}
+	buf = buf[n:]
+
+	digestSize, n := binary.Uvarint(buf)
+	if n <= 0 {
+		return StatsHistogram{}, base.CorruptionErrorf("cannot decode digest size from buf %x", buf)
+	}
+	buf = buf[n:]
+
+	if int(digestSize) != len(buf) {
+		return StatsHistogram{}, errors.Errorf("histogram digest size %d does not match remaining data %d",
+			digestSize, len(buf))
+	}
+
+	if digestSize > 0 {
+		var digest tdigest.TDigest
+		_, err := tdigest.Deserialize(&digest, buf[:digestSize])
+		if err != nil {
+			return StatsHistogram{}, err
+		}
+		h.digest = digest
+	}
+
+	return h, nil
+}
+
+// Merge combines another histogram into this one using a t-digest Merger.
+// This is used to aggregate statistics from multiple files.
+func (s *StatsHistogram) Merge(other *StatsHistogram) {
+	s.TotalBytes += other.TotalBytes
+	s.TotalCount += other.TotalCount
+	s.BytesNoAttr += other.BytesNoAttr
+
+	merger := tdigest.MakeMerger(digestDelta)
+	merger.Merge(&s.digest)
+	merger.Merge(&other.digest)
+	merged := merger.Digest()
+	s.digest = merged
+}
+
+// histogramWriter wraps a tdigest.Builder for building during sstable/blob file
+// writing.
+type histogramWriter struct {
+	builder    tdigest.Builder
+	totalBytes uint64
+	totalCount uint64
+	zeroBytes  uint64
+}
+
+func newHistogramWriter() *histogramWriter {
+	return &histogramWriter{
+		builder: tdigest.MakeBuilder(digestDelta),
+	}
+}
+
+// record adds a data point to the histogram. Records with attr=0 are tracked
+// separately and excluded from the t-digest - as zero typically indicates
+// an unset or special value that shouldn't influence tiering decisions.
+func (w *histogramWriter) record(attr base.TieringAttribute, bytes uint64) {
+	w.totalCount++
+	w.totalBytes += bytes
+	if attr == 0 {
+		w.zeroBytes += bytes
+		return
+	}
+	w.builder.Add(float64(attr), float64(bytes))
+}
+
+func (w *histogramWriter) encode() []byte {
+	digest := w.builder.Digest()
+	h := StatsHistogram{
+		TotalBytes:  w.totalBytes,
+		TotalCount:  w.totalCount,
+		BytesNoAttr: w.zeroBytes,
+		digest:      digest,
+	}
+	return h.encode()
+}

--- a/sstable/tieredmeta/histogram_block.go
+++ b/sstable/tieredmeta/histogram_block.go
@@ -1,0 +1,242 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package tieredmeta
+
+import (
+	"cmp"
+	"encoding/binary"
+	"maps"
+	"slices"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/colblk"
+)
+
+// A TieringHistogramBlockWriter writes a tiering histogram block. The block
+// records StatsHistograms for rows being written to a sstable or blob file.
+// There is a one-to-one mapping between TieringHistogramBlockWriter and files;
+// for example, writing a key-value pair that will be value-separated requires
+// two writers: one for the sstable (containing the key) and one for the blob
+// file (containing the value).
+//
+// The tier of the (sstable or blob) file to which the tiering histogram block
+// is being written is implicit in the context, and does not need to be stored
+// in the histogram.
+//
+// For an sstable, we want to distinguish which values it refers to are in only
+// cold storage. This is useful since before starting a future compaction, we
+// want to decide whether to write new blob files, and in which tier, and which
+// input blob files will have some spanIDs rewritten. This decision needs to be
+// made with the help of these histograms to balance the cost of rewriting with
+// the benefit, and to avoid producing tiny blob files. Additionally, we want to
+// know which values are inside the sstable and which are blob references, since
+// if most of the hot => cold transitions are for values inside the sstable, we
+// may choose to not rewrite the blob references since the gain is small.
+//
+// To handle the above cases, an sstable can have up to 3 histograms for a
+// spanID, the ones prefixed with SSTable in the KindAndTier enum. A blob file
+// has one histogram for the values it contains, BlobFileValueBytes.
+//
+// We also track per-sstable summary counters (not full histograms):
+//   - Key bytes: total and below-threshold, for future decisions about whether
+//     to also tier keys to cold storage.
+//   - Hot-and-cold blob reference bytes: values that exist in both tiers. The
+//     decision to drop the hot copy is based on storage pressure, not the
+//     tiering attribute distribution, so we just track total bytes.
+//
+// Below is the block structure:
+//
+//	SSTable's TieringHistogramBlock:
+//	│
+//	├── SSTableSummary (keyBytesTotal, keyBytesBelowThreshold, hotAndColdBlobRefBytes)
+//	├── Key{SSTableInPlaceValueBytes,      SpanID=1} → StatsHistogram
+//	├── Key{SSTableBlobReferenceHotBytes,  SpanID=1} → StatsHistogram
+//	├── Key{SSTableBlobReferenceColdBytes, SpanID=1} → StatsHistogram
+//	└── ...
+type KindAndTier uint8
+
+const (
+	// SSTableInPlaceValueBytes is the histogram for values stored inside the
+	// sstable.
+	SSTableInPlaceValueBytes KindAndTier = iota
+	// SSTableBlobReferenceHotBytes is the histogram for blob references from the
+	// sstable to hot tier blob files only. The size is the size of the value.
+	SSTableBlobReferenceHotBytes
+	// SSTableBlobReferenceColdBytes is the histogram for blob references from the
+	// sstable to cold tier blob files only. The size is the size of the value.
+	SSTableBlobReferenceColdBytes
+	NumKindAndTiers
+)
+
+// TieringHistogramBlockWriter is instantiated for each output file that
+// requires tiering histograms.
+type TieringHistogramBlockWriter struct {
+	writers map[Key]*histogramWriter
+	// Per-sstable summary counters.
+	keyBytesTotal          uint64
+	keyBytesBelowThreshold uint64
+	hotAndColdBlobRefBytes uint64
+}
+
+// Key is a unique identifier for a histogram.
+type Key struct {
+	KindAndTier
+	base.TieringSpanID
+}
+
+func (k *Key) encode() []byte {
+	buf := make([]byte, 1+binary.MaxVarintLen64)
+	buf[0] = byte(k.KindAndTier)
+	n := binary.PutUvarint(buf[1:], uint64(k.TieringSpanID))
+	return buf[:1+n]
+}
+
+func (k *Key) decode(data []byte) error {
+	if len(data) < 2 {
+		return errors.AssertionFailedf("key too short")
+	}
+	kt := KindAndTier(data[0])
+	if kt >= NumKindAndTiers {
+		return errors.AssertionFailedf("invalid KindAndTier %d", kt)
+	}
+	id, n := binary.Uvarint(data[1:])
+	if n <= 0 {
+		return errors.AssertionFailedf("cannot decode TieringSpanID")
+	}
+	*k = Key{KindAndTier: kt, TieringSpanID: base.TieringSpanID(id)}
+	return nil
+}
+
+func MakeTieringHistogramBlockWriter() TieringHistogramBlockWriter {
+	return TieringHistogramBlockWriter{
+		writers: make(map[Key]*histogramWriter),
+	}
+}
+
+func (w *TieringHistogramBlockWriter) Add(
+	kt KindAndTier, spanID base.TieringSpanID, attr base.TieringAttribute, bytes uint64,
+) {
+	k := Key{kt, spanID}
+	hw, ok := w.writers[k]
+	if !ok {
+		hw = newHistogramWriter()
+		w.writers[k] = hw
+	}
+	hw.record(attr, bytes)
+}
+
+// AddKeyBytes records key bytes for the per-sstable summary. If the key's
+// tiering attribute is below the threshold, the bytes are also counted toward
+// keyBytesBelowThreshold.
+func (w *TieringHistogramBlockWriter) AddKeyBytes(
+	attr base.TieringAttribute, threshold base.TieringAttribute, bytes uint64,
+) {
+	w.keyBytesTotal += bytes
+	if attr < threshold {
+		w.keyBytesBelowThreshold += bytes
+	}
+}
+
+// AddHotAndColdBlobRefBytes records bytes for values that exist in both hot and
+// cold tiers. These don't need a full histogram since the decision to drop the
+// hot copy is based on storage pressure, not the tiering attribute distribution.
+func (w *TieringHistogramBlockWriter) AddHotAndColdBlobRefBytes(bytes uint64) {
+	w.hotAndColdBlobRefBytes += bytes
+}
+
+// Reset clears the writer to an empty state, retaining the map for reuse.
+func (w *TieringHistogramBlockWriter) Reset() {
+	clear(w.writers)
+	w.keyBytesTotal = 0
+	w.keyBytesBelowThreshold = 0
+	w.hotAndColdBlobRefBytes = 0
+}
+
+// Finish returns the encoded block contents. The writer is reset and can be
+// reused after calling this method. The encoding format is:
+//
+//	<keyBytesTotal> <keyBytesBelowThreshold> <hotAndColdBlobRefBytes> <histograms>
+func (w *TieringHistogramBlockWriter) Finish() []byte {
+	var cw colblk.KeyValueBlockWriter
+	cw.Init()
+	keys := slices.Collect(maps.Keys(w.writers))
+	slices.SortFunc(keys, func(a, b Key) int {
+		return cmp.Or(
+			cmp.Compare(a.KindAndTier, b.KindAndTier), cmp.Compare(a.TieringSpanID, b.TieringSpanID))
+	})
+	for _, k := range keys {
+		cw.AddKV(k.encode(), w.writers[k].encode())
+	}
+	histograms := cw.Finish(cw.Rows())
+
+	// 3*binary.MaxVarintLen64 for the per-sstable summary, +len(histograms) for
+	// the histograms.
+	buf := make([]byte, 0, 3*binary.MaxVarintLen64+len(histograms))
+	buf = binary.AppendUvarint(buf, w.keyBytesTotal)
+	buf = binary.AppendUvarint(buf, w.keyBytesBelowThreshold)
+	buf = binary.AppendUvarint(buf, w.hotAndColdBlobRefBytes)
+	buf = append(buf, histograms...)
+
+	w.Reset()
+	return buf
+}
+
+// SSTableSummary is the per-sstable summary counters (not full histograms).
+type SSTableSummary struct {
+	// KeyBytesTotal is the total key bytes in the sstable.
+	KeyBytesTotal uint64
+	// KeyBytesBelowThreshold is key bytes with tiering attribute below threshold.
+	KeyBytesBelowThreshold uint64
+	// HotAndColdBlobRefBytes is bytes for values that exist in both hot and cold
+	// tiers. These don't need a histogram since the decision to drop the hot copy
+	// is based on storage pressure, not the tiering attribute distribution.
+	HotAndColdBlobRefBytes uint64
+}
+
+// DecodeTieringHistogramBlock decodes the tiering histogram block and returns
+// the in-memory contents: the per-sstable summary and the per-spanID histograms.
+func DecodeTieringHistogramBlock(data []byte) (SSTableSummary, map[Key]StatsHistogram, error) {
+	var summary SSTableSummary
+	var n int
+
+	summary.KeyBytesTotal, n = binary.Uvarint(data)
+	if n <= 0 {
+		return SSTableSummary{}, nil, errors.AssertionFailedf("cannot decode KeyBytesTotal")
+	}
+	data = data[n:]
+
+	summary.KeyBytesBelowThreshold, n = binary.Uvarint(data)
+	if n <= 0 {
+		return SSTableSummary{}, nil, errors.AssertionFailedf("cannot decode KeyBytesBelowThreshold")
+	}
+	data = data[n:]
+
+	summary.HotAndColdBlobRefBytes, n = binary.Uvarint(data)
+	if n <= 0 {
+		return SSTableSummary{}, nil, errors.AssertionFailedf("cannot decode HotAndColdBlobRefBytes")
+	}
+	data = data[n:]
+
+	var histograms map[Key]StatsHistogram
+	var decoder colblk.KeyValueBlockDecoder
+	decoder.Init(data)
+	for i := range decoder.BlockDecoder().Rows() {
+		var k Key
+		err := k.decode(decoder.KeyAt(i))
+		if err != nil {
+			return SSTableSummary{}, nil, err
+		}
+		hist, err := DecodeStatsHistogram(decoder.ValueAt(i))
+		if err != nil {
+			return SSTableSummary{}, nil, err
+		}
+		if histograms == nil {
+			histograms = make(map[Key]StatsHistogram)
+		}
+		histograms[k] = hist
+	}
+	return summary, histograms, nil
+}

--- a/sstable/tieredmeta/histogram_test.go
+++ b/sstable/tieredmeta/histogram_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package tieredmeta
+
+import (
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// expectedStats tracks expected histogram values for test verification.
+type expectedStats struct {
+	totalBytes uint64
+	totalCount uint64
+	zeroBytes  uint64
+}
+
+// generateRandomRecords generates numRecords random (attr, bytes) pairs, calls
+// recordFn for each, and returns the expected aggregate stats. Approximately
+// 20% of records will have attr=0.
+func generateRandomRecords(
+	prng *rand.Rand, numRecords int, recordFn func(attr base.TieringAttribute, bytes uint64),
+) expectedStats {
+	var stats expectedStats
+	for range numRecords {
+		var attr base.TieringAttribute
+		if prng.Float64() > 0.2 {
+			attr = base.TieringAttribute(testutils.RandIntInRange(prng, 1, 1000))
+		}
+		bytes := uint64(testutils.RandIntInRange(prng, 1, 10000))
+
+		recordFn(attr, bytes)
+
+		stats.totalBytes += bytes
+		stats.totalCount++
+		if attr == 0 {
+			stats.zeroBytes += bytes
+		}
+	}
+	return stats
+}
+
+// requireStatsEqual asserts that the decoded histogram matches the expected stats.
+func requireStatsEqual(t *testing.T, exp expectedStats, hist StatsHistogram, msgAndArgs ...any) {
+	t.Helper()
+	require.Equal(t, exp.totalBytes, hist.TotalBytes, msgAndArgs...)
+	require.Equal(t, exp.totalCount, hist.TotalCount, msgAndArgs...)
+	require.Equal(t, exp.zeroBytes, hist.BytesNoAttr, msgAndArgs...)
+	require.Equal(t, exp.totalBytes-exp.zeroBytes, hist.BytesWithAttr(), msgAndArgs...)
+}
+
+func TestHistogramBlock_Randomized(t *testing.T) {
+	prng := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))
+
+	for range 20 {
+		w := MakeTieringHistogramBlockWriter()
+		expected := make(map[Key]expectedStats)
+
+		// Generate random number of span IDs.
+		numSpans := testutils.RandIntInRange(prng, 1, 10)
+		spanIDs := make([]base.TieringSpanID, numSpans)
+		for i := range spanIDs {
+			spanIDs[i] = base.TieringSpanID(testutils.RandIntInRange(prng, 0, 1000))
+		}
+
+		// Track expected per-sstable summary.
+		var expectedKeyBytesTotal uint64
+		var expectedKeyBytesBelowThreshold uint64
+		var expectedHotAndColdBlobRefBytes uint64
+		threshold := base.TieringAttribute(testutils.RandIntInRange(prng, 100, 500))
+
+		// Add key bytes records.
+		numKeyRecords := testutils.RandIntInRange(prng, 10, 100)
+		for range numKeyRecords {
+			attr := base.TieringAttribute(testutils.RandIntInRange(prng, 0, 1000))
+			bytes := uint64(testutils.RandIntInRange(prng, 1, 10000))
+			w.AddKeyBytes(attr, threshold, bytes)
+			expectedKeyBytesTotal += bytes
+			if attr < threshold {
+				expectedKeyBytesBelowThreshold += bytes
+			}
+		}
+
+		// Add hot-and-cold blob ref bytes.
+		numHotAndColdRecords := testutils.RandIntInRange(prng, 5, 50)
+		for range numHotAndColdRecords {
+			bytes := uint64(testutils.RandIntInRange(prng, 1, 10000))
+			w.AddHotAndColdBlobRefBytes(bytes)
+			expectedHotAndColdBlobRefBytes += bytes
+		}
+
+		// For each span, add records with random KindAndTier.
+		for _, spanID := range spanIDs {
+			numKinds := testutils.RandIntInRange(prng, 1, int(NumKindAndTiers)+1)
+			for range numKinds {
+				kt := KindAndTier(testutils.RandIntInRange(prng, 0, int(NumKindAndTiers)))
+				numRecords := testutils.RandIntInRange(prng, 10, 100)
+				key := Key{kt, spanID}
+
+				stats := generateRandomRecords(prng, numRecords, func(attr base.TieringAttribute, bytes uint64) {
+					w.Add(kt, spanID, attr, bytes)
+				})
+
+				// Accumulate stats for this key.
+				existing := expected[key]
+				existing.totalBytes += stats.totalBytes
+				existing.totalCount += stats.totalCount
+				existing.zeroBytes += stats.zeroBytes
+				expected[key] = existing
+			}
+		}
+
+		// Encode and decode the block.
+		encoded := w.Finish()
+		summary, decoded, err := DecodeTieringHistogramBlock(encoded)
+		require.NoError(t, err)
+
+		// Verify per-sstable summary.
+		require.Equal(t, expectedKeyBytesTotal, summary.KeyBytesTotal)
+		require.Equal(t, expectedKeyBytesBelowThreshold, summary.KeyBytesBelowThreshold)
+		require.Equal(t, expectedHotAndColdBlobRefBytes, summary.HotAndColdBlobRefBytes)
+
+		// Verify all expected keys are present with correct statistics.
+		require.Len(t, decoded, len(expected))
+		for key, expStats := range expected {
+			hist, ok := decoded[key]
+			require.True(t, ok, "missing histogram for key %+v", key)
+			requireStatsEqual(t, expStats, hist, "key %+v", key)
+		}
+	}
+}
+
+func TestHistogramEncoding_Roundtrip(t *testing.T) {
+	prng := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))
+
+	for range 20 {
+		hw := newHistogramWriter()
+		numRecords := testutils.RandIntInRange(prng, 10, 200)
+
+		exp := generateRandomRecords(prng, numRecords, hw.record)
+
+		// Test encode/decode roundtrip.
+		encoded := hw.encode()
+		decoded, err := DecodeStatsHistogram(encoded)
+		require.NoError(t, err)
+
+		requireStatsEqual(t, exp, decoded)
+	}
+}


### PR DESCRIPTION
Add StatsHistogram, a quantile sketch backed by t-digest, to track byte distribution by TieringAttribute. The histogram supports CDF and quantile queries to estimate bytes above/below thresholds for tiering decisions.

Add TieringHistogramBlockWriter to encode multiple histograms per sstable or blob file, keyed by (KindAndTier, SpanID). The block will support histogram types for inline values and blob references (hot/cold).