### PR TITLE
objstorage: adjust remote.Locator to support redactability

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -49,7 +49,7 @@ func testCheckpointImpl(t *testing.T, ddFile string, createOnShared bool) {
 			Logger:                      testutils.Logger{T: t},
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": remoteMem,
+			remote.MakeLocator(""): remoteMem,
 		})
 		if createOnShared {
 			opts.Experimental.CreateOnShared = remote.CreateOnSharedAll

--- a/close_test.go
+++ b/close_test.go
@@ -34,7 +34,7 @@ func TestCloseWithBlockedRemoteIO(t *testing.T) {
 		L0StopWritesThreshold: 100,
 	}
 	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"blocking": storage,
+		remote.MakeLocator("blocking"): storage,
 	})
 
 	d, err := Open("", opts)
@@ -55,7 +55,7 @@ func TestCloseWithBlockedRemoteIO(t *testing.T) {
 	// Ingest the external file. This triggers table stats loading in the
 	// background, which will try to read from the blocking storage.
 	_, err = d.IngestExternalFiles(context.Background(), []ExternalFile{{
-		Locator:           "blocking",
+		Locator:           remote.MakeLocator("blocking"),
 		ObjName:           "ext1",
 		Size:              uint64(sz),
 		StartKey:          []byte("a"),

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -116,7 +116,7 @@ func newPebbleDB(dir string) DB {
 	if pathToLocalSharedStorage != "" {
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			// Store all shared objects on local disk, for convenience.
-			"": remote.NewLocalFS(pathToLocalSharedStorage, vfs.Default),
+			remote.MakeLocator(""): remote.NewLocalFS(pathToLocalSharedStorage, vfs.Default),
 		})
 		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 		if secondaryCacheSize != 0 {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2923,7 +2923,7 @@ func TestSharedObjectDeletePacing(t *testing.T) {
 	var opts Options
 	opts.FS = vfs.NewMem()
 	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"": remote.NewInMem(),
+		remote.MakeLocator(""): remote.NewInMem(),
 	})
 	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 	opts.DeletionPacing.BaselineRate = func() uint64 { return 1 }
@@ -3139,7 +3139,7 @@ func TestCompactionCorruption(t *testing.T) {
 	opts.WithFSDefaults()
 	remoteStorage := remote.NewInMem()
 	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"external-locator": remoteStorage,
+		remote.MakeLocator("external-locator"): remoteStorage,
 	})
 	d, err := Open("", opts)
 	require.NoError(t, err)

--- a/data_test.go
+++ b/data_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
 	"github.com/cockroachdb/pebble/wal"
+	"github.com/cockroachdb/redact"
 	"github.com/ghemawat/stream"
 	"github.com/stretchr/testify/require"
 )
@@ -1596,7 +1597,7 @@ func runIngestExternalCmd(
 			sz = 1024
 		}
 		ef := ExternalFile{
-			Locator:     remote.Locator(locator),
+			Locator:     remote.MakeLocator(redact.RedactableString(locator)),
 			ObjName:     objName,
 			HasPointKey: true,
 			Size:        uint64(sz),

--- a/disk_usage_test.go
+++ b/disk_usage_test.go
@@ -53,7 +53,7 @@ func TestEstimateDiskUsageDataDriven(t *testing.T) {
 			}
 			opts := &Options{FS: fs, FormatMajorVersion: FormatExciseBoundsRecord, DisableAutomaticCompactions: true}
 			opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-				"external-locator": remoteStorage,
+				remote.MakeLocator("external-locator"): remoteStorage,
 			})
 			require.NoError(t, parseDBOptionsArgs(opts, td.CmdArgs))
 			var err error

--- a/download_test.go
+++ b/download_test.go
@@ -136,7 +136,7 @@ func initDownloadTestProvider(t *testing.T) objstorage.Provider {
 	}
 	providerSettings.Local.FS = vfs.NewMem()
 	providerSettings.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"": remote.NewInMem(),
+		remote.MakeLocator(""): remote.NewInMem(),
 	})
 
 	objProvider, err := objstorageprovider.Open(providerSettings)
