### PR TITLE
keyspan: clean up interleaving iterator test output

### DIFF
--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -33,50 +33,26 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: artichoke#10,SET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: artichoke#8,SET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
--- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
-PointKey: c#inf,RANGEKEYSET
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
-PointKey: carrot#13,SET
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
-PointKey: cauliflower#9,DEL
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
--- SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
-PointKey: e#inf,RANGEKEYSET
-Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
--
--- SpanChanged(h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)})
-PointKey: h#inf,RANGEKEYDEL
-Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
--
--- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
-PointKey: l#inf,RANGEKEYUNSET
-Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
--
--- SpanChanged(nil)
-PointKey: parsnip#3,SET
-Span: <invalid>
--
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
-PointKey: tomato#2,SET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+. a#inf,RANGEKEYSET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. artichoke#10,SET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. artichoke#8,SET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+# SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
+. c#inf,RANGEKEYSET: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+. carrot#13,SET: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+. cauliflower#9,DEL: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+# SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
+. e#inf,RANGEKEYSET: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+# SpanChanged(h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)})
+. h#inf,RANGEKEYDEL: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
+# SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
+. l#inf,RANGEKEYUNSET: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
+# SpanChanged(nil)
+. parsnip#3,SET: (no span)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+. tomato#2,SET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 
 # Test interleaving end keys.
 
@@ -101,72 +77,34 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: artichoke#10,SET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: artichoke#8,SET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: c#inf,RANGEKEYSET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
--- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
-PointKey: c#inf,RANGEKEYSET
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
-PointKey: carrot#13,SET
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
-PointKey: cauliflower#9,DEL
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
-PointKey: d#inf,RANGEKEYSET
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
--- SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
-PointKey: e#inf,RANGEKEYSET
-Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
--
-PointKey: f#inf,RANGEKEYSET
-Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
--
--- SpanChanged(h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)})
-PointKey: h#inf,RANGEKEYDEL
-Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
--
-PointKey: j#inf,RANGEKEYDEL
-Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
--
--- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
-PointKey: l#inf,RANGEKEYUNSET
-Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
--
-PointKey: m#inf,RANGEKEYUNSET
-Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
--
--- SpanChanged(nil)
-PointKey: parsnip#3,SET
-Span: <invalid>
--
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
-PointKey: tomato#2,SET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
-PointKey: z#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
--- SpanChanged(nil)
-PointKey: zucchini#12,MERGE
-Span: <invalid>
--
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+. a#inf,RANGEKEYSET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. artichoke#10,SET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. artichoke#8,SET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. c#inf,RANGEKEYSET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+# SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
+. c#inf,RANGEKEYSET: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+. carrot#13,SET: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+. cauliflower#9,DEL: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+. d#inf,RANGEKEYSET: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+# SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
+. e#inf,RANGEKEYSET: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+. f#inf,RANGEKEYSET: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+# SpanChanged(h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)})
+. h#inf,RANGEKEYDEL: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
+. j#inf,RANGEKEYDEL: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
+# SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
+. l#inf,RANGEKEYUNSET: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
+. m#inf,RANGEKEYUNSET: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
+# SpanChanged(nil)
+. parsnip#3,SET: (no span)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+. tomato#2,SET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+. z#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+# SpanChanged(nil)
+. zucchini#12,MERGE: (no span)
 
 # Test set-bounds passes through to the underlying point iterator and truncates
 # a range key's end.
