### PR TITLE
Revert "internal/keyspan: fix interleaving iterator edge case"

### DIFF
--- a/internal/keyspan/interleaving_iter_test.go
+++ b/internal/keyspan/interleaving_iter_test.go
@@ -85,7 +85,7 @@ func runInterleavingIterTest(t *testing.T, filename string) {
 	var prevKV *base.InternalKV
 	formatKey := func(kv *base.InternalKV) {
 		if kv == nil {
-			fmt.Fprintln(&buf, ".")
+			fmt.Fprint(&buf, ".")
 			return
 		}
 		prevKV = kv

--- a/internal/keyspan/testdata/interleaving_iter
+++ b/internal/keyspan/testdata/interleaving_iter
@@ -231,8 +231,7 @@ seek-lt tomago
 . parsnip#3,SET: (no span)
 # SpanChanged(nil)
 # SpanChanged(nil)
-.
-# SpanChanged(nil)
+.# SpanChanged(nil)
 # SpanChanged(q-z:{(#14,RANGEKEYSET,@9,mangos)})
 . q#inf,RANGEKEYSET: q-z:{(#14,RANGEKEYSET,@9,mangos)}
 # SpanChanged(nil)
@@ -698,12 +697,14 @@ set-bounds a c
 seek-ge c
 ----
 # SpanChanged(nil)
+# SpanChanged(nil)
 .
 
 iter
 set-bounds a c
 seek-lt a
 ----
+# SpanChanged(nil)
 # SpanChanged(nil)
 .
 
@@ -726,6 +727,7 @@ iter
 set-bounds d e
 seek-lt d
 ----
+# SpanChanged(nil)
 # SpanChanged(nil)
 .
 
@@ -954,43 +956,3 @@ prev
 . a#inf,RANGEDEL: a-b:{(#5,RANGEDEL)}
 # SpanChanged(nil)
 .
-
-define-pointkeys
-a#10,SET
-b#10,SET
-c#10,SET
-d#10,SET
-----
-OK
-
-define-spans
-a-c:{(#11,RANGEDEL)}
-----
-OK
-
-iter interleave-end-keys
-set-bounds b c
-seek-lt b
-next
-next
-----
-# SpanChanged(nil)
-.
-# SpanChanged(nil)
-# SpanChanged(b-c:{(#11,RANGEDEL)})
-. b#inf,RANGEDEL: b-c:{(#11,RANGEDEL)}
-. b#10,SET: b-c:{(#11,RANGEDEL)}
-
-
-iter interleave-end-keys
-set-bounds a b
-seek-ge b
-prev
-prev
-----
-# SpanChanged(nil)
-.
-# SpanChanged(nil)
-. b#inf,RANGEDEL: a-b:{(#11,RANGEDEL)}
-# SpanChanged(a-b:{(#11,RANGEDEL)})
-. a#10,SET: a-b:{(#11,RANGEDEL)}

--- a/internal/keyspan/testdata/interleaving_iter_masking
+++ b/internal/keyspan/testdata/interleaving_iter_masking
@@ -263,8 +263,7 @@ next
 . a#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 . a@12#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 # SpanChanged(nil)
-.
-# SpanChanged(nil)
+.# SpanChanged(nil)
 .
 
 iter masking-threshold=@10
@@ -280,8 +279,7 @@ prev
 . a#1,SET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 . a#inf,RANGEKEYUNSET: a-c:{(#1,RANGEKEYUNSET,@5) (#1,RANGEKEYUNSET,@2)}
 # SpanChanged(nil)
-.
-# SpanChanged(nil)
+.# SpanChanged(nil)
 .
 
 # Test a scenario where a point key is masked in the forward direction, which in

--- a/testdata/iter_histories/probe_prefix
+++ b/testdata/iter_histories/probe_prefix
@@ -93,6 +93,8 @@ b@8: (b8, .)
 000004.RangeDels.opSpanSeekGE("b@20") = a@2-b@3:{(#10,RANGEDEL)}
 000004.RangeDels.opSpanSeekGE("b@20") = a@2-b@3:{(#10,RANGEDEL)}
 000004.PointKeys.Next() = (b@2#7,SET,"7")
+000004.PointKeys.SeekPrefixGE("c") = nil
+000004.RangeDels.opSpanSeekGE("c") = nil
 000004.PointKeys.Close() = nil
 000004.RangeDels.opSpanClose() = nil
 000004.RangeDels.opSpanClose() = nil


### PR DESCRIPTION
This reverts commit 057782e0f7c72100296c136453803b7ca90b93d4.

Close #5751.
Close #5754.
