### PR TITLE
internal/manifest: rename LevelFile to LevelTable

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1239,7 +1239,7 @@ func (c *tableCompaction) newInputIters(
 func (c *tableCompaction) newRangeDelIter(
 	ctx context.Context,
 	newIters tableNewIters,
-	f manifest.LevelFile,
+	f manifest.LevelTable,
 	opts IterOptions,
 	iiopts internalIterOpts,
 	l manifest.Layer,

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -680,7 +680,7 @@ type candidateLevelInfo struct {
 	// The file in level that will be compacted. Additional files may be
 	// picked by the compaction, and a pickedCompaction created for the
 	// compaction.
-	file manifest.LevelFile
+	file manifest.LevelTable
 }
 
 func (c *candidateLevelInfo) shouldCompact() bool {
@@ -1153,7 +1153,7 @@ func pickCompactionSeedFile(
 	level, outputLevel int,
 	earliestSnapshotSeqNum base.SeqNum,
 	problemSpans *problemspans.ByLevel,
-) (manifest.LevelFile, bool) {
+) (manifest.LevelTable, bool) {
 	// Select the file within the level to compact. We want to minimize write
 	// amplification, but also ensure that (a) deletes are propagated to the
 	// bottom level in a timely fashion, and (b) virtual sstables that are
@@ -1180,7 +1180,7 @@ func pickCompactionSeedFile(
 	startIter := vers.Levels[level].Iter()
 	outputIter := vers.Levels[outputLevel].Iter()
 
-	var file manifest.LevelFile
+	var file manifest.LevelTable
 	smallestRatio := uint64(math.MaxUint64)
 
 	outputFile := outputIter.First()

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -1419,7 +1419,7 @@ func TestCompactionPickerPickFile(t *testing.T) {
 			// initialization of the compaction-picking environment, but never
 			// pick a compaction; just call pickFile using the user-provided
 			// level.
-			var lf manifest.LevelFile
+			var lf manifest.LevelTable
 			var ok bool
 			func() {
 				d.mu.versions.logLock()


### PR DESCRIPTION
We've begun consistently referring to sstables as 'tables,' as opposed to 'files,' now that a table may be virtual and not have a 1:1 mapping to a physical file. Rename LevelFile to LevelTable accordingly. Update some related commentary too.