### PR TITLE
docs: snap chart hover elements to nearest data point

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -456,14 +456,7 @@ function renderChart(chart) {
                     : vals[i];
         const noData = mousex < x(vals[0].date);
 
-        let lineY = height;
-        if (!noData) {
-            if (hover == 1) {
-                lineY = pathGetY(path1.node(), mousex);
-            } else {
-                lineY = pathGetY(path2.node(), mousex);
-            }
-        }
+        const vx = x(v.date);
 
         let val, valY, valFormat;
         if (hover == 1) {
@@ -477,23 +470,23 @@ function renderChart(chart) {
         }
 
         lineHover
-            .attr("x1", mousex)
-            .attr("x2", mousex)
-            .attr("y1", lineY)
+            .attr("x1", vx)
+            .attr("x2", vx)
+            .attr("y1", valY)
             .attr("y2", height);
-        marker.attr("transform", "translate(" + x(v.date) + "," + valY + ")");
+        marker.attr("transform", "translate(" + vx + "," + valY + ")");
         dateHover
-            .attr("transform", "translate(" + mousex + "," + (height + 8) + ")")
-            .text(xFormat(date));
+            .attr("transform", "translate(" + vx + "," + (height + 8) + ")")
+            .text(xFormat(v.date));
         opsHover
             .attr(
                 "transform",
-                "translate(" + x(v.date) + "," + (valY - 7) + ")"
+                "translate(" + vx + "," + (valY - 7) + ")"
             )
             .text(valFormat(val));
         if (v.sha) {
             shaHover
-                .attr("transform", "translate(" + mousex + "," + (height + 19) + ")")
+                .attr("transform", "translate(" + vx + "," + (height + 19) + ")")
                 .text(v.sha.substring(0, 10))
                 .style("opacity", 1);
         } else {

--- a/docs/js/write-throughput.js
+++ b/docs/js/write-throughput.js
@@ -201,10 +201,7 @@ function renderWriteThroughputSummary(allData) {
                     : data[i];
         const noData = mousex < x(parseTime(data[0].date));
 
-        let lineY = height;
-        if (!noData) {
-            lineY = pathGetY(path.node(), mousex);
-        }
+        const vx = x(parseTime(v.date));
 
         let val, valY, valFormat;
         val = v.opsSec;
@@ -212,20 +209,20 @@ function renderWriteThroughputSummary(allData) {
         valFormat = d3.format(",.0f");
 
         lineHover
-            .attr("x1", mousex)
-            .attr("x2", mousex)
-            .attr("y1", lineY)
+            .attr("x1", vx)
+            .attr("x2", vx)
+            .attr("y1", valY)
             .attr("y2", height);
-        marker.attr("transform", "translate(" + x(parseTime(v.date)) + "," + valY + ")");
+        marker.attr("transform", "translate(" + vx + "," + valY + ")");
         dateHover
-            .attr("transform", "translate(" + mousex + "," + (height + 8) + ")")
-            .text(formatTime(date));
+            .attr("transform", "translate(" + vx + "," + (height + 8) + ")")
+            .text(formatTime(parseTime(v.date)));
         opsHover
-            .attr("transform", "translate(" + x(parseTime(v.date)) + "," + (valY - 7) + ")")
+            .attr("transform", "translate(" + vx + "," + (valY - 7) + ")")
             .text(valFormat(val));
         if (v.sha) {
             shaHover
-                .attr("transform", "translate(" + mousex + "," + (height + 19) + ")")
+                .attr("transform", "translate(" + vx + "," + (height + 19) + ")")
                 .text(v.sha.substring(0, 10))
                 .style("opacity", 1);
         } else {


### PR DESCRIPTION
Previously, the hover line, date, and SHA text followed the cursor
position while the marker dot snapped to the nearest data point. This
made the displayed date not match the highlighted point when hovering
between data points. Now all hover elements (line, marker, date,
ops/sec, SHA) snap to the nearest data point's position.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>