### PR TITLE
compaction: skip pre-valsep files in policy comparison, add annotations

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1802,6 +1802,11 @@ func TestCompactionTombstones(t *testing.T) {
 				opts.Experimental.CompactionScheduler = func() CompactionScheduler {
 					return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 				}
+				opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+					return ValueSeparationPolicy{
+						Enabled: false,
+					}
+				}
 				var err error
 				d, err = runDBDefineCmd(td, opts)
 				if err != nil {

--- a/compaction_value_separation.go
+++ b/compaction_value_separation.go
@@ -105,6 +105,7 @@ func shouldWriteBlobFiles(
 		// None of the input sstables reference blob files. It may be the case
 		// that these sstables were created before value separation was enabled.
 		// We should try to write to new blob files.
+		c.annotations = append(c.annotations, "write-blobs-input-depth-zero")
 		return true, 0
 	}
 
@@ -112,6 +113,7 @@ func shouldWriteBlobFiles(
 	// configured max, we should rewrite the values into new blob files to
 	// restore locality.
 	if inputReferenceDepth > manifest.BlobReferenceDepth(policy.MaxBlobReferenceDepth) {
+		c.annotations = append(c.annotations, "write-blobs-input-depth-exceeded")
 		return true, 0
 	}
 	// Compare policies used by each input file. If all input files have the
@@ -137,6 +139,7 @@ func shouldWriteBlobFiles(
 				if !spanPolicy.StillCovers(cmp, bounds.End.Key) {
 					// The table's key range now uses multiple span policies. Rewrite to new
 					// blob files so values are stored according to the current policy.
+					c.annotations = append(c.annotations, "write-blobs-multiple-policies")
 					return true, 0
 				}
 				if spanPolicy.ValueStoragePolicy.DisableBlobSeparation {
@@ -153,8 +156,22 @@ func shouldWriteBlobFiles(
 				}
 			}
 
-			if int(backingProps.ValueSeparationMinSize) != expectedMinSize ||
-				(expectedMinSize > 0 && backingProps.ValueSeparationBySuffixDisabled != expectedValSepBySuffixDisabled) {
+			if backingProps.ValueSeparationMinSize == 0 {
+				// This table was written with value separation disabled. Eventually
+				// this table will be input to a compaction that exceeds the blob
+				// reference depth threshold. Until then, don't eagerly rewrite. We
+				// don't want to have a situation where 1 out of 20 input sstables to
+				// a compaction was written when value separation was disabled, and
+				// now all the other 19 sstables have to rewrite their blob
+				// references.
+				continue
+			}
+			if int(backingProps.ValueSeparationMinSize) != expectedMinSize {
+				c.annotations = append(c.annotations, "write-blobs-min-size-mismatch")
+				return true, 0
+			}
+			if expectedMinSize > 0 && backingProps.ValueSeparationBySuffixDisabled != expectedValSepBySuffixDisabled {
+				c.annotations = append(c.annotations, "write-blobs-suffix-disabled-mismatch")
 				return true, 0
 			}
 		}

--- a/compaction_value_separation_test.go
+++ b/compaction_value_separation_test.go
@@ -1,0 +1,305 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestTableMeta creates a TableMetadata suitable for testing
+// shouldWriteBlobFiles. It initializes the physical backing and populates
+// properties relevant to value separation.
+func makeTestTableMeta(
+	cmp base.Compare,
+	tableNum base.TableNum,
+	smallest, largest base.InternalKey,
+	blobRefDepth manifest.BlobReferenceDepth,
+	valSepMinSize uint64,
+	valSepBySuffixDisabled bool,
+) *manifest.TableMetadata {
+	m := &manifest.TableMetadata{TableNum: tableNum, Size: 1024}
+	m.BlobReferenceDepth = blobRefDepth
+	m.ExtendPointKeyBounds(cmp, smallest, largest)
+	m.InitPhysicalBacking()
+	m.TableBacking.PopulateProperties(&sstable.Properties{
+		ValueSeparationMinSize:          valSepMinSize,
+		ValueSeparationBySuffixDisabled: valSepBySuffixDisabled,
+	})
+	return m
+}
+
+func TestShouldWriteBlobFiles(t *testing.T) {
+	cmp := base.DefaultComparer.Compare
+	ikey := func(userKey string, seqNum uint64) base.InternalKey {
+		return base.MakeInternalKey([]byte(userKey), base.SeqNum(seqNum), base.InternalKeyKindSet)
+	}
+	defaultPolicy := ValueSeparationPolicy{
+		Enabled:               true,
+		MinimumSize:           512,
+		MaxBlobReferenceDepth: 5,
+	}
+	defaultSpanPolicyFunc := SpanPolicyFunc(func(bounds base.UserKeyBounds) (base.SpanPolicy, error) {
+		return base.SpanPolicy{}, nil
+	})
+
+	type testCase struct {
+		name               string
+		kind               compactionKind
+		inputs             []compactionLevel
+		policy             ValueSeparationPolicy
+		spanPolicyFunc     SpanPolicyFunc
+		wantWriteBlobs     bool
+		wantReferenceDepth manifest.BlobReferenceDepth
+		wantAnnotations    []string
+	}
+	tests := []testCase{
+		{
+			name: "flush",
+			kind: compactionKindFlush,
+			// Flushes always write new blob files regardless of inputs.
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+		},
+		{
+			// A virtual rewrite materializes a virtual table without writing
+			// new blob files. The reference depth is preserved unchanged.
+			name: "virtual-rewrite",
+			kind: compactionKindVirtualRewrite,
+			inputs: []compactionLevel{
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 3, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     false,
+			wantReferenceDepth: 3,
+		},
+		{
+			name: "default-low-reference-depth",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 3, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 2, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     false,
+			wantReferenceDepth: 5, // 3 + 2
+		},
+		{
+			name: "all-pre-valsep",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 0, 0, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 0, 0, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-input-depth-zero"},
+		},
+		{
+			// A compaction mixing post-valsep L5 files with pre-valsep L6 files
+			// should NOT force a rewrite of the L5 blob references.
+			name: "mixed-pre-and-post-valsep",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 1, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 0, 0, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     false,
+			wantReferenceDepth: 1, // max(1) + max(0)
+		},
+		{
+			name: "depth-exceeded",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 3, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 3, 512, false),
+					}),
+				},
+			},
+			// inputReferenceDepth = 3 + 3 = 6 > MaxBlobReferenceDepth (5)
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-input-depth-exceeded"},
+		},
+		{
+			name: "min-size-mismatch",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						// MinSize=256 differs from policy MinimumSize=512.
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 1, 256, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 1, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-min-size-mismatch"},
+		},
+		{
+			name: "suffix-disabled-mismatch",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						// BySuffixDisabled=true but the default span policy expects false.
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 1, 512, true),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 1, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-suffix-disabled-mismatch"},
+		},
+		{
+			name: "multiple-span-policies",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						// File spans a→z but the span policy only covers a→m.
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("z", 5), 1, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 1, 512, false),
+					}),
+				},
+			},
+			spanPolicyFunc: func(bounds base.UserKeyBounds) (base.SpanPolicy, error) {
+				return base.SpanPolicy{
+					KeyRange: base.KeyRange{Start: []byte("a"), End: []byte("m")},
+				}, nil
+			},
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-multiple-policies"},
+		},
+		{
+			name: "all-matching",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 2, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 1, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     false,
+			wantReferenceDepth: 3, // 2 + 1
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := tt.policy
+			if policy == (ValueSeparationPolicy{}) {
+				policy = defaultPolicy
+			}
+			spanPolicyFunc := tt.spanPolicyFunc
+			if spanPolicyFunc == nil {
+				spanPolicyFunc = defaultSpanPolicyFunc
+			}
+			c := &tableCompaction{
+				kind:   tt.kind,
+				inputs: tt.inputs,
+			}
+			writeBlobs, refDepth := shouldWriteBlobFiles(c, policy, spanPolicyFunc, cmp)
+			require.Equal(t, tt.wantWriteBlobs, writeBlobs, "writeBlobs")
+			require.Equal(t, tt.wantReferenceDepth, refDepth, "referenceDepth")
+			if tt.wantAnnotations == nil {
+				require.Empty(t, c.annotations, "annotations")
+			} else {
+				require.Equal(t, tt.wantAnnotations, c.annotations, "annotations")
+			}
+		})
+	}
+}

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -1033,7 +1033,9 @@ compression: None:79
 define value-separation=(enabled, min-size=1, max-ref-depth=3, rw-min-age=0, garbage-ratios=1.0:1.0)
 ----
 
