### PR TITLE
db: fix iterator leak on close

### DIFF
--- a/table_stats.go
+++ b/table_stats.go
@@ -1061,6 +1061,7 @@ func newCombinedDeletionKeyspanIter(
 	mIter.Init(comparer, transform, new(keyspanimpl.MergingBuffers))
 	iter, err := r.NewRawRangeDelIter(ctx, m.FragmentIterTransforms(), env)
 	if err != nil {
+		mIter.Close()
 		return nil, err
 	}
 	if iter != nil {
@@ -1112,6 +1113,7 @@ func newCombinedDeletionKeyspanIter(
 
 	iter, err = r.NewRawRangeKeyIter(ctx, m.FragmentIterTransforms(), env)
 	if err != nil {
+		mIter.Close()
 		return nil, err
 	}
 	if iter != nil {


### PR DESCRIPTION
This change fixes an iterator leak in the table stats code. This leak
was exposed by #5813 which plumbed a context that gets canceled on
close. If the cancelation happens right as we're opening the range key
iterator, we leak the range del iterator.

Fixes #5843