### PR TITLE
internal/manifest: add tiering info to blob references 

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -678,6 +678,11 @@ type InternalKV struct {
 type KVMeta struct {
 	TieringSpanID    TieringSpanID
 	TieringAttribute TieringAttribute
+	// SecondaryBlobHandle holds the raw encoded secondary (cold tier) blob
+	// handle for dual-tier blob values. It is nil when the value does not have
+	// a secondary blob handle. The raw bytes can be decoded using
+	// blob.DecodeInlineHandlePreface and blob.DecodeHandleSuffix.
+	SecondaryBlobHandle []byte
 }
 
 func (m KVMeta) String() string {

--- a/internal/manifest/testdata/version_edit_decode
+++ b/internal/manifest/testdata/version_edit_decode
@@ -83,8 +83,8 @@ encode
   excise-op: [b, c] #3
 ----
 67061d000b626172000e0000000000000b666f6f010d0000000000000000
-45010129d8a301016baf0729d8a301f9a006006c21210a0162016301030b
-0537
+47010129d8a3010000016daf0729d8a301f9a00600006c21210a01620163
+01030b0537
   add-table:     L6 000029:[bar#14,DEL-foo#13,SET] seqnums:[#0-#0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952); depth:1]
   add-blob-file: B000943 physical:{000041 size:[20952 (20KB)] vals:[102521 (100KB)]}
   del-blob-file: B000033 000033
@@ -110,7 +110,7 @@ encode
   add-backing:   000009
 ----
 69096467031d000b626172000e0000000000000b666f6f010d0000000000
-000000420946010129d8a301e8f10101
+000000420947010129d8a301e8f1010001
   add-table:     L3 000029(000009):[bar#14,DEL-foo#13,SET] seqnums:[#0-#0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952/30952); depth:1]
   add-backing:   000009
 
@@ -128,7 +128,7 @@ encode
   add-table:     L3 000029:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952 / 30952); depth:1]
 ----
 67031d000b626172000e0000000000000b666f6f010d0000000000000000
-45010129d8a30101
+47010129d8a301e8f1010001
   add-table:     L3 000029:[bar#14,DEL-foo#13,SET] seqnums:[#0-#0] points:[bar#14,DEL-foo#13,SET] blobrefs:[(B000041: 20952/30952); depth:1]
 
 

--- a/internal/sstableinternal/options.go
+++ b/internal/sstableinternal/options.go
@@ -33,4 +33,11 @@ type WriterOptions struct {
 	// in order. It is intended for use only in the construction of invalid
 	// sstables for testing. See tool/make_test_sstables.go.
 	DisableKeyOrderChecks bool
+
+	// BlobReferenceTiers provides the storage tier (hot or cold) for each blob
+	// reference ID. Used when WriteTieringHistograms is true to categorize blob
+	// references by tier. The tier for reference ID i is BlobReferenceTiers[i].
+	// When a value exists in both tiers (hot-and-cold), there are two separate
+	// blob references with different IDs and tiers.
+	BlobReferenceTiers []base.StorageTier
 }

--- a/replay/testdata/corpus/simple_val_sep
+++ b/replay/testdata/corpus/simple_val_sep
@@ -101,7 +101,7 @@ simple_val_sep:
 stat simple_val_sep/MANIFEST-000013 simple_val_sep/000015.sst simple_val_sep/000016.blob
 ----
 simple_val_sep/MANIFEST-000013:
-  size: 250
+  size: 259
 simple_val_sep/000015.sst:
   size: 792
 simple_val_sep/000016.blob:

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -15,15 +15,15 @@ tree
      792      000015.sst
       97      000016.blob
        0      LOCK
-     152      MANIFEST-000010
-     250      MANIFEST-000013
+     158      MANIFEST-000010
+     259      MANIFEST-000013
     2942      OPTIONS-000002
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
      792      000015.sst
       97      000016.blob
-     250      MANIFEST-000013
+     259      MANIFEST-000013
               checkpoint/
      819        000005.sst
      101        000006.blob
@@ -31,7 +31,7 @@ tree
       97        000009.blob
       11        000011.log
      687        000012.sst
-     187        MANIFEST-000013
+     193        MANIFEST-000013
     2942        OPTIONS-000002
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -549,16 +549,17 @@ func (w *RawColumnWriter) addWithBlobHandleInternal(
 		if secondaryHandle != nil {
 			// Dual-tier case: track hot-and-cold blob reference bytes.
 			w.tieringHistogramBlock.AddHotAndColdBlobRefBytes(uint64(hotHandle.ValueLen))
-		} else if w.opts.BlobReferenceTierGetter != nil {
+		} else if w.opts.internal.BlobReferenceTiers != nil {
 			// Single-tier case: track by tier.
 			var kindAndTier tieredmeta.KindAndTier
-			switch w.opts.BlobReferenceTierGetter(hotHandle.ReferenceID) {
+			tier := w.opts.internal.BlobReferenceTiers[hotHandle.ReferenceID]
+			switch tier {
 			case base.HotTier:
 				kindAndTier = tieredmeta.SSTableBlobReferenceHotBytes
 			case base.ColdTier:
 				kindAndTier = tieredmeta.SSTableBlobReferenceColdBytes
 			default:
-				panic(errors.AssertionFailedf("unexpected tier %s", w.opts.BlobReferenceTierGetter(hotHandle.ReferenceID)))
+				panic(errors.AssertionFailedf("unexpected tier %s", tier))
 			}
 			w.tieringHistogramBlock.Add(kindAndTier, meta.TieringSpanID, meta.TieringAttribute, uint64(hotHandle.ValueLen))
 		}

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -245,18 +245,6 @@ type WriterOptions struct {
 	// sstable. Requires TieringSpanIDGetter and TieringAttributeExtractor to be set.
 	WriteTieringHistograms bool
 
-	// BlobReferenceTierGetter returns the storage tier (hot or cold) for a blob
-	// reference ID. Used when WriteTieringHistograms is true to categorize blob
-	// references by tier. When a value exists in both tiers (hot-and-cold), there
-	// are two separate blob references with different IDs, each returning its own
-	// tier.
-	//
-	// TODO(annie): This is temporary. Once each BlobReference in sstable metadata
-	// stores the tier (hot or cold) it was written to, we won't need this getter.
-	// The tier should be set based on which writer (hot or cold) created the blob
-	// file, and stored in both the BlobReference and PhysicalBlobFile metadata.
-	BlobReferenceTierGetter func(base.BlobReferenceID) base.StorageTier
-
 	// TieringThreshold is the tiering attribute threshold used to categorize keys
 	// as below or above threshold in the histogram summary.
 	TieringThreshold base.TieringAttribute

--- a/sstable/reader_blob_test.go
+++ b/sstable/reader_blob_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/crlib/testutils/leaktest"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/blobtest"
+	"github.com/cockroachdb/pebble/internal/sstableinternal"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/sstable/colblk"
+	"github.com/stretchr/testify/require"
+)
+
+// testBlobReferences implements BlobReferences.
+type testBlobReferences struct {
+	fileIDs []base.BlobFileID
+}
+
+func (t *testBlobReferences) BlobFileIDByID(i base.BlobReferenceID) base.BlobFileID {
+	return t.fileIDs[i]
+}
+func (t *testBlobReferences) IDByBlobFileID(fileID base.BlobFileID) (base.BlobReferenceID, bool) {
+	for i, id := range t.fileIDs {
+		if id == fileID {
+			return base.BlobReferenceID(i), true
+		}
+	}
+	return 0, false
+}
+
+// TestDualTierBlobHandlePrimaryAndSecondaryFetchMatch builds an sstable with
+// dual-tier blob values, then retrieves each value using both the primary
+// (hot) and secondary (cold) blob handles and validates that both fetches
+// return the same value.
+func TestDualTierBlobHandlePrimaryAndSecondaryFetchMatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	input := `e@100#1,SET:hot-blob{fileNum=1 valueID=0 valueLen=3 value=foo}cold-blob{fileNum=2 valueID=0 valueLen=3 value=foo}attr=10`
+
+	bv := &blobtest.Values{}
+	_, err := ParseTestKVsAndSpans(input, bv)
+	require.NoError(t, err)
+
+	keySchema := colblk.DefaultKeySchema(testkeys.Comparer, 16)
+	tiers := []base.StorageTier{base.HotTier, base.ColdTier}
+	opts := WriterOptions{
+		Comparer:                  testkeys.Comparer,
+		KeySchema:                 &keySchema,
+		TableFormat:               TableFormatMax,
+		TieringSpanIDGetter:       func(key []byte) base.TieringSpanID { return 0 },
+		TieringAttributeExtractor: func([]byte, int, []byte) (base.TieringAttribute, error) { return 0, nil },
+		WriteTieringHistograms:    true,
+		DisableValueBlocks:        true,
+	}
+	opts.SetInternal(sstableinternal.WriterOptions{BlobReferenceTiers: tiers})
+
+	obj := &objstorage.MemObj{}
+	w := NewRawWriter(obj, opts)
+	require.NoError(t, ParseTestSST(w, input, bv))
+	require.NoError(t, w.Close())
+
+	blobRefs := &testBlobReferences{fileIDs: []base.BlobFileID{1, 2}}
+
+	readerOpts := ReaderOptions{
+		Comparer:   opts.Comparer,
+		KeySchemas: KeySchemas{keySchema.Name: &keySchema},
+	}
+	r, err := NewMemReader(obj.Data(), readerOpts)
+	require.NoError(t, err)
+	defer r.Close()
+
+	blobCtx := TableBlobContext{ValueFetcher: bv, References: blobRefs}
+	iter, err := r.NewPointIter(context.Background(), IterOptions{
+		Transforms:  NoTransforms,
+		BlobContext: blobCtx,
+	})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	metaIter, ok := iter.(base.InternalIteratorWithKVMeta)
+	require.True(t, ok, "sstable iterator must implement InternalIteratorWithKVMeta")
+
+	ctx := context.Background()
+	for kv, meta := metaIter.FirstWithMeta(); kv != nil; kv, meta = metaIter.NextWithMeta() {
+		primaryVal, _, err := kv.Value(nil /* buf */)
+		require.NoError(t, err)
+
+		if len(meta.SecondaryBlobHandle) == 0 {
+			continue
+		}
+
+		secondaryVal, _, err := blobCtx.FetchValueFromSecondaryHandle(ctx, meta.SecondaryBlobHandle, nil)
+		require.NoError(t, err)
+		require.Equal(t, primaryVal, secondaryVal, "key %s: value from primary handle != value from secondary handle", kv.K.UserKey)
+	}
+}

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -109,7 +109,7 @@ type ParsedKVOrSpan struct {
 	//
 	// For blob values:
 	//   - Single-tier: Only BlobHandle is set. The tier (hot/cold) is determined
-	//     by BlobReferenceTierGetter based on the blob file's reference ID.
+	//     by sstableinternal.WriterOptions.BlobReferenceTiers[BlobHandle.ReferenceID].
 	//   - Dual-tier: Both BlobHandle and SecondaryBlobHandle are set, representing
 	//     a value that exists in both tiers simultaneously (typically hot + cold).
 	Value               []byte

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -2600,7 +2600,7 @@ Blob files:
 
 disk-usage
 ----
-7,605B
+7,617B
 
 init reopen
 ----
@@ -2608,4 +2608,4 @@ init reopen
 # The disk usage is expected to go down a bit because we remove the WALs.
 disk-usage
 ----
-7,088B
+7,100B


### PR DESCRIPTION
Previously, blob references did not store which tier (hot or cold) the blob
file was written to.

This patch adds a Tier field to both BlobReference and PhysicalBlobFile.
The tier is now persisted in version edits using new tags (tagNewBlobFile2 and
customTagBlobReferences3) that include tier information in the encoding.
Decoding of old formats defaults to HotTier for backward compatibility.

WriterOptions.BlobReferenceTierGetter is replaced with BlobReferenceTiers,
a slice indexed by reference ID.