### PR TITLE
objstorage: add encrypting writable and decrypting readable

### DIFF
--- a/objstorage/objstorageprovider/encryption.go
+++ b/objstorage/objstorageprovider/encryption.go
@@ -1,0 +1,261 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorageprovider
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	crypto_rand "crypto/rand"
+	"encoding/binary"
+	"sync"
+
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/pkg/errors"
+)
+
+const (
+	externalEncryptionVersion  = 2
+	externalEncryptionPreamble = "encrypt"
+
+	externalEncryptionNonceSize  = 12                                                                // GCM standard nonce
+	externalEncryptionHeaderSize = len(externalEncryptionPreamble) + 1 + externalEncryptionNonceSize // preamble + version + iv
+	externalEncryptionTagSize    = 16                                                                // GCM standard tag
+)
+
+var externalEncryptionChunkSize = 64 << 10 // 64kb
+
+type ExternalFileDecryptingReadable struct {
+	ciphertext objstorage.Readable
+
+	mu        sync.Mutex
+	g         cipher.AEAD
+	fileIV    []byte
+	ivScratch []byte
+	buf       []byte
+	chunk     int64
+}
+
+func NewExternalFileDecryptingReadable(
+	ctx context.Context, ciphertext objstorage.Readable, key [32]byte,
+) (objstorage.Readable, error) {
+	gcm, err := aesgcm(key[0:])
+	if err != nil {
+		return nil, err
+	}
+
+	header := make([]byte, externalEncryptionHeaderSize)
+	readHeaderErr := ciphertext.ReadAt(ctx, header, 0)
+
+	// Verify that the read data does indeed look like an encrypted file and has
+	// a encoding version we can decode.
+	if !ExternalFileAppearsEncrypted(header) {
+		return nil, errors.New("file does not appear to be encrypted")
+	}
+	if readHeaderErr != nil {
+		return nil, errors.Wrap(readHeaderErr, "invalid encryption header")
+	}
+
+	version := header[len(externalEncryptionPreamble)]
+	if version != externalEncryptionVersion {
+		return nil, errors.Errorf("unexpected encryption scheme/config version %d", version)
+	}
+	iv := header[len(externalEncryptionPreamble)+1:]
+
+	buf := make([]byte, externalEncryptionNonceSize, externalEncryptionChunkSize+externalEncryptionTagSize+externalEncryptionNonceSize)
+	ivScratch := buf[:externalEncryptionNonceSize]
+	buf = buf[externalEncryptionNonceSize:externalEncryptionNonceSize]
+	readable := &ExternalFileDecryptingReadable{
+		ciphertext: ciphertext,
+		mu:         sync.Mutex{},
+		g:          gcm,
+		fileIV:     iv,
+		ivScratch:  ivScratch,
+		buf:        buf,
+		chunk:      -1,
+	}
+	return readable, err
+}
+func (er *ExternalFileDecryptingReadable) ReadAt(ctx context.Context, p []byte, off int64) error {
+	// Ensure that the section we want to read is within bounds.
+	if off < 0 || er.Size() < off+int64(len(p)) {
+		return errors.New("bad offset")
+	}
+
+	er.mu.Lock()
+	defer er.mu.Unlock()
+
+	var read int
+	for {
+		chunk := off / int64(externalEncryptionChunkSize)
+		offsetInChunk := off % int64(externalEncryptionChunkSize)
+
+		if err := er.fill(ctx, chunk); err != nil {
+			return err
+		}
+
+		// Copy from the chunk.
+		n := copy(p[read:], er.buf[offsetInChunk:])
+		read += n
+
+		// Return if we've fulfilled the request.
+		if read == len(p) {
+			return nil
+		}
+
+		// Move offset by how much we read and go again.
+		off += int64(n)
+	}
+}
+func (er *ExternalFileDecryptingReadable) Close() error {
+	return er.ciphertext.Close()
+}
+func (er *ExternalFileDecryptingReadable) Size() int64 {
+	size := er.ciphertext.Size()
+	size -= int64(externalEncryptionHeaderSize)
+	size -= externalEncryptionTagSize * ((size / (int64(externalEncryptionChunkSize) + externalEncryptionTagSize)) + 1)
+	return size
+}
+func (er *ExternalFileDecryptingReadable) NewReadHandle(
+	readBeforeSize objstorage.ReadBeforeSize,
+) objstorage.ReadHandle {
+	handle := objstorage.MakeNoopReadHandle(er)
+	return &handle
+}
+
+func (er *ExternalFileDecryptingReadable) fill(ctx context.Context, chunk int64) error {
+	if chunk == er.chunk {
+		return nil // this chunk is already loaded in buf.
+	}
+
+	er.chunk = -1 // invalidate the current buffered chunk while we fill it.
+
+	// Load the region of ciphertext that corresponds to chunk.
+	ciphertextSize := er.ciphertext.Size()
+	ciphertextChunkSize := int64(externalEncryptionChunkSize) + externalEncryptionTagSize
+	start := int64(externalEncryptionHeaderSize) + chunk*ciphertextChunkSize
+	fillSize := min(cap(er.buf), int(ciphertextSize-start))
+	err := er.ciphertext.ReadAt(ctx, er.buf[:fillSize], start)
+	if err != nil {
+		return err
+	}
+	er.buf = er.buf[:fillSize]
+
+	buf, err := er.g.Open(er.buf[:0], er.chunkIV(chunk), er.buf, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to decrypt — maybe incorrect key")
+	}
+	er.buf = buf
+	er.chunk = chunk
+	return err
+}
+func (er *ExternalFileDecryptingReadable) chunkIV(num int64) []byte {
+	er.ivScratch = append(er.ivScratch[:0], er.fileIV...)
+	binary.BigEndian.PutUint64(
+		er.ivScratch[4:], binary.BigEndian.Uint64(er.ivScratch[4:])+uint64(num),
+	)
+	return er.ivScratch
+}
+
+type ExternalFileEncryptingWritable struct {
+	ciphertext objstorage.Writable
+	gcm        cipher.AEAD
+	iv         []byte
+
+	buf    []byte
+	bufPos int
+}
+
+func NewExternalFileEncryptingWritable(
+	ctx context.Context, ciphertext objstorage.Writable, key [32]byte,
+) (objstorage.Writable, error) {
+	gcm, err := aesgcm(key[0:])
+	if err != nil {
+		ciphertext.Abort()
+		return nil, err
+	}
+
+	header := make([]byte, len(externalEncryptionPreamble)+1+externalEncryptionNonceSize)
+	copy(header, externalEncryptionPreamble)
+	header[len(externalEncryptionPreamble)] = externalEncryptionVersion
+
+	// Pick a unique IV for this file and write it in the header.
+	ivStart := len(externalEncryptionPreamble) + 1
+	iv := make([]byte, externalEncryptionNonceSize)
+	if _, err := crypto_rand.Read(iv); err != nil {
+		ciphertext.Abort()
+		return nil, err
+	}
+	copy(header[ivStart:], iv)
+
+	// Write our header (preamble+version+IV) to the ciphertext sink.
+	if err := ciphertext.Write(header); err != nil {
+		ciphertext.Abort()
+		return nil, err
+	}
+
+	writable := &ExternalFileEncryptingWritable{
+		gcm: gcm, iv: iv, ciphertext: ciphertext, buf: make([]byte, externalEncryptionChunkSize+externalEncryptionTagSize),
+	}
+	return writable, nil
+}
+func (ew *ExternalFileEncryptingWritable) Write(p []byte) error {
+	var wrote int
+	for wrote < len(p) {
+		copied := copy(ew.buf[ew.bufPos:externalEncryptionChunkSize], p[wrote:])
+		ew.bufPos += copied
+		if ew.bufPos == externalEncryptionChunkSize {
+			if err := ew.flush(); err != nil {
+				return err
+			}
+		}
+		wrote += copied
+	}
+	return nil
+}
+func (ew *ExternalFileEncryptingWritable) Finish() error {
+	// Note: there may not be any plaintext left to seal if the chunk we just
+	// finished was the end of it, but sealing the (empty) remainder in a final
+	// chunk maintains the invariant that a chunked file always ends in a sealed
+	// chunk of less than chunk size, thus making tuncation, even along a chunk
+	// boundary, detectable.
+	if err := ew.flush(); err != nil {
+		ew.ciphertext.Abort()
+		return err
+	}
+	return ew.ciphertext.Finish()
+}
+func (ew *ExternalFileEncryptingWritable) StartMetadataPortion() error {
+	if err := ew.flush(); err != nil {
+		return err
+	}
+	return ew.ciphertext.StartMetadataPortion()
+}
+func (ew *ExternalFileEncryptingWritable) Abort() {
+	ew.ciphertext.Abort()
+}
+
+func (ew *ExternalFileEncryptingWritable) flush() error {
+	ew.buf = ew.gcm.Seal(ew.buf[:0], ew.iv, ew.buf[:ew.bufPos], nil)
+	if err := ew.ciphertext.Write(ew.buf); err != nil {
+		return err
+	}
+	binary.BigEndian.PutUint64(ew.iv[4:], binary.BigEndian.Uint64(ew.iv[4:])+1)
+	ew.bufPos = 0
+	return nil
+}
+
+func ExternalFileAppearsEncrypted(text []byte) bool {
+	return bytes.HasPrefix(text, []byte(externalEncryptionPreamble))
+}
+
+func aesgcm(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}