@@ -151,7 +151,7 @@ func initDownloadTestProvider(t *testing.T) objstorage.Provider {
 	}
 	var remoteObjs []objstorage.RemoteObjectToAttach
 	for i := base.DiskFileNum(100); i < 200; i++ {
-		backing, err := objProvider.CreateExternalObjectBacking("", fmt.Sprintf("external-%d", i))
+		backing, err := objProvider.CreateExternalObjectBacking(remote.MakeLocator(""), fmt.Sprintf("external-%d", i))
 		require.NoError(t, err)
 		remoteObjs = append(remoteObjs, objstorage.RemoteObjectToAttach{
 			FileNum:  i,

--- a/event.go
+++ b/event.go
@@ -73,7 +73,7 @@ func (i DataCorruptionInfo) String() string {
 func (i DataCorruptionInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("on-disk corruption: %s", redact.Safe(i.Path))
 	if i.IsRemote {
-		w.Printf(" (remote locator %q)", redact.Safe(i.Locator))
+		w.Printf(" (remote locator %q)", i.Locator)
 	}
 	w.Printf("; bounds: %s; details: %+v", i.Bounds.String(), i.Details)
 }

--- a/excise_test.go
+++ b/excise_test.go
@@ -88,7 +88,7 @@ func TestExcise(t *testing.T) {
 			opts.Levels[0].IndexBlockSize = 32 << 10
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"external-locator": remoteStorage,
+			remote.MakeLocator("external-locator"): remoteStorage,
 		})
 		opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
 		// Disable automatic compactions because otherwise we'll race with
@@ -453,10 +453,10 @@ func TestConcurrentExcise(t *testing.T) {
 		tel := TeeEventListener(lel, el)
 		opts1.EventListener = &tel
 		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": sstorage,
+			remote.MakeLocator(""): sstorage,
 		})
 		opts1.Experimental.CreateOnShared = remote.CreateOnSharedAll
-		opts1.Experimental.CreateOnSharedLocator = ""
+		opts1.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts1.DisableAutomaticCompactions = true
@@ -465,10 +465,10 @@ func TestConcurrentExcise(t *testing.T) {
 		opts2 := &Options{}
 		*opts2 = *opts1
 		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": sstorage,
+			remote.MakeLocator(""): sstorage,
 		})
 		opts2.Experimental.CreateOnShared = remote.CreateOnSharedAll
-		opts2.Experimental.CreateOnSharedLocator = ""
+		opts2.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
 		opts2.FS = mem2
 
 		var err error

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1219,10 +1219,10 @@ func testIngestSharedImpl(
 		lel := MakeLoggingEventListener(testutils.Logger{T: t})
 		opts1.EventListener = &lel
 		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": sstorage,
+			remote.MakeLocator(""): sstorage,
 		})
 		opts1.Experimental.CreateOnShared = createOnShared
-		opts1.Experimental.CreateOnSharedLocator = ""
+		opts1.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts1.DisableAutomaticCompactions = true
@@ -1230,10 +1230,10 @@ func testIngestSharedImpl(
 		opts2 = &Options{}
 		*opts2 = *opts1
 		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": sstorage,
+			remote.MakeLocator(""): sstorage,
 		})
 		opts2.Experimental.CreateOnShared = createOnShared
-		opts2.Experimental.CreateOnSharedLocator = ""
+		opts2.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
 		opts2.FS = mem2
 
 		var err error
@@ -1558,10 +1558,10 @@ func TestSimpleIngestShared(t *testing.T) {
 	providerSettings.Local.NoSyncOnClose = opts2.NoSyncOnClose
 	providerSettings.Local.BytesPerSync = opts2.BytesPerSync
 	providerSettings.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"": remote.NewInMem(),
+		remote.MakeLocator(""): remote.NewInMem(),
 	})
 	providerSettings.Remote.CreateOnShared = remote.CreateOnSharedAll
-	providerSettings.Remote.CreateOnSharedLocator = ""
+	providerSettings.Remote.CreateOnSharedLocator = remote.MakeLocator("")
 
 	provider2, err := objstorageprovider.Open(providerSettings)
 	require.NoError(t, err)
