### PR TITLE
internal/rangedel: return TombstoneSpanGetter from Interleave instead of func

### DIFF
--- a/db.go
+++ b/db.go
@@ -1389,7 +1389,7 @@ func (i *Iterator) constructPointIter(
 			li.initCombinedIterState(&i.lazyCombinedIter.combinedIterState)
 			mlevels[mlevelsIndex].levelIter = li
 			mlevels[mlevelsIndex].iter = invalidating.MaybeWrapIfInvariants(li)
-			mlevels[mlevelsIndex].getTombstone = li.getTombstone
+			mlevels[mlevelsIndex].getTombstone = li
 
 			levelsIndex++
 			mlevelsIndex++

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -78,6 +78,12 @@ type Key struct {
 	Value []byte
 }
 
+// TombstoneSpanGetter is implemented by iterators that can return the range
+// tombstone span covering the current iterator position.
+type TombstoneSpanGetter interface {
+	Span() *Span
+}
+
 // SeqNum returns the sequence number component of the key.
 func (k Key) SeqNum() base.SeqNum {
 	return k.Trailer.SeqNum()

--- a/internal/rangedel/rangedel.go
+++ b/internal/rangedel/rangedel.go
@@ -68,16 +68,16 @@ func DecodeIntoSpan(cmp base.Compare, ik base.InternalKey, v []byte, s *keyspan.
 // iterator that interleaves range deletion boundary keys at the maximal
 // sequence number among the stream of point keys.
 //
-// In addition, Interleave returns a function that may be used to retrieve the
-// range tombstone overlapping the current iterator position, if any. If range
-// deletion iterator is nil, the returned function is nil.
+// In addition, Interleave returns a TombstoneSpanGetter that may be used to
+// retrieve the range tombstone overlapping the current iterator position, if
+// any. If range deletion iterator is nil, the returned getter is nil.
 //
 // The returned iterator must only be closed once.
 func Interleave(
 	comparer *base.Comparer, iter base.InternalIterator, rangeDelIter keyspan.FragmentIterator,
-) (base.InternalIterator, func() *keyspan.Span) {
+) (base.InternalIterator, keyspan.TombstoneSpanGetter) {
 	// If there is no range deletion iterator, don't bother using an interleaving
-	// iterator. We can return iter verbatim and a nil func.
+	// iterator. We can return iter verbatim and a nil getter.
 	if rangeDelIter == nil {
 		return iter, nil
 	}
@@ -86,7 +86,7 @@ func Interleave(
 	ii.Init(comparer, iter, rangeDelIter, keyspan.InterleavingIterOpts{
 		InterleaveEndKeys: true,
 	})
-	return ii, ii.Span
+	return ii, ii
 }
 
 var interleavingIterPool = sync.Pool{

--- a/level_checker.go
+++ b/level_checker.go
@@ -59,7 +59,7 @@ type simpleMergingIterLevel struct {
 	iter internalIterator
 	// getTombstone returns the range deletion tombstone covering the current
 	// iterator position. getTombstone must not be called after iter is closed.
-	getTombstone func() *keyspan.Span
+	getTombstone keyspan.TombstoneSpanGetter
 	iterKV       *base.InternalKV
 }
 
@@ -259,7 +259,7 @@ func (m *simpleMergingIter) handleVisiblePoint(
 		if lvl.getTombstone == nil {
 			continue
 		}
-		t := lvl.getTombstone()
+		t := lvl.getTombstone.Span()
 		if t.Empty() {
 			continue
 		}
@@ -624,7 +624,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 			manifest.L0Sublevel(sublevel), internalOpts)
 		li.interleaveRangeDels = true
 		mlevelAlloc[0].iter = li
-		mlevelAlloc[0].getTombstone = li.getTombstone
+		mlevelAlloc[0].getTombstone = li
 		mlevelAlloc = mlevelAlloc[1:]
 		for f := range current.L0SublevelFiles[sublevel].All() {
 			allTables = append(allTables, f)
@@ -640,7 +640,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 			current.Levels[level].Iter(), manifest.Level(level), internalOpts)
 		li.interleaveRangeDels = true
 		mlevelAlloc[0].iter = li
-		mlevelAlloc[0].getTombstone = li.getTombstone
+		mlevelAlloc[0].getTombstone = li
 		mlevelAlloc = mlevelAlloc[1:]
 		for f := range current.Levels[level].All() {
 			allTables = append(allTables, f)

--- a/level_iter.go
+++ b/level_iter.go
@@ -610,7 +610,7 @@ func (l *levelIter) loadFile(file *manifest.TableMetadata, dir int) loadFileRetu
 			if l.rangeDelIterSetter != nil {
 				// TODO(jackson): This should be avoidable by teaching the
 				// merging iterator to read range deletions from
-				// levelIter.getTombstone() but requires some delicate
+				// levelIter.Span() but requires some delicate
 				// refactoring. See the unmerged PR #3600.
 				itersForSetter, err := l.newIters(l.ctx, l.iterFile, &l.tableOpts, l.internalOpts, iterRangeDeletions)
 				if err != nil {
@@ -1104,13 +1104,13 @@ func (l *levelIter) exhaustedBackward() {
 	l.exhaustedDir = -1
 }
 
-// getTombstone retrieves the range tombstone covering the current iterator
-// position. If there is none, or if the iterator is not configured to
-// interleave range deletions, getTombstone returns nil.
+// Span implements keyspan.TombstoneSpanGetter, returning the range tombstone
+// covering the current iterator position. If there is none, or if the iterator
+// is not configured to interleave range deletions, Span returns nil.
 //
 // The returned Span's memory is guaranteed to be valid until the iterator is
 // moved beyond the Span's interleaved boundary keys.
-func (l *levelIter) getTombstone() *keyspan.Span {
+func (l *levelIter) Span() *keyspan.Span {
 	if l.iter != &l.interleaving {
 		return nil
 	}

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -317,7 +317,7 @@ func TestMergingIterDataDriven(t *testing.T) {
 				li.interleaveRangeDels = true
 				levelIters = append(levelIters, mergingIterLevel{
 					iter:         li,
-					getTombstone: li.getTombstone,
+					getTombstone: li,
 				})
 			}
 			miter := &mergingIter{}
@@ -716,7 +716,7 @@ func buildMergingIter(readers [][]*sstable.Reader, levelSlices []manifest.LevelS
 			manifest.Level(level), internalIterOpts{})
 		l.interleaveRangeDels = true
 		mils[level].iter = l
-		mils[level].getTombstone = l.getTombstone
+		mils[level].getTombstone = l
 	}
 	var stats base.InternalIteratorStats
 	m := &mergingIter{}

--- a/treesteps_test.go
+++ b/treesteps_test.go
@@ -72,7 +72,7 @@ func TestTreeSteps(t *testing.T) {
 					var opts IterOptions
 					li := newLevelIter(t.Context(), opts, testkeys.Comparer, d.newIters, v.Levels[l].Iter(), manifest.Level(l), internalIterOpts{})
 					li.interleaveRangeDels = true
-					levelIters = append(levelIters, mergingIterLevel{iter: li, getTombstone: li.getTombstone})
+					levelIters = append(levelIters, mergingIterLevel{iter: li, getTombstone: li})
 				}
 				miter := &mergingIter{}
 				var stats base.InternalIteratorStats


### PR DESCRIPTION
Returning ii.Span allocated a method value that captured the interleaving iterator. This patch returns the iterator as a keyspan.TombstoneSpanGetter instead so callers call Span() on the interface with no allocation.