### PR TITLE
crl-release-26.1: compaction: skip pre-valsep files in policy comparison, add annotations

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -1787,6 +1787,11 @@ func TestCompactionTombstones(t *testing.T) {
 				opts.Experimental.CompactionScheduler = func() CompactionScheduler {
 					return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 				}
+				opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+					return ValueSeparationPolicy{
+						Enabled: false,
+					}
+				}
 				var err error
 				d, err = runDBDefineCmd(td, opts)
 				if err != nil {

--- a/compaction_value_separation.go
+++ b/compaction_value_separation.go
@@ -105,6 +105,7 @@ func shouldWriteBlobFiles(
 		// None of the input sstables reference blob files. It may be the case
 		// that these sstables were created before value separation was enabled.
 		// We should try to write to new blob files.
+		c.annotations = append(c.annotations, "write-blobs-input-depth-zero")
 		return true, 0
 	}
 
@@ -112,6 +113,7 @@ func shouldWriteBlobFiles(
 	// configured max, we should rewrite the values into new blob files to
 	// restore locality.
 	if inputReferenceDepth > manifest.BlobReferenceDepth(policy.MaxBlobReferenceDepth) {
+		c.annotations = append(c.annotations, "write-blobs-input-depth-exceeded")
 		return true, 0
 	}
 	// Compare policies used by each input file. If all input files have the
@@ -137,6 +139,7 @@ func shouldWriteBlobFiles(
 				if len(spanPolicyEndKey) > 0 && cmp(bounds.End.Key, spanPolicyEndKey) >= 0 {
 					// The table's key range now uses multiple span policies. Rewrite to new
 					// blob files so values are stored according to the current policy.
+					c.annotations = append(c.annotations, "write-blobs-multiple-policies")
 					return true, 0
 				}
 				if spanPolicy.ValueStoragePolicy.DisableBlobSeparation {
@@ -153,8 +156,22 @@ func shouldWriteBlobFiles(
 				}
 			}
 
-			if int(backingProps.ValueSeparationMinSize) != expectedMinSize ||
-				(expectedMinSize > 0 && backingProps.ValueSeparationBySuffixDisabled != expectedValSepBySuffixDisabled) {
+			if backingProps.ValueSeparationMinSize == 0 {
+				// This table was written with value separation disabled. Eventually
+				// this table will be input to a compaction that exceeds the blob
+				// reference depth threshold. Until then, don't eagerly rewrite. We
+				// don't want to have a situation where 1 out of 20 input sstables to
+				// a compaction was written when value separation was disabled, and
+				// now all the other 19 sstables have to rewrite their blob
+				// references.
+				continue
+			}
+			if int(backingProps.ValueSeparationMinSize) != expectedMinSize {
+				c.annotations = append(c.annotations, "write-blobs-min-size-mismatch")
+				return true, 0
+			}
+			if expectedMinSize > 0 && backingProps.ValueSeparationBySuffixDisabled != expectedValSepBySuffixDisabled {
+				c.annotations = append(c.annotations, "write-blobs-suffix-disabled-mismatch")
 				return true, 0
 			}
 		}

--- a/compaction_value_separation_test.go
+++ b/compaction_value_separation_test.go
@@ -1,0 +1,303 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestTableMeta creates a TableMetadata suitable for testing
+// shouldWriteBlobFiles. It initializes the physical backing and populates
+// properties relevant to value separation.
+func makeTestTableMeta(
+	cmp base.Compare,
+	tableNum base.TableNum,
+	smallest, largest base.InternalKey,
+	blobRefDepth manifest.BlobReferenceDepth,
+	valSepMinSize uint64,
+	valSepBySuffixDisabled bool,
+) *manifest.TableMetadata {
+	m := &manifest.TableMetadata{TableNum: tableNum, Size: 1024}
+	m.BlobReferenceDepth = blobRefDepth
+	m.ExtendPointKeyBounds(cmp, smallest, largest)
+	m.InitPhysicalBacking()
+	m.TableBacking.PopulateProperties(&sstable.Properties{
+		ValueSeparationMinSize:          valSepMinSize,
+		ValueSeparationBySuffixDisabled: valSepBySuffixDisabled,
+	})
+	return m
+}
+
+func TestShouldWriteBlobFiles(t *testing.T) {
+	cmp := base.DefaultComparer.Compare
+	ikey := func(userKey string, seqNum uint64) base.InternalKey {
+		return base.MakeInternalKey([]byte(userKey), base.SeqNum(seqNum), base.InternalKeyKindSet)
+	}
+	defaultPolicy := ValueSeparationPolicy{
+		Enabled:               true,
+		MinimumSize:           512,
+		MaxBlobReferenceDepth: 5,
+	}
+	defaultSpanPolicyFunc := SpanPolicyFunc(func(startKey []byte) (_ base.SpanPolicy, endKey []byte, _ error) {
+		return base.SpanPolicy{}, []byte("z"), nil
+	})
+
+	type testCase struct {
+		name               string
+		kind               compactionKind
+		inputs             []compactionLevel
+		policy             ValueSeparationPolicy
+		spanPolicyFunc     SpanPolicyFunc
+		wantWriteBlobs     bool
+		wantReferenceDepth manifest.BlobReferenceDepth
+		wantAnnotations    []string
+	}
+	tests := []testCase{
+		{
+			name: "flush",
+			kind: compactionKindFlush,
+			// Flushes always write new blob files regardless of inputs.
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+		},
+		{
+			// A virtual rewrite materializes a virtual table without writing
+			// new blob files. The reference depth is preserved unchanged.
+			name: "virtual-rewrite",
+			kind: compactionKindVirtualRewrite,
+			inputs: []compactionLevel{
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 3, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     false,
+			wantReferenceDepth: 3,
+		},
+		{
+			name: "default-low-reference-depth",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 3, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 2, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     false,
+			wantReferenceDepth: 5, // 3 + 2
+		},
+		{
+			name: "all-pre-valsep",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 0, 0, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 0, 0, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-input-depth-zero"},
+		},
+		{
+			// A compaction mixing post-valsep L5 files with pre-valsep L6 files
+			// should NOT force a rewrite of the L5 blob references.
+			name: "mixed-pre-and-post-valsep",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 1, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 0, 0, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     false,
+			wantReferenceDepth: 1, // max(1) + max(0)
+		},
+		{
+			name: "depth-exceeded",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 3, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 3, 512, false),
+					}),
+				},
+			},
+			// inputReferenceDepth = 3 + 3 = 6 > MaxBlobReferenceDepth (5)
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-input-depth-exceeded"},
+		},
+		{
+			name: "min-size-mismatch",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						// MinSize=256 differs from policy MinimumSize=512.
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 1, 256, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 1, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-min-size-mismatch"},
+		},
+		{
+			name: "suffix-disabled-mismatch",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						// BySuffixDisabled=true but the default span policy expects false.
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 1, 512, true),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 1, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-suffix-disabled-mismatch"},
+		},
+		{
+			name: "multiple-span-policies",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						// File spans a→z but the span policy only covers a→m.
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("z", 5), 1, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 1, 512, false),
+					}),
+				},
+			},
+			spanPolicyFunc: func(startKey []byte) (_ base.SpanPolicy, endKey []byte, _ error) {
+				return base.SpanPolicy{}, []byte("m"), nil
+			},
+			wantWriteBlobs:     true,
+			wantReferenceDepth: 0,
+			wantAnnotations:    []string{"write-blobs-multiple-policies"},
+		},
+		{
+			name: "all-matching",
+			kind: compactionKindDefault,
+			inputs: []compactionLevel{
+				{
+					level: 5,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 1, ikey("a", 5), ikey("m", 5), 2, 512, false),
+					}),
+				},
+				{
+					level: 6,
+					files: manifest.NewLevelSliceKeySorted(cmp, []*manifest.TableMetadata{
+						makeTestTableMeta(
+							cmp, 2, ikey("a", 4), ikey("m", 4), 1, 512, false),
+					}),
+				},
+			},
+			wantWriteBlobs:     false,
+			wantReferenceDepth: 3, // 2 + 1
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := tt.policy
+			if policy == (ValueSeparationPolicy{}) {
+				policy = defaultPolicy
+			}
+			spanPolicyFunc := tt.spanPolicyFunc
+			if spanPolicyFunc == nil {
+				spanPolicyFunc = defaultSpanPolicyFunc
+			}
+			c := &tableCompaction{
+				kind:   tt.kind,
+				inputs: tt.inputs,
+			}
+			writeBlobs, refDepth := shouldWriteBlobFiles(c, policy, spanPolicyFunc, cmp)
+			require.Equal(t, tt.wantWriteBlobs, writeBlobs, "writeBlobs")
+			require.Equal(t, tt.wantReferenceDepth, refDepth, "referenceDepth")
+			if tt.wantAnnotations == nil {
+				require.Empty(t, c.annotations, "annotations")
+			} else {
+				require.Equal(t, tt.wantAnnotations, c.annotations, "annotations")
+			}
+		})
+	}
+}

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -1119,10 +1119,11 @@ compact f-z
 L6:
   000018:[a#0,SET-b#0,SET] seqnums:[0-0] points:[a#0,SET-b#0,SET] size:779 blobrefs:[(B000019: 4); depth:1]
   000020:[f#0,SET-g#0,SET] seqnums:[0-0] points:[f#0,SET-g#0,SET] size:693
-  000021:[o#0,SET-p#0,SET] seqnums:[0-0] points:[o#0,SET-p#0,SET] size:779 blobrefs:[(B000022: 4); depth:1]
+  000021:[o#0,SET-p#0,SET] seqnums:[0-0] points:[o#0,SET-p#0,SET] size:786 blobrefs:[(B000017: 2), (B000008: 2); depth:2]
 Blob files:
+  B000008 physical:{000008 size:[94 (94B)] vals:[4 (4B)]}
+  B000017 physical:{000017 size:[91 (91B)] vals:[2 (2B)]}
   B000019 physical:{000019 size:[94 (94B)] vals:[4 (4B)]}
-  B000022 physical:{000022 size:[94 (94B)] vals:[4 (4B)]}
 
 # Default value separation.
 sstable-properties file=000018
@@ -1182,7 +1183,7 @@ rocksdb.deleted.keys: 0
 rocksdb.num.range-deletions: 0
 rocksdb.num.data.blocks: 1
 rocksdb.comparator: leveldb.BytewiseComparator
-rocksdb.data.size: 87
+rocksdb.data.size: 89
 rocksdb.filter.size: 0
 rocksdb.index.size: 36
 rocksdb.block.based.table.index.type: 0
@@ -1192,6 +1193,6 @@ rocksdb.merge.operands: 0
 pebble.num.values.in.blob-files: 2
 rocksdb.property.collectors: [obsolete-key]
 rocksdb.compression: Snappy
-pebble.compression_stats: None:56,Snappy:82/114
+pebble.compression_stats: None:61,Snappy:84/114
 pebble.value-separation.min-size: 1
 obsolete-key: hex:00


### PR DESCRIPTION
backport of https://github.com/cockroachdb/pebble/pull/5847

----

Previously, shouldWriteBlobFiles treated pre-valsep sstables (ValueSeparationMinSize == 0) as a policy mismatch, forcing all blob references in the compaction to be rewritten into new blob files. This was wasteful when a compaction mixed post-valsep files with pre-valsep files — the already-separated values were read and rewritten for no benefit.

Skip pre-valsep files (MinSize == 0) in the policy comparison loop so they do not trigger unnecessary rewrites. Also add annotation strings to each branch that returns writeBlobs=true, aiding debuggability.

Add TestShouldWriteBlobFiles covering all branches: flush, virtual rewrite, all-pre-valsep, mixed pre/post-valsep (the core fix), depth-exceeded, min-size mismatch, suffix-disabled mismatch, multiple span policies, and the all-matching preserve-references path.

Fixes #5846