### PR TITLE
db: add span policy enforcer background goroutine

### DIFF
--- a/db.go
+++ b/db.go
@@ -316,6 +316,10 @@ type DB struct {
 
 	compactionScheduler CompactionScheduler
 
+	// spanPolicyEnforcer is the background goroutine that scans the LSM for tables
+	// that violate the current span policy and marks those files for compaction.
+	spanPolicyEnforcer *spanPolicyEnforcer
+
 	// During an iterator close, we may asynchronously schedule read compactions.
 	// We want to wait for those goroutines to finish, before closing the DB.
 	// compactionShedulers.Wait() should not be called while the DB.mu is held.
@@ -467,6 +471,12 @@ type DB struct {
 			// compactions which we might have to perform.
 			readCompactions readCompactionQueue
 
+			// spanPolicyEnforcementFiles contains files that have been marked for
+			// span policy enforcement compaction by the background policy enforcer.
+			// Unlike MarkedForCompaction, this is not persisted to the manifest
+			// since the policy enforcer will re-scan on restart.
+			// TODO(xinhaoz): Create new compaction that will utilize this set.
+			spanPolicyEnforcementFiles manifest.MarkedForCompactionSet
 			// The cumulative duration of all completed compactions since Open.
 			// Does not include flushes.
 			duration time.Duration
@@ -1531,6 +1541,10 @@ func (d *DB) Close() error {
 	// CompactionScheduler will never again call a method on the DB. Note that
 	// this must be called without holding d.mu.
 	d.compactionScheduler.Unregister()
+	// Stop the background policy enforcer if it was started.
+	if d.spanPolicyEnforcer != nil {
+		d.spanPolicyEnforcer.Stop()
+	}
 	// Lock the commit pipeline for the duration of Close. This prevents a race
 	// with makeRoomForWrite. Rotating the WAL in makeRoomForWrite requires
 	// dropping d.mu several times for I/O. If Close only holds d.mu, an

--- a/internal/manifest/scan_cursor.go
+++ b/internal/manifest/scan_cursor.go
@@ -72,7 +72,7 @@ func MakeScanCursor(f *TableMetadata, level int) ScanCursor {
 // been processed.
 //
 // The cursor is positioned such that the file would be considered "before" the
-// cursor (i.e., cursor.Compare(MakeScanCursorAtFile(f)) > 0).
+// cursor (i.e., cursor.Compare(MakeScanCursor(f, level)) > 0).
 func MakeScanCursorAfterFile(f *TableMetadata, level int) ScanCursor {
 	return ScanCursor{
 		Level:  level,
@@ -164,7 +164,7 @@ func (c *ScanCursor) FirstExternalFileInLevelIter(
 	return nil
 }
 
-// NextFile returns the first file after the cursor, returning the file and the
+// NextFile returns the first file at or after the cursor, returning the file and the
 // level. If no such file exists, returns nil.
 func (c *ScanCursor) NextFile(cmp base.Compare, v *Version) (_ *TableMetadata, level int) {
 	for !c.AtEnd() {

--- a/internal/manifest/scan_cursor.go
+++ b/internal/manifest/scan_cursor.go
@@ -81,10 +81,10 @@ func MakeScanCursorAfterFile(f *TableMetadata, level int) ScanCursor {
 	}
 }
 
-// FileIsAfterCursor returns true if the given file is strictly after the cursor
+// FileIsAfterCursor returns true if the given file is at or after the cursor
 // position. This is useful for skipping files that have already been processed.
 func (c *ScanCursor) FileIsAfterCursor(cmp base.Compare, f *TableMetadata, level int) bool {
-	return c.Compare(cmp, MakeScanCursorAfterFile(f, level)) < 0
+	return c.Compare(cmp, MakeScanCursor(f, level)) <= 0
 }
 
 // NextExternalFile returns the first external file after the cursor, returning
@@ -131,6 +131,21 @@ func (c *ScanCursor) NextExternalFileOnLevel(
 	return first
 }
 
+// firstFileInLevelIter returns the first file at or after the cursor position
+// in the given level iterator. It is assumed that the iterator corresponds to
+// c.Level.
+func (c *ScanCursor) firstFileInLevelIter(cmp base.Compare, it *LevelIterator) *TableMetadata {
+	if len(c.Key) == 0 {
+		return it.First()
+	}
+	f := it.SeekGE(cmp, c.Key)
+	// Skip files that are before the cursor position.
+	for f != nil && !c.FileIsAfterCursor(cmp, f, c.Level) {
+		f = it.Next()
+	}
+	return f
+}
+
 // FirstExternalFileInLevelIter finds the first external file after the cursor
 // but which starts before the endBound. It is assumed that the iterator
 // corresponds to cursor.Level.
@@ -140,16 +155,51 @@ func (c *ScanCursor) FirstExternalFileInLevelIter(
 	it LevelIterator,
 	endBound base.UserKeyBoundary,
 ) *TableMetadata {
-	f := it.SeekGE(cmp, c.Key)
-	// Skip the file if it starts before cursor.Key or is at that same key with lower
-	// sequence number.
-	for f != nil && !c.FileIsAfterCursor(cmp, f, c.Level) {
-		f = it.Next()
-	}
+	f := c.firstFileInLevelIter(cmp, &it)
 	for ; f != nil && endBound.IsUpperBoundFor(cmp, f.Smallest().UserKey); f = it.Next() {
 		if f.Virtual && objstorage.IsExternalTable(objProvider, f.TableBacking.DiskFileNum) {
 			return f
 		}
 	}
 	return nil
+}
+
+// NextFile returns the first file after the cursor, returning the file and the
+// level. If no such file exists, returns nil.
+func (c *ScanCursor) NextFile(cmp base.Compare, v *Version) (_ *TableMetadata, level int) {
+	for !c.AtEnd() {
+		if f := c.nextFileOnLevel(cmp, v); f != nil {
+			return f, c.Level
+		}
+		// Go to the next level.
+		c.Key = nil
+		c.SeqNum = 0
+		c.Level++
+	}
+	return nil, NumLevels
+}
+
+// nextFileOnLevel returns the first file on c.Level which is at or after the
+// cursor position.
+func (c *ScanCursor) nextFileOnLevel(cmp base.Compare, v *Version) *TableMetadata {
+	if c.Level > 0 {
+		it := v.Levels[c.Level].Iter()
+		return c.firstFileInLevelIter(cmp, &it)
+	}
+	// For L0, we look at all sublevel iterators and take the first file
+	// (ordered by Smallest.UserKey, then by SeqNums.High).
+	var first *TableMetadata
+	var firstCursor ScanCursor
+	for _, sublevel := range v.L0SublevelFiles {
+		it := sublevel.Iter()
+		f := c.firstFileInLevelIter(cmp, &it)
+		if f != nil {
+			fc := MakeScanCursor(f, c.Level)
+			if first == nil || fc.Compare(cmp, firstCursor) < 0 {
+				first = f
+				firstCursor = fc
+			}
+		}
+	}
+	return first
 }

--- a/internal/manifest/testdata/scan_cursor
+++ b/internal/manifest/testdata/scan_cursor
@@ -46,6 +46,22 @@ iterate-external-files:
   file: 000005:[b#1,SET-c#1,SET]  level: 2
   no more files
 
+# Test NextFile with multiple L0 sublevels (reuses the version above).
+# Files are ordered by (Smallest.UserKey, SeqNums.High).
+cursor lower=a upper=z
+reset level=0
+iterate-files
+----
+reset:
+  level=0 key="" seqNum=0
+iterate-files:
+  file: 000004:[a#1,SET-c#1,SET]  level: 0
+  file: 000001:[a#1,SET-a#1,SET]  level: 0
+  file: 000002:[b#1,SET-d#1,SET]  level: 0
+  file: 000003:[e#1,SET-g#1,SET]  level: 0
+  file: 000005:[b#1,SET-c#1,SET]  level: 2
+  no more files
+
 # Verify that non-external files are skipped.
 define
 L0:
@@ -142,3 +158,78 @@ next-external-file:
   file: 000005:[d1#1,SET-g#1,SET]  level: 2
 next-external-file:
   file: <nil>  level: 7
+
+# Test NextFile: iterate through all files (not just external).
+# L0 files are ordered by (Smallest.UserKey, SeqNums.High).
+# Note: L0 files must be defined in decreasing seqnum order in input.
+define
+L0:
+  2:[c#1,SET-d#1,SET] seqnums:[#90-#100]
+  1:[a#1,SET-b#1,SET] seqnums:[#40-#50]
+L1:
+  3:[e#1,SET-f#1,SET]
+  4:[g#1,SET-h#1,SET]
+----
+L0.0:
+  000001:[a#1,SET-b#1,SET] seqnums:[#40-#50] points:[a#1,SET-b#1,SET]
+  000002:[c#1,SET-d#1,SET] seqnums:[#90-#100] points:[c#1,SET-d#1,SET]
+L1:
+  000003:[e#1,SET-f#1,SET] seqnums:[#0-#0] points:[e#1,SET-f#1,SET]
+  000004:[g#1,SET-h#1,SET] seqnums:[#0-#0] points:[g#1,SET-h#1,SET]
+
+# Iterate all files: L0 by (Smallest.UserKey, SeqNums.High), then L1 by key.
+cursor lower=a upper=z
+reset level=0
+iterate-files
+----
+reset:
+  level=0 key="" seqNum=0
+iterate-files:
+  file: 000001:[a#1,SET-b#1,SET]  level: 0
+  file: 000002:[c#1,SET-d#1,SET]  level: 0
+  file: 000003:[e#1,SET-f#1,SET]  level: 1
+  file: 000004:[g#1,SET-h#1,SET]  level: 1
+  no more files
+
+# Test NextFile: L1 and L2 only (no L0).
+define
+L1:
+  1:[a#1,SET-b#1,SET]
+  2:[c#1,SET-d#1,SET]
+L2:
+  3:[e#1,SET-f#1,SET]
+----
+L1:
+  000001:[a#1,SET-b#1,SET] seqnums:[#0-#0] points:[a#1,SET-b#1,SET]
+  000002:[c#1,SET-d#1,SET] seqnums:[#0-#0] points:[c#1,SET-d#1,SET]
+L2:
+  000003:[e#1,SET-f#1,SET] seqnums:[#0-#0] points:[e#1,SET-f#1,SET]
+
+cursor lower=a upper=z
+reset level=0
+iterate-files
+----
+reset:
+  level=0 key="" seqNum=0
+iterate-files:
+  file: 000001:[a#1,SET-b#1,SET]  level: 1
+  file: 000002:[c#1,SET-d#1,SET]  level: 1
+  file: 000003:[e#1,SET-f#1,SET]  level: 2
+  no more files
+
+# Test NextFile: skip empty levels.
+define
+L2:
+  3:[e#1,SET-f#1,SET]
+----
+L2:
+  000003:[e#1,SET-f#1,SET] seqnums:[#0-#0] points:[e#1,SET-f#1,SET]
+
+cursor lower=a upper=z
+reset level=1
+next-file
+----
+reset:
+  level=1 key="" seqNum=0
+next-file:
+  file: 000003:[e#1,SET-f#1,SET]  level: 2

--- a/open.go
+++ b/open.go
@@ -481,6 +481,12 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	d.maybeScheduleFlush()
 	d.maybeScheduleCompaction()
 
+	// Start the background policy enforcer if enabled.
+	if opts.Experimental.SpanPolicyEnforcerOptions != nil {
+		d.spanPolicyEnforcer = newSpanPolicyEnforcer(d, *opts.Experimental.SpanPolicyEnforcerOptions)
+		d.spanPolicyEnforcer.Start()
+	}
+
 	// Locks in RecoveryDirLocks can be closed as soon as we've finished opening
 	// the database.
 	if err = rs.dirs.RecoveryDirLocks.Close(); err != nil {

--- a/options.go
+++ b/options.go
@@ -789,6 +789,13 @@ type Options struct {
 		// SpanPolicyFunc is used to determine the SpanPolicy for a key region.
 		SpanPolicyFunc SpanPolicyFunc
 
+		// SpanPolicyEnforcerOptions configures the background policy enforcer that
+		// scans the LSM for span policy violations. If nil, the policy enforcer
+		// is disabled.
+		//
+		// Default: nil (disabled).
+		SpanPolicyEnforcerOptions *SpanPolicyEnforcerOptions
+
 		// VirtualTableRewriteUnreferencedFraction configures the minimum fraction of
 		// unreferenced data in a backing table required to trigger a virtual table
 		// rewrite compaction. This is calculated as the ratio of unreferenced

--- a/span_policy_enforcer.go
+++ b/span_policy_enforcer.go
@@ -1,0 +1,275 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/compression"
+	"github.com/cockroachdb/pebble/internal/manifest"
+)
+
+// spanPolicyEnforcer is a background process that periodically scans the LSM to
+// detect span policy violations and marks those files for compaction.
+//
+// Scan rate is determined by checkInterval. Scanning pauses when there are
+// pending files violating policies marked for compaction.
+type spanPolicyEnforcer struct {
+	db  *DB
+	cmp base.Compare
+
+	// checkInterval is the time between file checks.
+	checkInterval time.Duration
+
+	// cursor tracks the current position in the LSM scan.
+	cursor manifest.ScanCursor
+
+	// stopCh is closed to signal the background goroutine to stop.
+	stopCh chan struct{}
+	// wg is used to wait for the background goroutine to finish.
+	wg sync.WaitGroup
+}
+
+// SpanPolicyEnforcerOptions contains options for the policy enforcer.
+type SpanPolicyEnforcerOptions struct {
+	// CheckInterval is the time between file checks.
+	//
+	// Default: 1 second.
+	CheckInterval time.Duration
+}
+
+// DefaultPolicyEnforcerOptions returns the default options.
+func DefaultPolicyEnforcerOptions() SpanPolicyEnforcerOptions {
+	return SpanPolicyEnforcerOptions{
+		CheckInterval: time.Second,
+	}
+}
+
+// newSpanPolicyEnforcer creates a new policy enforcer.
+func newSpanPolicyEnforcer(db *DB, opts SpanPolicyEnforcerOptions) *spanPolicyEnforcer {
+	if opts.CheckInterval <= 0 {
+		opts.CheckInterval = time.Second
+	}
+	enforcer := &spanPolicyEnforcer{
+		db:            db,
+		cmp:           db.cmp,
+		checkInterval: opts.CheckInterval,
+		cursor:        manifest.ScanCursor{Level: 0},
+		stopCh:        make(chan struct{}),
+	}
+	return enforcer
+}
+
+// Start begins the background policy enforcement goroutine.
+func (s *spanPolicyEnforcer) Start() {
+	s.wg.Add(1)
+	go s.run()
+}
+
+// Stop stops the background policy enforcement goroutine and waits for it to
+// finish.
+func (s *spanPolicyEnforcer) Stop() {
+	close(s.stopCh)
+	// Broadcast in case the goroutine is waiting on db.mu.compact.cond.
+	s.db.mu.Lock()
+	s.db.mu.compact.cond.Broadcast()
+	s.db.mu.Unlock()
+	s.wg.Wait()
+}
+
+// isStopped returns true if Stop has been called.
+func (s *spanPolicyEnforcer) isStopped() bool {
+	select {
+	case <-s.stopCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// run is the main loop for the policy enforcer.
+func (s *spanPolicyEnforcer) run() {
+	defer s.wg.Done()
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		// Sleep to maintain the target rate.
+		if !s.waitForInterval(timer, s.checkInterval) {
+			return
+		}
+
+		nextFile, level, endOfScan := s.getNextFile(true /* waitForPendingWork */)
+		if endOfScan {
+			continue
+		}
+		if nextFile == nil {
+			// File was compacting, skip it.
+			continue
+		}
+
+		// Check if this file violates any policy.
+		if s.checkPolicyViolation(nextFile) {
+			s.markForEnforcement(nextFile, level)
+		}
+	}
+}
+
+// getNextFile finds the file to check for policy violations, advances the cursor past
+// the file, and returns the file. If waitForPendingWork is true, it blocks until there
+// are no files marked for policy enforcement waiting to be compacted.
+func (s *spanPolicyEnforcer) getNextFile(
+	waitForPendingWork bool,
+) (f *manifest.TableMetadata, level int, endOfScan bool) {
+	s.db.mu.Lock()
+	defer s.db.mu.Unlock()
+
+	if waitForPendingWork {
+		// Wait until there's no pending compaction work from the enforcer
+		// to prevent us from queuing up too much work at one time.
+		for s.db.mu.compact.spanPolicyEnforcementFiles.Count() > 0 && !s.isStopped() {
+			s.db.mu.compact.cond.Wait()
+		}
+		// Check if we're shutting down.
+		if s.isStopped() {
+			return nil, 0, true
+		}
+	}
+
+	vers := s.db.mu.versions.currentVersion()
+	nextFile, level := s.cursor.NextFile(s.cmp, vers)
+	if nextFile == nil {
+		// Reached end of scan. Reset cursor.
+		s.cursor = manifest.ScanCursor{Level: 0}
+		return nil, 0, true
+	}
+
+	// Advance cursor past this file.
+	s.cursor = manifest.MakeScanCursorAfterFile(nextFile, level)
+
+	// If the file is already compacting, skip it.
+	if nextFile.IsCompacting() {
+		return nil, 0, false
+	}
+
+	return nextFile, level, false
+}
+
+// waitForInterval waits for the interval or returns false if stopCh is closed.
+func (s *spanPolicyEnforcer) waitForInterval(timer *time.Timer, interval time.Duration) bool {
+	timer.Reset(interval)
+	select {
+	case <-s.stopCh:
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// checkPolicyViolation checks if a file violates any span policies across its
+// key range.
+func (s *spanPolicyEnforcer) checkPolicyViolation(f *manifest.TableMetadata) bool {
+	// SpanPolicyFunc may be nil if not configured.
+	if s.db.opts.Experimental.SpanPolicyFunc == nil {
+		return false
+	}
+
+	props, ok := f.TableBacking.Properties()
+	if !ok {
+		// Properties not yet populated; skip this file for now.
+		return false
+	}
+
+	// Get the file's key bounds and iterate over all policies that apply.
+	// In practice, there should only be one policy that applies to a file.
+	bounds := f.UserKeyBounds()
+	for {
+		policy, err := s.db.opts.Experimental.SpanPolicyFunc(bounds)
+		if err != nil {
+			// On error, skip further policy checks for this file.
+			s.db.opts.Logger.Errorf(
+				"policy enforcer: span policy lookup failed for %s: %v",
+				f.TableNum,
+				err,
+			)
+			break
+		}
+
+		// Check compression policy for this span.
+		if s.checkCompressionViolation(props, policy) {
+			return true
+		}
+
+		// TODO(xinhaoz): Check other policy violations here (tiering, file size).
+
+		if len(policy.KeyRange.End) == 0 {
+			// Policy extends to the end of the keyspace.
+			break
+		}
+		cmpResult := s.cmp(bounds.End.Key, policy.KeyRange.End)
+		if cmpResult < 0 || (cmpResult == 0 && bounds.End.Kind == base.Exclusive) {
+			// Policy covers the key range.
+			break
+		}
+		bounds.Start = policy.KeyRange.End
+	}
+
+	return false
+}
+
+// checkCompressionViolation checks if a file violates the compression policy.
+// When PreferFastCompression is true, the file should only use the designated
+// fast compression algorithms (Snappy or MinLZ) or no compression. Using Zstd
+// or other slower compression algorithms is a violation.
+func (s *spanPolicyEnforcer) checkCompressionViolation(
+	props *manifest.TableBackingProperties, policy base.SpanPolicy,
+) bool {
+	if !policy.PreferFastCompression {
+		return false
+	}
+
+	// If using PreferFastCompression, the file should only use fast compression
+	// for all blocks.
+	// Check compression settings used in this file. A violation occurs if
+	// any blocks use a non-fast compression algorithm. Fast compression means
+	// Snappy or MinLZ; Zstd is considered slow.
+	for setting := range props.CompressionStats.All() {
+		switch setting.Algorithm {
+		case compression.NoAlgorithm, compression.Snappy, compression.MinLZ:
+			continue
+		default:
+			// Unknown or other algorithms are also considered violations.
+			return true
+		}
+	}
+	return false
+}
+
+// markForEnforcement marks a file for policy enforcement compaction.
+func (s *spanPolicyEnforcer) markForEnforcement(f *manifest.TableMetadata, level int) {
+	s.db.mu.Lock()
+	defer s.db.mu.Unlock()
+
+	vers := s.db.mu.versions.currentVersion()
+
+	// Verify the file still exists at this level in the current version.
+	// The file may have been compacted away between detection and marking.
+	if !vers.Contains(level, f) {
+		return
+	}
+
+	// Check if file is already marked.
+	if s.db.mu.compact.spanPolicyEnforcementFiles.Contains(f, level) {
+		return
+	}
+
+	// Mark the file for policy enforcement.
+	s.db.mu.compact.spanPolicyEnforcementFiles.Insert(f, level)
+
+	// Trigger compaction scheduling.
+	s.db.maybeScheduleCompaction()
+}

--- a/span_policy_enforcer_test.go
+++ b/span_policy_enforcer_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestTableMeta(tableNum int, smallest, largest string) *manifest.TableMetadata {
+	meta := &manifest.TableMetadata{
+		TableNum: base.TableNum(tableNum),
+		Size:     1,
+	}
+	meta.SeqNums.Low = base.SeqNum(tableNum)
+	meta.SeqNums.High = base.SeqNum(tableNum)
+	meta.LargestSeqNumAbsolute = base.SeqNum(tableNum)
+	smallestKey := base.MakeInternalKey([]byte(smallest), meta.SeqNums.Low, base.InternalKeyKindSet)
+	largestKey := base.MakeInternalKey([]byte(largest), meta.SeqNums.High, base.InternalKeyKindSet)
+	meta.ExtendPointKeyBounds(base.DefaultComparer.Compare, smallestKey, largestKey)
+	meta.InitPhysicalBacking()
+	return meta
+}
+
+func TestSpanPolicyEnforcerCompressionViolation(t *testing.T) {
+	enforcer := &spanPolicyEnforcer{}
+	fastPolicy := base.SpanPolicy{PreferFastCompression: true}
+	noPolicy := base.SpanPolicy{}
+
+	for _, tc := range []struct {
+		stats     string
+		policy    base.SpanPolicy
+		violation bool
+	}{
+		{"Zstd1:100/200", fastPolicy, true},
+		{"Zstd1:100/200", noPolicy, false},
+		{"Snappy:100/200", fastPolicy, false},
+		{"MinLZ1:100/200", fastPolicy, false},
+		{"None:100", fastPolicy, false},
+		{"Snappy:50/100,Zstd1:50/100", fastPolicy, true},
+	} {
+		compressionStats, err := block.ParseCompressionStats(tc.stats)
+		if err != nil {
+			t.Fatalf("error parsing compression stats: %v", err)
+		}
+		backingProps := &manifest.TableBackingProperties{CompressionStats: compressionStats}
+		require.Equal(t, tc.violation, enforcer.checkCompressionViolation(backingProps, tc.policy),
+			"stats=%s", tc.stats)
+	}
+}
+
+func TestSpanPolicyEnforcerCheckPolicyViolation(t *testing.T) {
+	opts := &Options{Comparer: base.DefaultComparer}
+	opts.Experimental.SpanPolicyFunc = func(bounds base.UserKeyBounds) (base.SpanPolicy, error) {
+		// Policy changes at "m": no preference before, fast preference after.
+		if string(bounds.Start) < "m" {
+			return base.SpanPolicy{KeyRange: base.KeyRange{Start: []byte("a"), End: []byte("m")}}, nil
+		}
+		return base.SpanPolicy{KeyRange: base.KeyRange{Start: []byte("m"), End: []byte("z")}, PreferFastCompression: true}, nil
+	}
+	db := &DB{opts: opts, cmp: base.DefaultComparer.Compare}
+	enforcer := &spanPolicyEnforcer{db: db, cmp: base.DefaultComparer.Compare}
+
+	testCases := []struct {
+		tableMeta         *manifest.TableMetadata
+		compressionStats  string
+		expectedViolation bool
+	}{
+		// File in first span (no compression preference) - no violation.
+		{makeTestTableMeta(1, "a", "l"), "Zstd1:100/200", false},
+		// File in second span (fast compression) - violation.
+		{makeTestTableMeta(2, "n", "z"), "Zstd1:100/200", true},
+		// File spanning both policies - violation in second policy.
+		{makeTestTableMeta(3, "a", "z"), "Zstd1:100/200", true},
+	}
+	for _, tc := range testCases {
+		tc.tableMeta.TableBacking.PopulateProperties(&sstable.Properties{CompressionStats: tc.compressionStats})
+		require.Equal(t, tc.expectedViolation, enforcer.checkPolicyViolation(tc.tableMeta))
+	}
+}


### PR DESCRIPTION
#### manifest: add NextFile functions to ScanCursor

Add NextFile function to ScanCursor, which returns the first file after the
cursor position.

#### db: add span policy enforcer background goroutine 
Add a background span policy enforcer that scans the LSM to detect files
violating compression policies and marks them for policy enforcement compaction
(a new compaction type that will be introduced in a later commit).

Currently disabled by default, this initial implementation scans at a rate of
1 file per second, and checks only for a violation on the compression settings
in the span policy.

Part of: https://github.com/cockroachdb/pebble/issues/5657