### PR TITLE
db: add cumulative flushable mem bytes metrics

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1858,6 +1858,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 				}
 			}
 		}
+		d.mu.versions.metrics.Flush.FlushableMemBytesIn += inputBytes
 		d.maybeTransitionSnapshotsToFileOnlyLocked()
 	}
 	// Signal FlushEnd after installing the new readState. This helps for unit

--- a/db.go
+++ b/db.go
@@ -407,6 +407,9 @@ type DB struct {
 			// footprint of memtables when lots of DB instances are used concurrently
 			// in test environments.
 			nextSize uint64
+			// cumulativeImmutableFlushableInuseBytes is the cumulative sum of
+			// inuseBytes() for all flushables that have become immutable.
+			cumulativeImmutableFlushableInuseBytes uint64
 		}
 
 		compact struct {
@@ -1966,6 +1969,8 @@ func (d *DB) Metrics() *Metrics {
 	metrics.MemTable.Count = int64(len(d.mu.mem.queue))
 	metrics.MemTable.ZombieCount = d.memTableCount.Load() - metrics.MemTable.Count
 	metrics.MemTable.ZombieSize = uint64(d.memTableReserved.Load()) - metrics.MemTable.Size
+	metrics.MemTable.CumulativeFlushableMemBytes =
+		d.mu.mem.cumulativeImmutableFlushableInuseBytes + d.mu.mem.mutable.inuseBytes()
 	metrics.WAL.ObsoleteFiles = int64(walStats.ObsoleteFileCount)
 	metrics.WAL.ObsoletePhysicalSize = walStats.ObsoleteFileSize
 	metrics.WAL.Files = int64(walStats.LiveFileCount)
@@ -2525,6 +2530,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			// The large batch is by definition large. Reserve space from the cache
 			// for it until it is flushed.
 			entry.releaseMemAccounting = d.opts.Cache.Reserve(int(b.flushable.totalBytes()))
+			d.mu.mem.cumulativeImmutableFlushableInuseBytes += b.flushable.inuseBytes()
 			d.mu.mem.queue = append(d.mu.mem.queue, entry)
 		} else {
 			minSize = b.memTableSize
@@ -2592,6 +2598,17 @@ func (d *DB) rotateMemtable(
 	// the most recent flushable.
 	d.logSize.Store(0)
 	d.updateReadStateLocked(nil)
+	// NB: prev.inuseBytes() may undercount the final inuseBytes of prev.
+	// Another goroutine may have called mem.prepare(b) (which does writerRef
+	// and reserves space) before we acquired DB.mu+commitPipeline.mu for
+	// rotation, and its commitApply may still be in-flight, writing to the
+	// skiplist arena. The writerUnref below will not be the last ref in that
+	// case. When that goroutine finishes applying, it will increase
+	// skl.Size() (and thus inuseBytes()) beyond what we read here. The
+	// undercount is bounded by the size of such in-flight batches. We
+	// tolerate this for a metric that doesn't need to be precise, rather
+	// than adding synchronization that would reduce commit concurrency.
+	d.mu.mem.cumulativeImmutableFlushableInuseBytes += prev.inuseBytes()
 	if prev.writerUnref() {
 		d.maybeScheduleFlush()
 	}

--- a/flushable.go
+++ b/flushable.go
@@ -355,8 +355,8 @@ func (s *ingestedFlushable) containsRangeKeys() bool {
 
 // inuseBytes is part of the flushable interface.
 func (s *ingestedFlushable) inuseBytes() uint64 {
-	// inuseBytes is only used when memtables are flushed to disk as sstables.
-	panic("pebble: not implemented")
+	// Ingested flushables don't have in-memory bytes to track.
+	return 0
 }
 
 // totalBytes is part of the flushable interface.

--- a/metrics.go
+++ b/metrics.go
@@ -223,6 +223,10 @@ type Metrics struct {
 		ZombieSize uint64
 		// The count of zombie memtables.
 		ZombieCount int64
+		// CumulativeFlushableMemBytes is a monotonically increasing counter of
+		// the cumulative inuseBytes of all flushables that have been created.
+		// It includes the current mutable memtable's inuseBytes.
+		CumulativeFlushableMemBytes uint64
 	}
 
 	Keys KeysMetrics
@@ -469,6 +473,9 @@ type FlushMetrics struct {
 	// AsIngestBytes is a monotonically increasing counter of the bytes flushed
 	// for flushables that originated as ingestion operations.
 	AsIngestBytes uint64
+	// FlushableMemBytesIn is a monotonically increasing counter of the
+	// inuseBytes consumed by flush operations.
+	FlushableMemBytesIn uint64
 }
 
 type KeysMetrics struct {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -95,6 +95,7 @@ func exampleMetrics() Metrics {
 	m.Flush.AsIngestCount = 4
 	m.Flush.AsIngestTableCount = 5
 	m.Flush.AsIngestBytes = 6
+	m.Flush.FlushableMemBytesIn = 20 * MB
 
 	m.Filter.Hits = 9
 	m.Filter.Misses = 10
@@ -133,6 +134,7 @@ func exampleMetrics() Metrics {
 	m.MemTable.Count = 12
 	m.MemTable.ZombieSize = 13 * MB
 	m.MemTable.ZombieCount = 5
+	m.MemTable.CumulativeFlushableMemBytes = 100 * MB
 
 	m.Keys.RangeKeySetsCount = 123
 	m.Keys.TombstoneCount = 456
@@ -656,4 +658,54 @@ func TestMetricsWALBytesWrittenMonotonicity(t *testing.T) {
 		}
 	}()
 	wg.Wait()
+}
+
+func TestCumulativeFlushableMemBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	runTest := func(t *testing.T, disableWAL bool) {
+		opts := &Options{
+			FS:         vfs.NewMem(),
+			DisableWAL: disableWAL,
+		}
+		opts.DisableAutomaticCompactions = true
+		d, err := Open("", opts)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, d.Close()) }()
+
+		writeData := func(keys ...string) {
+			b := d.NewBatch()
+			for _, k := range keys {
+				require.NoError(t, b.Set([]byte(k), []byte("v"), nil))
+			}
+			var wo *WriteOptions
+			if disableWAL {
+				wo = &WriteOptions{Sync: false}
+			}
+			require.NoError(t, b.Commit(wo))
+		}
+
+		// Write some data and check metrics before flush.
+		writeData("a", "b", "c")
+		m := d.Metrics()
+		require.Greater(t, m.MemTable.CumulativeFlushableMemBytes, uint64(0))
+		require.Equal(t, uint64(0), m.Flush.FlushableMemBytesIn)
+		cumBytesBeforeFlush := m.MemTable.CumulativeFlushableMemBytes
+
+		// Flush and check both metrics are > 0.
+		require.NoError(t, d.Flush())
+		m = d.Metrics()
+		require.Equal(t, cumBytesBeforeFlush, m.MemTable.CumulativeFlushableMemBytes)
+		require.Equal(t, cumBytesBeforeFlush, m.Flush.FlushableMemBytesIn)
+
+		// Write more data without flushing. CumulativeFlushableMemBytes should
+		// increase but FlushableMemBytesIn should stay the same.
+		writeData("d", "e")
+		m = d.Metrics()
+		require.Greater(t, m.MemTable.CumulativeFlushableMemBytes, cumBytesBeforeFlush)
+		require.Equal(t, cumBytesBeforeFlush, m.Flush.FlushableMemBytesIn)
+	}
+
+	t.Run("wal-enabled", func(t *testing.T) { runTest(t, false) })
+	t.Run("wal-disabled", func(t *testing.T) { runTest(t, true) })
 }


### PR DESCRIPTION
The admission control two-stage model (cockroachdb/cockroach#156880) needs cumulative flushable memtable byte metrics from Pebble to map memtable bytes to L0 flushed bytes. The previous thinking had been to map cumulative WAL bytes to L0 flushed bytes (we already were tracking all the relevant WAL metrics). However, with raft and state machine engine separation, the state machine engine has no WAL, and we need a modeling approach that will work for it.

Add two new metrics:
- Metrics.MemTable.CumulativeFlushableMemBytes: cumulative inuseBytes of all flushables that have been created, including the current mutable memtable.
- FlushMetrics.FlushableMemBytesIn: cumulative inuseBytes consumed by flush operations.

The cumulative counter is maintained by accumulating inuseBytes() when flushables become immutable (memtable rotation and large batch path). The value read at rotation time may undercount due to in-flight writers that called prepare() before rotation but have not finished applying; this is acceptable for a metric used in admission control heuristics.

Also fix ingestedFlushable.inuseBytes() to return 0 instead of panicking, since ingested flushables do not have in-memory bytes.

Informs https://github.com/cockroachdb/cockroach/issues/156880