@@ -1702,7 +1702,7 @@ func TestIngestExternal(t *testing.T) {
 			Logger:             testutils.Logger{T: t},
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"external-locator": remoteStorage,
+			remote.MakeLocator("external-locator"): remoteStorage,
 		})
 		opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
 		opts.Experimental.IngestSplit = func() bool {

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/rangekey"
 	"github.com/cockroachdb/pebble/internal/treesteps"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
@@ -1072,7 +1073,7 @@ func (o *ingestExternalFilesOp) run(t *Test, h historyRecorder) {
 
 			meta := t.getExternalObj(obj.externalObjID)
 			external[i] = pebble.ExternalFile{
-				Locator:           "external",
+				Locator:           remote.MakeLocator("external"),
 				ObjName:           meta.objName,
 				Size:              meta.sstMeta.Size,
 				StartKey:          obj.bounds.Start,

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -291,10 +291,10 @@ func (t *Test) finalizeOptions() pebble.Options {
 		if err := o.FS.MkdirAll(sharedDir, 0755); err != nil {
 			panic(errors.AssertionFailedf("failed to create directory %q: %s", sharedDir, err))
 		}
-		m[""] = remote.NewLocalFS(sharedDir, o.FS)
+		m[remote.MakeLocator("")] = remote.NewLocalFS(sharedDir, o.FS)
 	}
 	if t.testOpts.externalStorageEnabled || t.testOpts.initialStatePath != "" {
-		m["external"] = t.externalStorage
+		m[remote.MakeLocator("external")] = t.externalStorage
 	}
 	if len(m) > 0 {
 		o.Experimental.RemoteStorage = remote.MakeSimpleFactory(m)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -291,7 +291,7 @@ func TestMetrics(t *testing.T) {
 		opts.MemTableStopWritesThreshold = 4
 
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": remoteStorage,
+			remote.MakeLocator(""): remoteStorage,
 		})
 		if createOnSharedLower {
 			opts.Experimental.CreateOnShared = remote.CreateOnSharedLower

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -43,7 +43,7 @@ func TestProvider(t *testing.T) {
 			log.Infof("<remote> "+fmt, args...)
 		})
 		sharedFactory := remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": sharedStore,
+			remote.MakeLocator(""): sharedStore,
 		})
 		tmpFileCounter := 0
 
@@ -100,7 +100,7 @@ func TestProvider(t *testing.T) {
 				if creatorID != 0 {
 					st.Remote.StorageFactory = sharedFactory
 					st.Remote.CreateOnShared = remote.CreateOnSharedAll
-					st.Remote.CreateOnSharedLocator = ""
+					st.Remote.CreateOnSharedLocator = remote.MakeLocator("")
 				}
 				st.Local.ReadaheadConfig = readaheadConfig
 				if coldDir != "" {
@@ -346,15 +346,15 @@ func TestProvider(t *testing.T) {
 func TestSharedMultipleLocators(t *testing.T) {
 	ctx := context.Background()
 	stores := map[remote.Locator]remote.Storage{
-		"foo": remote.NewInMem(),
-		"bar": remote.NewInMem(),
+		remote.MakeLocator("foo"): remote.NewInMem(),
+		remote.MakeLocator("bar"): remote.NewInMem(),
 	}
 	sharedFactory := remote.MakeSimpleFactory(stores)
 
 	st1 := DefaultSettings(vfs.NewMem(), "")
 	st1.Remote.StorageFactory = sharedFactory
 	st1.Remote.CreateOnShared = remote.CreateOnSharedAll
-	st1.Remote.CreateOnSharedLocator = "foo"
+	st1.Remote.CreateOnSharedLocator = remote.MakeLocator("foo")
 	p1, err := Open(st1)
 	require.NoError(t, err)
 	require.NoError(t, p1.SetCreatorID(1))
@@ -362,7 +362,7 @@ func TestSharedMultipleLocators(t *testing.T) {
 	st2 := DefaultSettings(vfs.NewMem(), "")
 	st2.Remote.StorageFactory = sharedFactory
 	st2.Remote.CreateOnShared = remote.CreateOnSharedAll
-	st2.Remote.CreateOnSharedLocator = "bar"
+	st2.Remote.CreateOnSharedLocator = remote.MakeLocator("bar")
 	p2, err := Open(st2)
 	require.NoError(t, err)
 	require.NoError(t, p2.SetCreatorID(2))
@@ -455,7 +455,7 @@ func TestAttachExternalObject(t *testing.T) {
 	ctx := context.Background()
 	storage := remote.NewInMem()
 	sharedFactory := remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"foo": storage,
+		remote.MakeLocator("foo"): storage,
 	})
 
 	st1 := DefaultSettings(vfs.NewMem(), "")
@@ -473,7 +473,7 @@ func TestAttachExternalObject(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
-	backing, err := p1.CreateExternalObjectBacking("foo", "some-obj-name")
+	backing, err := p1.CreateExternalObjectBacking(remote.MakeLocator("foo"), "some-obj-name")
 	require.NoError(t, err)
 
 	_, err = p1.AttachRemoteObjects([]objstorage.RemoteObjectToAttach{{
@@ -492,7 +492,7 @@ func TestAttachExternalObject(t *testing.T) {
 	require.Equal(t, byte(123), checkData(t, 0, buf))
 	require.NoError(t, r.Close())
 
-	require.Equal(t, []base.DiskFileNum{1}, p1.GetExternalObjects("foo", "some-obj-name"))
+	require.Equal(t, []base.DiskFileNum{1}, p1.GetExternalObjects(remote.MakeLocator("foo"), "some-obj-name"))
 
 	// Verify that we can extract a correct backing from this provider and attach
 	// the object to another provider.
@@ -533,10 +533,10 @@ func TestNotExistError(t *testing.T) {
 	st := DefaultSettings(fs, "")
 	sharedStorage := remote.NewInMem()
 	st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"": sharedStorage,
+		remote.MakeLocator(""): sharedStorage,
 	})
 	st.Remote.CreateOnShared = remote.CreateOnSharedAll
-	st.Remote.CreateOnSharedLocator = ""
+	st.Remote.CreateOnSharedLocator = remote.MakeLocator("")
 	provider, err := Open(st)
 	require.NoError(t, err)
 	require.NoError(t, provider.SetCreatorID(1))
@@ -621,11 +621,11 @@ func TestParallelSync(t *testing.T) {
 			fs := vfs.NewCrashableMem()
 			st := DefaultSettings(fs, "")
 			st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-				"": remote.NewInMem(),
+				remote.MakeLocator(""): remote.NewInMem(),
 			})
 
 			st.Remote.CreateOnShared = remote.CreateOnSharedAll
-			st.Remote.CreateOnSharedLocator = ""
+			st.Remote.CreateOnSharedLocator = remote.MakeLocator("")
 			p, err := Open(st)
 			require.NoError(t, err)
 			require.NoError(t, p.SetCreatorID(1))

--- a/objstorage/objstorageprovider/remote.go
+++ b/objstorage/objstorageprovider/remote.go
@@ -275,7 +275,7 @@ func (p *provider) sharedSync() error {
 }
 
 func (p *provider) remotePath(meta objstorage.ObjectMetadata) string {
-	if meta.Remote.Locator != "" {
+	if meta.Remote.Locator.RawRedactableString != "" {
 		return fmt.Sprintf("remote-%s://%s", meta.Remote.Locator, remoteObjectName(meta))
 	}
 	return "remote://" + remoteObjectName(meta)

--- a/objstorage/objstorageprovider/remote_backing.go
+++ b/objstorage/objstorageprovider/remote_backing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/remote"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -60,9 +61,9 @@ func (p *provider) encodeRemoteObjectBacking(
 		buf = binary.AppendUvarint(buf, uint64(p.remote.shared.creatorID))
 		buf = binary.AppendUvarint(buf, uint64(meta.DiskFileNum))
 	}
-	if meta.Remote.Locator != "" {
+	if meta.Remote.Locator.RawRedactableString != "" {
 		buf = binary.AppendUvarint(buf, tagLocator)
-		buf = encodeString(buf, string(meta.Remote.Locator))
+		buf = encodeString(buf, string(meta.Remote.Locator.RawRedactableString))
 	}
 	if meta.Remote.CustomObjectName != "" {
 		buf = binary.AppendUvarint(buf, tagCustomObjectName)
@@ -204,7 +205,7 @@ func decodeRemoteObjectBacking(
 		res.refToCheck.creatorID = objstorage.CreatorID(refCheckCreatorID)
 		res.refToCheck.fileNum = base.DiskFileNum(refCheckFileNum)
 	}
-	res.meta.Remote.Locator = remote.Locator(locator)
+	res.meta.Remote.Locator = remote.MakeLocator(redact.RedactableString(locator))
 	res.meta.Remote.CustomObjectName = customObjName
 	return res, nil
 }

--- a/objstorage/objstorageprovider/remote_backing_test.go
+++ b/objstorage/objstorageprovider/remote_backing_test.go
@@ -32,7 +32,7 @@ func TestSharedObjectBacking(t *testing.T) {
 					st := DefaultSettings(vfs.NewMem(), "")
 					sharedStorage := remote.NewInMem()
 					st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-						"foo": sharedStorage,
+						remote.MakeLocator("foo"): sharedStorage,
 					})
 					p, err := Open(st)
 					require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestSharedObjectBacking(t *testing.T) {
 					meta.Remote.CreatorID = 100
 					meta.Remote.CreatorFileNum = base.DiskFileNum(200)
 					meta.Remote.CleanupMethod = cleanup
-					meta.Remote.Locator = "foo"
+					meta.Remote.Locator = remote.MakeLocator("foo")
 					meta.Remote.CustomObjectName = "obj-name"
 					meta.Remote.Storage = sharedStorage
 
@@ -112,7 +112,7 @@ func TestCreateSharedObjectBacking(t *testing.T) {
 			st := DefaultSettings(vfs.NewMem(), "")
 			sharedStorage := remote.NewInMem()
 			st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-				"foo": sharedStorage,
+				remote.MakeLocator("foo"): sharedStorage,
 			})
 			p, err := Open(st)
 			require.NoError(t, err)
@@ -120,13 +120,13 @@ func TestCreateSharedObjectBacking(t *testing.T) {
 
 			require.NoError(t, p.SetCreatorID(1))
 
-			backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
+			backing, err := p.CreateExternalObjectBacking(remote.MakeLocator("foo"), "custom-obj-name")
 			require.NoError(t, err)
 			d, err := decodeRemoteObjectBacking(fileType, base.DiskFileNum(100), backing)
 			require.NoError(t, err)
 			require.Equal(t, uint64(100), uint64(d.meta.DiskFileNum))
 			require.Equal(t, fileType, d.meta.FileType)
-			require.Equal(t, remote.Locator("foo"), d.meta.Remote.Locator)
+			require.Equal(t, remote.MakeLocator("foo"), d.meta.Remote.Locator)
 			require.Equal(t, "custom-obj-name", d.meta.Remote.CustomObjectName)
 			require.Equal(t, objstorage.SharedNoCleanup, d.meta.Remote.CleanupMethod)
 		})
@@ -139,13 +139,13 @@ func TestAttachRemoteObjects(t *testing.T) {
 			st := DefaultSettings(vfs.NewMem(), "")
 			sharedStorage := remote.NewInMem()
 			st.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-				"foo": sharedStorage,
+				remote.MakeLocator("foo"): sharedStorage,
 			})
 			p, err := Open(st)
 			require.NoError(t, err)
 			defer p.Close()
 			require.NoError(t, p.SetCreatorID(1))
-			backing, err := p.CreateExternalObjectBacking("foo", "custom-obj-name")
+			backing, err := p.CreateExternalObjectBacking(remote.MakeLocator("foo"), "custom-obj-name")
 			require.NoError(t, err)
 			_, err = p.AttachRemoteObjects([]objstorage.RemoteObjectToAttach{{
 				FileType: fileType,
@@ -166,7 +166,7 @@ func TestAttachRemoteObjects(t *testing.T) {
 			objs := p.List()
 			require.Len(t, objs, 1)
 			o := objs[0]
-			require.Equal(t, remote.Locator("foo"), o.Remote.Locator)
+			require.Equal(t, remote.MakeLocator("foo"), o.Remote.Locator)
 			require.Equal(t, "custom-obj-name", o.Remote.CustomObjectName)
 			require.Equal(t, uint64(100), uint64(o.DiskFileNum))
 			require.Equal(t, fileType, o.FileType)

--- a/objstorage/objstorageprovider/remote_readable_test.go
+++ b/objstorage/objstorageprovider/remote_readable_test.go
@@ -116,9 +116,9 @@ func TestErrorWhenObjectDisappears(t *testing.T) {
 	remoteStorage := remote.NewInMem()
 	settings := DefaultSettings(vfs.NewMem(), "")
 	settings.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"locator": remoteStorage,
+		remote.MakeLocator("locator"): remoteStorage,
 	})
-	settings.Remote.CreateOnSharedLocator = "locator"
+	settings.Remote.CreateOnSharedLocator = remote.MakeLocator("locator")
 	settings.Remote.CreateOnShared = remote.CreateOnSharedAll
 	provider, err := Open(settings)
 	require.NoError(t, err)

--- a/objstorage/objstorageprovider/remoteobjcat/version_edit.go
+++ b/objstorage/objstorageprovider/remoteobjcat/version_edit.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/remote"
+	"github.com/cockroachdb/redact"
 )
 
 // VersionEdit is a modification to the remote object state which can be encoded
@@ -87,9 +88,9 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 		buf = binary.AppendUvarint(buf, uint64(meta.CreatorID))
 		buf = binary.AppendUvarint(buf, uint64(meta.CreatorFileNum))
 		buf = binary.AppendUvarint(buf, uint64(meta.CleanupMethod))
-		if meta.Locator != "" {
+		if meta.Locator.RawRedactableString != "" {
 			buf = binary.AppendUvarint(buf, uint64(tagNewObjectLocator))
-			buf = encodeString(buf, string(meta.Locator))
+			buf = encodeString(buf, string(meta.Locator.RawRedactableString))
 		}
 		if meta.CustomObjectName != "" {
 			buf = binary.AppendUvarint(buf, uint64(tagNewObjectCustomName))
@@ -175,7 +176,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 					CreatorID:        objstorage.CreatorID(creatorID),
 					CreatorFileNum:   base.DiskFileNum(creatorFileNum),
 					CleanupMethod:    objstorage.SharedCleanupMethod(cleanupMethod),
-					Locator:          remote.Locator(locator),
+					Locator:          remote.MakeLocator(redact.RedactableString(locator)),
 					CustomObjectName: customName,
 				})
 			}

--- a/objstorage/objstorageprovider/remoteobjcat/version_edit_test.go
+++ b/objstorage/objstorageprovider/remoteobjcat/version_edit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/kr/pretty"
 )
 
@@ -29,7 +30,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					CreatorID:        12,
 					CreatorFileNum:   base.DiskFileNum(123),
 					CleanupMethod:    objstorage.SharedNoCleanup,
-					Locator:          "",
+					Locator:          remote.MakeLocator(""),
 					CustomObjectName: "foo",
 				},
 			},
@@ -42,7 +43,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					CreatorID:        12,
 					CreatorFileNum:   base.DiskFileNum(123),
 					CleanupMethod:    objstorage.SharedNoCleanup,
-					Locator:          "",
+					Locator:          remote.MakeLocator(""),
 					CustomObjectName: "foo",
 				},
 			},
@@ -59,7 +60,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					CreatorID:        12,
 					CreatorFileNum:   base.DiskFileNum(123),
 					CleanupMethod:    objstorage.SharedRefTracking,
-					Locator:          "foo",
+					Locator:          remote.MakeLocator("foo"),
 					CustomObjectName: "",
 				},
 				{
@@ -67,7 +68,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					FileType:         base.FileTypeTable,
 					CreatorID:        22,
 					CreatorFileNum:   base.DiskFileNum(223),
-					Locator:          "bar",
+					Locator:          remote.MakeLocator("bar"),
 					CustomObjectName: "obj1",
 				},
 				{
@@ -76,7 +77,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					CreatorID:        32,
 					CreatorFileNum:   base.DiskFileNum(323),
 					CleanupMethod:    objstorage.SharedRefTracking,
-					Locator:          "baz",
+					Locator:          remote.MakeLocator("baz"),
 					CustomObjectName: "obj2",
 				},
 			},
@@ -91,7 +92,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					CreatorID:        12,
 					CreatorFileNum:   base.DiskFileNum(123),
 					CleanupMethod:    objstorage.SharedRefTracking,
-					Locator:          "foo",
+					Locator:          remote.MakeLocator("foo"),
 					CustomObjectName: "",
 				},
 				{
@@ -99,7 +100,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					FileType:         base.FileTypeBlob,
 					CreatorID:        22,
 					CreatorFileNum:   base.DiskFileNum(223),
-					Locator:          "bar",
+					Locator:          remote.MakeLocator("bar"),
 					CustomObjectName: "obj1",
 				},
 				{
@@ -108,7 +109,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					CreatorID:        32,
 					CreatorFileNum:   base.DiskFileNum(323),
 					CleanupMethod:    objstorage.SharedRefTracking,
-					Locator:          "baz",
+					Locator:          remote.MakeLocator("baz"),
 					CustomObjectName: "obj2",
 				},
 			},

