### PR TITLE
sstable: return error from EncodeSpan on same-boundary trailer misord…

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -325,6 +325,7 @@ func (w *RawColumnWriter) EncodeSpan(span keyspan.Span) error {
 		}
 		for i := range w.blockPropCollectors {
 			if err := w.blockPropCollectors[i].AddRangeKeys(span); err != nil {
+				w.err = err
 				return err
 			}
 		}
@@ -339,6 +340,7 @@ func (w *RawColumnWriter) EncodeSpan(span keyspan.Span) error {
 					w.opts.Comparer.FormatKey(prevStart),
 					w.opts.Comparer.FormatKey(prevEnd),
 					prevTrailer, span.Pretty(w.opts.Comparer.FormatKey))
+				return w.err
 			}
 		} else if c := w.opts.Comparer.Compare(prevEnd, span.Start); c > 0 {
 			w.err = errors.Errorf("pebble: keys must be added in order: %s-%s:{(#%s)}, %s",

--- a/sstable/testdata/writer_v5
+++ b/sstable/testdata/writer_v5
@@ -166,7 +166,7 @@ build-raw
 Span: a-c:{(#1,RANGEDEL)}
 Span: a-c:{(#2,RANGEDEL)}
 ----
-pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
+failed to write Span: a-c:{(#2,RANGEDEL)}: pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
 
 build-raw
 Span: a-c:{(#1,RANGEDEL)}

--- a/sstable/testdata/writer_v6
+++ b/sstable/testdata/writer_v6
@@ -166,7 +166,7 @@ build-raw
 Span: a-c:{(#1,RANGEDEL)}
 Span: a-c:{(#2,RANGEDEL)}
 ----
-pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
+failed to write Span: a-c:{(#2,RANGEDEL)}: pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
 
 build-raw
 Span: a-c:{(#1,RANGEDEL)}

--- a/sstable/testdata/writer_v7
+++ b/sstable/testdata/writer_v7
@@ -166,7 +166,7 @@ build-raw
 Span: a-c:{(#1,RANGEDEL)}
 Span: a-c:{(#2,RANGEDEL)}
 ----
-pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
+failed to write Span: a-c:{(#2,RANGEDEL)}: pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
 
 build-raw
 Span: a-c:{(#1,RANGEDEL)}

--- a/sstable/testdata/writer_v8
+++ b/sstable/testdata/writer_v8
@@ -166,7 +166,7 @@ build-raw
 Span: a-c:{(#1,RANGEDEL)}
 Span: a-c:{(#2,RANGEDEL)}
 ----
-pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
+failed to write Span: a-c:{(#2,RANGEDEL)}: pebble: keys must be added in order: a-c:{(#1,RANGEDEL)}, a-c:{(#2,RANGEDEL)}
 
 build-raw
 Span: a-c:{(#1,RANGEDEL)}


### PR DESCRIPTION
…ering

RawColumnWriter.EncodeSpan had two error paths for span ordering violations: one for same boundaries with wrong trailer order, and one for overlapping different boundaries. The second path returned the error to the caller, but the first only stored it in w.err without returning, allowing the invalid span to be silently added to the block.

Add the missing `return w.err` so the error is surfaced immediately, consistent with the other error path.