### PR TITLE
compaction: fix race in auto-compact test command

### DIFF
--- a/compaction_scheduler.go
+++ b/compaction_scheduler.go
@@ -438,6 +438,14 @@ func (s *ConcurrencyLimitScheduler) adjustRunningCompactionsForTesting(delta int
 	}
 }
 
+// TriggerGrantingForTest explicitly triggers the granting mechanism. This is
+// needed for tests that disable periodic granting but still need cached
+// compactions to run when TrySchedule returns false.
+func (s *ConcurrencyLimitScheduler) TriggerGrantingForTest() {
+	s.mu.Lock()
+	s.tryGrantLockedAndUnlock() // This unlocks s.mu
+}
+
 // schedulerTimeSource is used to abstract time.NewTicker for
 // ConcurrencyLimitScheduler.
 type schedulerTimeSource interface {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1245,9 +1245,26 @@ func runCompactionTest(
 				defer d.mu.Unlock()
 				prev := d.opts.DisableAutomaticCompactions
 				d.opts.DisableAutomaticCompactions = false
-				d.maybeScheduleCompaction()
-				for d.mu.compact.compactProcesses > 0 {
-					d.mu.compact.cond.Wait()
+				for {
+					d.maybeScheduleCompaction()
+					if d.mu.compact.compactProcesses == 0 {
+						// No compactions running. Check if there's a cached compaction
+						// waiting. If TrySchedule returned false, the picked compaction
+						// may be cached but not started yet.
+						if !d.mu.versions.pickedCompactionCache.isWaiting() {
+							break
+						}
+						// Cached compaction waiting but couldn't be scheduled. Release
+						// the lock and explicitly trigger the scheduler's granting
+						// mechanism to run the cached compaction.
+						d.mu.Unlock()
+						d.compactionScheduler.(*ConcurrencyLimitScheduler).TriggerGrantingForTest()
+						d.mu.Lock()
+						continue
+					}
+					for d.mu.compact.compactProcesses > 0 {
+						d.mu.compact.cond.Wait()
+					}
 				}
 				d.opts.DisableAutomaticCompactions = prev
 				return nil


### PR DESCRIPTION
The auto-compact test command could exit prematurely when maybeScheduleCompaction() picked a compaction but TrySchedule() returned false. In this case, the compaction was cached (isWaiting=true) but compactProcesses remained 0, causing the wait loop to exit immediately without running the cached compaction.

This race was particularly problematic with the test scheduler that disables periodic granting. Normally, cached compactions run via the periodic granter or the Done() callback when anothercompaction finishes. With neither mechanism available, cached compactions were stuck.

Add TriggerGrantingForTest() to ConcurrencyLimitScheduler that explicitly invokes tryGrantLockedAndUnlock(), the scheduler's designed granting mechanism. Update auto-compact to detect cached compactions (isWaiting=true with compactProcesses=0) and trigger granting through this method, which properly invokes db.Schedule() with correct scheduler accounting.

The work and the message above were completed with assistance from Claude Code.

Fix #5761 