### PR TITLE
wal: validate recovery directory through a stable identifier

### DIFF
--- a/open.go
+++ b/open.go
@@ -303,6 +303,12 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 
 	// Configure failover-specific histograms and options
 	if !opts.ReadOnly && opts.WALFailover != nil {
+		if walOpts.Secondary.ID == "" {
+			walOpts.Secondary.ID = opts.WALFailover.Secondary.ID
+		} else if opts.WALFailover.Secondary.ID != "" && walOpts.Secondary.ID != opts.WALFailover.Secondary.ID {
+			return nil, errors.Errorf("WAL failover secondary identifier mismatch: OPTIONS file has %q but %q was provided - wrong disk may be mounted",
+				walOpts.Secondary.ID, opts.WALFailover.Secondary.ID)
+		}
 		walSecondaryFileOpHistogram := prometheus.NewHistogram(prometheus.HistogramOpts{
 			Buckets: FsyncLatencyBuckets,
 		})
@@ -315,12 +321,19 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		walOpts.FailoverWriteAndSyncLatency = walFailoverWriteAndSyncHistogram
 
 		walOpts.FailoverOptions = opts.WALFailover.FailoverOptions
-	}
 
+		walDir, err := wal.ValidateOrInitWALDir(walOpts.Secondary)
+		if err != nil {
+			return nil, err
+		}
+		walOpts.Secondary = walDir
+		opts.WALFailover.Secondary.ID = walDir.ID
+	}
 	walManager, err := wal.Init(walOpts, rs.walsReplay)
 	if err != nil {
 		return nil, err
 	}
+
 	defer maybeCleanUp(walManager.Close)
 	d.mu.log.manager = walManager
 