-# With these span policies, only values for keys n-z will be separated.
+# With these span policies, only values for keys o-z will be separated. [a, f)
+# has a value separation policy but the size threshold is too high for the
+# values in this test.
 set-span-policies
 a,f val-sep-minimum-size=100
 f,o val-sep-minimum-size=0
@@ -1066,8 +1068,9 @@ L6:
 Blob files:
   B000008 physical:{000008 size:[94 (94B)] vals:[4 (4B)]}
 
-# Adjust the span policies. The first span policy is truncated to only cover d-f.
-# The second span policy's minimum size changes from 0 to 10 bytes.
+# Adjust the span policies. The first span policy is truncated to only cover
+# d-f. The second span policy's minimum size changes from 0 to 10 bytes, which
+# means value separation goes from disabled to enabled for keys [f, o).
 set-span-policies
 d,f val-sep-minimum-size=100
 f,o val-sep-minimum-size=10
@@ -1096,8 +1099,10 @@ Blob files:
   B000017 physical:{000017 size:[91 (91B)] vals:[2 (2B)]}
 
 
-# This should rewrite blob references for input tables, since the span policies changed
-# so the table's key range is longer covered by a span policy.
+# This should rewrite blob references for input tables, since the span
+# policies changed so the table's key range is longer covered by a span
+# policy, and [a,d) now can use the default policy of separating at the 1 byte
+# threshold.
 compact a-e
 ----
 L0.0:
