### PR TITLE
binaryfuse: preallocate small builders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cockroachdb/pebble
 
 require (
 	github.com/DataDog/zstd v1.5.7
-	github.com/FastFilter/xorfilter v0.4.0
+	github.com/FastFilter/xorfilter v0.4.2-0.20260120015552-4e5a4d9df65a
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/RaduBerinde/axisds v0.0.0-20260105221726-1be486564c85
 	github.com/RaduBerinde/tdigest v0.0.0-20251022152254-90e030c3a314

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/FastFilter/xorfilter v0.4.0 h1:wpTfe21YeoHjpUi8ACZzXbBnIPJu0NfJXHmbdSIsb/k=
-github.com/FastFilter/xorfilter v0.4.0/go.mod h1:h+9l02/leuyyhepO30BKr25MkZdy7LHcfPRBDRuflXw=
+github.com/FastFilter/xorfilter v0.4.2-0.20260120015552-4e5a4d9df65a h1:5UUjmRtsNJ/tcinsb/QBUnjrCinStXO5QsC4cWsgYfk=
+github.com/FastFilter/xorfilter v0.4.2-0.20260120015552-4e5a4d9df65a/go.mod h1:h+9l02/leuyyhepO30BKr25MkZdy7LHcfPRBDRuflXw=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/sstable/tablefilters/binaryfuse/hash_collector.go
+++ b/sstable/tablefilters/binaryfuse/hash_collector.go
@@ -80,31 +80,6 @@ func (hc *hashCollector) Blocks() iter.Seq[[]uint64] {
 	}
 }
 
-// BlocksAndReset iterates blocks and returns each page to the pool after
-// yielding. After iteration completes, the hashCollector is reset.
-func (hc *hashCollector) BlocksAndReset() iter.Seq[[]uint64] {
-	return func(yield func([]uint64) bool) {
-		defer hc.Reset()
-		for len(hc.blocks) > 1 {
-			block := hc.blocks[0]
-			if !yield(block[:]) {
-				return
-			}
-			hc.blocks = hc.blocks[1:]
-			hashBlockPool.Put(block)
-		}
-		// Last block may be partially filled.
-		if len(hc.blocks) == 1 {
-			lastBlock := hc.blocks[0]
-			ofs := hc.numHashes % hashBlockLen
-			if ofs == 0 {
-				ofs = hashBlockLen
-			}
-			yield(lastBlock[:ofs])
-		}
-	}
-}
-
 // Reset releases the hash blocks back to the pool.
 func (hc *hashCollector) Reset() {
 	// Release the hash blocks.


### PR DESCRIPTION
Bump xorfilters and use new API to preallocate small builders to their
maximum size and avoid allocations ramping up (which can happen
periodically if the GC releases pool objects).

Also fix the hash copying in buildFilter to reallocate the slice at
most once.