@@ -177,16 +115,12 @@ seek-ge b
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
-PointKey: b#inf,RANGEKEYSET
-Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
--- SpanChanged(c-carrot:{(#4,RANGEKEYSET,@3,coconut)})
-PointKey: c#inf,RANGEKEYSET
-Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+. b#inf,RANGEKEYSET: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+# SpanChanged(c-carrot:{(#4,RANGEKEYSET,@3,coconut)})
+. c#inf,RANGEKEYSET: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
+# SpanChanged(nil)
 .
 
 
@@ -199,16 +133,12 @@ seek-lt carrot
 prev
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(c-carrot:{(#4,RANGEKEYSET,@3,coconut)})
-PointKey: c#inf,RANGEKEYSET
-Span: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
--
--- SpanChanged(b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
-PointKey: b#inf,RANGEKEYSET
-Span: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(c-carrot:{(#4,RANGEKEYSET,@3,coconut)})
+. c#inf,RANGEKEYSET: c-carrot:{(#4,RANGEKEYSET,@3,coconut)}
+# SpanChanged(b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+. b#inf,RANGEKEYSET: b-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+# SpanChanged(nil)
 .
 
 # Test seek-ge.
@@ -221,31 +151,21 @@ seek-ge p
 seek-ge yyy
 seek-ge z
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: parsnip#3,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: yyy#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: zucchini#12,MERGE
-Span: <invalid>
--
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+. a#inf,RANGEKEYSET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+. a#inf,RANGEKEYSET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+# SpanChanged(nil)
+# SpanChanged(nil)
+. parsnip#3,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. yyy#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+# SpanChanged(nil)
+# SpanChanged(nil)
+. zucchini#12,MERGE: (no span)
 
 iter
 last
@@ -258,42 +178,24 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: zucchini#12,MERGE
-Span: <invalid>
--
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: tomato#2,SET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
--- SpanChanged(nil)
-PointKey: parsnip#3,SET
-Span: <invalid>
--
--- SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
-PointKey: l#inf,RANGEKEYUNSET
-Span: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: parsnip#3,SET
-Span: <invalid>
--
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
-PointKey: tomato#2,SET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
--- SpanChanged(nil)
-PointKey: zucchini#12,MERGE
-Span: <invalid>
--
+# SpanChanged(nil)
+# SpanChanged(nil)
+. zucchini#12,MERGE: (no span)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. tomato#2,SET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+# SpanChanged(nil)
+. parsnip#3,SET: (no span)
+# SpanChanged(l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)})
+. l#inf,RANGEKEYUNSET: l-m:{(#2,RANGEKEYUNSET,@9) (#2,RANGEKEYUNSET,@5)}
+# SpanChanged(nil)
+# SpanChanged(nil)
+. parsnip#3,SET: (no span)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+. tomato#2,SET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+# SpanChanged(nil)
+. zucchini#12,MERGE: (no span)
 
 iter
 seek-ge tomato
@@ -302,28 +204,18 @@ seek-ge q
 seek-ge parsnip
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: tomato#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
-PointKey: tomato#2,SET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
--- SpanChanged(nil)
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: parsnip#3,SET
-Span: <invalid>
--
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
+# SpanChanged(nil)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. tomato#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+. tomato#2,SET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+# SpanChanged(nil)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+# SpanChanged(nil)
+# SpanChanged(nil)
+. parsnip#3,SET: (no span)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 
 iter
 seek-lt tomato
@@ -332,28 +224,19 @@ seek-lt a
 seek-lt tomato
 seek-lt tomago
 ----
--- SpanChanged(nil)
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
--- SpanChanged(nil)
-PointKey: parsnip#3,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-.
--- SpanChanged(nil)
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
--- SpanChanged(nil)
--- SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
-PointKey: q#inf,RANGEKEYSET
-Span: q-z:{(#14,RANGEKEYSET,@9,mangos)}
--
+# SpanChanged(nil)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+# SpanChanged(nil)
+. parsnip#3,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(nil)
+.# SpanChanged(nil)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
+# SpanChanged(nil)
+# SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
+. q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 
 define-spans
 a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
@@ -381,26 +264,18 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: a#10,SET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: a#8,SET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: b#13,SET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+. a#inf,RANGEKEYSET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. a#10,SET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. a#8,SET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. b#13,SET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
 
 iter
 seek-lt a
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
 .
 
 iter
@@ -413,36 +288,20 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
-PointKey: ab#inf,RANGEKEYSET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
-PointKey: b#13,SET
-Span: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
--
--- SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
-PointKey: c#inf,RANGEKEYSET
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
-PointKey: c#9,DEL
-Span: c-d:{(#4,RANGEKEYSET,@3,coconut)}
--
--- SpanChanged(nil)
-PointKey: d#3,SET
-Span: <invalid>
--
--- SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
-PointKey: e#inf,RANGEKEYSET
-Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
--
-PointKey: e#2,SET
-Span: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
--
--- SpanChanged(h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)})
-PointKey: h#inf,RANGEKEYDEL
-Span: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
--
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)})
+. ab#inf,RANGEKEYSET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+. b#13,SET: a-c:{(#10,RANGEKEYSET,@5,apples) (#10,RANGEKEYDEL) (#8,RANGEKEYUNSET,@1) (#4,RANGEKEYSET,@3,bananas) (#4,RANGEKEYSET,@2,oranges)}
+# SpanChanged(c-d:{(#4,RANGEKEYSET,@3,coconut)})
+. c#inf,RANGEKEYSET: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+. c#9,DEL: c-d:{(#4,RANGEKEYSET,@3,coconut)}
+# SpanChanged(nil)
+. d#3,SET: (no span)
+# SpanChanged(e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)})
+. e#inf,RANGEKEYSET: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+. e#2,SET: e-f:{(#20,RANGEKEYSET,@5,pineapple) (#20,RANGEKEYSET,@3,guava)}
+# SpanChanged(h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)})
+. h#inf,RANGEKEYDEL: h-j:{(#22,RANGEKEYDEL) (#21,RANGEKEYSET,@5,peaches) (#21,RANGEKEYSET,@3,starfruit)}
 
 define-spans
 a-z:{(#5,RANGEKEYSET,@5,apples)}
@@ -467,26 +326,14 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: a#10,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: a#8,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: b#13,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: c#9,DEL
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: d#3,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. a#inf,RANGEKEYSET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. a#10,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. a#8,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. b#13,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. c#9,DEL: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. d#3,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
 
 # Switch to reverse within a range key.
 # NB: The seek-ge b should truncate the range key a-z to b.
@@ -495,16 +342,12 @@ iter
 seek-ge b
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: b#inf,RANGEKEYSET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: a#8,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. b#inf,RANGEKEYSET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. a#8,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
 
 # Switch to reverse after a seek-ge. Reverse iteration should not revisit the
 # interleaved range-key start at the seek-ge bound: The range-key start should
@@ -517,25 +360,15 @@ prev
 prev
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: b#inf,RANGEKEYSET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: b#13,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: a#8,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: a#10,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: a#inf,RANGEKEYSET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. b#inf,RANGEKEYSET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. b#13,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. a#8,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. a#10,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. a#inf,RANGEKEYSET: a-z:{(#5,RANGEKEYSET,@5,apples)}
 
 # Switch to forward iteration after a seek-lt.
 
@@ -543,35 +376,25 @@ iter
 seek-lt c
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: b#13,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: c#9,DEL
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. b#13,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. c#9,DEL: a-z:{(#5,RANGEKEYSET,@5,apples)}
 
 iter
 seek-lt c
 prev
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: b#13,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
-PointKey: a#8,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
-PointKey: b#13,SET
-Span: a-z:{(#5,RANGEKEYSET,@5,apples)}
--
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. b#13,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+. a#8,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@5,apples)})
+. b#13,SET: a-z:{(#5,RANGEKEYSET,@5,apples)}
 
 # Test sparse range keys.
 
@@ -602,47 +425,31 @@ prev
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: a#9,SET
-Span: <invalid>
--
--- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
-PointKey: ace#inf,RANGEKEYSET
-Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
--
-PointKey: b#13,SET
-Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
--
--- SpanChanged(nil)
--- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
-PointKey: ace#inf,RANGEKEYSET
-Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
--
--- SpanChanged(nil)
--- SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
-PointKey: b#13,SET
-Span: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
--
--- SpanChanged(nil)
-PointKey: c#9,DEL
-Span: <invalid>
--
+# SpanChanged(nil)
+# SpanChanged(nil)
+. a#9,SET: (no span)
+# SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
+. ace#inf,RANGEKEYSET: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
+. b#13,SET: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
+# SpanChanged(nil)
+# SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
+. ace#inf,RANGEKEYSET: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
+# SpanChanged(nil)
+# SpanChanged(ace-bat:{(#5,RANGEKEYSET,@5,v5)})
+. b#13,SET: ace-bat:{(#5,RANGEKEYSET,@5,v5)}
+# SpanChanged(nil)
+. c#9,DEL: (no span)
 
 iter
 seek-lt ace
 seek-lt zoo
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: a#9,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: z#3,SET
-Span: <invalid>
--
+# SpanChanged(nil)
+# SpanChanged(nil)
+. a#9,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. z#3,SET: (no span)
 
 iter
 last
@@ -650,21 +457,15 @@ prev
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: z#3,SET
-Span: <invalid>
--
--- SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
-PointKey: y#3,SET
-Span: x-z:{(#6,RANGEKEYSET,@6,v5)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: z#3,SET
-Span: <invalid>
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. z#3,SET: (no span)
+# SpanChanged(x-z:{(#6,RANGEKEYSET,@6,v5)})
+. y#3,SET: x-z:{(#6,RANGEKEYSET,@6,v5)}
+# SpanChanged(nil)
+# SpanChanged(nil)
+. z#3,SET: (no span)
+# SpanChanged(nil)
 .
 
 iter
@@ -673,26 +474,18 @@ next
 seek-ge m
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: d#18,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: m#4,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: m#4,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: d#18,SET
-Span: <invalid>
--
+# SpanChanged(nil)
+# SpanChanged(nil)
+. d#18,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. m#4,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. m#4,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. d#18,SET: (no span)
 
 # First, Last, SeekLT and SeekGE elide spans without Sets.
 
@@ -713,26 +506,18 @@ last
 seek-ge a
 seek-lt d
 ----
--- SpanChanged(nil)
--- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
-PointKey: b#inf,RANGEKEYDEL
-Span: b-d:{(#5,RANGEKEYDEL)}
--
--- SpanChanged(nil)
--- SpanChanged(f-g:{(#6,RANGEKEYDEL)})
-PointKey: f#inf,RANGEKEYDEL
-Span: f-g:{(#6,RANGEKEYDEL)}
--
--- SpanChanged(nil)
--- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
-PointKey: b#inf,RANGEKEYDEL
-Span: b-d:{(#5,RANGEKEYDEL)}
--
--- SpanChanged(nil)
--- SpanChanged(b-d:{(#5,RANGEKEYDEL)})
-PointKey: c#8,SET
-Span: b-d:{(#5,RANGEKEYDEL)}
--
+# SpanChanged(nil)
+# SpanChanged(b-d:{(#5,RANGEKEYDEL)})
+. b#inf,RANGEKEYDEL: b-d:{(#5,RANGEKEYDEL)}
+# SpanChanged(nil)
+# SpanChanged(f-g:{(#6,RANGEKEYDEL)})
+. f#inf,RANGEKEYDEL: f-g:{(#6,RANGEKEYDEL)}
+# SpanChanged(nil)
+# SpanChanged(b-d:{(#5,RANGEKEYDEL)})
+. b#inf,RANGEKEYDEL: b-d:{(#5,RANGEKEYDEL)}
+# SpanChanged(nil)
+# SpanChanged(b-d:{(#5,RANGEKEYDEL)})
+. c#8,SET: b-d:{(#5,RANGEKEYDEL)}
 
 # Test a scenario where Next is out of point keys, the current range key has
 # already been interleaved, and there are no more range keys.
@@ -753,18 +538,12 @@ first
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(w-y:{(#5,RANGEKEYSET,@1,v1)})
-PointKey: w#inf,RANGEKEYSET
-Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
--
-PointKey: x#8,SET
-Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
--
--- SpanChanged(y-z:{(#5,RANGEKEYDEL)})
-PointKey: y#inf,RANGEKEYDEL
-Span: y-z:{(#5,RANGEKEYDEL)}
--
+# SpanChanged(nil)
+# SpanChanged(w-y:{(#5,RANGEKEYSET,@1,v1)})
+. w#inf,RANGEKEYSET: w-y:{(#5,RANGEKEYSET,@1,v1)}
+. x#8,SET: w-y:{(#5,RANGEKEYSET,@1,v1)}
+# SpanChanged(y-z:{(#5,RANGEKEYDEL)})
+. y#inf,RANGEKEYDEL: y-z:{(#5,RANGEKEYDEL)}
 
 # Test a scenario where we change direction on a synthetic range key boundary
 # key.
@@ -772,13 +551,11 @@ iter
 first
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(w-y:{(#5,RANGEKEYSET,@1,v1)})
-PointKey: w#inf,RANGEKEYSET
-Span: w-y:{(#5,RANGEKEYSET,@1,v1)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(w-y:{(#5,RANGEKEYSET,@1,v1)})
+. w#inf,RANGEKEYSET: w-y:{(#5,RANGEKEYSET,@1,v1)}
+# SpanChanged(nil)
+# SpanChanged(nil)
 .
 
 define-spans
@@ -796,21 +573,15 @@ seek-ge c
 prev
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
-PointKey: c#inf,RANGEKEYSET
-Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
--
--- SpanChanged(nil)
--- SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-z:{(#5,RANGEKEYSET,@1,v1)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: z#8,SET
-Span: <invalid>
--
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
+. c#inf,RANGEKEYSET: a-z:{(#5,RANGEKEYSET,@1,v1)}
+# SpanChanged(nil)
+# SpanChanged(a-z:{(#5,RANGEKEYSET,@1,v1)})
+. a#inf,RANGEKEYSET: a-z:{(#5,RANGEKEYSET,@1,v1)}
+# SpanChanged(nil)
+# SpanChanged(nil)
+. z#8,SET: (no span)
 
 iter
 set-bounds . c
@@ -820,21 +591,15 @@ last
 prev
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#5,RANGEKEYSET,@1,v1)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#5,RANGEKEYSET,@1,v1)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: z#8,SET
-Span: <invalid>
--
--- SpanChanged(c-z:{(#5,RANGEKEYSET,@1,v1)})
-PointKey: c#inf,RANGEKEYSET
-Span: c-z:{(#5,RANGEKEYSET,@1,v1)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#5,RANGEKEYSET,@1,v1)})
+. a#inf,RANGEKEYSET: a-c:{(#5,RANGEKEYSET,@1,v1)}
+# SpanChanged(nil)
+# SpanChanged(nil)
+. z#8,SET: (no span)
+# SpanChanged(c-z:{(#5,RANGEKEYSET,@1,v1)})
+. c#inf,RANGEKEYSET: c-z:{(#5,RANGEKEYSET,@1,v1)}
+# SpanChanged(nil)
 .
 
 # Test switching directions after exhausting a range key iterator.
@@ -863,36 +628,22 @@ prev
 prev
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: z#1,SET
-Span: <invalid>
--
--- SpanChanged(nil)
-PointKey: v#1,SET
-Span: <invalid>
--
--- SpanChanged(nil)
-PointKey: v#2,SET
-Span: <invalid>
--
--- SpanChanged(nil)
-PointKey: s#1,SET
-Span: <invalid>
--
--- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
-PointKey: j#inf,RANGEKEYSET
-Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
--
--- SpanChanged(nil)
-PointKey: g#1,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
-PointKey: j#inf,RANGEKEYSET
-Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
--
+# SpanChanged(nil)
+# SpanChanged(nil)
+. z#1,SET: (no span)
+# SpanChanged(nil)
+. v#1,SET: (no span)
+# SpanChanged(nil)
+. v#2,SET: (no span)
+# SpanChanged(nil)
+. s#1,SET: (no span)
+# SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
+. j#inf,RANGEKEYSET: j-l:{(#3,RANGEKEYSET,@1,v0)}
+# SpanChanged(nil)
+. g#1,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
+. j#inf,RANGEKEYSET: j-l:{(#3,RANGEKEYSET,@1,v0)}
 
 # Test switching directions after exhausting a range key iterator.
 # Switching forward to reverse iteration.
@@ -916,27 +667,17 @@ next
 next
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: a#1,SET
-Span: <invalid>
--
--- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
-PointKey: j#inf,RANGEKEYSET
-Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
--
-PointKey: k#1,SET
-Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
--
--- SpanChanged(nil)
-PointKey: m#1,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
-PointKey: k#1,SET
-Span: j-l:{(#3,RANGEKEYSET,@1,v0)}
--
+# SpanChanged(nil)
+# SpanChanged(nil)
+. a#1,SET: (no span)
+# SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
+. j#inf,RANGEKEYSET: j-l:{(#3,RANGEKEYSET,@1,v0)}
+. k#1,SET: j-l:{(#3,RANGEKEYSET,@1,v0)}
+# SpanChanged(nil)
+. m#1,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(j-l:{(#3,RANGEKEYSET,@1,v0)})
+. k#1,SET: j-l:{(#3,RANGEKEYSET,@1,v0)}
 
 # Test a seek that moves the lower bound beyond the upper bound.
 
@@ -955,16 +696,16 @@ iter
 set-bounds a c
 seek-ge c
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
 .
 
 iter
 set-bounds a c
 seek-lt a
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
 .
 
 # Test a SeekLT that searches a keyspace exclusive with the iterator's bounds.
@@ -986,8 +727,8 @@ iter
 set-bounds d e
 seek-lt d
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
 .
 
 # Test seek-prefix-ge and its truncation of bounds to the prefix's bounds.
@@ -1010,27 +751,17 @@ seek-prefix-ge c
 next
 seek-ge c
 ----
--- SpanChanged(nil)
--- SpanChanged(b-b\x00:{(#5,RANGEKEYSET,@1,foo)})
-PointKey: b#inf,RANGEKEYSET
-Span: b-b\x00:{(#5,RANGEKEYSET,@1,foo)}
--
-PointKey: c#8,SET
-Span: b-b\x00:{(#5,RANGEKEYSET,@1,foo)}
--
--- SpanChanged(nil)
--- SpanChanged(c-c\x00:{(#5,RANGEKEYSET,@1,foo)})
-PointKey: c#inf,RANGEKEYSET
-Span: c-c\x00:{(#5,RANGEKEYSET,@1,foo)}
--
-PointKey: c#8,SET
-Span: c-c\x00:{(#5,RANGEKEYSET,@1,foo)}
--
--- SpanChanged(nil)
--- SpanChanged(b-d:{(#5,RANGEKEYSET,@1,foo)})
-PointKey: c#inf,RANGEKEYSET
-Span: b-d:{(#5,RANGEKEYSET,@1,foo)}
--
+# SpanChanged(nil)
+# SpanChanged(b-b\x00:{(#5,RANGEKEYSET,@1,foo)})
+. b#inf,RANGEKEYSET: b-b\x00:{(#5,RANGEKEYSET,@1,foo)}
+. c#8,SET: b-b\x00:{(#5,RANGEKEYSET,@1,foo)}
+# SpanChanged(nil)
+# SpanChanged(c-c\x00:{(#5,RANGEKEYSET,@1,foo)})
+. c#inf,RANGEKEYSET: c-c\x00:{(#5,RANGEKEYSET,@1,foo)}
+. c#8,SET: c-c\x00:{(#5,RANGEKEYSET,@1,foo)}
+# SpanChanged(nil)
+# SpanChanged(b-d:{(#5,RANGEKEYSET,@1,foo)})
+. c#inf,RANGEKEYSET: b-d:{(#5,RANGEKEYSET,@1,foo)}
 
 # Test NextPrefix
 
@@ -1059,30 +790,18 @@ next-prefix
 next-prefix
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: a@4#8,SET
-Span: <invalid>
--
--- SpanChanged(b-e:{(#5,RANGEKEYSET,@9,foo)})
-PointKey: b#inf,RANGEKEYSET
-Span: b-e:{(#5,RANGEKEYSET,@9,foo)}
--
-PointKey: c@11#8,SET
-Span: b-e:{(#5,RANGEKEYSET,@9,foo)}
--
-PointKey: d@5#3,SET
-Span: b-e:{(#5,RANGEKEYSET,@9,foo)}
--
--- SpanChanged(nil)
-PointKey: e@9#2,SET
-Span: <invalid>
--
--- SpanChanged(f-g:{(#6,RANGEKEYSET,@9,foo)})
-PointKey: f#inf,RANGEKEYSET
-Span: f-g:{(#6,RANGEKEYSET,@9,foo)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. a@4#8,SET: (no span)
+# SpanChanged(b-e:{(#5,RANGEKEYSET,@9,foo)})
+. b#inf,RANGEKEYSET: b-e:{(#5,RANGEKEYSET,@9,foo)}
+. c@11#8,SET: b-e:{(#5,RANGEKEYSET,@9,foo)}
+. d@5#3,SET: b-e:{(#5,RANGEKEYSET,@9,foo)}
+# SpanChanged(nil)
+. e@9#2,SET: (no span)
+# SpanChanged(f-g:{(#6,RANGEKEYSET,@9,foo)})
+. f#inf,RANGEKEYSET: f-g:{(#6,RANGEKEYSET,@9,foo)}
+# SpanChanged(nil)
 .
 
 define-spans
@@ -1114,42 +833,22 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: a@4#8,SET
-Span: <invalid>
--
--- SpanChanged(b-e:{(#5,RANGEDEL)})
-PointKey: b#inf,RANGEDEL
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: c@11#8,SET
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: c@3#8,SET
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: c@1#4,SET
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: d@5#3,SET
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: e#inf,RANGEDEL
-Span: b-e:{(#5,RANGEDEL)}
--
--- SpanChanged(nil)
-PointKey: e@9#2,SET
-Span: <invalid>
--
--- SpanChanged(f-g:{(#6,RANGEDEL)})
-PointKey: f#inf,RANGEDEL
-Span: f-g:{(#6,RANGEDEL)}
--
-PointKey: g#inf,RANGEDEL
-Span: f-g:{(#6,RANGEDEL)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. a@4#8,SET: (no span)
+# SpanChanged(b-e:{(#5,RANGEDEL)})
+. b#inf,RANGEDEL: b-e:{(#5,RANGEDEL)}
+. c@11#8,SET: b-e:{(#5,RANGEDEL)}
+. c@3#8,SET: b-e:{(#5,RANGEDEL)}
+. c@1#4,SET: b-e:{(#5,RANGEDEL)}
+. d@5#3,SET: b-e:{(#5,RANGEDEL)}
+. e#inf,RANGEDEL: b-e:{(#5,RANGEDEL)}
+# SpanChanged(nil)
+. e@9#2,SET: (no span)
+# SpanChanged(f-g:{(#6,RANGEDEL)})
+. f#inf,RANGEDEL: f-g:{(#6,RANGEDEL)}
+. g#inf,RANGEDEL: f-g:{(#6,RANGEDEL)}
+# SpanChanged(nil)
 .
 
 iter interleave-end-keys
@@ -1165,69 +864,41 @@ prev
 prev
 prev
 ----
--- SpanChanged(nil)
-PointKey: g#inf,RANGEDEL
-Span: f-g:{(#6,RANGEDEL)}
--
--- SpanChanged(f-g:{(#6,RANGEDEL)})
-PointKey: f#inf,RANGEDEL
-Span: f-g:{(#6,RANGEDEL)}
--
--- SpanChanged(nil)
-PointKey: e@9#2,SET
-Span: <invalid>
--
-PointKey: e#inf,RANGEDEL
-Span: b-e:{(#5,RANGEDEL)}
--
--- SpanChanged(b-e:{(#5,RANGEDEL)})
-PointKey: d@5#3,SET
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: c@1#4,SET
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: c@3#8,SET
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: c@11#8,SET
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: b#inf,RANGEDEL
-Span: b-e:{(#5,RANGEDEL)}
--
--- SpanChanged(nil)
-PointKey: a@4#8,SET
-Span: <invalid>
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+. g#inf,RANGEDEL: f-g:{(#6,RANGEDEL)}
+# SpanChanged(f-g:{(#6,RANGEDEL)})
+. f#inf,RANGEDEL: f-g:{(#6,RANGEDEL)}
+# SpanChanged(nil)
+. e@9#2,SET: (no span)
+. e#inf,RANGEDEL: b-e:{(#5,RANGEDEL)}
+# SpanChanged(b-e:{(#5,RANGEDEL)})
+. d@5#3,SET: b-e:{(#5,RANGEDEL)}
+. c@1#4,SET: b-e:{(#5,RANGEDEL)}
+. c@3#8,SET: b-e:{(#5,RANGEDEL)}
+. c@11#8,SET: b-e:{(#5,RANGEDEL)}
+. b#inf,RANGEDEL: b-e:{(#5,RANGEDEL)}
+# SpanChanged(nil)
+. a@4#8,SET: (no span)
+# SpanChanged(nil)
 .
 
 iter interleave-end-keys
 seek-ge c@1
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(b-e:{(#5,RANGEDEL)})
-PointKey: c@1#inf,RANGEDEL
-Span: b-e:{(#5,RANGEDEL)}
--
-PointKey: c@1#4,SET
-Span: b-e:{(#5,RANGEDEL)}
--
+# SpanChanged(nil)
+# SpanChanged(b-e:{(#5,RANGEDEL)})
+. c@1#inf,RANGEDEL: b-e:{(#5,RANGEDEL)}
+. c@1#4,SET: b-e:{(#5,RANGEDEL)}
 
 iter interleave-end-keys
 seek-lt c@10
 prev
 ----
--- SpanChanged(nil)
-PointKey: e#inf,RANGEDEL
-Span: b-e:{(#5,RANGEDEL)}
--
--- SpanChanged(b-e:{(#5,RANGEDEL)})
-PointKey: c@11#8,SET
-Span: b-e:{(#5,RANGEDEL)}
--
+# SpanChanged(nil)
+. e#inf,RANGEDEL: b-e:{(#5,RANGEDEL)}
+# SpanChanged(b-e:{(#5,RANGEDEL)})
+. c@11#8,SET: b-e:{(#5,RANGEDEL)}
 
 # Test abutting spans.
 
@@ -1252,41 +923,25 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-b:{(#5,RANGEDEL)})
-PointKey: a#inf,RANGEDEL
-Span: a-b:{(#5,RANGEDEL)}
--
-PointKey: a@4#8,SET
-Span: a-b:{(#5,RANGEDEL)}
--
-PointKey: b#inf,RANGEDEL
-Span: a-b:{(#5,RANGEDEL)}
--
--- SpanChanged(b-c:{(#6,RANGEDEL)})
-PointKey: b#inf,RANGEDEL
-Span: b-c:{(#6,RANGEDEL)}
--
-PointKey: b@9#2,DEL
-Span: b-c:{(#6,RANGEDEL)}
--
+# SpanChanged(nil)
+# SpanChanged(a-b:{(#5,RANGEDEL)})
+. a#inf,RANGEDEL: a-b:{(#5,RANGEDEL)}
+. a@4#8,SET: a-b:{(#5,RANGEDEL)}
+. b#inf,RANGEDEL: a-b:{(#5,RANGEDEL)}
+# SpanChanged(b-c:{(#6,RANGEDEL)})
+. b#inf,RANGEDEL: b-c:{(#6,RANGEDEL)}
+. b@9#2,DEL: b-c:{(#6,RANGEDEL)}
 
 iter interleave-end-keys
 seek-ge a@9
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-b:{(#5,RANGEDEL)})
-PointKey: a@9#inf,RANGEDEL
-Span: a-b:{(#5,RANGEDEL)}
--
-PointKey: a@4#8,SET
-Span: a-b:{(#5,RANGEDEL)}
--
-PointKey: b#inf,RANGEDEL
-Span: a-b:{(#5,RANGEDEL)}
--
+# SpanChanged(nil)
+# SpanChanged(a-b:{(#5,RANGEDEL)})
+. a@9#inf,RANGEDEL: a-b:{(#5,RANGEDEL)}
+. a@4#8,SET: a-b:{(#5,RANGEDEL)}
+. b#inf,RANGEDEL: a-b:{(#5,RANGEDEL)}
 
 iter interleave-end-keys
 seek-lt a@1
@@ -1294,16 +949,10 @@ prev
 prev
 prev
 ----
--- SpanChanged(nil)
-PointKey: b#inf,RANGEDEL
-Span: a-b:{(#5,RANGEDEL)}
--
--- SpanChanged(a-b:{(#5,RANGEDEL)})
-PointKey: a@4#8,SET
-Span: a-b:{(#5,RANGEDEL)}
--
-PointKey: a#inf,RANGEDEL
-Span: a-b:{(#5,RANGEDEL)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+. b#inf,RANGEDEL: a-b:{(#5,RANGEDEL)}
+# SpanChanged(a-b:{(#5,RANGEDEL)})
+. a@4#8,SET: a-b:{(#5,RANGEDEL)}
+. a#inf,RANGEDEL: a-b:{(#5,RANGEDEL)}
+# SpanChanged(nil)
 .

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -41,35 +41,21 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: b@2#1,SET
-Span: <invalid>
--
--- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
-PointKey: e#inf,RANGEKEYSET
-Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
--
--- SpanChanged(f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)})
-PointKey: f#inf,RANGEKEYSET
-Span: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
--
--- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
-PointKey: h#inf,RANGEKEYSET
-Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
--
--- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
-PointKey: l#inf,RANGEKEYSET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
-PointKey: l@8#1,SET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
-PointKey: m#inf,RANGEKEYSET
-Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. b@2#1,SET: (no span)
+# SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
+. e#inf,RANGEKEYSET: e-f:{(#1,RANGEKEYSET,@9,foo)}
+# SpanChanged(f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)})
+. f#inf,RANGEKEYSET: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
+# SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
+. h#inf,RANGEKEYSET: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+# SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
+. l#inf,RANGEKEYSET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+. l@8#1,SET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
+. m#inf,RANGEKEYSET: m-q:{(#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(nil)
 .
 
 iter masking-threshold=@7
@@ -82,35 +68,21 @@ prev
 prev
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
-PointKey: m#inf,RANGEKEYSET
-Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
-PointKey: l@8#1,SET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
-PointKey: l#inf,RANGEKEYSET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
-PointKey: h#inf,RANGEKEYSET
-Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
--
--- SpanChanged(f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)})
-PointKey: f#inf,RANGEKEYSET
-Span: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
--
--- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
-PointKey: e#inf,RANGEKEYSET
-Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
--
--- SpanChanged(nil)
-PointKey: b@2#1,SET
-Span: <invalid>
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
+. m#inf,RANGEKEYSET: m-q:{(#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
+. l@8#1,SET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+. l#inf,RANGEKEYSET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
+. h#inf,RANGEKEYSET: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+# SpanChanged(f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)})
+. f#inf,RANGEKEYSET: f-h:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@3,bar)}
+# SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
+. e#inf,RANGEKEYSET: e-f:{(#1,RANGEKEYSET,@9,foo)}
+# SpanChanged(nil)
+. b@2#1,SET: (no span)
+# SpanChanged(nil)
 .
 
 iter masking-threshold=@7
@@ -123,41 +95,27 @@ next
 seek-ge m
 seek-ge r
 ----
--- SpanChanged(nil)
--- SpanChanged(nil)
-PointKey: b@2#1,SET
-Span: <invalid>
--
--- SpanChanged(nil)
--- SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
-PointKey: e#inf,RANGEKEYSET
-Span: e-f:{(#1,RANGEKEYSET,@9,foo)}
--
--- SpanChanged(nil)
--- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
-PointKey: h#inf,RANGEKEYSET
-Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
--
--- SpanChanged(nil)
--- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
-PointKey: i#inf,RANGEKEYSET
-Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
--
--- SpanChanged(nil)
--- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
-PointKey: l#inf,RANGEKEYSET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
-PointKey: l@8#1,SET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(nil)
--- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
-PointKey: m#inf,RANGEKEYSET
-Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(nil)
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(nil)
+. b@2#1,SET: (no span)
+# SpanChanged(nil)
+# SpanChanged(e-f:{(#1,RANGEKEYSET,@9,foo)})
+. e#inf,RANGEKEYSET: e-f:{(#1,RANGEKEYSET,@9,foo)}
+# SpanChanged(nil)
+# SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
+. h#inf,RANGEKEYSET: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+# SpanChanged(nil)
+# SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
+. i#inf,RANGEKEYSET: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+# SpanChanged(nil)
+# SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
+. l#inf,RANGEKEYSET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+. l@8#1,SET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(nil)
+# SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
+. m#inf,RANGEKEYSET: m-q:{(#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(nil)
+# SpanChanged(nil)
 .
 
 # Setting the masking threshold to @9 should result in l@8 being masked by
@@ -170,43 +128,29 @@ seek-lt l
 seek-lt ll
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
-PointKey: l#inf,RANGEKEYSET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
-PointKey: m#inf,RANGEKEYSET
-Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(nil)
--- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
-PointKey: h#inf,RANGEKEYSET
-Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
--
--- SpanChanged(nil)
--- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
-PointKey: l#inf,RANGEKEYSET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
-PointKey: h#inf,RANGEKEYSET
-Span: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
--
+# SpanChanged(nil)
+# SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
+. l#inf,RANGEKEYSET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
+. m#inf,RANGEKEYSET: m-q:{(#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(nil)
+# SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
+. h#inf,RANGEKEYSET: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
+# SpanChanged(nil)
+# SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
+. l#inf,RANGEKEYSET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)})
+. h#inf,RANGEKEYSET: h-l:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax) (#1,RANGEKEYSET,@3,bar)}
 
 iter masking-threshold=@9
 seek-ge l
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
-PointKey: l#inf,RANGEKEYSET
-Span: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
--
--- SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
-PointKey: m#inf,RANGEKEYSET
-Span: m-q:{(#1,RANGEKEYSET,@6,bax)}
--
+# SpanChanged(nil)
+# SpanChanged(l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)})
+. l#inf,RANGEKEYSET: l-m:{(#1,RANGEKEYSET,@9,foo) (#1,RANGEKEYSET,@6,bax)}
+# SpanChanged(m-q:{(#1,RANGEKEYSET,@6,bax)})
+. m#inf,RANGEKEYSET: m-q:{(#1,RANGEKEYSET,@6,bax)}
 
 define-spans
 a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
@@ -231,18 +175,12 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
--
-PointKey: a#1,SET
-Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
--
-PointKey: a@12#1,SET
-Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)})
+. a#inf,RANGEKEYSET: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+. a#1,SET: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+. a@12#1,SET: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+# SpanChanged(nil)
 .
 
 iter masking-threshold=@10
@@ -251,18 +189,12 @@ prev
 prev
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)})
-PointKey: a@12#1,SET
-Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
--
-PointKey: a#1,SET
-Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
--
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)})
+. a@12#1,SET: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+. a#1,SET: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+. a#inf,RANGEKEYSET: a-c:{(#1,RANGEKEYSET,@5,apples) (#1,RANGEKEYSET,@2,bananas)}
+# SpanChanged(nil)
 .
 
 # Try the same test, but with a range key that sorts before the masking
@@ -281,24 +213,14 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#2,RANGEKEYSET,@20,apples)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
-PointKey: a#1,SET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
-PointKey: a@3#1,SET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
-PointKey: a@12#1,SET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
-PointKey: b@2#1,SET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#2,RANGEKEYSET,@20,apples)})
+. a#inf,RANGEKEYSET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+. a#1,SET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+. a@3#1,SET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+. a@12#1,SET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+. b@2#1,SET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+# SpanChanged(nil)
 .
 
 iter masking-threshold=@10
@@ -309,24 +231,14 @@ prev
 prev
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#2,RANGEKEYSET,@20,apples)})
-PointKey: b@2#1,SET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
-PointKey: a@12#1,SET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
-PointKey: a@3#1,SET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
-PointKey: a#1,SET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#2,RANGEKEYSET,@20,apples)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#2,RANGEKEYSET,@20,apples)})
+. b@2#1,SET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+. a@12#1,SET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+. a@3#1,SET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+. a#1,SET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+. a#inf,RANGEKEYSET: a-c:{(#2,RANGEKEYSET,@20,apples)}
+# SpanChanged(nil)
 .
 
 # Try the original test, but with an internal range key containing just an
@@ -345,20 +257,13 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)})
-PointKey: a#inf,RANGEKEYUNSET
-Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
--
-PointKey: a#1,SET
-Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
--
-PointKey: a@12#1,SET
-Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
--
--- SpanChanged(nil)
-.
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)})
+. a#inf,RANGEKEYUNSET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+. a#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+. a@12#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+# SpanChanged(nil)
+.# SpanChanged(nil)
 .
 
 iter masking-threshold=@10
@@ -368,20 +273,13 @@ prev
 prev
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)})
-PointKey: a@12#1,SET
-Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
--
-PointKey: a#1,SET
-Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
--
-PointKey: a#inf,RANGEKEYUNSET
-Span: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
--
--- SpanChanged(nil)
-.
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)})
+. a@12#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+. a#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+. a#inf,RANGEKEYUNSET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
+# SpanChanged(nil)
+.# SpanChanged(nil)
 .
 
 # Test a scenario where a point key is masked in the forward direction, which in
@@ -405,36 +303,24 @@ first
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
--
--- SpanChanged(c-z:{(#1,RANGEKEYSET,@10,bananas)})
-PointKey: c#inf,RANGEKEYSET
-Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
--
-PointKey: j@11#3,SET
-Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
--
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples)})
+. a#inf,RANGEKEYSET: a-c:{(#1,RANGEKEYSET,@5,apples)}
+# SpanChanged(c-z:{(#1,RANGEKEYSET,@10,bananas)})
+. c#inf,RANGEKEYSET: c-z:{(#1,RANGEKEYSET,@10,bananas)}
+. j@11#3,SET: c-z:{(#1,RANGEKEYSET,@10,bananas)}
 
 iter masking-threshold=@20
 last
 prev
 prev
 ----
--- SpanChanged(nil)
--- SpanChanged(c-z:{(#1,RANGEKEYSET,@10,bananas)})
-PointKey: j@11#3,SET
-Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
--
-PointKey: c#inf,RANGEKEYSET
-Span: c-z:{(#1,RANGEKEYSET,@10,bananas)}
--
--- SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#1,RANGEKEYSET,@5,apples)}
--
+# SpanChanged(nil)
+# SpanChanged(c-z:{(#1,RANGEKEYSET,@10,bananas)})
+. j@11#3,SET: c-z:{(#1,RANGEKEYSET,@10,bananas)}
+. c#inf,RANGEKEYSET: c-z:{(#1,RANGEKEYSET,@10,bananas)}
+# SpanChanged(a-c:{(#1,RANGEKEYSET,@5,apples)})
+. a#inf,RANGEKEYSET: a-c:{(#1,RANGEKEYSET,@5,apples)}
 
 # Test a scenario where a there's an empty range key, requiring the interleaving
 # iter to call SpanChanged(nil) which should clear the previous mask.
@@ -459,18 +345,12 @@ next
 next
 next
 ----
--- SpanChanged(nil)
--- SpanChanged(a-c:{(#1,RANGEKEYSET,@10,apples)})
-PointKey: a#inf,RANGEKEYSET
-Span: a-c:{(#1,RANGEKEYSET,@10,apples)}
--
--- SpanChanged(nil)
-PointKey: d@9#3,SET
-Span: <invalid>
--
--- SpanChanged(e-f:{(#1,RANGEKEYSET,@5,bananas)})
-PointKey: e#inf,RANGEKEYSET
-Span: e-f:{(#1,RANGEKEYSET,@5,bananas)}
--
--- SpanChanged(nil)
+# SpanChanged(nil)
+# SpanChanged(a-c:{(#1,RANGEKEYSET,@10,apples)})
+. a#inf,RANGEKEYSET: a-c:{(#1,RANGEKEYSET,@10,apples)}
+# SpanChanged(nil)
+. d@9#3,SET: (no span)
+# SpanChanged(e-f:{(#1,RANGEKEYSET,@5,bananas)})
+. e#inf,RANGEKEYSET: e-f:{(#1,RANGEKEYSET,@5,bananas)}
+# SpanChanged(nil)
 .


### PR DESCRIPTION
Clean up the interleaving iterator test output to avoid multiple lines corresponding to a single iterator position, which made it difficult to parse.