### PR TITLE
sstable: write tiering histogram block to sstables

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -687,16 +687,24 @@ type TieringSpanID uint64
 //
 // These methods exist to support compaction-only logic (eg, `compaction.Iter`).
 // Regular iteration should use the standard methods that do not surface metadata.
+//
+// The zero-value TieringAttribute indicates no metadata is available.
 type KVMeta struct {
 	TieringSpanID    TieringSpanID
 	TieringAttribute TieringAttribute
 }
 
 func (m KVMeta) String() string {
-	if m == (KVMeta{}) {
+	if !m.IsSet() {
 		return "<no meta>"
 	}
 	return fmt.Sprintf("tiering:span=%d,attr=%d", m.TieringSpanID, m.TieringAttribute)
+}
+
+// IsSet returns true if valid tiering metadata is present. Returns false if
+// TieringAttribute is 0.
+func (m KVMeta) IsSet() bool {
+	return m.TieringAttribute != 0
 }
 
 // Kind returns the KV's internal key kind.

--- a/metrics.go
+++ b/metrics.go
@@ -1256,7 +1256,7 @@ func (m *Metrics) StringForTests() string {
 
 	// We recalculate the file cache size using the 64-bit sizes, and we ignore
 	// the genericcache metadata size which is harder to adjust.
-	const sstableReaderSize64bit = 288
+	const sstableReaderSize64bit = 304
 	const blobFileReaderSize64bit = 120
 	mCopy.FileCache.Size = mCopy.FileCache.TableCount*sstableReaderSize64bit + mCopy.FileCache.BlobFileCount*blobFileReaderSize64bit
 	if math.MaxInt == math.MaxInt64 {

--- a/sstable/block/blockkind/kind.go
+++ b/sstable/block/blockkind/kind.go
@@ -16,6 +16,7 @@ const (
 	SSTableValue
 	BlobValue
 	BlobReferenceValueLivenessIndex
+	TieringHistogram
 	Filter
 	RangeDel
 	RangeKey
@@ -31,6 +32,7 @@ var kindString = [...]string{
 	SSTableValue:                    "sstval",
 	BlobValue:                       "blobval",
 	BlobReferenceValueLivenessIndex: "blobrefval",
+	TieringHistogram:                "tieringhist",
 	Filter:                          "filter",
 	RangeDel:                        "rangedel",
 	RangeKey:                        "rangekey",

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable/block/blockkind"
 	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/cockroachdb/pebble/sstable/rowblk"
+	"github.com/cockroachdb/pebble/sstable/tieredmeta"
 	"github.com/cockroachdb/pebble/sstable/valblk"
 )
 
@@ -59,6 +60,7 @@ type RawColumnWriter struct {
 	rangeKeyBlock             colblk.KeyspanBlockWriter
 	valueBlock                *valblk.Writer // nil iff WriterOptions.DisableValueBlocks=true
 	blobRefLivenessIndexBlock blobRefValueLivenessWriter
+	tieringHistogramBlock     tieredmeta.TieringHistogramBlockWriter
 	// filterWriter accumulates the filter block. If not nil, the filter writer
 	// ingests the prefix of each key.
 	filterWriter base.TableFilterWriter
@@ -142,6 +144,7 @@ func newColumnarWriter(
 	w.topLevelIndexBlock.Init()
 	w.rangeDelBlock.Init(w.comparer.Equal)
 	w.rangeKeyBlock.Init(w.comparer.Equal)
+	w.tieringHistogramBlock = tieredmeta.TieringHistogramBlockWriter{}
 	if !o.DisableValueBlocks {
 		flushGovernor := block.MakeFlushGovernor(o.BlockSize, o.BlockSizeThreshold, o.SizeClassAwareThreshold, o.AllocatorSizeClasses)
 		// We use the value block writer in the same goroutine so it's safe to share
@@ -411,6 +414,25 @@ func (w *RawColumnWriter) Add(
 			valuePrefix = block.InPlaceValuePrefix(eval.kcmp.PrefixEqual())
 		}
 	}
+
+	// Track in-place value bytes in tiering histogram.
+	if w.opts.TieringSpanIDGetter != nil && w.opts.TieringAttributeExtractor != nil {
+		if !meta.IsSet() {
+			meta.TieringSpanID = w.opts.TieringSpanIDGetter(key.UserKey)
+			attribute, err := w.opts.TieringAttributeExtractor(key.UserKey, int(eval.kcmp.PrefixLen), value)
+			if err != nil {
+				return err
+			}
+			meta.TieringAttribute = attribute
+		}
+		w.tieringHistogramBlock.Add(tieredmeta.SSTableInPlaceValueBytes, meta.TieringSpanID,
+			meta.TieringAttribute, uint64(len(value)))
+
+		// Track key bytes in tiering histogram summary.
+		w.tieringHistogramBlock.AddKeyBytes(meta.TieringAttribute, w.opts.TieringThreshold,
+			uint64(len(key.UserKey)))
+	}
+
 	return w.add(key, len(value), valueStoredWithKey, valuePrefix, eval, meta)
 }
 
@@ -454,6 +476,37 @@ func (w *RawColumnWriter) AddWithBlobHandle(
 	if err := w.blobRefLivenessIndexBlock.addLiveValue(h.ReferenceID, h.BlockID, h.ValueID, uint64(h.ValueLen)); err != nil {
 		return err
 	}
+
+	// Track blob reference bytes in tiering histogram by tier.
+	if w.opts.TieringSpanIDGetter != nil && w.opts.TieringAttributeExtractor != nil && w.opts.BlobReferenceTierGetter != nil {
+		if !meta.IsSet() {
+			meta.TieringSpanID = w.opts.TieringSpanIDGetter(key.UserKey)
+			attribute, err := w.opts.TieringAttributeExtractor(key.UserKey, int(eval.kcmp.PrefixLen), nil /* value */)
+			if err != nil {
+				return err
+			}
+			meta.TieringAttribute = attribute
+		}
+
+		var kindAndTier tieredmeta.KindAndTier
+		switch w.opts.BlobReferenceTierGetter(h.ReferenceID) {
+		case base.HotTier:
+			kindAndTier = tieredmeta.SSTableBlobReferenceHotBytes
+		case base.ColdTier:
+			kindAndTier = tieredmeta.SSTableBlobReferenceColdBytes
+		default:
+			panic(errors.AssertionFailedf("unexpected tier %s", w.opts.BlobReferenceTierGetter(h.ReferenceID)))
+		}
+		w.tieringHistogramBlock.Add(kindAndTier, meta.TieringSpanID, meta.TieringAttribute,
+			uint64(h.ValueLen))
+
+		// TODO(annie): track hot-and-cold blob reference bytes when a value exists
+		// in both tiers. This requires an extra column and changes to pass both
+		// hot and cold blob handles. Use AddHotAndColdBlobRefBytes once implemented.
+
+		w.tieringHistogramBlock.AddKeyBytes(meta.TieringAttribute, w.opts.TieringThreshold, uint64(len(key.UserKey)))
+	}
+
 	return nil
 }
 
@@ -1004,6 +1057,13 @@ func (w *RawColumnWriter) Close() (err error) {
 			encoder.AddReferenceLiveness(int(refID), buf)
 		}
 		if _, err := w.layout.WriteBlobRefIndexBlock(encoder.Finish()); err != nil {
+			return err
+		}
+	}
+
+	// Write the tiering histogram block if non-empty.
+	if !w.tieringHistogramBlock.IsEmpty() {
+		if _, err := w.layout.WriteTieringHistogramBlock(w.tieringHistogramBlock.Finish()); err != nil {
 			return err
 		}
 	}

--- a/sstable/compressionanalyzer/testdata/buckets
+++ b/sstable/compressionanalyzer/testdata/buckets
@@ -53,55 +53,55 @@ compressibility
 
 example-buckets-string
 ----
-Kind        Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       Zstd1        Auto1/30     Auto1/15     Zstd3
-sstval      24-48KB     >2.5     6        46.5KB ± 41%  CR      1.64 ± 15%   2.37 ± 7%    3.58 ± 5%    4.40 ± 4%    5.44 ± 5%    6.28 ± 4%
-                                                        Comp    92MBps ± 3%  46MBps ± 2%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%
-                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-blobrefval  <24KB       <1.1     20       36.2KB ± 52%  CR      1.42 ± 19%   2.35 ± 12%   3.54 ± 8%    4.41 ± 6%    5.30 ± 4%    6.49 ± 4%
-                                                        Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 1%
-                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-blobrefval  24-48KB     <1.1     4        39.0KB ± 63%  CR      1.34 ± 10%   2.35 ± 6%    3.62 ± 6%    4.48 ± 7%    5.31 ± 6%    6.72 ± 3%
-                                                        Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 0%  19MBps ± 1%  16MBps ± 0%
-                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-filter      24-48KB     1.5-2.5  1        15.0KB ± 0%   CR      1.30 ± 0%    2.50 ± 0%    3.50 ± 0%    4.30 ± 0%    5.10 ± 0%    6.20 ± 0%
-                                                        Comp    89MBps ± 0%  46MBps ± 0%  31MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
-                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-rangedel    48-128KB    >2.5     6        39.8KB ± 34%  CR      1.38 ± 18%   2.57 ± 11%   3.44 ± 7%    4.54 ± 5%    5.41 ± 5%    6.45 ± 4%
-                                                        Comp    92MBps ± 2%  46MBps ± 1%  31MBps ± 1%  24MBps ± 0%  19MBps ± 1%  16MBps ± 0%
-                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-rangedel    >128KB      1.1-1.5  1        30.3KB ± 0%   CR      1.60 ± 0%    2.50 ± 0%    3.70 ± 0%    4.30 ± 0%    5.60 ± 0%    6.70 ± 0%
-                                                        Comp    89MBps ± 0%  47MBps ± 0%  32MBps ± 0%  24MBps ± 0%  19MBps ± 0%  16MBps ± 0%
-                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-rangekey    >128KB      1.5-2.5  8        29.9KB ± 54%  CR      1.42 ± 21%   2.54 ± 10%   3.48 ± 8%    4.61 ± 7%    5.58 ± 5%    6.36 ± 3%
-                                                        Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 1%
-                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-metadata    >128KB      1.1-1.5  5        35.4KB ± 33%  CR      1.41 ± 20%   2.35 ± 11%   3.33 ± 3%    4.71 ± 3%    5.49 ± 4%    6.59 ± 2%
-                                                        Comp    91MBps ± 3%  46MBps ± 1%  32MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
-                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+Kind         Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       Zstd1        Auto1/30     Auto1/15     Zstd3
+sstval       24-48KB     >2.5     6        46.5KB ± 41%  CR      1.64 ± 15%   2.37 ± 7%    3.58 ± 5%    4.40 ± 4%    5.44 ± 5%    6.28 ± 4%
+                                                         Comp    92MBps ± 3%  46MBps ± 2%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%
+                                                         Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+blobrefval   24-48KB     <1.1     4        39.0KB ± 63%  CR      1.34 ± 10%   2.35 ± 6%    3.62 ± 6%    4.48 ± 7%    5.31 ± 6%    6.72 ± 3%
+                                                         Comp    93MBps ± 2%  47MBps ± 1%  31MBps ± 1%  23MBps ± 0%  19MBps ± 1%  16MBps ± 0%
+                                                         Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+tieringhist  <24KB       <1.1     20       36.2KB ± 52%  CR      1.42 ± 19%   2.35 ± 12%   3.54 ± 8%    4.41 ± 6%    5.30 ± 4%    6.49 ± 4%
+                                                         Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 1%
+                                                         Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+filter       24-48KB     1.5-2.5  1        15.0KB ± 0%   CR      1.30 ± 0%    2.50 ± 0%    3.50 ± 0%    4.30 ± 0%    5.10 ± 0%    6.20 ± 0%
+                                                         Comp    89MBps ± 0%  46MBps ± 0%  31MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
+                                                         Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangedel     48-128KB    >2.5     6        39.8KB ± 34%  CR      1.38 ± 18%   2.57 ± 11%   3.44 ± 7%    4.54 ± 5%    5.41 ± 5%    6.45 ± 4%
+                                                         Comp    92MBps ± 2%  46MBps ± 1%  31MBps ± 1%  24MBps ± 0%  19MBps ± 1%  16MBps ± 0%
+                                                         Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangedel     >128KB      1.1-1.5  1        30.3KB ± 0%   CR      1.60 ± 0%    2.50 ± 0%    3.70 ± 0%    4.30 ± 0%    5.60 ± 0%    6.70 ± 0%
+                                                         Comp    89MBps ± 0%  47MBps ± 0%  32MBps ± 0%  24MBps ± 0%  19MBps ± 0%  16MBps ± 0%
+                                                         Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangekey     >128KB      1.5-2.5  8        29.9KB ± 54%  CR      1.42 ± 21%   2.54 ± 10%   3.48 ± 8%    4.61 ± 7%    5.58 ± 5%    6.36 ± 3%
+                                                         Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 1%
+                                                         Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+metadata     >128KB      1.1-1.5  5        35.4KB ± 33%  CR      1.41 ± 20%   2.35 ± 11%   3.33 ± 3%    4.71 ± 3%    5.49 ± 4%    6.59 ± 2%
+                                                         Comp    91MBps ± 3%  46MBps ± 1%  32MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
+                                                         Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
 
 example-buckets-string min-samples=5
 ----
-Kind        Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       Zstd1        Auto1/30     Auto1/15     Zstd3
-sstval      24-48KB     >2.5     6        46.5KB ± 41%  CR      1.64 ± 15%   2.37 ± 7%    3.58 ± 5%    4.40 ± 4%    5.44 ± 5%    6.28 ± 4%
-                                                        Comp    92MBps ± 3%  46MBps ± 2%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%
-                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-blobrefval  <24KB       <1.1     20       36.2KB ± 52%  CR      1.42 ± 19%   2.35 ± 12%   3.54 ± 8%    4.41 ± 6%    5.30 ± 4%    6.49 ± 4%
-                                                        Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 1%
-                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-rangedel    48-128KB    >2.5     6        39.8KB ± 34%  CR      1.38 ± 18%   2.57 ± 11%   3.44 ± 7%    4.54 ± 5%    5.41 ± 5%    6.45 ± 4%
-                                                        Comp    92MBps ± 2%  46MBps ± 1%  31MBps ± 1%  24MBps ± 0%  19MBps ± 1%  16MBps ± 0%
-                                                        Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-rangekey    >128KB      1.5-2.5  8        29.9KB ± 54%  CR      1.42 ± 21%   2.54 ± 10%   3.48 ± 8%    4.61 ± 7%    5.58 ± 5%    6.36 ± 3%
-                                                        Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 1%
-                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
-metadata    >128KB      1.1-1.5  5        35.4KB ± 33%  CR      1.41 ± 20%   2.35 ± 11%   3.33 ± 3%    4.71 ± 3%    5.49 ± 4%    6.59 ± 2%
-                                                        Comp    91MBps ± 3%  46MBps ± 1%  32MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
-                                                        Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+Kind         Size Range  Test CR  Samples  Size                  Snappy       MinLZ1       Zstd1        Auto1/30     Auto1/15     Zstd3
+sstval       24-48KB     >2.5     6        46.5KB ± 41%  CR      1.64 ± 15%   2.37 ± 7%    3.58 ± 5%    4.40 ± 4%    5.44 ± 5%    6.28 ± 4%
+                                                         Comp    92MBps ± 3%  46MBps ± 2%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 0%
+                                                         Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+tieringhist  <24KB       <1.1     20       36.2KB ± 52%  CR      1.42 ± 19%   2.35 ± 12%   3.54 ± 8%    4.41 ± 6%    5.30 ± 4%    6.49 ± 4%
+                                                         Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 1%  16MBps ± 1%
+                                                         Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangedel     48-128KB    >2.5     6        39.8KB ± 34%  CR      1.38 ± 18%   2.57 ± 11%   3.44 ± 7%    4.54 ± 5%    5.41 ± 5%    6.45 ± 4%
+                                                         Comp    92MBps ± 2%  46MBps ± 1%  31MBps ± 1%  24MBps ± 0%  19MBps ± 1%  16MBps ± 0%
+                                                         Decomp  10MBps ± 0%  5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+rangekey     >128KB      1.5-2.5  8        29.9KB ± 54%  CR      1.42 ± 21%   2.54 ± 10%   3.48 ± 8%    4.61 ± 7%    5.58 ± 5%    6.36 ± 3%
+                                                         Comp    92MBps ± 3%  47MBps ± 1%  31MBps ± 1%  24MBps ± 1%  19MBps ± 0%  16MBps ± 1%
+                                                         Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
+metadata     >128KB      1.1-1.5  5        35.4KB ± 33%  CR      1.41 ± 20%   2.35 ± 11%   3.33 ± 3%    4.71 ± 3%    5.49 ± 4%    6.59 ± 2%
+                                                         Comp    91MBps ± 3%  46MBps ± 1%  32MBps ± 0%  23MBps ± 0%  19MBps ± 0%  16MBps ± 0%
+                                                         Decomp  9MBps ± 0%   5MBps ± 0%   3MBps ± 0%   2MBps ± 0%   2MBps ± 0%   2MBps ± 0%
 
 example-buckets-csv min-samples=6
 ----
 Kind,Size Range,Test CR,Samples,Size,Size±,Snappy CR,Snappy CR±,Snappy Comp ns/b,Snappy Comp±,Snappy Decomp ns/b,Snappy Decomp±,MinLZ1 CR,MinLZ1 CR±,MinLZ1 Comp ns/b,MinLZ1 Comp±,MinLZ1 Decomp ns/b,MinLZ1 Decomp±,Zstd1 CR,Zstd1 CR±,Zstd1 Comp ns/b,Zstd1 Comp±,Zstd1 Decomp ns/b,Zstd1 Decomp±,Auto1/30 CR,Auto1/30 CR±,Auto1/30 Comp ns/b,Auto1/30 Comp±,Auto1/30 Decomp ns/b,Auto1/30 Decomp±,Auto1/15 CR,Auto1/15 CR±,Auto1/15 Comp ns/b,Auto1/15 Comp±,Auto1/15 Decomp ns/b,Auto1/15 Decomp±,Zstd3 CR,Zstd3 CR±,Zstd3 Comp ns/b,Zstd3 Comp±,Zstd3 Decomp ns/b,Zstd3 Decomp±
 sstval,24-48KB,>2.5,6,47579,19300,1.640,0.252,10.376,0.288,100.403,0.236,2.367,0.173,20.517,0.322,200.543,0.241,3.576,0.188,30.577,0.178,300.182,0.215,4.404,0.188,40.482,0.308,400.396,0.105,5.439,0.248,50.383,0.303,500.222,0.169,6.282,0.264,60.394,0.141,600.513,0.233
-blobrefval,<24KB,<1.1,20,37081,19435,1.416,0.271,10.331,0.272,100.335,0.280,2.349,0.275,20.430,0.304,200.565,0.252,3.538,0.297,30.488,0.245,300.514,0.259,4.409,0.253,40.509,0.225,400.566,0.234,5.295,0.232,50.430,0.305,500.411,0.333,6.492,0.251,60.395,0.312,600.378,0.293
+tieringhist,<24KB,<1.1,20,37081,19435,1.416,0.271,10.331,0.272,100.335,0.280,2.349,0.275,20.430,0.304,200.565,0.252,3.538,0.297,30.488,0.245,300.514,0.259,4.409,0.253,40.509,0.225,400.566,0.234,5.295,0.232,50.430,0.305,500.411,0.333,6.492,0.251,60.395,0.312,600.378,0.293
 rangedel,48-128KB,>2.5,6,40738,13854,1.378,0.243,10.373,0.177,100.283,0.197,2.571,0.290,20.588,0.306,200.599,0.308,3.444,0.256,30.451,0.320,300.384,0.236,4.536,0.240,40.309,0.129,400.200,0.264,5.409,0.268,50.541,0.328,500.355,0.252,6.450,0.244,60.407,0.202,600.624,0.242
 rangekey,>128KB,1.5-2.5,8,30567,16391,1.421,0.304,10.373,0.332,100.577,0.261,2.538,0.241,20.263,0.208,200.289,0.215,3.479,0.282,30.575,0.253,300.612,0.210,4.605,0.302,40.420,0.265,400.473,0.187,5.583,0.285,50.347,0.245,500.596,0.330,6.355,0.217,60.364,0.361,600.632,0.203

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -231,6 +231,29 @@ type WriterOptions struct {
 	// Options.Experimental.ShortAttributeExtractor.
 	ShortAttributeExtractor base.ShortAttributeExtractor
 
+	// TieringSpanIDGetter returns the tiering span ID for a key. The span ID
+	// is determined by policy (e.g., which logical partition the key belongs to).
+	// Used to populate tiering histograms when WriteTieringHistograms is true.
+	TieringSpanIDGetter func(key []byte) base.TieringSpanID
+
+	// TieringAttributeExtractor extracts the tiering attribute from a key-value
+	// pair. The attribute is data-driven metadata (e.g., access frequency).
+	// Used to populate tiering histograms when WriteTieringHistograms is true.
+	TieringAttributeExtractor func(key []byte, keyPrefixLen int, value []byte) (base.TieringAttribute, error)
+
+	// WriteTieringHistograms enables writing tiering histogram blocks to the
+	// sstable. Requires TieringSpanIDGetter and TieringAttributeExtractor to be set.
+	WriteTieringHistograms bool
+
+	// BlobReferenceTierGetter returns the storage tier for a blob reference ID.
+	// Used when WriteTieringHistograms is true to categorize blob references as
+	// hot or cold tier.
+	BlobReferenceTierGetter func(base.BlobReferenceID) base.StorageTier
+
+	// TieringThreshold is the tiering attribute threshold used to categorize keys
+	// as below or above threshold in the histogram summary.
+	TieringThreshold base.TieringAttribute
+
 	// DisableValueBlocks is only used for TableFormat >= TableFormatPebblev3,
 	// and if set to true, does not write any values to value blocks. This is
 	// only intended for cases where the in-memory buffering of all value blocks

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -226,13 +226,13 @@ const (
 	levelDBFormatVersion  = 0
 	rocksDBFormatVersion2 = 2
 
-	metaRangeKeyName        = "pebble.range_key"
-	metaValueIndexName      = "pebble.value_index"
-	metaPropertiesName      = "rocksdb.properties"
-	metaRangeDelV1Name      = "rocksdb.range_del"
-	metaRangeDelV2Name      = "rocksdb.range_del2"
-	metaBlobRefIndexName    = "pebble.blob_ref_index"
-	metaBlobRefLivenessName = "pebble.blob_ref_liveness"
+	metaRangeKeyName         = "pebble.range_key"
+	metaValueIndexName       = "pebble.value_index"
+	metaPropertiesName       = "rocksdb.properties"
+	metaRangeDelV1Name       = "rocksdb.range_del"
+	metaRangeDelV2Name       = "rocksdb.range_del2"
+	metaBlobRefIndexName     = "pebble.blob_ref_index"
+	metaTieringHistogramName = "pebble.tiering_histogram"
 
 	// Index Types.
 	// A space efficient index block that is optimized for binary-search-based

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -143,6 +143,7 @@ func (kv ParsedKVOrSpan) String() string {
 //	a#1,SET:a
 //	force-obsolete: d#2,SET:d
 //	f#3,SET:blob{fileNum=1 blockNum=2 offset=110 valueLen=200}attr=7
+//	a#1,SET:valueA;tiering:span=1,attr=10
 //	Span: d-e:{(#4,RANGEDEL)}
 //	Span: a-d:{(#11,RANGEKEYSET,@10,foo)}
 //	Span: g-l:{(#5,RANGEDEL)}
@@ -166,6 +167,7 @@ func ParseTestKVsAndSpans(input string, bv *blobtest.Values) (_ []ParsedKVOrSpan
 
 		var kv ParsedKVOrSpan
 		line, kv.ForceObsolete = strings.CutPrefix(line, "force-obsolete:")
+
 		internalKV := base.ParseInternalKV(line)
 		kv.Key = internalKV.K
 		kv.Value = internalKV.InPlaceValue()

--- a/sstable/testdata/writer_tiering_histogram
+++ b/sstable/testdata/writer_tiering_histogram
@@ -1,0 +1,161 @@
+build table-format=Pebble,v8
+a@10#1,SET:valueA;tiering:span=1,attr=10
+b@20#2,SET:valueB;tiering:span=1,attr=20
+c@30#3,SET:valueCCCCC;tiering:span=2,attr=30
+d@40#4,SET:valueDDDDDDDDD;tiering:span=2,attr=40
+----
+point:    [a@10#1,SET-d@40#4,SET]
+seqnums:  [1-4]
+
+layout
+----
+sstable
+ ├── data  offset: 0  length: 191
+ │    ├── data block header
+ │    │    ├── columnar block header
+ │    │    │    ├── 000-004: x 04000000 # maximum key length: 4
+ │    │    │    ├── 004-005: x 01       # version 1
+ │    │    │    ├── 005-007: x 0900     # 9 columns
+ │    │    │    ├── 007-011: x 04000000 # 4 rows
+ │    │    │    ├── 011-012: b 00000100 # col 0: prefixbytes
+ │    │    │    ├── 012-016: x 38000000 # col 0: page start 56
+ │    │    │    ├── 016-017: b 00000011 # col 1: bytes
+ │    │    │    ├── 017-021: x 44000000 # col 1: page start 68
+ │    │    │    ├── 021-022: b 00000010 # col 2: uint
+ │    │    │    ├── 022-026: x 56000000 # col 2: page start 86
+ │    │    │    ├── 026-027: b 00000001 # col 3: bool
+ │    │    │    ├── 027-031: x 60000000 # col 3: page start 96
+ │    │    │    ├── 031-032: b 00000011 # col 4: bytes
+ │    │    │    ├── 032-036: x 78000000 # col 4: page start 120
+ │    │    │    ├── 036-037: b 00000001 # col 5: bool
+ │    │    │    ├── 037-041: x fe000000 # col 5: page start 254
+ │    │    │    ├── 041-042: b 00000001 # col 6: bool
+ │    │    │    ├── 042-046: x ff000000 # col 6: page start 255
+ │    │    │    ├── 046-047: b 00000010 # col 7: uint
+ │    │    │    ├── 047-051: x 00010000 # col 7: page start 256
+ │    │    │    ├── 051-052: b 00000010 # col 8: uint
+ │    │    │    └── 052-056: x 05010000 # col 8: page start 261
+ │    │    ├── data for column 0 (prefixbytes)
+ │    │    │    ├── 056-057: x 04 # bundle size: 16
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 057-058: x 01 # encoding: 1b
+ │    │    │    │    ├── 058-059: x 00 # data[0] = 0 [64 overall]
+ │    │    │    │    ├── 059-060: x 00 # data[1] = 0 [64 overall]
+ │    │    │    │    ├── 060-061: x 01 # data[2] = 1 [65 overall]
+ │    │    │    │    ├── 061-062: x 02 # data[3] = 2 [66 overall]
+ │    │    │    │    ├── 062-063: x 03 # data[4] = 3 [67 overall]
+ │    │    │    │    └── 063-064: x 04 # data[5] = 4 [68 overall]
+ │    │    │    └── data
+ │    │    │         ├── 064-064: x    # data[00]:  (block prefix)
+ │    │    │         ├── 064-064: x    # data[01]:  (bundle prefix)
+ │    │    │         ├── 064-065: x 61 # data[02]: a
+ │    │    │         ├── 065-066: x 62 # data[03]: b
+ │    │    │         ├── 066-067: x 63 # data[04]: c
+ │    │    │         └── 067-068: x 64 # data[05]: d
+ │    │    ├── data for column 1 (bytes)
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 068-069: x 01 # encoding: 1b
+ │    │    │    │    ├── 069-070: x 00 # data[0] = 0 [74 overall]
+ │    │    │    │    ├── 070-071: x 03 # data[1] = 3 [77 overall]
+ │    │    │    │    ├── 071-072: x 06 # data[2] = 6 [80 overall]
+ │    │    │    │    ├── 072-073: x 09 # data[3] = 9 [83 overall]
+ │    │    │    │    └── 073-074: x 0c # data[4] = 12 [86 overall]
+ │    │    │    └── data
+ │    │    │         ├── 074-077: x 403130 # data[0]: @10
+ │    │    │         ├── 077-080: x 403230 # data[1]: @20
+ │    │    │         ├── 080-083: x 403330 # data[2]: @30
+ │    │    │         └── 083-086: x 403430 # data[3]: @40
+ │    │    ├── data for column 2 (uint)
+ │    │    │    ├── 086-087: x 02   # encoding: 2b
+ │    │    │    ├── 087-088: x 00   # padding (aligning to 16-bit boundary)
+ │    │    │    ├── 088-090: x 0101 # data[0] = 257
+ │    │    │    ├── 090-092: x 0102 # data[1] = 513
+ │    │    │    ├── 092-094: x 0103 # data[2] = 769
+ │    │    │    └── 094-096: x 0104 # data[3] = 1025
+ │    │    ├── data for column 3 (bool)
+ │    │    │    ├── 096-097: x 00                                                               # default bitmap encoding
+ │    │    │    ├── 097-104: x 00000000000000                                                   # padding to align to 64-bit boundary
+ │    │    │    ├── 104-112: b 0000111100000000000000000000000000000000000000000000000000000000 # bitmap word 0
+ │    │    │    └── 112-120: b 0000000100000000000000000000000000000000000000000000000000000000 # bitmap summary word 0-63
+ │    │    ├── data for column 4 (bytes)
+ │    │    │    ├── offsets table
+ │    │    │    │    ├── 120-121: x 01 # encoding: 1b
+ │    │    │    │    ├── 121-122: x 00 # data[0] = 0 [126 overall]
+ │    │    │    │    ├── 122-123: x 1d # data[1] = 29 [155 overall]
+ │    │    │    │    ├── 123-124: x 3a # data[2] = 58 [184 overall]
+ │    │    │    │    ├── 124-125: x 5b # data[3] = 91 [217 overall]
+ │    │    │    │    └── 125-126: x 80 # data[4] = 128 [254 overall]
+ │    │    │    └── data
+ │    │    │         ├── 126-146: x 76616c7565413b74696572696e673a7370616e3d # data[0]: valueA;tiering:span=1,attr=10
+ │    │    │         ├── 146-155: x 312c617474723d3130                       # (continued...)
+ │    │    │         ├── 155-175: x 76616c7565423b74696572696e673a7370616e3d # data[1]: valueB;tiering:span=1,attr=20
+ │    │    │         ├── 175-184: x 312c617474723d3230                       # (continued...)
+ │    │    │         ├── 184-204: x 76616c756543434343433b74696572696e673a73 # data[2]: valueCCCCC;tiering:span=2,attr=30
+ │    │    │         ├── 204-217: x 70616e3d322c617474723d3330               # (continued...)
+ │    │    │         ├── 217-237: x 76616c75654444444444444444443b7469657269 # data[3]: valueDDDDDDDDD;tiering:span=2,attr=40
+ │    │    │         └── 237-254: x 6e673a7370616e3d322c617474723d3430       # (continued...)
+ │    │    ├── data for column 5 (bool)
+ │    │    │    └── 254-255: x 01 # zero bitmap encoding
+ │    │    ├── data for column 6 (bool)
+ │    │    │    └── 255-256: x 01 # zero bitmap encoding
+ │    │    ├── data for column 7 (uint)
+ │    │    │    ├── 256-257: x 01 # encoding: 1b
+ │    │    │    ├── 257-258: x 01 # data[0] = 1
+ │    │    │    ├── 258-259: x 01 # data[1] = 1
+ │    │    │    ├── 259-260: x 02 # data[2] = 2
+ │    │    │    └── 260-261: x 02 # data[3] = 2
+ │    │    ├── data for column 8 (uint)
+ │    │    │    ├── 261-262: x 01 # encoding: 1b
+ │    │    │    ├── 262-263: x 0a # data[0] = 10
+ │    │    │    ├── 263-264: x 14 # data[1] = 20
+ │    │    │    ├── 264-265: x 1e # data[2] = 30
+ │    │    │    └── 265-266: x 28 # data[3] = 40
+ │    │    └── 266-267: x 00 # block padding byte
+ │    ├── a@10#1,SET:valueA;tiering:span=1,attr=10
+ │    ├── b@20#2,SET:valueB;tiering:span=1,attr=20
+ │    ├── c@30#3,SET:valueCCCCC;tiering:span=2,attr=30
+ │    ├── d@40#4,SET:valueDDDDDDDDD;tiering:span=2,attr=40
+ │    └── trailer [compression=snappy checksum=0xed6fa1bc]
+ ├── index  offset: 196  length: 36
+ │    ├── 00000    block:0/191
+ │    │   
+ │    └── trailer [compression=none checksum=0xb31e7aee]
+ ├── tiering-histogram  offset: 237  length: 169
+ │    ├── summary: key-bytes=16 key-bytes-below-threshold=0 hot-cold-blob-ref-bytes=0
+ │    ├── span=1 kind=0: total-bytes=58 total-count=2 bytes-no-attr=0
+ │    ├── span=2 kind=0: total-bytes=70 total-count=2 bytes-no-attr=0
+ │    └── trailer [compression=none checksum=0x61b67832]
+ ├── properties  offset: 411  length: 427
+ │    ├── 00000    obsolete-key (13)
+ │    ├── 00013    pebble.colblk.schema (65)
+ │    ├── 00078    pebble.compression_stats (47)
+ │    ├── 00125    rocksdb.block.based.table.index.type (40)
+ │    ├── 00165    rocksdb.comparator (42)
+ │    ├── 00207    rocksdb.compression (25)
+ │    ├── 00232    rocksdb.data.size (19)
+ │    ├── 00251    rocksdb.deleted.keys (21)
+ │    ├── 00272    rocksdb.filter.size (20)
+ │    ├── 00292    rocksdb.index.size (19)
+ │    ├── 00311    rocksdb.merge.operands (23)
+ │    ├── 00334    rocksdb.merge.operator (40)
+ │    ├── 00374    rocksdb.num.data.blocks (24)
+ │    ├── 00398    rocksdb.num.entries (20)
+ │    ├── 00418    rocksdb.num.range-deletions (28)
+ │    ├── 00446    rocksdb.property.collectors (41)
+ │    ├── 00487    rocksdb.raw.key.size (21)
+ │    ├── 00508    rocksdb.raw.value.size (24)
+ │    └── trailer [compression=snappy checksum=0x13df3d9b]
+ ├── meta-index  offset: 843  length: 76
+ │    ├── 0000    pebble.tiering_histogram block:237/169
+ │    │   
+ │    ├── 0001    rocksdb.properties block:411/427
+ │    │   
+ │    └── trailer [compression=none checksum=0x4de405a7]
+ └── footer  offset: 924  length: 61
+      ├── 000  checksum type: crc32c
+      ├── 001  meta: offset=843, length=76
+      ├── 004  index: offset=196, length=36
+      ├── 041  attributes: [PointKeys]
+      ├── 045  footer checksum: 0x9ac1b8db
+      ├── 049  version: 8
+      └── 053  magic number: 0xf09faab3f09faab3

--- a/sstable/tieredmeta/histogram.go
+++ b/sstable/tieredmeta/histogram.go
@@ -169,7 +169,7 @@ type histogramWriter struct {
 	zeroBytes  uint64
 }
 
-func newHistogramWriter() *histogramWriter {
+func makeHistogramWriter() *histogramWriter {
 	return &histogramWriter{
 		builder: tdigest.MakeBuilder(digestDelta),
 	}

--- a/sstable/tieredmeta/histogram_test.go
+++ b/sstable/tieredmeta/histogram_test.go
@@ -59,7 +59,7 @@ func TestHistogramBlock_Randomized(t *testing.T) {
 	prng := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))
 
 	for range 20 {
-		w := MakeTieringHistogramBlockWriter()
+		w := TieringHistogramBlockWriter{}
 		expected := make(map[Key]expectedStats)
 
 		// Generate random number of span IDs.
@@ -140,7 +140,7 @@ func TestHistogramEncoding_Roundtrip(t *testing.T) {
 	prng := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))
 
 	for range 20 {
-		hw := newHistogramWriter()
+		hw := makeHistogramWriter()
 		numRecords := testutils.RandIntInRange(prng, 10, 200)
 
 		exp := generateRandomRecords(prng, numRecords, hw.record)

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -72,7 +72,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-   4 (1.1KB) |      90.0% |        0.0% |           0 |           0
+   4 (1.2KB) |      90.0% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -190,7 +190,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    1 (408B) |      89.6% |        0.0% |           0 |           0
+    1 (424B) |      89.6% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote
@@ -519,7 +519,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    1 (528B) |      78.6% |        0.0% |           0 |           0
+    1 (544B) |      78.6% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote

--- a/testdata/compaction/virtual_rewrite
+++ b/testdata/compaction/virtual_rewrite
@@ -175,7 +175,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-   4 (1.1KB) |      91.9% |        0.0% |           0 |           0
+   4 (1.2KB) |      91.9% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -67,7 +67,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    1 (288B) |      50.0% |        0.0% |           0 |           0
+    1 (304B) |      50.0% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -174,7 +174,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    1 (288B) |       0.0% |        0.0% |           1 |           0
+    1 (304B) |       0.0% |        0.0% |           1 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote
@@ -302,7 +302,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    2 (576B) |      66.7% |        0.0% |           2 |           0
+    2 (608B) |      66.7% |        0.0% |           2 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote
@@ -413,7 +413,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    2 (576B) |      66.7% |        0.0% |           2 |           0
+    2 (608B) |      66.7% |        0.0% |           2 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote
@@ -521,7 +521,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    1 (288B) |      66.7% |        0.0% |           1 |           0
+    1 (304B) |      66.7% |        0.0% |           1 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote
@@ -2413,7 +2413,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    2 (576B) |       0.0% |        0.0% |           0 |           0
+    2 (608B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote
@@ -2517,7 +2517,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    2 (576B) |       0.0% |        0.0% |           0 |           0
+    2 (608B) |       0.0% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote


### PR DESCRIPTION
Previously, the tiering histogram structure and encoding were defined but not integrated into the sstable writing and layout. This commit adds writing and reading support for histogram blocks in columnar sstables.

Fixes: #5690