### PR TITLE
internal/keyspan: fix swallowed error in InterleavingIter.NextPrefix

### DIFF
--- a/internal/keyspan/interleaving_iter.go
+++ b/internal/keyspan/interleaving_iter.go
@@ -492,7 +492,9 @@ func (i *InterleavingIter) NextPrefix(succKey []byte) *base.InternalKV {
 		return nil
 	case posPointKey:
 		i.savePoint(i.pointIter.NextPrefix(succKey))
-		if i.withinSpan {
+		if i.err != nil {
+			i.pos = posExhausted
+		} else if i.withinSpan {
 			if i.pointKV == nil || i.cmp(i.span.End, i.pointKV.K.UserKey) <= 0 {
 				i.pos = posKeyspanEnd
 			} else {


### PR DESCRIPTION
Cherry-pick a fix into 25.2.

```
Previously if the internal point iterator encountered an error during NextPrefix and the iterator was currently positioned within a span, the InterleavingIter improperly swallowed the error without surfacing an exhausted iterator position (indicating that the caller should call Error()).

Fix #5032.
Informs #2785.
```
See Jackson's original ticket #5032
Fix #5725