### PR TITLE
internal/keyspan: fix interleaving iterator edge case

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -182,6 +182,8 @@ type interleavePos int8
 
 const (
 	posUninitialized interleavePos = iota
+	posBeyondLowerBound
+	posBeyondUpperBound
 	posExhausted
 	posPointKey
 	posKeyspanStart
@@ -239,9 +241,18 @@ func (i *InterleavingIter) InitSeekGE(
 	prefix, key []byte, pointKV *base.InternalKV,
 ) *base.InternalKV {
 	i.dir = +1
-	i.clearMask()
 	i.prefix = prefix
+	i.clearMask()
 	i.savePoint(pointKV)
+	// During a Seek[Prefix]GE, cascading seeks due to range deletions may
+	// result in seeking to or beyond the upper bound. Such a seek is a no-op.
+	// We leave i.pos as posBeyondUpperBound so that a subsequent Prev will seek
+	// the iterator approriately for the upper bound.
+	if i.opts.UpperBound != nil && i.cmp(key, i.opts.UpperBound) >= 0 {
+		i.pos = posBeyondUpperBound
+		return nil
+	}
+
 	// NB: This keyspanSeekGE call will truncate the span to the seek key if
 	// necessary. This truncation is important for cases where a switch to
 	// combined iteration is made during a user-initiated SeekGE.
@@ -264,6 +275,15 @@ func (i *InterleavingIter) InitSeekLT(key []byte, pointKV *base.InternalKV) *bas
 	i.dir = -1
 	i.clearMask()
 	i.savePoint(pointKV)
+	// During a SeekLT, cascading seeks due to range deletions may result in
+	// seeking to or beyond the lower bound. Such a seek is a no-op.  We leave
+	// i.pos as posBeyondLowerBound so that a subsequent Next will seek the
+	// iterator approriately for the lower bound.
+	if i.opts.LowerBound != nil && i.cmp(i.opts.LowerBound, key) >= 0 {
+		i.pos = posBeyondLowerBound
+		return nil
+	}
+
 	i.keyspanSeekLT(key)
 	i.computeLargestPos()
 	return i.yieldPosition(i.opts.LowerBound, i.prevPos)
@@ -282,8 +302,18 @@ func (i *InterleavingIter) InitSeekLT(key []byte, pointKV *base.InternalKV) *bas
 //	i.lower ≤ key
 func (i *InterleavingIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	i.err = nil
+	i.dir = +1
 	i.clearMask()
 	i.disablePrefixMode()
+	// During a Seek[Prefix]GE, cascading seeks due to range deletions may
+	// result in seeking to or beyond the upper bound. Such a seek is a no-op.
+	// We leave i.pos as posBeyondUpperBound so that a subsequent Prev will seek
+	// the iterator approriately for the upper bound.
+	if i.opts.UpperBound != nil && i.cmp(key, i.opts.UpperBound) >= 0 {
+		i.pos = posBeyondUpperBound
+		return nil
+	}
+
 	i.savePoint(i.pointIter.SeekGE(key, flags))
 
 	// We need to seek the keyspan iterator too. If the keyspan iterator was
@@ -294,12 +324,10 @@ func (i *InterleavingIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.Inte
 		// truncate the span to the iterator's bounds.
 		i.saveSpan(i.span, nil)
 		i.enforceBoundsForward()
-		i.savedKeyspan()
 	} else {
 		i.keyspanSeekGE(key)
 	}
 
-	i.dir = +1
 	i.computeSmallestPos()
 	return i.yieldPosition(key, i.nextPos)
 }
@@ -319,8 +347,18 @@ func (i *InterleavingIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
 ) *base.InternalKV {
 	i.err = nil
+	i.dir = +1
 	i.clearMask()
 	i.prefix = prefix
+	// During a Seek[Prefix]GE, cascading seeks due to range deletions may
+	// result in seeking to or beyond the upper bound. Such a seek is a no-op.
+	// We leave i.pos as posBeyondUpperBound so that a subsequent Prev will seek
+	// the iterator approriately for the upper bound.
+	if i.opts.UpperBound != nil && i.cmp(key, i.opts.UpperBound) >= 0 {
+		i.pos = posBeyondUpperBound
+		return nil
+	}
+
 	i.savePoint(i.pointIter.SeekPrefixGE(prefix, key, flags))
 
 	// We need to seek the keyspan iterator too. If the keyspan iterator was
@@ -352,7 +390,6 @@ func (i *InterleavingIter) SeekPrefixGE(
 			// truncate the span to the iterator's bounds.
 			i.saveSpan(i.span, nil)
 			i.enforceBoundsForward()
-			i.savedKeyspan()
 			seekKeyspanIter = false
 		}
 	}
@@ -360,7 +397,6 @@ func (i *InterleavingIter) SeekPrefixGE(
 		i.keyspanSeekGE(key)
 	}
 
-	i.dir = +1
 	i.computeSmallestPos()
 	return i.yieldPosition(key, i.nextPos)
 }
@@ -368,8 +404,18 @@ func (i *InterleavingIter) SeekPrefixGE(
 // SeekLT implements (base.InternalIterator).SeekLT.
 func (i *InterleavingIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	i.err = nil
+	i.dir = -1
 	i.clearMask()
 	i.disablePrefixMode()
+	// During a SeekLT, cascading seeks due to range deletions may result in
+	// seeking to or beyond the lower bound. Such a seek is a no-op.  We leave
+	// i.pos as posBeyondLowerBound so that a subsequent Next will seek the
+	// iterator approriately for the lower bound.
+	if i.opts.LowerBound != nil && i.cmp(i.opts.LowerBound, key) >= 0 {
+		i.pos = posBeyondLowerBound
+		return nil
+	}
+
 	i.savePoint(i.pointIter.SeekLT(key, flags))
 
 	// We need to seek the keyspan iterator too. If the keyspan iterator was
@@ -380,27 +426,10 @@ func (i *InterleavingIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.Inte
 		// truncate the span to the iterator's bounds.
 		i.saveSpan(i.span, nil)
 		i.enforceBoundsBackward()
-		// The span's start key is still not guaranteed to be less than key,
-		// because of the bounds enforcement. Consider the following example:
-		//
-		// Bounds are set to [d,e). The user performs a SeekLT(d). The
-		// FragmentIterator.SeekLT lands on a span [b,f). This span has a start
-		// key less than d, as expected. Above, saveSpanBackward truncates the
-		// span to match the iterator's current bounds, modifying the span to
-		// [d,e), which does not overlap the search space of [-∞, d).
-		//
-		// This problem is a consequence of the SeekLT's exclusive search key
-		// and the fact that we don't perform bounds truncation at every leaf
-		// iterator.
-		if i.span != nil && i.truncated && i.cmp(i.truncatedSpan.Start, key) >= 0 {
-			i.span = nil
-		}
-		i.savedKeyspan()
 	} else {
 		i.keyspanSeekLT(key)
 	}
 
-	i.dir = -1
 	i.computeLargestPos()
 	return i.yieldPosition(i.opts.LowerBound, i.prevPos)
 }
@@ -413,7 +442,6 @@ func (i *InterleavingIter) First() *base.InternalKV {
 	i.savePoint(i.pointIter.First())
 	i.saveSpan(i.keyspanIter.First())
 	i.enforceBoundsForward()
-	i.savedKeyspan()
 	i.dir = +1
 	i.computeSmallestPos()
 	return i.yieldPosition(i.opts.LowerBound, i.nextPos)
@@ -427,7 +455,6 @@ func (i *InterleavingIter) Last() *base.InternalKV {
 	i.savePoint(i.pointIter.Last())
 	i.saveSpan(i.keyspanIter.Last())
 	i.enforceBoundsBackward()
-	i.savedKeyspan()
 	i.dir = -1
 	i.computeLargestPos()
 	return i.yieldPosition(i.opts.LowerBound, i.prevPos)
@@ -436,9 +463,12 @@ func (i *InterleavingIter) Last() *base.InternalKV {
 // Next implements (base.InternalIterator).Next.
 func (i *InterleavingIter) Next() *base.InternalKV {
 	if i.dir == -1 {
+		if i.pos == posBeyondLowerBound {
+			return i.seekBeginning()
+		}
+
 		// Switching directions.
 		i.dir = +1
-
 		if i.opts.Mask != nil {
 			// Clear the mask while we reposition the point iterator. While
 			// switching directions, we may move the point iterator outside of
@@ -465,7 +495,6 @@ func (i *InterleavingIter) Next() *base.InternalKV {
 			if !i.withinSpan {
 				i.saveSpan(i.keyspanIter.Next())
 				i.enforceBoundsForward()
-				i.savedKeyspan()
 			}
 		case posKeyspanStart:
 			i.withinSpan = true
@@ -518,6 +547,10 @@ func (i *InterleavingIter) NextPrefix(succKey []byte) *base.InternalKV {
 // Prev implements (base.InternalIterator).Prev.
 func (i *InterleavingIter) Prev() *base.InternalKV {
 	if i.dir == +1 {
+		if i.pos == posBeyondUpperBound {
+			return i.seekEnd()
+		}
+
 		// Switching directions.
 		i.dir = -1
 
@@ -547,7 +580,6 @@ func (i *InterleavingIter) Prev() *base.InternalKV {
 			if !i.withinSpan {
 				i.saveSpan(i.keyspanIter.Prev())
 				i.enforceBoundsBackward()
-				i.savedKeyspan()
 			}
 		case posKeyspanStart:
 			// Since we're positioned on a Span, the pointIter is positioned
@@ -578,10 +610,7 @@ func (i *InterleavingIter) Prev() *base.InternalKV {
 			i.switchPointIteratorIntoReverse()
 		}
 
-		if i.spanMarkerTruncated {
-			// Save the keyspan again to clear truncation.
-			i.savedKeyspan()
-		}
+		i.spanMarkerTruncated = false
 		// Fallthrough to calling i.prevPos.
 	}
 	i.prevPos()
@@ -626,6 +655,20 @@ func (i *InterleavingIter) computeLargestPos() {
 	i.pos = posExhausted
 }
 
+func (i *InterleavingIter) seekBeginning() *base.InternalKV {
+	if i.opts.LowerBound == nil {
+		return i.First()
+	}
+	return i.SeekGE(i.opts.LowerBound, base.SeekGEFlagsNone)
+}
+
+func (i *InterleavingIter) seekEnd() *base.InternalKV {
+	if i.opts.UpperBound == nil {
+		return i.Last()
+	}
+	return i.SeekLT(i.opts.UpperBound, base.SeekLTFlagsNone)
+}
+
 // nextPos advances the iterator one position in the forward direction.
 func (i *InterleavingIter) nextPos() {
 	if invariants.Enabled {
@@ -650,7 +693,6 @@ func (i *InterleavingIter) nextPos() {
 		i.switchPointIteratorIntoForward()
 		i.saveSpan(i.keyspanIter.Next())
 		i.enforceBoundsForward()
-		i.savedKeyspan()
 		i.computeSmallestPos()
 	case posPointKey:
 		i.savePoint(i.pointIter.Next())
@@ -693,7 +735,6 @@ func (i *InterleavingIter) nextPos() {
 	case posKeyspanEnd:
 		i.saveSpan(i.keyspanIter.Next())
 		i.enforceBoundsForward()
-		i.savedKeyspan()
 		i.computeSmallestPos()
 	default:
 		panic(fmt.Sprintf("unexpected pos=%d", i.pos))
@@ -724,7 +765,6 @@ func (i *InterleavingIter) prevPos() {
 		i.switchPointIteratorIntoReverse()
 		i.saveSpan(i.keyspanIter.Prev())
 		i.enforceBoundsBackward()
-		i.savedKeyspan()
 		i.computeLargestPos()
 	case posPointKey:
 		i.savePoint(i.pointIter.Prev())
@@ -755,7 +795,6 @@ func (i *InterleavingIter) prevPos() {
 	case posKeyspanStart:
 		i.saveSpan(i.keyspanIter.Prev())
 		i.enforceBoundsBackward()
-		i.savedKeyspan()
 		i.computeLargestPos()
 	case posKeyspanEnd:
 		// Either a point key or the span's start key is previous.
@@ -840,28 +879,12 @@ func (i *InterleavingIter) yieldPosition(lowerBound []byte, advance func()) *bas
 func (i *InterleavingIter) keyspanSeekGE(k []byte) {
 	i.saveSpan(i.keyspanIter.SeekGE(k))
 	i.enforceBoundsForward()
-	i.savedKeyspan()
 }
 
 // keyspanSeekLT seeks the keyspan iterator to the last span covering a key < k.
 func (i *InterleavingIter) keyspanSeekLT(k []byte) {
 	i.saveSpan(i.keyspanIter.SeekLT(k))
 	i.enforceBoundsBackward()
-	// The current span's start key is not guaranteed to be less than key,
-	// because of the bounds enforcement. Consider the following example:
-	//
-	// Bounds are set to [d,e). The user performs a SeekLT(d). The
-	// FragmentIterator.SeekLT lands on a span [b,f). This span has a start key
-	// less than d, as expected. Above, saveSpanBackward truncates the span to
-	// match the iterator's current bounds, modifying the span to [d,e), which
-	// does not overlap the search space of [-∞, d).
-	//
-	// This problem is a consequence of the SeekLT's exclusive search key and
-	// the fact that we don't perform bounds truncation at every leaf iterator.
-	if i.span != nil && i.truncated && i.cmp(i.truncatedSpan.Start, k) >= 0 {
-		i.span = nil
-	}
-	i.savedKeyspan()
 }
 
 // switchPointIteratorIntoReverse switches the direction of the point iterator
@@ -896,6 +919,8 @@ func (i *InterleavingIter) saveSpan(span *Span, err error) {
 }
 
 func (i *InterleavingIter) enforceBoundsForward() {
+	i.spanMarkerTruncated = false
+	i.maskSpanChangedCalled = false
 	if i.span == nil {
 		return
 	}
@@ -908,6 +933,8 @@ func (i *InterleavingIter) enforceBoundsForward() {
 }
 
 func (i *InterleavingIter) enforceBoundsBackward() {
+	i.spanMarkerTruncated = false
+	i.maskSpanChangedCalled = false
 	if i.span == nil {
 		return
 	}
@@ -949,11 +976,6 @@ func (i *InterleavingIter) maybeTruncateSpan() {
 			i.truncatedSpan.End = i.nextPrefixBuf
 		}
 	}
-	// If the span is truncated and the start and end keys are the same, the
-	// span is empty.
-	if i.truncated && i.comparer.Equal(i.truncatedSpan.Start, i.truncatedSpan.End) {
-		i.span = nil
-	}
 }
 
 func (i *InterleavingIter) yieldNil() *base.InternalKV {
@@ -975,15 +997,6 @@ func (i *InterleavingIter) yieldSyntheticSpanStartMarker(lowerBound []byte) *bas
 	// argument is guaranteed to be ≥ i.lower. It may be equal to the SetBounds
 	// lower bound, or it could come from a SeekGE or SeekPrefixGE search key.
 	if lowerBound != nil && i.cmp(lowerBound, i.startKey()) > 0 {
-		// Truncating to the lower bound may violate the upper bound if
-		// lowerBound == i.upper. For example, a SeekGE(k) uses k as a lower
-		// bound for truncating a span. The span a-z will be truncated to [k,
-		// z). If i.upper == k, we'd mistakenly try to return a span [k, k), an
-		// invariant violation.
-		if i.comparer.Equal(lowerBound, i.opts.UpperBound) {
-			return i.yieldNil()
-		}
-
 		// If the lowerBound argument came from a SeekGE or SeekPrefixGE
 		// call, and it may be backed by a user-provided byte slice that is not
 		// guaranteed to be stable.
@@ -1038,11 +1051,6 @@ func (i *InterleavingIter) verify(kv *base.InternalKV) *base.InternalKV {
 		}
 	}
 	return kv
-}
-
-func (i *InterleavingIter) savedKeyspan() {
-	i.spanMarkerTruncated = false
-	i.maskSpanChangedCalled = false
 }
 
 // updateMask updates the current mask, if a mask is configured and the mask

--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -85,7 +85,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 	var prevKV *base.InternalKV
 	formatKey := func(kv *base.InternalKV) {
 		if kv == nil {
-			fmt.Fprint(&buf, ".")
+			fmt.Fprintln(&buf, ".")
 			return
 		}
 		prevKV = kv

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -231,7 +231,8 @@ seek-lt tomago
 . parsnip#3,SET: (no span)
 # SpanChanged(nil)
 # SpanChanged(nil)
-.# SpanChanged(nil)
+.
+# SpanChanged(nil)
 # SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 . q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 # SpanChanged(nil)
@@ -697,14 +698,12 @@ set-bounds a c
 seek-ge c
 ----
 # SpanChanged(nil)
-# SpanChanged(nil)
 .
 
 iter
 set-bounds a c
 seek-lt a
 ----
-# SpanChanged(nil)
 # SpanChanged(nil)
 .
 
@@ -727,7 +726,6 @@ iter
 set-bounds d e
 seek-lt d
 ----
-# SpanChanged(nil)
 # SpanChanged(nil)
 .
 
@@ -956,3 +954,43 @@ prev
 . a#inf,RANGEDEL: a-b:{(#5,RANGEDEL)}
 # SpanChanged(nil)
 .
+
+define-pointkeys
+a#10,SET
+b#10,SET
+c#10,SET
+d#10,SET
+----
+OK
+
+define-spans
+a-c:{(#11,RANGEDEL)}
+----
+OK
+
+iter interleave-end-keys
+set-bounds b c
+seek-lt b
+next
+next
+----
+# SpanChanged(nil)
+.
+# SpanChanged(nil)
+# SpanChanged(b-c:{(#11,RANGEDEL)})
+. b#inf,RANGEDEL: b-c:{(#11,RANGEDEL)}
+. b#10,SET: b-c:{(#11,RANGEDEL)}
+
+
+iter interleave-end-keys
+set-bounds a b
+seek-ge b
+prev
+prev
+----
+# SpanChanged(nil)
+.
+# SpanChanged(nil)
+. b#inf,RANGEDEL: a-b:{(#11,RANGEDEL)}
+# SpanChanged(a-b:{(#11,RANGEDEL)})
+. a#10,SET: a-b:{(#11,RANGEDEL)}

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -263,7 +263,8 @@ next
 . a#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 . a@12#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 # SpanChanged(nil)
-.# SpanChanged(nil)
+.
+# SpanChanged(nil)
 .
 
 iter masking-threshold=@10
@@ -279,7 +280,8 @@ prev
 . a#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 . a#inf,RANGEKEYUNSET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 # SpanChanged(nil)
-.# SpanChanged(nil)
+.
+# SpanChanged(nil)
 .
 
 # Test a scenario where a point key is masked in the forward direction, which in

--- a/testdata/iter_histories/probe_prefix
+++ b/testdata/iter_histories/probe_prefix
@@ -93,8 +93,6 @@ b@8: (b8, .)
 000004.RangeDels.opSpanSeekGE("b@20") = a@2-b@3:{(#10,RANGEDEL)}
 000004.RangeDels.opSpanSeekGE("b@20") = a@2-b@3:{(#10,RANGEDEL)}
 000004.PointKeys.Next() = (b@2#7,SET,"7")
-000004.PointKeys.SeekPrefixGE("c") = nil
-000004.RangeDels.opSpanSeekGE("c") = nil
 000004.PointKeys.Close() = nil
 000004.RangeDels.opSpanClose() = nil
 000004.RangeDels.opSpanClose() = nil


### PR DESCRIPTION
Fix an edge case in the interleaving iterator when seeking to, or beyond, an
iterator bound. Previously, an interleaving iterator configured with an upper
bound 'b' that executed a SeekGE('b') would leave the iterator in such a state
that a subsequent Prev could omit a span entirely.

This commit fixes the bug by detecting these problematic seeks upfront, and
eliding the seek altogether if necessary. Relative positioning operations
detect that the iterator is still unpositioned and perform seeks to position
the iterator at the appropriate bound.