### PR TITLE
colblk: widen Decode function offset/count types to prevent overflow

### DIFF
--- a/cockroachkvs/cockroachkvs.go
+++ b/cockroachkvs/cockroachkvs.go
@@ -784,7 +784,7 @@ func (ks *cockroachKeySeeker) init(
 	// Note that we call DecodeColumn directly rather than using the
 	// BlockDecoder's type-specific convenience methods (e.g. PrefixBytes,
 	// Uints, etc) to avoid bd from escaping to the heap.
-	rows := int(bd.Rows())
+	rows := uint32(bd.Rows())
 	ks.roachKeys = colblk.DecodeColumn(&bd, cockroachColRoachKey, rows, colblk.DataTypePrefixBytes, colblk.DecodePrefixBytes)
 	ks.roachKeyChanged = d.PrefixChanged()
 	ks.mvccWallTimes = colblk.DecodeColumn(&bd, cockroachColMVCCWallTime, rows, colblk.DataTypeUint, colblk.DecodeUnsafeUints)

--- a/cockroachkvs/cockroachkvs_test.go
+++ b/cockroachkvs/cockroachkvs_test.go
@@ -211,10 +211,10 @@ func TestKeySchema_KeyWriter(t *testing.T) {
 			for i := 0; i < kw.NumColumns(); i++ {
 				offs[i+1] = kw.Finish(i, row, offs[i], b)
 			}
-			roachKeys, _ := colblk.DecodePrefixBytes(b, offs[cockroachColRoachKey], row)
-			mvccWallTimes, _ := colblk.DecodeUnsafeUints(b, offs[cockroachColMVCCWallTime], row)
-			mvccLogicalTimes, _ := colblk.DecodeUnsafeUints(b, offs[cockroachColMVCCLogical], row)
-			untypedVersions, _ := colblk.DecodeRawBytes(b, offs[cockroachColUntypedVersion], row)
+			roachKeys, _ := colblk.DecodePrefixBytes(b, uint64(offs[cockroachColRoachKey]), uint32(row))
+			mvccWallTimes, _ := colblk.DecodeUnsafeUints(b, uint64(offs[cockroachColMVCCWallTime]), uint32(row))
+			mvccLogicalTimes, _ := colblk.DecodeUnsafeUints(b, uint64(offs[cockroachColMVCCLogical]), uint32(row))
+			untypedVersions, _ := colblk.DecodeRawBytes(b, uint64(offs[cockroachColUntypedVersion]), uint32(row))
 			tbl := tablewriter.NewWriter(&buf)
 			tbl.SetHeader([]string{"Key", "Wall", "Logical", "Untyped"})
 			for i := 0; i < row; i++ {

--- a/sstable/blob/blocks.go
+++ b/sstable/blob/blocks.go
@@ -6,6 +6,7 @@ package blob
 
 import (
 	"encoding/binary"
+	"math"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
@@ -161,11 +162,14 @@ func (d *indexBlockDecoder) Init(data []byte) {
 	d.virtualBlockCount = int(binary.LittleEndian.Uint32(data))
 	d.bd.Init(data, indexBlockCustomHeaderSize)
 	d.virtualBlocks = colblk.DecodeColumn(&d.bd, indexBlockColumnVirtualBlocksIdx,
-		d.virtualBlockCount, colblk.DataTypeUint, colblk.DecodeUnsafeUints)
+		uint32(d.virtualBlockCount), colblk.DataTypeUint, colblk.DecodeUnsafeUints)
+	if d.bd.Rows() == math.MaxUint32 {
+		panic(errors.AssertionFailedf("invalid row count"))
+	}
 	// Decode the offsets column. We pass rows+1 because an index block encoding
 	// n block handles encodes n+1 offsets.
 	d.offsets = colblk.DecodeColumn(&d.bd, indexBlockColumnOffsetsIdx,
-		d.bd.Rows()+1, colblk.DataTypeUint, colblk.DecodeUnsafeUints)
+		uint32(d.bd.Rows()+1), colblk.DataTypeUint, colblk.DecodeUnsafeUints)
 }
 
 // BlockHandle returns the block handle for the given block index in the

--- a/sstable/colblk/bitmap.go
+++ b/sstable/colblk/bitmap.go
@@ -40,22 +40,23 @@ var _ Array[bool] = Bitmap{}
 // reads from b supporting bitCount logical bits. No bounds checking is
 // performed, so the caller must guarantee the bitmap is appropriately sized and
 // the provided bitCount correctly identifies the number of bits in the bitmap.
-func DecodeBitmap(b []byte, off uint32, bitCount int) (bitmap Bitmap, endOffset uint32) {
+func DecodeBitmap(b []byte, off uint64, bitCount uint32) (bitmap Bitmap, endOffset uint64) {
 	encoding := bitmapEncoding(b[off])
 	off++
 	if encoding == zeroBitmapEncoding {
-		return Bitmap{bitCount: bitCount}, off
+		return Bitmap{bitCount: int(bitCount)}, off
 	}
 	off = align(off, align64)
-	sz := bitmapRequiredSize(bitCount)
-	if len(b) < int(off)+sz {
+	sz := bitmapRequiredSize(int(bitCount))
+	endOffset = off + uint64(sz)
+	if endOffset > uint64(len(b)) {
 		panic(errors.AssertionFailedf("bitmap of %d bits requires at least %d bytes; provided with %d-byte slice",
-			errors.Safe(bitCount), errors.Safe(bitmapRequiredSize(bitCount)), errors.Safe(len(b[off:]))))
+			errors.Safe(bitCount), errors.Safe(sz), errors.Safe(len(b[off:]))))
 	}
 	return Bitmap{
 		data:     makeUnsafeUint64Decoder(b[off:], sz>>align64Shift),
-		bitCount: bitCount,
-	}, off + uint32(sz)
+		bitCount: int(bitCount),
+	}, endOffset
 }
 
 // Assert that DecodeBitmap implements DecodeFunc.

--- a/sstable/colblk/bitmap_test.go
+++ b/sstable/colblk/bitmap_test.go
@@ -55,7 +55,7 @@ func TestBitmapFixed(t *testing.T) {
 			if endOffset != size {
 				td.Fatalf(t, "endOffset=%d size=%d", endOffset, size)
 			}
-			bitmap, _ = DecodeBitmap(data, off, n)
+			bitmap, _ = DecodeBitmap(data, uint64(off), uint32(n))
 			dumpBitmap(&buf, bitmap)
 			fmt.Fprint(&buf, "\nBinary representation:\n")
 			f := binfmt.New(data)
@@ -174,8 +174,8 @@ func TestBitmapRandom(t *testing.T) {
 
 		data := make([]byte, builder.Size(size, 0))
 		_ = builder.Finish(0, size, 0, data)
-		bitmap, endOffset := DecodeBitmap(data, 0, size)
-		require.Equal(t, uint32(len(data)), endOffset)
+		bitmap, endOffset := DecodeBitmap(data, 0, uint32(size))
+		require.Equal(t, uint64(len(data)), endOffset)
 		for i := 0; i < size; i++ {
 			if got := bitmap.At(i); got != v[i] {
 				t.Fatalf("b.Get(%d) = %t; want %t", i, got, v[i])

--- a/sstable/colblk/block.go
+++ b/sstable/colblk/block.go
@@ -285,7 +285,7 @@ func FinishBlock(rows int, writers []ColumnWriter) []byte {
 // DecodeColumn decodes the col'th column of the provided reader's block as a
 // column of dataType using decodeFunc.
 func DecodeColumn[V any](
-	d *BlockDecoder, col int, rows int, dataType DataType, decodeFunc DecodeFunc[V],
+	d *BlockDecoder, col int, rows uint32, dataType DataType, decodeFunc DecodeFunc[V],
 ) V {
 	if uint16(col) >= d.header.Columns {
 		panic(errors.AssertionFailedf("column %d is out of range [0, %d)", errors.Safe(col), errors.Safe(d.header.Columns)))
@@ -346,25 +346,25 @@ func (d *BlockDecoder) dataType(col int) DataType {
 // Bitmap retrieves the col'th column as a bitmap. The column must be of type
 // DataTypeBool.
 func (d *BlockDecoder) Bitmap(col int) Bitmap {
-	return DecodeColumn(d, col, int(d.header.Rows), DataTypeBool, DecodeBitmap)
+	return DecodeColumn(d, col, d.header.Rows, DataTypeBool, DecodeBitmap)
 }
 
 // RawBytes retrieves the col'th column as a column of byte slices. The column
 // must be of type DataTypeBytes.
 func (d *BlockDecoder) RawBytes(col int) RawBytes {
-	return DecodeColumn(d, col, int(d.header.Rows), DataTypeBytes, DecodeRawBytes)
+	return DecodeColumn(d, col, d.header.Rows, DataTypeBytes, DecodeRawBytes)
 }
 
 // PrefixBytes retrieves the col'th column as a prefix-compressed byte slice column. The column
 // must be of type DataTypePrefixBytes.
 func (d *BlockDecoder) PrefixBytes(col int) PrefixBytes {
-	return DecodeColumn(d, col, int(d.header.Rows), DataTypePrefixBytes, DecodePrefixBytes)
+	return DecodeColumn(d, col, d.header.Rows, DataTypePrefixBytes, DecodePrefixBytes)
 }
 
 // Uints retrieves the col'th column as a column of uints. The column must be
 // of type DataTypeUint.
 func (d *BlockDecoder) Uints(col int) UnsafeUints {
-	return DecodeColumn(d, col, int(d.header.Rows), DataTypeUint, DecodeUnsafeUints)
+	return DecodeColumn(d, col, d.header.Rows, DataTypeUint, DecodeUnsafeUints)
 }
 
 // Data returns the underlying buffer.
@@ -377,13 +377,13 @@ func (d *BlockDecoder) Header() []byte {
 	return d.data[:d.customHeaderSize]
 }
 
-func (d *BlockDecoder) pageStart(col int) uint32 {
+func (d *BlockDecoder) pageStart(col int) uint64 {
 	if uint16(col) >= d.header.Columns {
 		// -1 for the trailing version byte
-		return uint32(len(d.data) - 1)
+		return uint64(len(d.data) - 1)
 	}
-	return binary.LittleEndian.Uint32(
-		unsafe.Slice((*byte)(d.pointer(d.customHeaderSize+uint32(blockHeaderBaseSize+columnHeaderSize*col+1))), 4))
+	return uint64(binary.LittleEndian.Uint32(
+		unsafe.Slice((*byte)(d.pointer(d.customHeaderSize+uint32(blockHeaderBaseSize+columnHeaderSize*col+1))), 4)))
 }
 
 func (d *BlockDecoder) pointer(offset uint32) unsafe.Pointer {

--- a/sstable/colblk/column.go
+++ b/sstable/colblk/column.go
@@ -92,7 +92,7 @@ type Encoder interface {
 // accessor for the data and the offset of the first byte after the structure.
 // The rows argument must be number of logical rows encoded within the data
 // structure.
-type DecodeFunc[T any] func(buf []byte, offset uint32, rows int) (decoded T, nextOffset uint32)
+type DecodeFunc[T any] func(buf []byte, offset uint64, rows uint32) (decoded T, nextOffset uint64)
 
 // An Array provides indexed access to an array of values.
 type Array[V any] interface {

--- a/sstable/colblk/keyspan.go
+++ b/sstable/colblk/keyspan.go
@@ -238,9 +238,9 @@ func (d *KeyspanDecoder) Init(data []byte) {
 	// columns, so we call DecodeColumn directly, taking care to pass in
 	// rows=r.boundaryKeysCount.
 	d.boundaryKeys = DecodeColumn(&d.blockDecoder, keyspanColBoundaryUserKeys,
-		int(d.boundaryKeysCount), DataTypeBytes, DecodeRawBytes)
+		d.boundaryKeysCount, DataTypeBytes, DecodeRawBytes)
 	d.boundaryKeyIndices = DecodeColumn(&d.blockDecoder, keyspanColBoundaryKeyIndices,
-		int(d.boundaryKeysCount), DataTypeUint, DecodeUnsafeUints)
+		d.boundaryKeysCount, DataTypeUint, DecodeUnsafeUints)
 
 	d.trailers = d.blockDecoder.Uints(keyspanColTrailers)
 	d.suffixes = d.blockDecoder.RawBytes(keyspanColSuffixes)

--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -204,8 +204,8 @@ var _ Array[[]byte] = PrefixBytes{}
 // PrefixBytesBuilder. Count must be the number of logical slices within the
 // array.
 func DecodePrefixBytes(
-	b []byte, offset uint32, count int,
-) (prefixBytes PrefixBytes, endOffset uint32) {
+	b []byte, offset uint64, count uint32,
+) (prefixBytes PrefixBytes, endOffset uint64) {
 	if count == 0 {
 		panic(errors.AssertionFailedf("empty PrefixBytes"))
 	}
@@ -214,12 +214,16 @@ func DecodePrefixBytes(
 	// power of two)
 	bundleShift := uint32(*((*uint8)(unsafe.Pointer(&b[offset]))))
 	calc := makeBundleCalc(bundleShift)
-	nBundles := int(calc.bundleCount(count))
+	nBundles := uint32(calc.bundleCount(int(count)))
+	totalSlices := count + nBundles
+	if totalSlices < count {
+		panic(errors.AssertionFailedf("overflow in PrefixBytes slice count: %d + %d", errors.Safe(count), errors.Safe(nBundles)))
+	}
 
-	rb, endOffset := DecodeRawBytes(b, offset+1, count+nBundles)
+	rb, endOffset := DecodeRawBytes(b, offset+1, totalSlices)
 	pb := PrefixBytes{
 		bundleCalc: calc,
-		rows:       count,
+		rows:       int(count),
 		rawBytes:   rb,
 	}
 	pb.sharedPrefixLen = int(pb.rawBytes.offsets.At(0))
@@ -618,7 +622,7 @@ func prefixBytesToBinFormatter(
 	data := f.RelativeData()
 	off := f.RelativeOffset()
 	start := unsafe.Pointer(&data[off])
-	pb, _ := DecodePrefixBytes(data, uint32(off), count)
+	pb, _ := DecodePrefixBytes(data, uint64(off), uint32(count))
 
 	f.HexBytesln(1, "bundle size: %d", 1<<pb.bundleShift)
 	f.ToTreePrinter(tp)

--- a/sstable/colblk/prefix_bytes_test.go
+++ b/sstable/colblk/prefix_bytes_test.go
@@ -82,9 +82,9 @@ func TestPrefixBytes(t *testing.T) {
 			f := binfmt.New(buf)
 			tp := treeprinter.New()
 			prefixBytesToBinFormatter(f, tp.Child("prefix-bytes"), rows, nil)
-			var endOffset uint32
-			pb, endOffset = DecodePrefixBytes(buf, 0, rows)
-			require.Equal(t, offset, endOffset)
+			var endOffset uint64
+			pb, endOffset = DecodePrefixBytes(buf, 0, uint32(rows))
+			require.Equal(t, uint64(offset), endOffset)
 			require.Equal(t, rows, pb.Rows())
 			return tp.String()
 		case "get":
@@ -185,8 +185,8 @@ func TestPrefixBytesRandomized(t *testing.T) {
 		t.Logf("Size: %d; NumUserKeys: %d (%d); Aggregate pre-compressed string data: %d",
 			size, n, len(userKeys), totalSize)
 
-		pb, endOffset := DecodePrefixBytes(buf, 0, n)
-		require.Equal(t, offset, endOffset)
+		pb, endOffset := DecodePrefixBytes(buf, 0, uint32(n))
+		require.Equal(t, uint64(offset), endOffset)
 		f := binfmt.New(buf)
 		tp := treeprinter.New()
 		prefixBytesToBinFormatter(f, tp.Child("prefix-bytes"), n, nil)
@@ -315,7 +315,7 @@ func BenchmarkPrefixBytes(b *testing.B) {
 		b.Run("iteration", func(b *testing.B) {
 			n := len(userKeys)
 			buf = build(n)
-			pb, _ := DecodePrefixBytes(buf, 0, n)
+			pb, _ := DecodePrefixBytes(buf, 0, uint32(n))
 			b.ResetTimer()
 			var pbi PrefixBytesIter
 			pbi.Buf = make([]byte, 0, maxLen)

--- a/sstable/colblk/raw_bytes.go
+++ b/sstable/colblk/raw_bytes.go
@@ -8,8 +8,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"unsafe"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/binfmt"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
@@ -58,16 +60,24 @@ var _ Array[[]byte] = RawBytes{}
 // DecodeRawBytes decodes the structure of a RawBytes, constructing an accessor
 // for an array of byte slices constructed by RawBytesBuilder. Count must be the
 // number of byte slices within the array.
-func DecodeRawBytes(b []byte, offset uint32, count int) (rawBytes RawBytes, endOffset uint32) {
+func DecodeRawBytes(b []byte, offset uint64, count uint32) (rawBytes RawBytes, endOffset uint64) {
 	if count == 0 {
 		return RawBytes{}, offset
 	}
+	if count == math.MaxUint32 {
+		panic(errors.AssertionFailedf("count overflow"))
+	}
 	offsets, dataOff := DecodeUnsafeOffsets(b, offset, count+1 /* +1 offset */)
+	endOffset = dataOff + uint64(offsets.At(int(count)))
+	if endOffset > uint64(len(b)) {
+		panic(errors.AssertionFailedf("RawBytes data extends beyond slice: end offset %d, slice length %d",
+			errors.Safe(endOffset), errors.Safe(len(b))))
+	}
 	return RawBytes{
-		slices:  count,
+		slices:  int(count),
 		offsets: offsets,
 		data:    unsafe.Pointer(&b[dataOff]),
-	}, dataOff + offsets.At(count)
+	}, endOffset
 }
 
 // Assert that DecodeRawBytes implements DecodeFunc.
@@ -93,7 +103,7 @@ func rawBytesToBinFormatter(
 	data := f.RelativeData()
 	off := f.RelativeOffset()
 	start := unsafe.Pointer(&data[off])
-	rb, _ := DecodeRawBytes(data, uint32(off), count)
+	rb, _ := DecodeRawBytes(data, uint64(off), uint32(count))
 	dataOffset := uint64(off) + uint64(uintptr(rb.data)-uintptr(start))
 	n := tp.Child("offsets table")
 	uintsToBinFormatter(f, n, count+1, func(offset, base uint64) string {

--- a/sstable/colblk/raw_bytes_test.go
+++ b/sstable/colblk/raw_bytes_test.go
@@ -55,9 +55,9 @@ func TestRawBytes(t *testing.T) {
 				f.ToTreePrinter(n)
 			}
 			rawBytesToBinFormatter(f, n, count, nil)
-			var decodedEndOffset uint32
-			rawBytes, decodedEndOffset = DecodeRawBytes(buf[startOffset:], 0, count)
-			require.Equal(t, endOffset, decodedEndOffset+uint32(startOffset))
+			var decodedEndOffset uint64
+			rawBytes, decodedEndOffset = DecodeRawBytes(buf[startOffset:], 0, uint32(count))
+			require.Equal(t, uint64(endOffset), decodedEndOffset+uint64(startOffset))
 			return tp.String()
 		case "at":
 			var indices []int
@@ -133,7 +133,7 @@ func BenchmarkRawBytes(b *testing.B) {
 			b.Run(fmt.Sprintf("sliceLen=%d", sz), func(b *testing.B) {
 				slices := generateRandomSlices(sz, 32<<10 /* 32 KiB */)
 				data := buildRawBytes(slices)
-				rb, _ := DecodeRawBytes(data, 0, len(slices))
+				rb, _ := DecodeRawBytes(data, 0, uint32(len(slices)))
 				b.ResetTimer()
 				b.SetBytes(32 << 10)
 				for i := 0; i < b.N; i++ {

--- a/sstable/colblk/uints_test.go
+++ b/sstable/colblk/uints_test.go
@@ -221,8 +221,8 @@ func TestUintsRandomized(t *testing.T) {
 		off := b.Finish(0, cfg.rowsFinish, 0, buf)
 		require.Equal(t, sz, off)
 
-		uu, endOff := DecodeUnsafeUints(buf, 0, cfg.rowsFinish)
-		require.Equal(t, endOff, off)
+		uu, endOff := DecodeUnsafeUints(buf, 0, uint32(cfg.rowsFinish))
+		require.Equal(t, endOff, uint64(off))
 		for i := 0; i < cfg.rowsFinish; i++ {
 			if uu.At(i) != vals[i] {
 				t.Fatalf("At(%d) = %d, want %d", i, uu.At(i), vals[i])

--- a/sstable/colblk/unsafe_uints.go
+++ b/sstable/colblk/unsafe_uints.go
@@ -29,7 +29,7 @@ var _ Array[uint64] = UnsafeUints{}
 
 // DecodeUnsafeUints decodes the structure of a slice of uints from a
 // byte slice.
-func DecodeUnsafeUints(b []byte, off uint32, rows int) (_ UnsafeUints, endOffset uint32) {
+func DecodeUnsafeUints(b []byte, off uint64, rows uint32) (_ UnsafeUints, endOffset uint64) {
 	if rows == 0 {
 		// NB: &b[off] is actually pointing beyond the uints serialization.  We
 		// ensure this is always valid at the block-level by appending a
@@ -50,9 +50,9 @@ func DecodeUnsafeUints(b []byte, off uint32, rows int) (_ UnsafeUints, endOffset
 	}
 	w := encoding.Width()
 	if w > 0 {
-		off = align(off, uint32(w))
+		off = align(off, uint64(w))
 	}
-	return makeUnsafeUints(base, unsafe.Pointer(&b[off]), w), off + uint32(rows*w)
+	return makeUnsafeUints(base, unsafe.Pointer(&b[off]), w), off + uint64(rows)*uint64(w)
 }
 
 // Assert that DecodeUnsafeIntegerSlice implements DecodeFunc.
@@ -84,7 +84,7 @@ type UnsafeOffsets struct {
 
 // DecodeUnsafeOffsets decodes the structure of a slice of offsets from a byte
 // slice.
-func DecodeUnsafeOffsets(b []byte, off uint32, rows int) (_ UnsafeOffsets, endOffset uint32) {
+func DecodeUnsafeOffsets(b []byte, off uint64, rows uint32) (_ UnsafeOffsets, endOffset uint64) {
 	ints, endOffset := DecodeUnsafeUints(b, off, rows)
 	if ints.base != 0 || ints.width == 8 {
 		panic(errors.AssertionFailedf("unexpected offsets encoding (base=%d, width=%d)", errors.Safe(ints.base), errors.Safe(ints.width)))

--- a/sstable/colblk/unsafe_uints_test.go
+++ b/sstable/colblk/unsafe_uints_test.go
@@ -34,14 +34,14 @@ func TestUnsafeUints(t *testing.T) {
 					buf := crbytes.AllocAligned(int(sz) + 1 /* trailing padding byte */)
 					_ = ub.Finish(0, rows, 0, buf)
 
-					uints, _ := DecodeUnsafeUints(buf, 0, rows)
+					uints, _ := DecodeUnsafeUints(buf, 0, uint32(rows))
 					for i := range rows {
 						if v := uints.At(i); v != vals[i] {
 							t.Fatalf("mismatch at row %d: got %X, expected %X", i, v, vals[i])
 						}
 					}
 					if encoding := UintEncoding(buf[0]); encoding.Width() <= 4 && !encoding.IsDelta() {
-						offsets, _ := DecodeUnsafeOffsets(buf, 0, rows)
+						offsets, _ := DecodeUnsafeOffsets(buf, 0, uint32(rows))
 						for i := range rows {
 							if v := uint64(offsets.At(i)); v != vals[i] {
 								t.Fatalf("mismatch at row %d: got %X, expected %X", i, v, vals[i])
@@ -102,7 +102,7 @@ func encodeRandUints(rng *rand.Rand, rows int, intRange intRange) []byte {
 func benchmarkUnsafeUints(b *testing.B, rng *rand.Rand, rows int, intRange intRange) {
 	b.Run(intRange.ExpectedEncoding.String(), func(b *testing.B) {
 		buf := encodeRandUints(rng, rows, intRange)
-		s, _ := DecodeUnsafeUints(buf, 0, rows)
+		s, _ := DecodeUnsafeUints(buf, 0, uint32(rows))
 		var reads [256]int
 		for i := range reads {
 			reads[i] = rng.IntN(rows)
@@ -133,7 +133,7 @@ func BenchmarkUnsafeUintOffsets(b *testing.B) {
 func benchmarkUnsafeOffsets(b *testing.B, rng *rand.Rand, rows int, intRange intRange) {
 	b.Run(intRange.ExpectedEncoding.String(), func(b *testing.B) {
 		buf := encodeRandUints(rng, rows, intRange)
-		s, _ := DecodeUnsafeOffsets(buf, 0, rows)
+		s, _ := DecodeUnsafeOffsets(buf, 0, uint32(rows))
 		var reads [256]int
 		for i := range reads {
 			reads[i] = rng.IntN(rows)


### PR DESCRIPTION
The Decode functions in the colblk package (DecodeBitmap, DecodeRawBytes,
DecodePrefixBytes, DecodeUnsafeUints, DecodeUnsafeOffsets) previously used
uint32 for offsets and int for counts. Arithmetic on these values (e.g.
off + uint32(rows*w)) was prone to overflow.

Change the offset parameter and return type from uint32 to uint64, and the
count/rows parameter from int to uint32. This eliminates overflow in offset
arithmetic while keeping counts bounded to the uint32 range which is
sufficient for row counts. Note that offsets are checked against the
length of the buffer so they can't get large enough to cause 64-bit
overflows.

Also add bounds checks: an overflow check for count+nBundles in
DecodePrefixBytes, and an endOffset vs len(b) check in DecodeRawBytes.

The DecodeFunc type, DecodeColumn, and pageStart are updated accordingly.
All callers are updated with appropriate casts.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>