--- a/objstorage/objstorageprovider/encryption_test.go
+++ b/objstorage/objstorageprovider/encryption_test.go
@@ -1,0 +1,314 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package objstorageprovider
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/internal/testutils"
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	seed := uint64(time.Now().UnixNano())
+	rng := rand.New(rand.NewPCG(seed, seed))
+	var key [32]byte
+	copy(key[:], testutils.RandBytes(rng, 32))
+
+	t.Run("EncryptFile+DecryptFile", func(t *testing.T) {
+		for _, textCopies := range []int{1, 3, 10, 100, 10000} {
+			plaintext := bytes.Repeat([]byte("hello world\n"), textCopies)
+			t.Run(fmt.Sprintf("copies=%d", textCopies), func(t *testing.T) {
+				for _, chunkSize := range []int{1, 7, 64, 1 << 10, 1 << 20} {
+					externalEncryptionChunkSize = chunkSize
+
+					t.Run("chunk="+fmt.Sprintf("%d", chunkSize), func(t *testing.T) {
+						ciphertext, err := fullEncrypt(t.Context(), plaintext, key)
+						require.NoError(t, err)
+						require.True(t, ExternalFileAppearsEncrypted(ciphertext), "cipher text should appear encrypted")
+
+						decrypted, err := fullDecrypt(t.Context(), ciphertext, key)
+						require.NoError(t, err)
+						require.Equal(t, plaintext, decrypted)
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("helpful error on bad input", func(t *testing.T) {
+		_, err := fullDecrypt(t.Context(), []byte("a"), key)
+		require.EqualError(t, err, "file does not appear to be encrypted")
+	})
+
+	t.Run("ReadAt", func(t *testing.T) {
+		rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
+
+		externalEncryptionChunkSize = 32
+
+		plaintext := testutils.RandBytes(rng, 256)
+		plainReadable := plainReadable(t, plaintext)
+
+		ciphertext, err := fullEncrypt(t.Context(), plaintext, key)
+		require.NoError(t, err)
+
+		var encryptedReadable objstorage.MemObj
+		require.NoError(t, encryptedReadable.Write(ciphertext))
+		decryptingReadable, err := NewExternalFileDecryptingReadable(
+			t.Context(), &encryptedReadable, key,
+		)
+		require.NoError(t, err)
+
+		t.Run("start", func(t *testing.T) {
+			expected := make([]byte, 24)
+			got := make([]byte, len(expected))
+
+			require.NoError(t, plainReadable.ReadAt(t.Context(), expected, 0))
+			require.NoError(t, decryptingReadable.ReadAt(t.Context(), got, 0))
+			require.Equal(t, expected, got)
+		})
+
+		t.Run("spanning", func(t *testing.T) {
+			expected := make([]byte, 24)
+			got := make([]byte, len(expected))
+
+			require.NoError(t, plainReadable.ReadAt(t.Context(), expected, 30))
+			require.NoError(t, decryptingReadable.ReadAt(t.Context(), got, 30))
+			require.Equal(t, expected, got)
+
+			expectedEmpty := make([]byte, 0)
+			gotEmpty := make([]byte, 0)
+			expectedEmptyErr := plainReadable.ReadAt(t.Context(), expectedEmpty, 30)
+			gotEmptyErr := decryptingReadable.ReadAt(t.Context(), gotEmpty, 30)
+
+			require.Equal(t, expectedEmptyErr != nil, gotEmptyErr != nil)
+			require.Equal(t, expectedEmpty, gotEmpty)
+		})
+
+		t.Run("to-end", func(t *testing.T) {
+			expected := make([]byte, 24)
+			got := make([]byte, len(expected))
+
+			require.NoError(t, plainReadable.ReadAt(t.Context(), expected, 256-24))
+			require.NoError(t, decryptingReadable.ReadAt(t.Context(), got, 256-24))
+			require.Equal(t, expected, got)
+		})
+
+		t.Run("spanning-end", func(t *testing.T) {
+			expected := make([]byte, 100)
+			got := make([]byte, len(expected))
+
+			require.Error(t, plainReadable.ReadAt(t.Context(), expected, 180))
+			require.Error(t, decryptingReadable.ReadAt(t.Context(), got, 180))
+			require.Equal(t, expected, got)
+		})
+
+		t.Run("after-end", func(t *testing.T) {
+			expected := make([]byte, 24)
+			got := make([]byte, len(expected))
+
+			require.Error(t, plainReadable.ReadAt(t.Context(), expected, 300))
+			require.Error(t, decryptingReadable.ReadAt(t.Context(), got, 300))
+			require.Equal(t, expected, got)
+
+			expectedEmpty := make([]byte, 0)
+			gotEmpty := make([]byte, 0)
+			require.Error(t, plainReadable.ReadAt(t.Context(), expectedEmpty, 300))
+			require.Error(t, decryptingReadable.ReadAt(t.Context(), gotEmpty, 300))
+			require.Equal(t, expectedEmpty, gotEmpty)
+		})
+	})
+
+	t.Run("Random", func(t *testing.T) {
+		t.Run("DecryptFile", func(t *testing.T) {
+			// For some number of randomly chosen chunk-sizes, generate a number
+			// of random length plaintexts of random bytes and ensure they each
+			// round-trip.
+			for i := 0; i < 10; i++ {
+				externalEncryptionChunkSize = rng.IntN(1024*24) + 1
+				for j := 0; j < 100; j++ {
+					plaintext := testutils.RandBytes(rng, rng.IntN(1024*32))
+					ciphertext, err := fullEncrypt(t.Context(), plaintext, key)
+					require.NoError(t, err)
+					decrypted, err := fullDecrypt(t.Context(), ciphertext, key)
+					require.NoError(t, err)
+					if len(plaintext) == 0 {
+						require.Equal(t, len(plaintext), len(decrypted))
+					} else {
+						require.Equal(t, plaintext, decrypted)
+					}
+				}
+			}
+		})
+
+		t.Run("ReadAt", func(t *testing.T) {
+			// For each random size of chunk and text, verify random reads.
+			const chunkSizes, textSizes, reads = 10, 100, 500
+
+			for i := 0; i < chunkSizes; i++ {
+				externalEncryptionChunkSize = rng.IntN(1024*24) + 1
+				for j := 0; j < textSizes; j++ {
+					plaintext := testutils.RandBytes(rng, rng.IntN(1024*32))
+					plainReadable := plainReadable(t, plaintext)
+
+					ciphertext, err := fullEncrypt(t.Context(), plaintext, key)
+					require.NoError(t, err)
+
+					var encryptedReadable objstorage.MemObj
+					require.NoError(t, encryptedReadable.Write(ciphertext))
+					decryptingReadable, err := NewExternalFileDecryptingReadable(t.Context(), &encryptedReadable, key)
+					require.NoError(t, err)
+
+					for k := 0; k < reads; k++ {
+						start := rng.Int64N(int64(float64(len(plaintext)+1) * 1.1))
+
+						expected := make([]byte, rng.Int64N(int64(len(plaintext)/2+1)))
+						got := make([]byte, len(expected))
+						expectedErr := plainReadable.ReadAt(t.Context(), expected, start)
+						gotErr := decryptingReadable.ReadAt(t.Context(), got, start)
+
+						if expectedErr != nil {
+							require.Error(t, gotErr)
+						} else {
+							require.NoError(t, gotErr)
+						}
+						require.Equal(t, expected, got)
+					}
+				}
+			}
+		})
+	})
+}
+
+func BenchmarkEncryptDecrypt(b *testing.B) {
+	seed := uint64(time.Now().UnixNano())
+	rng := rand.New(rand.NewPCG(seed, seed))
+	var key [32]byte
+	copy(key[:], testutils.RandBytes(rng, 32))
+
+	plaintext1KB := bytes.Repeat([]byte("0123456789abcdef"), 64)
+	plaintext100KB := bytes.Repeat(plaintext1KB, 100)
+	plaintext1MB := bytes.Repeat(plaintext1KB, 1024)
+	plaintext64MB := bytes.Repeat(plaintext1MB, 64)
+
+	chunkSizes := []int{100, 4096, 512 << 10, 1 << 20}
+	ciphertext1KB := make([][]byte, len(chunkSizes))
+	ciphertext100KB := make([][]byte, len(chunkSizes))
+	ciphertext1MB := make([][]byte, len(chunkSizes))
+	ciphertext64MB := make([][]byte, len(chunkSizes))
+	b.ResetTimer()
+
+	b.Run("EncryptFile", func(b *testing.B) {
+		for _, plaintext := range [][]byte{plaintext1KB, plaintext100KB, plaintext1MB, plaintext64MB} {
+			b.Run(fmt.Sprintf("%d", len(plaintext)), func(b *testing.B) {
+				for _, chunkSize := range chunkSizes {
+					externalEncryptionChunkSize = chunkSize
+					b.Run(fmt.Sprintf("chunk=%d", chunkSize), func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							_, err := fullEncrypt(b.Context(), plaintext, key)
+							if err != nil {
+								b.Fatal(err)
+							}
+						}
+						b.SetBytes(int64(len(plaintext)))
+					})
+				}
+			})
+		}
+	})
+
+	var err error
+	for i, chunkSize := range chunkSizes {
+		externalEncryptionChunkSize = chunkSize
+		ciphertext1KB[i], err = fullEncrypt(b.Context(), plaintext1KB, key)
+		require.NoError(b, err)
+		ciphertext100KB[i], err = fullEncrypt(b.Context(), plaintext100KB, key)
+		require.NoError(b, err)
+		ciphertext1MB[i], err = fullEncrypt(b.Context(), plaintext1MB, key)
+		require.NoError(b, err)
+		ciphertext64MB[i], err = fullEncrypt(b.Context(), plaintext64MB, key)
+		require.NoError(b, err)
+	}
+	b.ResetTimer()
+
+	b.Run("DecryptFile", func(b *testing.B) {
+		for _, ciphertextOriginal := range [][][]byte{
+			ciphertext1KB, ciphertext100KB, ciphertext1MB, ciphertext64MB,
+		} {
+			// Decrypt reuses/clobbers the original ciphertext slice.
+			b.Run(fmt.Sprintf("%d", len(ciphertextOriginal[0])), func(b *testing.B) {
+				for chunkSizeNum, chunkSize := range chunkSizes {
+					externalEncryptionChunkSize = chunkSize
+
+					b.Run(fmt.Sprintf("chunk=%d", chunkSize), func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							_, err := fullDecrypt(b.Context(), ciphertextOriginal[chunkSizeNum], key)
+							if err != nil {
+								b.Fatal(err)
+							}
+						}
+						b.SetBytes(int64(len(ciphertextOriginal[chunkSizeNum])))
+					})
+				}
+			})
+		}
+	})
+}
+
+func fullEncrypt(ctx context.Context, plaintext []byte, key [32]byte) ([]byte, error) {
+	var b objstorage.MemObj
+	w, err := NewExternalFileEncryptingWritable(ctx, &b, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := w.Write(plaintext); err != nil {
+		w.Abort()
+		return nil, err
+	}
+
+	if err := w.Finish(); err != nil {
+		return nil, err
+	}
+
+	return b.Data(), nil
+}
+
+func fullDecrypt(ctx context.Context, ciphertext []byte, key [32]byte) ([]byte, error) {
+	var w objstorage.MemObj
+	err := w.Write(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := NewExternalFileDecryptingReadable(ctx, &w, key)
+	if err != nil {
+		return nil, err
+	}
+
+	decrypted := make([]byte, r.Size())
+	err = r.ReadAt(ctx, decrypted, 0)
+	if err != nil {
+		return nil, err
+	}
+	return decrypted, nil
+}
+
+// plainReadable returns a MemObj with bytes loaded in.
+// Note that this function will make a copy of bytes as Writable.Write is allowed to mangle
+// buffers, so this function ensures the passed bytes are not mangled themselves.
+func plainReadable(t *testing.T, bytes []byte) objstorage.Readable {
+	b := make([]byte, len(bytes))
+	copy(b, bytes)
+	var r objstorage.MemObj
+	require.NoError(t, r.Write(b))
+	return &r
+}


### PR DESCRIPTION
This patch adds encrypting writable and decrypting readable implementations for the purposes of supporting encrypted backups in online restore.