### PR TITLE
checkpoint: copy ingestedFlushable SST files into checkpoint directory

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -171,9 +171,10 @@ func (d *DB) Checkpoint(
 	}
 
 	// Disable file deletions.
-	// We acquire a reference on the version down below that will prevent any
-	// sstables or blob files from becoming "obsolete" and potentially deleted,
-	// but this doesn't protect the current WALs or manifests.
+	//
+	// We acquire a reference on the version down below that will prevent any sstables or blob
+	// files, or flushable ingest files, from becoming "obsolete" and potentially deleted, but this
+	// doesn't protect the current WALs or manifests.
 	d.mu.Lock()
 	d.disableFileDeletions()
 	defer func() {
@@ -207,6 +208,25 @@ func (d *DB) Checkpoint(
 	// flush that might mark a log that's relevant to `current` as obsolete
 	// before our call to List.
 	allLogicalLogs := d.mu.log.manager.List()
+
+	// Collect SSTable files referenced by flushable ingest entries. These files
+	// are not yet part of the LSM (not in current) but are referenced by WAL
+	// IngestSST records that will be replayed when the checkpoint is opened.
+	// They must be copied to the checkpoint directory.
+	//
+	// Note: we always copy these regardless of any restrictToSpans option.
+	// When WAL is enabled, the IngestSST WAL records referencing these files
+	// are included in the checkpoint's WAL and will be replayed unconditionally
+	// on open. When WAL is disabled no such replay occurs, but copying the files
+	// is harmless.
+	var flushableIngestFiles []base.DiskFileNum
+	for _, entry := range d.mu.mem.queue {
+		if fi, ok := entry.flushable.(*ingestedFlushable); ok {
+			for _, f := range fi.files {
+				flushableIngestFiles = append(flushableIngestFiles, f.TableBacking.DiskFileNum)
+			}
+		}
+	}
 
 	// Grab the visible sequence number. The checkpoint's view of the state of
 	// the database will be equivalent to an iterator that acquired this same
@@ -366,6 +386,18 @@ func (d *DB) Checkpoint(
 			removeBackingTables = append(removeBackingTables, diskFileNum)
 		}
 	}
+
+	// Copy SSTable files referenced by flushable ingest entries (collected
+	// above while holding d.mu). These files are protected from deletion by the
+	// disableFileDeletions call above. Unlike LSM files, span restriction does
+	// not apply here; the WAL always references these files and they must exist.
+	for _, fileNum := range flushableIngestFiles {
+		ckErr = copyFile(base.FileTypeTable, fileNum)
+		if ckErr != nil {
+			return ckErr
+		}
+	}
+
 	// Record the blob files that are not referenced by any included sstables.
 	// When we write the MANIFEST of the checkpoint, we'll include a final
 	// VersionEdit that removes these blob files so that the checkpointed

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testutils"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -480,4 +481,76 @@ func TestCheckpointManyFiles(t *testing.T) {
 		require.NoError(t, d.Close())
 		require.Equal(t, 10, n)
 	}
+}
+
+// TestCheckpointFlushableIngest is a regression test: a Checkpoint taken while
+// there are pending flushable ingest entries in the memtable queue must copy
+// the corresponding SSTable files to the checkpoint directory. Without the fix,
+// opening the checkpoint would fail with:
+//
+//	pebble: error when opening flushable ingest files: file does not exist
+func TestCheckpointFlushableIngest(t *testing.T) {
+	mem := vfs.NewMem()
+	require.NoError(t, mem.MkdirAll("ext", 0755))
+
+	opts := &Options{
+		FS:                          mem,
+		FormatMajorVersion:          internalFormatNewest,
+		DisableAutomaticCompactions: true,
+		Logger:                      testutils.Logger{T: t},
+	}
+	d, err := Open("db", opts)
+	require.NoError(t, err)
+
+	// Write a key to the memtable. A subsequent ingest whose key range overlaps
+	// with the memtable is taken along the flushable-ingest path instead of
+	// forcing a synchronous flush, which is the scenario under test.
+	require.NoError(t, d.Set([]byte("b"), []byte("memtable"), Sync))
+
+	// Build a small SSTable in the external directory containing the same key.
+	sstPath := "ext/foo.sst"
+	f, err := mem.Create(sstPath, vfs.WriteCategoryUnspecified)
+	require.NoError(t, err)
+	w := sstable.NewWriter(objstorageprovider.NewFileWritable(f), d.opts.MakeWriterOptions(0, d.TableFormat()))
+	require.NoError(t, w.Set([]byte("b"), []byte("ingested")))
+	require.NoError(t, w.Close())
+
+	// Ingest the SSTable. Because it overlaps with the memtable key "b", it is
+	// added to the flushable queue as an ingestedFlushable rather than being
+	// placed directly into L0.
+	require.NoError(t, d.Ingest(context.Background(), []string{sstPath}))
+
+	// Confirm that the ingest went through the flushable path.
+	d.mu.Lock()
+	var hasFlushableIngest bool
+	for _, entry := range d.mu.mem.queue {
+		if _, ok := entry.flushable.(*ingestedFlushable); ok {
+			hasFlushableIngest = true
+			break
+		}
+	}
+	d.mu.Unlock()
+	require.True(t, hasFlushableIngest, "expected ingest to be enqueued as a flushable ingest")
+
+	// Checkpoint without flushing first. The checkpoint must copy the
+	// ingestedFlushable SSTable files so that WAL replay on open succeeds.
+	require.NoError(t, d.Checkpoint("checkpoint"))
+	require.NoError(t, d.Close())
+
+	// Opening the checkpoint previously failed with:
+	//   pebble: error when opening flushable ingest files: file does not exist
+	d2, err := Open("checkpoint", &Options{
+		FS:                 mem,
+		FormatMajorVersion: internalFormatNewest,
+		Logger:             testutils.Logger{T: t},
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, d2.Close()) }()
+
+	// The ingested value (higher sequence number) should shadow the memtable
+	// value for key "b".
+	val, closer, err := d2.Get([]byte("b"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("ingested"), val)
+	closer.Close()
 }


### PR DESCRIPTION
Checkpoint() did not copy SST files held in ingestedFlushable entries in d.mu.mem.queue. When the checkpoint was opened, WAL replay would attempt to open these missing files and fail with:

> pebble: error when opening flushable ingest files:
> file N (type sstable) unknown to the objstorage provider:
> file does not exist

Fix: while holding d.mu, collect the DiskFileNums of all SST files in ingestedFlushable queue entries and copy them to the checkpoint directory alongside the LSM files. The span restriction from WithRestrictToSpans is not applied to these files since their WAL records are always replayed on open.