@@ -1112,17 +1117,20 @@ Blob files:
   B000017 physical:{000017 size:[91 (91B)] vals:[2 (2B)]}
   B000019 physical:{000019 size:[94 (94B)] vals:[4 (4B)]}
 
-# Compacting key range f-z should also rewrite blob references, even though the o-z input range
-# is using the same value separation settings, since the f-o span policy changed.
+# Compacting key range f-z. Even though the o-z input range is using the same
+# value separation settings, the f-o span policy changed. However, it
+# transitioned from disabled to enabled, and we don't eagerly rewrite in this
+# case. As the blob reference depth is low, blob files are not rewritten.
 compact f-z
 ----
 L6:
   000018:[a#0,SET-b#0,SET] seqnums:[#0-#0] points:[a#0,SET-b#0,SET] size:779 blobrefs:[(B000019: 4); depth:1]
   000020:[f#0,SET-g#0,SET] seqnums:[#0-#0] points:[f#0,SET-g#0,SET] size:693
-  000021:[o#0,SET-p#0,SET] seqnums:[#0-#0] points:[o#0,SET-p#0,SET] size:779 blobrefs:[(B000022: 4); depth:1]
+  000021:[o#0,SET-p#0,SET] seqnums:[#0-#0] points:[o#0,SET-p#0,SET] size:786 blobrefs:[(B000017: 2), (B000008: 2); depth:2]
 Blob files:
+  B000008 physical:{000008 size:[94 (94B)] vals:[4 (4B)]}
+  B000017 physical:{000017 size:[91 (91B)] vals:[2 (2B)]}
   B000019 physical:{000019 size:[94 (94B)] vals:[4 (4B)]}
-  B000022 physical:{000022 size:[94 (94B)] vals:[4 (4B)]}
 
 # Default value separation.
 sstable-properties file=000018
@@ -1182,7 +1190,7 @@ rocksdb.deleted.keys: 0
 rocksdb.num.range-deletions: 0
 rocksdb.num.data.blocks: 1
 rocksdb.comparator: leveldb.BytewiseComparator
-rocksdb.data.size: 87
+rocksdb.data.size: 89
 rocksdb.filter.size: 0
 rocksdb.index.size: 36
 rocksdb.block.based.table.index.type: 0
@@ -1192,6 +1200,6 @@ rocksdb.merge.operands: 0
 pebble.num.values.in.blob-files: 2
 rocksdb.property.collectors: [obsolete-key]
 rocksdb.compression: Snappy
-pebble.compression_stats: None:56,Snappy:82/114
+pebble.compression_stats: None:61,Snappy:84/114
 pebble.value-separation.min-size: 1
 obsolete-key: hex:00

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -43,7 +43,7 @@ compression: None:85
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (678B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(elision-only) L6 [000004] (649B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # Test a table that straddles a snapshot. It should not be compacted.
 define snapshots=(50) auto-compactions=off
@@ -89,7 +89,7 @@ compression: None:124
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (736B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (686B), in 1.0s (2.0s total), output rate 686B/s
+[JOB 100] compacted(elision-only) L6 [000004] (700B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 version
 ----
@@ -215,7 +215,7 @@ compression: None:16929
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=88.62 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (865B), in 1.0s (2.0s total), output rate 865B/s
+[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=88.39 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
 
 define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
@@ -251,7 +251,7 @@ compression: None:128
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004] (740B) Score=6.03 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
+[JOB 100] compacted(default) L5 [000004] (704B) Score=5.95 + L6 [000006] (13KB) Score=0.00 -> L6 [] (0B), in 1.0s (2.0s total), output rate 0B/s
 
 # A table containing only range keys is not eligible for elision.
 # RANGEKEYDEL or RANGEKEYUNSET.
@@ -335,7 +335,7 @@ compression: None:227
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (887B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (692B), in 1.0s (2.0s total), output rate 692B/s
+[JOB 100] compacted(elision-only) L6 [000004] (859B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (661B), in 1.0s (2.0s total), output rate 661B/s
 
 # Close the DB, asserting that the reference counts balance.
 close
@@ -389,9 +389,9 @@ compression: None:87,Snappy:73/84
 # numbers, so the test overwrites them to 0.
 maybe-compact
 ----
-[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.8KB), in 1.0s (2.0s total), output rate 8.8KB/s
+[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
 [JOB 101] compacted(delete-only) [excise] L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 102] compacted(default) L5 [000004] (732B) Score=1.43 + L6 [000006] (13KB) Score=1.05 -> L6 [000000] (796B), in 1.0s (2.0s total), output rate 796B/s
+[JOB 102] compacted(default) L5 [000004] (696B) Score=1.36 + L6 [000006] (13KB) Score=1.05 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -438,9 +438,9 @@ compression: None:87,Snappy:73/84
 # numbers, so the test overwrites them to 0.
 maybe-compact
 ----
-[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.8KB), in 1.0s (2.0s total), output rate 8.8KB/s
+[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
 [JOB 101] compacted(delete-only) [excise] L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 102] compacted(default) L5 [000004] (732B) Score=1.43 + L6 [000006] (13KB) Score=1.05 -> L6 [000000] (796B), in 1.0s (2.0s total), output rate 796B/s
+[JOB 102] compacted(default) L5 [000004] (696B) Score=1.36 + L6 [000006] (13KB) Score=1.05 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 
 # These tests demonstrate the behavior of the tombstone density compaction feature
@@ -518,8 +518,8 @@ compression: None:36,Snappy:95/108
 # should indicate "move" as the compaction type.
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L5 [000004] (752B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (692B), in 1.0s (2.0s total), output rate 692B/s
-[JOB 101] compacted(move) L4 [000004] (752B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (752B), in 1.0s (2.0s total), output rate 752B/s
+[JOB 100] compacted(tombstone-density) L5 [000004] (716B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (661B), in 1.0s (2.0s total), output rate 661B/s
+[JOB 101] compacted(move) L4 [000004] (716B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (716B), in 1.0s (2.0s total), output rate 716B/s
 
 # Verify the result - the file should now be in L5
 # The file should maintain its original content since it was just moved rather than recompacted
@@ -579,7 +579,7 @@ compression: None:36,Snappy:95/108
 # because there are overlapping files in L5 that prevent the optimization
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L4 [000004] (752B) Score=0.00 + L5 [000005] (697B) Score=0.00 -> L5 [000007] (692B), in 1.0s (2.0s total), output rate 692B/s
+[JOB 100] compacted(tombstone-density) L4 [000004] (716B) Score=0.00 + L5 [000005] (666B) Score=0.00 -> L5 [000007] (661B), in 1.0s (2.0s total), output rate 661B/s
 
 # Verify the result - the file was recompacted with the overlapping L5 file
 # The output file should be different from the input files

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -216,7 +216,7 @@ close: db/marker.manifest.000004.MANIFEST-000011
 remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
 [JOB 6] MANIFEST created 000011
-[JOB 6] compacted(default) L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (683B), in 1.0s (4.0s total), output rate 683B/s
+[JOB 6] compacted(default) write-blobs-input-depth-zero L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (683B), in 1.0s (4.0s total), output rate 683B/s
 close: db/000005.sst
 close: db/000008.sst
 remove: db/MANIFEST-000006

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -20,8 +20,8 @@ marked L0.000004
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000005] (696B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (696B), in 1.0s (2.0s total), output rate 696B/s
-[JOB 100] compacted(rewrite) L0 [000004] (685B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (685B), in 1.0s (2.0s total), output rate 685B/s
+[JOB 100] compacted(rewrite) write-blobs-input-depth-zero L1 [000005] (696B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (696B), in 1.0s (2.0s total), output rate 696B/s
+[JOB 100] compacted(rewrite) write-blobs-input-depth-zero L0 [000004] (685B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (685B), in 1.0s (2.0s total), output rate 685B/s
 L0.0:
   000007:[c#11,SET-c#11,SET] seqnums:[#11-#11] points:[c#11,SET-c#11,SET] size:685
 L1:
@@ -41,8 +41,8 @@ reopen
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000006] (696B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000012] (696B), in 1.0s (2.0s total), output rate 696B/s
-[JOB 100] compacted(rewrite) L0 [000007] (685B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000013] (685B), in 1.0s (2.0s total), output rate 685B/s
+[JOB 100] compacted(rewrite) write-blobs-input-depth-zero L1 [000006] (696B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000012] (696B), in 1.0s (2.0s total), output rate 696B/s
+[JOB 100] compacted(rewrite) write-blobs-input-depth-zero L0 [000007] (685B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000013] (685B), in 1.0s (2.0s total), output rate 685B/s
 L0.0:
   000013:[c#11,SET-c#11,SET] seqnums:[#11-#11] points:[c#11,SET-c#11,SET] size:685
 L1:
@@ -66,8 +66,8 @@ reopen
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000012] (696B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000019] (696B), in 1.0s (2.0s total), output rate 696B/s
-[JOB 100] compacted(rewrite) L0 [000013] (685B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000020] (685B), in 1.0s (2.0s total), output rate 685B/s
+[JOB 100] compacted(rewrite) write-blobs-input-depth-zero L1 [000012] (696B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000019] (696B), in 1.0s (2.0s total), output rate 696B/s
+[JOB 100] compacted(rewrite) write-blobs-input-depth-zero L0 [000013] (685B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000020] (685B), in 1.0s (2.0s total), output rate 685B/s
 L0.0:
   000020:[c#11,SET-c#11,SET] seqnums:[#11-#11] points:[c#11,SET-c#11,SET] size:685
 L1:


### PR DESCRIPTION
Previously, shouldWriteBlobFiles treated pre-valsep sstables (ValueSeparationMinSize == 0) as a policy mismatch, forcing all blob references in the compaction to be rewritten into new blob files. This was wasteful when a compaction mixed post-valsep files with pre-valsep files — the already-separated values were read and rewritten for no benefit.

Skip pre-valsep files (MinSize == 0) in the policy comparison loop so they do not trigger unnecessary rewrites. Also add annotation strings to each branch that returns writeBlobs=true, aiding debuggability.

Add TestShouldWriteBlobFiles covering all branches: flush, virtual rewrite, all-pre-valsep, mixed pre/post-valsep (the core fix), depth-exceeded, min-size mismatch, suffix-disabled mismatch, multiple span policies, and the all-matching preserve-references path.

Fixes #5846