### PR TITLE
db: extract cursor from download compactions for reuse

### DIFF
--- a/download.go
+++ b/download.go
@@ -5,9 +5,7 @@
 package pebble
 
 import (
-	"cmp"
 	"context"
-	"fmt"
 	"slices"
 
 	"github.com/cockroachdb/errors"
@@ -218,7 +216,7 @@ type downloadSpanTask struct {
 
 	// Keeps track of the current position; all files up to these position were
 	// examined and were either downloaded or we have bookmarks for them.
-	cursor downloadCursor
+	cursor manifest.ScanCursor
 
 	// Bookmarks remember areas which correspond to downloads that we started or
 	// files that were undergoing other compactions and which we need to check
@@ -234,7 +232,7 @@ type downloadSpanTask struct {
 // downloadBookmark represents an area that was swept by the task cursor which
 // corresponds to a file that was part of a running compaction or download.
 type downloadBookmark struct {
-	start    downloadCursor
+	start    manifest.ScanCursor
 	endBound base.UserKeyBoundary
 	// downloadDoneCh is set if this bookmark corresponds to a download we
 	// started; in this case the channel will report the status of that
@@ -258,10 +256,10 @@ func (d *DB) newDownloadSpanTask(
 			bounds.Start = f.Smallest().UserKey
 		}
 	}
-	startCursor := downloadCursor{
-		level:  0,
-		key:    bounds.Start,
-		seqNum: 0,
+	startCursor := manifest.ScanCursor{
+		Level:  0,
+		Key:    bounds.Start,
+		SeqNum: 0,
 	}
 	f, level := startCursor.NextExternalFile(d.cmp, d.objProvider, bounds, vers)
 	if f == nil {
@@ -273,148 +271,8 @@ func (d *DB) newDownloadSpanTask(
 		downloadSpan:      sp,
 		bounds:            bounds,
 		taskCompletedChan: make(chan error, 1),
-		cursor:            makeCursorAtFile(f, level),
+		cursor:            manifest.MakeScanCursor(f, level),
 	}, true
-}
-
-// downloadCursor represents a position in the download process, which does not
-// depend on a specific version.
-//
-// The Download process scans for external files level-by-level (starting with
-// L0), and left-to-right (in terms of Smallest.UserKey) within each level. In
-// L0, we break ties by the LargestSeqNum.
-//
-// A cursor can be thought of as a boundary between two files in a version
-// (ordered by level, then by Smallest.UserKey, then by LargestSeqNum). A file
-// is either "before" or "after" the cursor.
-type downloadCursor struct {
-	// LSM level (0 to NumLevels). When level=NumLevels, the cursor is at the end.
-	level int
-	// Inclusive lower bound for Smallest.UserKey for tables on level.
-	key []byte
-	// Inclusive lower bound for sequence number for tables on level with
-	// Smallest.UserKey equaling key. Used to break ties within L0, and also used
-	// to position a cursor immediately after a given file.
-	seqNum base.SeqNum
-}
-
-var endCursor = downloadCursor{level: manifest.NumLevels}
-
-// AtEnd returns true if the cursor is after all relevant files.
-func (c downloadCursor) AtEnd() bool {
-	return c.level >= manifest.NumLevels
-}
-
-func (c downloadCursor) String() string {
-	return fmt.Sprintf("level=%d key=%q seqNum=%d", c.level, c.key, c.seqNum)
-}
-
-// makeCursorAtFile returns a downloadCursor that is immediately before the
-// given file. Calling nextExternalFile on the resulting cursor (using the same
-// version) should return f.
-func makeCursorAtFile(f *manifest.TableMetadata, level int) downloadCursor {
-	return downloadCursor{
-		level:  level,
-		key:    f.Smallest().UserKey,
-		seqNum: f.SeqNums.High,
-	}
-}
-
-// makeCursorAfterFile returns a downloadCursor that is immediately
-// after the given file.
-func makeCursorAfterFile(f *manifest.TableMetadata, level int) downloadCursor {
-	return downloadCursor{
-		level:  level,
-		key:    f.Smallest().UserKey,
-		seqNum: f.SeqNums.High + 1,
-	}
-}
-
-func (c downloadCursor) FileIsAfterCursor(
-	cmp base.Compare, f *manifest.TableMetadata, level int,
-) bool {
-	return c.Compare(cmp, makeCursorAfterFile(f, level)) < 0
-}
-
-func (c downloadCursor) Compare(keyCmp base.Compare, other downloadCursor) int {
-	if c := cmp.Compare(c.level, other.level); c != 0 {
-		return c
-	}
-	if c := keyCmp(c.key, other.key); c != 0 {
-		return c
-	}
-	return cmp.Compare(c.seqNum, other.seqNum)
-}
-
-// NextExternalFile returns the first file after the cursor, returning the file
-// and the level. If no such file exists, returns nil fileMetadata.
-func (c downloadCursor) NextExternalFile(
-	cmp base.Compare, objProvider objstorage.Provider, bounds base.UserKeyBounds, v *manifest.Version,
-) (_ *manifest.TableMetadata, level int) {
-	for !c.AtEnd() {
-		if f := c.NextExternalFileOnLevel(cmp, objProvider, bounds.End, v); f != nil {
-			return f, c.level
-		}
-		// Go to the next level.
-		c.key = bounds.Start
-		c.seqNum = 0
-		c.level++
-	}
-	return nil, manifest.NumLevels
-}
-
-// NextExternalFileOnLevel returns the first external file on c.level which is
-// after c and with Smallest.UserKey within the end bound.
-func (c downloadCursor) NextExternalFileOnLevel(
-	cmp base.Compare,
-	objProvider objstorage.Provider,
-	endBound base.UserKeyBoundary,
-	v *manifest.Version,
-) *manifest.TableMetadata {
-	if c.level > 0 {
-		it := v.Levels[c.level].Iter()
-		return firstExternalFileInLevelIter(cmp, objProvider, c, it, endBound)
-	}
-	// For L0, we look at all sublevel iterators and take the first file.
-	var first *manifest.TableMetadata
-	var firstCursor downloadCursor
-	for _, sublevel := range v.L0SublevelFiles {
-		f := firstExternalFileInLevelIter(cmp, objProvider, c, sublevel.Iter(), endBound)
-		if f != nil {
-			c := makeCursorAtFile(f, c.level)
-			if first == nil || c.Compare(cmp, firstCursor) < 0 {
-				first = f
-				firstCursor = c
-			}
-			// Trim the end bound as an optimization.
-			endBound = base.UserKeyInclusive(f.Smallest().UserKey)
-		}
-	}
-	return first
-}
-
-// firstExternalFileInLevelIter finds the first external file after the cursor
-// but which starts before the endBound. It is assumed that the iterator
-// corresponds to cursor.level.
-func firstExternalFileInLevelIter(
-	cmp base.Compare,
-	objProvider objstorage.Provider,
-	cursor downloadCursor,
-	it manifest.LevelIterator,
-	endBound base.UserKeyBoundary,
-) *manifest.TableMetadata {
-	f := it.SeekGE(cmp, cursor.key)
-	// Skip the file if it starts before cursor.key or is at that same key with lower
-	// sequence number.
-	for f != nil && !cursor.FileIsAfterCursor(cmp, f, cursor.level) {
-		f = it.Next()
-	}
-	for ; f != nil && endBound.IsUpperBoundFor(cmp, f.Smallest().UserKey); f = it.Next() {
-		if f.Virtual && objstorage.IsExternalTable(objProvider, f.TableBacking.DiskFileNum) {
-			return f
-		}
-	}
-	return nil
 }
 
 // tryLaunchDownloadForFile attempt to launch a download compaction for the
@@ -514,8 +372,8 @@ func (d *DB) tryLaunchDownloadCompaction(
 		}
 
 		// Move up the bookmark position to point at this file.
-		b.start = makeCursorAtFile(f, b.start.level)
-		doneCh, ok := d.tryLaunchDownloadForFile(vers, l0Organizer, env, download, b.start.level, f)
+		b.start = manifest.MakeScanCursor(f, b.start.Level)
+		doneCh, ok := d.tryLaunchDownloadForFile(vers, l0Organizer, env, download, b.start.Level, f)
 		if ok {
 			b.downloadDoneCh = doneCh
 			return launchedCompaction
@@ -529,17 +387,17 @@ func (d *DB) tryLaunchDownloadCompaction(
 	for len(download.bookmarks) < maxConcurrentDownloads {
 		f, level := download.cursor.NextExternalFile(d.cmp, d.objProvider, download.bounds, vers)
 		if f == nil {
-			download.cursor = endCursor
+			download.cursor = manifest.EndScanCursor
 			if len(download.bookmarks) == 0 {
 				download.taskCompletedChan <- nil
 				return downloadTaskCompleted
 			}
 			return didNotLaunchCompaction
 		}
-		download.cursor = makeCursorAfterFile(f, level)
+		download.cursor = manifest.MakeScanCursorAfterFile(f, level)
 
 		download.bookmarks = append(download.bookmarks, downloadBookmark{
-			start:    makeCursorAtFile(f, level),
+			start:    manifest.MakeScanCursor(f, level),
 			endBound: base.UserKeyInclusive(f.Largest().UserKey),
 		})
 		doneCh, ok := d.tryLaunchDownloadForFile(vers, l0Organizer, env, download, level, f)

--- a/internal/manifest/scan_cursor.go
+++ b/internal/manifest/scan_cursor.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	stdcmp "cmp"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
+)
+
+// ScanCursor represents a position in an LSM scan. The scan proceeds
+// level-by-level, and within each level files are ordered by their smallest
+// user key. For L0, we break ties using SeqNums.High since files can overlap.
+//
+// A cursor can be thought of as a boundary between two files in a version
+// (ordered by level, then by Smallest.UserKey, then by SeqNums.High). A file
+// is either "before" or "after" the cursor.
+type ScanCursor struct {
+	// Level is the LSM level (0 to NumLevels). When Level=NumLevels, the cursor
+	// is at the end and the scan is complete.
+	Level int
+	// Key is an inclusive lower bound for Smallest.UserKey for tables on Level.
+	Key []byte
+	// SeqNum is an inclusive lower bound for SeqNums.High for tables on Level
+	// with Smallest.UserKey equaling Key. Used to break ties within L0, and also
+	// used to position a cursor immediately after a given file.
+	SeqNum base.SeqNum
+}
+
+// EndScanCursor is a cursor that is past all files in the LSM.
+var EndScanCursor = ScanCursor{Level: NumLevels}
+
+// AtEnd returns true if the cursor is after all files in the LSM.
+func (c *ScanCursor) AtEnd() bool {
+	return c.Level >= NumLevels
+}
+
+// String implements fmt.Stringer.
+func (c *ScanCursor) String() string {
+	return fmt.Sprintf("level=%d key=%q seqNum=%d", c.Level, c.Key, c.SeqNum)
+}
+
+// Compare compares two cursors. Returns -1 if c < other, 0 if c == other,
+// 1 if c > other.
+func (c ScanCursor) Compare(keyCmp base.Compare, other ScanCursor) int {
+	if v := stdcmp.Compare(c.Level, other.Level); v != 0 {
+		return v
+	}
+	if v := keyCmp(c.Key, other.Key); v != 0 {
+		return v
+	}
+	return stdcmp.Compare(c.SeqNum, other.SeqNum)
+}
+
+// MakeScanCursor returns a cursor that points exactly at the given file.
+// This is used when comparing whether a candidate file is at or after a
+// boundary position in the scan.
+func MakeScanCursor(f *TableMetadata, level int) ScanCursor {
+	return ScanCursor{
+		Level:  level,
+		Key:    f.Smallest().UserKey,
+		SeqNum: f.SeqNums.High,
+	}
+}
+
+// MakeScanCursorAfterFile returns a cursor that is immediately after the given
+// file. This is used to advance the scan position past a file that has just
+// been processed.
+//
+// The cursor is positioned such that the file would be considered "before" the
+// cursor (i.e., cursor.Compare(MakeScanCursorAtFile(f)) > 0).
+func MakeScanCursorAfterFile(f *TableMetadata, level int) ScanCursor {
+	return ScanCursor{
+		Level:  level,
+		Key:    f.Smallest().UserKey,
+		SeqNum: f.SeqNums.High + 1,
+	}
+}
+
+// FileIsAfterCursor returns true if the given file is strictly after the cursor
+// position. This is useful for skipping files that have already been processed.
+func (c *ScanCursor) FileIsAfterCursor(cmp base.Compare, f *TableMetadata, level int) bool {
+	return c.Compare(cmp, MakeScanCursorAfterFile(f, level)) < 0
+}
+
+// NextExternalFile returns the first external file after the cursor, returning
+// the file and the level. If no such file exists, returns nil fileMetadata.
+func (c *ScanCursor) NextExternalFile(
+	cmp base.Compare, objProvider objstorage.Provider, bounds base.UserKeyBounds, v *Version,
+) (_ *TableMetadata, level int) {
+	for !c.AtEnd() {
+		if f := c.NextExternalFileOnLevel(cmp, objProvider, bounds.End, v); f != nil {
+			return f, c.Level
+		}
+		// Go to the next level.
+		c.Key = bounds.Start
+		c.SeqNum = 0
+		c.Level++
+	}
+	return nil, NumLevels
+}
+
+// NextExternalFileOnLevel returns the first external file on c.Level which is
+// after c and with Smallest.UserKey within the end bound.
+func (c *ScanCursor) NextExternalFileOnLevel(
+	cmp base.Compare, objProvider objstorage.Provider, endBound base.UserKeyBoundary, v *Version,
+) *TableMetadata {
+	if c.Level > 0 {
+		it := v.Levels[c.Level].Iter()
+		return c.FirstExternalFileInLevelIter(cmp, objProvider, it, endBound)
+	}
+	// For L0, we look at all sublevel iterators and take the first file.
+	var first *TableMetadata
+	var firstCursor ScanCursor
+	for _, sublevel := range v.L0SublevelFiles {
+		f := c.FirstExternalFileInLevelIter(cmp, objProvider, sublevel.Iter(), endBound)
+		if f != nil {
+			fc := MakeScanCursor(f, c.Level)
+			if first == nil || fc.Compare(cmp, firstCursor) < 0 {
+				first = f
+				firstCursor = fc
+			}
+			// Trim the end bound as an optimization.
+			endBound = base.UserKeyInclusive(f.Smallest().UserKey)
+		}
+	}
+	return first
+}
+
+// FirstExternalFileInLevelIter finds the first external file after the cursor
+// but which starts before the endBound. It is assumed that the iterator
+// corresponds to cursor.Level.
+func (c *ScanCursor) FirstExternalFileInLevelIter(
+	cmp base.Compare,
+	objProvider objstorage.Provider,
+	it LevelIterator,
+	endBound base.UserKeyBoundary,
+) *TableMetadata {
+	f := it.SeekGE(cmp, c.Key)
+	// Skip the file if it starts before cursor.Key or is at that same key with lower
+	// sequence number.
+	for f != nil && !c.FileIsAfterCursor(cmp, f, c.Level) {
+		f = it.Next()
+	}
+	for ; f != nil && endBound.IsUpperBoundFor(cmp, f.Smallest().UserKey); f = it.Next() {
+		if f.Virtual && objstorage.IsExternalTable(objProvider, f.TableBacking.DiskFileNum) {
+			return f
+		}
+	}
+	return nil
+}

--- a/internal/manifest/scan_cursor_test.go
+++ b/internal/manifest/scan_cursor_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage"
+)
+
+// mockExternalObjProvider is a minimal objstorage.Provider implementation for testing.
+// It only implements Lookup; other methods panic.
+type mockExternalObjProvider struct {
+	objstorage.Provider
+	externalThreshold base.DiskFileNum
+}
+
+func (m *mockExternalObjProvider) Lookup(
+	fileType base.FileType, fileNum base.DiskFileNum,
+) (objstorage.ObjectMetadata, error) {
+	meta := objstorage.ObjectMetadata{
+		DiskFileNum: fileNum,
+		FileType:    fileType,
+	}
+	if fileNum >= m.externalThreshold {
+		// Set CustomObjectName to make IsExternal() return true.
+		meta.Remote.CustomObjectName = "external"
+	}
+	return meta, nil
+}
+
+// TestScanCursor tests the ScanCursor with external file iteration.
+// This verifies the cursor correctly tracks position across levels and advances
+// past processed files.
+func TestScanCursor(t *testing.T) {
+	cmp := bytes.Compare
+	// Backings >= 100 are external.
+	objProvider := &mockExternalObjProvider{externalThreshold: 100}
+
+	var vers *Version
+	var cursor ScanCursor
+	datadriven.RunTest(t, "testdata/scan_cursor", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "define":
+			var err error
+			const flushSplitBytes = 10 * 1024 * 1024
+			l0Organizer := NewL0Organizer(base.DefaultComparer, flushSplitBytes)
+			vers, err = ParseVersionDebug(base.DefaultComparer, l0Organizer, td.Input)
+			if err != nil {
+				td.Fatalf(t, "%v", err)
+			}
+			return vers.DebugString()
+
+		case "cursor":
+			var lower, upper string
+			td.ScanArgs(t, "lower", &lower)
+			td.ScanArgs(t, "upper", &upper)
+			bounds := base.UserKeyBoundsEndExclusive([]byte(lower), []byte(upper))
+
+			var buf strings.Builder
+			for line := range crstrings.LinesSeq(td.Input) {
+				fields := strings.Fields(line)
+				fmt.Fprintf(&buf, "%s:\n", fields[0])
+				switch cmd := fields[0]; cmd {
+				case "start":
+					cursor = ScanCursor{
+						Level:  0,
+						Key:    bounds.Start,
+						SeqNum: 0,
+					}
+					fmt.Fprintf(&buf, "  %s\n", &cursor)
+
+				case "next-external-file":
+					f, level := cursor.NextExternalFile(cmp, objProvider, bounds, vers)
+					if f != nil {
+						// Verify that cursor still points to this file.
+						f2, level2 := cursor.NextExternalFile(cmp, objProvider, bounds, vers)
+						if f != f2 {
+							td.Fatalf(t, "NextExternalFile returned different file")
+						}
+						if level != level2 {
+							td.Fatalf(t, "NextExternalFile returned different level")
+						}
+						cursor = MakeScanCursorAfterFile(f, level)
+					}
+					fmt.Fprintf(&buf, "  file: %v  level: %d\n", f, level)
+
+				case "iterate-external-files":
+					for {
+						f, level := cursor.NextExternalFile(cmp, objProvider, bounds, vers)
+						if f == nil {
+							fmt.Fprintf(&buf, "  no more files\n")
+							break
+						}
+						fmt.Fprintf(&buf, "  file: %v  level: %d\n", f, level)
+						cursor = MakeScanCursorAfterFile(f, level)
+					}
+
+				default:
+					td.Fatalf(t, "unknown cursor command %q", cmd)
+				}
+			}
+			return buf.String()
+
+		default:
+			td.Fatalf(t, "unknown command: %s", td.Cmd)
+			return ""
+		}
+	})
+}

--- a/internal/manifest/testdata/scan_cursor
+++ b/internal/manifest/testdata/scan_cursor
@@ -1,4 +1,4 @@
-# This file tests the download cursor functionality.
+# This file tests the ScanCursor functionality.
 # Backings >= 100 are external.
 
 # Basic test to verify cursor iteration.
@@ -23,11 +23,11 @@ L2:
 # Verify iteration.
 cursor lower=a upper=d
 start
-iterate
+iterate-external-files
 ----
 start:
   level=0 key="a" seqNum=0
-iterate:
+iterate-external-files:
   file: 000004:[a#1,SET-c#1,SET]  level: 0
   file: 000001:[a#1,SET-a#1,SET]  level: 0
   file: 000002:[b#1,SET-d#1,SET]  level: 0
@@ -36,11 +36,11 @@ iterate:
 
 cursor lower=b upper=z
 start
-iterate
+iterate-external-files
 ----
 start:
   level=0 key="b" seqNum=0
-iterate:
+iterate-external-files:
   file: 000002:[b#1,SET-d#1,SET]  level: 0
   file: 000003:[e#1,SET-g#1,SET]  level: 0
   file: 000005:[b#1,SET-c#1,SET]  level: 2
@@ -67,11 +67,11 @@ L2:
 
 cursor lower=a upper=z
 start
-iterate
+iterate-external-files
 ----
 start:
   level=0 key="a" seqNum=0
-iterate:
+iterate-external-files:
   file: 000004:[a#1,SET-c#1,SET]  level: 0
   file: 000002:[b#1,SET-d#1,SET]  level: 0
   file: 000005:[b#1,SET-c#1,SET]  level: 2
@@ -97,17 +97,17 @@ L2:
 
 cursor lower=a upper=z
 start
-next-file
-next-file
-next-file
+next-external-file
+next-external-file
+next-external-file
 ----
 start:
   level=0 key="a" seqNum=0
-next-file:
+next-external-file:
   file: 000001:[a#1,SET-b#1,SET]  level: 1
-next-file:
+next-external-file:
   file: 000002:[c#1,SET-d#1,SET]  level: 1
-next-file:
+next-external-file:
   file: 000003:[e#1,SET-f#1,SET]  level: 1
 
 define
@@ -129,16 +129,16 @@ L2:
 
 # Continue the cursor above. We should see table 2 again.
 cursor lower=a upper=z
-next-file
-next-file
-next-file
-next-file
+next-external-file
+next-external-file
+next-external-file
+next-external-file
 ----
-next-file:
+next-external-file:
   file: 000004:[a1#1,SET-b#1,SET]  level: 2
-next-file:
+next-external-file:
   file: 000002:[c#1,SET-d#1,SET]  level: 2
-next-file:
+next-external-file:
   file: 000005:[d1#1,SET-g#1,SET]  level: 2
-next-file:
+next-external-file:
   file: <nil>  level: 7


### PR DESCRIPTION
Extract the downloadCursor type and its methods into a new shared ScanCursor. This cursor type represents a position in an LSM scan (level, key, seqNum) and can be used by processes that need to scan the LSM tree.

Supports: https://github.com/cockroachdb/pebble/issues/5657