### PR TITLE
pebble: add top-level support for binary fuse filters

### DIFF
--- a/cmd/pebble/replay.go
+++ b/cmd/pebble/replay.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/pebble/cockroachkvs"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/replay"
-	"github.com/cockroachdb/pebble/sstable/tablefilters/bloom"
+	"github.com/cockroachdb/pebble/sstable/tablefilters"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
 )
@@ -298,15 +298,10 @@ func (c *replayConfig) parseHooks() *pebble.ParseHooks {
 	return &pebble.ParseHooks{
 		NewComparer: makeComparer,
 		NewFilterPolicy: func(name string) (pebble.TableFilterPolicy, error) {
-			if p, ok := bloom.PolicyFromName(name); ok {
+			if p, ok := tablefilters.PolicyFromName(name); ok {
 				return p, nil
 			}
-			switch name {
-			case "none":
-				return base.NoFilterPolicy, nil
-			default:
-				return nil, errors.Errorf("invalid filter policy name %q", name)
-			}
+			return nil, errors.Errorf("invalid filter policy name %q", name)
 		},
 		NewMerger: makeMerger,
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -1698,7 +1698,6 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 				return err
 			}
 			fp := func() TableFilterPolicy { return bloom.FilterPolicy(uint32(v)) }
-			opts.TableFilterDecoders = []TableFilterDecoder{bloom.Decoder}
 			for i := range opts.Levels {
 				opts.Levels[i].TableFilterPolicy = fp
 			}

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -294,7 +294,6 @@ func TestScanInternal(t *testing.T) {
 					return nil, err
 				}
 				fp := func() TableFilterPolicy { return bloom.FilterPolicy(uint32(v)) }
-				opts.TableFilterDecoders = []TableFilterDecoder{bloom.Decoder}
 				for i := range opts.Levels {
 					opts.Levels[i].TableFilterPolicy = fp
 				}

--- a/sstable/tablefilters/table_filters.go
+++ b/sstable/tablefilters/table_filters.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package tablefilters
+
+import (
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/sstable/tablefilters/binaryfuse"
+	"github.com/cockroachdb/pebble/sstable/tablefilters/bloom"
+)
+
+// Decoders contains the decoders for bloom and binary fuse filters.
+var Decoders = []base.TableFilterDecoder{bloom.Decoder, binaryfuse.Decoder}
+
+// PolicyFromName returns the TableFilterPolicy corresponding to the given name,
+// or false if the string is not recognized as a binary fuse filter policy.
+//
+// Supports bloom filters and binary fuse filters. The "none" policy is also
+// supported.
+func PolicyFromName(name string) (_ base.TableFilterPolicy, ok bool) {
+	if name == "none" {
+		return base.NoFilterPolicy, true
+	}
+	if p, ok := bloom.PolicyFromName(name); ok {
+		return p, true
+	}
+	if p, ok := binaryfuse.PolicyFromName(name); ok {
+		return p, true
+	}
+	return nil, false
+}

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable/blob"
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/colblk"
-	"github.com/cockroachdb/pebble/sstable/tablefilters/bloom"
+	"github.com/cockroachdb/pebble/sstable/tablefilters"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
 )
@@ -172,7 +172,7 @@ func New(opts ...Option) *T {
 
 	opts = append(opts,
 		Comparers(base.DefaultComparer),
-		FilterDecoders(bloom.Decoder),
+		FilterDecoders(tablefilters.Decoders...),
 		Mergers(base.DefaultMerger))
 
 	for _, opt := range opts {


### PR DESCRIPTION
And add meta test coverage.