### PR TITLE
crl-release-25.3: db: fix TestCompactionCorruption flake

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3123,6 +3123,7 @@ func TestCompactionCorruption(t *testing.T) {
 		}
 		// wait until fn() returns true.
 		wait := func(what string, fn func() bool) {
+			// Decrease to 5 * time.Second to repro flakes.
 			const timeout = 2 * time.Minute
 			start := time.Now()
 			for !fn() {
@@ -3183,16 +3184,17 @@ func TestCompactionCorruption(t *testing.T) {
 			})
 
 		case "manual-compaction":
-			if err := d.Compact(
-				context.Background(), []byte("a"), []byte("z9999999"), true /* parallelize */); err != nil {
-				td.Fatalf(t, "manual compaction failed: %s", err)
-			}
-			v := d.DebugCurrentVersion()
-			for i := 0; i < numLevels-1; i++ {
-				if v.Levels[i].Len() > 0 {
-					td.Fatalf(t, "expected no tables on L%d", i)
+			// If some background process (like loading stats) was in the process of
+			// opening the file, we could see the same error it sees because of the
+			// file cache. So we retry for a while.
+			wait("manual compaction", func() bool {
+				err := d.Compact(context.Background(), []byte("a"), []byte("z9999999"), true /* parallelize */)
+				if err == nil {
+					return true
 				}
-			}
+				td.Logf(t, "manual compaction error: %s", err)
+				return false
+			})
 
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)


### PR DESCRIPTION
The test checks that we can issue a manual compaction if the file
comes back, even if it is marked as a problem span.

There is a subtle race with background loading of stats which may try
to open the same file right before we rename it. Because all file
opens are serialized through the file cache, the manual compaction
might see the same (now stale) error. The fix is to simply retry the
manual compaction.

Informs #5372