### PR TITLE
binaryfuse: add 10 bit support

### DIFF
--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -798,7 +798,9 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	fpList := []pebble.DBTableFilterPolicy{
 		pebble.UniformDBTableFilterPolicy(pebble.NoFilterPolicy),
 		pebble.UniformDBTableFilterPolicy(bloom.FilterPolicy(1 + rng.Uint32N(20))),
-		pebble.UniformDBTableFilterPolicy(binaryfuse.FilterPolicy(4 * (1 + rng.IntN(4)))),
+		pebble.UniformDBTableFilterPolicy(binaryfuse.FilterPolicy(
+			binaryfuse.SupportedBitsPerFingerprint[rng.IntN(len(binaryfuse.SupportedBitsPerFingerprint))],
+		)),
 		pebble.DBTableFilterPolicyUniform,
 		pebble.DBTableFilterPolicyProgressive,
 		pebble.DBTableFilterPolicyBinaryFuseProgressive,

--- a/options.go
+++ b/options.go
@@ -1510,15 +1510,15 @@ var (
 	// DBTableFilterPolicyBinaryFuseProgressive uses binary fuse filters, with
 	// better filters for higher levels.
 	DBTableFilterPolicyBinaryFuseProgressive = func() DBTableFilterPolicy {
-		// Binary fuse filters have FPR = 1/2^bitsPerFingerprint. For T=10,
-		// the bits per fingerprint should increase by ~3.3; we round up to 4 since
-		// we only support multiples of 4.
+		// Binary fuse filters have FPR = 1/2^bitsPerFingerprint. For T=10, the
+		// bits per fingerprint should increase by ~3.3. In practice, we see
+		// closer to T=8 when the LSM has submaximal size.
 		return DBTableFilterPolicy{
 			0: binaryfuse.FilterPolicy(16),
 			1: binaryfuse.FilterPolicy(16),
 			2: binaryfuse.FilterPolicy(16),
-			3: binaryfuse.FilterPolicy(16),
-			4: binaryfuse.FilterPolicy(12),
+			3: binaryfuse.FilterPolicy(12),
+			4: binaryfuse.FilterPolicy(10),
 			5: binaryfuse.FilterPolicy(8),
 			6: binaryfuse.FilterPolicy(4),
 		}

--- a/sstable/tablefilters/binaryfuse/binary_fuse_test.go
+++ b/sstable/tablefilters/binaryfuse/binary_fuse_test.go
@@ -14,51 +14,25 @@ import (
 func TestEndToEnd(t *testing.T) {
 	filtertestutils.RunEndToEndTest(t, FilterPolicy(4), Decoder, 0.5)
 	filtertestutils.RunEndToEndTest(t, FilterPolicy(8), Decoder, 0.2)
+	filtertestutils.RunEndToEndTest(t, FilterPolicy(10), Decoder, 0.2)
 	filtertestutils.RunEndToEndTest(t, FilterPolicy(12), Decoder, 0.1)
 	filtertestutils.RunEndToEndTest(t, FilterPolicy(16), Decoder, 0.1)
 }
 
 // Results on n4d-standard-8 (AMD EPYC Turin, go 1.25):
 //
-// name                                         MKeys/s
-// Writer/bits=4/len=6/n=10K-8                     47.2 ± 1%
-// Writer/bits=4/len=6/n=100K-8                    30.0 ± 0%
-// Writer/bits=4/len=6/n=1M-8                      26.4 ± 1%
-// Writer/bits=4/len=16/n=10K-8                    46.4 ± 2%
-// Writer/bits=4/len=16/n=100K-8                   29.8 ± 0%
-// Writer/bits=4/len=16/n=1M-8                     26.1 ± 2%
-// Writer/bits=4/len=128/n=10K-8                   41.1 ± 2%
-// Writer/bits=4/len=128/n=100K-8                  27.4 ± 0%
-// Writer/bits=4/len=128/n=1M-8                    24.2 ± 1%
-// Writer/bits=8/len=6/n=10K-8                     46.4 ± 1%
-// Writer/bits=8/len=6/n=100K-8                    30.0 ± 0%
-// Writer/bits=8/len=6/n=1M-8                      26.6 ± 1%
-// Writer/bits=8/len=16/n=10K-8                    45.4 ± 3%
-// Writer/bits=8/len=16/n=100K-8                   29.8 ± 1%
-// Writer/bits=8/len=16/n=1M-8                     26.2 ± 2%
-// Writer/bits=8/len=128/n=10K-8                   40.5 ± 2%
-// Writer/bits=8/len=128/n=100K-8                  27.5 ± 1%
-// Writer/bits=8/len=128/n=1M-8                    24.3 ± 1%
-// Writer/bits=12/len=6/n=10K-8                    47.3 ± 1%
-// Writer/bits=12/len=6/n=100K-8                   31.5 ± 1%
-// Writer/bits=12/len=6/n=1M-8                     26.2 ± 2%
-// Writer/bits=12/len=16/n=10K-8                   46.7 ± 2%
-// Writer/bits=12/len=16/n=100K-8                  31.2 ± 1%
-// Writer/bits=12/len=16/n=1M-8                    26.2 ± 2%
-// Writer/bits=12/len=128/n=10K-8                  41.5 ± 0%
-// Writer/bits=12/len=128/n=100K-8                 28.7 ± 0%
-// Writer/bits=12/len=128/n=1M-8                   23.5 ± 2%
-// Writer/bits=16/len=6/n=10K-8                    47.5 ± 1%
-// Writer/bits=16/len=6/n=100K-8                   31.6 ± 1%
-// Writer/bits=16/len=6/n=1M-8                     26.7 ± 2%
-// Writer/bits=16/len=16/n=10K-8                   46.7 ± 1%
-// Writer/bits=16/len=16/n=100K-8                  31.4 ± 1%
-// Writer/bits=16/len=16/n=1M-8                    26.6 ± 3%
-// Writer/bits=16/len=128/n=10K-8                  41.3 ± 1%
-// Writer/bits=16/len=128/n=100K-8                 28.9 ± 1%
-// Writer/bits=16/len=128/n=1M-8                   24.1 ± 2%
+// name \ MKeys/s            bits=4       bits=8       bits=10      bits=12      bits=16
+// len=6/n=10K-8             46.5 ± 1%    47.5 ± 1%    47.5 ± 1%    47.4 ± 1%    47.9 ± 1%
+// len=6/n=100K-8            29.5 ± 1%    29.6 ± 1%    31.3 ± 1%    31.4 ± 1%    31.5 ± 1%
+// len=6/n=1M-8              25.7 ± 1%    25.7 ± 1%    25.8 ± 1%    25.5 ± 2%    25.9 ± 2%
+// len=16/n=10K-8            47.4 ± 3%    48.0 ± 1%    48.0 ± 1%    47.7 ± 2%    48.5 ± 1%
+// len=16/n=100K-8           29.7 ± 1%    29.7 ± 0%    31.4 ± 0%    31.3 ± 1%    31.7 ± 1%
+// len=16/n=1M-8             25.9 ± 1%    26.0 ± 1%    25.7 ± 1%    25.4 ± 2%    26.2 ± 1%
+// len=128/n=10K-8           41.7 ± 2%    41.9 ± 2%    41.9 ± 0%    41.8 ± 0%    42.2 ± 1%
+// len=128/n=100K-8          27.3 ± 0%    27.4 ± 0%    28.8 ± 1%    28.7 ± 1%    28.8 ± 1%
+// len=128/n=1M-8            23.4 ± 1%    23.5 ± 1%    23.3 ± 1%    23.1 ± 1%    23.5 ± 1%
 func BenchmarkWriter(b *testing.B) {
-	for _, fpBits := range []int{4, 8, 12, 16} {
+	for _, fpBits := range SupportedBitsPerFingerprint {
 		b.Run(fmt.Sprintf("bits=%d", fpBits), func(b *testing.B) {
 			filtertestutils.BenchmarkWriter(b, FilterPolicy(fpBits))
 		})
@@ -67,80 +41,27 @@ func BenchmarkWriter(b *testing.B) {
 
 // Results on n4d-standard-8 (AMD EPYC Turin, go 1.25):
 //
-// MayContain/bits=4/len=6/n=10K/positive-8      11.9ns ± 0%
-// MayContain/bits=4/len=6/n=10K/negative-8      11.8ns ± 0%
-// MayContain/bits=4/len=6/n=100K/positive-8     12.0ns ± 0%
-// MayContain/bits=4/len=6/n=100K/negative-8     11.9ns ± 0%
-// MayContain/bits=4/len=6/n=1M/positive-8       12.5ns ± 0%
-// MayContain/bits=4/len=6/n=1M/negative-8       12.3ns ± 0%
-// MayContain/bits=4/len=16/n=10K/positive-8     11.6ns ± 0%
-// MayContain/bits=4/len=16/n=10K/negative-8     11.4ns ± 0%
-// MayContain/bits=4/len=16/n=100K/positive-8    11.8ns ± 0%
-// MayContain/bits=4/len=16/n=100K/negative-8    11.6ns ± 0%
-// MayContain/bits=4/len=16/n=1M/positive-8      12.1ns ± 0%
-// MayContain/bits=4/len=16/n=1M/negative-8      11.9ns ± 0%
-// MayContain/bits=4/len=128/n=10K/positive-8    14.8ns ± 0%
-// MayContain/bits=4/len=128/n=10K/negative-8    14.8ns ± 0%
-// MayContain/bits=4/len=128/n=100K/positive-8   15.1ns ± 0%
-// MayContain/bits=4/len=128/n=100K/negative-8   15.1ns ± 0%
-// MayContain/bits=4/len=128/n=1M/positive-8     16.2ns ± 1%
-// MayContain/bits=4/len=128/n=1M/negative-8     17.4ns ± 0%
-// MayContain/bits=8/len=6/n=10K/positive-8      10.6ns ± 0%
-// MayContain/bits=8/len=6/n=10K/negative-8      10.4ns ± 0%
-// MayContain/bits=8/len=6/n=100K/positive-8     10.7ns ± 0%
-// MayContain/bits=8/len=6/n=100K/negative-8     10.6ns ± 0%
-// MayContain/bits=8/len=6/n=1M/positive-8       10.8ns ± 0%
-// MayContain/bits=8/len=6/n=1M/negative-8       10.8ns ± 0%
-// MayContain/bits=8/len=16/n=10K/positive-8     10.3ns ± 0%
-// MayContain/bits=8/len=16/n=10K/negative-8     10.1ns ± 0%
-// MayContain/bits=8/len=16/n=100K/positive-8    10.3ns ± 0%
-// MayContain/bits=8/len=16/n=100K/negative-8    10.3ns ± 0%
-// MayContain/bits=8/len=16/n=1M/positive-8      10.6ns ± 0%
-// MayContain/bits=8/len=16/n=1M/negative-8      10.5ns ± 1%
-// MayContain/bits=8/len=128/n=10K/positive-8    13.7ns ± 0%
-// MayContain/bits=8/len=128/n=10K/negative-8    13.7ns ± 0%
-// MayContain/bits=8/len=128/n=100K/positive-8   14.1ns ± 0%
-// MayContain/bits=8/len=128/n=100K/negative-8   14.0ns ± 0%
-// MayContain/bits=8/len=128/n=1M/positive-8     15.4ns ± 0%
-// MayContain/bits=8/len=128/n=1M/negative-8     15.9ns ± 1%
-// MayContain/bits=12/len=6/n=10K/positive-8     13.1ns ± 0%
-// MayContain/bits=12/len=6/n=10K/negative-8     12.8ns ± 0%
-// MayContain/bits=12/len=6/n=100K/positive-8    13.2ns ± 0%
-// MayContain/bits=12/len=6/n=100K/negative-8    13.1ns ± 0%
-// MayContain/bits=12/len=6/n=1M/positive-8      14.5ns ± 1%
-// MayContain/bits=12/len=6/n=1M/negative-8      14.0ns ± 0%
-// MayContain/bits=12/len=16/n=10K/positive-8    12.6ns ± 0%
-// MayContain/bits=12/len=16/n=10K/negative-8    12.5ns ± 0%
-// MayContain/bits=12/len=16/n=100K/positive-8   12.9ns ± 0%
-// MayContain/bits=12/len=16/n=100K/negative-8   12.7ns ± 0%
-// MayContain/bits=12/len=16/n=1M/positive-8     13.9ns ± 1%
-// MayContain/bits=12/len=16/n=1M/negative-8     14.3ns ± 0%
-// MayContain/bits=12/len=128/n=10K/positive-8   16.0ns ± 0%
-// MayContain/bits=12/len=128/n=10K/negative-8   15.9ns ± 0%
-// MayContain/bits=12/len=128/n=100K/positive-8  16.3ns ± 0%
-// MayContain/bits=12/len=128/n=100K/negative-8  16.2ns ± 0%
-// MayContain/bits=12/len=128/n=1M/positive-8    19.0ns ± 0%
-// MayContain/bits=12/len=128/n=1M/negative-8    19.0ns ± 1%
-// MayContain/bits=16/len=6/n=10K/positive-8     10.8ns ± 0%
-// MayContain/bits=16/len=6/n=10K/negative-8     10.6ns ± 0%
-// MayContain/bits=16/len=6/n=100K/positive-8    10.9ns ± 0%
-// MayContain/bits=16/len=6/n=100K/negative-8    10.8ns ± 0%
-// MayContain/bits=16/len=6/n=1M/positive-8      12.7ns ± 0%
-// MayContain/bits=16/len=6/n=1M/negative-8      12.6ns ± 1%
-// MayContain/bits=16/len=16/n=10K/positive-8    10.5ns ± 0%
-// MayContain/bits=16/len=16/n=10K/negative-8    10.3ns ± 0%
-// MayContain/bits=16/len=16/n=100K/positive-8   10.6ns ± 0%
-// MayContain/bits=16/len=16/n=100K/negative-8   10.5ns ± 0%
-// MayContain/bits=16/len=16/n=1M/positive-8     11.6ns ± 0%
-// MayContain/bits=16/len=16/n=1M/negative-8     11.3ns ± 1%
-// MayContain/bits=16/len=128/n=10K/positive-8   14.1ns ± 0%
-// MayContain/bits=16/len=128/n=10K/negative-8   13.9ns ± 0%
-// MayContain/bits=16/len=128/n=100K/positive-8  14.2ns ± 0%
-// MayContain/bits=16/len=128/n=100K/negative-8  14.2ns ± 0%
-// MayContain/bits=16/len=128/n=1M/positive-8    17.3ns ± 1%
-// MayContain/bits=16/len=128/n=1M/negative-8    17.4ns ± 1%
+// name                       bits=4        bits=8        bits=10       bits=12       bits=16
+// len=6/n=10K/positive-8     11.9ns ± 0%   10.5ns ± 0%   12.6ns ± 0%   13.0ns ± 0%   10.7ns ± 0%
+// len=6/n=10K/negative-8     11.8ns ± 0%   10.5ns ± 0%   12.5ns ± 0%   12.9ns ± 0%   10.6ns ± 0%
+// len=6/n=100K/positive-8    12.1ns ± 0%   10.7ns ± 0%   12.9ns ± 0%   13.3ns ± 0%   10.9ns ± 0%
+// len=6/n=100K/negative-8    11.9ns ± 0%   10.6ns ± 0%   12.7ns ± 0%   13.1ns ± 0%   10.9ns ± 0%
+// len=6/n=1M/positive-8      12.5ns ± 0%   10.9ns ± 1%   13.6ns ± 1%   14.2ns ± 1%   11.7ns ± 0%
+// len=6/n=1M/negative-8      12.4ns ± 0%   10.8ns ± 0%   13.4ns ± 0%   14.3ns ± 0%   12.1ns ± 1%
+// len=16/n=10K/positive-8    11.5ns ± 0%   10.2ns ± 0%   12.3ns ± 0%   12.6ns ± 0%   10.5ns ± 0%
+// len=16/n=10K/negative-8    11.5ns ± 0%   10.1ns ± 0%   12.2ns ± 0%   12.6ns ± 0%   10.3ns ± 0%
+// len=16/n=100K/positive-8   11.7ns ± 0%   10.3ns ± 0%   12.5ns ± 0%   12.9ns ± 0%   10.5ns ± 0%
+// len=16/n=100K/negative-8   11.6ns ± 0%   10.2ns ± 0%   12.5ns ± 0%   12.8ns ± 0%   10.5ns ± 0%
+// len=16/n=1M/positive-8     12.1ns ± 0%   11.5ns ± 6%   13.1ns ± 1%   14.0ns ± 3%   11.5ns ± 1%
+// len=16/n=1M/negative-8     12.0ns ± 0%   10.9ns ± 2%   12.8ns ± 0%   13.4ns ± 0%   11.9ns ± 0%
+// len=128/n=10K/positive-8   14.9ns ± 0%   13.8ns ± 0%   15.6ns ± 0%   16.2ns ± 0%   14.1ns ± 0%
+// len=128/n=10K/negative-8   14.8ns ± 0%   13.7ns ± 0%   15.6ns ± 0%   16.0ns ± 0%   13.9ns ± 0%
+// len=128/n=100K/positive-8  15.2ns ± 0%   14.2ns ± 0%   16.1ns ± 0%   16.5ns ± 0%   14.4ns ± 1%
+// len=128/n=100K/negative-8  15.1ns ± 0%   14.0ns ± 0%   16.0ns ± 1%   16.3ns ± 0%   14.3ns ± 0%
+// len=128/n=1M/positive-8    16.1ns ± 0%   15.8ns ± 0%   18.2ns ± 0%   19.2ns ± 0%   17.5ns ± 1%
+// len=128/n=1M/negative-8    16.0ns ± 0%   15.7ns ± 1%   18.5ns ± 0%   19.3ns ± 0%   17.8ns ± 0%
 func BenchmarkMayContain(b *testing.B) {
-	for _, fpBits := range []int{4, 8, 12, 16} {
+	for _, fpBits := range SupportedBitsPerFingerprint {
 		b.Run(fmt.Sprintf("bits=%d", fpBits), func(b *testing.B) {
 			filtertestutils.BenchmarkMayContain(b, FilterPolicy(fpBits), Decoder)
 		})

--- a/sstable/tablefilters/binaryfuse/filter_test.go
+++ b/sstable/tablefilters/binaryfuse/filter_test.go
@@ -42,7 +42,7 @@ func testBuild(t *testing.T, hashes []uint64) {
 	for _, hash := range hashes {
 		hc.Add(hash)
 	}
-	fpVals := []int{4, 8, 12, 16}
+	fpVals := []int{4, 8, 10, 12, 16}
 	filter, ok := buildFilter(&hc, fpVals[rand.IntN(len(fpVals))])
 	require.True(t, ok)
 	for range min(len(hashes), 100_000) {


### PR DESCRIPTION
The jump from 8 bits for L5 to 12 bits for L4 is significant and could
add some non-trivial filter size without much benefit (especially when
the LSM is not ideally shaped). Add support for 10
bits-per-fingerprint and use that for L4.