--- a/open_test.go
+++ b/open_test.go
@@ -266,6 +266,14 @@ func TestOpen_WALFailover(t *testing.T) {
 			if o.FS == nil {
 				return "no path"
 			}
+			// Use a counter for identifier generation so tests can detect bugs
+			// where we incorrectly generate a new identifier.
+			idCounter := 0
+			wal.SetGenerateStableIdentifierForTesting(func() string {
+				idCounter++
+				return fmt.Sprintf("test-identifier-%d", idCounter)
+			})
+			defer wal.ResetGenerateStableIdentifierForTesting()
 			d, err := Open(dataDir, o)
 			if err != nil {
 				return err.Error()

--- a/options.go
+++ b/options.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/crlib/fifo"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/deletepacer"
@@ -1911,6 +1912,9 @@ func (o *Options) String() string {
 		fmt.Fprintf(&buf, "\n")
 		fmt.Fprintf(&buf, "[WAL Failover]\n")
 		fmt.Fprintf(&buf, "  secondary_dir=%s\n", o.WALFailover.Secondary.Dirname)
+		if o.WALFailover.Secondary.ID != "" {
+			fmt.Fprintf(&buf, "  secondary_identifier=%s\n", o.WALFailover.Secondary.ID)
+		}
 		fmt.Fprintf(&buf, "  primary_dir_probe_interval=%s\n", o.WALFailover.FailoverOptions.PrimaryDirProbeInterval)
 		fmt.Fprintf(&buf, "  healthy_probe_latency_threshold=%s\n", o.WALFailover.FailoverOptions.HealthyProbeLatencyThreshold)
 		fmt.Fprintf(&buf, "  healthy_interval=%s\n", o.WALFailover.FailoverOptions.HealthyInterval)
@@ -2385,6 +2389,8 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			switch key {
 			case "secondary_dir":
 				o.WALFailover.Secondary = wal.Dir{Dirname: value, FS: vfs.Default}
+			case "secondary_identifier":
+				o.WALFailover.Secondary.ID = value
 			case "primary_dir_probe_interval":
 				o.WALFailover.PrimaryDirProbeInterval, err = time.ParseDuration(value)
 			case "healthy_probe_latency_threshold":
@@ -2522,6 +2528,21 @@ func (e ErrMissingWALRecoveryDir) Error() string {
 	return fmt.Sprintf("directory %q may contain relevant WALs but is not in WALRecoveryDirs%s", e.Dir, e.ExtraInfo)
 }
 
+// ErrSecondaryIdentifierMismatch is an error returned when the secondary directory
+// identifier doesn't match the expected identifier, indicating the wrong disk
+// may have been mounted at the expected path.
+type ErrSecondaryIdentifierMismatch struct {
+	ExpectedIdentifier string
+	ActualIdentifier   string
+	SecondaryDir       string
+}
+
+// Error implements error.
+func (e ErrSecondaryIdentifierMismatch) Error() string {
+	return fmt.Sprintf("secondary directory %q has identifier %q but expected %q - wrong disk may be mounted",
+		e.SecondaryDir, e.ActualIdentifier, e.ExpectedIdentifier)
+}
+
 // CheckCompatibility verifies the options are compatible with the previous options
 // serialized by Options.String(). For example, the Comparer and Merger must be
 // the same, or data will not be able to be properly read from the DB.
@@ -2589,6 +2610,16 @@ func (o *Options) checkWALDir(storeDir, walDir, errContext string) error {
 	for _, d := range o.WALRecoveryDirs {
 		// TODO(radu): should we also check that d.FS is the same as walDir's FS?
 		if walPath == resolveStorePath(storeDir, d.Dirname) {
+			// Only validate the stable identifier if this recovery directory matches
+			// the current secondary location. If it's a previous secondary (specified
+			// via prev_path), we're just recovering from it and shouldn't validate
+			// its identifier against the current options.
+			if d.ID != "" && o.WALFailover != nil &&
+				walPath == resolveStorePath(storeDir, o.WALFailover.Secondary.Dirname) {
+				if err := o.validateWALRecoveryDirIdentifier(d); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
 	}
@@ -2892,4 +2923,30 @@ func resolveStorePath(storeDir, path string) string {
 		return storeDir + remainder
 	}
 	return path
+}
+
+// validateWALRecoveryDirIdentifier validates that the identifier in the
+// provided wal.Dir matches the expected ID encoded in the OPTIONS file to
+// ensure that we're using the correct directory.
+func (o *Options) validateWALRecoveryDirIdentifier(d wal.Dir) error {
+	identifierFile := d.FS.PathJoin(d.Dirname, wal.StableIdentifierFilename)
+	f, err := d.FS.Open(identifierFile)
+	if err != nil {
+		if oserror.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	existingIdentifier, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	trimmedIdentifier := strings.TrimSpace(string(existingIdentifier))
+	if trimmedIdentifier != d.ID {
+		return errors.Newf("WALRecoveryDir %q has identifier %q but expected %q",
+			d.Dirname, trimmedIdentifier, d.ID)
+	}
+	return nil
 }

--- a/options_test.go
+++ b/options_test.go
@@ -7,6 +7,7 @@ package pebble
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"runtime"
 	"strings"
@@ -281,7 +282,6 @@ func TestOptionsCheckCompatibility(t *testing.T) {
 
 	// Check that an OPTIONS file that configured an explicit WALDir that will
 	// no longer be used errors if it's not also present in WALRecoveryDirs.
-	//require.Equal(t, ErrMissingWALRecoveryDir{Dir: "external-wal-dir"},
 	err := DefaultOptions().CheckCompatibility(storeDir, `
 [Options]
   wal_dir=external-wal-dir
@@ -359,6 +359,70 @@ func TestOptionsCheckCompatibility(t *testing.T) {
 [WAL Failover]
   secondary_dir=failover-wal-dir
 `))
+}
+
+func TestWALRecoveryDirValidation(t *testing.T) {
+	storeDir := "/mnt/foo"
+	mem := vfs.NewMem()
+
+	// Test that when a WALRecoveryDir is NOT the current secondary
+	// (i.e., it's an old secondary we're recovering from), we should NOT
+	// validate its identifier, even if it has one.
+	oldSecondaryDir := "/mnt/old-secondary"
+	err := mem.MkdirAll(oldSecondaryDir, 0755)
+	require.NoError(t, err)
+
+	// Create stable_identifier file in the old secondary with its own ID.
+	oldIdentifierFile := mem.PathJoin(oldSecondaryDir, wal.StableIdentifierFilename)
+	err = writeTestIdentifierToFile(mem, oldIdentifierFile, "11111111111111111111111111111111")
+	require.NoError(t, err)
+
+	currentSecondaryDir := "/mnt/current-secondary"
+	err = mem.MkdirAll(currentSecondaryDir, 0755)
+	require.NoError(t, err)
+
+	opts := &Options{
+		FS: mem,
+		WALFailover: &WALFailoverOptions{
+			Secondary: wal.Dir{
+				FS:      mem,
+				Dirname: currentSecondaryDir,
+				ID:      "22222222222222222222222222222222",
+			},
+		},
+		WALRecoveryDirs: []wal.Dir{
+			{
+				// Old secondary with an ID from when it was the current secondary.
+				// This ID doesn't match the identifier file in oldSecondaryDir,
+				// but we shouldn't validate because it's not the current secondary.
+				FS:      mem,
+				Dirname: oldSecondaryDir,
+				ID:      "99999999999999999999999999999999",
+			},
+		},
+	}
+	opts.EnsureDefaults()
+
+	// This should succeed because oldSecondaryDir is not the current secondary,
+	// so we don't validate its identifier.
+	err = opts.checkWALDir(storeDir, oldSecondaryDir, "test context")
+	require.NoError(t, err)
+}
+
+// writeTestIdentifierToFile is a helper function to write an identifier to a file
+func writeTestIdentifierToFile(fs vfs.FS, filename, identifier string) error {
+	f, err := fs.Create(filename, "pebble-wal")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.WriteString(f, identifier)
+	if err != nil {
+		return err
+	}
+
+	return f.Sync()
 }
 
 type testCleaner struct{}

--- a/testdata/open_wal_failover
+++ b/testdata/open_wal_failover
@@ -46,6 +46,7 @@ list path=(a,data)
 grep-between path=(a,data/OPTIONS-000005) start=(\[WAL Failover\]) end=^$
 ----
   secondary_dir=secondary-wals
+  secondary_identifier=test-identifier-1
   primary_dir_probe_interval=1s
   healthy_probe_latency_threshold=25ms
   healthy_interval=15s

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -6,16 +6,19 @@ package wal
 
 import (
 	"cmp"
+	crand "crypto/rand"
 	"fmt"
 	"io"
-	"math/rand/v2"
+	mathrand "math/rand/v2"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/vfs"
@@ -53,6 +56,78 @@ const probeHistoryLength = 128
 // Large value.
 const failedProbeDuration = 24 * 60 * 60 * time.Second
 
+// For testing, generateStableIdentifierForTesting can be overridden to return
+// a deterministic value when we generate stable identifiers.
+var generateStableIdentifierForTesting func() string
+
+// SetGenerateStableIdentifierForTesting sets a function to generate identifiers
+// for testing.
+func SetGenerateStableIdentifierForTesting(f func() string) {
+	generateStableIdentifierForTesting = f
+}
+
+// ResetGenerateStableIdentifierForTesting resets the testing override.
+// This should only be used in tests.
+func ResetGenerateStableIdentifierForTesting() {
+	generateStableIdentifierForTesting = nil
+}
+
+// generateStableIdentifier generates a random hex string from 16 bytes.
+func generateStableIdentifier() (string, error) {
+	// For testing, use the override function if set.
+	if generateStableIdentifierForTesting != nil {
+		return generateStableIdentifierForTesting(), nil
+	}
+
+	var id [16]byte
+	crand.Read(id[:])
+	return fmt.Sprintf("%x", id), nil
+}
+
+// readSecondaryIdentifier reads the identifier from the secondary directory.
+func readSecondaryIdentifier(fs vfs.FS, identifierFile string) (string, error) {
+	f, err := fs.Open(identifierFile)
+	if err != nil {
+		if oserror.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	// Trim whitespace and return the identifier.
+	return strings.TrimSpace(string(data)), nil
+}
+
+// writeSecondaryIdentifier writes the identifier to the secondary directory.
+func writeSecondaryIdentifier(fs vfs.FS, identifierFile string, identifier string) error {
+	f, err := fs.Create(identifierFile, "pebble-wal")
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.WriteString(f, identifier); err != nil {
+		f.Close()
+		return errors.CombineErrors(err, fs.Remove(identifierFile))
+	}
+
+	if err := errors.CombineErrors(f.Sync(), f.Close()); err != nil {
+		return errors.CombineErrors(err, fs.Remove(identifierFile))
+	}
+
+	// Sync the containing directory to ensure the new file is durably visible.
+	dir, err := fs.OpenDir(fs.PathDir(identifierFile))
+	if err != nil {
+		return err
+	}
+	return errors.CombineErrors(dir.Sync(), dir.Close())
+}
+
 // init takes a stopper in order to connect the dirProber's long-running
 // goroutines with the stopper's wait group, but the dirProber has its own
 // stop() method that should be invoked to trigger the shutdown.
@@ -74,7 +149,7 @@ func (p *dirProber) init(
 	}
 	// Random bytes for writing, to defeat any FS compression optimization.
 	for i := range p.buf {
-		p.buf[i] = byte(rand.Uint32())
+		p.buf[i] = byte(mathrand.Uint32())
 	}
 	// dirProber has an explicit stop() method instead of listening on
 	// stopper.shouldQuiesce. This structure helps negotiate the shutdown
@@ -547,6 +622,48 @@ func (wm *failoverManager) init(o Options, initial Logs) error {
 	return nil
 }
 
+// ValidateOrInitWALDir manages the secondary directory identifier for
+// failover validation. It ensures the correct secondary directory is mounted
+// by validating or generating a stable identifier.
+func ValidateOrInitWALDir(walDir Dir) (Dir, error) {
+	identifierFile := walDir.FS.PathJoin(walDir.Dirname, StableIdentifierFilename)
+	existingIdentifier, err := readSecondaryIdentifier(walDir.FS, identifierFile)
+	if err != nil {
+		return Dir{}, errors.Newf("failed to read secondary identifier: %v", err)
+	}
+
+	// If the directory already has an identifier, validate or adopt it.
+	if existingIdentifier != "" {
+		// If OPTIONS also has an identifier, validate they match.
+		// This ensures we didn't mount the wrong disk.
+		if walDir.ID != "" && existingIdentifier != walDir.ID {
+			return Dir{}, errors.Newf("secondary directory %q has identifier %q but expected %q - wrong disk may be mounted",
+				walDir.Dirname, existingIdentifier, walDir.ID)
+		}
+		// Use the existing identifier from the directory.
+		walDir.ID = existingIdentifier
+		return walDir, nil
+	}
+
+	// Directory has no identifier, generate a new one. This happens when
+	// opening a database with WAL failover for the first time, or when
+	// switching to a new secondary directory.
+	//
+	// If we crash after writing the identifier file but before the OPTIONS file
+	// is updated, the next open will find the identifier in the directory but
+	// not in OPTIONS. In that case, we'll adopt the existing identifier (see
+	// the existingIdentifier != "" branch above), which is safe.
+	identifier, err := generateStableIdentifier()
+	if err != nil {
+		return Dir{}, errors.Newf("failed to generate ID: %v", err)
+	}
+	if err := writeSecondaryIdentifier(walDir.FS, identifierFile, identifier); err != nil {
+		return Dir{}, errors.Newf("failed to write secondary identifier: %v", err)
+	}
+	walDir.ID = identifier
+	return walDir, nil
+}
+
 // List implements Manager.
 func (wm *failoverManager) List() Logs {
 	wm.mu.Lock()
@@ -869,6 +986,11 @@ func (wm *failoverManager) logCreator(
 	}
 	r.writeEnd(err)
 	return logFile, 0, err
+}
+
+// Opts implements Manager.
+func (wm *failoverManager) Opts() Options {
+	return wm.opts
 }
 
 type stopper struct {

--- a/wal/standalone_manager.go
+++ b/wal/standalone_manager.go
@@ -276,6 +276,11 @@ func (m *StandaloneManager) Close() error {
 	return err
 }
 
+// Opts implements Manager.
+func (m *StandaloneManager) Opts() Options {
+	return m.o
+}
+
 // RecyclerForTesting implements Manager.
 func (m *StandaloneManager) RecyclerForTesting() *LogRecycler {
 	return &m.recycler

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -21,11 +21,22 @@ import (
 
 // TODO(sumeer): write a high-level comment describing the approach.
 
+// StableIdentifierFilename is the name of the file within a WAL directory that
+// stores a stable ID identifying that directory. This is used to detect when
+// the wrong disk has been mounted at the expected path during recovery.
+const StableIdentifierFilename = "stable_identifier"
+
 // Dir is used for storing log files.
 type Dir struct {
 	Lock    *base.DirLock
 	FS      vfs.FS
 	Dirname string
+	// ID is a stable ID that uniquely identifies the directory. This
+	// identifier is persisted both in the OPTIONS file in the primary directory
+	// and in a file (stable_identifier) within the secondary directory to detect
+	// incorrectness/corruptions (e.g. when the wrong disk has been mounted at
+	// the expected path during recovery).
+	ID string
 }
 
 // NumWAL is the number of the virtual WAL. It can map to one or more physical
@@ -367,6 +378,8 @@ type Manager interface {
 	// Close the manager.
 	// REQUIRES: Writers and Readers have already been closed.
 	Close() error
+	// Opts returns the Options used to initialize the Manager.
+	Opts() Options
 
 	// RecyclerForTesting exposes the internal LogRecycler.
 	RecyclerForTesting() *LogRecycler

--- a/wal_failover_identifier_test.go
+++ b/wal_failover_identifier_test.go
@@ -1,0 +1,246 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/pebble/wal"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWALFailoverIdentifier tests the WAL failover identifier mechanism, which
+// ensures that the correct secondary WAL directory is being used during database
+// recovery. The identifier is a unique string stored in a "stable_identifier"
+// file in the secondary WAL directory that helps prevent accidental use of the
+// wrong secondary directory (e.g., when the wrong disk is mounted).
+//
+// The test covers four scenarios:
+//  1. first_time_generation: when opening a database with WAL failover for the
+//     first time, a new identifier should be generated and written to both the
+//     secondary directory and the OPTIONS file
+//  2. identifier_mismatch_error: when the secondary directory contains a
+//     different identifier than what's expected in the options, the database
+//     should fail to open with an error indicating the wrong disk may be mounted
+//  3. no_primary_has_secondary: when no identifier is specified in options but
+//     the secondary directory already contains an identifier, the database should
+//     adopt the existing identifier and write it to the OPTIONS file
+//  4. reopen_with_different_user_id: when reopening a database with a different
+//     user-provided identifier than what was stored in the OPTIONS file, the
+//     database should fail to open with an error indicating the wrong disk may
+//     be mounted
+func TestWALFailoverIdentifier(t *testing.T) {
+	t.Run("first_time_generation", func(t *testing.T) {
+		mem := vfs.NewMem()
+
+		// First time opening with WAL failover should generate an identifier.
+		opts := &Options{
+			FS: mem,
+			WALFailover: &WALFailoverOptions{
+				Secondary: wal.Dir{Dirname: "secondary", FS: mem},
+			},
+		}
+
+		db, err := Open("testdb", opts)
+		require.NoError(t, err, "failed to open database")
+		defer db.Close()
+
+		// Check that identifier file exists in secondary directory.
+		identifierFile := mem.PathJoin("secondary", wal.StableIdentifierFilename)
+		failoverId, err := mem.Open(identifierFile)
+		require.NoError(t, err)
+
+		// Read the identifier from the file.
+		defer failoverId.Close()
+		data := make([]byte, 100)
+		n, err := failoverId.Read(data)
+		if err != nil && err != io.EOF {
+			t.Fatalf("failed to read identifier file: %v", err)
+		}
+
+		identifier := strings.TrimSpace(string(data[:n]))
+		require.True(t, identifier != "", "expected identifier to be written to file")
+		t.Logf("identifier from stable_identifier file: %q", identifier)
+
+		// Check that the identifier is written to the OPTIONS file.
+		entries, err := mem.List("testdb")
+		require.NoError(t, err, "failed to list testdb directory")
+		var optionsFile string
+		for _, entry := range entries {
+			if strings.HasPrefix(entry, "OPTIONS-") {
+				optionsFile = mem.PathJoin("testdb", entry)
+				break
+			}
+		}
+		require.NotEmpty(t, optionsFile, "OPTIONS file should exist")
+
+		optionsF, err := mem.Open(optionsFile)
+		require.NoError(t, err, "failed to open OPTIONS file")
+		defer optionsF.Close()
+
+		optionsData, err := io.ReadAll(optionsF)
+		require.NoError(t, err, "failed to read OPTIONS file")
+
+		optionsContent := string(optionsData)
+		// Verify the OPTIONS file contains the [WAL Failover] section with the
+		// identifier we found in the stable_identifier above.
+		require.Contains(t, optionsContent, "[WAL Failover]",
+			"OPTIONS file should contain WAL Failover section")
+		require.Contains(t, optionsContent, "secondary_identifier="+identifier,
+			"OPTIONS file should contain the generated identifier")
+	})
+
+	t.Run("identifier_mismatch_error", func(t *testing.T) {
+		mem := vfs.NewMem()
+		secondaryDir := "secondary"
+		err := mem.MkdirAll(secondaryDir, 0755)
+		require.NoError(t, err)
+
+		// Create a secondary directory with a different identifier.
+		identifierFile := mem.PathJoin("secondary", wal.StableIdentifierFilename)
+		existingIdentifier := "44444444444444444444444444444444"
+		err = writeTestIdentifier(mem, identifierFile, existingIdentifier)
+		require.NoError(t, err)
+
+		// Try to open with a different identifier in options.
+		opts := &Options{
+			FS: mem,
+			WALFailover: &WALFailoverOptions{
+				Secondary: wal.Dir{
+					Dirname: "secondary",
+					FS:      mem,
+					ID:      "7f495fb4914ecfc04deeafa41de42b78",
+				},
+			},
+		}
+
+		_, err = Open("testdb", opts)
+		require.Error(t, err, "expected error due to identifier mismatch")
+		require.Contains(t, err.Error(), "wrong disk may be mounted")
+	})
+
+	t.Run("no_primary_has_secondary", func(t *testing.T) {
+		// Test case: no identifier in primary options, secondary has identifier
+		// The system should adopt the existing identifier from the secondary directory.
+		mem := vfs.NewMem()
+		identifierFile := mem.PathJoin("secondary", wal.StableIdentifierFilename)
+		err := mem.MkdirAll("secondary", 0755)
+		require.NoError(t, err)
+
+		// Write an existing identifier to the secondary directory.
+		existingIdentifier := "44444444444444444444444444444444"
+		err = writeTestIdentifier(mem, identifierFile, existingIdentifier)
+		require.NoError(t, err)
+
+		// Open without specifying SecondaryIdentifier in options.
+		opts := &Options{
+			FS: mem,
+			WALFailover: &WALFailoverOptions{
+				Secondary: wal.Dir{Dirname: "secondary", FS: mem},
+			},
+		}
+
+		db, err := Open("testdb", opts)
+		require.NoError(t, err, "should succeed and adopt the existing identifier")
+		defer db.Close()
+
+		// Verify that the OPTIONS file now contains the adopted identifier.
+		entries, err := mem.List("testdb")
+		require.NoError(t, err, "failed to list testdb directory")
+		var optionsFile string
+		for _, entry := range entries {
+			if strings.HasPrefix(entry, "OPTIONS-") {
+				optionsFile = mem.PathJoin("testdb", entry)
+				break
+			}
+		}
+		require.NotEmpty(t, optionsFile, "OPTIONS file should exist")
+
+		optionsF, err := mem.Open(optionsFile)
+		require.NoError(t, err, "failed to open OPTIONS file")
+		defer optionsF.Close()
+
+		optionsData, err := io.ReadAll(optionsF)
+		require.NoError(t, err, "failed to read OPTIONS file")
+
+		optionsContent := string(optionsData)
+		require.Contains(t, optionsContent, "[WAL Failover]",
+			"OPTIONS file should contain WAL Failover section")
+		require.Contains(t, optionsContent, "secondary_identifier="+existingIdentifier,
+			"OPTIONS file should contain the adopted identifier")
+	})
+
+	// Reopen a database with a different user-provided ID than was
+	// previously stored. The user-provided ID should be validated against
+	// the recovered ID from the OPTIONS file.
+	t.Run("reopen_with_different_user_id", func(t *testing.T) {
+		mem := vfs.NewMem()
+
+		// First, open the database with WAL failover to generate an identifier.
+		opts := &Options{
+			FS: mem,
+			WALFailover: &WALFailoverOptions{
+				Secondary: wal.Dir{Dirname: "secondary", FS: mem},
+			},
+		}
+
+		db, err := Open("testdb", opts)
+		require.NoError(t, err, "failed to open database")
+
+		// Read the generated identifier from the stable_identifier file.
+		identifierFile := mem.PathJoin("secondary", wal.StableIdentifierFilename)
+		f, err := mem.Open(identifierFile)
+		require.NoError(t, err)
+		data, err := io.ReadAll(f)
+		require.NoError(t, err)
+		f.Close()
+		generatedID := strings.TrimSpace(string(data))
+		require.NotEmpty(t, generatedID, "expected identifier to be generated")
+		t.Logf("generated identifier: %q", generatedID)
+
+		// Close the database.
+		require.NoError(t, db.Close())
+
+		// Reopen the database with a different user-provided ID.
+		differentID := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		require.NotEqual(t, generatedID, differentID, "test requires different IDs")
+
+		opts2 := &Options{
+			FS: mem,
+			WALFailover: &WALFailoverOptions{
+				Secondary: wal.Dir{
+					Dirname: "secondary",
+					FS:      mem,
+					ID:      differentID,
+				},
+			},
+		}
+
+		// This should error because the user-provided ID doesn't match the
+		// recovered ID from the OPTIONS file.
+		_, err = Open("testdb", opts2)
+		require.Error(t, err, "expected error when user-provided ID doesn't match recovered ID")
+		require.Contains(t, err.Error(), "wrong disk may be mounted",
+			"error should indicate potential wrong disk")
+	})
+}
+
+func writeTestIdentifier(fs vfs.FS, filename, identifier string) error {
+	f, err := fs.Create(filename, "pebble-wal")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.WriteString(f, identifier)
+	if err != nil {
+		return err
+	}
+
+	return f.Sync()
+}


### PR DESCRIPTION
We now persist a stable identifier to both the OPTIONS file and a file within the secondary directory (stable_identifier). When a WAL recovery directory is also the current secondary location, we validate that its identifier matches what's in the OPTIONS file. If the identifiers don't match, we abort recovery indicating that the secondary seems incorrect / corrupt.

Recovery directories that are NOT the current secondary (i.e., previous secondaries specified via prev_path) are not validated, as they have their own identifiers from when they were the active secondary.

Fixes: #4416