--- a/objstorage/remote/storage.go
+++ b/objstorage/remote/storage.go
@@ -13,14 +13,26 @@ import (
 
 // Locator is an opaque string identifying a remote.Storage implementation.
 //
-// The Locator must not contain secrets (like authentication keys). Locators are
-// stored on disk in the shared object catalog and are passed around as part of
-// RemoteObjectBacking; they can also appear in error messages.
-type Locator string
+// Locators are stored on disk in the shared object catalog and are passed around as part of
+// RemoteObjectBacking. They can also appear in error messages.
+// As such, if a Locator contains secrets, the constructor must ensure that the necessary redaction
+// is implemented.
+type Locator struct {
+	RawRedactableString redact.RedactableString
+}
+
+// MakeLocator constructs a Locator from a plain string.
+func MakeLocator(r redact.RedactableString) Locator {
+	return Locator{RawRedactableString: r}
+}
 
 // SafeFormat implements redact.SafeFormatter.
-func (l Locator) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("%s", redact.SafeString(l))
+func (l Locator) SafeFormat(w redact.SafePrinter, r rune) {
+	l.RawRedactableString.SafeFormat(w, r)
+}
+
+func (l Locator) String() string {
+	return string(l.RawRedactableString.Redact())
 }
 
 // StorageFactory is used to return Storage implementations based on locators. A

--- a/open_test.go
+++ b/open_test.go
@@ -1783,7 +1783,7 @@ func TestOpenRatchetsNextFileNum(t *testing.T) {
 	opts := &Options{FS: mem, Logger: testutils.Logger{T: t}}
 	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
 	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"": memShared,
+		remote.MakeLocator(""): memShared,
 	})
 	d, err := Open("", opts)
 	require.NoError(t, err)

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -73,10 +73,10 @@ func TestScanStatistics(t *testing.T) {
 			},
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"": remote.NewInMem(),
+			remote.MakeLocator(""): remote.NewInMem(),
 		})
 		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
