### PR TITLE
crl-release-26.1: db: fix TestCompactionCorruption flake in wait-for-no-external-files

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3226,6 +3226,11 @@ func TestCompactionCorruption(t *testing.T) {
 
 		case "wait-for-no-external-files":
 			wait("no external files", func() bool {
+				// Keep advancing fake time to expire any problem spans
+				// that may have been re-created by a compaction failure
+				// racing with the table stats goroutine through the file
+				// cache (see the comment on the manual-compaction case).
+				now.Store(now.Load() + crtime.Mono(30*time.Minute))
 				return !hasExternalFiles(d)
 			})
 


### PR DESCRIPTION
After expire-spans advances fake time, an automatic L0→L6 compaction can race with the background table stats goroutine through the file cache. If the stats goroutine begins opening the external file before move-remote-object completes, both it and the compaction share the same in-progress file cache entry and receive a stale "object does not exist" error. The failed compaction then calls RecordError, which creates a new problem span on L6 with a 5-minute expiration relative to the (already advanced) fake time. Since fake time is never advanced again, this problem span never expires and all overlapping L0→L6 compactions are permanently blocked.

The fix mirrors the approach used for the manual-compaction case: continuously advance fake time during the wait-for-no-external-files poll loop so that any re-created problem spans expire promptly, allowing the compaction to retry and succeed.

I'm not entirely sure why we do not see this problem on master (I also tried to get Claude to do some thorough investigation, but it came up short) - my only guess is due to new code/refactorings that change the shape of the LSM  between versions. I stressed this for 15 hours on my gce worker on 25.4 with the 5 sec timeout in the code and all runs have been successful.

Informs: #5752