### PR TITLE
sstable: clear cached iter error when using synthetic key

### DIFF
--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -924,6 +924,10 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 				// to still be open by the time singleLevelIterator.Next is called
 				// and we use the seek key to actually perform the seek.
 				i.synthetic.seekKey = append(i.synthetic.seekKey[:0], key...)
+				// Clear any stale error from previous operations before returning
+				// a valid key. The seekPrefixGE helper clears i.err, but this
+				// early return bypasses it.
+				i.err = nil
 				return &i.synthetic.kv
 			}
 		}

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -532,6 +532,10 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 				// to still be open by the time singleLevelIterator.Next is called
 				// and we use the seek key to actually perform the seek.
 				i.secondLevel.synthetic.seekKey = append(i.secondLevel.synthetic.seekKey[:0], key...)
+				// Clear any stale error from previous operations before returning
+				// a valid key. The seekPrefixGE helper clears i.secondLevel.err,
+				// but this early return bypasses it.
+				i.secondLevel.err = nil
 				return &i.secondLevel.synthetic.kv
 			}
 		}


### PR DESCRIPTION
Clear previous iterator errors when using the synthetic key optimization branch.

Fixes: #5664