### PR TITLE
db: re-disable compactions in some datadriven tests

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1815,6 +1815,9 @@ func TestCompactionTombstones(t *testing.T) {
 			case "maybe-compact":
 				d.mu.Lock()
 				d.opts.DisableAutomaticCompactions = false
+				defer func() {
+					d.opts.DisableAutomaticCompactions = true
+				}()
 				d.maybeScheduleCompaction()
 				s := compactionString()
 				d.mu.Unlock()
@@ -2058,6 +2061,9 @@ func TestCompactionReadTriggered(t *testing.T) {
 			case "maybe-compact":
 				d.mu.Lock()
 				d.opts.DisableAutomaticCompactions = false
+				defer func() {
+					d.opts.DisableAutomaticCompactions = true
+				}()
 				d.maybeScheduleCompaction()
 				s := compactionString()
 				d.mu.Unlock()

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -139,7 +139,7 @@ close-snapshot
 close-snapshot
 103
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (874B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+(none)
 
 # Test a table that contains both deletions and non-deletions, but whose
 # non-deletions well outnumber its deletions. The table should not be


### PR DESCRIPTION
These tests were enabling compactions for a `maybe-compact` command
but they were leaving them enabled.