-		opts.Experimental.CreateOnSharedLocator = ""
+		opts.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
 		opts.DisableAutomaticCompactions = true
 		opts.EnsureDefaults()
 		opts.WithFSDefaults()
@@ -249,11 +249,11 @@ func TestScanInternal(t *testing.T) {
 			},
 		}
 		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-			"external-storage": extStorage,
-			"":                 remote.NewInMem(),
+			remote.MakeLocator("external-storage"): extStorage,
+			remote.MakeLocator(""):                 remote.NewInMem(),
 		})
 		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
-		opts.Experimental.CreateOnSharedLocator = ""
+		opts.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
 		opts.DisableAutomaticCompactions = true
 		opts.EnsureDefaults()
 		opts.WithFSDefaults()
@@ -490,7 +490,7 @@ func TestScanInternal(t *testing.T) {
 				writeSST(points, rangeDels, rangeKeys, objstorageprovider.NewRemoteWritable(file))
 				ef := ExternalFile{
 					ObjName:           objName,
-					Locator:           remote.Locator("external-storage"),
+					Locator:           remote.MakeLocator("external-storage"),
 					Size:              10,
 					StartKey:          smallest.UserKey,
 					EndKey:            largest.UserKey,

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -2589,9 +2589,9 @@ func TestReaderReportsCorruption(t *testing.T) {
 	remoteStorage := remote.NewInMem()
 	settings := objstorageprovider.DefaultSettings(vfs.NewMem(), "")
 	settings.Remote.StorageFactory = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"locator": remoteStorage,
+		remote.MakeLocator("locator"): remoteStorage,
 	})
-	settings.Remote.CreateOnSharedLocator = "locator"
+	settings.Remote.CreateOnSharedLocator = remote.MakeLocator("locator")
 	settings.Remote.CreateOnShared = remote.CreateOnSharedAll
 	provider, err := objstorageprovider.Open(settings)
 	require.NoError(t, err)


### PR DESCRIPTION
This patch adjusts `remote.Locator` to support redaction by changing the underlying type from a raw string to a `redact.RedactableString`. This puts the responsibility on the constructor of a `remote.Locator` to insert the necessary markers if redaction is required.