### PR TITLE
db: add IngestAndExciseWithBlobs

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -404,7 +404,7 @@ func TestIngestLocalWithBlobs(t *testing.T) {
 				exciseSpan.Start = []byte(fields[0])
 				exciseSpan.End = []byte(fields[1])
 			}
-			_, err := db.IngestLocal(ctx, localTables, exciseSpan)
+			_, err := db.IngestAndExciseWithBlobs(ctx, localTables, nil /* shared */, nil /* external */, exciseSpan)
 			if err != nil {
 				return err.Error()
 			}
@@ -494,7 +494,7 @@ func TestFlushableIngestWithBlobs(t *testing.T) {
 			BlobPaths: blobPaths,
 		},
 	}
-	stats, err := db.IngestLocal(ctx, localTables, KeyRange{})
+	stats, err := db.IngestAndExciseWithBlobs(ctx, localTables, nil /* shared */, nil /* external */, KeyRange{})
 	require.NoError(t, err)
 	// ApproxIngestedIntoL0Bytes > 0 indicates the file went through the
 	// flushable ingest path (overlapped with memtable).
@@ -644,7 +644,7 @@ func TestFlushableIngestWithBlobsWALRecovery(t *testing.T) {
 			BlobPaths: blobPaths,
 		},
 	}
-	stats, err := db.IngestLocal(ctx, localTables, KeyRange{} /* exciseSpan */)
+	stats, err := db.IngestAndExciseWithBlobs(ctx, localTables, nil /* shared */, nil /* external */, KeyRange{})
 	require.NoError(t, err)
 	// ApproxIngestedIntoL0Bytes > 0 indicates the file went through the
 	// flushable ingest path (overlapped with memtable).
@@ -765,7 +765,7 @@ func TestIngestLocalErrors(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { require.NoError(t, db.Close()) }()
 
-		_, err = db.IngestLocal(ctx, LocalSSTables{LocalSST{Path: "test.sst"}}, KeyRange{})
+		_, err = db.IngestAndExciseWithBlobs(ctx, LocalSSTables{LocalSST{Path: "test.sst"}}, nil /* shared */, nil /* external */, KeyRange{})
 		require.ErrorIs(t, err, ErrReadOnly)
 	})
 
@@ -778,7 +778,7 @@ func TestIngestLocalErrors(t *testing.T) {
 
 		localTables := LocalSSTables{LocalSST{Path: "test.sst"}}
 		exciseSpan := KeyRange{Start: []byte("a@1"), End: []byte("z")}
-		_, err = db.IngestLocal(ctx, localTables, exciseSpan)
+		_, err = db.IngestAndExciseWithBlobs(ctx, localTables, nil /* shared */, nil /* external */, exciseSpan)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "suffixed start key")
 	})

--- a/ingest_with_blobs.go
+++ b/ingest_with_blobs.go
@@ -34,40 +34,6 @@ type LocalSST struct {
 	BlobPaths []string
 }
 
-// IngestLocal ingests the provided local sstables into the DB. If a valid
-// excise span is provided, any existing keys in exciseSpan are deleted by
-// turning existing sstables into virtual sstables (if not virtual already)
-// and shrinking their spans to exclude exciseSpan. See the comment at Ingest
-// for a more complete picture of the ingestion process.
-func (d *DB) IngestLocal(
-	ctx context.Context, localSSTs LocalSSTables, exciseSpan KeyRange,
-) (IngestOperationStats, error) {
-	if err := d.closed.Load(); err != nil {
-		panic(err)
-	}
-	if d.opts.ReadOnly {
-		return IngestOperationStats{}, ErrReadOnly
-	}
-
-	if exciseSpan.Valid() {
-		// Excise is only supported on prefix keys.
-		if d.opts.Comparer.Split(exciseSpan.Start) != len(exciseSpan.Start) {
-			return IngestOperationStats{}, errors.New("IngestLocal called with suffixed start key")
-		}
-		if d.opts.Comparer.Split(exciseSpan.End) != len(exciseSpan.End) {
-			return IngestOperationStats{}, errors.New("IngestLocal called with suffixed end key")
-		}
-	}
-
-	args := ingestArgs{
-		Local:              localSSTs,
-		ExciseSpan:         exciseSpan,
-		ExciseBoundsPolicy: tightExciseBounds,
-	}
-
-	return d.ingest(ctx, args)
-}
-
 // closeReadables closes all readables in the slice, combining any errors.
 func closeReadables(readables []objstorage.Readable) error {
 	var errs error

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -739,7 +739,7 @@ func (o *ingestOp) run(t *Test, h historyRecorder) {
 	}
 
 	err = firstError(err, t.withRetries(func() error {
-		_, ingestErr := t.getDB(o.dbID).IngestLocal(context.Background(), localSSTs, pebble.KeyRange{})
+		_, ingestErr := t.getDB(o.dbID).IngestAndExciseWithBlobs(context.Background(), localSSTs, nil /* shared */, nil /* external */, pebble.KeyRange{})
 		return ingestErr
 	}))
 
@@ -960,7 +960,7 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 			pebble.LocalSST{Path: path, BlobPaths: blobPaths},
 		}
 		err = firstError(err, t.withRetries(func() error {
-			_, ingestErr := db.IngestLocal(context.Background(), localSSTs, exciseSpan)
+			_, ingestErr := db.IngestAndExciseWithBlobs(context.Background(), localSSTs, nil /* shared */, nil /* external */, exciseSpan)
 			return ingestErr
 		}))
 	} else {
@@ -969,7 +969,7 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 			pebble.LocalSST{Path: path, BlobPaths: blobPaths},
 		}
 		err = firstError(err, t.withRetries(func() error {
-			_, ingestErr := db.IngestLocal(context.Background(), localSSTs, pebble.KeyRange{})
+			_, ingestErr := db.IngestAndExciseWithBlobs(context.Background(), localSSTs, nil /* shared */, nil /* external */, pebble.KeyRange{})
 			return ingestErr
 		}))
 	}


### PR DESCRIPTION
Update exported ingest function for crdb side ingest. This method allows for excising and ingesting local ssts with blob files along with shared and external ssts.