### PR TITLE
db: fix TestIteratorErrors timeout

### DIFF
--- a/external_test.go
+++ b/external_test.go
@@ -61,8 +61,12 @@ func TestIteratorErrors(t *testing.T) {
 	_ = vfs.Root(testOpts.Opts.FS).(*vfs.MemFS)
 
 	{
+		// Disable restarts during the write phase. DB.Close() during a restart
+		// blocks on the cleanup manager draining its queue of obsolete file
+		// deletions; with aggressive random options (tiny TargetFileSizes) this
+		// queue can grow large and take minutes to drain on slow machines.
 		test, err := metamorphic.New(metamorphic.GenerateOps(
-			rng, 10000, kf, metamorphic.WriteOpConfig()),
+			rng, 10000, kf, metamorphic.WriteOpConfig().WithOpWeight(metamorphic.OpDBRestart, 0)),
 			testOpts, "" /* dir */, io.Discard)
 		require.NoError(t, err)
 		require.NoError(t, metamorphic.Execute(test))


### PR DESCRIPTION
The test has two phases: a write phase that constructs a random database using 10,000 metamorphic operations, and a read phase that runs 5,000 read operations with 50% VFS error injection. The test blocked in the write phase, inside Execute()'s errgroup.Wait(). One worker goroutine was executing a dbRestartOp, stuck in DB.Close() waiting on cleanupManager.Close(). The cleanup manager had accumulated hundreds of obsolete file deletion jobs. This is due to aggressive random options (e.g. TargetFileSizes as small as 12 bytes) producing thousands of tiny sstables that compactions quickly made obsolete. DB.Close() blocks until the cleanup manager fully drains this queue. This could lead to timeout. The other two errgroup workers were blocked on synchronization dependencies waiting for the restart to complete.

Fix this by disabling OpDBRestart in the write phase config using WithOpWeight. Restarts are not needed for this test's purpose: it only constructs a database with random state to verify that injected read errors are properly surfaced. The write phase still generates flushes and compactions, producing a complex multi-level database without the unbounded DB.Close() blocking.

Fixes #5793 