### PR TITLE
vfs/errorfs,internal/dsl: add CallStackIncludes

### DIFF
--- a/internal/dsl/dsl.go
+++ b/internal/dsl/dsl.go
@@ -33,6 +33,7 @@ func NewPredicateParser[E any]() *Parser[Predicate[E]] {
 	p.DefineFunc("And", parseAnd[E])
 	p.DefineFunc("Or", parseOr[E])
 	p.DefineFunc("OnIndex", parseOnIndex[E])
+	p.DefineFunc("CallStackIncludes", parseCallStackIncludes[E])
 	return p
 }
 

--- a/internal/dsl/predicates_test.go
+++ b/internal/dsl/predicates_test.go
@@ -1,0 +1,17 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package dsl
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/crlib/testutils/require"
+)
+
+func TestCallStackIncludes(t *testing.T) {
+	require.True(t, CallStackIncludes[string]("TestCallStackIncludes").Evaluate(""))
+	require.True(t, CallStackIncludes[string]("internal/dsl").Evaluate(""))
+	require.False(t, CallStackIncludes[string]("pebble.NewIter").Evaluate(""))
+}

--- a/vfs/errorfs/testdata/errorfs
+++ b/vfs/errorfs/testdata/errorfs
@@ -64,6 +64,7 @@ parse-dsl
 (ErrInjected (Randomly 18520850252 0.25))
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))
+(ErrInjected (And (PathMatch "*.sst") (CallStackIncludes "newPointIter")))
 ----
 parsing err: dsl: unexpected token (INT, "0") at pos 24; expected FLOAT
 (ErrInjected (Randomly 0.10))
@@ -73,6 +74,7 @@ parsing err: dsl: unexpected token - at pos 24; expected FLOAT
 parsing err: dsl: unexpected token (INT, "18520850252") at pos 24; expected FLOAT
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05 185957252)))
 (ErrInjected (And (PathMatch "*.sst") (Randomly 0.05)))
+(ErrInjected (And (PathMatch "*.sst") (CallStackIncludes "newPointIter")))
 
 parse-dsl
 (RandomLatency "1.5ms" 0)
@@ -81,6 +83,7 @@ parse-dsl
 (RandomLatency "200bingos" 18520850252  (PathMatch "*.log"))
 (RandomLatency "200µs" (PathMatch "*.log"))
 (RandomLatency "1.5ms" 0
+(RandomLatency "1.5ms" 0 (CallStackIncludes "pebble.NewIterWithContext"))
 ----
 (RandomLatency "1.5ms" 0)
 (RandomLatency "1.5ms" 0 (Randomly 0.10))
@@ -88,3 +91,4 @@ parse-dsl
 parsing err: parsing RandomLatency: time: unknown unit "bingos" in duration "200bingos"
 parsing err: dsl: unexpected token ( at pos 25; expected INT
 parsing err: errorfs: unexpected token (;, "\n") at pos 25; expected )
+(RandomLatency "1.5ms" 0 (CallStackIncludes "pebble.NewIterWithContext"))


### PR DESCRIPTION
Add a new CallStackIncludes predicate that evaluates to true if at evaluation time the call stack includes a function containing the configured substring. I'm intending to use this within some CockroachDB randomized error injection tests to limit error injection to CockroachDB iterators (as opposed to compactions, table stats), so that an error injection is guaranteed to translate to an iterator error.

This technique is a bit fragile because it's sensitive to function renames, but there's limited risk if we use functions within the exported Pebble interface. In the future if we extend the VFS interface by propagating read categories, we can replace usages with a predicate on the read category.