### PR TITLE
db: add ApproximateMidKey for efficient range bisection

### DIFF
--- a/file_cache.go
+++ b/file_cache.go
@@ -338,6 +338,16 @@ func (h *fileCacheHandle) estimateSize(
 	return size, err
 }
 
+func (h *fileCacheHandle) collectBlockEntries(
+	ctx context.Context, meta *manifest.TableMetadata, start, end []byte,
+) (entries []sstable.BlockEntry, err error) {
+	err = h.withReader(ctx, block.NoReadEnv, meta, func(r *sstable.Reader, env sstable.ReadEnv) error {
+		entries, err = r.CollectBlockEntries(ctx, start, end, env, meta.IterTransforms())
+		return err
+	})
+	return entries, err
+}
+
 func createReader(
 	v *fileCacheValue, meta *manifest.TableMetadata,
 ) (*sstable.Reader, sstable.ReadEnv) {

--- a/mid_key.go
+++ b/mid_key.go
@@ -1,0 +1,279 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	stdcmp "cmp"
+	"context"
+	"slices"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/sstable"
+)
+
+// ApproximateMidKey returns a key that approximately bisects the estimated disk
+// usage of the key range kr, along with the estimated size of the left
+// subrange [kr.Start, midKey). Callers can use the returned size to decide
+// whether the bisection is worthwhile (e.g. skip splitting tiny ranges).
+//
+// The estimation uses only SST metadata and index blocks — no data blocks are
+// read. The epsilon parameter controls precision: the returned key will bisect
+// the range to within epsilon bytes. Larger values require less I/O; smaller
+// values read more index blocks for a tighter result.
+//
+// The returned key is a separator from an SST index block. It is ≥ every key
+// in its data block but may not correspond to any key stored in the database.
+//
+// If the range cannot be bisected (e.g. no SSTs overlap it or the range is too
+// small relative to epsilon), midKey is nil and lhsSize is 0.
+func (d *DB) ApproximateMidKey(
+	ctx context.Context, kr KeyRange, epsilon uint64,
+) (midKey []byte, lhsSize uint64, _ error) {
+	if err := d.closed.Load(); err != nil {
+		panic(err)
+	}
+	if d.cmp(kr.Start, kr.End) >= 0 {
+		return nil, 0, errors.New("invalid key-range specified (start >= end)")
+	}
+
+	readState := d.loadReadState()
+	defer readState.unref()
+
+	ssts := d.collectMidKeySSTs(readState.current, kr)
+	if len(ssts) == 0 {
+		return nil, 0, nil
+	}
+
+	totalSize, err := d.resolveEdgeSizes(ssts, kr, epsilon)
+	if err != nil {
+		return nil, 0, err
+	}
+	if totalSize <= 2*epsilon {
+		// The range is too small relative to the error bar for a
+		// meaningful bisection.
+		return nil, 0, nil
+	}
+
+	return d.findMidKey(ctx, ssts, kr, totalSize/2, epsilon)
+}
+
+// midKeySST tracks per-SST metadata for the mid-key computation.
+type midKeySST struct {
+	meta       *manifest.TableMetadata
+	upperBound []byte // min(meta.Largest().UserKey, kr.End)
+	fullSize   uint64 // meta.Size + meta.EstimatedReferenceSize()
+	contained  bool   // fully within kr
+
+	// effectiveSize is the best estimate of this SST's data within kr.
+	// For contained SSTs it equals fullSize. For partially-overlapping
+	// SSTs it may be reduced by resolveEdgeSizes; until then it equals
+	// fullSize (an upper bound).
+	effectiveSize uint64
+}
+
+// collectMidKeySSTs returns metadata for all SSTs that overlap kr.
+func (d *DB) collectMidKeySSTs(v *manifest.Version, kr KeyRange) []midKeySST {
+	bounds := base.UserKeyBoundsEndExclusive(kr.Start, kr.End)
+	var ssts []midKeySST
+
+	addFile := func(m *manifest.TableMetadata) {
+		fullSize := m.Size + m.EstimatedReferenceSize()
+		ub := m.Largest().UserKey
+		if d.cmp(ub, kr.End) >= 0 {
+			ub = kr.End
+		}
+		ssts = append(ssts, midKeySST{
+			meta:          m,
+			upperBound:    ub,
+			fullSize:      fullSize,
+			contained:     m.ContainedWithinSpan(d.cmp, kr.Start, kr.End),
+			effectiveSize: fullSize,
+		})
+	}
+
+	// L0: iterate sublevels individually to avoid the transitive bound
+	// expansion that Version.Overlaps performs for level 0.
+	for _, ls := range v.L0SublevelFiles {
+		for m := range ls.All() {
+			if m.Overlaps(d.cmp, &bounds) {
+				addFile(m)
+			}
+		}
+	}
+	for level := 1; level < manifest.NumLevels; level++ {
+		for m := range v.Overlaps(level, bounds).All() {
+			addFile(m)
+		}
+	}
+	return ssts
+}
+
+// resolveEdgeSizes reads index blocks for partially-overlapping SSTs to
+// narrow uncertainty on the total size. It resolves the largest edge SSTs
+// first, stopping once uncertainty is within 2*epsilon. Returns the best
+// estimate of total data size within kr.
+func (d *DB) resolveEdgeSizes(ssts []midKeySST, kr KeyRange, epsilon uint64) (uint64, error) {
+	var knownSize uint64      // sum of resolved SST sizes
+	var uncertainty uint64    // sum of fullSize for unresolved partial SSTs
+	var unresolvedEdges []int // indices into ssts
+
+	for i := range ssts {
+		if ssts[i].contained {
+			knownSize += ssts[i].fullSize
+		} else {
+			uncertainty += ssts[i].fullSize
+			unresolvedEdges = append(unresolvedEdges, i)
+		}
+	}
+
+	if uncertainty > 2*epsilon {
+		// Sort unresolved edges by size descending so we resolve the
+		// largest contributors to uncertainty first.
+		slices.SortFunc(unresolvedEdges, func(a, b int) int {
+			return stdcmp.Compare(ssts[b].fullSize, ssts[a].fullSize)
+		})
+		for _, idx := range unresolvedEdges {
+			if uncertainty <= 2*epsilon {
+				break
+			}
+			overlapSize, err := d.fileCache.estimateSize(
+				ssts[idx].meta, kr.Start, kr.End,
+			)
+			if err != nil {
+				return 0, err
+			}
+			var resolvedSize uint64
+			if ssts[idx].meta.Size > 0 {
+				resolvedSize = uint64(float64(overlapSize) *
+					float64(ssts[idx].fullSize) / float64(ssts[idx].meta.Size))
+			}
+			ssts[idx].effectiveSize = resolvedSize
+			knownSize += resolvedSize
+			uncertainty -= ssts[idx].fullSize
+		}
+	}
+
+	// Best estimate. Remaining uncertainty is ≤ 2*epsilon; split the
+	// difference.
+	return knownSize + uncertainty/2, nil
+}
+
+// findMidKey finds a key that bisects ssts to within epsilon of target. It
+// sorts SSTs by upper-bound key and walks them, accumulating effective sizes.
+// If an SST boundary lands within epsilon of the target, it is returned
+// directly. Otherwise, SSTs that straddle the target are refined at block
+// granularity via mergeWalkStraddlers.
+func (d *DB) findMidKey(
+	ctx context.Context, ssts []midKeySST, kr KeyRange, target, epsilon uint64,
+) ([]byte, uint64, error) {
+	slices.SortFunc(ssts, func(a, b midKeySST) int {
+		return d.cmp(a.upperBound, b.upperBound)
+	})
+
+	var sum uint64
+	for i := range ssts {
+		sz := ssts[i].effectiveSize
+		if sum+sz > target+epsilon {
+			// This SST overshoots. Refine at block granularity.
+			midKey, blockSum, err := d.mergeWalkStraddlers(
+				ctx, ssts[i:], kr, target-sum, epsilon,
+			)
+			if err != nil || midKey == nil {
+				return nil, 0, err
+			}
+			return midKey, sum + blockSum, nil
+		}
+		sum += sz
+		if sum >= target-epsilon {
+			// Within epsilon of target. Use this SST's upper bound.
+			ub := ssts[i].upperBound
+			if d.cmp(ub, kr.Start) <= 0 || d.cmp(ub, kr.End) >= 0 {
+				return nil, 0, nil
+			}
+			return slices.Clone(ub), sum, nil
+		}
+	}
+
+	// All SSTs consumed without reaching the target. This shouldn't happen
+	// (target is derived from the same SST sizes), but can due to rounding.
+	return nil, 0, nil
+}
+
+// mergeWalkStraddlers finds the mid key by reading index blocks from SSTs that
+// individually overshoot the target window. SSTs with effective size ≤ epsilon
+// are skipped (they can be absorbed within the error budget). The remaining
+// SSTs' index blocks are read and their block entries are merged in key order,
+// accumulating sizes until the deficit is reached.
+func (d *DB) mergeWalkStraddlers(
+	ctx context.Context, ssts []midKeySST, kr KeyRange, deficit, epsilon uint64,
+) ([]byte, uint64, error) {
+	type straddler struct {
+		entries []sstable.BlockEntry
+		pos     int
+	}
+	var straddlers []straddler
+
+	for i := range ssts {
+		if ssts[i].effectiveSize <= epsilon {
+			continue
+		}
+		entries, err := d.fileCache.collectBlockEntries(
+			ctx, ssts[i].meta, kr.Start, kr.End,
+		)
+		if err != nil {
+			return nil, 0, err
+		}
+		if len(entries) > 0 {
+			straddlers = append(straddlers, straddler{entries: entries})
+		}
+	}
+
+	if len(straddlers) == 0 {
+		// No straddlers large enough to refine. Fall back to the first
+		// SST's upper bound if it's usable.
+		ub := ssts[0].upperBound
+		if d.cmp(ub, kr.Start) > 0 && d.cmp(ub, kr.End) < 0 {
+			return slices.Clone(ub), 0, nil
+		}
+		return nil, 0, nil
+	}
+
+	// Merge-walk: repeatedly advance the straddler with the smallest
+	// current separator, accumulating block sizes until the deficit is
+	// reached.
+	var sum uint64
+	for sum < deficit {
+		best := -1
+		for i := range straddlers {
+			if straddlers[i].pos >= len(straddlers[i].entries) {
+				continue
+			}
+			if best == -1 || d.cmp(
+				straddlers[i].entries[straddlers[i].pos].Separator,
+				straddlers[best].entries[straddlers[best].pos].Separator,
+			) < 0 {
+				best = i
+			}
+		}
+		if best == -1 {
+			break
+		}
+
+		e := &straddlers[best].entries[straddlers[best].pos]
+		sum += e.Size
+		if sum >= deficit {
+			sep := e.Separator
+			if d.cmp(sep, kr.Start) <= 0 || d.cmp(sep, kr.End) >= 0 {
+				return nil, 0, nil
+			}
+			return slices.Clone(sep), sum, nil
+		}
+		straddlers[best].pos++
+	}
+
+	return nil, 0, nil
+}

