### PR TITLE
crl-release-25.2: metamorphic: cap cache size on 32-bit builds

### DIFF
--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
@@ -653,7 +654,13 @@ func RandomOptions(
 	}
 
 	opts.BytesPerSync = 1 << uint(rng.IntN(28)) // 1B - 256MB
-	opts.CacheSize = 1 << uint(rng.IntN(30))    // 1B - 1GB
+	cacheSizeMax := 30                          // 1B - 1GB
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		// Cap the cache size on 32-bit builds to avoid OOMs due to the
+		// limited user-space address space (~3GB on Linux).
+		cacheSizeMax = 27 // 1B - 128MB
+	}
+	opts.CacheSize = 1 << uint(rng.IntN(cacheSizeMax))
 	opts.DisableWAL = rng.IntN(2) == 0
 	opts.FlushDelayDeleteRange = time.Millisecond * time.Duration(5*rng.IntN(245)) // 5-250ms
 	opts.FlushDelayRangeKey = time.Millisecond * time.Duration(5*rng.IntN(245))    // 5-250ms


### PR DESCRIPTION
Backport e332a165 from master to crl-release-25.2 to fix #5814

RandomOptions could generate cache sizes up to 1 GB (2^30). On 32-bit Linux, the ~3 GB user-space address space limit meant that combined with Go runtime overhead and CockroachDB's key encoding, individual TestMetaCockroachKVs child processes could consume 3.3-3.8 GB and OOM.

Cap the upper bound to 128 MB (2^27) on 32-bit builds. This is the largest power of 2 that keeps worst-case total memory under ~3 GB.

Similar to #5795 