### PR TITLE
sstable: Expose block‑cache configuration for sstable.ReaderOptions

### DIFF
--- a/sstable/external_reader.go
+++ b/sstable/external_reader.go
@@ -43,9 +43,6 @@ type CacheHandle = cache.Handle
 // cache handle and file number. The file number is caller-assigned and must be
 // unique within the cache handle's namespace to avoid collisions.
 func SetCacheOptions(opts *ReaderOptions, handle *CacheHandle, fileNum uint64) {
-	if opts == nil || handle == nil {
-		return
-	}
 	opts.CacheOpts = sstableinternal.CacheOptions{
 		CacheHandle: handle,
 		FileNum:     base.DiskFileNum(fileNum),
@@ -56,8 +53,5 @@ func SetCacheOptions(opts *ReaderOptions, handle *CacheHandle, fileNum uint64) {
 // from the cache handle. Call this when an sstable is no longer needed to free
 // cache space.
 func CacheHandleEvictFile(handle *CacheHandle, fileNum uint64) {
-	if handle == nil {
-		return
-	}
 	handle.EvictFile(base.DiskFileNum(fileNum))
 }


### PR DESCRIPTION
## What
This PR adds a small public shim to configure the block cache used by sstable.ReaderOptions.

## Why

* The block cache (cache.Cache) is already public, but callers cannot use it with sstable.ReaderOptions because
    CacheOpts is internal (sstableinternal.CacheOptions).
* This prevents external users who call sstable.NewReader directly from enabling block caching or evicting per‑file
    blocks.
    
## Changes:
* Added CacheHandle alias.
* Added sstable.SetCacheOptions and CacheHandleEvictFile helpers.
* No behavioral changes; fully backward compatible.


### Shim Example Usage.

```
  c := pebble.NewCache(128 << 20)
  defer c.Unref()
  h := c.NewHandle()
  defer h.Close()

  // Configure ReaderOptions to use the cache through the shim API
  opts := sstable.ReaderOptions{}
  sstable.SetCacheOptions(&opts, h, fileNum)

  r, err := sstable.NewReader(ctx, readable, opts)
  if err != nil {
  }
  defer r.Close()
```

