### PR TITLE
cache: mark cache panic messages as redact.Safe

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/metricsutil"
+	"github.com/cockroachdb/redact"
 )
 
 // Cache implements Pebble's sharded block cache. The Clock-PRO algorithm is
@@ -327,7 +328,7 @@ func (c *Handle) GetWithReadHandle(
 // REQUIRES: value.refs() == 1
 func (c *Handle) Set(fileNum base.DiskFileNum, offset uint64, value *Value) {
 	if n := value.refs(); n != 1 {
-		panic(fmt.Sprintf("pebble: Value has already been added to the cache: refs=%d", n))
+		panic(redact.Safe(fmt.Sprintf("pebble: Value has already been added to the cache: refs=%d", n)))
 	}
 	k := makeKey(c.id, fileNum, offset)
 	c.cache.getShard(k).set(k, value, false /*markAccessed*/)

--- a/internal/cache/read_shard.go
+++ b/internal/cache/read_shard.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/redact"
 	"github.com/cockroachdb/swiss"
 )
 
@@ -295,7 +296,7 @@ func (e *readEntry) unrefAndTryRemoveFromMap() {
 
 func (e *readEntry) setReadValue(v *Value) {
 	if n := v.refs(); n != 1 {
-		panic(fmt.Sprintf("pebble: Value has already been added to the cache: refs=%d", n))
+		panic(redact.Safe(fmt.Sprintf("pebble: Value has already been added to the cache: refs=%d", n)))
 	}
 	concurrentRequesters := false
 	e.mu.Lock()

--- a/internal/cache/value.go
+++ b/internal/cache/value.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manual"
+	"github.com/cockroachdb/redact"
 )
 
 // ValueMetadataSize denotes the number of bytes of metadata allocated for a
@@ -143,7 +144,7 @@ func (v *Value) Release() {
 // Free. Do not call Free on a value that has been added to the cache.
 func Free(v *Value) {
 	if n := v.refs(); n > 1 {
-		panic(fmt.Sprintf("pebble: Value has been added to the cache: refs=%d", n))
+		panic(redact.Safe(fmt.Sprintf("pebble: Value has been added to the cache: refs=%d", n)))
 	}
 	v.Release()
 }


### PR DESCRIPTION
## Summary

- Wrap three `panic(fmt.Sprintf(...))` calls in the `internal/cache` package
  with `redact.Safe()` so that the interpolated ref counts are visible in
  CockroachDB's redacted logs.

Fixes cockroachdb/cockroach#164740.