### PR TITLE
block: allow more slack when fitting blocks to size classes

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -250,6 +250,14 @@ const MetadataSize = 280
 // block data buffer aligned.
 const _ uint = -(MetadataSize % 8)
 
+// TODO(radu): increase MetadataSize so that the total overhead is a multiple of
+// 64 bytes (the typical cache line size). Some blocks, like bloom filters,
+// benefit from 64-byte alignment of data.
+//
+// We can only do this a few releases after introducing some slack into the
+// AllocationOverheadAllowance.
+// const _ uint = -((cache.ValueMetadataSize + MetadataSize) % 64)
+
 // NoReadEnv is the empty ReadEnv which reports no stats and does not use a
 // buffer pool.
 var NoReadEnv = ReadEnv{}

--- a/sstable/block/testdata/flush_governor
+++ b/sstable/block/testdata/flush_governor
@@ -25,12 +25,12 @@ should-flush size-before=899 size-after=10000
 ----
 should not flush
 
-# Size classes. Note that the block allocation overhead is 312.
-init target-block-size=800 size-class-aware-threshold=60 size-classes=(820, 1020, 1320, 1820)
+# Size classes. Note that the block allocation overhead is 384.
+init target-block-size=800 size-class-aware-threshold=60 size-classes=(900, 1100, 1400, 1900)
 ----
 low watermark: 480
-high watermark: 1008
-targetBoundary: 708
+high watermark: 1016
+targetBoundary: 716
 
 # Should not flush when the "after" block fits in the same size class.
 should-flush size-before=600 size-after=650
@@ -82,8 +82,8 @@ targetBoundary: 1000
 init target-block-size=32768 jemalloc-size-classes
 ----
 low watermark: 19661
-high watermark: 40648
-targetBoundary: 32456
+high watermark: 40576
+targetBoundary: 32384
 
 # We should not flush until exceeding the boundary.
 should-flush size-before=30000 size-after=31000


### PR DESCRIPTION
We currently take into account the in-memory metadata when trying to
fit blocks into size classes (when we create new blocks).

Growing the size of the metadata is problematic: all blocks written by
the previous release(s) will cause significant fragmentation, as they
will require an allocation a few bytes larger than a size class.
Typical data blocks of 32KiB will take up 40KiB (20% fragmentation).

This change adds some more slack into this fitting, leaving out
384-312=72 extra bytes for future growth of the metadata. This is only
an extra 0.2% of the typical data block size of 32KiB.
