### PR TITLE
ingest: skip data overlap probing for external file ingestion

### DIFF
--- a/internal/overlap/checker_test.go
+++ b/internal/overlap/checker_test.go
@@ -101,8 +101,13 @@ func TestChecker(t *testing.T) {
 
 		case "overlap":
 			var metas []*manifest.TableMetadata
+			skipProbe := false
 			lines := strings.Split(d.Input, "\n")
 			for _, arg := range d.CmdArgs {
+				if arg.Key == "skip-probe" {
+					skipProbe = true
+					continue
+				}
 				name := arg.String()
 				m := byName[name]
 				if m == nil {
@@ -112,6 +117,9 @@ func TestChecker(t *testing.T) {
 			}
 			levelMeta := manifest.MakeLevelMetadata(bytes.Compare, 1 /* level */, metas)
 			c := MakeChecker(bytes.Compare, tables)
+			if skipProbe {
+				c.SkipProbe = func(m *manifest.TableMetadata) bool { return true }
+			}
 			var buf strings.Builder
 			for _, l := range lines {
 				bounds := base.ParseUserKeyBounds(l)

--- a/internal/overlap/testdata/checker
+++ b/internal/overlap/testdata/checker
@@ -26,6 +26,17 @@ overlap t1
 [u, w]: possible data overlap   iterators opened: none
 [v, w]: no overlap   iterators opened: none
 
+# With skip-probe, regions that would be probed (single enclosing file,
+# no endpoint match) are pessimistically reported as Data without opening
+# iterators. Compare [b1, b2] and [e, u) above which returned OnlyBoundary.
+
+overlap t1 skip-probe
+[b1, b2]
+[e, u)
+----
+[b1, b2]: possible data overlap   iterators opened: none
+[e, u): possible data overlap   iterators opened: none
+
 define t2
 range-dels:
   b-e:{#1,RANGEDEL}


### PR DESCRIPTION
IngestExternalFiles opens existing LSM files to probe for data overlap
during level targeting. For external files with remote backings, this
triggers network I/O on what should be a metadata-only path.

Add a SkipLevelProbe option that makes the overlap checker
pessimistically assume data overlap when an existing file's bounds
enclose the ingested file's region, rather than opening the file. This
avoids I/O at the cost of placing files higher in the LSM than
necessary; normal compactions move them down eventually.

Set SkipLevelProbe for IngestExternalFiles. IngestAndExciseWithBlobs
does not need it because external files within the excise span get
direct placement without overlap checking.