### PR TITLE
treesteps,invariants: add blank import of errors in off.go files

### DIFF
--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -6,6 +6,8 @@
 
 package invariants
 
+import _ "github.com/cockroachdb/errors"
+
 // Sometimes returns true percent% of the time if invariants are Enabled (i.e.
 // we were built with the "invariants" or "race" build tags). Otherwise, always
 // returns false.

--- a/internal/treesteps/tree_steps_off.go
+++ b/internal/treesteps/tree_steps_off.go
@@ -6,6 +6,8 @@
 
 package treesteps
 
+import _ "github.com/cockroachdb/errors"
+
 const Enabled = false
 
 type RecordingOption struct{}


### PR DESCRIPTION
This ensures that the cockroachdb/errors dependency is present in the
BUILD.bazel deps unconditionally, which is needed because the CockroachDB
bazel patch unconditionally compiles the on.go files (which import
errors) in crdb_test mode.