### PR TITLE
crl-release-25.3: compaction: fix race in auto-compact test command

### DIFF
--- a/compaction_scheduler.go
+++ b/compaction_scheduler.go
@@ -431,6 +431,14 @@ func (s *ConcurrencyLimitScheduler) adjustRunningCompactionsForTesting(delta int
 	}
 }
 
+// TriggerGrantingForTest explicitly triggers the granting mechanism. This is
+// needed for tests that disable periodic granting but still need cached
+// compactions to run when TrySchedule returns false.
+func (s *ConcurrencyLimitScheduler) TriggerGrantingForTest() {
+	s.mu.Lock()
+	s.tryGrantLockedAndUnlock() // This unlocks s.mu
+}
+
 func (s *ConcurrencyLimitScheduler) isUnregisteredForTesting() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Backport of 79fc5832 from master to crl-release-25.3.

The auto-compact test command could exit prematurely when `maybeScheduleCompaction()` picked a compaction but `TrySchedule()` returned false. In this case, the compaction was cached (`isWaiting=true`) but `compactingCount` remained 0, causing the wait loop to exit immediately without running the cached compaction.

This race was particularly problematic with the test scheduler that disables periodic granting. Normally, cached compactions run via the periodic granter or the Done() callback when another compaction finishes. With neither mechanism available, cached compactions were stuck.

Add `TriggerGrantingForTest()` to `ConcurrencyLimitScheduler` that explicitly invokes `tryGrantLockedAndUnlock()`, the scheduler's designed granting mechanism. Update auto-compact to detect cached compactions (`isWaiting=true` with `compactingCount=0`) and trigger granting through this method, which properly invokes `db.Schedule()` with correct scheduler accounting.

Differences from master: the release branch stores the scheduler in `d.opts.Experimental.CompactionScheduler` (master uses `d.compactionScheduler`) and tracks running compactions as `d.mu.compact.compactingCount` (master uses `d.mu.compact.compactProcesses`).

The work and the message above were completed with assistance from Claude Code.

Fix #5761 
Also see #5766