### PR TITLE
crl-release-26.1: metamorphic: cap cache size on 32-bit builds

### DIFF
--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -652,7 +653,13 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	}
 
 	opts.BytesPerSync = int(randPowerOf2(rng, 0, 28)) // 1B - 256MB
-	opts.CacheSize = int64(randPowerOf2(rng, 0, 30))  // 1B - 1GB
+	cacheSizeMax := 30                                // 1B - 1GB
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		// Cap the cache size on 32-bit builds to avoid OOMs due to the
+		// limited user-space address space (~3GB on Linux).
+		cacheSizeMax = 27 // 1B - 128MB
+	}
+	opts.CacheSize = int64(randPowerOf2(rng, 0, cacheSizeMax))
 	opts.DisableWAL = rng.IntN(2) == 0
 	opts.FlushDelayDeleteRange = time.Millisecond * time.Duration(randInRange(rng, 5, 250)) // 5-250ms
 	opts.FlushDelayRangeKey = time.Millisecond * time.Duration(randInRange(rng, 5, 250))    // 5-250ms


### PR DESCRIPTION
Backport e332a165 from master to crl-release-26.1

RandomOptions could generate cache sizes up to 1 GB (2^30). On 32-bit Linux, the ~3 GB user-space address space limit meant that combined with Go runtime overhead and CockroachDB's key encoding, individual TestMetaCockroachKVs child processes could consume 3.3-3.8 GB and OOM.

Cap the upper bound to 128 MB (2^27) on 32-bit builds. This is the largest power of 2 that keeps worst-case total memory under ~3 GB.