--- a/mid_key_test.go
+++ b/mid_key_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApproximateMidKey(t *testing.T) {
+	opts := &Options{
+		FS:                          vfs.NewMem(),
+		DisableAutomaticCompactions: true,
+	}
+	opts.ApplyCompressionSettings(func() DBCompressionSettings {
+		return DBCompressionNone
+	})
+	d, err := Open("", opts)
+	require.NoError(t, err)
+	defer d.Close()
+
+	// Use 4KB random values. Each KV pair exceeds the default 4KB block
+	// size, so each gets its own data block. This gives SSTs many index
+	// entries for the merge-walk to bisect within.
+	value := make([]byte, 4096)
+	rand.Read(value)
+
+	// Set up a single LSM with distinct key ranges that have different
+	// structures. After setup the LSM looks like:
+	//
+	//         a       b        c          d        e
+	//
+	// L0.0          |b000---b063|                          ~260KB
+	//               |c000-c015|                           ~65KB each
+	//                 |c016-c031|
+	//                   |c032-c047|
+	//                     |c048-c063|
+	//                                 |d032-d063|         ~130KB
+	//                                             |e0-e3| ~0.5KB
+	// L6                              |d000-d031|         ~130KB
+	//
+	// Key ranges and what they exercise:
+	//   "a___": no data (empty span)
+	//   "b___": single SST — forces merge-walk into one SST's index
+	//   "c___": four L0 SSTs — coarse walk may find the boundary
+	//   "d___": data across L0 and L6
+	//   "e___": tiny data — below epsilon, returns nil
+
+	// "b" range: one flush → single SST.
+	for i := 0; i < 64; i++ {
+		require.NoError(t, d.Set([]byte(fmt.Sprintf("b%03d", i)), value, nil))
+	}
+	require.NoError(t, d.Flush())
+
+	// "c" range: flush every 16 keys → four SSTs.
+	for i := 0; i < 64; i++ {
+		require.NoError(t, d.Set([]byte(fmt.Sprintf("c%03d", i)), value, nil))
+		if (i+1)%16 == 0 {
+			require.NoError(t, d.Flush())
+		}
+	}
+
+	// "d" range: write + flush + compact to lower level, then write more to L0.
+	for i := 0; i < 32; i++ {
+		require.NoError(t, d.Set([]byte(fmt.Sprintf("d%03d", i)), value, nil))
+	}
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Compact(context.Background(), []byte("d000"), []byte("d999"), false))
+	for i := 32; i < 64; i++ {
+		require.NoError(t, d.Set([]byte(fmt.Sprintf("d%03d", i)), value, nil))
+	}
+	require.NoError(t, d.Flush())
+
+	// "e" range: a few small values.
+	for _, k := range []string{"e000", "e001", "e002", "e003"} {
+		require.NoError(t, d.Set([]byte(k), []byte("v"), nil))
+	}
+	require.NoError(t, d.Flush())
+
+	for _, tc := range []struct {
+		name    string
+		kr      KeyRange
+		epsilon uint64
+		wantNil bool // true if we expect no mid key
+	}{
+		{
+			name:    "empty-span",
+			kr:      KeyRange{Start: []byte("a000"), End: []byte("a999")},
+			epsilon: 64 << 10,
+			wantNil: true,
+		},
+		{
+			name:    "too-small-for-epsilon",
+			kr:      KeyRange{Start: []byte("e000"), End: []byte("e999")},
+			epsilon: 64 << 10,
+			wantNil: true,
+		},
+		{
+			name:    "single-sst",
+			kr:      KeyRange{Start: []byte("b000"), End: []byte("b999")},
+			epsilon: 64 << 10,
+		},
+		{
+			name:    "multiple-ssts",
+			kr:      KeyRange{Start: []byte("c000"), End: []byte("c999")},
+			epsilon: 64 << 10,
+		},
+		{
+			name:    "multiple-levels",
+			kr:      KeyRange{Start: []byte("d000"), End: []byte("d999")},
+			epsilon: 64 << 10,
+		},
+		{
+			name:    "tight-epsilon",
+			kr:      KeyRange{Start: []byte("c000"), End: []byte("c999")},
+			epsilon: 1 << 10,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			midKey, _, err := d.ApproximateMidKey(context.Background(), tc.kr, tc.epsilon)
+			require.NoError(t, err)
+
+			if tc.wantNil {
+				require.Nil(t, midKey)
+				return
+			}
+
+			require.NotNil(t, midKey, "expected a mid key")
+			require.True(t, d.cmp(midKey, tc.kr.Start) > 0, "mid key %s <= start", midKey)
+			require.True(t, d.cmp(midKey, tc.kr.End) < 0, "mid key %s >= end", midKey)
+
+			leftSize, err := d.EstimateDiskUsage(tc.kr.Start, midKey)
+			require.NoError(t, err)
+			rightSize, err := d.EstimateDiskUsage(midKey, tc.kr.End)
+			require.NoError(t, err)
+			total := leftSize + rightSize
+			if total > 0 {
+				leftPct := float64(leftSize) / float64(total)
+				require.Greater(t, leftPct, 0.15,
+					"left side too small: left=%d right=%d", leftSize, rightSize)
+				require.Less(t, leftPct, 0.85,
+					"left side too large: left=%d right=%d", leftSize, rightSize)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, finding a key that bisects a range by byte size required
iterating all keys to locate the midpoint — an O(n) scan that is
expensive for large ranges (~512MB).

Add DB.ApproximateMidKey(ctx, start, end, minSize, errBar) which finds
an approximate midpoint using only SST metadata and index blocks,
avoiding data block I/O. The errBar parameter controls precision vs I/O:
larger values need fewer index block reads, smaller values give tighter
results.

The algorithm works in three phases:

Phase 1 — Determine total size: SSTs fully contained in [start, end)
contribute exact sizes. Partially-overlapping edge SSTs are resolved
from largest to smallest by reading their index blocks until the total
size uncertainty is within 2×errBar (since target = totalSize/2, this
ensures the target is known to within errBar).

Phase 2 — Coarse walk: SSTs are walked in upper-bound key order,
accumulating sizes. If the cumulative total lands within errBar of
totalSize/2, the SST boundary where this happens is a good-enough mid
key with no further I/O.

Phase 3 — Merge-walk straddlers: SSTs that individually overshoot the
target ± errBar window must be partially consumed. Their index blocks
are read and block entries are merge-walked in key order across all
straddling SSTs (at most one per LSM level), accumulating sizes until
the deficit is reached. The set of indexes opened is provably minimal:
if a file's size were ≤ errBar it could have been fully added or
skipped, so its index read would never be needed.