### PR TITLE
sstable: fix mvcc garbage check in SSTBlobWriter

### DIFF
--- a/valsep/sst_blob_writer.go
+++ b/valsep/sst_blob_writer.go
@@ -141,7 +141,8 @@ func (w *SSTBlobWriter) Set(key, value []byte) error {
 
 	w.kvScratch.K = base.MakeInternalKey(key, 0, sstable.InternalKeyKindSet)
 	w.kvScratch.V = base.MakeInPlaceValue(value)
-	isLikelyMVCCGarbage := w.SSTWriter.Raw().IsLikelyMVCCGarbage(w.kvScratch.K.UserKey, w.kvScratch.Kind())
+	isLikelyMVCCGarbage := len(value) > w.valSep.OutputConfig().MinimumMVCCGarbageSize &&
+		w.SSTWriter.Raw().IsLikelyMVCCGarbage(w.kvScratch.K.UserKey, w.kvScratch.Kind())
 	return w.valSep.Add(w.SSTWriter.Raw(), &w.kvScratch, false, isLikelyMVCCGarbage, base.KVMeta{})
 }
 

--- a/valsep/sst_blob_writer_test.go
+++ b/valsep/sst_blob_writer_test.go
@@ -59,6 +59,7 @@ func parseSpanPolicy(t *testing.T, spanPolicyStr string) base.SpanPolicy {
 func parseBuildSSTBlobWriterOptions(t *testing.T, td *datadriven.TestData) SSTBlobWriterOptions {
 	opts := SSTBlobWriterOptions{}
 	td.MaybeScanArgs(t, "value-separation-min-size", &opts.ValueSeparationMinSize)
+	td.MaybeScanArgs(t, "mvcc-garbage-value-separation-min-size", &opts.MVCCGarbageValueSeparationMinSize)
 
 	var spanPolicyStr string
 	td.MaybeScanArgs(t, "span-policy", &spanPolicyStr)

--- a/valsep/testdata/sst_blob_writer
+++ b/valsep/testdata/sst_blob_writer
@@ -61,6 +61,18 @@ size:758
 blobfiles:
 1: {BlockCount: 1, ValueCount: 3, UncompressedValueBytes: 10 (0% MVCCGarbage), FileLen: 101}
 
+# Test that MVCC garbage smaller than mvcc-garbage-value-separation-min-size is not separated.
+# Only b@1 (5 bytes) is separated; a@1 (3 bytes) is not.
+build value-separation-min-size=100 mvcc-garbage-value-separation-min-size=4
+a@3#2,SET:aaa
+a@1#1,SET:aaa
+b@3#3,SET:bbbbb
+b@1#1,SET:bbbbb
+----
+size:874
+blobfiles:
+1: {BlockCount: 1, ValueCount: 1, UncompressedValueBytes: 5 (100% MVCCGarbage), FileLen: 94}
+
 # Keys should be added in increasing order.
 build value-separation-min-size=4
 a#1,SET:aaaa


### PR DESCRIPTION
Previously, we were allowing mvcc garbage values that did not meet the minimum value threshold to be written into blob files.

Fixes: #5711