### PR TITLE
sstable: add error handling to DecodeBlobRefLivenessEncoding

### DIFF
--- a/blob_rewrite.go
+++ b/blob_rewrite.go
@@ -477,7 +477,11 @@ func (rw *blobFileRewriter) generateHeap(ctx context.Context) error {
 			// TODO(annie): We should instead maintain 1 heap item per sstable
 			// instead of 1 heap item per sstable block ref to reduce the heap
 			// comparisons to O(sstables).
-			for _, enc := range sstable.DecodeBlobRefLivenessEncoding(bitmapEncodings) {
+			blocks, err := sstable.DecodeBlobRefLivenessEncoding(bitmapEncodings)
+			if err != nil {
+				return err
+			}
+			for _, enc := range blocks {
 				heap.Push(&rw.blkHeap, &enc)
 			}
 			return nil

--- a/ingest.go
+++ b/ingest.go
@@ -535,7 +535,11 @@ func constructBlobFileMetadataForIngestedTable(
 	for i, p := range blobPaths {
 		blockEncodings := decoder.LivenessAtReference(i)
 		var valueSize uint64
-		for _, enc := range sstable.DecodeBlobRefLivenessEncoding(blockEncodings) {
+		blocks, err := sstable.DecodeBlobRefLivenessEncoding(blockEncodings)
+		if err != nil {
+			return nil, err
+		}
+		for _, enc := range blocks {
 			// There should be only one encoding per blob file.
 			valueSize += uint64(enc.ValuesSize)
 		}

--- a/level_checker.go
+++ b/level_checker.go
@@ -748,7 +748,11 @@ func performValidationForSSTable(
 	}
 	for refID, blockValues := range referenced {
 		bitmapEncodings := slices.Clone(decoder.LivenessAtReference(refID))
-		for _, blockEnc := range sstable.DecodeBlobRefLivenessEncoding(bitmapEncodings) {
+		blocks, err := sstable.DecodeBlobRefLivenessEncoding(bitmapEncodings)
+		if err != nil {
+			return err
+		}
+		for _, blockEnc := range blocks {
 			blockID := blockEnc.BlockID
 			vi, ok := blockValues[blockID]
 			if !ok {

--- a/sstable/blob_reference_index_test.go
+++ b/sstable/blob_reference_index_test.go
@@ -38,7 +38,8 @@ func TestBlobRefValueLivenessWriter(t *testing.T) {
 
 		encodings := maps.Collect(w.finish())
 		require.Len(t, encodings, 1)
-		blocks := DecodeBlobRefLivenessEncoding(encodings[0])
+		blocks, err := DecodeBlobRefLivenessEncoding(encodings[0])
+		require.NoError(t, err)
 		require.Len(t, blocks, 2)
 
 		// Verify first block (refID=0, blockID=0).
@@ -71,7 +72,8 @@ func TestBlobRefValueLivenessWriter(t *testing.T) {
 
 		encodings := maps.Collect(w.finish())
 		require.Len(t, encodings, 1)
-		blocks := DecodeBlobRefLivenessEncoding(encodings[0])
+		blocks, err := DecodeBlobRefLivenessEncoding(encodings[0])
+		require.NoError(t, err)
 		require.Len(t, blocks, 1)
 
 		require.Equal(t, blob.BlockID(0), blocks[0].BlockID)
@@ -129,7 +131,11 @@ func TestBlobRefLivenessEncoding_Randomized(t *testing.T) {
 		// Reinitialize the writer before reconstructing values.
 		w.init()
 		for refID, blockEnc := range encoded {
-			for _, block := range DecodeBlobRefLivenessEncoding(blockEnc) {
+			blocks, err := DecodeBlobRefLivenessEncoding(blockEnc)
+			if err != nil {
+				t.Fatalf("cannot decode blob reference liveness encoding for refID %d: %v", refID, err)
+			}
+			for _, block := range blocks {
 				// Reconstruct the live values from the bitmap and add them to
 				// the writer.
 				for valueID := range IterSetBitsInRunLengthBitmap(block.Bitmap) {

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -368,7 +368,10 @@ func (l *Layout) Describe(
 				offset := 0
 				for i := range decoder.BlockDecoder().Rows() {
 					value := decoder.LivenessAtReference(i)
-					encs := DecodeBlobRefLivenessEncoding(value)
+					encs, err := DecodeBlobRefLivenessEncoding(value)
+					if err != nil {
+						return err
+					}
 					length := len(value)
 					parent := tpNode.Childf("%05d (%d)", offset, length)
 					for _, enc := range encs {


### PR DESCRIPTION
DecodeBlobRefLivenessEncoding now returns an error when binary.Uvarint decodes fail, surfacing corruption instead of silently producing invalid results.