### PR TITLE
db: refactor delete-only compactions

### DIFF
--- a/compaction_delete.go
+++ b/compaction_delete.go
@@ -5,13 +5,7 @@
 package pebble
 
 import (
-	"bytes"
-	stdcmp "cmp"
 	"context"
-	"fmt"
-	"maps"
-	"slices"
-	"sort"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -19,40 +13,38 @@ import (
 	"github.com/cockroachdb/pebble/internal/compact"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/tombspan"
 )
 
 // tryScheduleDeleteOnlyCompaction tries to kick off a delete-only compaction
-// for all files that can be deleted as suggested by deletionHints.
+// for all files that can be deleted as suggested by wide tombstones.
 //
-// Requires d.mu to be held. Updates d.mu.compact.deletionHints.
+// Requires d.mu to be held. Updates d.mu.compact.wideTombstones.
 //
 // Returns true iff a compaction was started.
 func (d *DB) tryScheduleDeleteOnlyCompaction() bool {
-	if d.opts.private.disableDeleteOnlyCompactions || d.opts.DisableAutomaticCompactions ||
-		len(d.mu.compact.deletionHints) == 0 {
+	if d.opts.private.disableDeleteOnlyCompactions ||
+		d.opts.DisableAutomaticCompactions {
 		return false
 	}
 	if _, maxConcurrency := d.opts.CompactionConcurrencyRange(); d.mu.compact.compactingCount >= maxConcurrency {
 		return false
 	}
 	v := d.mu.versions.currentVersion()
-	snapshots := d.mu.snapshots.toSlice()
-	// We need to save the value of exciseEnabled in the compaction itself, as
-	// it can change dynamically between now and when the compaction runs.
-	exciseEnabled := d.FormatMajorVersion() >= FormatVirtualSSTables &&
-		d.opts.Experimental.EnableDeleteOnlyCompactionExcises != nil && d.opts.Experimental.EnableDeleteOnlyCompactionExcises()
-	inputs, resolvedHints, unresolvedHints := checkDeleteCompactionHints(d.cmp, v, d.mu.compact.deletionHints, snapshots, exciseEnabled)
-	d.mu.compact.deletionHints = unresolvedHints
+	isExciseAllowed := d.FormatMajorVersion() >= FormatVirtualSSTables &&
+		d.opts.Experimental.EnableDeleteOnlyCompactionExcises != nil &&
+		d.opts.Experimental.EnableDeleteOnlyCompactionExcises()
 
-	if len(inputs) > 0 {
-		c := newDeleteOnlyCompaction(d.opts, v, inputs, d.opts.private.timeNow(), resolvedHints, exciseEnabled)
-		d.mu.compact.compactingCount++
-		d.mu.compact.compactProcesses++
-		c.AddInProgressLocked(d)
-		go d.compact(c, nil)
-		return true
+	picked, ok := d.mu.compact.wideTombstones.PickCompaction(v, isExciseAllowed)
+	if !ok {
+		return false
 	}
-	return false
+	c := newDeleteOnlyCompaction(d.opts, v, picked, d.opts.private.timeNow())
+	d.mu.compact.compactingCount++
+	d.mu.compact.compactProcesses++
+	c.AddInProgressLocked(d)
+	go d.compact(c, nil)
+	return true
 }
 
 // newDeleteOnlyCompaction constructs a delete-only compaction from the provided
@@ -61,26 +53,24 @@ func (d *DB) tryScheduleDeleteOnlyCompaction() bool {
 // The compaction is created with a reference to its version that must be
 // released when the compaction is complete.
 func newDeleteOnlyCompaction(
-	opts *Options,
-	cur *manifest.Version,
-	inputs []compactionLevel,
-	beganAt time.Time,
-	hints []deleteCompactionHint,
-	exciseEnabled bool,
+	opts *Options, cur *manifest.Version, picked tombspan.DeleteOnlyCompaction, beganAt time.Time,
 ) *tableCompaction {
 	c := &tableCompaction{
-		kind:        compactionKindDeleteOnly,
-		comparer:    opts.Comparer,
-		logger:      opts.Logger,
-		version:     cur,
-		inputs:      inputs,
+		kind:     compactionKindDeleteOnly,
+		comparer: opts.Comparer,
+		logger:   opts.Logger,
+		version:  cur,
+		inputs: []compactionLevel{{
+			level: picked.Level,
+			files: picked.Table.Slice(),
+		}},
+		deleteOnly:  picked,
 		grantHandle: noopGrantHandle{},
 		metrics: compactionMetrics{
 			beganAt: beganAt,
 		},
 	}
-	c.deleteOnly.hints = hints
-	c.deleteOnly.exciseEnabled = exciseEnabled
+	c.outputLevel = &c.inputs[0]
 	// Acquire a reference to the version to ensure that files and in-memory
 	// version state necessary for reading files remain available. Ignoring
 	// excises, this isn't strictly necessary for reading the sstables that are
@@ -95,13 +85,58 @@ func newDeleteOnlyCompaction(
 	// reference ensures that all these files remain available for the
 	// compaction's reads.
 	c.version.Ref()
-
-	// Set c.smallest, c.largest.
-	cmp := opts.Comparer.Compare
-	for _, in := range inputs {
-		c.bounds = manifest.ExtendKeyRange(cmp, c.bounds, in.files.All())
-	}
+	c.bounds = picked.Table.UserKeyBounds()
 	return c
+}
+
+// Runs a delete-only compaction.
+//
+// d.mu must be held when calling this.
+func (d *DB) runDeleteOnlyCompaction(
+	c *tableCompaction,
+) (ve *manifest.VersionEdit, stats compact.Stats, blobs []compact.OutputBlob, retErr error) {
+	// Release the d.mu lock while doing I/O.
+	// Note the unusual order: Unlock and then Lock.
+	d.mu.Unlock()
+	defer d.mu.Lock()
+
+	if c.deleteOnly.Excise && d.FormatMajorVersion() < FormatVirtualSSTables {
+		panic(errors.AssertionFailedf("excise is not supported at this format major version"))
+	}
+
+	lm := c.metrics.perLevel.level(c.deleteOnly.Level)
+	ve = &manifest.VersionEdit{
+		DeletedTables: make(map[manifest.DeletedTableEntry]*manifest.TableMetadata, 1),
+	}
+
+	if !c.deleteOnly.Excise {
+		ve.DeletedTables[manifest.DeletedTableEntry{
+			Level:   c.deleteOnly.Level,
+			FileNum: c.deleteOnly.Table.TableNum,
+		}] = c.deleteOnly.Table.TableMetadata
+		lm.TablesDeleted++
+	} else {
+		left, right, err := d.exciseTable(
+			context.TODO(), c.deleteOnly.Bounds, c.deleteOnly.Table.TableMetadata,
+			c.deleteOnly.Level, tightExciseBounds)
+		if err != nil {
+			return nil, stats, blobs, errors.Wrap(err, "error when running excise for delete-only compaction")
+		}
+		if left != nil && right != nil {
+			return nil, stats, blobs, errors.AssertionFailedf(
+				"delete-only compaction excised the middle of a table")
+		}
+		ve.NewTables = applyExciseToVersionEdit(ve, c.deleteOnly.Table.TableMetadata,
+			left, right, c.deleteOnly.Level)
+		lm.TablesExcised++
+
+		c.annotations = append(c.annotations, "[excise]")
+	}
+
+	// Refresh the disk available statistic whenever a compaction/flush
+	// completes, before re-acquiring the mutex.
+	d.calculateDiskAvailableBytes()
+	return ve, stats, blobs, nil
 }
 
 // tombstoneTypeFromKeys returns a manifest.KeyType given a slice of
@@ -128,494 +163,4 @@ func tombstoneKeyTypeFromKeys(keys []keyspan.Key) manifest.KeyType {
 	default:
 		panic(errors.AssertionFailedf("no keys"))
 	}
-}
-
-// A deleteCompactionHint records a user key and sequence number span that has
-// been deleted by tombstones. A hint is recorded if at least one sstable
-// containing keys older than the tombstones and either (a) completely falls
-// within both the user key, or (b) has a boundary that overlaps with the span
-// [which could be shorted with an excise]. Once the tombstones fall into the
-// last snapshot stripe, a delete-only compaction may delete or excise any
-// applicable sstables within the range.
-type deleteCompactionHint struct {
-	// The type of key span that generated this hint (point key, range key, or
-	// both).
-	keyType manifest.KeyType
-	// bounds are the bounds of the tombstone(s).
-	bounds base.UserKeyBounds
-	// The level of the file containing the range tombstone(s) when the hint
-	// was created. Only lower levels need to be searched for files that may
-	// be deleted.
-	tombstoneLevel int
-	// The file containing the range tombstone(s) that created the hint.
-	tombstoneFile *manifest.TableMetadata
-	// The sequence number range of the abutting tombstones merged to form this
-	// hint. All of a tables' keys must be less than the sequence number range
-	// to be deleted. All of a tables' sequence numbers must fall into the same
-	// snapshot stripe as the high end of the sequence number range to be
-	// deleted.
-	tombstoneSeqNums base.SeqNumRange
-}
-
-type deletionHintOverlap int8
-
-const (
-	// hintDoesNotApply indicates that the hint does not apply to the file.
-	hintDoesNotApply deletionHintOverlap = iota
-	// hintExcisesFile indicates that the hint excises a portion of the file,
-	// and the format major version of the DB supports excises.
-	hintExcisesFile
-	// hintDeletesFile indicates that the hint deletes the entirety of the file.
-	hintDeletesFile
-)
-
-func (h deleteCompactionHint) String() string {
-	return fmt.Sprintf(
-		"L%d.%s %s seqnums(tombstone=%s, type=%s)",
-		h.tombstoneLevel, h.tombstoneFile.TableNum, h.bounds,
-		h.tombstoneSeqNums, h.keyType)
-}
-
-func (h *deleteCompactionHint) canDeleteOrExcise(
-	cmp Compare, m *manifest.TableMetadata, exciseEnabled bool,
-) deletionHintOverlap {
-	// The file can only be deleted if all of its keys are older than the
-	// earliest tombstone aggregated into the hint. Note that we use
-	// m.LargestSeqNumAbsolute, not m.LargestSeqNum. Consider a compaction that
-	// zeroes sequence numbers. A compaction may zero the sequence number of a
-	// key with a sequence number > h.tombstoneSmallestSeqNum and set it to
-	// zero. If we looked at m.LargestSeqNum, the resulting output file would
-	// appear to not contain any keys more recent than the oldest tombstone. To
-	// avoid this error, the largest pre-zeroing sequence number is maintained
-	// in LargestSeqNumAbsolute and used here to make the determination whether
-	// the file's keys are older than all of the hint's tombstones.
-	if m.LargestSeqNumAbsolute >= h.tombstoneSeqNums.Low {
-		return hintDoesNotApply
-	}
-
-	switch h.keyType {
-	case manifest.KeyTypePoint:
-		// A hint generated by a range del span cannot delete tables that contain
-		// range keys.
-		if m.HasRangeKeys {
-			return hintDoesNotApply
-		}
-	case manifest.KeyTypeRange:
-		// A hint generated by a range key del span cannot delete tables that
-		// contain point keys.
-		if m.HasPointKeys {
-			return hintDoesNotApply
-		}
-	case manifest.KeyTypePointAndRange:
-		// A hint from a span that contains both range dels *and* range keys can
-		// only be deleted if both bounds fall within the hint. The next check takes
-		// care of this.
-	default:
-		panic(errors.AssertionFailedf("pebble: unknown delete compaction key type: %s", h.keyType))
-	}
-	tableBounds := m.UserKeyBounds()
-	if h.bounds.ContainsBounds(cmp, tableBounds) {
-		return hintDeletesFile
-	}
-	if !exciseEnabled {
-		// The file's keys must be completely contained within the hint range; excises
-		// aren't allowed.
-		return hintDoesNotApply
-	} else if !h.bounds.Overlaps(cmp, tableBounds) {
-		// Disjoint.
-		return hintDoesNotApply
-	} else if cmp(tableBounds.Start, h.bounds.Start) < 0 &&
-		tableBounds.End.CompareUpperBounds(cmp, h.bounds.End) > 0 {
-		// If the table's bounds completely contain the hint, applying the hint
-		// would cut the table into two virtual sstables, increasing the number
-		// of tables in the level. We only pursue excises if they shorten an
-		// existing table's bounds.
-		return hintDoesNotApply
-	}
-	return hintExcisesFile
-}
-
-// checkDeleteCompactionHints checks the passed-in deleteCompactionHints for those that
-// can be resolved and those that cannot. A hint is considered resolved when its largest
-// tombstone sequence number and the smallest sequence number of covered files fall in
-// the same snapshot stripe. No more than maxHintsPerDeleteOnlyCompaction will be resolved
-// per method call. Resolved and unresolved hints are returned in separate return values.
-// The files that the resolved hints apply to, are returned as compactionLevels.
-func checkDeleteCompactionHints(
-	cmp Compare,
-	v *manifest.Version,
-	hints []deleteCompactionHint,
-	snapshots compact.Snapshots,
-	exciseEnabled bool,
-) (levels []compactionLevel, resolved, unresolved []deleteCompactionHint) {
-	var files map[*manifest.TableMetadata]bool
-	var byLevel [numLevels][]*manifest.TableMetadata
-
-	// Delete-only compactions can be quadratic (O(mn)) in terms of runtime
-	// where m = number of files in the delete-only compaction and n = number
-	// of resolved hints. To prevent these from growing unbounded, we cap
-	// the number of hints we resolve for one delete-only compaction. This
-	// cap only applies if exciseEnabled == true.
-	const maxHintsPerDeleteOnlyCompaction = 10
-
-	unresolvedHints := hints[:0]
-	// Lazily populate resolvedHints, similar to files above.
-	resolvedHints := make([]deleteCompactionHint, 0)
-	for _, h := range hints {
-		// Check each compaction hint to see if it's resolvable. Resolvable
-		// hints are removed and trigger a delete-only compaction if any files
-		// in the current LSM still meet their criteria. Unresolvable hints
-		// are saved and don't trigger a delete-only compaction.
-		//
-		// When a compaction hint is created, the sequence numbers of the range
-		// tombstones are recorded. The largest tombstone sequence number must
-		// be in the last snapshot stripe for the hint to be resolved. Note that
-		// technically the largest tombstone sequence number only needs to be in
-		// the same snapshot stripe as an affected table's lowest sequence
-		// number. The difference is unlikely to delay hint resolution
-		// significantly, and we don't know candidate tables' lowest sequence
-		// numbers until we examine the LSM.
-		//
-		// The below graphic models a compaction hint covering the keyspace [b,
-		// r). The hint completely contains two files, 000002 and 000003. The
-		// file 000003 contains the lowest covered sequence number at #90. The
-		// tombstone b.RANGEDEL.230:h has the highest tombstone sequence number
-		// incorporated into the hint. The hint may be resolved only once all
-		// the snapshots are closed. File 000001 is not included within the hint
-		// because it extends beyond the range tombstones in user key space.
-		//
-		// 250
-		//
-		//       |-b...230:h-|
-		// _____________________________________________________ snapshot #210
-		// 200               |--h.RANGEDEL.200:r--|
-		//
-		// _____________________________________________________ snapshot #180
-		//
-		// 150                     +--------+
-		//           +---------+   | 000003 |
-		//           | 000002  |   |        |
-		//           +_________+   |        |
-		// 100_____________________|________|___________________ snapshot #100
-		//                         +--------+
-		// _____________________________________________________ snapshot #70
-		//                             +---------------+
-		//  50                         | 000001        |
-		//                             |               |
-		//                             +---------------+
-		// ______________________________________________________________
-		//     a b c d e f g h i j k l m n o p q r s t u v w x y z
-
-		if snapshots.Index(h.tombstoneSeqNums.High) != 0 ||
-			(len(resolvedHints) >= maxHintsPerDeleteOnlyCompaction && exciseEnabled) {
-			// Cannot resolve yet.
-			unresolvedHints = append(unresolvedHints, h)
-			continue
-		}
-
-		// The hint h will be resolved and dropped, if it either affects no files at all
-		// or if the number of files it creates (eg. through excision) is less than or
-		// equal to the number of files it deletes. First, determine how many files are
-		// affected by this hint.
-		filesDeletedByCurrentHint := 0
-		var filesDeletedByLevel [7][]*manifest.TableMetadata
-		for l := h.tombstoneLevel + 1; l < numLevels; l++ {
-			for m := range v.Overlaps(l, h.bounds).All() {
-				doesHintApply := h.canDeleteOrExcise(cmp, m, exciseEnabled)
-				if m.IsCompacting() || doesHintApply == hintDoesNotApply || files[m] {
-					continue
-				}
-				switch doesHintApply {
-				case hintDeletesFile:
-					filesDeletedByCurrentHint++
-				case hintExcisesFile:
-					// Account for the original file being deleted.
-					filesDeletedByCurrentHint++
-					// An excise could produce up to 2 new files. If the hint
-					// leaves a fragment of the file on the left, decrement
-					// the counter once. If the hint leaves a fragment of the
-					// file on the right, decrement the counter once.
-					if cmp(h.bounds.Start, m.Smallest().UserKey) > 0 {
-						filesDeletedByCurrentHint--
-					}
-					if m.UserKeyBounds().End.IsUpperBoundFor(cmp, h.bounds.End.Key) {
-						filesDeletedByCurrentHint--
-					}
-				}
-				filesDeletedByLevel[l] = append(filesDeletedByLevel[l], m)
-			}
-		}
-		if filesDeletedByCurrentHint < 0 {
-			// This hint does not delete a sufficient number of files to warrant
-			// a delete-only compaction at this stage. Drop it (ie. don't add it
-			// to either resolved or unresolved hints) so it doesn't stick around
-			// forever.
-			continue
-		}
-		// This hint will be resolved and dropped.
-		for l := h.tombstoneLevel + 1; l < numLevels; l++ {
-			byLevel[l] = append(byLevel[l], filesDeletedByLevel[l]...)
-			for _, m := range filesDeletedByLevel[l] {
-				if files == nil {
-					// Construct files lazily, assuming most calls will not
-					// produce delete-only compactions.
-					files = make(map[*manifest.TableMetadata]bool)
-				}
-				files[m] = true
-			}
-		}
-		resolvedHints = append(resolvedHints, h)
-	}
-
-	var compactLevels []compactionLevel
-	for l, files := range byLevel {
-		if len(files) == 0 {
-			continue
-		}
-		compactLevels = append(compactLevels, compactionLevel{
-			level: l,
-			files: manifest.NewLevelSliceKeySorted(cmp, files),
-		})
-	}
-	return compactLevels, resolvedHints, unresolvedHints
-}
-
-// Runs a delete-only compaction.
-//
-// d.mu must be held when calling this.
-func (d *DB) runDeleteOnlyCompaction(
-	c *tableCompaction, snapshots compact.Snapshots,
-) (ve *manifest.VersionEdit, stats compact.Stats, blobs []compact.OutputBlob, retErr error) {
-	// Release the d.mu lock while doing I/O.
-	// Note the unusual order: Unlock and then Lock.
-	d.mu.Unlock()
-	defer d.mu.Lock()
-
-	// If any snapshots exist beneath the largest tombstone sequence number,
-	// then deleting data beneath the tombstone violates the snapshot's
-	// isolation. Validate that all hints' tombstones' sequence numbers fall
-	// within the last snapshot stripe.
-	for _, h := range c.deleteOnly.hints {
-		if snapshots.Index(h.tombstoneSeqNums.High) != 0 {
-			return nil, stats, blobs, errors.AssertionFailedf(
-				"tombstone largest sequence number is not in the last snapshot stripe")
-		}
-	}
-
-	fragments := fragmentDeleteCompactionHints(d.cmp, c.deleteOnly.hints)
-	ve = &manifest.VersionEdit{
-		DeletedTables: map[manifest.DeletedTableEntry]*manifest.TableMetadata{},
-	}
-	for _, cl := range c.inputs {
-		levelMetrics := c.metrics.perLevel.level(cl.level)
-		err := d.runDeleteOnlyCompactionForLevel(cl, levelMetrics, ve, fragments, c.deleteOnly.exciseEnabled)
-		if err != nil {
-			return nil, stats, blobs, err
-		}
-	}
-	// Remove any files that were added and deleted in the same versionEdit.
-	ve.NewTables = slices.DeleteFunc(ve.NewTables, func(e manifest.NewTableEntry) bool {
-		entry := manifest.DeletedTableEntry{Level: e.Level, FileNum: e.Meta.TableNum}
-		if _, deleted := ve.DeletedTables[entry]; deleted {
-			delete(ve.DeletedTables, entry)
-			return true
-		}
-		return false
-	})
-	sort.Slice(ve.NewTables, func(i, j int) bool {
-		return ve.NewTables[i].Meta.TableNum < ve.NewTables[j].Meta.TableNum
-	})
-	deletedTableEntries := slices.Collect(maps.Keys(ve.DeletedTables))
-	slices.SortFunc(deletedTableEntries, func(a, b manifest.DeletedTableEntry) int {
-		return stdcmp.Compare(a.FileNum, b.FileNum)
-	})
-	// Remove any entries from CreatedBackingTables that are not used in any
-	// NewFiles.
-	usedBackingFiles := make(map[base.DiskFileNum]struct{})
-	for _, e := range ve.NewTables {
-		if e.Meta.Virtual {
-			usedBackingFiles[e.Meta.TableBacking.DiskFileNum] = struct{}{}
-		}
-	}
-	ve.CreatedBackingTables = slices.DeleteFunc(ve.CreatedBackingTables, func(b *manifest.TableBacking) bool {
-		_, used := usedBackingFiles[b.DiskFileNum]
-		return !used
-	})
-
-	// Iterate through the deleted tables and new tables to annotate excised tables.
-	// If a new table is virtual and the base.DiskFileNum is the same as a deleted table, then
-	// our deleted table was excised.
-	for _, table := range deletedTableEntries {
-		for _, newEntry := range ve.NewTables {
-			if newEntry.Meta.Virtual &&
-				newEntry.Meta.TableBacking.DiskFileNum == ve.DeletedTables[table].TableBacking.DiskFileNum {
-				c.annotations = append(c.annotations,
-					fmt.Sprintf("(excised: %s)", ve.DeletedTables[table].TableNum))
-				break
-			}
-		}
-
-	}
-
-	// Refresh the disk available statistic whenever a compaction/flush
-	// completes, before re-acquiring the mutex.
-	d.calculateDiskAvailableBytes()
-	return ve, stats, blobs, nil
-}
-
-// deleteCompactionHintFragment represents a fragment of the key space and
-// contains a set of deleteCompactionHints that apply to that fragment; a
-// fragment starts at the start field and ends where the next fragment starts.
-type deleteCompactionHintFragment struct {
-	start []byte
-	hints []deleteCompactionHint
-}
-
-// Delete compaction hints can overlap with each other, and multiple fragments
-// can apply to a single file. This function takes a list of hints and fragments
-// them, to make it easier to apply them to non-overlapping files occupying a level;
-// that way, files and hint fragments can be iterated on in lockstep, while efficiently
-// being able to apply all hints overlapping with a given file.
-func fragmentDeleteCompactionHints(
-	cmp Compare, hints []deleteCompactionHint,
-) []deleteCompactionHintFragment {
-	fragments := make([]deleteCompactionHintFragment, 0, len(hints)*2)
-	for i := range hints {
-		fragments = append(fragments, deleteCompactionHintFragment{start: hints[i].bounds.Start},
-			deleteCompactionHintFragment{start: hints[i].bounds.End.Key})
-	}
-	slices.SortFunc(fragments, func(i, j deleteCompactionHintFragment) int {
-		return cmp(i.start, j.start)
-	})
-	fragments = slices.CompactFunc(fragments, func(i, j deleteCompactionHintFragment) bool {
-		return bytes.Equal(i.start, j.start)
-	})
-	for _, h := range hints {
-		startIdx := sort.Search(len(fragments), func(i int) bool {
-			return cmp(fragments[i].start, h.bounds.Start) >= 0
-		})
-		endIdx := sort.Search(len(fragments), func(i int) bool {
-			return cmp(fragments[i].start, h.bounds.End.Key) >= 0
-		})
-		for i := startIdx; i < endIdx; i++ {
-			fragments[i].hints = append(fragments[i].hints, h)
-		}
-	}
-	return fragments
-}
-
-// applyHintOnFile applies a deleteCompactionHint to a file, and updates the
-// versionEdit accordingly. It returns a list of new files that were created
-// if the hint was applied partially to a file (eg. through an exciseTable as opposed
-// to an outright deletion). levelMetrics is kept up-to-date with the number
-// of tables deleted or excised.
-func (d *DB) applyHintOnFile(
-	h deleteCompactionHint,
-	f *manifest.TableMetadata,
-	level int,
-	levelMetrics *LevelMetrics,
-	ve *manifest.VersionEdit,
-	hintOverlap deletionHintOverlap,
-) (newFiles []manifest.NewTableEntry, err error) {
-	if hintOverlap == hintDoesNotApply {
-		return nil, nil
-	}
-
-	// The hint overlaps with at least part of the file.
-	if hintOverlap == hintDeletesFile {
-		// The hint deletes the entirety of this file.
-		ve.DeletedTables[manifest.DeletedTableEntry{
-			Level:   level,
-			FileNum: f.TableNum,
-		}] = f
-		levelMetrics.TablesDeleted++
-		return nil, nil
-	}
-	// The hint overlaps with only a part of the file, not the entirety of it. We need
-	// to use d.exciseTable. (hintOverlap == hintExcisesFile)
-	if d.FormatMajorVersion() < FormatVirtualSSTables {
-		panic("pebble: delete-only compaction hint excising a file is not supported in this version")
-	}
-
-	levelMetrics.TablesExcised++
-	leftTable, rightTable, err := d.exciseTable(context.TODO(), h.bounds, f, level, tightExciseBounds)
-	if err != nil {
-		return nil, errors.Wrap(err, "error when running excise for delete-only compaction")
-	}
-	newFiles = applyExciseToVersionEdit(ve, f, leftTable, rightTable, level)
-	return newFiles, nil
-}
-
-func (d *DB) runDeleteOnlyCompactionForLevel(
-	cl compactionLevel,
-	levelMetrics *LevelMetrics,
-	ve *manifest.VersionEdit,
-	fragments []deleteCompactionHintFragment,
-	exciseEnabled bool,
-) error {
-	if cl.level == 0 {
-		panic("cannot run delete-only compaction for L0")
-	}
-	curFragment := 0
-
-	// Outer loop loops on files. Middle loop loops on fragments. Inner loop
-	// loops on raw fragments of hints. Number of fragments are bounded by
-	// the number of hints this compaction was created with, which is capped
-	// in the compaction picker to avoid very CPU-hot loops here.
-	for f := range cl.files.All() {
-		// curFile usually matches f, except if f got excised in which case
-		// it maps to a virtual file that replaces f, or nil if f got removed
-		// in its entirety.
-		curFile := f
-		for curFragment < len(fragments) && d.cmp(fragments[curFragment].start, f.Smallest().UserKey) <= 0 {
-			curFragment++
-		}
-		if curFragment > 0 {
-			curFragment--
-		}
-
-		for ; curFragment < len(fragments); curFragment++ {
-			if f.UserKeyBounds().End.CompareUpperBounds(d.cmp, base.UserKeyInclusive(fragments[curFragment].start)) < 0 {
-				break
-			}
-			// Process all overlapping hints with this file. Note that applying
-			// a hint twice is idempotent; curFile should have already been excised
-			// the first time, resulting in no change the second time.
-			for _, h := range fragments[curFragment].hints {
-				if h.tombstoneLevel >= cl.level {
-					// We cannot excise out the deletion tombstone itself, or anything
-					// above it.
-					continue
-				}
-				hintOverlap := h.canDeleteOrExcise(d.cmp, curFile, exciseEnabled)
-				if hintOverlap == hintDoesNotApply {
-					continue
-				}
-				newFiles, err := d.applyHintOnFile(h, curFile, cl.level, levelMetrics, ve, hintOverlap)
-				if err != nil {
-					return err
-				}
-				if _, ok := ve.DeletedTables[manifest.DeletedTableEntry{Level: cl.level, FileNum: curFile.TableNum}]; ok {
-					curFile = nil
-				}
-				if len(newFiles) > 0 {
-					curFile = newFiles[len(newFiles)-1].Meta
-				} else if curFile == nil {
-					// Nothing remains of the file.
-					break
-				}
-			}
-			if curFile == nil {
-				// Nothing remains of the file.
-				break
-			}
-		}
-		if _, ok := ve.DeletedTables[manifest.DeletedTableEntry{
-			Level:   cl.level,
-			FileNum: f.TableNum,
-		}]; !ok {
-			panic("pebble: delete-only compaction scheduled with hints that did not delete or excise a file")
-		}
-	}
-	return nil
 }

--- a/compaction_delete_test.go
+++ b/compaction_delete_test.go
@@ -6,19 +6,16 @@ package pebble
 
 import (
 	"bytes"
-	"cmp"
 	"fmt"
+	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -27,11 +24,6 @@ import (
 func TestCompactionDeleteOnlyHints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	parseUint64 := func(s string) uint64 {
-		v, err := strconv.ParseUint(s, 10, 64)
-		require.NoError(t, err)
-		return v
-	}
 	var d *DB
 	defer func() {
 		if d != nil {
@@ -73,9 +65,10 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 			//		compactInfo = &info
 			//	},
 			// },
-			EventListener:      &el,
-			FormatMajorVersion: internalFormatNewest,
-			Logger:             testutils.Logger{T: t},
+			EventListener:              &el,
+			FormatMajorVersion:         internalFormatNewest,
+			Logger:                     testutils.Logger{T: t},
+			CompactionConcurrencyRange: func() (lower, upper int) { return 1, 1 },
 		}
 		opts.WithFSDefaults()
 		opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool { return true }
@@ -87,24 +80,28 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 		for d.mu.compact.compactProcesses > 0 {
 			d.mu.compact.cond.Wait()
 		}
-		slices.SortFunc(compactInfo, func(a, b CompactionInfo) int {
-			return cmp.Compare(a.String(), b.String())
-		})
-
-		var b strings.Builder
 		if len(compactInfo) == 0 {
 			return "(none)\n"
 		}
-
+		var lines []string
 		for _, c := range compactInfo {
-			// Fix the job ID and durations for determinism.
+			// Fix the job ID, durations and file numbers for determinism.
 			c.JobID = 100
 			c.Duration = time.Second
 			c.TotalDuration = 2 * time.Second
-			b.WriteString(fmt.Sprintf("%s\n", c.String()))
+			for i := range c.Input {
+				for j := range c.Input[i].Tables {
+					c.Input[i].Tables[j].FileNum = 0
+				}
+			}
+			for i := range c.Output.Tables {
+				c.Output.Tables[i].FileNum = 0
+			}
+			lines = append(lines, c.String())
 		}
 		compactInfo = nil
-		return b.String()
+		slices.Sort(lines)
+		return strings.Join(lines, "\n")
 	}
 
 	var err error
@@ -143,52 +140,6 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				}
 				return runLSMCmd(td, d)
 
-			case "force-set-hints":
-				d.mu.Lock()
-				defer d.mu.Unlock()
-				d.mu.compact.deletionHints = d.mu.compact.deletionHints[:0]
-				var buf bytes.Buffer
-				for data := range crstrings.LinesSeq(td.Input) {
-					parts := strings.FieldsFunc(strings.TrimSpace(data),
-						func(r rune) bool { return r == '-' || r == ' ' || r == '.' })
-
-					start, end := []byte(parts[2]), []byte(parts[3])
-
-					var tombstoneFile *manifest.TableMetadata
-					tombstoneLevel := int(parseUint64(parts[0][1:]))
-
-					// Set file number to the value provided in the input.
-					tombstoneFile = &manifest.TableMetadata{
-						TableNum: base.TableNum(parseUint64(parts[1])),
-					}
-
-					var keyType manifest.KeyType
-					switch typ := parts[6]; typ {
-					case "point_key_only":
-						keyType = manifest.KeyTypePoint
-					case "range_key_only":
-						keyType = manifest.KeyTypeRange
-					case "point_and_range_key":
-						keyType = manifest.KeyTypePointAndRange
-					default:
-						return fmt.Sprintf("unknown hint type: %s", typ)
-					}
-
-					h := deleteCompactionHint{
-						keyType:        keyType,
-						bounds:         base.UserKeyBoundsEndExclusive(start, end),
-						tombstoneLevel: tombstoneLevel,
-						tombstoneFile:  tombstoneFile,
-						tombstoneSeqNums: base.SeqNumRange{
-							Low:  base.SeqNum(parseUint64(parts[4])),
-							High: base.SeqNum(parseUint64(parts[5])),
-						},
-					}
-					d.mu.compact.deletionHints = append(d.mu.compact.deletionHints, h)
-					fmt.Fprintln(&buf, h.String())
-				}
-				return buf.String()
-
 			case "get-hints":
 				d.mu.Lock()
 				defer d.mu.Unlock()
@@ -213,31 +164,17 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 						d.waitTableStats()
 					}
 				}()
-
-				hints := d.mu.compact.deletionHints
-				if len(hints) == 0 {
-					return "(none)"
-				}
-				var buf bytes.Buffer
-				for _, h := range hints {
-					buf.WriteString(h.String() + "\n")
-				}
-				return buf.String()
+				return d.mu.compact.wideTombstones.String()
 
 			case "maybe-compact":
 				d.mu.Lock()
 				d.maybeScheduleCompaction()
 
 				var buf bytes.Buffer
-				fmt.Fprintf(&buf, "Deletion hints:\n")
-				for _, h := range d.mu.compact.deletionHints {
-					fmt.Fprintf(&buf, "  %s\n", h.String())
-				}
-				if len(d.mu.compact.deletionHints) == 0 {
-					fmt.Fprintf(&buf, "  (none)\n")
-				}
-				fmt.Fprintf(&buf, "Compactions:\n")
-				fmt.Fprintf(&buf, "  %s", compactionString())
+				fmt.Fprint(&buf, strings.TrimSpace(d.mu.compact.wideTombstones.String()))
+				fmt.Fprintln(&buf)
+				fmt.Fprintln(&buf, "Compactions:")
+				fmt.Fprint(&buf, compactionString())
 				d.mu.Unlock()
 				return buf.String()
 
@@ -246,10 +183,9 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 					return err.Error()
 				}
 				d.mu.Lock()
+				defer d.mu.Unlock()
 				compactInfo = nil
-				s := d.mu.versions.currentVersion().String()
-				d.mu.Unlock()
-				return s
+				return d.mu.versions.currentVersion().String()
 
 			case "close-snapshot":
 				seqNum := base.ParseSeqNum(strings.TrimSpace(td.Input))
@@ -269,10 +205,9 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				}
 
 				d.mu.Lock()
+				defer d.mu.Unlock()
 				// Closing the snapshot may have triggered a compaction.
-				str := compactionString()
-				d.mu.Unlock()
-				return str
+				return compactionString()
 
 			case "iter":
 				snap := Snapshot{
@@ -310,10 +245,13 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 				return "OK"
 
 			case "describe-lsm":
+				// File numbers are nondeterministic in this test, so replace
+				// them with XXXXXX.
+				fileNumRegexp := regexp.MustCompile(`(?m)(^\s*)([0-9]*):`)
 				d.mu.Lock()
 				s := d.mu.versions.currentVersion().String()
 				d.mu.Unlock()
-				return s
+				return fileNumRegexp.ReplaceAllString(s, "${1}XXXXXX:")
 
 			default:
 				return fmt.Sprintf("unknown command: %s", td.Cmd)

--- a/db.go
+++ b/db.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
 	"github.com/cockroachdb/pebble/internal/problemspans"
+	"github.com/cockroachdb/pebble/internal/tombspan"
 	"github.com/cockroachdb/pebble/metrics"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/remote"
@@ -420,9 +421,10 @@ type DB struct {
 			compactProcesses int
 			// The number of download compactions.
 			downloadingCount int
-			// The list of deletion hints, suggesting ranges for delete-only
-			// compactions.
-			deletionHints []deleteCompactionHint
+			// The set of wide tombstoned spans. Spans are added by the table
+			// stats collector, used to inform compaction picking and then
+			// dropped when no longer useful.
+			wideTombstones tombspan.Set
 			// The list of manual compactions. The next manual compaction to perform
 			// is at the start of the list. New entries are added to the end.
 			manual    []*manualCompaction

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -614,6 +614,19 @@ func (v *Version) AllLevelsAndSublevels() iter.Seq2[Layer, LevelSlice] {
 	}
 }
 
+// AllTables returns an iterator over all tables in the version.
+func (v *Version) AllTables() iter.Seq2[Layer, *TableMetadata] {
+	return func(yield func(Layer, *TableMetadata) bool) {
+		for layer, tables := range v.AllLevelsAndSublevels() {
+			for table := range tables.All() {
+				if !yield(layer, table) {
+					return
+				}
+			}
+		}
+	}
+}
+
 // CheckOrdering checks that the files are consistent with respect to
 // increasing file numbers (for level 0 files) and increasing and non-
 // overlapping internal key ranges (for level non-0 files).

--- a/internal/strparse/strparse.go
+++ b/internal/strparse/strparse.go
@@ -242,6 +242,16 @@ func (p *Parser) HashSeqNum() base.SeqNum {
 	return base.ParseSeqNum(tok[1:])
 }
 
+// SeqNumRange parses the next token as a sequence number range.
+func (p *Parser) SeqNumRange() base.SeqNumRange {
+	p.Expect("[")
+	low := p.HashSeqNum()
+	p.Expect("-")
+	high := p.HashSeqNum()
+	p.Expect("]")
+	return base.SeqNumRange{Low: low, High: high}
+}
+
 // BlobFileID parses the next token as a BlobFileID.
 func (p *Parser) BlobFileID() base.BlobFileID {
 	s := p.Next()

--- a/internal/tombspan/testdata/set
+++ b/internal/tombspan/testdata/set
@@ -1,0 +1,82 @@
+define-version
+L0
+000029:[b#230,RANGEDEL-r#inf,RANGEDEL] seqnums:[#230-#230]
+L2
+000019:[b#201,SET-c#198,SET] seqnums:[#198-#201]
+000011:[d#71,SET-f#70,SET] seqnums:[#70-#71]
+L3
+000008:[c#28,SET-g#29,SET] seqnums:[#28-#29]
+L4
+000005:[a#12,SET-g#11,SET] seqnums:[#11-#12]
+----
+v0:
+L0.0:
+  000029:[b#230,RANGEDEL-r#inf,RANGEDEL] seqnums:[#230-#230] points:[b#230,RANGEDEL-r#inf,RANGEDEL]
+L2:
+  000019:[b#201,SET-c#198,SET] seqnums:[#198-#201] points:[b#201,SET-c#198,SET]
+  000011:[d#71,SET-f#70,SET] seqnums:[#70-#71] points:[d#71,SET-f#70,SET]
+L3:
+  000008:[c#28,SET-g#29,SET] seqnums:[#28-#29] points:[c#28,SET-g#29,SET]
+L4:
+  000005:[a#12,SET-g#11,SET] seqnums:[#11-#12] points:[a#12,SET-g#11,SET]
+
+add
+L0.000029 [b, r) seqnums{point=[#230-#230]}
+----
+Pending:
+  L0.000029 [b, r) seqnums{point=[#230-#230]}
+
+update-with-earliest-snapshot 250
+----
+Tombstoned spans:
+[b, r) = {point=230}
+
+# Pick a compaction, no excise allowed.
+
+pick-compaction v=0
+----
+delete L3.000008:[c#28,SET-g#29,SET] (completely contained within [b, r))
+Tombstoned spans:
+[b, r) = {point=230}
+
+# Try again, after marking 000008 as compacting. A new file should be discovered.
+
+mark-as-compacting table=000008
+----
+
+pick-compaction v=0
+----
+delete L2.000019:[b#201,SET-c#198,SET] (completely contained within [b, r))
+Tombstoned spans:
+[b, r) = {point=230}
+
+# Try again, this time with excise allowed. It'll pick a different compaction.
+
+pick-compaction v=0 exciseAllowed
+----
+excise L4.000005:[a#12,SET-g#11,SET] (partially overlapping with [b, r))
+Tombstoned spans:
+[b, r) = {point=230}
+
+# Define a new version, v1, after all the effects of the tombstones have been
+# applied.
+
+define-version
+L0
+000029:[b#230,RANGEDEL-r#inf,RANGEDEL] seqnums:[#230-#230]
+L4:
+ 000031:[a#12,SET-a#12,SET] seqnums:[#11-#12] points:[a#12,SET-a#12,SET]
+----
+v1:
+L0.0:
+  000029:[b#230,RANGEDEL-r#inf,RANGEDEL] seqnums:[#230-#230] points:[b#230,RANGEDEL-r#inf,RANGEDEL]
+L4:
+  000031:[a#12,SET-a#12,SET] seqnums:[#11-#12] points:[a#12,SET-a#12,SET]
+
+# Picking a compaction against v1 should find no compaction, and should clear
+# the set of tombstoned spans.
+
+pick-compaction v=1 exciseAllowed
+----
+none
+(none)

--- a/internal/tombspan/tombspan.go
+++ b/internal/tombspan/tombspan.go
@@ -1,0 +1,605 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// Package tombspan implements tracking of ranged tombstones (RANGEDELs,
+// RANGEKEYDELs) for the purpose of efficiently handling bulk deletions.
+//
+// # Ranged tombstones
+//
+// Pebble has two key types: point keys that are defined at a singular user key,
+// and range keys that are defined over a span [start,end) of user key space.
+// Pebble defines a separate ranged tombstone key kind for each.
+//
+// A RANGEDEL ("range deletion") tombstone deletes all point keys within a span
+// [start,end). Like all keys in Pebble, a RANGEDEL tombstone has a sequence
+// number that dictates its ordering within the history of writes. A range
+// deletion tombstone applies to all point keys contained within the [start,end)
+// bounds with sequence numbers less than the tombstone's sequence number.
+//
+// A RANGEKEYDEL ("range key deletion") tombstone deletes all range keys defined
+// within a span [start,end). A "range key deletion" tombstone applies to all
+// range keys defined within the [start,end) span with lesser sequence numbers.
+// If a range key extends beyond the [start,end) span, it's truncated or split
+// such that the range key is no longer defined within the bounds of the
+// tombstone.
+//
+// ## Disk space reclamation
+//
+// Pebble reclaims disk space of keys deleted by ranged tombstones during
+// asynchronous compactions.
+//
+// Regular default compactions read sstables from two or more levels, merge
+// them, and output new sstables. If input sstables contain ranged tombstones,
+// regular compactions read them and apply them, eliding keys that are deleted
+// by the tombstones. Only ranged tombstones that are contained within the input
+// sstables are applied. The ranged tombstones contained in other sstables
+// higher in the LSM are not considered (see #1961).
+//
+// This regular default compaction process thus requires a ranged tombstone to
+// be compacted all the way down the LSM to reclaim all the available disk
+// space. This results in slow, asynchronous disk space reclamation and incurs
+// write amplification (sstables may contain both live and deleted data,
+// requring rewriting the live data). This is okay for narrow ranged tombstones
+// deleting tens or hundreds of keys.
+//
+// However range deletions may be used to efficiently bulk delete wide swaths of
+// the keyspace. In CockroachDB this may happen when an entire table or index is
+// dropped, or a replica is removed from a node for rebalancing. We need to more
+// promptly reclaim disk space for these bulk deletions. We can do this by
+// maintaining information about "wide" ranged tombstones outside the narrow
+// scope of a regular compaction between two levels.
+//
+// ## Table stats collection
+//
+// Whenever a new table is added to the LSM, Pebble's table stats collector
+// computes stats for the table to be held in-memory for the lifetime of the
+// table. The stats collector reads the table's ranged tombstones and finds the
+// set of tables lower in the LSM that overlap. It uses this set to calculate an
+// approximation of the amount of disk space that falls within the tombstoned
+// span and thus could be reclaimed by compactions. This estimate is used to
+// prioritize regular default compactions.
+//
+// At the same, the table stats collector compares the overlapping tables'
+// bounds against the tombstones' bounds, looking for tables that (a) are wholly
+// deleted by the tombstones, or (b) have a prefix or suffix of their data
+// deleted by the tombstones. If any such tables are found, the tombstone span
+// is considered "wide".
+//
+// # Tombstone span tracking
+//
+// The [Set] type defined within this package maintains a set of "tombstone
+// spans", describing "wide" ranged tombstones that were observed by the table
+// stats collector. The table stats collector constructs a WideTombstone
+// representing 1 or more ranged tombstones (degfragmented, deduplicated) and
+// calls [Set.AddTombstones] to add it to the set.
+//
+// Tombstones added to the [Set] are not immediately able to drive compactions.
+// If a LSM snapshot is open at sequence number beneath one of the originating
+// tombstones' sequence numbers, deleting data beneath the tombstone may violate
+// that snapshot's isolation.
+//
+// Consider the below graphic, modelling a wide tombstone covering the keyspace
+// [b, r), constructed from the abutting tombstone fragments [b,h)#230,RANGEDEL
+// and [h,r)#200,RANGEDEL (assuming they're contained within the same sstable).
+//
+//	250
+//
+//	      |-b...230:h-|
+//	_____________________________________________________ snapshot #210
+//	200               |--h.RANGEDEL.200:r--|
+//
+//	_____________________________________________________ snapshot #180
+//
+//	150                     +--------+
+//	          +---------+   | 000003 |
+//	          | 000002  |   |        |
+//	          +_________+   |        |
+//	100_____________________|________|___________________ snapshot #100
+//	                        +--------+
+//	_____________________________________________________ snapshot #70
+//	                            +---------------+
+//	 50                         | 000001        |
+//	                            |               |
+//	                            +---------------+
+//	______________________________________________________________
+//	    a b c d e f g h i j k l m n o p q r s t u v w x y z
+//
+// A tombstone is only allowed to drop a key once the tombstone and the key fall
+// into the same snapshot stripe (i.e., no snapshots exist at sequence numbers
+// between the keys' sequence numbers). To simplify logic, we only act on a
+// WideTombstone once there are no snapshots at any sequence number less than
+// the WideTombstone's highest sequence number. (The WideTombstone falls into
+// the last snapshot stripe.)
+//
+// In the above diagram, the tombstone [b,h)#230,RANGEDEL has the highest
+// tombstone sequence number incorporated into the WideTombstone. Initially the
+// wide tombstone is held in a queue of pending tombstones. After adding hints or
+// when the earliest snapshot close, the caller is responsible for calling
+// [Set.UpdateWithEarliestSnapshot]. When the earliest snapshot exceeds the
+// WideTombstone's highest seqnum (#230 in the above diagram), the tombstone
+// migrates from the pending queue to being incorporated into a region tree
+// recording tombstoned spans.
+//
+// ## Region tree
+//
+// The region tree maps [start,end) spans to sequence numbers at which keys
+// within the span are known to be tombstoned. The region tree maintains
+// separate sequence numbers for point keys and range keys. When a WideTombstone
+// migrates from its pending state to the tree, the WideTombstone's span is
+// updated. The lowest sequence number of an originating tombstone is inserted
+// into the tree. In the above diagram, the [h,r)#200,RANGEDEL fragment has the
+// lowest sequence number, so the tree is updated to record that over the span
+// [b,r) all point keys are deleted beneath sequence number #200.
+//
+// If a span is already tombstoned, the span is updated to the more powerful of
+// the tombstones (i.e, the higher of the sequence numbers).
+//
+// ## Compaction picking
+//
+// The tombstone set and the region tree are used to drive compaction picking
+// decisions, picking a special type of compaction called a "delete-only
+// compaction." These compactions are lightweight metadata compactions that
+// apply version edits to the LSM without reading or iterating over sstables.
+//
+// At the beginning of compaction picking, the compaction picker calls
+// [Set.PickCompaction] to check if any delete-only compactions are available to
+// be picked. PickCompaction walks the region tree in order. For each defined
+// span, it finds sstables that overlap the span across levels of the LSM. It
+// searches for tables older than the tombstone that (a) are entirely deleted by
+// the tombstone, or (b) have a prefix or suffix of data that is entirely
+// deleted by the tombstone.
+//
+// In the above example, the WideTombstone completely contains two tables,
+// 000002 and 000003. The WideTombstone also overlaps the beginning of table
+// 000001. All three of these tables may be returned by [Set.PickCompaction]:
+// 000002 and 000003 for deletion, and 000001 for excise. PickCompaction will
+// return information about only 1 of the tables. The compaction picker will
+// then schedule a compaction to perform the table deletion or excise.
+//
+// If PickCompaction finds that no tables are affected by a tombstoned span, the
+// span is forgotten. If any tables would be affected by the tombstoned span if
+// they weren't already in the process of being compacted, the span is preserved
+// in case the compaction is ultimately cancelled or produces a new output
+// sstable that's eligible for a compaction.
+//
+// ### LargestSeqNumAbsolute
+//
+// It's crucial that compaction picking only chooses tables that contain data
+// older than the tombstones. Sequence numbers provide a total ordering over
+// committed writes, and we know a table can be deleted as long as all its keys
+// were committed with sequence numbers less than the tombstone sequence number.
+//
+// However, there's a subtlety. When a regular default compaction observes that
+// there is no data within the LSM beneath the compaction, it elides tombstones
+// and applies an optimization that updates the keys' sequence numbers to zero.
+// If default compactions compact the tombstones that originated a
+// WideTombstone, default compactions may begin to update newer keys to have
+// zeroed sequence numbers. This zeroing erases the knowledge that keys are too
+// recent to delete.
+//
+// To account for this subtlety, [manifest.TableMetadata] has a
+// [LargestSeqNumAbsolute] field. LargestSeqNumAbsolute provides an upper bound
+// on the original, commit-time sequence numbers of all keys within the table.
+// Compaction picking uses this sequence number when determining whether a table
+// contains exclusively data older than the tombstone.
+//
+// This field is in-memory only and is reset to the TableMetadata's largest
+// sequence number on process restart. This lossy behavior is okay, because the
+// [Set] is also in-memory only and wiped on restart. On [pebble.Open], the
+// table stats collector will scan tables with ranged tombstones to repopulate
+// the tombstone spans. Since a key can only have its sequence number zeroed if
+// nothing exists beneath it, any tombstones that are more recent than zeroed
+// keys have already been removed from the LSM.
+
+package tombspan
+
+import (
+	"bytes"
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/RaduBerinde/axisds"
+	"github.com/RaduBerinde/axisds/regiontree"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+)
+
+// A WideTombstone summarizes a set of tombstones that together delete a wide
+// swath of the keyspace.
+//
+// A WideTombstone is recorded if the stats collector observed at least one
+// sstable that is (a) entirely deleted by the described tombstones, or (b) has
+// a prefix or suffix of its data that is entirely deleted by the described
+// tombstones.
+type WideTombstone struct {
+	// PointSeqNums and RangeSeqNums are the sequence number ranges of the point
+	// and range tombstones used to construct the WideTombstone. The upper bound
+	// determines *when* it's safe to delete data (preserving snapshots'
+	// isolation guarantees), and the lower bound determines *what* data can be
+	// deleted. All of a tables' keys must be less than the sequence number
+	// range to be deleted. All of a tables' sequence numbers must fall into
+	// the same snapshot stripe as the high end of the sequence number range,
+	// and must all be less than the low end of the sequence number range to be
+	// deleted.
+	PointSeqNums base.SeqNumRange
+	RangeSeqNums base.SeqNumRange
+	// Bounds are the bounds of the tombstone(s).
+	Bounds base.UserKeyBounds
+	// Level of the table in the LSM containing the range tombstone(s) when the
+	// WideTombstone was created. Only lower levels need to be searched for
+	// files that may be deleted.
+	Level int
+	// Table identifies the sstable containing the range tombstone(s) that
+	// created the WideTombstone.
+	Table *manifest.TableMetadata
+}
+
+// HighestSeqNum returns the highest sequence number of all the tombstones
+// described by the WideTombstone (across both point and range key kinds).
+func (wt WideTombstone) HighestSeqNum() base.SeqNum {
+	return max(wt.PointSeqNums.High, wt.RangeSeqNums.High)
+}
+
+// String implements fmt.Stringer.
+func (wt WideTombstone) String() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "L%d.%s %s seqnums{", wt.Level, wt.Table.TableNum, wt.Bounds)
+	if wt.PointSeqNums.High > 0 {
+		fmt.Fprintf(&buf, "point=%s", wt.PointSeqNums)
+	}
+	if wt.RangeSeqNums.High > 0 {
+		if wt.PointSeqNums.High > 0 {
+			fmt.Fprint(&buf, ", ")
+		}
+		fmt.Fprintf(&buf, "range=%s", wt.RangeSeqNums)
+	}
+	fmt.Fprint(&buf, "}")
+	return buf.String()
+}
+
+// Make creates a new tombstone set.
+func Make(comparer *base.Comparer) Set {
+	return Set{
+		comparer: comparer,
+		tombstonedSpans: regiontree.Make(
+			axisds.CompareFn[[]byte](comparer.Compare),
+			func(a, b tombstoneSeqNums) bool { return a == b },
+		),
+	}
+}
+
+// Set maintains a set of tombstoned spans. It's used to trigger delete
+// compactions that efficiently remove data from the LSM.
+//
+// Set is not safe for concurrent use.
+type Set struct {
+	comparer *base.Comparer
+	// pending is the set of WideTombstones that cannot yet be used to schedule
+	// delete-only compactions, because at least one of their tombstones are not
+	// yet in the last snapshot stripe. Pending is sorted by HighestSeqNum() in
+	// descending order.
+	//
+	// When UpdateWithEarliestSnapshot is called with a sufficiently high
+	// snapshot sequence number, a prefix of the pending WideTombstones are
+	// incorporated into tombstonedSpans and removed from pending.
+	pending []WideTombstone
+	// tombstonedSpans is a region tree of tombstoned spans with sequence
+	// numbers that fall into the last snapshot stripe (i.e, the keys are older
+	// than the oldest snapshot). During compaction picking, the tree is scanned
+	// and for each span, the current LSM version is examined to see if any
+	// tables can be deleted outright or excised. If no relevant tables are
+	// found, the span is removed from the tree.
+	tombstonedSpans regiontree.T[[]byte, tombstoneSeqNums]
+	// scratch is a temporary buffer to avoid allocations while collecting the
+	// bounds of spans to remove from the tree of tombstoned spans.
+	scratch []base.UserKeyBounds
+}
+
+// tombstoneSeqNums holds the earliest sequence numbers for both point and range
+// tombstones within a particular span. The zero sequence number indicates the
+// absence of a tombstone of the kind within the span.
+type tombstoneSeqNums struct {
+	pointSeqNum base.SeqNum
+	rangeSeqNum base.SeqNum
+}
+
+// BoundsSeqNums returns true if all the keys in the provided table are older
+// than the tombstones of the provided span, and all keys in the table are
+// deleted by tombstones within the span. If the table contains keys of a type
+// (Point vs Range) not deleted by the span, the function returns false.
+func (ts tombstoneSeqNums) BoundsSeqNums(m *manifest.TableMetadata) bool {
+	// A table can only be deleted if all of its keys are older than the
+	// earliest tombstone aggregated into the span (for both point and range
+	// keys, if any).
+	//
+	// Note that we use m.LargestSeqNumAbsolute, not m.LargestSeqNum. Consider a
+	// compaction that zeroes sequence numbers. A compaction may zero the
+	// sequence number of a key with a sequence number >
+	// h.tombstoneSmallestSeqNum and set it to zero. If we looked at
+	// m.LargestSeqNum, the resulting output file would appear to not contain
+	// any keys more recent than the oldest tombstone. To avoid this error, the
+	// largest pre-zeroing sequence number is maintained in
+	// LargestSeqNumAbsolute and used here to make the determination whether the
+	// file's keys are older than all of the span's tombstones.
+	return (!m.HasPointKeys || ts.pointSeqNum > 0 && m.LargestSeqNumAbsolute < ts.pointSeqNum) &&
+		(!m.HasRangeKeys || ts.rangeSeqNum > 0 && m.LargestSeqNumAbsolute < ts.rangeSeqNum)
+}
+
+// String returns a string representation of the tombstoned span.
+func (ts tombstoneSeqNums) String() string {
+	var buf bytes.Buffer
+	fmt.Fprint(&buf, "{")
+	if ts.pointSeqNum > 0 {
+		fmt.Fprintf(&buf, "point=%s", ts.pointSeqNum)
+	}
+	if ts.rangeSeqNum > 0 {
+		if ts.pointSeqNum > 0 {
+			fmt.Fprint(&buf, ", ")
+		}
+		fmt.Fprintf(&buf, "range=%s", ts.rangeSeqNum)
+	}
+	fmt.Fprint(&buf, "}")
+	return buf.String()
+}
+
+// mergeTombstonedSpans is used when updating the tree to contain a new
+// tombstoned span. Tombstones with higher sequence numbers are more powerful,
+// deleting strictly more data, so merging preserves the highest sequence
+// number.
+func mergeTombstonedSpans(a, b tombstoneSeqNums) tombstoneSeqNums {
+	return tombstoneSeqNums{
+		pointSeqNum: max(a.pointSeqNum, b.pointSeqNum),
+		rangeSeqNum: max(a.rangeSeqNum, b.rangeSeqNum),
+	}
+}
+
+// AddTombstones adds the given WideTombstones to the set of tombstones. Callers
+// should invoke UpdateWithEarliestSnapshot after adding additional tombstones.
+//
+// AddTombstones must not be called concurrently with any other method.
+func (fs *Set) AddTombstones(tombstones ...WideTombstone) {
+	fs.pending = append(fs.pending, tombstones...)
+	slices.SortFunc(fs.pending, func(a, b WideTombstone) int {
+		return cmp.Compare(b.HighestSeqNum(), a.HighestSeqNum())
+	})
+}
+
+// UpdateWithEarliestSnapshot updates the set's state with the current oldest
+// snapshot. A call to UpdateWithEarliestSnapshot ensures that any subsequent
+// call to PickCompaction will consider all tombstoned spans with sequence
+// numbers that now fall into the last snapshot stripe.
+//
+// UpdateWithEarliestSnapshot must not be called concurrently with any other
+// method.
+func (ts *Set) UpdateWithEarliestSnapshot(earliestSnapshot base.SeqNum) {
+	// When a WideTombstone is created, the sequence numbers of the described
+	// tombstones are recorded. The highest tombstone sequence number must be in
+	// the last snapshot stripe for the WideTombstone to be used to actually
+	// delete data.
+	for i, h := range ts.pending {
+		if earliestSnapshot <= h.HighestSeqNum() {
+			// All remaining WideTombstones are not yet in the last snapshot
+			// stripe.
+			ts.pending = append(ts.pending[:0], ts.pending[i:]...)
+			return
+		}
+		// This WideTombstone's tombstones are now in the last snapshot stripe.
+		// Add a tombstoned span.
+		s := tombstoneSeqNums{
+			pointSeqNum: h.PointSeqNums.Low,
+			rangeSeqNum: h.RangeSeqNums.Low,
+		}
+		ts.tombstonedSpans.Update(h.Bounds.Start, h.Bounds.End.Key,
+			func(curr tombstoneSeqNums) tombstoneSeqNums {
+				return mergeTombstonedSpans(curr, s)
+			})
+	}
+	// All WideTombstones were added to the tombstoned spans.
+	ts.pending = ts.pending[:0]
+}
+
+// DeleteOnlyCompaction describes a picked delete-only compaction, applying to a
+// single sstable within the LSM.
+type DeleteOnlyCompaction struct {
+	Level  int
+	Table  manifest.LevelTable
+	Bounds base.UserKeyBounds
+	Excise bool
+}
+
+// String implements fmt.Stringer.
+func (d DeleteOnlyCompaction) String() string {
+	if d.Excise {
+		return fmt.Sprintf("excise L%d.%s (partially overlapping with %s)",
+			d.Level, d.Table, d.Bounds)
+	}
+	return fmt.Sprintf("delete L%d.%s (completely contained within %s)",
+		d.Level, d.Table, d.Bounds)
+}
+
+// PickCompaction consults the set of tombstoned spans to determine if any
+// tables within the provided version can be deleted outright, or excised (if
+// isExciseAllowed is true). If for any span within the set, no eligible tables
+// are found, the set is updated to clear the span.
+//
+// PickCompaction must not be called concurrently with any other method.
+func (ts *Set) PickCompaction(
+	v *manifest.Version, isExciseAllowed bool,
+) (picked DeleteOnlyCompaction, ok bool) {
+	// pickCompactionForSpan is a helper function that picks a compaction for a
+	// given tombstoned span. It returns the picked compaction, a boolean
+	// indicating whether a compaction was found, and a boolean indicating
+	// whether the span should be cleared because it's unlikely to be able to
+	// schedule new delete only compactions in the future.
+	clearSpans := ts.scratch[:0]
+	pickCompactionForSpan := func(tombBounds base.UserKeyBounds, span tombstoneSeqNums) (picked DeleteOnlyCompaction, ok bool) {
+		var skippedDueToCompacting bool
+		for level := manifest.NumLevels - 1; level > 0; level-- {
+			overlaps := v.Overlaps(level, tombBounds)
+			iter := overlaps.Iter()
+			for m := iter.First(); m != nil; m = iter.Next() {
+				// A table can only be deleted if all of its keys are older than
+				// the earliest tombstone aggregated into the span, and the
+				// tombstone covers all the key kinds contained within the
+				// table.
+				if !span.BoundsSeqNums(m) {
+					continue
+				}
+
+				// Skip any currently compacting tables.
+				if m.IsCompacting() {
+					skippedDueToCompacting = true
+					continue
+				}
+
+				eligibility := canDeleteOrExciseTable(ts.comparer.Compare, tombBounds, m.UserKeyBounds(), isExciseAllowed)
+				if eligibility == tableEligibilityDelete {
+					return DeleteOnlyCompaction{
+						Level:  level,
+						Table:  iter.Take(),
+						Bounds: tombBounds,
+						Excise: false,
+					}, true /* ok */
+				} else if eligibility == tableEligibilityExcise && isExciseAllowed {
+					return DeleteOnlyCompaction{
+						Level:  level,
+						Table:  iter.Take(),
+						Bounds: tombBounds,
+						Excise: true,
+					}, true /* ok */
+				}
+			}
+		}
+
+		// We didn't find any tables to delete or excise.
+		//
+		// If we skipped any tables because they were in the process of being
+		// compacted, this tombstone span might be able to delete a table
+		// outputted by the in-progress compaction. Or that compaction could be
+		// cancelled. In this case we keep the span around so we can try again
+		// when the compaction completes.
+		//
+		// Otherwise, it's unlikely this tombstone span will ever allow us to
+		// delete or excise anything. A future compaction would need to split
+		// tables in lower levels more favorably, an unlikely event. In this
+		// case we record that the span should be cleared. When we're done
+		// iterating, we'll clear anything we appended to clearSpans.
+		if !skippedDueToCompacting {
+			clearSpans = append(clearSpans, tombBounds)
+		}
+		return DeleteOnlyCompaction{}, false /* ok */
+	}
+
+	for bounds, span := range ts.tombstonedSpans.All() {
+		tombBounds := base.UserKeyBoundsEndExclusive(bounds.Start, bounds.End)
+		if picked, ok = pickCompactionForSpan(tombBounds, span); ok {
+			// Found a compaction.
+			break
+		}
+	}
+
+	// Clear any spans that we found are no longer useful.
+	//
+	// TODO(jackson): Amend the region tree to allow clearing spans while
+	// iterating.
+	for _, bounds := range clearSpans {
+		ts.tombstonedSpans.Update(bounds.Start, bounds.End.Key,
+			func(curr tombstoneSeqNums) tombstoneSeqNums { return tombstoneSeqNums{} })
+	}
+	clear(clearSpans)
+	ts.scratch = clearSpans[:0]
+
+	// Return the picked compaction, if any.
+	return picked, ok
+}
+
+type tableEligibility int8
+
+const (
+	tableEligibilityNone tableEligibility = iota
+	tableEligibilityDelete
+	tableEligibilityExcise
+)
+
+func canDeleteOrExciseTable(
+	cmp base.Compare, tombBounds, tableBounds base.UserKeyBounds, isExciseAllowed bool,
+) tableEligibility {
+	if tombBounds.ContainsBounds(cmp, tableBounds) {
+		// The table is completely contained within the tombstone's
+		// bounds. The table can be deleted outright.
+		//
+		//	  |------------tombstone-------------|
+		//	    |--------sstable--------|
+		//
+		return tableEligibilityDelete
+	}
+
+	// We can't delete the table outright. If excise is enabled and
+	// allowed by the format major version, we can try to excise the
+	// table. Otherwise, we can continue to the next table.
+	if !isExciseAllowed {
+		return tableEligibilityNone
+	}
+
+	if cmp(tombBounds.Start, tableBounds.Start) <= 0 ||
+		tombBounds.End.CompareUpperBounds(cmp, tableBounds.End) >= 0 {
+		// The tombstone straddles the left or right boundary of the
+		// table, making the table eligible for an excise.
+		//
+		//	  |---tombstone---|
+		//	       |------sstable------|
+		//
+		// or
+		//
+		//	        |---tombstone---|
+		//	  |------sstable------|
+		return tableEligibilityExcise
+	}
+
+	// The table was returned by Overlaps, so it must overlap the
+	// tombstone's bounds.
+	//
+	// We checked that the table isn't completely contianed within
+	// the bounds of the tombstone, and we checked that neither of
+	// its boundaries fall within the bounds of the tombstone.
+	//
+	// In the remaining case, the tombstone lies completely within
+	// the table's bounds:
+	//
+	//	            |---tombstone----|
+	//	      |-----------sstable------------|
+	//
+	// We choose to do nothing in this case, because we don't know
+	// how much data the sstable actually contains within the
+	// tombstone's span. If we split the sstable into two virtual
+	// tables, we'd increase the number of tables in the level
+	// metadata which has its own cost. Eventually an ordinary
+	// compaction will delete the data if the table indeed contains
+	// keys within the tombstone's span.
+	return tableEligibilityNone
+}
+
+// String returns a string representation of the tombstones.
+func (ts *Set) String() string {
+	var buf bytes.Buffer
+	if len(ts.pending) > 0 {
+		fmt.Fprintf(&buf, "Pending:\n")
+		for _, h := range ts.pending {
+			fmt.Fprintf(&buf, "  %s\n", h.String())
+		}
+	}
+	if !ts.tombstonedSpans.IsEmpty() {
+		fmt.Fprintln(&buf, "Tombstoned spans:")
+		fmt.Fprintln(&buf, ts.tombstonedSpans.String(
+			axisds.MakeIntervalFormatter(func(b []byte) string {
+				return fmt.Sprint(ts.comparer.FormatKey(b))
+			})))
+	}
+	if buf.Len() == 0 {
+		return "(none)"
+	}
+	return strings.TrimSpace(buf.String())
+}

--- a/internal/tombspan/tombspan_test.go
+++ b/internal/tombspan/tombspan_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package tombspan
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/internal/strparse"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+)
+
+func TestSet(t *testing.T) {
+	tables := make(map[base.DiskFileNum]*manifest.TableMetadata)
+	set := Make(testkeys.Comparer)
+	var versions []*manifest.Version
+
+	parseWideTombstone := func(line string) WideTombstone {
+		// Example: L1.1 [a,b) seqnums{point=[1-2], range=[3-4]}
+		var h WideTombstone
+		p := strparse.MakeParser(`-[]()={}.,`, line)
+		h.Level = p.Level()
+		p.Expect(".")
+		h.Table = tables[p.DiskFileNum()]
+		p.Expect("[")
+		h.Bounds.Start = []byte(p.Next())
+		p.Expect(",")
+		h.Bounds.End.Key = []byte(p.Next())
+		h.Bounds.End.Kind = base.Exclusive
+		p.Expect(")")
+		p.Expect("seqnums")
+		p.Expect("{")
+		if p.Peek() == "point" {
+			p.Expect("point")
+			p.Expect("=")
+			h.PointSeqNums = p.SeqNumRange()
+		}
+		if p.Peek() == "," {
+			p.Expect(",")
+		}
+		if p.Peek() == "range" {
+			p.Expect("range")
+			h.RangeSeqNums = p.SeqNumRange()
+		}
+		p.Expect("}")
+		return h
+	}
+
+	datadriven.RunTest(t, "testdata/set", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define-version":
+			l0Organizer := manifest.NewL0Organizer(testkeys.Comparer, 64*1024 /* flushSplitBytes */)
+			v, err := manifest.ParseVersionDebug(testkeys.Comparer, l0Organizer, td.Input)
+			if err != nil {
+				return err.Error()
+			}
+			for _, table := range v.AllTables() {
+				dfn := base.DiskFileNum(table.TableNum)
+				if _, ok := tables[dfn]; !ok {
+					tables[dfn] = table
+				}
+			}
+			versions = append(versions, v)
+			return fmt.Sprintf("v%d:\n%s", len(versions)-1, v.DebugString())
+		case "add":
+			var tombs []WideTombstone
+			for line := range crstrings.LinesSeq(td.Input) {
+				tombs = append(tombs, parseWideTombstone(line))
+			}
+			set.AddTombstones(tombs...)
+			return set.String()
+		case "update-with-earliest-snapshot":
+			v, err := strconv.ParseInt(td.CmdArgs[0].String(), 10, 64)
+			if err != nil {
+				return err.Error()
+			}
+			set.UpdateWithEarliestSnapshot(base.SeqNum(v))
+			return set.String()
+		case "pick-compaction":
+			var versionIndex int
+			td.ScanArgs(t, "v", &versionIndex)
+			excise := td.HasArg("exciseAllowed")
+			picked, ok := set.PickCompaction(versions[versionIndex], excise)
+			if !ok {
+				return fmt.Sprintf("none\n%s", set.String())
+			}
+			return fmt.Sprintf("%s\n%s", picked.String(), set.String())
+		case "mark-as-compacting":
+			var tableNum uint64
+			td.ScanArgs(t, "table", &tableNum)
+			tables[base.DiskFileNum(tableNum)].CompactionState = manifest.CompactionStateCompacting
+			return ""
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
+}

--- a/open.go
+++ b/open.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/manual"
+	"github.com/cockroachdb/pebble/internal/tombspan"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/vfs"
@@ -225,6 +226,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	d.mu.formatVers.vers.Store(uint64(formatVersion))
 	d.mu.formatVers.marker = rs.fmvMarker
 	d.openedAt = d.opts.private.timeNow()
+	d.mu.compact.wideTombstones = tombspan.Make(opts.Comparer)
 
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/snapshot.go
+++ b/snapshot.go
@@ -94,6 +94,7 @@ func (s *Snapshot) closeLocked() error {
 	// If s was the previous earliest snapshot, we might be able to reclaim
 	// disk space by dropping obsolete records that were pinned by s.
 	if e := s.db.mu.snapshots.earliest(); e > s.seqNum {
+		s.db.mu.compact.wideTombstones.UpdateWithEarliestSnapshot(e)
 		// NB: maybeScheduleCompaction also picks elision-only compactions.
 		s.db.maybeScheduleCompaction()
 	}

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -49,14 +49,15 @@ L4:
 
 get-hints
 ----
-L0.000004 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Pending:
+  L0.000004 [b, r) seqnums{point=[#200-#230]}
 
 maybe-compact
 ----
-Deletion hints:
-  L0.000004 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Pending:
+  L0.000004 [b, r) seqnums{point=[#200-#230]}
 Compactions:
-  (none)
+(none)
 
 # Adopt the same LSM but without snapshots 100, 180 and 210.
 
@@ -81,14 +82,15 @@ L4:
 
 get-hints
 ----
-L0.000004 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Pending:
+  L0.000004 [b, r) seqnums{point=[#200-#230]}
 
 maybe-compact
 ----
-Deletion hints:
-  L0.000004 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Pending:
+  L0.000004 [b, r) seqnums{point=[#200-#230]}
 Compactions:
-  (none)
+(none)
 
 # Verify that compaction correctly handles the presence of multiple
 # overlapping hints which might delete a file multiple times. All of the
@@ -119,17 +121,22 @@ L4:
 
 get-hints
 ----
-L0.000004 [a, k) seqnums(tombstone=[#300-#300], type=point)
-L1.000005 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Tombstoned spans:
+[a, k) = {point=300}
+[k, r) = {point=200}
 
 maybe-compact
 ----
-Deletion hints:
-  (none)
+Tombstoned spans:
+[a, k) = {point=300}
+[k, r) = {point=200}
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (649B) Score=0.00 + L2 [000006] (666B) Score=0.00 + L3 [000007] (666B) Score=0.00 + L4 [000008] (666B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
-[JOB 100] compacted(virtual-sst-rewrite) L1 [000009] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [] (0B), in 1.0s (2.0s total), output rate 0B/s
-[JOB 100] compacted(virtual-sst-rewrite) L4 [000010] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000011] (655B), in 1.0s (2.0s total), output rate 655B/s
+[JOB 100] compacted(delete-only) L2 [000000] (666B) Score=0.00 -> L2 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L3 [000000] (666B) Score=0.00 -> L3 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) [excise] L1 [000000] (649B) Score=0.00 -> L1 [000000] (1B), in 1.0s (2.0s total), output rate 1B/s
+[JOB 100] compacted(delete-only) [excise] L4 [000000] (666B) Score=0.00 -> L4 [000000] (94B), in 1.0s (2.0s total), output rate 94B/s
+[JOB 100] compacted(virtual-sst-rewrite) L1 [000000] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000000] (643B), in 1.0s (2.0s total), output rate 643B/s
+[JOB 100] compacted(virtual-sst-rewrite) L4 [000000] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000000] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 # Test a range tombstone that is already compacted into L6.
 
@@ -154,7 +161,8 @@ L4:
 
 get-hints
 ----
-L0.000004 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Pending:
+  L0.000004 [b, r) seqnums{point=[#200-#230]}
 
 compact a-z
 ----
@@ -163,10 +171,10 @@ L5:
 
 maybe-compact
 ----
-Deletion hints:
-  L0.000004 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Pending:
+  L0.000004 [b, r) seqnums{point=[#200-#230]}
 Compactions:
-  (none)
+(none)
 
 # The same test case, without snapshots, with a table (000008) that exists
 # within the range del user key bounds, but above it in the LSM.
@@ -196,7 +204,8 @@ L4:
 
 get-hints
 ----
-L1.000004 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Tombstoned spans:
+[b, r) = {point=200}
 
 # Tables 000005 and 000006 can be deleted as their largest sequence numbers fall
 # below the smallest sequence number of the range del. Table 000007 falls
@@ -205,11 +214,13 @@ L1.000004 [b, r) seqnums(tombstone=[#200-#230], type=point)
 
 maybe-compact
 ----
-Deletion hints:
-  (none)
+Tombstoned spans:
+[b, r) = {point=200}
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (666B) Score=0.00 + L3 [000006] (666B) Score=0.00 + L4 [000007] (666B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
-[JOB 100] compacted(virtual-sst-rewrite) L4 [000009] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000010] (655B), in 1.0s (2.0s total), output rate 655B/s
+[JOB 100] compacted(delete-only) L2 [000000] (666B) Score=0.00 -> L2 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L3 [000000] (666B) Score=0.00 -> L3 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) [excise] L4 [000000] (666B) Score=0.00 -> L4 [000000] (94B), in 1.0s (2.0s total), output rate 94B/s
+[JOB 100] compacted(virtual-sst-rewrite) L4 [000000] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000000] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 # A deletion hint present on an sstable in a higher level should NOT result in a
 # deletion-only compaction incorrectly removing an sstable in L6 following an
@@ -231,78 +242,6 @@ L6:
 get-hints
 ----
 (none)
-
-# Place a compaction hint on a non-existent table in a higher level in the LSM.
-#
-# The selection of the sequence numbers for the hints is nuanced, and warrants
-# some explanation. The largest tombstone sequence number (27) was chosen such
-# that it does NOT fall into the final snapshot stripe, ensuring the hint is not
-# resolved and dropped. The deletion range 5-27 is also chosen such that it
-# covers the sequence number range from the table, i.e. 15-20, which *appears*
-# to make the keys eligible for deletion.
-force-set-hints
-L0.000001 a-z 5-27 point_key_only
-----
-L0.000001 [a, z) seqnums(tombstone=[#5-#27], type=point)
-
-# Hints on the table are unchanged, as the new sstable is at L6, and hints are
-# not generated on tables at this level.
-get-hints
-----
-L0.000001 [a, z) seqnums(tombstone=[#5-#27], type=point)
-
-# Closing snapshot 10 triggers an elision-only compaction in L6 rather than a
-# deletion-only compaction, as the earliest snapshot that remains open is 25,
-# preventing the delete compaction hint from being resolved as it does not exist
-# in the same snapshot stripe as the table in L6.
-close-snapshot
-10
-----
-[JOB 100] compacted(elision-only) L6 [000004] (739B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (655B), in 1.0s (2.0s total), output rate 655B/s
-
-# In previous versions of the code, the deletion hint was removed by the
-# elision-only compaction because it zeroed sequence numbers of keys with
-# sequence numbers higher than the lowest tombstone sequence number.
-#
-# In the current code, the hint remains but when the hint is resolved the hint
-# will not apply to any sstables containing keys that previously had sequence
-# numbers higher than the hint's lowest tombstone sequence number. We use
-# TableMetadata.LargestSeqNumAbsolute for this purpose.
-
-get-hints
-----
-L0.000001 [a, z) seqnums(tombstone=[#5-#27], type=point)
-
-# The LSM contains the key, as expected.
-iter
-first
-next
-----
-a: (b, .)
-.
-
-# Closing the next snapshot should NOT trigger another compaction but SHOULD
-# clear the hint. Although the file 000005's largest sequence number is zero
-# (due to sequence number zeroing), the file's LargestSeqNumAbsolute
-# indicates that some of the keys previously had higher sequence numbers, so
-# the hint cannot be used to drop the file 000005.
-
-close-snapshot
-25
-----
-(none)
-
-get-hints
-----
-(none)
-
-# The key remains in the LSM.
-iter
-first
-next
-----
-a: (b, .)
-.
 
 # Construct a scenario with tables containing a mixture of range dels and range
 # key dels that sit within different types of hints.
@@ -410,30 +349,37 @@ OK
 describe-lsm
 ----
 L0.0:
-  000013:[a#19,RANGEDEL-z#inf,RANGEKEYDEL]
+  XXXXXX:[a#19,RANGEDEL-z#inf,RANGEKEYDEL]
 L6:
-  000004:[a#10,RANGEKEYSET-c#10,SET]
-  000005:[d#11,RANGEKEYSET-f#inf,RANGEKEYSET]
-  000006:[g#12,SET-h#12,SET]
-  000007:[i#13,RANGEKEYSET-k#13,SET]
-  000008:[l#14,RANGEKEYSET-n#inf,RANGEKEYSET]
-  000009:[o#15,SET-q#15,SET]
-  000010:[r#16,RANGEKEYSET-t#16,SET]
-  000011:[u#17,RANGEKEYSET-w#inf,RANGEKEYSET]
-  000012:[x#18,SET-z#18,SET]
+  XXXXXX:[a#10,RANGEKEYSET-c#10,SET]
+  XXXXXX:[d#11,RANGEKEYSET-f#inf,RANGEKEYSET]
+  XXXXXX:[g#12,SET-h#12,SET]
+  XXXXXX:[i#13,RANGEKEYSET-k#13,SET]
+  XXXXXX:[l#14,RANGEKEYSET-n#inf,RANGEKEYSET]
+  XXXXXX:[o#15,SET-q#15,SET]
+  XXXXXX:[r#16,RANGEKEYSET-t#16,SET]
+  XXXXXX:[u#17,RANGEKEYSET-w#inf,RANGEKEYSET]
+  XXXXXX:[x#18,SET-z#18,SET]
 
 get-hints
 ----
-L0.000013 [a, i) seqnums(tombstone=[#19-#19], type=point)
-L0.000013 [i, r) seqnums(tombstone=[#19-#19], type=point-and-range)
-L0.000013 [r, z) seqnums(tombstone=[#19-#19], type=range)
+Tombstoned spans:
+[a, i) = {point=19}
+[i, r) = {point=19, range=19}
+[r, z) = {range=19}
 
 maybe-compact
 ----
-Deletion hints:
-  (none)
+Tombstoned spans:
+[a, i) = {point=19}
+[i, r) = {point=19, range=19}
+[r, z) = {range=19}
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000006 000007 000008 000009 000011] (3.4KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000000] (661B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000000] (661B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000000] (696B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000000] (696B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000000] (796B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Verify that a delete-only compaction can partially excise a file.
 
@@ -462,8 +408,9 @@ L4:
 
 get-hints
 ----
-L0.000004 [a, k) seqnums(tombstone=[#300-#300], type=point)
-L1.000005 [b, r) seqnums(tombstone=[#200-#230], type=point)
+Tombstoned spans:
+[a, k) = {point=300}
+[k, r) = {point=200}
 
 iter
 first
@@ -474,19 +421,25 @@ u: (u, .)
 
 maybe-compact
 ----
-Deletion hints:
-  (none)
+Tombstoned spans:
+[a, k) = {point=300}
+[k, r) = {point=200}
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (649B) Score=0.00 + L2 [000006] (666B) Score=0.00 + L3 [000007] (666B) Score=0.00 + L4 [000008] (666B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
-[JOB 100] compacted(virtual-sst-rewrite) L1 [000009] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [] (0B), in 1.0s (2.0s total), output rate 0B/s
-[JOB 100] compacted(virtual-sst-rewrite) L4 [000010] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000011] (655B), in 1.0s (2.0s total), output rate 655B/s
+[JOB 100] compacted(delete-only) L2 [000000] (666B) Score=0.00 -> L2 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L3 [000000] (666B) Score=0.00 -> L3 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) [excise] L1 [000000] (649B) Score=0.00 -> L1 [000000] (1B), in 1.0s (2.0s total), output rate 1B/s
+[JOB 100] compacted(delete-only) [excise] L4 [000000] (666B) Score=0.00 -> L4 [000000] (94B), in 1.0s (2.0s total), output rate 94B/s
+[JOB 100] compacted(virtual-sst-rewrite) L1 [000000] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000000] (643B), in 1.0s (2.0s total), output rate 643B/s
+[JOB 100] compacted(virtual-sst-rewrite) L4 [000000] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000000] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 describe-lsm
 ----
 L0.0:
-  000004:[a#300,RANGEDEL-k#inf,RANGEDEL]
+  XXXXXX:[a#300,RANGEDEL-k#inf,RANGEDEL]
+L1:
+  XXXXXX:[k#200,RANGEDEL-r#inf,RANGEDEL]
 L4:
-  000011:[u#0,SET-u#0,SET]
+  XXXXXX:[u#0,SET-u#0,SET]
 
 iter
 first
@@ -526,14 +479,15 @@ OK
 describe-lsm
 ----
 L0.0:
-  000006:[b#12,RANGEDEL-r#inf,RANGEDEL]
+  XXXXXX:[b#12,RANGEDEL-r#inf,RANGEDEL]
 L6:
-  000005:[d#11,SET-i#11,SET]
-  000004:[k#10,RANGEKEYSET-o#10,SET]
+  XXXXXX:[d#11,SET-i#11,SET]
+  XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
 
 get-hints
 ----
-L0.000006 [b, r) seqnums(tombstone=[#12-#12], type=point)
+Tombstoned spans:
+[b, r) = {point=12}
 
 iter
 first
@@ -542,17 +496,17 @@ first
 
 maybe-compact
 ----
-Deletion hints:
-  (none)
+Tombstoned spans:
+[b, r) = {point=12}
 Compactions:
-  [JOB 100] compacted(delete-only) L6 [000005] (661B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000000] (661B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 describe-lsm
 ----
 L0.0:
-  000006:[b#12,RANGEDEL-r#inf,RANGEDEL]
+  XXXXXX:[b#12,RANGEDEL-r#inf,RANGEDEL]
 L6:
-  000004:[k#10,RANGEKEYSET-o#10,SET]
+  XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
 
 iter
 first
@@ -588,14 +542,15 @@ OK
 describe-lsm
 ----
 L0.0:
-  000005:[b#11,RANGEKEYDEL-p#inf,RANGEDEL]
+  XXXXXX:[b#11,RANGEKEYDEL-p#inf,RANGEDEL]
 L6:
-  000004:[k#10,RANGEKEYSET-o#10,SET]
+  XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
 
 get-hints
 ----
-L0.000005 [b, l) seqnums(tombstone=[#11-#11], type=point-and-range)
-L0.000005 [m, p) seqnums(tombstone=[#11-#11], type=point-and-range)
+Tombstoned spans:
+[b, l) = {point=11, range=11}
+[m, p) = {point=11, range=11}
 
 iter
 first
@@ -606,18 +561,20 @@ ll: (mm, .)
 
 maybe-compact
 ----
-Deletion hints:
-  (none)
+Tombstoned spans:
+[b, l) = {point=11, range=11}
+[m, p) = {point=11, range=11}
 Compactions:
-  [JOB 100] compacted(delete-only) (excised: 000004) L6 [000004] (810B) Score=0.00 -> L6 [000007] (93B), in 1.0s (2.0s total), output rate 93B/s
-[JOB 100] compacted(virtual-sst-rewrite) L6 [000007] (93B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000008] (788B), in 1.0s (2.0s total), output rate 788B/s
+[JOB 100] compacted(delete-only) [excise] L6 [000000] (810B) Score=0.00 -> L6 [000000] (93B), in 1.0s (2.0s total), output rate 93B/s
+[JOB 100] compacted(delete-only) [excise] L6 [000000] (93B) Score=0.00 -> L6 [000000] (93B), in 1.0s (2.0s total), output rate 93B/s
+[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (93B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (788B), in 1.0s (2.0s total), output rate 788B/s
 
 describe-lsm
 ----
 L0.0:
-  000005:[b#11,RANGEKEYDEL-p#inf,RANGEDEL]
+  XXXXXX:[b#11,RANGEKEYDEL-p#inf,RANGEDEL]
 L6:
-  000008:[l#10,RANGEKEYSET-m#inf,RANGEKEYSET]
+  XXXXXX:[l#10,RANGEKEYSET-m#inf,RANGEKEYSET]
 
 iter
 first
@@ -654,9 +611,9 @@ OK
 describe-lsm
 ----
 L0.0:
-  000005:[l#11,RANGEKEYDEL-m#inf,RANGEDEL]
+  XXXXXX:[l#11,RANGEKEYDEL-m#inf,RANGEDEL]
 L6:
-  000004:[k#10,RANGEKEYSET-o#10,SET]
+  XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
 
 get-hints
 ----
@@ -675,17 +632,16 @@ o: (o, .)
 
 maybe-compact
 ----
-Deletion hints:
-  (none)
+(none)
 Compactions:
-  (none)
+(none)
 
 describe-lsm
 ----
 L0.0:
-  000005:[l#11,RANGEKEYDEL-m#inf,RANGEDEL]
+  XXXXXX:[l#11,RANGEKEYDEL-m#inf,RANGEDEL]
 L6:
-  000004:[k#10,RANGEKEYSET-o#10,SET]
+  XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
 
 iter
 first
@@ -724,7 +680,7 @@ OK
 describe-lsm
 ----
 L6:
-  000004:[c#10,RANGEKEYDEL-h#inf,RANGEDEL]
+  XXXXXX:[c#10,RANGEKEYDEL-h#inf,RANGEDEL]
 
 snapshot
 ----
@@ -747,9 +703,10 @@ L6:
 
 get-hints
 ----
-L0.000006 [c, h) seqnums(tombstone=[#11-#12], type=point-and-range)
+Pending:
+  L0.000006 [c, h) seqnums{point=[#11-#11], range=[#12-#12]}
 
 close-snapshot
 11
 ----
-[JOB 100] compacted(delete-only) L6 [000004] (867B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(delete-only) L6 [000000] (867B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -390,8 +390,8 @@ compression: None:87,Snappy:73/84
 maybe-compact
 ----
 [JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
-[JOB 101] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 102] compacted(default) L5 [000004] (696B) Score=2.72 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(delete-only) [excise] L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
+[JOB 102] compacted(default) L5 [000004] (696B) Score=1.36 + L6 [000006] (13KB) Score=1.05 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -439,8 +439,8 @@ compression: None:87,Snappy:73/84
 maybe-compact
 ----
 [JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
-[JOB 101] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 102] compacted(default) L5 [000004] (696B) Score=2.72 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 101] compacted(delete-only) [excise] L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
+[JOB 102] compacted(default) L5 [000004] (696B) Score=1.36 + L6 [000006] (13KB) Score=1.05 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 
 # These tests demonstrate the behavior of the tombstone density compaction feature


### PR DESCRIPTION
This commit refactors the implementation of delete-only compactions to simplify
logic and resolve a bug (https://github.com/cockroachdb/pebble/issues/4883) where an unfortunately timed excise could
cancel a delete-only compaction, preventing the delete-only compaction from
ever executing.

Previously, delete-only compaction picking scheduled large compactions deleting
and excising as many tables as possible from a set of resolved 'hints.' This
could result in large delete-only compactions with wide bounds, making
compaction cancellation more likely during bulk removal like a DROP TABLE
command in CockroachDB. Because the 'hints' were resolved during picking, the
knowledge of the wide tombstones that originated the compaction was lost and no
replacement delete-only compaction was scheduled.

This commit extracts the externalized, in-memory tracking of "wide tombstones"
into a new internal/tombspan package. The table stats collector propagates
knowledge of these wide tombstones to a [tombspan.Set]. When a wide tombstone
falls into the final snapshot stripe, knowledge of the tombstone is
incorporated into a region tree. Compaction picking consults the tombspan.Set.
Rather than large, multi-level and multi-file delete-only compactions,
compaction-picking now picks compactions that delete or excise 1 table at a
time.

These smaller delete-only compactions are less likely to be cancelled, complete
more quickly, and are more understandable within the event log. The
[tombspan.Set] only forgets a tombstoned span once it observes that there are
no tables eligible for a delete-only compaction within the span. If eligible
tables are currently compacting, the span is preserved, ensuring knowledge of
the tombstone survives compaction cancellation.

Fix https://github.com/cockroachdb/pebble/issues/4883.