### PR TITLE
db: disable delete pacing on cleanupManager.Close()

### DIFF
--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -10,6 +10,7 @@ import (
 	"runtime/pprof"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/crlib/crtime"
@@ -41,6 +42,9 @@ type cleanupManager struct {
 	jobsCh chan *cleanupJob
 	// waitGroup is used to wait for the background goroutine to exit.
 	waitGroup sync.WaitGroup
+	// closedFlag is set when Close() is called. maybePace checks this to
+	// disable pacing during close, allowing the queue to drain quickly.
+	closedFlag atomic.Bool
 
 	mu struct {
 		sync.Mutex
@@ -116,6 +120,7 @@ func openCleanupManager(
 // Close stops the background goroutine, waiting until all queued jobs are completed.
 // Delete pacing is disabled for the remaining jobs.
 func (cm *cleanupManager) Close() {
+	cm.closedFlag.Store(true)
 	close(cm.jobsCh)
 	cm.waitGroup.Wait()
 }
@@ -219,6 +224,9 @@ func (cm *cleanupManager) needsPacing(fileType base.FileType, fileNumIfSST base.
 func (cm *cleanupManager) maybePace(
 	tb *tokenbucket.TokenBucket, fileType base.FileType, fileNum base.DiskFileNum, fileSize uint64,
 ) {
+	if cm.closedFlag.Load() {
+		return
+	}
 	if !cm.needsPacing(fileType, fileNum) {
 		return
 	}


### PR DESCRIPTION
TestIteratorErrors timed out on crl-release-25.2. The CI stack trace showed DB.Close() blocked in cleanupManager.Close() waiting for the background goroutine to finish processing obsolete file deletions with pacing enabled.

The root cause is that cleanupManager.Close() does not disable delete pacing, despite the comment on Close() stating "Delete pacing is disabled for the remaining jobs." When Close() is called, the channel is closed and `for job := range cm.jobsCh` drains remaining items. As the queue drains, len(cm.jobsCh) drops below the high threshold (75%), causing maybePace() to re-enable pacing for remaining files. Each file that PacingDelay() returns a nonzero token value for then blocks on the token bucket (1 token/sec refill). With many obsolete files from aggressive random options (tiny TargetFileSizes), the cumulative pacing delay causes Close() to block for minutes.

This was already fixed on master by commit e56c4c91 (db: delete pacer rewrite), which used a stopCh channel and select statement to break out of the pacing sleep on close. That fix is part of a 42-file update unsuitable for cherry-picking into a release branch.

This change adds an atomic.Bool closedFlag to cleanupManager. Close() sets it before closing the channel. maybePace() checks it at the top and returns immediately if set, skipping all pacing. No code was copied from the master fix.

Fixes #5793

The previous attempt (#5810) was against the master branch, which is not right and is abandoned. 