### PR TITLE
lint: add linter to catch panic with string literal arguments

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -597,7 +597,7 @@ func (b *Batch) refreshMemTableSize() error {
 // Apply returns ErrInvalidBatch if the provided batch is invalid in any way.
 func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 	if b.ingestedSSTBatch {
-		panic("pebble: invalid batch application")
+		panic(errors.AssertionFailedf("pebble: invalid batch application"))
 	}
 	if len(batch.data) == 0 {
 		return nil
@@ -633,7 +633,7 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 			case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
 				b.countRangeKeys++
 			case InternalKeyKindIngestSST, InternalKeyKindIngestSSTWithBlobs, InternalKeyKindExcise:
-				panic("pebble: invalid key kind for batch")
+				panic(errors.AssertionFailedf("pebble: invalid key kind for batch"))
 			case InternalKeyKindLogData:
 				// LogData does not contribute to memtable size.
 				continue
@@ -695,7 +695,7 @@ func (b *Batch) Get(key []byte) ([]byte, io.Closer, error) {
 
 func (b *Batch) prepareDeferredKeyValueRecord(keyLen, valueLen int, kind InternalKeyKind) {
 	if b.committing {
-		panic("pebble: batch already committing")
+		panic(errors.AssertionFailedf("pebble: batch already committing"))
 	}
 	if len(b.data) == 0 {
 		b.init(keyLen + valueLen + 2*binary.MaxVarintLen64 + batchrepr.HeaderLen)
@@ -747,7 +747,7 @@ func (b *Batch) prepareDeferredKeyValueRecord(keyLen, valueLen int, kind Interna
 
 func (b *Batch) prepareDeferredKeyRecord(keyLen int, kind InternalKeyKind) {
 	if b.committing {
-		panic("pebble: batch already committing")
+		panic(errors.AssertionFailedf("pebble: batch already committing"))
 	}
 	if len(b.data) == 0 {
 		b.init(keyLen + binary.MaxVarintLen64 + batchrepr.HeaderLen)
@@ -796,7 +796,7 @@ func (b *Batch) AddInternalKey(key *base.InternalKey, value []byte, _ *WriteOpti
 	hasValue := false
 	switch kind := key.Kind(); kind {
 	case InternalKeyKindRangeDelete:
-		panic("unexpected range delete in AddInternalKey")
+		panic(errors.AssertionFailedf("unexpected range delete in AddInternalKey"))
 	case InternalKeyKindSingleDelete, InternalKeyKindDelete:
 		b.prepareDeferredKeyRecord(keyLen, kind)
 		b.deferredOp.index = b.index
@@ -1052,10 +1052,10 @@ func (b *Batch) RangeKeySet(start, end, suffix, value []byte, _ *WriteOptions) e
 	if invariants.Enabled && b.db != nil {
 		// RangeKeySet is only supported on prefix keys.
 		if b.db.opts.Comparer.Split(start) != len(start) {
-			panic("RangeKeySet called with suffixed start key")
+			panic(errors.AssertionFailedf("RangeKeySet called with suffixed start key"))
 		}
 		if b.db.opts.Comparer.Split(end) != len(end) {
-			panic("RangeKeySet called with suffixed end key")
+			panic(errors.AssertionFailedf("RangeKeySet called with suffixed end key"))
 		}
 	}
 	suffixValues := [1]rangekey.SuffixValue{{Suffix: suffix, Value: value}}
@@ -1065,7 +1065,7 @@ func (b *Batch) RangeKeySet(start, end, suffix, value []byte, _ *WriteOptions) e
 	copy(deferredOp.Key, start)
 	n := rangekey.EncodeSetValue(deferredOp.Value, end, suffixValues[:])
 	if n != internalValueLen {
-		panic("unexpected internal value length mismatch")
+		panic(errors.AssertionFailedf("unexpected internal value length mismatch"))
 	}
 
 	// Manually inline DeferredBatchOp.Finish().
@@ -1108,10 +1108,10 @@ func (b *Batch) RangeKeyUnset(start, end, suffix []byte, _ *WriteOptions) error 
 	if invariants.Enabled && b.db != nil {
 		// RangeKeyUnset is only supported on prefix keys.
 		if b.db.opts.Comparer.Split(start) != len(start) {
-			panic("RangeKeyUnset called with suffixed start key")
+			panic(errors.AssertionFailedf("RangeKeyUnset called with suffixed start key"))
 		}
 		if b.db.opts.Comparer.Split(end) != len(end) {
-			panic("RangeKeyUnset called with suffixed end key")
+			panic(errors.AssertionFailedf("RangeKeyUnset called with suffixed end key"))
 		}
 	}
 	suffixes := [1][]byte{suffix}
@@ -1121,7 +1121,7 @@ func (b *Batch) RangeKeyUnset(start, end, suffix []byte, _ *WriteOptions) error 
 	copy(deferredOp.Key, start)
 	n := rangekey.EncodeUnsetValue(deferredOp.Value, end, suffixes[:])
 	if n != internalValueLen {
-		panic("unexpected internal value length mismatch")
+		panic(errors.AssertionFailedf("unexpected internal value length mismatch"))
 	}
 
 	// Manually inline DeferredBatchOp.Finish()
@@ -1150,10 +1150,10 @@ func (b *Batch) RangeKeyDelete(start, end []byte, _ *WriteOptions) error {
 	if invariants.Enabled && b.db != nil {
 		// RangeKeyDelete is only supported on prefix keys.
 		if b.db.opts.Comparer.Split(start) != len(start) {
-			panic("RangeKeyDelete called with suffixed start key")
+			panic(errors.AssertionFailedf("RangeKeyDelete called with suffixed start key"))
 		}
 		if b.db.opts.Comparer.Split(end) != len(end) {
-			panic("RangeKeyDelete called with suffixed end key")
+			panic(errors.AssertionFailedf("RangeKeyDelete called with suffixed end key"))
 		}
 	}
 	deferredOp := b.RangeKeyDeleteDeferred(len(start), len(end))
@@ -1208,7 +1208,7 @@ func (b *Batch) ingestSST(tableNum base.TableNum, blobFileIDs []base.BlobFileID)
 		b.ingestedSSTBatch = true
 	} else if !b.ingestedSSTBatch {
 		// Batch contains other key kinds.
-		panic("pebble: invalid call to ingestSST")
+		panic(errors.AssertionFailedf("pebble: invalid call to ingestSST"))
 	}
 
 	origMemTableSize := b.memTableSize
@@ -1252,7 +1252,7 @@ func (b *Batch) excise(start, end []byte) {
 		b.ingestedSSTBatch = true
 	} else if !b.ingestedSSTBatch {
 		// Batch contains other key kinds.
-		panic("pebble: invalid call to excise")
+		panic(errors.AssertionFailedf("pebble: invalid call to excise"))
 	}
 
 	origMemTableSize := b.memTableSize
@@ -2430,17 +2430,17 @@ func (i *flushFlushableBatchIter) String() string {
 }
 
 func (i *flushFlushableBatchIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
-	panic("pebble: SeekGE unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekGE unimplemented"))
 }
 
 func (i *flushFlushableBatchIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
 ) *base.InternalKV {
-	panic("pebble: SeekPrefixGE unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekPrefixGE unimplemented"))
 }
 
 func (i *flushFlushableBatchIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
-	panic("pebble: SeekLT unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekLT unimplemented"))
 }
 
 func (i *flushFlushableBatchIter) First() *base.InternalKV {
@@ -2449,7 +2449,7 @@ func (i *flushFlushableBatchIter) First() *base.InternalKV {
 }
 
 func (i *flushFlushableBatchIter) NextPrefix(succKey []byte) *base.InternalKV {
-	panic("pebble: Prev unimplemented")
+	panic(errors.AssertionFailedf("pebble: Prev unimplemented"))
 }
 
 // Note: flushFlushableBatchIter.Next mirrors the implementation of
@@ -2466,7 +2466,7 @@ func (i *flushFlushableBatchIter) Next() *base.InternalKV {
 }
 
 func (i flushFlushableBatchIter) Prev() *base.InternalKV {
-	panic("pebble: Prev unimplemented")
+	panic(errors.AssertionFailedf("pebble: Prev unimplemented"))
 }
 
 // batchOptions holds the parameters to configure batch.

--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -403,7 +403,7 @@ func (y *ycsb) run(db DB) {
 		case ycsbUpdate:
 			y.update(db, buf)
 		default:
-			panic("not reached")
+			panic(errors.AssertionFailedf("not reached"))
 		}
 
 		latency[op].Record(time.Since(start))

--- a/commit.go
+++ b/commit.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/batchrepr"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/record"
@@ -64,7 +65,7 @@ func (q *commitQueue) enqueue(b *Batch) {
 	if (tail+uint32(len(q.slots)))&(1<<dequeueBits-1) == head {
 		// Queue is full. This should never be reached because commitPipeline.commitQueueSem
 		// limits the number of concurrent operations.
-		panic("pebble: not reached")
+		panic(errors.AssertionFailedf("pebble: not reached"))
 	}
 	slot := &q.slots[head&uint32(len(q.slots)-1)]
 
@@ -494,7 +495,7 @@ func (p *commitPipeline) publish(b *Batch) {
 			break
 		}
 		if !t.applied.Load() {
-			panic("not reached")
+			panic(errors.AssertionFailedf("not reached"))
 		}
 
 		// We're responsible for publishing the sequence number for batch t, but

--- a/compaction.go
+++ b/compaction.go
@@ -848,7 +848,7 @@ func newFlush(
 	if len(flushing) > 0 {
 		if _, ok := flushing[0].flushable.(*ingestedFlushable); ok {
 			if len(flushing) != 1 {
-				panic("pebble: ingestedFlushable must be flushed one at a time.")
+				panic(errors.AssertionFailedf("pebble: ingestedFlushable must be flushed one at a time."))
 			}
 			c.kind = compactionKindIngestedFlushable
 			return c, nil
@@ -857,7 +857,7 @@ func newFlush(
 			// in the list.
 			for _, f := range c.flush.flushables[1:] {
 				if _, ok := f.flushable.(*ingestedFlushable); ok {
-					panic("pebble: flushables shouldn't contain ingestedFlushable")
+					panic(errors.AssertionFailedf("pebble: flushables shouldn't contain ingestedFlushable"))
 				}
 			}
 		}
@@ -1010,7 +1010,7 @@ func (c *tableCompaction) newInputIters(
 		}
 		if c.startLevel.level == 0 {
 			if c.startLevel.l0SublevelInfo == nil {
-				panic("l0SublevelInfo not created for compaction out of L0")
+				panic(errors.AssertionFailedf("l0SublevelInfo not created for compaction out of L0"))
 			}
 			for _, info := range c.startLevel.l0SublevelInfo {
 				err := manifest.CheckOrdering(c.comparer, info.sublevel, info.Iter())
@@ -1021,7 +1021,7 @@ func (c *tableCompaction) newInputIters(
 		}
 		if len(c.extraLevels) > 0 {
 			if len(c.extraLevels) > 1 {
-				panic("n>2 multi level compaction not implemented yet")
+				panic(errors.AssertionFailedf("n>2 multi level compaction not implemented yet"))
 			}
 			interLevel := c.extraLevels[0]
 			err := manifest.CheckOrdering(c.comparer, manifest.Level(interLevel.level),
@@ -1505,7 +1505,7 @@ func (d *DB) flush() {
 // while runIngestFlush is called.
 func (d *DB) runIngestFlush(c *tableCompaction) (*manifest.VersionEdit, error) {
 	if len(c.flush.flushables) != 1 {
-		panic("pebble: ingestedFlushable must be flushed one at a time.")
+		panic(errors.AssertionFailedf("pebble: ingestedFlushable must be flushed one at a time."))
 	}
 
 	// Finding the target level for ingestion must use the latest version
@@ -1657,7 +1657,7 @@ func (d *DB) flush1() (bytesFlushed uint64, err error) {
 				if !f.readyForFlush() {
 					// This check is almost unnecessary, but we guard against it
 					// just in case this invariant changes in the future.
-					panic("pebble: ingestedFlushable should always be ready to flush.")
+					panic(errors.AssertionFailedf("pebble: ingestedFlushable should always be ready to flush."))
 				}
 				// By setting n = 1, we ensure that the first flushable(n == 0)
 				// is scheduled for a flush. The number of tables added is equal to the
@@ -2700,7 +2700,7 @@ func (d *DB) runCompaction(
 	case compactionKindCopy:
 		return d.runCopyCompaction(jobID, c)
 	case compactionKindIngestedFlushable:
-		panic("pebble: runCompaction cannot handle compactionKindIngestedFlushable.")
+		panic(errors.AssertionFailedf("pebble: runCompaction cannot handle compactionKindIngestedFlushable."))
 	}
 	return d.runDefaultTableCompaction(jobID, c)
 }

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -278,7 +278,7 @@ func newPickedTableCompaction(
 	startLevel, outputLevel, baseLevel int,
 ) *pickedTableCompaction {
 	if baseLevel == 0 {
-		panic("base level cannot be 0")
+		panic(errors.AssertionFailedf("base level cannot be 0"))
 	}
 	if startLevel > 0 && startLevel < baseLevel {
 		panic(errors.AssertionFailedf("invalid compaction: start level %d should not be empty (base level %d)",
@@ -304,7 +304,7 @@ func adjustedOutputLevel(outputLevel int, baseLevel int) int {
 		return 0
 	}
 	if baseLevel == 0 {
-		panic("base level cannot be 0")
+		panic(errors.AssertionFailedf("base level cannot be 0"))
 	}
 	// Output level is in the range [baseLevel, numLevels). For the purpose of
 	// determining the target output file size, overlap bytes, and expanded
@@ -1906,12 +1906,12 @@ func pickAutoLPositive(
 	baseLevel int,
 ) (pc *pickedTableCompaction) {
 	if cInfo.level == 0 {
-		panic("pebble: pickAutoLPositive called for L0")
+		panic(errors.AssertionFailedf("pebble: pickAutoLPositive called for L0"))
 	}
 
 	pc = newPickedTableCompaction(opts, vers, l0Organizer, cInfo.level, defaultOutputLevel(cInfo.level, baseLevel), baseLevel)
 	if pc.outputLevel.level != cInfo.outputLevel {
-		panic("pebble: compaction picked unexpected output level")
+		panic(errors.AssertionFailedf("pebble: compaction picked unexpected output level"))
 	}
 	pc.startLevel.files = cInfo.file.Slice()
 
@@ -2175,7 +2175,7 @@ func newPickedManualCompaction(
 		if len(pc.inputs) > 2 {
 			// Multilevel compactions relax this invariant.
 		} else {
-			panic("pebble: compaction picked unexpected output level")
+			panic(errors.AssertionFailedf("pebble: compaction picked unexpected output level"))
 		}
 	}
 	return pc, false
@@ -2199,7 +2199,7 @@ func pickDownloadCompaction(
 		return nil
 	}
 	if kind != compactionKindCopy && kind != compactionKindRewrite {
-		panic("invalid download/rewrite compaction kind")
+		panic(errors.AssertionFailedf("invalid download/rewrite compaction kind"))
 	}
 	pc = newPickedTableCompaction(opts, vers, l0Organizer, level, level, baseLevel)
 	pc.kind = kind
@@ -2210,7 +2210,7 @@ func pickDownloadCompaction(
 		return nil
 	}
 	if pc.outputLevel.level != level {
-		panic("pebble: download compaction picked unexpected output level")
+		panic(errors.AssertionFailedf("pebble: download compaction picked unexpected output level"))
 	}
 	return pc
 }

--- a/compaction_scheduler.go
+++ b/compaction_scheduler.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 )
 
@@ -307,7 +308,7 @@ func (s *ConcurrencyLimitScheduler) Register(numGoroutinesPerCompaction int, db 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mu.unregistered {
-		panic("cannot reuse ConcurrencyLimitScheduler")
+		panic(errors.AssertionFailedf("cannot reuse ConcurrencyLimitScheduler"))
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -789,10 +789,10 @@ func (d *DB) applyInternal(batch *Batch, opts *WriteOptions, noSyncWait bool) er
 		panic(err)
 	}
 	if batch.committing {
-		panic("pebble: batch already committing")
+		panic(errors.AssertionFailedf("pebble: batch already committing"))
 	}
 	if batch.applied.Load() {
-		panic("pebble: batch already applied")
+		panic(errors.AssertionFailedf("pebble: batch already applied"))
 	}
 	if d.opts.ReadOnly {
 		return ErrReadOnly
@@ -1065,10 +1065,10 @@ func (d *DB) newIter(
 ) *Iterator {
 	if newIterOpts.batch.batchOnly {
 		if batch == nil {
-			panic("batchOnly is true, but batch is nil")
+			panic(errors.AssertionFailedf("batchOnly is true, but batch is nil"))
 		}
 		if newIterOpts.snapshot.vers != nil {
-			panic("batchOnly is true, but snapshotIterOpts is initialized")
+			panic(errors.AssertionFailedf("batchOnly is true, but snapshotIterOpts is initialized"))
 		}
 	}
 	if err := d.closed.Load(); err != nil {
@@ -1076,14 +1076,14 @@ func (d *DB) newIter(
 	}
 	seqNum := newIterOpts.snapshot.seqNum
 	if o != nil && o.RangeKeyMasking.Suffix != nil && o.KeyTypes != IterKeyTypePointsAndRanges {
-		panic("pebble: range key masking requires IterKeyTypePointsAndRanges")
+		panic(errors.AssertionFailedf("pebble: range key masking requires IterKeyTypePointsAndRanges"))
 	}
 	if (batch != nil || seqNum != 0) && (o != nil && o.OnlyReadGuaranteedDurable) {
 		// We could add support for OnlyReadGuaranteedDurable on snapshots if
 		// there was a need: this would require checking that the sequence number
 		// of the snapshot has been flushed, by comparing with
 		// DB.mem.queue[0].logSeqNum.
-		panic("OnlyReadGuaranteedDurable is not supported for batches or snapshots")
+		panic(errors.AssertionFailedf("OnlyReadGuaranteedDurable is not supported for batches or snapshots"))
 	}
 	var readState *readState
 	var newIters tableNewIters
@@ -1517,7 +1517,7 @@ func (d *DB) NewEventuallyFileOnlySnapshot(keyRanges []KeyRange) *EventuallyFile
 	}
 	for i := range keyRanges {
 		if i > 0 && d.cmp(keyRanges[i-1].End, keyRanges[i].Start) > 0 {
-			panic("pebble: key ranges for eventually-file-only-snapshot not in order")
+			panic(errors.AssertionFailedf("pebble: key ranges for eventually-file-only-snapshot not in order"))
 		}
 	}
 	return d.makeEventuallyFileOnlySnapshot(keyRanges)
@@ -1594,7 +1594,7 @@ func (d *DB) Close() error {
 			err = firstError(err, err2)
 		}
 	} else if d.mu.log.writer != nil {
-		panic("pebble: log-writer should be nil in read-only mode")
+		panic(errors.AssertionFailedf("pebble: log-writer should be nil in read-only mode"))
 	}
 	err = firstError(err, d.mu.log.manager.Close())
 
@@ -1648,7 +1648,7 @@ func (d *DB) Close() error {
 	// Sanity check compaction metrics.
 	if invariants.Enabled {
 		if d.mu.compact.compactingCount > 0 || d.mu.compact.downloadingCount > 0 || d.mu.versions.atomicInProgressBytes.Load() > 0 {
-			panic("compacting counts not 0 on close")
+			panic(errors.AssertionFailedf("compacting counts not 0 on close"))
 		}
 	}
 
@@ -2491,7 +2491,7 @@ func (d *DB) maybeInduceWriteStall(b *Batch) {
 // may be released and reacquired.
 func (d *DB) makeRoomForWrite(b *Batch) error {
 	if b != nil && b.ingestedSSTBatch {
-		panic("pebble: invalid function call")
+		panic(errors.AssertionFailedf("pebble: invalid function call"))
 	}
 	d.maybeInduceWriteStall(b)
 
@@ -2621,7 +2621,7 @@ func (d *DB) rotateMemtable(
 // may be released and reacquired.
 func (d *DB) rotateWAL() (newLogNum base.DiskFileNum, prevLogSize uint64) {
 	if d.opts.DisableWAL {
-		panic("pebble: invalid function call")
+		panic(errors.AssertionFailedf("pebble: invalid function call"))
 	}
 	jobID := d.newJobIDLocked()
 	newLogNum = d.mu.versions.getNextDiskFileNum()

--- a/event.go
+++ b/event.go
@@ -800,7 +800,7 @@ func (i PossibleAPIMisuseInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 		w.Printf("possible API misuse: %s (key=%q, %s)", redact.Safe(i.Kind), i.UserKey, i.ExtraInfo)
 	default:
 		if invariants.Enabled {
-			panic("invalid API misuse event")
+			panic(errors.AssertionFailedf("invalid API misuse event"))
 		}
 		w.Printf("invalid API misuse event")
 	}
@@ -1398,7 +1398,7 @@ func (r *lowDiskSpaceReporter) findThreshold(
 // to the event listener and also adds a DataCorruptionInfo payload to the error.
 func (d *DB) reportCorruption(meta base.ObjectInfo, err error) error {
 	if invariants.Enabled && !IsCorruptionError(err) {
-		panic("not a corruption error")
+		panic(errors.AssertionFailedf("not a corruption error"))
 	}
 	fileType, fileNum := meta.FileInfo()
 

--- a/excise.go
+++ b/excise.go
@@ -236,7 +236,7 @@ func exciseOverlapBounds(
 		}
 		if invariants.Enabled {
 			if s.efos.hasTransitioned() {
-				panic("unexpected transitioned EFOS in snapshots list")
+				panic(errors.AssertionFailedf("unexpected transitioned EFOS in snapshots list"))
 			}
 		}
 		for i := range s.efos.protectedRanges {

--- a/external_iterator.go
+++ b/external_iterator.go
@@ -89,7 +89,7 @@ func NewExternalIterWithContext(
 			// (see TODO below), we'll need to adjust this tableNewIters
 			// implementation to open iterators by looking up f in a map
 			// of readers indexed by *fileMetadata.
-			panic("unreachable")
+			panic(errors.AssertionFailedf("unreachable"))
 		},
 		seqNum: base.SeqNumMax,
 	}

--- a/file_cache.go
+++ b/file_cache.go
@@ -356,7 +356,7 @@ func createReader(
 	if meta.Virtual {
 		if invariants.Enabled {
 			if meta.VirtualParams.FileNum == 0 || meta.VirtualParams.Lower.UserKey == nil || meta.VirtualParams.Upper.UserKey == nil {
-				panic("virtual params not initialized")
+				panic(errors.AssertionFailedf("virtual params not initialized"))
 			}
 		}
 		env.Virtual = meta.VirtualParams
@@ -386,7 +386,7 @@ func (h *fileCacheHandle) withReader(
 	if meta.Virtual {
 		if invariants.Enabled {
 			if meta.VirtualParams.FileNum == 0 || meta.VirtualParams.Lower.UserKey == nil || meta.VirtualParams.Upper.UserKey == nil {
-				panic("virtual params not initialized")
+				panic(errors.AssertionFailedf("virtual params not initialized"))
 			}
 		}
 		env.Virtual = meta.VirtualParams
@@ -473,9 +473,9 @@ func optsFromBlockReadEnv(blockEnv block.ReadEnv) initFileOpts {
 // reference to the file cache.
 func NewFileCache(numShards int, size int) *FileCache {
 	if size == 0 {
-		panic("pebble: cannot create a file cache of size 0")
+		panic(errors.AssertionFailedf("pebble: cannot create a file cache of size 0"))
 	} else if numShards == 0 {
-		panic("pebble: cannot create a file cache with 0 shards")
+		panic(errors.AssertionFailedf("pebble: cannot create a file cache with 0 shards"))
 	}
 
 	c := &FileCache{}
@@ -506,7 +506,7 @@ func NewFileCache(numShards int, size int) *FileCache {
 		case base.FileTypeBlob:
 			c.counts.blobFiles.Add(1)
 		default:
-			panic("unexpected file type")
+			panic(errors.AssertionFailedf("unexpected file type"))
 		}
 		return nil
 	}
@@ -980,7 +980,7 @@ func (rp *tableCacheShardReaderProvider) Close() {
 	rp.mu.refCount--
 	if rp.mu.refCount <= 0 {
 		if rp.mu.refCount < 0 {
-			panic("pebble: sstable.ReaderProvider misuse")
+			panic(errors.AssertionFailedf("pebble: sstable.ReaderProvider misuse"))
 		}
 		rp.mu.r.Unref()
 		rp.mu.r = genericcache.ValueRef[fileCacheKey, fileCacheValue, initFileOpts]{}

--- a/flushable.go
+++ b/flushable.go
@@ -143,7 +143,7 @@ func (e *flushableEntry) readerUnrefHelper(
 		panic(errors.AssertionFailedf("pebble: inconsistent reference count: %d", errors.Safe(v)))
 	case v == 0:
 		if e.releaseMemAccounting == nil {
-			panic("pebble: memtable reservation already released")
+			panic(errors.AssertionFailedf("pebble: memtable reservation already released"))
 		}
 		e.releaseMemAccounting()
 		e.releaseMemAccounting = nil
@@ -267,7 +267,7 @@ func (s *ingestedFlushable) newFlushIter(*IterOptions) internalIterator {
 	// newFlushIter is only used for writing memtables to disk as sstables.
 	// Since ingested sstables are already present on disk, they don't need to
 	// make use of a flush iter.
-	panic("pebble: not implemented")
+	panic(errors.AssertionFailedf("pebble: not implemented"))
 }
 
 func (s *ingestedFlushable) constructRangeDelIter(

--- a/get.go
+++ b/get.go
@@ -183,7 +183,7 @@ func (g *getIter) String() string {
 }
 
 func (g *getIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
-	panic("pebble: SeekGE unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekGE unimplemented"))
 }
 
 func (g *getIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
@@ -191,11 +191,11 @@ func (g *getIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base
 }
 
 func (g *getIter) SeekPrefixGEStrict(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
-	panic("pebble: SeekPrefixGE unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekPrefixGE unimplemented"))
 }
 
 func (g *getIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
-	panic("pebble: SeekLT unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekLT unimplemented"))
 }
 
 func (g *getIter) First() *base.InternalKV {
@@ -203,7 +203,7 @@ func (g *getIter) First() *base.InternalKV {
 }
 
 func (g *getIter) Last() *base.InternalKV {
-	panic("pebble: Last unimplemented")
+	panic(errors.AssertionFailedf("pebble: Last unimplemented"))
 }
 
 func (g *getIter) Next() *base.InternalKV {
@@ -266,11 +266,11 @@ func (g *getIter) Next() *base.InternalKV {
 }
 
 func (g *getIter) Prev() *base.InternalKV {
-	panic("pebble: Prev unimplemented")
+	panic(errors.AssertionFailedf("pebble: Prev unimplemented"))
 }
 
 func (g *getIter) NextPrefix([]byte) *base.InternalKV {
-	panic("pebble: NextPrefix unimplemented")
+	panic(errors.AssertionFailedf("pebble: NextPrefix unimplemented"))
 }
 
 func (g *getIter) Error() error {
@@ -288,7 +288,7 @@ func (g *getIter) Close() error {
 }
 
 func (g *getIter) SetBounds(lower, upper []byte) {
-	panic("pebble: SetBounds unimplemented")
+	panic(errors.AssertionFailedf("pebble: SetBounds unimplemented"))
 }
 
 func (g *getIter) SetContext(_ context.Context) {}

--- a/ingest.go
+++ b/ingest.go
@@ -1727,7 +1727,7 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 	shared := args.Shared
 	external := args.External
 	if len(shared) > 0 && d.opts.Experimental.RemoteStorage == nil {
-		panic("cannot ingest shared sstables with nil SharedStorage")
+		panic(errors.AssertionFailedf("cannot ingest shared sstables with nil SharedStorage"))
 	}
 	if (args.ExciseSpan.Valid() || len(shared) > 0 || len(external) > 0) && d.FormatMajorVersion() < FormatVirtualSSTables {
 		return IngestOperationStats{}, errors.New("pebble: format major version too old for excise, shared or external sstable ingestion")
@@ -1885,7 +1885,7 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 					// An excise span or an EventuallyFileOnlySnapshot protected range;
 					// not a file.
 				default:
-					panic("unreachable")
+					panic(errors.AssertionFailedf("unreachable"))
 				}
 				return continueIteration
 			}, overlapBounds...)
@@ -2184,7 +2184,7 @@ func (d *DB) ingestSplit(
 						// where we overlap with two or more files in `replaced` is if we
 						// actually had data overlap all along, or if the ingestion files
 						// were overlapping, either of which is an invariant violation.
-						panic("updated with two files in ingestSplit")
+						panic(errors.AssertionFailedf("updated with two files in ingestSplit"))
 					}
 					splitFile = replaced[i].Meta
 					updatedSplitFile = true
@@ -2223,7 +2223,7 @@ func (d *DB) ingestSplit(
 		for i := range added {
 			addedBounds := added[i].Meta.UserKeyBounds()
 			if s.ingestFile.Overlaps(d.cmp, &addedBounds) {
-				panic("ingest-time split produced a file that overlaps with ingested file")
+				panic(errors.AssertionFailedf("ingest-time split produced a file that overlaps with ingested file"))
 			}
 		}
 	}
@@ -2374,7 +2374,7 @@ func (d *DB) ingestApply(
 				if splitTable != nil {
 					if invariants.Enabled {
 						if lf := current.Levels[f.Level].Find(d.cmp, splitTable); lf.Empty() {
-							panic("splitFile returned is not in level it should be")
+							panic(errors.AssertionFailedf("splitFile returned is not in level it should be"))
 						}
 					}
 					// We take advantage of the fact that we won't drop the db mutex

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -17,7 +17,10 @@
 
 package arenaskl
 
-import "github.com/cockroachdb/pebble/internal/base"
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+)
 
 // flushIterator is an iterator over the skiplist object. Use Skiplist.NewFlushIter
 // to construct an iterator. The current state of the iterator can be cloned by
@@ -34,15 +37,15 @@ func (it *flushIterator) String() string {
 }
 
 func (it *flushIterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
-	panic("pebble: SeekGE unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekGE unimplemented"))
 }
 
 func (it *flushIterator) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
-	panic("pebble: SeekPrefixGE unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekPrefixGE unimplemented"))
 }
 
 func (it *flushIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
-	panic("pebble: SeekLT unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekLT unimplemented"))
 }
 
 // First seeks position at the first entry in list. Returns the key and value
@@ -68,9 +71,9 @@ func (it *flushIterator) Next() *base.InternalKV {
 }
 
 func (it *flushIterator) NextPrefix(succKey []byte) *base.InternalKV {
-	panic("pebble: NextPrefix unimplemented")
+	panic(errors.AssertionFailedf("pebble: NextPrefix unimplemented"))
 }
 
 func (it *flushIterator) Prev() *base.InternalKV {
-	panic("pebble: Prev unimplemented")
+	panic(errors.AssertionFailedf("pebble: Prev unimplemented"))
 }

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"sync/atomic"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 )
 
@@ -70,18 +71,18 @@ func newNode(
 	arena *Arena, height uint32, key base.InternalKey, value []byte,
 ) (nd *node, err error) {
 	if height < 1 || height > maxHeight {
-		panic("height cannot be less than one or greater than the max height")
+		panic(errors.AssertionFailedf("height cannot be less than one or greater than the max height"))
 	}
 	keySize := len(key.UserKey)
 	if int64(keySize) > math.MaxUint32 {
-		panic("key is too large")
+		panic(errors.AssertionFailedf("key is too large"))
 	}
 	valueSize := len(value)
 	if int64(len(value)) > math.MaxUint32 {
-		panic("value is too large")
+		panic(errors.AssertionFailedf("value is too large"))
 	}
 	if int64(len(value))+int64(keySize)+int64(maxNodeSize) > math.MaxUint32 {
-		panic("combined key and value size is too large")
+		panic(errors.AssertionFailedf("combined key and value size is too large"))
 	}
 
 	nd, err = newRawNode(arena, height, uint32(keySize), uint32(valueSize))

--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -132,13 +132,13 @@ func (s *Skiplist) Reset(arena *Arena, cmp base.Compare) {
 	// Allocate head and tail nodes.
 	head, err := newRawNode(arena, maxHeight, 0, 0)
 	if err != nil {
-		panic("arenaSize is not large enough to hold the head node")
+		panic(errors.AssertionFailedf("arenaSize is not large enough to hold the head node"))
 	}
 	head.keyOffset = 0
 
 	tail, err := newRawNode(arena, maxHeight, 0, 0)
 	if err != nil {
-		panic("arenaSize is not large enough to hold the tail node")
+		panic(errors.AssertionFailedf("arenaSize is not large enough to hold the tail node"))
 	}
 	tail.keyOffset = 0
 
@@ -210,7 +210,7 @@ func (s *Skiplist) addInternal(key base.InternalKey, value []byte, ins *Inserter
 			// New node increased the height of the skiplist, so assume that the
 			// new level has not yet been populated.
 			if next != nil {
-				panic("next is expected to be nil, since prev is nil")
+				panic(errors.AssertionFailedf("next is expected to be nil, since prev is nil"))
 			}
 
 			prev = s.head
@@ -274,7 +274,7 @@ func (s *Skiplist) addInternal(key base.InternalKey, value []byte, ins *Inserter
 			prev, next, found = s.findSpliceForLevel(key, i, prev)
 			if found {
 				if i != 0 {
-					panic("how can another thread have inserted a node at a non-base level?")
+					panic(errors.AssertionFailedf("how can another thread have inserted a node at a non-base level?"))
 				}
 
 				return ErrRecordExists

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -260,7 +260,7 @@ func (c *Comparer) EnsureDefaults() *Comparer {
 		return DefaultComparer
 	}
 	if c.AbbreviatedKey == nil || c.Separator == nil || c.Successor == nil || c.Name == "" {
-		panic("invalid Comparer: mandatory field not set")
+		panic(errors.AssertionFailedf("invalid Comparer: mandatory field not set"))
 	}
 	if c.CompareRangeSuffixes != nil && c.ComparePointSuffixes != nil && c.Compare != nil && c.Equal != nil && c.Split != nil && c.FormatKey != nil {
 		return c
@@ -429,7 +429,7 @@ func MakeAssertComparer(c Comparer) Comparer {
 			eq := c.Equal(a, b)
 			// Verify that Equal is consistent with Compare.
 			if expected := c.Compare(a, b); eq != (expected == 0) {
-				panic("Compare and Equal are not consistent")
+				panic(errors.AssertionFailedf("Compare and Equal are not consistent"))
 			}
 			return eq
 		},

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -189,7 +189,7 @@ func MakeFilename(fileType FileType, dfn DiskFileNum) string {
 func appendFilename(buf []byte, fileType FileType, dfn DiskFileNum) []byte {
 	switch fileType {
 	case FileTypeLog:
-		panic("the pebble/wal pkg is responsible for constructing WAL filenames")
+		panic(errors.AssertionFailedf("the pebble/wal pkg is responsible for constructing WAL filenames"))
 	case FileTypeLock:
 		buf = append(buf, "LOCK"...)
 	case FileTypeTable:
@@ -207,7 +207,7 @@ func appendFilename(buf []byte, fileType FileType, dfn DiskFileNum) []byte {
 	case FileTypeBlobMeta:
 		buf = fmt.Appendf(buf, "%06d.blobmeta", uint64(dfn))
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 	return buf
 }

--- a/internal/base/key_bounds.go
+++ b/internal/base/key_bounds.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -169,7 +170,7 @@ func UserKeyBoundsEndExclusiveIf(start []byte, end []byte, exclusive bool) UserK
 // smallest must not be an exclusive sentinel.
 func UserKeyBoundsFromInternal(smallest, largest InternalKey) UserKeyBounds {
 	if invariants.Enabled && smallest.IsExclusiveSentinel() {
-		panic("smallest key is exclusive sentinel")
+		panic(errors.AssertionFailedf("smallest key is exclusive sentinel"))
 	}
 	return UserKeyBoundsEndExclusiveIf(smallest.UserKey, largest.UserKey, largest.IsExclusiveSentinel())
 }

--- a/internal/base/logger.go
+++ b/internal/base/logger.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -114,14 +115,14 @@ var _ LoggerAndTracer = &LoggerWithNoopTracer{}
 // Eventf implements LoggerAndTracer.
 func (*LoggerWithNoopTracer) Eventf(ctx context.Context, format string, args ...interface{}) {
 	if invariants.Enabled && ctx == nil {
-		panic("Eventf context is nil")
+		panic(errors.AssertionFailedf("Eventf context is nil"))
 	}
 }
 
 // IsTracingEnabled implements LoggerAndTracer.
 func (*LoggerWithNoopTracer) IsTracingEnabled(ctx context.Context) bool {
 	if invariants.Enabled && ctx == nil {
-		panic("IsTracingEnabled ctx is nil")
+		panic(errors.AssertionFailedf("IsTracingEnabled ctx is nil"))
 	}
 	return false
 }
@@ -145,14 +146,14 @@ func (l NoopLoggerAndTracer) Fatalf(format string, args ...interface{}) {}
 // Eventf implements LoggerAndTracer.
 func (l NoopLoggerAndTracer) Eventf(ctx context.Context, format string, args ...interface{}) {
 	if invariants.Enabled && ctx == nil {
-		panic("Eventf context is nil")
+		panic(errors.AssertionFailedf("Eventf context is nil"))
 	}
 }
 
 // IsTracingEnabled implements LoggerAndTracer.
 func (l NoopLoggerAndTracer) IsTracingEnabled(ctx context.Context) bool {
 	if invariants.Enabled && ctx == nil {
-		panic("IsTracingEnabled ctx is nil")
+		panic(errors.AssertionFailedf("IsTracingEnabled ctx is nil"))
 	}
 	return false
 }

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -4,6 +4,8 @@
 
 package base
 
+import "github.com/cockroachdb/errors"
+
 // SSTable block defaults.
 const (
 	DefaultBlockRestartInterval      = 16
@@ -71,7 +73,7 @@ var NoFilterPolicy TableFilterPolicy = noFilter{}
 type noFilter struct{}
 
 func (noFilter) Name() string                 { return "none" }
-func (noFilter) NewWriter() TableFilterWriter { panic("not implemented") }
+func (noFilter) NewWriter() TableFilterWriter { panic(errors.AssertionFailedf("not implemented")) }
 
 // BlockPropertyFilter is used in an Iterator to filter sstables and blocks
 // within the sstable. It should not maintain any per-sstable state, and must

--- a/internal/base/span_policy.go
+++ b/internal/base/span_policy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -70,7 +71,7 @@ func (p *SpanPolicy) IsDefault() bool {
 // any) and returns whether the key is still within the span policy end key.
 func (p *SpanPolicy) StillCovers(cmp Compare, key []byte) bool {
 	if invariants.Enabled && len(p.KeyRange.Start) > 0 && cmp(p.KeyRange.Start, key) > 0 {
-		panic("key too small")
+		panic(errors.AssertionFailedf("key too small"))
 	}
 	return len(p.KeyRange.End) == 0 || cmp(key, p.KeyRange.End) < 0
 }

--- a/internal/base/value.go
+++ b/internal/base/value.go
@@ -4,7 +4,10 @@
 
 package base
 
-import "github.com/cockroachdb/pebble/internal/invariants"
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
 
 // An InternalValue represents a value. The value may be in-memory, immediately
 // accessible, or it may be stored out-of-band and need to be fetched when
@@ -44,7 +47,7 @@ func (v *InternalValue) IsInPlaceValue() bool {
 // This is for Pebble-internal code.
 func (v *InternalValue) InPlaceValue() []byte {
 	if invariants.Enabled && v.lazyValue.Fetcher != nil {
-		panic("value must be in-place")
+		panic(errors.AssertionFailedf("value must be in-place"))
 	}
 	return v.lazyValue.ValueOrHandle
 }

--- a/internal/batchskl/skl.go
+++ b/internal/batchskl/skl.go
@@ -277,7 +277,7 @@ func (s *Skiplist) newNode(
 	offset, keyStart, keyEnd uint32, abbreviatedKey uint64,
 ) (uint32, error) {
 	if height < 1 || height > maxHeight {
-		panic("height cannot be less than one or greater than the max height")
+		panic(errors.AssertionFailedf("height cannot be less than one or greater than the max height"))
 	}
 
 	unusedSize := uint64(maxHeight-int(height)) * linksSize

--- a/internal/binfmt/binfmt.go
+++ b/internal/binfmt/binfmt.go
@@ -16,6 +16,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/treeprinter"
 )
 
@@ -103,7 +104,7 @@ func (f *Formatter) PeekUint(w int) uint64 {
 	case 8:
 		return binary.LittleEndian.Uint64(f.data[f.off:])
 	default:
-		panic("unsupported width")
+		panic(errors.AssertionFailedf("unsupported width"))
 	}
 }
 
@@ -259,7 +260,7 @@ func (l Line) Append(s string) Line {
 // a zero or one.
 func (l Line) Binary(n int) Line {
 	if n+l.i > l.n {
-		panic("binary data exceeds consumed line length")
+		panic(errors.AssertionFailedf("binary data exceeds consumed line length"))
 	}
 	for i := 0; i < n; i++ {
 		l.f.printf("%08b", l.f.data[l.f.off+l.i])
@@ -271,7 +272,7 @@ func (l Line) Binary(n int) Line {
 // HexBytes formats the next n bytes in hexadecimal format.
 func (l Line) HexBytes(n int) Line {
 	if n+l.i > l.n {
-		panic("binary data exceeds consumed line length")
+		panic(errors.AssertionFailedf("binary data exceeds consumed line length"))
 	}
 	l.f.printf("%0"+strconv.Itoa(n*2)+"x", l.f.data[l.f.off+l.i:l.f.off+l.i+n])
 	l.i += n
@@ -281,7 +282,7 @@ func (l Line) HexBytes(n int) Line {
 // Done finishes the line, appending the provided comment if any.
 func (l Line) Done(format string, args ...interface{}) int {
 	if l.n != l.i {
-		panic("unconsumed data in line")
+		panic(errors.AssertionFailedf("unconsumed data in line"))
 	}
 	l.f.newline(l.f.buf.String(), fmt.Sprintf(format, args...))
 	l.f.off += l.n

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -201,7 +201,7 @@ func (c *Cache) Reserve(n int) func() {
 	}
 	return func() {
 		if shardN == -1 {
-			panic("pebble: cache reservation already released")
+			panic(errors.AssertionFailedf("pebble: cache reservation already released"))
 		}
 		for i := range c.shards {
 			c.shards[i].Reserve(-shardN)

--- a/internal/cache/clockpro.go
+++ b/internal/cache/clockpro.go
@@ -49,7 +49,7 @@ func makeKey(id handleID, fileNum base.DiskFileNum, offset uint64) key {
 // shardIdx determines the shard index for the given key.
 func (k *key) shardIdx(numShards int) int {
 	if k.id == 0 {
-		panic("pebble: 0 cache handleID is invalid")
+		panic(errors.AssertionFailedf("pebble: 0 cache handleID is invalid"))
 	}
 	// Same as fibonacciHash() but without the cast to uintptr.
 	const m = 11400714819323198485
@@ -235,7 +235,7 @@ func (c *shard) set(k key, value *Value, markAccessed bool) {
 		c.countTest--
 		v := c.metaDel(e)
 		if invariants.Enabled && v != nil {
-			panic("value should be nil")
+			panic(errors.AssertionFailedf("value should be nil"))
 		}
 		c.metaCheck(e)
 

--- a/internal/cache/read_shard.go
+++ b/internal/cache/read_shard.go
@@ -95,7 +95,7 @@ func (rs *readShard) acquireReadEntry(k key) *readEntry {
 		// An entry we found in the map while holding the mutex must have a non-zero
 		// reference count.
 		if e.refCount < 1 {
-			panic("invalid reference count")
+			panic(errors.AssertionFailedf("invalid reference count"))
 		}
 		e.refCount++
 		return e
@@ -189,17 +189,17 @@ func (e *readEntry) waitForReadPermissionOrHandle(
 ) (cv *Value, errorDuration time.Duration, err error) {
 	constructValueLocked := func() *Value {
 		if e.mu.v == nil {
-			panic("value is nil")
+			panic(errors.AssertionFailedf("value is nil"))
 		}
 		e.mu.v.acquire()
 		return e.mu.v
 	}
 	becomeReaderLocked := func() {
 		if e.mu.v != nil {
-			panic("value is non-nil")
+			panic(errors.AssertionFailedf("value is non-nil"))
 		}
 		if e.mu.isReading {
-			panic("isReading is already true")
+			panic(errors.AssertionFailedf("isReading is already true"))
 		}
 		e.mu.isReading = true
 		if e.mu.ch != nil {
@@ -249,7 +249,7 @@ func (e *readEntry) waitForReadPermissionOrHandle(
 				// Channel closed, so value was read.
 				e.mu.RLock()
 				if e.mu.v == nil {
-					panic("value is nil")
+					panic(errors.AssertionFailedf("value is nil"))
 				}
 				h := constructValueLocked()
 				errorDuration = e.mu.errorDuration
@@ -276,12 +276,12 @@ func (e *readEntry) unrefAndTryRemoveFromMap() {
 		return
 	}
 	if e.refCount < 0 {
-		panic("invalid reference count")
+		panic(errors.AssertionFailedf("invalid reference count"))
 	}
 	// The refcount is now 0; remove from the map.
 	if invariants.Enabled {
 		if e2, ok := rs.mu.readMap.Get(e.key); !ok || e2 != e {
-			panic("entry not in readMap")
+			panic(errors.AssertionFailedf("entry not in readMap"))
 		}
 	}
 	rs.mu.readMap.Delete(e.key)
@@ -302,11 +302,11 @@ func (e *readEntry) setReadValue(v *Value) {
 	// Acquire a ref for readEntry, since we are going to remember it in e.mu.v.
 	v.acquire()
 	if e.mu.v != nil {
-		panic("value already set")
+		panic(errors.AssertionFailedf("value already set"))
 	}
 	e.mu.v = v
 	if !e.mu.isReading {
-		panic("isReading is false")
+		panic(errors.AssertionFailedf("isReading is false"))
 	}
 	e.mu.isReading = false
 	if e.mu.ch != nil {
@@ -326,14 +326,14 @@ func (e *readEntry) setReadValue(v *Value) {
 func (e *readEntry) setReadError(err error) {
 	e.mu.Lock()
 	if !e.mu.isReading {
-		panic("isReading is false")
+		panic(errors.AssertionFailedf("isReading is false"))
 	}
 	e.mu.isReading = false
 	if e.mu.ch != nil {
 		select {
 		case e.mu.ch <- struct{}{}:
 		default:
-			panic("channel is not empty")
+			panic(errors.AssertionFailedf("channel is not empty"))
 		}
 	}
 	e.mu.errorDuration += time.Since(e.mu.readStart)

--- a/internal/compact/iterator.go
+++ b/internal/compact/iterator.go
@@ -828,7 +828,7 @@ func (i *Iter) nextInStripeHelper() stripeChangeType {
 			// sequence number for a given user key, and the first key after one
 			// is always considered a newStripeNewKey, so we should never reach
 			// this.
-			panic("unreachable")
+			panic(errors.AssertionFailedf("unreachable"))
 		case base.InternalKeyKindDelete, base.InternalKeyKindSet, base.InternalKeyKindMerge, base.InternalKeyKindSingleDelete,
 			base.InternalKeyKindSetWithDelete, base.InternalKeyKindDeleteSized:
 			// Fall through
@@ -1067,7 +1067,7 @@ func (i *Iter) singleDeleteNext() bool {
 				}
 			case newStripeNewKey:
 			default:
-				panic("unreachable")
+				panic(errors.AssertionFailedf("unreachable"))
 			}
 			return false
 
@@ -1167,7 +1167,7 @@ func (i *Iter) skipDueToSingleDeleteElision() {
 							"unexpected internal key kind: %d", errors.Safe(i.iterKV.Kind())))
 					}
 				default:
-					panic("unreachable")
+					panic(errors.AssertionFailedf("unreachable"))
 				}
 				// Whether in same stripe or new stripe, this key is not consumed by
 				// the SingleDelete.
@@ -1178,7 +1178,7 @@ func (i *Iter) skipDueToSingleDeleteElision() {
 					"unexpected internal key kind: %d", errors.Safe(i.iterKV.Kind())))
 			}
 		default:
-			panic("unreachable")
+			panic(errors.AssertionFailedf("unreachable"))
 		}
 	}
 }
@@ -1479,7 +1479,7 @@ func (i *Iter) tombstoneCovers(key base.InternalKey, snapshot base.SeqNum) cover
 
 func (i *Iter) setLastRangeDelSpan(span *keyspan.Span) {
 	if invariants.Enabled && !i.lastRangeDelSpan.Empty() {
-		panic("last range del span overwritten")
+		panic(errors.AssertionFailedf("last range del span overwritten"))
 	}
 	i.lastRangeDelSpan.CopyFrom(span)
 	i.lastRangeDelSpanFrontier.Update(i.lastRangeDelSpan.End)

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -187,7 +187,7 @@ func (r *Runner) WriteTable(
 	valueSeparation valsep.ValueSeparation,
 ) {
 	if r.err != nil {
-		panic("error already encountered")
+		panic(errors.AssertionFailedf("error already encountered"))
 	}
 
 	// Set the value separation props on the writer.

--- a/internal/compact/spans.go
+++ b/internal/compact/spans.go
@@ -5,6 +5,7 @@
 package compact
 
 import (
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -47,7 +48,7 @@ func MakeRangeDelSpanCompactor(
 // non-overlapping.
 func (c *RangeDelSpanCompactor) Compact(span, output *keyspan.Span) {
 	if invariants.Enabled && span.KeysOrder != keyspan.ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	output.Reset()
 	// Apply the snapshot stripe rules, keeping only the latest tombstone for
@@ -118,7 +119,7 @@ func MakeRangeKeySpanCompactor(
 // non-overlapping.
 func (c *RangeKeySpanCompactor) Compact(span, output *keyspan.Span) {
 	if invariants.Enabled && span.KeysOrder != keyspan.ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	// snapshots are in ascending order, while s.keys are in descending seqnum
 	// order. Partition s.keys by snapshot stripes, and call rangekey.Coalesce

--- a/internal/compact/splitting.go
+++ b/internal/compact/splitting.go
@@ -146,7 +146,7 @@ func NewOutputSplitter(
 	}
 	if len(limit) > 0 {
 		if invariants.Enabled && cmp(startKey, limit) >= 0 {
-			panic("limit <= startKey")
+			panic(errors.AssertionFailedf("limit <= startKey"))
 		}
 		s.limit = slices.Clone(limit)
 	}
@@ -157,7 +157,7 @@ func NewOutputSplitter(
 	}
 	s.setNextBoundary(grandparent)
 	if invariants.Enabled && s.nextBoundary.key != nil && s.cmp(s.nextBoundary.key, startKey) <= 0 {
-		panic("first boundary is not after startKey")
+		panic(errors.AssertionFailedf("first boundary is not after startKey"))
 	}
 	// We start using the frontier after the first ShouldSplitBefore call.
 	s.frontier.Init(frontiers, nil, s.boundaryReached)
@@ -210,7 +210,7 @@ func (s *OutputSplitter) ShouldSplitBefore(
 	nextUserKey []byte, estimatedFileSize uint64, equalPrevFn func([]byte) bool,
 ) ShouldSplit {
 	if invariants.Enabled && s.splitKey != nil {
-		panic("ShouldSplitBefore called after it returned SplitNow")
+		panic(errors.AssertionFailedf("ShouldSplitBefore called after it returned SplitNow"))
 	}
 	if !s.shouldSplitCalled {
 		// The boundary could have been advanced to nextUserKey before the splitter
@@ -223,13 +223,13 @@ func (s *OutputSplitter) ShouldSplitBefore(
 	}
 
 	if invariants.Enabled && s.nextBoundary.key != nil && s.cmp(s.nextBoundary.key, nextUserKey) <= 0 {
-		panic("boundary is behind the next key (or startKey was before the boundary)")
+		panic(errors.AssertionFailedf("boundary is behind the next key (or startKey was before the boundary)"))
 	}
 	// Note: s.reachedBoundary can be empty.
 	reachedBoundary := s.reachedBoundary
 	s.reachedBoundary = splitterBoundary{}
 	if invariants.Enabled && reachedBoundary.key != nil && s.cmp(reachedBoundary.key, nextUserKey) > 0 {
-		panic("reached boundary ahead of the next user key")
+		panic(errors.AssertionFailedf("reached boundary ahead of the next user key"))
 	}
 	if reachedBoundary.key != nil && !reachedBoundary.isGrandparent {
 		// Limit was reached.
@@ -440,7 +440,7 @@ func (f *frontier) Update(key []byte) {
 			return
 		}
 	}
-	panic("unreachable")
+	panic(errors.AssertionFailedf("unreachable"))
 }
 
 // Frontiers is used to track progression of a task (eg, compaction) across the

--- a/internal/compact/tombstone_elision.go
+++ b/internal/compact/tombstone_elision.go
@@ -7,6 +7,7 @@ package compact
 import (
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -108,7 +109,7 @@ func (te *pointTombstoneElider) ShouldElide(key []byte) bool {
 
 	inUseRanges := te.elision.inUseRanges
 	if invariants.Enabled && te.inUseIdx > 0 && inUseRanges[te.inUseIdx-1].End.IsUpperBoundFor(te.cmp, key) {
-		panic("ShouldElidePoint called with out-of-order key")
+		panic(errors.AssertionFailedf("ShouldElidePoint called with out-of-order key"))
 	}
 	// Advance inUseIdx to the first in-use range that ends after key.
 	for te.inUseIdx < len(te.elision.inUseRanges) && !inUseRanges[te.inUseIdx].End.IsUpperBoundFor(te.cmp, key) {
@@ -148,7 +149,7 @@ func (te *rangeTombstoneElider) ShouldElide(start, end []byte) bool {
 
 	inUseRanges := te.elision.inUseRanges
 	if invariants.Enabled && te.inUseIdx > 0 && inUseRanges[te.inUseIdx-1].End.IsUpperBoundFor(te.cmp, start) {
-		panic("ShouldElideRange called with out-of-order key")
+		panic(errors.AssertionFailedf("ShouldElideRange called with out-of-order key"))
 	}
 	// Advance inUseIdx to the first in-use range that ends after start.
 	for te.inUseIdx < len(te.elision.inUseRanges) && !inUseRanges[te.inUseIdx].End.IsUpperBoundFor(te.cmp, start) {

--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/minio/minlz"
 )
 
@@ -119,7 +120,7 @@ func GetCompressor(s Setting) Compressor {
 	case MinLZ:
 		return getMinlzCompressor(int(s.Level))
 	default:
-		panic("Invalid compression type.")
+		panic(errors.AssertionFailedf("Invalid compression type."))
 	}
 }
 
@@ -152,7 +153,7 @@ func GetDecompressor(a Algorithm) Decompressor {
 	case MinLZ:
 		return minlzDecompressor{}
 	default:
-		panic("Invalid compression type.")
+		panic(errors.AssertionFailedf("Invalid compression type."))
 	}
 }
 

--- a/internal/compression/zstd_cgo.go
+++ b/internal/compression/zstd_cgo.go
@@ -55,10 +55,10 @@ func (z *zstdCompressor) Compress(compressedBuf []byte, b []byte) ([]byte, Setti
 	varIntLen := binary.PutUvarint(compressedBuf, uint64(len(b)))
 	result, err := z.ctx.CompressLevel(compressedBuf[varIntLen:varIntLen+bound], b, z.level)
 	if err != nil {
-		panic("Error while compressing using Zstd.")
+		panic(errors.AssertionFailedf("Error while compressing using Zstd."))
 	}
 	if &result[0] != &compressedBuf[varIntLen] {
-		panic("Allocated a new buffer despite checking CompressBound.")
+		panic(errors.AssertionFailedf("Allocated a new buffer despite checking CompressBound."))
 	}
 	msanWrite(result)
 

--- a/internal/datatest/datatest.go
+++ b/internal/datatest/datatest.go
@@ -136,7 +136,7 @@ func NewCompactionTracker(options *pebble.Options) *CompactionTracker {
 func (cql *CompactionTracker) WaitForInflightCompactionsToEqual(target int) {
 	cql.L.Lock()
 	if !cql.attached {
-		panic("Cannot wait for compactions if listener has not been attached")
+		panic(errors.AssertionFailedf("Cannot wait for compactions if listener has not been attached"))
 	}
 	for cql.count != target {
 		cql.Wait()

--- a/internal/deletepacer/delete_pacer.go
+++ b/internal/deletepacer/delete_pacer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/metrics"
@@ -224,7 +225,7 @@ func (dp *DeletePacer) Enqueue(jobID int, files ...ObsoleteFile) {
 	defer dp.mu.Unlock()
 	if dp.mu.closed {
 		if invariants.Enabled {
-			panic("Enqueue called after Close")
+			panic(errors.AssertionFailedf("Enqueue called after Close"))
 		}
 		return
 	}

--- a/internal/deletepacer/rate_calc.go
+++ b/internal/deletepacer/rate_calc.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/errors"
 )
 
 // rateCalculator computes the target deletion throughput (bytes/sec) for a
@@ -167,7 +168,7 @@ func (rc *rateCalculator) InDebt() bool {
 // This method panics if called when there is no debt (InDebt() returns false).
 func (rc *rateCalculator) DebtWaitTime() time.Duration {
 	if rc.debtBytes == 0 {
-		panic("no debt")
+		panic(errors.AssertionFailedf("no debt"))
 	}
 	// We add 1ns as a way to round up. We must also make sure we never return 0,
 	// as that will be problematic with synctest (which has exact sleeps).

--- a/internal/ewma/ewma_bytes.go
+++ b/internal/ewma/ewma_bytes.go
@@ -7,6 +7,7 @@ package ewma
 import (
 	"math"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -56,7 +57,7 @@ func (b *Bytes) Estimate() float64 {
 func (b *Bytes) NoSample(numBytes int64) {
 	if numBytes < 0 {
 		if invariants.Enabled {
-			panic("invalid numBytes")
+			panic(errors.AssertionFailedf("invalid numBytes"))
 		}
 		return
 	}
@@ -70,7 +71,7 @@ func (b *Bytes) NoSample(numBytes int64) {
 func (b *Bytes) SampledBlock(numBytes int64, value float64) {
 	if numBytes < 1 {
 		if invariants.Enabled {
-			panic("invalid numBytes")
+			panic(errors.AssertionFailedf("invalid numBytes"))
 		}
 		return
 	}

--- a/internal/genericcache/cache.go
+++ b/internal/genericcache/cache.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"unsafe"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -110,7 +111,7 @@ type ValueRef[K Key, V any, InitOpts any] struct {
 // until ref.Unref() is called.
 func (ref ValueRef[K, V, InitOpts]) Value() *V {
 	if invariants.Enabled && ref.value.err != nil {
-		panic("ValueRef with error")
+		panic(errors.AssertionFailedf("ValueRef with error"))
 	}
 	return &ref.value.v
 }

--- a/internal/genericcache/shard.go
+++ b/internal/genericcache/shard.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -362,7 +363,7 @@ func (s *shard[K, V, InitOpts]) Evict(key K) {
 
 	if v != nil {
 		if v.refCount.Add(-1) != 0 {
-			panic("element has outstanding references")
+			panic(errors.AssertionFailedf("element has outstanding references"))
 		}
 		<-v.initialized
 		if v.err == nil {
@@ -397,7 +398,7 @@ func (s *shard[K, V, InitOpts]) EvictAll(predicate func(K) bool) []K {
 		defer s.mu.RUnlock()
 		s.forAllNodesLocked(func(n *node[K, V]) {
 			if predicate(n.key) {
-				panic("evictable key added in shard")
+				panic(errors.AssertionFailedf("evictable key added in shard"))
 			}
 		})
 	}
@@ -425,7 +426,7 @@ func (s *shard[K, V, InitOpts]) Close() {
 		n := s.mu.handHot
 		if v := n.value; v != nil {
 			if v.refCount.Add(-1) != 0 {
-				panic("element has outstanding references")
+				panic(errors.AssertionFailedf("element has outstanding references"))
 			}
 			s.releasingCh <- v
 		}

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -37,7 +37,7 @@ func (d *CloseChecker) Close() {
 		// Note: to debug a double-close, you can add a stack field to CloseChecker
 		// and set it to string(debug.Stack()) in Close, then print that in this
 		// panic.
-		panic("double close")
+		panic(errors.AssertionFailedf("double close"))
 	}
 	d.closed = true
 }
@@ -45,14 +45,14 @@ func (d *CloseChecker) Close() {
 // AssertClosed panics in invariant builds if Close was not called.
 func (d *CloseChecker) AssertClosed() {
 	if !d.closed {
-		panic("not closed")
+		panic(errors.AssertionFailedf("not closed"))
 	}
 }
 
 // AssertNotClosed panics in invariant builds if Close was called.
 func (d *CloseChecker) AssertNotClosed() {
 	if d.closed {
-		panic("closed")
+		panic(errors.AssertionFailedf("closed"))
 	}
 }
 

--- a/internal/keyspan/bounded.go
+++ b/internal/keyspan/bounded.go
@@ -7,6 +7,7 @@ package keyspan
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/treesteps"
 )
@@ -166,7 +167,7 @@ func (i *BoundedIter) Next() (*Span, error) {
 		// Already exhausted.
 		return nil, nil
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 }
 
@@ -202,7 +203,7 @@ func (i *BoundedIter) Prev() (*Span, error) {
 		i.pos = posAtIterSpan
 		return i.iterSpan, nil
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 }
 

--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/bytealloc"
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -53,7 +54,7 @@ func (f DefragmentMethodFunc) ShouldDefragment(
 // required their fragmentation has been dropped.
 var DefragmentInternal DefragmentMethod = DefragmentMethodFunc(func(suffixCmp base.CompareRangeSuffixes, a, b *Span) bool {
 	if a.KeysOrder != ByTrailerDesc || b.KeysOrder != ByTrailerDesc {
-		panic("pebble: span keys unexpectedly not in trailer descending order")
+		panic(errors.AssertionFailedf("pebble: span keys unexpectedly not in trailer descending order"))
 	}
 	if len(a.Keys) != len(b.Keys) {
 		return false
@@ -343,7 +344,7 @@ func (i *DefragmentingIter) Next() (*Span, error) {
 		if err != nil {
 			return nil, err
 		} else if i.iterSpan == nil {
-			panic("pebble: invariant violation: no next span while switching directions")
+			panic(errors.AssertionFailedf("pebble: invariant violation: no next span while switching directions"))
 		}
 		// We're now positioned on the first span that was defragmented into the
 		// current iterator position. Skip over the rest of the current iterator
@@ -364,7 +365,7 @@ func (i *DefragmentingIter) Next() (*Span, error) {
 		// iterPosCurr is only used when the iter is exhausted or when the iterator
 		// is at an empty span.
 		if invariants.Enabled && i.iterSpan != nil && !i.iterSpan.Empty() {
-			panic("pebble: invariant violation: iterPosCurr with valid iterSpan")
+			panic(errors.AssertionFailedf("pebble: invariant violation: iterPosCurr with valid iterSpan"))
 		}
 
 		var err error
@@ -382,7 +383,7 @@ func (i *DefragmentingIter) Next() (*Span, error) {
 		}
 		return i.defragmentForward()
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 }
 
@@ -400,7 +401,7 @@ func (i *DefragmentingIter) Prev() (*Span, error) {
 		// iterPosCurr is only used when the iter is exhausted or when the iterator
 		// is at an empty span.
 		if invariants.Enabled && i.iterSpan != nil && !i.iterSpan.Empty() {
-			panic("pebble: invariant violation: iterPosCurr with valid iterSpan")
+			panic(errors.AssertionFailedf("pebble: invariant violation: iterPosCurr with valid iterSpan"))
 		}
 
 		var err error
@@ -428,7 +429,7 @@ func (i *DefragmentingIter) Prev() (*Span, error) {
 		if err != nil {
 			return nil, err
 		} else if i.iterSpan == nil {
-			panic("pebble: invariant violation: no previous span while switching directions")
+			panic(errors.AssertionFailedf("pebble: invariant violation: no previous span while switching directions"))
 		}
 		// We're now positioned on the last span that was defragmented into the
 		// current iterator position. Skip over the rest of the current iterator
@@ -446,7 +447,7 @@ func (i *DefragmentingIter) Prev() (*Span, error) {
 		}
 		return i.defragmentBackward()
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 }
 

--- a/internal/keyspan/fragmenter.go
+++ b/internal/keyspan/fragmenter.go
@@ -135,9 +135,9 @@ func (f *Fragmenter) checkInvariants(buf []Span) {
 // Add requires the provided span's keys are sorted in InternalKeyTrailer descending order.
 func (f *Fragmenter) Add(s Span) {
 	if f.finished {
-		panic("pebble: span fragmenter already finished")
+		panic(errors.AssertionFailedf("pebble: span fragmenter already finished"))
 	} else if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span keys unexpectedly not in trailer descending order")
+		panic(errors.AssertionFailedf("pebble: span keys unexpectedly not in trailer descending order"))
 	}
 	if f.flushedKey != nil {
 		switch c := f.Cmp(s.Start, f.flushedKey); {
@@ -315,7 +315,7 @@ func (f *Fragmenter) flush(buf []Span, lastKey []byte) {
 // this if any other spans will be added.
 func (f *Fragmenter) Finish() {
 	if f.finished {
-		panic("pebble: span fragmenter already finished")
+		panic(errors.AssertionFailedf("pebble: span fragmenter already finished"))
 	}
 	f.flush(f.pending, nil)
 	f.finished = true

--- a/internal/keyspan/keyspanimpl/level_iter.go
+++ b/internal/keyspan/keyspanimpl/level_iter.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -109,7 +110,7 @@ func (l *LevelIter) Init(
 	keyType manifest.KeyType,
 ) {
 	if keyType != manifest.KeyTypePoint && keyType != manifest.KeyTypeRange {
-		panic("keyType must be point or range")
+		panic(errors.AssertionFailedf("keyType must be point or range"))
 	}
 	*l = LevelIter{
 		cmp:       cmp,
@@ -344,7 +345,7 @@ func (l *LevelIter) Prev() (*keyspan.Span, error) {
 
 func (l *LevelIter) moveToNextFile() (*keyspan.Span, error) {
 	if invariants.Enabled && l.pos == beforeFile {
-		panic("moveToNextFile with beforeFile pos")
+		panic(errors.AssertionFailedf("moveToNextFile with beforeFile pos"))
 	}
 	for {
 		nextFile := l.files.Next()
@@ -370,7 +371,7 @@ func (l *LevelIter) moveToNextFile() (*keyspan.Span, error) {
 
 func (l *LevelIter) moveToPrevFile() (*keyspan.Span, error) {
 	if invariants.Enabled && l.pos == afterFile {
-		panic("eofBackward with afterFile pos")
+		panic(errors.AssertionFailedf("eofBackward with afterFile pos"))
 	}
 	for {
 		prevFile := l.files.Prev()

--- a/internal/keyspan/keyspanimpl/merging_iter.go
+++ b/internal/keyspan/keyspanimpl/merging_iter.go
@@ -764,7 +764,7 @@ func (m *MergingIter) switchToMinHeap() error {
 		for i := range m.levels {
 			l := &m.levels[i]
 			if l.heapKey.kind != boundKindInvalid && m.comparer.Compare(l.heapKey.key, m.start) > 0 {
-				panic("pebble: invariant violation: max-heap key > m.start")
+				panic(errors.AssertionFailedf("pebble: invariant violation: max-heap key > m.start"))
 			}
 		}
 	}
@@ -819,7 +819,7 @@ func (m *MergingIter) switchToMaxHeap() error {
 		for i := range m.levels {
 			l := &m.levels[i]
 			if l.heapKey.kind != boundKindInvalid && m.comparer.Compare(l.heapKey.key, m.end) < 0 {
-				panic("pebble: invariant violation: min-heap key < m.end")
+				panic(errors.AssertionFailedf("pebble: invariant violation: min-heap key < m.end"))
 			}
 		}
 	}

--- a/internal/keyspan/span.go
+++ b/internal/keyspan/span.go
@@ -172,9 +172,9 @@ func (s *Span) Bounds() base.UserKeyBounds {
 // contains no keys or its keys are sorted in a different order.
 func (s *Span) SmallestKey() base.InternalKey {
 	if len(s.Keys) == 0 {
-		panic("pebble: Span contains no keys")
+		panic(errors.AssertionFailedf("pebble: Span contains no keys"))
 	} else if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	// The first key has the highest (sequence number,kind) tuple.
 	return base.InternalKey{
@@ -193,9 +193,9 @@ func (s *Span) SmallestKey() base.InternalKey {
 // contains no keys or its keys are sorted in a different order.
 func (s *Span) LargestKey() base.InternalKey {
 	if len(s.Keys) == 0 {
-		panic("pebble: Span contains no keys")
+		panic(errors.AssertionFailedf("pebble: Span contains no keys"))
 	} else if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	// The last key has the lowest (sequence number,kind) tuple.
 	kind := s.Keys[len(s.Keys)-1].Kind()
@@ -207,9 +207,9 @@ func (s *Span) LargestKey() base.InternalKey {
 // the span contains no keys or its keys are sorted in a different order.
 func (s *Span) SmallestSeqNum() base.SeqNum {
 	if len(s.Keys) == 0 {
-		panic("pebble: Span contains no keys")
+		panic(errors.AssertionFailedf("pebble: Span contains no keys"))
 	} else if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 
 	return s.Keys[len(s.Keys)-1].SeqNum()
@@ -220,9 +220,9 @@ func (s *Span) SmallestSeqNum() base.SeqNum {
 // the span contains no keys or its keys are sorted in a different order.
 func (s *Span) LargestSeqNum() base.SeqNum {
 	if len(s.Keys) == 0 {
-		panic("pebble: Span contains no keys")
+		panic(errors.AssertionFailedf("pebble: Span contains no keys"))
 	} else if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	return s.Keys[0].SeqNum()
 }
@@ -235,9 +235,9 @@ func (s *Span) LargestVisibleSeqNum(snapshot base.SeqNum) (largest base.SeqNum, 
 	if s == nil {
 		return 0, false
 	} else if len(s.Keys) == 0 {
-		panic("pebble: Span contains no keys")
+		panic(errors.AssertionFailedf("pebble: Span contains no keys"))
 	} else if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	for i := range s.Keys {
 		if s.Keys[i].VisibleAt(snapshot) {
@@ -258,7 +258,7 @@ func (s *Span) LargestVisibleSeqNum(snapshot base.SeqNum) (largest base.SeqNum, 
 // non-allocating methods when possible.
 func (s Span) Visible(snapshot base.SeqNum) Span {
 	if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 
 	ret := Span{Start: s.Start, End: s.End}
@@ -335,7 +335,7 @@ func (s Span) Visible(snapshot base.SeqNum) Span {
 // the span's keys are sorted in a different order.
 func (s *Span) VisibleAt(snapshot base.SeqNum) bool {
 	if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	if len(s.Keys) == 0 {
 		return false
@@ -379,7 +379,7 @@ func (s *Span) Contains(cmp base.Compare, key []byte) bool {
 // span's keys are sorted in a different order.
 func (s Span) Covers(seqNum base.SeqNum) bool {
 	if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	return !s.Empty() && s.Keys[0].SeqNum() > seqNum
 }
@@ -395,7 +395,7 @@ func (s Span) Covers(seqNum base.SeqNum) bool {
 // span's keys are sorted in a different order.
 func (s *Span) CoversAt(snapshot, seqNum base.SeqNum) bool {
 	if s.KeysOrder != ByTrailerDesc {
-		panic("pebble: span's keys unexpectedly not in trailer order")
+		panic(errors.AssertionFailedf("pebble: span's keys unexpectedly not in trailer order"))
 	}
 	// NB: A key is visible at `snapshot` if its sequence number is strictly
 	// less than `snapshot`. See base.Visible.

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -191,19 +191,22 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	// Disallow panic(fmt.Sprintf(...)); use panic(errors.AssertionFailedf(...))
-	// instead so that panic messages are not redacted in CockroachDB logs and
-	// include proper stack traces.
-	t.Run("TestPanicFmtSprintf", func(t *testing.T) {
+	// Disallow panic("...") with string literals and panic(fmt.Sprintf(...));
+	// use panic(errors.AssertionFailedf(...)) instead so that panic messages
+	// are not redacted in CockroachDB logs and include proper stack traces.
+	t.Run("TestPanicArgs", func(t *testing.T) {
 		t.Parallel()
 
 		if err := stream.ForEach(
 			stream.Sequence(
-				dirCmd(t, pkg.Dir, "git", "grep", "-B1", `panic(fmt\.Sprintf(`, "--", "*.go"),
-				lintIgnore("lint:ignore PanicFmtSprintf"),
+				dirCmd(t, pkg.Dir, "git", "grep", "-B1", "-nE",
+					`panic\((fmt\.Sprintf\(|"[^"]*"\))`, "--", "*.go"),
+				stream.GrepNot(`^--$`),
+				stream.GrepNot(`_test\.go[-:]`),
 				stream.GrepNot(`^internal/lint/lint_test.go`),
+				lintIgnore("lint:ignore PanicArgs"),
 			), func(s string) {
-				t.Errorf("\n%s <- please use \"panic(errors.AssertionFailedf(...))\" instead", s)
+				t.Errorf("\n%s <- please use \"panic(errors.AssertionFailedf(...))\" instead; wrap non-sensitive args with redact.Safe()", s)
 			}); err != nil {
 			t.Error(err)
 		}

--- a/internal/manifest/annotator_blob.go
+++ b/internal/manifest/annotator_blob.go
@@ -4,6 +4,8 @@
 
 package manifest
 
+import "github.com/cockroachdb/errors"
+
 // A BlobFileAnnotator defines a computation over a version's set of blob files.
 type BlobFileAnnotator[T any] struct {
 	annotator[T, BlobFileMetadata]
@@ -57,7 +59,7 @@ type BlobFileAnnotationIdx int
 func NewBlobAnnotationIdx() BlobFileAnnotationIdx {
 	n := nextBlobAnnotationID
 	if n >= maxAnnotationsPerNode {
-		panic("too many blob annotations")
+		panic(errors.AssertionFailedf("too many blob annotations"))
 	}
 	nextBlobAnnotationID++
 	return n

--- a/internal/manifest/annotator_table.go
+++ b/internal/manifest/annotator_table.go
@@ -7,6 +7,7 @@ package manifest
 import (
 	"sort"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 )
 
@@ -62,7 +63,7 @@ type TableAnnotationIdx int
 func NewTableAnnotationIdx() TableAnnotationIdx {
 	n := nextTableAnnotationIdx
 	if n >= maxAnnotationsPerNode {
-		panic("too many table annotations")
+		panic(errors.AssertionFailedf("too many table annotations"))
 	}
 	nextTableAnnotationIdx++
 	return n

--- a/internal/manifest/blob_metadata.go
+++ b/internal/manifest/blob_metadata.go
@@ -186,7 +186,7 @@ func (m *PhysicalBlobFile) PopulateProperties(props *blob.FileProperties) {
 	m.props = *props
 	oldPropsValid := m.propsValid.Swap(true)
 	if invariants.Enabled && oldPropsValid {
-		panic("props set twice")
+		panic(errors.AssertionFailedf("props set twice"))
 	}
 }
 
@@ -952,7 +952,7 @@ func (s *CurrentBlobFileSet) ApplyAndUpdateVersionEdit(ve *VersionEdit) error {
 				// is the first time a reference to the file has been removed.
 				heap.Push(&s.rewrite.candidates, cbf)
 			default:
-				panic("unreachable")
+				panic(errors.AssertionFailedf("unreachable"))
 			}
 		}
 	}

--- a/internal/manifest/btree.go
+++ b/internal/manifest/btree.go
@@ -53,7 +53,7 @@ func btreeCmpSpecificOrder(files []*TableMetadata) btreeCmp[*TableMetadata] {
 		ai, aok := m[a]
 		bi, bok := m[b]
 		if !aok || !bok {
-			panic("btreeCmpSliceOrder called with unknown files")
+			panic(errors.AssertionFailedf("btreeCmpSliceOrder called with unknown files"))
 		}
 		return stdcmp.Compare(ai, bi)
 	}
@@ -1028,7 +1028,7 @@ func (i iterator[M]) String() string {
 
 func cmpIter[M fileMetadata](a, b iterator[M]) int {
 	if a.r != b.r {
-		panic("compared iterators from different btrees")
+		panic(errors.AssertionFailedf("compared iterators from different btrees"))
 	}
 
 	// Each iterator has a stack of frames marking the path from the root node
@@ -1087,7 +1087,7 @@ func cmpIter[M fileMetadata](a, b iterator[M]) int {
 
 		// aok && bok
 		if af.n != bf.n {
-			panic("nonmatching nodes during btree iterator comparison")
+			panic(errors.AssertionFailedf("nonmatching nodes during btree iterator comparison"))
 		}
 		if v := stdcmp.Compare(af.pos, bf.pos); v != 0 {
 			return v
@@ -1097,10 +1097,10 @@ func cmpIter[M fileMetadata](a, b iterator[M]) int {
 	}
 
 	if aok && bok {
-		panic("expected one or more stacks to have been exhausted")
+		panic(errors.AssertionFailedf("expected one or more stacks to have been exhausted"))
 	}
 	if an != bn {
-		panic("nonmatching nodes during btree iterator comparison")
+		panic(errors.AssertionFailedf("nonmatching nodes during btree iterator comparison"))
 	}
 	if v := stdcmp.Compare(apos, bpos); v != 0 {
 		return v
@@ -1240,7 +1240,7 @@ func (i *iterator[M]) valid() bool {
 // illegal to call cur if the iterator is not valid.
 func (i *iterator[M]) cur() M {
 	if invariants.Enabled && !i.valid() {
-		panic("btree iterator.cur invoked on invalid iterator")
+		panic(errors.AssertionFailedf("btree iterator.cur invoked on invalid iterator"))
 	}
 	return i.n.items[i.pos]
 }

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -397,13 +397,13 @@ func (s *l0Sublevels) canUseAddL0Files(
 ) (filesToAddInOrder []*TableMetadata, ok bool) {
 	if s.addL0FilesCalled {
 		if invariants.Enabled {
-			panic("addL0Files called twice on the same receiver")
+			panic(errors.AssertionFailedf("addL0Files called twice on the same receiver"))
 		}
 		return nil, false
 	}
 	if s.levelMetadata.Len()+len(addedTables) != levelMetadata.Len() {
 		if invariants.Enabled {
-			panic("levelMetadata mismatch")
+			panic(errors.AssertionFailedf("levelMetadata mismatch"))
 		}
 		return nil, false
 	}
@@ -449,7 +449,7 @@ func (s *l0Sublevels) addL0Files(
 	files []*TableMetadata, flushSplitMaxBytes int64, levelMetadata *LevelMetadata,
 ) *l0Sublevels {
 	if s.addL0FilesCalled {
-		panic("addL0Files called twice on the same receiver")
+		panic(errors.AssertionFailedf("addL0Files called twice on the same receiver"))
 	}
 	s.addL0FilesCalled = true
 
@@ -493,7 +493,7 @@ func (s *l0Sublevels) addL0Files(
 	if invariants.Enabled {
 		for i := 1; i < len(keys); i++ {
 			if intervalKeyCompare(newVal.cmp, keys[i-1].startKey, keys[i].startKey) >= 0 {
-				panic("keys not sorted correctly")
+				panic(errors.AssertionFailedf("keys not sorted correctly"))
 			}
 		}
 	}
@@ -796,15 +796,15 @@ func (s *l0Sublevels) Check() {
 		}
 	}
 	if len(s.Levels) != len(s.levelFiles) {
-		panic("Levels and levelFiles inconsistency")
+		panic(errors.AssertionFailedf("Levels and levelFiles inconsistency"))
 	}
 	for i := range s.Levels {
 		if s.Levels[i].Len() != len(s.levelFiles[i]) {
-			panic("Levels and levelFiles inconsistency")
+			panic(errors.AssertionFailedf("Levels and levelFiles inconsistency"))
 		}
 		for _, t := range s.levelFiles[i] {
 			if t.SubLevel != i {
-				panic("t.SubLevel out of sync")
+				panic(errors.AssertionFailedf("t.SubLevel out of sync"))
 			}
 		}
 	}
@@ -2147,7 +2147,7 @@ type L0PreparedUpdate struct {
 // This method cannot be called concurrently with any other methods.
 func (o *L0Organizer) PerformUpdate(prepared L0PreparedUpdate, newVersion *Version) {
 	if prepared.generation != o.generation {
-		panic("invalid L0 update generation")
+		panic(errors.AssertionFailedf("invalid L0 update generation"))
 	}
 	o.levelMetadata = newVersion.Levels[0]
 	o.generation++
@@ -2205,27 +2205,27 @@ func verifyLevelMetadataTransition(
 	}
 	for n, t := range addedTables {
 		if m[n] != nil {
-			panic("added table that already exists in old level")
+			panic(errors.AssertionFailedf("added table that already exists in old level"))
 		}
 		m[n] = t
 	}
 	for n, t := range deletedTables {
 		if m[n] == nil {
-			panic("deleted table not in old level")
+			panic(errors.AssertionFailedf("deleted table not in old level"))
 		}
 		if m[n] != t {
-			panic("deleted table does not match old level")
+			panic(errors.AssertionFailedf("deleted table does not match old level"))
 		}
 		delete(m, n)
 	}
 	iter = newLevel.Iter()
 	for t := iter.First(); t != nil; t = iter.Next() {
 		if m[t.TableNum] == nil {
-			panic("unknown table in new level")
+			panic(errors.AssertionFailedf("unknown table in new level"))
 		}
 		delete(m, t.TableNum)
 	}
 	if len(m) != 0 {
-		panic("tables missing from the new level")
+		panic(errors.AssertionFailedf("tables missing from the new level"))
 	}
 }

--- a/internal/manifest/layer.go
+++ b/internal/manifest/layer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
 
@@ -24,7 +25,7 @@ type Layer struct {
 // Level returns a Layer that represents an entire level (L0 through L6).
 func Level(level int) Layer {
 	if level < 0 || level >= NumLevels {
-		panic("invalid level")
+		panic(errors.AssertionFailedf("invalid level"))
 	}
 	return Layer{
 		kind:  levelLayer,
@@ -36,7 +37,7 @@ func Level(level int) Layer {
 func L0Sublevel(sublevel int) Layer {
 	// Note: Pebble stops writes once we get to 1000 sublevels.
 	if sublevel < 0 || sublevel > math.MaxUint16 {
-		panic("invalid sublevel")
+		panic(errors.AssertionFailedf("invalid sublevel"))
 	}
 	return Layer{
 		kind:  l0SublevelLayer,
@@ -76,9 +77,9 @@ func (l Layer) Level() int {
 	case l0SublevelLayer:
 		return 0
 	case flushableIngestsLayer:
-		panic("flushable ingests layer")
+		panic(errors.AssertionFailedf("flushable ingests layer"))
 	default:
-		panic("invalid layer")
+		panic(errors.AssertionFailedf("invalid layer"))
 	}
 }
 
@@ -86,7 +87,7 @@ func (l Layer) Level() int {
 // an L0 sublevel.
 func (l Layer) Sublevel() int {
 	if !l.IsL0Sublevel() {
-		panic("not an L0 sublevel layer")
+		panic(errors.AssertionFailedf("not an L0 sublevel layer"))
 	}
 	return int(l.value)
 }

--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -579,7 +579,7 @@ func (i *LevelIterator) Next() *TableMetadata {
 		return nil
 	}
 	if invariants.Enabled && (i.iter.pos >= i.iter.n.count || (i.end != nil && cmpIter(i.iter, *i.end) > 0)) {
-		panic("pebble: cannot next forward-exhausted iterator")
+		panic(errors.AssertionFailedf("pebble: cannot next forward-exhausted iterator"))
 	}
 	i.iter.next()
 	if !i.iter.valid() {
@@ -594,7 +594,7 @@ func (i *LevelIterator) PeekNext() *TableMetadata {
 		return nil
 	}
 	if invariants.Enabled && (i.iter.pos >= i.iter.n.count || (i.end != nil && cmpIter(i.iter, *i.end) > 0)) {
-		panic("pebble: cannot peek next on forward-exhausted iterator")
+		panic(errors.AssertionFailedf("pebble: cannot peek next on forward-exhausted iterator"))
 	}
 	// Fast path: we're in a leaf and there are more items after the current
 	// position. Scan forward within the leaf for an item matching the filter.
@@ -622,7 +622,7 @@ func (i *LevelIterator) Prev() *TableMetadata {
 		return nil
 	}
 	if invariants.Enabled && (i.iter.pos < 0 || (i.start != nil && cmpIter(i.iter, *i.start) < 0)) {
-		panic("pebble: cannot prev backward-exhausted iterator")
+		panic(errors.AssertionFailedf("pebble: cannot prev backward-exhausted iterator"))
 	}
 	i.iter.prev()
 	if !i.iter.valid() {
@@ -751,7 +751,7 @@ func (i *LevelIterator) SeekLT(cmp Compare, userKey []byte) *TableMetadata {
 	if i.filter != KeyTypePointAndRange && m != nil {
 		b, ok := m.SmallestBound(i.filter)
 		if !ok {
-			panic("unreachable")
+			panic(errors.AssertionFailedf("unreachable"))
 		}
 		if cmp(b.UserKey, userKey) >= 0 {
 			// This table does not contain any keys of desired key types
@@ -768,7 +768,7 @@ func (i *LevelIterator) SeekLT(cmp Compare, userKey []byte) *TableMetadata {
 func (i *LevelIterator) assertNotL0Cmp() {
 	if invariants.Enabled {
 		if reflect.ValueOf(i.iter.cmp).Pointer() == reflect.ValueOf(btreeCmpSeqNum).Pointer() {
-			panic("Seek used with btreeCmpSeqNum")
+			panic(errors.AssertionFailedf("Seek used with btreeCmpSeqNum"))
 		}
 	}
 }
@@ -855,7 +855,7 @@ func (i *LevelIterator) Take() LevelTable {
 	if !i.iter.valid() ||
 		(i.end != nil && cmpIter(i.iter, *i.end) > 0) ||
 		(i.start != nil && cmpIter(i.iter, *i.start) < 0) {
-		panic("Take called on invalid LevelIterator")
+		panic(errors.AssertionFailedf("Take called on invalid LevelIterator"))
 	}
 	m := i.iter.cur()
 	// LevelSlice's start and end fields are immutable and are positioned to the

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -282,14 +282,14 @@ func (m *TableMetadata) FragmentIterTransforms() sstable.FragmentIterTransforms 
 
 func (m *TableMetadata) PhysicalMeta() *TableMetadata {
 	if m.Virtual {
-		panic("pebble: table metadata does not belong to a physical sstable")
+		panic(errors.AssertionFailedf("pebble: table metadata does not belong to a physical sstable"))
 	}
 	return m
 }
 
 func (m *TableMetadata) VirtualMeta() *TableMetadata {
 	if !m.Virtual {
-		panic("pebble: table metadata does not belong to a virtual sstable")
+		panic(errors.AssertionFailedf("pebble: table metadata does not belong to a virtual sstable"))
 	}
 	return m
 }
@@ -471,7 +471,7 @@ func (b *TableBacking) PopulateProperties(props *sstable.Properties) *TableBacki
 	}
 	oldStatsValid := b.propsValid.Swap(true)
 	if invariants.Enabled && oldStatsValid {
-		panic("stats set twice")
+		panic(errors.AssertionFailedf("stats set twice"))
 	}
 	return &b.props
 }
@@ -485,10 +485,10 @@ func (b *TableBacking) PopulateProperties(props *sstable.Properties) *TableBacki
 // TableMetadata is not necessary in tests which don't rely on TableBacking.
 func (m *TableMetadata) InitPhysicalBacking() {
 	if m.Virtual {
-		panic("pebble: virtual sstables should use a pre-existing TableBacking")
+		panic(errors.AssertionFailedf("pebble: virtual sstables should use a pre-existing TableBacking"))
 	}
 	if m.TableBacking != nil {
-		panic("backing already initialized")
+		panic(errors.AssertionFailedf("backing already initialized"))
 	}
 
 	var blobValueSizeTotal uint64
@@ -518,14 +518,14 @@ func (m *TableMetadata) InitVirtualBacking(fileNum base.DiskFileNum, size uint64
 // The Smallest/Largest bounds must already be set to their final values.
 func (m *TableMetadata) AttachVirtualBacking(backing *TableBacking) {
 	if !m.Virtual {
-		panic("pebble: provider-backed sstables must be virtual")
+		panic(errors.AssertionFailedf("pebble: provider-backed sstables must be virtual"))
 	}
 	if m.TableBacking != nil {
-		panic("backing already initialized")
+		panic(errors.AssertionFailedf("backing already initialized"))
 	}
 	m.TableBacking = backing
 	if m.Smallest().UserKey == nil || m.Largest().UserKey == nil {
-		panic("bounds must be set before attaching backing")
+		panic(errors.AssertionFailedf("bounds must be set before attaching backing"))
 	}
 	m.VirtualParams = &virtual.VirtualReaderParams{
 		Lower:   m.Smallest(),
@@ -539,17 +539,17 @@ func (m *TableMetadata) AttachVirtualBacking(backing *TableBacking) {
 func (m *TableMetadata) ValidateVirtual(createdFrom *TableMetadata) {
 	switch {
 	case !m.Virtual:
-		panic("pebble: invalid virtual sstable")
+		panic(errors.AssertionFailedf("pebble: invalid virtual sstable"))
 	case createdFrom.SeqNums.Low != m.SeqNums.Low:
-		panic("pebble: invalid smallest sequence number for virtual sstable")
+		panic(errors.AssertionFailedf("pebble: invalid smallest sequence number for virtual sstable"))
 	case createdFrom.SeqNums.High != m.SeqNums.High:
-		panic("pebble: invalid largest sequence number for virtual sstable")
+		panic(errors.AssertionFailedf("pebble: invalid largest sequence number for virtual sstable"))
 	case createdFrom.LargestSeqNumAbsolute != m.LargestSeqNumAbsolute:
-		panic("pebble: invalid largest absolute sequence number for virtual sstable")
+		panic(errors.AssertionFailedf("pebble: invalid largest absolute sequence number for virtual sstable"))
 	case createdFrom.TableBacking != nil && createdFrom.TableBacking != m.TableBacking:
-		panic("pebble: invalid physical sstable state for virtual sstable")
+		panic(errors.AssertionFailedf("pebble: invalid physical sstable state for virtual sstable"))
 	case m.Size == 0:
-		panic("pebble: virtual sstable size must be set upon creation")
+		panic(errors.AssertionFailedf("pebble: virtual sstable size must be set upon creation"))
 	}
 }
 
@@ -601,7 +601,7 @@ func (m *TableMetadata) PopulateStats(stats *TableStats) {
 	m.stats = *stats
 	oldStatsValid := m.statsValid.Swap(true)
 	if invariants.Enabled && oldStatsValid {
-		panic("stats set twice")
+		panic(errors.AssertionFailedf("stats set twice"))
 	}
 }
 
@@ -708,7 +708,7 @@ func (m *TableMetadata) ContainsKeyType(kt KeyType) bool {
 	case KeyTypeRange:
 		return m.HasRangeKeys
 	default:
-		panic("unrecognized key type")
+		panic(errors.AssertionFailedf("unrecognized key type"))
 	}
 }
 
@@ -727,7 +727,7 @@ func (m *TableMetadata) SmallestBound(kt KeyType) (InternalKey, bool) {
 		}
 		return m.RangeKeyBounds.Smallest(), m.HasRangeKeys
 	default:
-		panic("unrecognized key type")
+		panic(errors.AssertionFailedf("unrecognized key type"))
 	}
 }
 
@@ -747,7 +747,7 @@ func (m *TableMetadata) LargestBound(kt KeyType) (InternalKey, bool) {
 		}
 		return m.RangeKeyBounds.Largest(), m.HasRangeKeys
 	default:
-		panic("unrecognized key type")
+		panic(errors.AssertionFailedf("unrecognized key type"))
 	}
 }
 

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -721,7 +721,7 @@ func (l *VersionList) Back() *Version {
 // becomes the "newest" version in the list.
 func (l *VersionList) PushBack(v *Version) {
 	if v.list != nil || v.prev != nil || v.next != nil {
-		panic("pebble: version list is inconsistent")
+		panic(errors.AssertionFailedf("pebble: version list is inconsistent"))
 	}
 	v.prev = l.root.prev
 	v.prev.next = v
@@ -733,10 +733,10 @@ func (l *VersionList) PushBack(v *Version) {
 // Remove removes the specified version from the list.
 func (l *VersionList) Remove(v *Version) {
 	if v == &l.root {
-		panic("pebble: cannot remove version list root node")
+		panic(errors.AssertionFailedf("pebble: cannot remove version list root node"))
 	}
 	if v.list != l {
-		panic("pebble: version list is inconsistent")
+		panic(errors.AssertionFailedf("pebble: version list is inconsistent"))
 	}
 	v.prev.next = v.next
 	v.next.prev = v.prev

--- a/internal/manifest/virtual_backings.go
+++ b/internal/manifest/virtual_backings.go
@@ -360,7 +360,7 @@ func (bv *VirtualBackings) String() string {
 func (bv *VirtualBackings) mustAdd(v *backingWithMetadata) {
 	_, ok := bv.m[v.backing.DiskFileNum]
 	if ok {
-		panic("pebble: trying to add an existing file backing")
+		panic(errors.AssertionFailedf("pebble: trying to add an existing file backing"))
 	}
 	bv.m[v.backing.DiskFileNum] = v
 }

--- a/internal/manual/manual_nocgo.go
+++ b/internal/manual/manual_nocgo.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"unsafe"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -59,7 +60,7 @@ func init() {
 // sizeClass determines the smallest n such that 1 << n >= size
 func sizeClass(size uintptr) int {
 	if invariants.Enabled && size == 0 {
-		panic("zero size should never get through New")
+		panic(errors.AssertionFailedf("zero size should never get through New"))
 	}
 	return bits.Len(uint(size - 1))
 }

--- a/internal/randvar/zipf.go
+++ b/internal/randvar/zipf.go
@@ -90,7 +90,7 @@ func NewZipf(min, max uint64, theta float64) (*Zipf, error) {
 // zeta(oldMax, theta). Returns zeta(max, theta), computed incrementally.
 func computeZetaIncrementally(oldMax, max uint64, theta float64, sum float64) float64 {
 	if max < oldMax {
-		panic("unable to decrement max!")
+		panic(errors.AssertionFailedf("unable to decrement max!"))
 	}
 	for i := oldMax + 1; i <= max; i++ {
 		sum += 1.0 / math.Pow(float64(i), theta)

--- a/internal/rangekey/coalesce.go
+++ b/internal/rangekey/coalesce.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"slices"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -76,7 +77,7 @@ func CoalesceInto(
 	deleteIdx := -1
 	for i := range keys {
 		if invariants.Enabled && i > 0 && keys[i].Trailer > keys[i-1].Trailer {
-			panic("pebble: invariant violation: span keys unordered")
+			panic(errors.AssertionFailedf("pebble: invariant violation: span keys unordered"))
 		}
 		if !keys[i].VisibleAt(snapshot) {
 			continue
@@ -178,11 +179,11 @@ func (f *ForeignSSTTransformer) Transform(
 		switch keys[i].Kind() {
 		case base.InternalKeyKindRangeKeySet:
 			if invariants.Enabled && len(dst.Keys) > 0 && suffixCmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
-				panic("pebble: keys unexpectedly not in ascending suffix order")
+				panic(errors.AssertionFailedf("pebble: keys unexpectedly not in ascending suffix order"))
 			}
 		case base.InternalKeyKindRangeKeyUnset:
 			if invariants.Enabled && len(dst.Keys) > 0 && suffixCmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
-				panic("pebble: keys unexpectedly not in ascending suffix order")
+				panic(errors.AssertionFailedf("pebble: keys unexpectedly not in ascending suffix order"))
 			}
 		case base.InternalKeyKindRangeKeyDelete:
 			// Nothing to do.

--- a/internal/rangekeystack/user_iterator.go
+++ b/internal/rangekeystack/user_iterator.go
@@ -7,6 +7,7 @@ package rangekeystack
 import (
 	"bytes"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -152,7 +153,7 @@ func (ui *UserIteratorConfig) Transform(
 	ui.bufs.sortBuf = rangekey.CoalesceInto(suffixCmp, ui.bufs.sortBuf[:0], ui.snapshot, s.Keys)
 	if ui.internalKeys {
 		if s.KeysOrder != keyspan.ByTrailerDesc {
-			panic("unexpected key ordering in UserIteratorTransform with internalKeys = true")
+			panic(errors.AssertionFailedf("unexpected key ordering in UserIteratorTransform with internalKeys = true"))
 		}
 		dst.Keys = ui.bufs.sortBuf
 		keyspan.SortKeysByTrailer(dst.Keys)
@@ -166,12 +167,12 @@ func (ui *UserIteratorConfig) Transform(
 		switch keys[i].Kind() {
 		case base.InternalKeyKindRangeKeySet:
 			if invariants.Enabled && len(dst.Keys) > 0 && suffixCmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
-				panic("pebble: keys unexpectedly not in ascending suffix order")
+				panic(errors.AssertionFailedf("pebble: keys unexpectedly not in ascending suffix order"))
 			}
 			dst.Keys = append(dst.Keys, keys[i])
 		case base.InternalKeyKindRangeKeyUnset:
 			if invariants.Enabled && len(dst.Keys) > 0 && suffixCmp(dst.Keys[len(dst.Keys)-1].Suffix, keys[i].Suffix) > 0 {
-				panic("pebble: keys unexpectedly not in ascending suffix order")
+				panic(errors.AssertionFailedf("pebble: keys unexpectedly not in ascending suffix order"))
 			}
 			// Skip.
 			continue
@@ -200,7 +201,7 @@ func (ui *UserIteratorConfig) ShouldDefragment(
 ) bool {
 	// This method is not called with internalKeys = true.
 	if ui.internalKeys {
-		panic("unexpected call to ShouldDefragment with internalKeys = true")
+		panic(errors.AssertionFailedf("unexpected call to ShouldDefragment with internalKeys = true"))
 	}
 	// This implementation must only be used on spans that have transformed by
 	// ui.Transform. The transform applies shadowing, removes all keys besides
@@ -211,7 +212,7 @@ func (ui *UserIteratorConfig) ShouldDefragment(
 		return false
 	}
 	if a.KeysOrder != keyspan.BySuffixAsc || b.KeysOrder != keyspan.BySuffixAsc {
-		panic("pebble: range key span's keys unexpectedly not in ascending suffix order")
+		panic(errors.AssertionFailedf("pebble: range key span's keys unexpectedly not in ascending suffix order"))
 	}
 
 	ret := true
@@ -219,11 +220,11 @@ func (ui *UserIteratorConfig) ShouldDefragment(
 		if invariants.Enabled {
 			if a.Keys[i].Kind() != base.InternalKeyKindRangeKeySet ||
 				b.Keys[i].Kind() != base.InternalKeyKindRangeKeySet {
-				panic("pebble: unexpected non-RangeKeySet during defragmentation")
+				panic(errors.AssertionFailedf("pebble: unexpected non-RangeKeySet during defragmentation"))
 			}
 			if i > 0 && (suffixCmp(a.Keys[i].Suffix, a.Keys[i-1].Suffix) < 0 ||
 				suffixCmp(b.Keys[i].Suffix, b.Keys[i-1].Suffix) < 0) {
-				panic("pebble: range keys not ordered by suffix during defragmentation")
+				panic(errors.AssertionFailedf("pebble: range keys not ordered by suffix during defragmentation"))
 			}
 		}
 		if suffixCmp(a.Keys[i].Suffix, b.Keys[i].Suffix) != 0 {

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -102,7 +102,7 @@ var Comparer = &base.Comparer{
 		// representable prefix keys containing characters a-z.
 		ai := split(a)
 		if ai != len(a) {
-			panic("pebble: ImmediateSuccessor invoked with a non-prefix key")
+			panic(errors.AssertionFailedf("pebble: ImmediateSuccessor invoked with a non-prefix key"))
 		}
 		return append(append(dst, a...), 0x00)
 	},
@@ -312,12 +312,12 @@ func keyCount(n, l int) uint64 {
 	res := uint64(0)
 	for i := 1; i <= l; i++ {
 		if x >= math.MaxInt64/uint64(n) {
-			panic("overflow")
+			panic(errors.AssertionFailedf("overflow"))
 		}
 		x *= uint64(n)
 		res += x
 		if res < x {
-			panic("overflow")
+			panic(errors.AssertionFailedf("overflow"))
 		}
 	}
 	return res
@@ -437,7 +437,7 @@ func RandomPrefixInRange(a, b []byte, rng *rand.Rand) []byte {
 	apIdx := computeAlphabetKeyIndex(aPiece, inverseAlphabet, maxLength)
 	bpIdx := computeAlphabetKeyIndex(bPiece, inverseAlphabet, maxLength)
 	if bpIdx <= apIdx {
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 	generatedIdx := apIdx + rng.Uint64N(bpIdx-apIdx)
 	if generatedIdx == apIdx {

--- a/internal/treeprinter/tree_printer.go
+++ b/internal/treeprinter/tree_printer.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+
+	"github.com/cockroachdb/errors"
 )
 
 var (
@@ -260,7 +262,7 @@ func (n Node) DotDotDot() {
 	if len(t.stack) <= n.level {
 		// No siblings; Connect to parent.
 		if len(t.stack) != n.level {
-			panic("misuse of node")
+			panic(errors.AssertionFailedf("misuse of node"))
 		}
 		parentRow := t.stack[n.level-1].firstChildConnectRow
 		for i := parentRow + 1; i < rowIdx; i++ {
@@ -307,12 +309,12 @@ func (n Node) childLine(text string) Node {
 	if n.level == 0 {
 		// Case 1: root.
 		if len(t.stack) != 0 {
-			panic("multiple root nodes")
+			panic(errors.AssertionFailedf("multiple root nodes"))
 		}
 	} else if len(t.stack) <= n.level {
 		// Case 2: first child. Connect to parent.
 		if len(t.stack) != n.level {
-			panic("misuse of node")
+			panic(errors.AssertionFailedf("misuse of node"))
 		}
 		parentRow := t.stack[n.level-1].firstChildConnectRow
 		for i := parentRow + 1; i < rowIdx; i++ {
@@ -353,7 +355,7 @@ func (n Node) AddEmptyLine() {
 // treeprinter.New.
 func (n Node) FormattedRows() []string {
 	if n.level != 0 {
-		panic("Only the root can be stringified")
+		panic(errors.AssertionFailedf("Only the root can be stringified"))
 	}
 	res := make([]string, len(n.tree.rows))
 	for i, r := range n.tree.rows {
@@ -364,7 +366,7 @@ func (n Node) FormattedRows() []string {
 
 func (n Node) String() string {
 	if n.level != 0 {
-		panic("Only the root can be stringified")
+		panic(errors.AssertionFailedf("Only the root can be stringified"))
 	}
 	var buf bytes.Buffer
 	for _, r := range n.tree.rows {

--- a/iterator.go
+++ b/iterator.go
@@ -1494,7 +1494,7 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	i.err = nil // clear cached iteration error
 	i.stats.ForwardSeekCount[InterfaceCall]++
 	if i.comparer.ImmediateSuccessor == nil && i.opts.KeyTypes != IterKeyTypePointsOnly {
-		panic("pebble: ImmediateSuccessor must be provided for SeekPrefixGE with range keys")
+		panic(errors.AssertionFailedf("pebble: ImmediateSuccessor must be provided for SeekPrefixGE with range keys"))
 	}
 	prefixLen := i.comparer.Split(key)
 	keyPrefix := key[:prefixLen]
@@ -1505,7 +1505,7 @@ func (i *Iterator) SeekPrefixGE(key []byte) bool {
 	}
 	if lastPositioningOp == seekPrefixGELastPositioningOp {
 		if !i.hasPrefix {
-			panic("lastPositioningOpsIsSeekPrefixGE is true, but hasPrefix is false")
+			panic(errors.AssertionFailedf("lastPositioningOpsIsSeekPrefixGE is true, but hasPrefix is false"))
 		}
 		// The iterator has not been repositioned after the last SeekPrefixGE.
 		// See if we are seeking to a larger key, since then we can optimize
@@ -2275,7 +2275,7 @@ func (i *Iterator) saveRangeKey() {
 	}
 
 	if s.KeysOrder != keyspan.BySuffixAsc {
-		panic("pebble: range key span's keys unexpectedly not in ascending suffix order")
+		panic(errors.AssertionFailedf("pebble: range key span's keys unexpectedly not in ascending suffix order"))
 	}
 
 	// Although `i.rangeKey.stale` is true, the span s may still be identical
@@ -2308,9 +2308,9 @@ func (i *Iterator) saveRangeKey() {
 	for j := 0; j < len(s.Keys); j++ {
 		if invariants.Enabled {
 			if s.Keys[j].Kind() != base.InternalKeyKindRangeKeySet {
-				panic("pebble: user iteration encountered non-RangeKeySet key kind")
+				panic(errors.AssertionFailedf("pebble: user iteration encountered non-RangeKeySet key kind"))
 			} else if j > 0 && i.comparer.CompareRangeSuffixes(s.Keys[j].Suffix, s.Keys[j-1].Suffix) < 0 {
-				panic("pebble: user iteration encountered range keys not in suffix order")
+				panic(errors.AssertionFailedf("pebble: user iteration encountered range keys not in suffix order"))
 			}
 		}
 		var rkd RangeKeyData
@@ -3223,7 +3223,7 @@ func (i *Iterator) internalNext() (internalNextValidity, base.InternalKeyKind) {
 		//     user key that's not equal to i.Iterator.Key().
 		return internalNextExhausted, base.InternalKeyKindInvalid
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 }
 

--- a/mem_table.go
+++ b/mem_table.go
@@ -234,7 +234,7 @@ func (m *memTable) apply(batch *Batch, seqNum base.SeqNum) error {
 			// to the memtable.
 			seqNum--
 		case InternalKeyKindIngestSST, InternalKeyKindIngestSSTWithBlobs, InternalKeyKindExcise:
-			panic("pebble: cannot apply ingested sstable or excise kind keys to memtable")
+			panic(errors.AssertionFailedf("pebble: cannot apply ingested sstable or excise kind keys to memtable"))
 		default:
 			err = ins.Add(&m.skl, ikey, value)
 		}

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -1270,7 +1270,7 @@ func (m *mergingIter) NextPrefix(succKey []byte) (kv *base.InternalKV) {
 		}()
 	}
 	if m.dir != 1 {
-		panic("pebble: cannot switch directions with NextPrefix")
+		panic(errors.AssertionFailedf("pebble: cannot switch directions with NextPrefix"))
 	}
 	if m.err != nil || m.heap.len() == 0 {
 		return nil

--- a/merging_iter_heap.go
+++ b/merging_iter_heap.go
@@ -4,7 +4,10 @@
 
 package pebble
 
-import "github.com/cockroachdb/pebble/internal/invariants"
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
 
 // mergingIterHeap is a heap of mergingIterLevels. It only reads
 // mergingIterLevel.iterKV.K.
@@ -122,7 +125,7 @@ func (h *mergingIterHeap) down(i, n int) {
 					wc = winnerChildRight
 				}
 				if wc != winnerChildUnknown && wc != h.items[i].winnerChild {
-					panic("winnerChild mismatch")
+					panic(errors.AssertionFailedf("winnerChild mismatch"))
 				}
 			}
 			if h.items[i].winnerChild == winnerChildRight {

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -109,7 +109,7 @@ func writeSSTForIngestion(
 	}
 
 	if syntheticSuffix.IsSet() && rangeDelIter != nil {
-		panic("synthetic suffix with RangeDel")
+		panic(errors.AssertionFailedf("synthetic suffix with RangeDel"))
 	}
 	if err := writeRangeDeletes(w, rangeDelIter, t.opts.Comparer, outputKey); err != nil {
 		return nil, err
@@ -349,7 +349,7 @@ func writeRangeKeys(
 			keys = slices.Clone(span.Keys)
 			for i := range keys {
 				if keys[i].Kind() == base.InternalKeyKindRangeKeyUnset {
-					panic("RangeKeyUnset with synthetic suffix")
+					panic(errors.AssertionFailedf("RangeKeyUnset with synthetic suffix"))
 				}
 				if len(keys[i].Suffix) > 0 {
 					keys[i].Suffix = syntheticSuffix

--- a/metamorphic/cockroachkvs.go
+++ b/metamorphic/cockroachkvs.go
@@ -125,7 +125,7 @@ func (kg *cockroachKeyGenerator) RandPrefix(newPrefix float64) []byte {
 		prefix := kg.generateKeyWithSuffix(4, 12, 0)
 		if !kg.keyManager.prefixExists(prefix) {
 			if !kg.keyManager.addNewKey(prefix) {
-				panic("key must not exist if prefix doesn't exist")
+				panic(errors.AssertionFailedf("key must not exist if prefix doesn't exist"))
 			}
 			return prefix
 		}
@@ -267,7 +267,7 @@ func (kg *cockroachKeyGenerator) randKey(
 			key := kg.generateKeyWithSuffix(4, 12, suffixIdx)
 			if !kg.keyManager.prefixExists(kg.keyManager.kf.Comparer.Split.Prefix(key)) {
 				if !kg.keyManager.addNewKey(key) {
-					panic("key must not exist if prefix doesn't exist")
+					panic(errors.AssertionFailedf("key must not exist if prefix doesn't exist"))
 				}
 				return key
 			}

--- a/metamorphic/generator.go
+++ b/metamorphic/generator.go
@@ -1378,7 +1378,7 @@ func (g *generator) writerIngestExternalFiles() {
 			objEnd = g.keyGenerator.ExtendPrefix(objEnd)
 		}
 		if g.cmp(objStart, objEnd) >= 0 {
-			panic("bug in generating obj bounds")
+			panic(errors.AssertionFailedf("bug in generating obj bounds"))
 		}
 		// Generate two random keys within the given bounds.
 		// First, generate a start key in the range [objStart, objEnd).
@@ -1635,7 +1635,7 @@ func uniqueKeys(cmp base.Compare, n int, genFn func() []byte) [][]byte {
 				break
 			}
 			if attempts > 100000 {
-				panic("could not generate unique key")
+				panic(errors.AssertionFailedf("could not generate unique key"))
 			}
 		}
 		used[string(keys[i])] = struct{}{}

--- a/metamorphic/history.go
+++ b/metamorphic/history.go
@@ -53,7 +53,7 @@ func (h *history) Recordf(op int, format string, args ...interface{}) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.mu.closed {
-		panic("Recordf after close")
+		panic(errors.AssertionFailedf("Recordf after close"))
 	}
 	if strings.Contains(format, "\n") {
 		// We could remove this restriction but suffixing every line with "#<seq>".
@@ -204,7 +204,7 @@ func reorderHistory(lines []string) []string {
 		}
 		idx := extractOp(l)
 		if idx >= len(reordered) {
-			panic("incomplete test history; this shouldn't happen given that execution completed successfully")
+			panic(errors.AssertionFailedf("incomplete test history; this shouldn't happen given that execution completed successfully"))
 		}
 		reordered[idx] = l
 	}

--- a/metamorphic/ops.go
+++ b/metamorphic/ops.go
@@ -937,7 +937,7 @@ func (o *ingestAndExciseOp) run(t *Test, h historyRecorder) {
 	b := t.getBatch(o.batchID)
 	t.clearObj(o.batchID)
 	if t.testOpts.Opts.Comparer.Compare(o.exciseEnd, o.exciseStart) <= 0 {
-		panic("non-well-formed excise span")
+		panic(errors.AssertionFailedf("non-well-formed excise span"))
 	}
 	db := t.getDB(o.dbID)
 	if b.Empty() {
@@ -1528,7 +1528,7 @@ func validityStateToStr(validity pebble.IterValidityState) (bool, string) {
 	case pebble.IterValid:
 		return true, "valid"
 	default:
-		panic("unknown validity")
+		panic(errors.AssertionFailedf("unknown validity"))
 	}
 }
 
@@ -1862,7 +1862,7 @@ type newSnapshotOp struct {
 func (o *newSnapshotOp) run(t *Test, h historyRecorder) {
 	bounds := o.bounds
 	if len(bounds) == 0 {
-		panic("bounds unexpectedly unset for newSnapshotOp")
+		panic(errors.AssertionFailedf("bounds unexpectedly unset for newSnapshotOp"))
 	}
 	// Fibonacci hash https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
 	createEfos := ((11400714819323198485 * uint64(t.idx) * t.testOpts.seedEFOS) >> 63) == 1
@@ -1946,7 +1946,7 @@ func (o *newExternalObjOp) run(t *Test, h historyRecorder) {
 	}
 	if !sstMeta.HasPointKeys && !sstMeta.HasRangeDelKeys && !sstMeta.HasRangeKeys {
 		// This can occur when using --try-to-reduce.
-		panic("metamorphic test internal error: external object empty")
+		panic(errors.AssertionFailedf("metamorphic test internal error: external object empty"))
 	}
 	t.setExternalObj(o.externalObjID, externalObjMeta{
 		objName: objName,

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -1064,7 +1064,7 @@ func filterPolicyFromName(name string) (pebble.TableFilterPolicy, error) {
 // randInRange returns an integer in the range [minRange,maxRange].
 func randInRange(rng *rand.Rand, minRange, maxRange int) int {
 	if minRange > maxRange {
-		panic("minRange must be <= maxRange")
+		panic(errors.AssertionFailedf("minRange must be <= maxRange"))
 	}
 	return minRange + rng.IntN(maxRange-minRange+1)
 }
@@ -1072,10 +1072,10 @@ func randInRange(rng *rand.Rand, minRange, maxRange int) int {
 // randPowerOf2 returns a power of 2 in the range [2^minExp,2^maxExp].
 func randPowerOf2(rng *rand.Rand, minExp, maxExp int) uint64 {
 	if minExp < 0 {
-		panic("exponents must be non-negative")
+		panic(errors.AssertionFailedf("exponents must be non-negative"))
 	}
 	if minExp > maxExp {
-		panic("minExp must be <= maxExp")
+		panic(errors.AssertionFailedf("minExp must be <= maxExp"))
 	}
 	return 1 << randInRange(rng, minExp, maxExp)
 }

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -431,7 +431,7 @@ func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
 		case ignoreExtraArgs:
 		default:
 			// We already checked for these types when we set varArgs.
-			panic("unreachable")
+			panic(errors.AssertionFailedf("unreachable"))
 		}
 	}
 }

--- a/metamorphic/testkeys.go
+++ b/metamorphic/testkeys.go
@@ -118,7 +118,7 @@ func (kg *testkeyKeyGenerator) RandPrefix(newPrefix float64) []byte {
 		prefix := kg.generateKeyWithSuffix(4, 12, 0)
 		if !kg.keyManager.prefixExists(prefix) {
 			if !kg.keyManager.addNewKey(prefix) {
-				panic("key must not exist if prefix doesn't exist")
+				panic(errors.AssertionFailedf("key must not exist if prefix doesn't exist"))
 			}
 			return prefix
 		}
@@ -267,7 +267,7 @@ func (kg *testkeyKeyGenerator) randKey(newKeyProbability float64, bounds *pebble
 			key := kg.generateKeyWithSuffix(4, 12, suffix)
 			if !kg.keyManager.prefixExists(kg.prefix(key)) {
 				if !kg.keyManager.addNewKey(key) {
-					panic("key must not exist if prefix doesn't exist")
+					panic(errors.AssertionFailedf("key must not exist if prefix doesn't exist"))
 				}
 				return key
 			}

--- a/objstorage/objstorage.go
+++ b/objstorage/objstorage.go
@@ -495,7 +495,7 @@ var _ Readable = (*SimpleReadable)(nil)
 func (s *SimpleReadable) ReadAt(_ context.Context, p []byte, off int64) error {
 	n, err := s.f.ReadAt(p, off)
 	if invariants.Enabled && err == nil && n != len(p) {
-		panic("short read")
+		panic(errors.AssertionFailedf("short read"))
 	}
 	return err
 }

--- a/objstorage/objstorageprovider/provider.go
+++ b/objstorage/objstorageprovider/provider.go
@@ -600,7 +600,7 @@ func (p *provider) unprotectObject(fileNum base.DiskFileNum) {
 	defer p.mu.Unlock()
 	v := p.mu.protectedObjects[fileNum]
 	if invariants.Enabled && v == 0 {
-		panic("invalid protection count")
+		panic(errors.AssertionFailedf("invalid protection count"))
 	}
 	if v > 1 {
 		p.mu.protectedObjects[fileNum] = v - 1

--- a/objstorage/objstorageprovider/readahead.go
+++ b/objstorage/objstorageprovider/readahead.go
@@ -4,7 +4,10 @@
 
 package objstorageprovider
 
-import "github.com/cockroachdb/pebble/internal/invariants"
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/invariants"
+)
 
 const (
 	// Constants for dynamic readahead of data blocks. Note that the size values
@@ -58,7 +61,7 @@ func (rs *readaheadState) maybeReadaheadOrCacheHit(
 	offset, blockLength int64, readahead bool,
 ) int64 {
 	if invariants.Enabled && rs.maxReadaheadSize == 0 {
-		panic("readaheadState not initialized")
+		panic(errors.AssertionFailedf("readaheadState not initialized"))
 	}
 	currentReadEnd := offset + blockLength
 	if rs.numReads >= minFileReadsForReadahead {

--- a/objstorage/objstorageprovider/remote_obj_name.go
+++ b/objstorage/objstorageprovider/remote_obj_name.go
@@ -7,6 +7,7 @@ package objstorageprovider
 import (
 	"fmt"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/objstorage"
 )
@@ -31,7 +32,7 @@ func remoteObjectName(meta objstorage.ObjectMetadata) string {
 			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum,
 		)
 	}
-	panic("unknown FileType")
+	panic(errors.AssertionFailedf("unknown FileType"))
 }
 
 // sharedObjectRefName returns the name of the object's ref marker associated
@@ -43,7 +44,7 @@ func sharedObjectRefName(
 	meta objstorage.ObjectMetadata, refCreatorID objstorage.CreatorID, refFileNum base.DiskFileNum,
 ) string {
 	if meta.Remote.CleanupMethod != objstorage.SharedRefTracking {
-		panic("ref object used when ref tracking disabled")
+		panic(errors.AssertionFailedf("ref object used when ref tracking disabled"))
 	}
 	if meta.Remote.CustomObjectName != "" {
 		return fmt.Sprintf(
@@ -62,7 +63,7 @@ func sharedObjectRefName(
 			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum, refCreatorID, refFileNum,
 		)
 	}
-	panic("unknown FileType")
+	panic(errors.AssertionFailedf("unknown FileType"))
 }
 
 func sharedObjectRefPrefix(meta objstorage.ObjectMetadata) string {
@@ -81,7 +82,7 @@ func sharedObjectRefPrefix(meta objstorage.ObjectMetadata) string {
 			objHash(meta), meta.Remote.CreatorID, meta.Remote.CreatorFileNum,
 		)
 	}
-	panic("unknown FileType")
+	panic(errors.AssertionFailedf("unknown FileType"))
 }
 
 // sharedObjectRefName returns the name of the object's ref marker associated
@@ -91,7 +92,7 @@ func sharedObjectRefPrefix(meta objstorage.ObjectMetadata) string {
 // For example: 1a3f-2-000001.sst.ref.5.000008
 func (p *provider) sharedObjectRefName(meta objstorage.ObjectMetadata) string {
 	if meta.Remote.CleanupMethod != objstorage.SharedRefTracking {
-		panic("ref object used when ref tracking disabled")
+		panic(errors.AssertionFailedf("ref object used when ref tracking disabled"))
 	}
 	return sharedObjectRefName(meta, p.remote.shared.creatorID, meta.DiskFileNum)
 }

--- a/objstorage/objstorageprovider/sharedcache/shared_cache.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache.go
@@ -664,7 +664,7 @@ func (s *shard) set(fileNum base.DiskFileNum, p []byte, ofs int64) error {
 		var cacheBlockIdx cacheBlockIndex
 		if s.mu.freeHead == invalidBlockIndex {
 			if invariants.Enabled && s.mu.lruHead == invalidBlockIndex {
-				panic("both LRU and free lists empty")
+				panic(errors.AssertionFailedf("both LRU and free lists empty"))
 			}
 
 			// Find the last element in the LRU list which is not locked.
@@ -750,7 +750,7 @@ func (s *shard) assertShardStateIsConsistent() {
 		for b := s.mu.lruHead; ; {
 			lruLen++
 			if idx, ok := s.mu.where[s.mu.blocks[b].logical]; !ok || idx != b {
-				panic("block in LRU list with no entry in where map")
+				panic(errors.AssertionFailedf("block in LRU list with no entry in where map"))
 			}
 			b = s.lruNext(b)
 			if b == s.mu.lruHead {

--- a/objstorage/objstorageprovider/vfs.go
+++ b/objstorage/objstorageprovider/vfs.go
@@ -84,7 +84,7 @@ func metaFileType(fileType base.FileType) base.FileType {
 	case base.FileTypeBlob:
 		return base.FileTypeBlobMeta
 	default:
-		panic("unsupported file type for metaFileType")
+		panic(errors.AssertionFailedf("unsupported file type for metaFileType"))
 	}
 }
 

--- a/objstorage/objstorageprovider/vfs_readable.go
+++ b/objstorage/objstorageprovider/vfs_readable.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"sync"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/vfs"
@@ -66,7 +67,7 @@ func newFileReadable(
 func (r *fileReadable) ReadAt(_ context.Context, p []byte, off int64) error {
 	n, err := r.file.ReadAt(p, off)
 	if invariants.Enabled && err == nil && n != len(p) {
-		panic("short read")
+		panic(errors.AssertionFailedf("short read"))
 	}
 	return err
 }
@@ -145,7 +146,7 @@ func (rh *vfsReadHandle) ReadAt(_ context.Context, p []byte, offset int64) error
 		// Use OS-level read-ahead.
 		n, err := rh.sequentialFile.ReadAt(p, offset)
 		if invariants.Enabled && err == nil && n != len(p) {
-			panic("short read")
+			panic(errors.AssertionFailedf("short read"))
 		}
 		return err
 	}
@@ -162,7 +163,7 @@ func (rh *vfsReadHandle) ReadAt(_ context.Context, p []byte, offset int64) error
 	}
 	n, err := rh.r.file.ReadAt(p, offset)
 	if invariants.Enabled && err == nil && n != len(p) {
-		panic("short read")
+		panic(errors.AssertionFailedf("short read"))
 	}
 	return err
 }
@@ -177,7 +178,7 @@ func (rh *vfsReadHandle) SetupForCompaction() {
 
 func (rh *vfsReadHandle) switchToOSReadahead() {
 	if invariants.Enabled && rh.readaheadMode != FadviseSequential {
-		panic("readheadMode not respected")
+		panic(errors.AssertionFailedf("readheadMode not respected"))
 	}
 	if rh.sequentialFile != nil {
 		return
@@ -217,7 +218,7 @@ func TestingCheckMaxReadahead(rh objstorage.ReadHandle) bool {
 	case *PreallocatedReadHandle:
 		return rh.sequentialFile != nil
 	default:
-		panic("unknown ReadHandle type")
+		panic(errors.AssertionFailedf("unknown ReadHandle type"))
 	}
 }
 

--- a/objstorage/remote/localfs.go
+++ b/objstorage/remote/localfs.go
@@ -119,7 +119,7 @@ func (s *localFSStore) CreateObject(objName string) (io.WriteCloser, error) {
 // List is part of the remote.Storage interface.
 func (s *localFSStore) List(prefix, delimiter string) ([]string, error) {
 	if delimiter != "" {
-		panic("delimiter unimplemented")
+		panic(errors.AssertionFailedf("delimiter unimplemented"))
 	}
 	files, err := s.vfs.List(s.dirname)
 	if err != nil {

--- a/objstorage/remote/mem.go
+++ b/objstorage/remote/mem.go
@@ -96,7 +96,7 @@ var _ io.WriteCloser = (*inMemWriter)(nil)
 
 func (o *inMemWriter) Write(p []byte) (n int, err error) {
 	if o.store == nil {
-		panic("Write after Close")
+		panic(errors.AssertionFailedf("Write after Close"))
 	}
 	return o.buf.Write(p)
 }
@@ -114,7 +114,7 @@ func (o *inMemWriter) Close() error {
 
 func (s *inMemStore) List(prefix, delimiter string) ([]string, error) {
 	if delimiter != "" {
-		panic("delimiter unimplemented")
+		panic(errors.AssertionFailedf("delimiter unimplemented"))
 	}
 
 	s.mu.Lock()

--- a/objstorage/remote/storage.go
+++ b/objstorage/remote/storage.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
 
@@ -73,7 +74,7 @@ func ShouldCreateShared(strategy CreateOnSharedStrategy, level int) bool {
 	case CreateOnSharedLower:
 		return level >= SharedLevelsStart
 	default:
-		panic("unexpected CreateOnSharedStrategy value")
+		panic(errors.AssertionFailedf("unexpected CreateOnSharedStrategy value"))
 	}
 }
 

--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -228,7 +228,7 @@ func (d *DB) disableFileDeletions() {
 // d.mu must be held when calling this method.
 func (d *DB) enableFileDeletions() {
 	if d.mu.fileDeletions.disableCount <= 0 {
-		panic("pebble: file deletion disablement invariant violated")
+		panic(errors.AssertionFailedf("pebble: file deletion disablement invariant violated"))
 	}
 	d.mu.fileDeletions.disableCount--
 	if d.mu.fileDeletions.disableCount > 0 {

--- a/options.go
+++ b/options.go
@@ -1326,7 +1326,7 @@ func MakeStaticSpanPolicyFunc(cmp base.Compare, inputPolicies ...SpanPolicy) Spa
 	for i := range inputPolicies {
 		r := inputPolicies[i].KeyRange
 		if len(r.Start) == 0 || len(r.End) == 0 || cmp(r.Start, r.End) >= 0 {
-			panic("invalid key range in input policy")
+			panic(errors.AssertionFailedf("invalid key range in input policy"))
 		}
 		uniqueKeys = append(uniqueKeys, r.Start)
 		uniqueKeys = append(uniqueKeys, r.End)
@@ -1345,7 +1345,7 @@ func MakeStaticSpanPolicyFunc(cmp base.Compare, inputPolicies ...SpanPolicy) Spa
 	for _, p := range inputPolicies {
 		idx, _ := slices.BinarySearchFunc(uniqueKeys, p.KeyRange.Start, cmp)
 		if cmp(p.KeyRange.End, uniqueKeys[idx+1]) != 0 {
-			panic("overlapping key ranges in input policies")
+			panic(errors.AssertionFailedf("overlapping key ranges in input policies"))
 		}
 		policies[idx] = p
 		policies[idx].KeyRange = KeyRange{Start: uniqueKeys[idx], End: uniqueKeys[idx+1]}
@@ -2854,12 +2854,12 @@ func MakeUserKeyCategories(cmp base.Compare, categories ...UserKeyCategory) User
 		return UserKeyCategories{}
 	}
 	if categories[n-1].UpperBound != nil {
-		panic("last category UpperBound must be nil")
+		panic(errors.AssertionFailedf("last category UpperBound must be nil"))
 	}
 	// Verify that the partitions are ordered as expected.
 	for i := 1; i < n-1; i++ {
 		if cmp(categories[i-1].UpperBound, categories[i].UpperBound) >= 0 {
-			panic("invalid UserKeyCategories: key prefixes must be sorted")
+			panic(errors.AssertionFailedf("invalid UserKeyCategories: key prefixes must be sorted"))
 		}
 	}
 

--- a/range_keys.go
+++ b/range_keys.go
@@ -501,10 +501,10 @@ func (i *lazyCombinedIter) initCombinedIteration(
 	// Invariant: !i.combinedIterState.initialized.
 	if invariants.Enabled {
 		if i.combinedIterState.initialized {
-			panic("pebble: combined iterator already initialized")
+			panic(errors.AssertionFailedf("pebble: combined iterator already initialized"))
 		}
 		if i.parent.rangeKey != nil {
-			panic("pebble: iterator already has a range-key iterator stack")
+			panic(errors.AssertionFailedf("pebble: iterator already has a range-key iterator stack"))
 		}
 	}
 

--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -97,7 +97,7 @@ func (q *syncQueue) push(wg *sync.WaitGroup, err *error) {
 	ptrs := q.headTail.Load()
 	head, tail := q.unpack(ptrs)
 	if (tail+uint32(len(q.slots)))&(1<<dequeueBits-1) == head {
-		panic("pebble: queue is full")
+		panic(errors.AssertionFailedf("pebble: queue is full"))
 	}
 
 	slot := &q.slots[head&uint32(len(q.slots)-1)]

--- a/record/record.go
+++ b/record/record.go
@@ -716,7 +716,7 @@ func NewWriter(w io.Writer) *Writer {
 // fillHeader fills in the header for the pending chunk.
 func (w *Writer) fillHeader(last bool) {
 	if w.i+legacyHeaderSize > w.j || w.j > blockSize {
-		panic("pebble/record: bad writer state")
+		panic(errors.AssertionFailedf("pebble/record: bad writer state"))
 	}
 	if last {
 		if w.first {

--- a/recovery.go
+++ b/recovery.go
@@ -375,11 +375,11 @@ func recoverVersion(
 		// from an empty state.
 		for _, deletedLevel := range bve.DeletedTables {
 			if len(deletedLevel) != 0 {
-				panic("deleted files after manifest replay")
+				panic(errors.AssertionFailedf("deleted files after manifest replay"))
 			}
 		}
 		if len(bve.RemovedFileBacking) > 0 {
-			panic("deleted backings after manifest replay")
+			panic(errors.AssertionFailedf("deleted backings after manifest replay"))
 		}
 	}
 
@@ -636,7 +636,7 @@ func (d *DB) replayIngestedFlushable(
 	addFileNum := func(encodedFileNum []byte) base.DiskFileNum {
 		fileNum, n := binary.Uvarint(encodedFileNum)
 		if n <= 0 {
-			panic("pebble: ingest sstable file num is invalid")
+			panic(errors.AssertionFailedf("pebble: ingest sstable file num is invalid"))
 		}
 		diskFileNum := base.DiskFileNum(fileNum)
 		fileNums = append(fileNums, diskFileNum)
@@ -649,14 +649,14 @@ func (d *DB) replayIngestedFlushable(
 			return nil, err
 		}
 		if kind != InternalKeyKindIngestSST && kind != InternalKeyKindIngestSSTWithBlobs && kind != InternalKeyKindExcise {
-			panic("pebble: invalid batch key kind")
+			panic(errors.AssertionFailedf("pebble: invalid batch key kind"))
 		}
 		if !ok {
-			panic("pebble: invalid batch count")
+			panic(errors.AssertionFailedf("pebble: invalid batch count"))
 		}
 		if kind == base.InternalKeyKindExcise {
 			if exciseSpan.Valid() {
-				panic("pebble: multiple excise spans in a single batch")
+				panic(errors.AssertionFailedf("pebble: multiple excise spans in a single batch"))
 			}
 			exciseSpan.Start = slices.Clone(key)
 			exciseSpan.End = slices.Clone(val)
@@ -666,7 +666,7 @@ func (d *DB) replayIngestedFlushable(
 		if kind == InternalKeyKindIngestSSTWithBlobs {
 			blobFileIDs, ok := batchrepr.DecodeBlobFileIDs(val)
 			if !ok {
-				panic("pebble: corrupt blob file IDs in InternalKeyKindIngestSSTWithBlobs")
+				panic(errors.AssertionFailedf("pebble: corrupt blob file IDs in InternalKeyKindIngestSSTWithBlobs"))
 			}
 			tableBlobFileIDs[fileNum] = blobFileIDs
 		}
@@ -675,7 +675,7 @@ func (d *DB) replayIngestedFlushable(
 	if _, _, _, ok, err := br.Next(); err != nil {
 		return nil, err
 	} else if ok {
-		panic("pebble: invalid number of entries in batch")
+		panic(errors.AssertionFailedf("pebble: invalid number of entries in batch"))
 	}
 
 	meta := make([]*manifest.TableMetadata, len(fileNums))
@@ -719,7 +719,7 @@ func (d *DB) replayIngestedFlushable(
 		numFiles++
 	}
 	if uint32(numFiles) != b.Count() {
-		panic("pebble: couldn't load all files in WAL entry")
+		panic(errors.AssertionFailedf("pebble: couldn't load all files in WAL entry"))
 	}
 
 	return d.newIngestedFlushableEntry(meta, seqNum, logNum, exciseSpan, blobFiles)

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -740,7 +740,7 @@ func (r *Runner) applyWorkloadSteps(ctx context.Context) error {
 			// No-op.
 			// TODO(jackson): Should we elide this earlier?
 		default:
-			panic("unreachable")
+			panic(errors.AssertionFailedf("unreachable"))
 		}
 	}
 }

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -353,7 +353,7 @@ func (p *pointCollapsingIterator) SeekGE(key []byte, flags base.SeekGEFlags) *ba
 
 // SeekLT implements the InternalIterator interface.
 func (p *pointCollapsingIterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
-	panic("unimplemented")
+	panic(errors.AssertionFailedf("unimplemented"))
 }
 
 func (p *pointCollapsingIterator) resetKey() {
@@ -393,7 +393,7 @@ func (p *pointCollapsingIterator) findNextEntry() *base.InternalKV {
 		if s := p.iter.Span(); s != nil && s.CoversAt(p.seqNum, p.iterKV.SeqNum()) {
 			// All future keys for this user key must be deleted.
 			if p.savedKey.Kind() == InternalKeyKindSingleDelete {
-				panic("cannot process singledel key in point collapsing iterator")
+				panic(errors.AssertionFailedf("cannot process singledel key in point collapsing iterator"))
 			}
 			// Fast forward to the next user key.
 			p.saveKey()
@@ -426,10 +426,10 @@ func (p *pointCollapsingIterator) findNextEntry() *base.InternalKV {
 			return p.verifySeqNum(p.iterKV)
 		case InternalKeyKindSingleDelete:
 			// Panic, as this iterator is not expected to observe single deletes.
-			panic("cannot process singledel key in point collapsing iterator")
+			panic(errors.AssertionFailedf("cannot process singledel key in point collapsing iterator"))
 		case InternalKeyKindMerge:
 			// Panic, as this iterator is not expected to observe merges.
-			panic("cannot process merge key in point collapsing iterator")
+			panic(errors.AssertionFailedf("cannot process merge key in point collapsing iterator"))
 		case InternalKeyKindRangeDelete:
 			// These are interleaved by the interleaving iterator ahead of all points.
 			// We should pass them as-is, but also account for any points ahead of
@@ -457,7 +457,7 @@ func (p *pointCollapsingIterator) First() *base.InternalKV {
 
 // Last implements the InternalIterator interface.
 func (p *pointCollapsingIterator) Last() *base.InternalKV {
-	panic("unimplemented")
+	panic(errors.AssertionFailedf("unimplemented"))
 }
 
 func (p *pointCollapsingIterator) saveKey() {
@@ -508,12 +508,12 @@ func (p *pointCollapsingIterator) Next() *base.InternalKV {
 
 // NextPrefix implements the InternalIterator interface.
 func (p *pointCollapsingIterator) NextPrefix(succKey []byte) *base.InternalKV {
-	panic("unimplemented")
+	panic(errors.AssertionFailedf("unimplemented"))
 }
 
 // Prev implements the InternalIterator interface.
 func (p *pointCollapsingIterator) Prev() *base.InternalKV {
-	panic("unimplemented")
+	panic(errors.AssertionFailedf("unimplemented"))
 }
 
 // Error implements the InternalIterator interface.
@@ -856,7 +856,7 @@ func scanInternalImpl(
 	ctx context.Context, iter *scanInternalIterator, opts *ScanInternalOptions,
 ) error {
 	if opts.VisitSharedFile != nil && (opts.LowerBound == nil || opts.UpperBound == nil) {
-		panic("lower and upper bounds must be specified in skip-shared iteration mode")
+		panic(errors.AssertionFailedf("lower and upper bounds must be specified in skip-shared iteration mode"))
 	}
 	if opts.VisitSharedFile != nil && opts.VisitExternalFile != nil {
 		return base.AssertionFailedf("cannot provide both a shared-file and external-file visitor")
@@ -877,7 +877,7 @@ func scanInternalImpl(
 
 	if opts.VisitSharedFile != nil || opts.VisitExternalFile != nil {
 		if provider == nil {
-			panic("expected non-nil Provider in skip-shared iteration mode")
+			panic(errors.AssertionFailedf("expected non-nil Provider in skip-shared iteration mode"))
 		}
 
 		firstLevelWithRemote := opts.skipLevelForOpts()

--- a/snapshot.go
+++ b/snapshot.go
@@ -163,7 +163,7 @@ func (l *snapshotList) toSlice() []base.SeqNum {
 
 func (l *snapshotList) pushBack(s *Snapshot) {
 	if s.list != nil || s.prev != nil || s.next != nil {
-		panic("pebble: snapshot list is inconsistent")
+		panic(errors.AssertionFailedf("pebble: snapshot list is inconsistent"))
 	}
 	s.prev = l.root.prev
 	s.prev.next = s
@@ -174,10 +174,10 @@ func (l *snapshotList) pushBack(s *Snapshot) {
 
 func (l *snapshotList) remove(s *Snapshot) {
 	if s == &l.root {
-		panic("pebble: cannot remove snapshot list root node")
+		panic(errors.AssertionFailedf("pebble: cannot remove snapshot list root node"))
 	}
 	if s.list != l {
-		panic("pebble: snapshot list is inconsistent")
+		panic(errors.AssertionFailedf("pebble: snapshot list is inconsistent"))
 	}
 	s.prev.next = s.next
 	s.next.prev = s.prev
@@ -359,7 +359,7 @@ func (es *EventuallyFileOnlySnapshot) transitionToFileOnlySnapshot(vers *manifes
 	}
 	if es.mu.snap == nil {
 		es.mu.Unlock()
-		panic("pebble: tried to transition an eventually-file-only-snapshot twice")
+		panic(errors.AssertionFailedf("pebble: tried to transition an eventually-file-only-snapshot twice"))
 	}
 	// The caller has already called Ref() on vers.
 	es.mu.vers = vers
@@ -449,7 +449,7 @@ func (es *EventuallyFileOnlySnapshot) WaitForFileOnlySnapshot(
 		// Since we aren't returning an error, we _must_ have transitioned to a
 		// file-only snapshot by now.
 		if !es.hasTransitioned() {
-			panic("expected EFOS to have transitioned to file-only snapshot after flush")
+			panic(errors.AssertionFailedf("expected EFOS to have transitioned to file-only snapshot after flush"))
 		}
 	}
 	return nil

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -106,7 +106,7 @@ func (r *ValueFetcher) Init(
 	r.readerProvider = rp
 	r.env = env
 	if r.readerProvider == nil {
-		panic("readerProvider is nil")
+		panic(errors.AssertionFailedf("readerProvider is nil"))
 	}
 	r.maxCachedReaders = maxCachedReaders
 }

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -451,7 +451,7 @@ func (r *Reader) Read(
 
 	if cv != nil {
 		if invariants.Enabled && crh.Valid() {
-			panic("cache.ReadHandle must not be valid")
+			panic(errors.AssertionFailedf("cache.ReadHandle must not be valid"))
 		}
 		if hit {
 			recordCacheHit(ctx, env, readHandle, bh, kind)

--- a/sstable/block/buffer_pool.go
+++ b/sstable/block/buffer_pool.go
@@ -59,7 +59,7 @@ func (b Value) MakeHandle() BufferHandle {
 
 func (b *Value) SetInCacheForTesting(h *cache.Handle, fileNum base.DiskFileNum, offset uint64) {
 	if b.buf.Valid() {
-		panic("block value must be backed by a cache.Value")
+		panic(errors.AssertionFailedf("block value must be backed by a cache.Value"))
 	}
 	h.Set(fileNum, offset, b.v)
 	b.v.Release()

--- a/sstable/block/category_stats.go
+++ b/sstable/block/category_stats.go
@@ -62,11 +62,11 @@ func (c Category) SafeFormat(p redact.SafePrinter, verb rune) {
 // Only CategoryMax categories can be registered in total.
 func RegisterCategory(name string, qosLevel QoSLevel) Category {
 	if categoriesList != nil {
-		panic("ReigsterCategory called after Categories()")
+		panic(errors.AssertionFailedf("ReigsterCategory called after Categories()"))
 	}
 	c := Category(numRegisteredCategories.Add(1))
 	if c > CategoryMax {
-		panic("too many categories")
+		panic(errors.AssertionFailedf("too many categories"))
 	}
 	categories[c].name = name
 	categories[c].qosLevel = qosLevel

--- a/sstable/block/compression.go
+++ b/sstable/block/compression.go
@@ -229,7 +229,7 @@ func (i CompressionIndicator) Algorithm() compression.Algorithm {
 	case MinLZCompressionIndicator:
 		return compression.MinLZ
 	default:
-		panic("Invalid compression type.")
+		panic(errors.AssertionFailedf("Invalid compression type."))
 	}
 }
 
@@ -244,7 +244,7 @@ func compressionIndicatorFromAlgorithm(algo compression.Algorithm) CompressionIn
 	case compression.MinLZ:
 		return MinLZCompressionIndicator
 	default:
-		panic("invalid algorithm")
+		panic(errors.AssertionFailedf("invalid algorithm"))
 	}
 }
 

--- a/sstable/block/compression_stats.go
+++ b/sstable/block/compression_stats.go
@@ -68,7 +68,7 @@ func (c *CompressionStats) addOne(setting compression.Setting, stats Compression
 	case compression.NoCompression:
 		c.noCompressionBytes += stats.UncompressedBytes
 		if invariants.Enabled && stats.UncompressedBytes != stats.CompressedBytes {
-			panic("invalid stats for no-compression")
+			panic(errors.AssertionFailedf("invalid stats for no-compression"))
 		}
 	case fastestCompression:
 		c.fastest.Add(stats)

--- a/sstable/block/physical.go
+++ b/sstable/block/physical.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage"
 )
@@ -184,7 +185,7 @@ type TempBuffer struct {
 func NewTempBuffer() *TempBuffer {
 	tb := tempBufferPool.Get().(*TempBuffer)
 	if invariants.Enabled && len(tb.b) > 0 {
-		panic("NewTempBuffer length not 0")
+		panic(errors.AssertionFailedf("NewTempBuffer length not 0"))
 	}
 	return tb
 }

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -270,7 +270,7 @@ func NewBlockIntervalCollector(
 	name string, mapper IntervalMapper, suffixReplacer BlockIntervalSuffixReplacer,
 ) BlockPropertyCollector {
 	if mapper == nil {
-		panic("mapper must be provided")
+		panic(errors.AssertionFailedf("mapper must be provided"))
 	}
 	return &BlockIntervalCollector{
 		name:           name,
@@ -619,7 +619,7 @@ func (d *blockPropertiesDecoder) Next() (id shortID, prop []byte, err error) {
 
 	if len(d.props) == 0 || shortID(d.props[0]) != id {
 		if invariants.Enabled && len(d.props) > 0 && shortID(d.props[0]) < id {
-			panic("shortIDs are not in order")
+			panic(errors.AssertionFailedf("shortIDs are not in order"))
 		}
 		// This property was omitted because it was empty.
 		return id, nil, nil

--- a/sstable/colblk/block.go
+++ b/sstable/colblk/block.go
@@ -455,7 +455,7 @@ func (d *BlockDecoder) ColumnToBinFormatter(
 		case DataTypeBytes:
 			rawBytesToBinFormatter(f, n, rows, nil)
 		default:
-			panic("unimplemented")
+			panic(errors.AssertionFailedf("unimplemented"))
 		}
 	})
 

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -1091,7 +1091,7 @@ func (d *DataBlockDecoder) PrefixChanged() Bitmap {
 // Init initializes the data block reader with the given serialized data block.
 func (d *DataBlockDecoder) Init(schema *KeySchema, data []byte) BlockDecoder {
 	if uintptr(unsafe.Pointer(unsafe.SliceData(data)))&7 != 0 {
-		panic("data buffer not 8-byte aligned")
+		panic(errors.AssertionFailedf("data buffer not 8-byte aligned"))
 	}
 	bd := BlockDecoder{}
 	bd.Init(data, DataBlockCustomHeaderSize+schema.HeaderSize)
@@ -1460,7 +1460,7 @@ func (i *DataBlockIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags)
 	// circuit the search if the prefix isn't found within the prefix column.
 	// There's some subtlety around ensuring we continue to benefit from the
 	// TrySeekUsingNext optimization.
-	panic("pebble: SeekPrefixGE unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekPrefixGE unimplemented"))
 }
 
 // SeekLT implements the base.InternalIterator interface.
@@ -1697,7 +1697,7 @@ func (i *DataBlockIter) Prev() *base.InternalKV {
 //gcassert:inline
 func (i *DataBlockIter) atObsoletePointForward() bool {
 	if invariants.Enabled && i.row > i.nextObsoletePoint {
-		panic("invalid nextObsoletePoint")
+		panic(errors.AssertionFailedf("invalid nextObsoletePoint"))
 	}
 	return i.row == i.nextObsoletePoint && i.row <= i.maxRow
 }
@@ -1733,7 +1733,7 @@ func (i *DataBlockIter) atObsoletePointCheck() {
 	// error from GCAssert about At not being inlined because it is compiled out
 	// altogether in non-invariant builds.
 	if !i.transforms.HideObsoletePoints || !i.d.isObsolete.At(i.row) {
-		panic("expected obsolete point")
+		panic(errors.AssertionFailedf("expected obsolete point"))
 	}
 }
 
@@ -1746,7 +1746,7 @@ func (i *DataBlockIter) Error() error {
 // SetBounds implements the base.InternalIterator interface.
 func (i *DataBlockIter) SetBounds(lower, upper []byte) {
 	// This should never be called as bounds are handled by sstable.Iterator.
-	panic("pebble: SetBounds unimplemented")
+	panic(errors.AssertionFailedf("pebble: SetBounds unimplemented"))
 }
 
 // SetContext implements the base.InternalIterator interface.

--- a/sstable/colblk/prefix_bytes.go
+++ b/sstable/colblk/prefix_bytes.go
@@ -983,7 +983,7 @@ func writePrefixCompressed[T Uint](
 	b *PrefixBytesBuilder, rows int, sz *prefixBytesSizing, offsetDeltas uintsEncoder[T], buf []byte,
 ) {
 	if invariants.Enabled && offsetDeltas.Len() != sz.offsetCount {
-		panic("incorrect offsetDeltas length")
+		panic(errors.AssertionFailedf("incorrect offsetDeltas length"))
 	}
 	if rows <= 1 {
 		if rows == 1 {
@@ -1094,7 +1094,7 @@ func (b *PrefixBytesBuilder) Finish(
 		writePrefixCompressed[uint32](b, rows, sz, offsetDest, buf[stringDataOffset:])
 		offsetDest.Finish()
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 	return stringDataOffset + uint32(sz.compressedDataLen)
 }

--- a/sstable/colblk/uints.go
+++ b/sstable/colblk/uints.go
@@ -387,7 +387,7 @@ func uintColumnFinish(
 	offset = alignWithZeroes(buf, offset, width)
 
 	if invariants.Enabled && len(buf) < int(offset)+rows*e.Width() {
-		panic("buffer too small")
+		panic(errors.AssertionFailedf("buffer too small"))
 	}
 	switch e.Width() {
 	case 1:
@@ -410,7 +410,7 @@ func uintColumnFinish(
 
 	case 8:
 		if deltaBase != 0 {
-			panic("unreachable")
+			panic(errors.AssertionFailedf("unreachable"))
 		}
 		dest := unsafe.Slice((*uint64)(unsafe.Pointer(&buf[offset])), rows)
 		copy(dest, values)
@@ -422,7 +422,7 @@ func uintColumnFinish(
 		}
 
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 	return offset + uint32(rows)*width
 }
@@ -446,17 +446,17 @@ func reduceUints[N constraints.Integer](minimum uint64, values []uint64, dst []N
 	for i, v := range values {
 		if invariants.Enabled {
 			if v < minimum {
-				panic("incorrect minimum value")
+				panic(errors.AssertionFailedf("incorrect minimum value"))
 			}
 			if v-minimum > uint64(N(0)-1) {
-				panic("incorrect target width")
+				panic(errors.AssertionFailedf("incorrect target width"))
 			}
 		}
 		//gcassert:bce
 		dst[i] = N(v - minimum)
 	}
 	if invariants.Enabled && len(values) < len(dst) && minimum != 0 {
-		panic("incorrect minimum value")
+		panic(errors.AssertionFailedf("incorrect minimum value"))
 	}
 	for i := len(values); i < len(dst); i++ {
 		dst[i] = 0

--- a/sstable/colblk/unsafe_uints.go
+++ b/sstable/colblk/unsafe_uints.go
@@ -62,7 +62,7 @@ func makeUnsafeUints(base uint64, ptr unsafe.Pointer, width int) UnsafeUints {
 	switch width {
 	case 0, 1, 2, 4, 8:
 	default:
-		panic("invalid width")
+		panic(errors.AssertionFailedf("invalid width"))
 	}
 	return UnsafeUints{
 		base:  base,

--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -122,7 +122,7 @@ func newColumnarWriter(
 	writable objstorage.Writable, o WriterOptions, cpuMeasurer base.CPUMeasurer,
 ) *RawColumnWriter {
 	if writable == nil {
-		panic("pebble: nil writable")
+		panic(errors.AssertionFailedf("pebble: nil writable"))
 	}
 	if !o.TableFormat.BlockColumnar() {
 		panic(errors.AssertionFailedf("newColumnarWriter cannot create sstables with %s format", o.TableFormat))
@@ -965,7 +965,7 @@ func (w *RawColumnWriter) flushBufferedIndexBlocks() (rootIndex block.Handle, er
 		// above this switch statement if there are no buffered partitions
 		// (regardless of whether there are data block handles in the index
 		// block).
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	case 1:
 		// Single-level index.
 		rootIndex, err = w.layout.WriteIndexBlock(w.indexBuffering.partitions[0].block)
@@ -1340,7 +1340,7 @@ func (w *RawColumnWriter) copyDataBlocks(
 	var buf []byte
 	readAndFlushBlocks := func(firstBlockIdx, lastBlockIdx int) error {
 		if firstBlockIdx > lastBlockIdx {
-			panic("pebble: readAndFlushBlocks called with invalid block range")
+			panic(errors.AssertionFailedf("pebble: readAndFlushBlocks called with invalid block range"))
 		}
 		// We need to flush blocks[firstBlockIdx:lastBlockIdx+1] into the write queue.
 		// We do this by issuing one big read from the read handle into the buffer, and
@@ -1372,7 +1372,7 @@ func (w *RawColumnWriter) copyDataBlocks(
 	lastBlockOffset := uint64(0)
 	for i := 0; i < len(blocks); {
 		if blocks[i].bh.Offset < lastBlockOffset {
-			panic("pebble: copyDataBlocks called with blocks out of order")
+			panic(errors.AssertionFailedf("pebble: copyDataBlocks called with blocks out of order"))
 		}
 		start := i
 		// Note the i++ in the initializing condition; this means we will always flush at least

--- a/sstable/compressionanalyzer/file_analyzer.go
+++ b/sstable/compressionanalyzer/file_analyzer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"slices"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -32,7 +33,7 @@ func NewFileAnalyzer(
 	if sstReadOpts.CacheOpts.CacheHandle != nil {
 		// We do not support using a cache here (we don't properly populate the
 		// block metadata).
-		panic("sstReadOpts.CacheOpts.CacheHandle must be nil")
+		panic(errors.AssertionFailedf("sstReadOpts.CacheOpts.CacheHandle must be nil"))
 	}
 	return &FileAnalyzer{
 		blockAnalyzer: NewBlockAnalyzer(),

--- a/sstable/format.go
+++ b/sstable/format.go
@@ -351,7 +351,7 @@ func (f TableFormat) AsTuple() (string, uint32) {
 	case TableFormatPebblev8:
 		return pebbleDBMagic, 8
 	default:
-		panic("sstable: unknown table format version tuple")
+		panic(errors.AssertionFailedf("sstable: unknown table format version tuple"))
 	}
 }
 
@@ -381,7 +381,7 @@ func (f TableFormat) String() string {
 	case TableFormatPebblev8:
 		return "(Pebble,v8)"
 	default:
-		panic("sstable: unknown table format version tuple")
+		panic(errors.AssertionFailedf("sstable: unknown table format version tuple"))
 	}
 }
 

--- a/sstable/layout.go
+++ b/sstable/layout.go
@@ -148,7 +148,7 @@ func (l *Layout) Describe(
 			magicNumber := trailer[len(trailer)-magicLen:]
 			format, err := parseTableFormat(magicNumber, version)
 			if err != nil {
-				panic("Error parsing table format.")
+				panic(errors.AssertionFailedf("Error parsing table format."))
 			}
 
 			var attributes Attributes

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -1074,7 +1074,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) bloomFilterMayContain(prefix []byte)
 // virtualLast should only be called if i.readBlockEnv.Virtual != nil
 func (i *singleLevelIterator[I, PI, D, PD]) virtualLast() *base.InternalKV {
 	if i.readEnv.Virtual == nil {
-		panic("pebble: invalid call to virtualLast")
+		panic(errors.AssertionFailedf("pebble: invalid call to virtualLast"))
 	}
 
 	if !i.endKeyInclusive {
@@ -1099,7 +1099,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) virtualLastSeekLE() *base.InternalKV
 	// TODO(bananabrick): We can optimize this check away for the level iter
 	// if necessary.
 	if !i.endKeyInclusive {
-		panic("unexpected virtualLastSeekLE with exclusive upper bounds")
+		panic(errors.AssertionFailedf("unexpected virtualLastSeekLE with exclusive upper bounds"))
 	}
 	key := i.upper
 
@@ -1441,7 +1441,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) Last() (kv *base.InternalKV) {
 	}
 
 	if i.upper != nil {
-		panic("singleLevelIterator.Last() used despite upper bound")
+		panic(errors.AssertionFailedf("singleLevelIterator.Last() used despite upper bound"))
 	}
 	i.positionedUsingLatestBounds = true
 	return i.lastInternal()
@@ -1527,14 +1527,14 @@ func (i *singleLevelIterator[I, PI, D, PD]) nextInternal(
 		// filter miss, the data block should not have been invalidated. This assertion
 		// ensures the optimization to preserve loaded blocks is working correctly.
 		if PD(&i.data).IsDataInvalidated() {
-			panic("pebble: data block was invalidated after SeekPrefixGE returned nil due to bloom filter miss")
+			panic(errors.AssertionFailedf("pebble: data block was invalidated after SeekPrefixGE returned nil due to bloom filter miss"))
 		}
 	}
 	// Clear the tracking flag since this is no longer the next operation after SeekPrefixGE
 	i.lastOpWasSeekPrefixGE.Set(false)
 
 	if i.exhaustedBounds == +1 {
-		panic("Next called even though exhausted upper bound")
+		panic(errors.AssertionFailedf("Next called even though exhausted upper bound"))
 	}
 	i.exhaustedBounds = 0
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
@@ -1574,7 +1574,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) NextPrefix(succKey []byte) (kv *base
 	// Clear the tracking flag since this is a relative positioning operation
 	i.lastOpWasSeekPrefixGE.Set(false)
 	if i.exhaustedBounds == +1 {
-		panic("NextPrefix called even though exhausted upper bound")
+		panic(errors.AssertionFailedf("NextPrefix called even though exhausted upper bound"))
 	}
 	i.exhaustedBounds = 0
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
@@ -1660,7 +1660,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) Prev() (kv *base.InternalKV) {
 	// Clear the tracking flag since this is a relative positioning operation
 	i.lastOpWasSeekPrefixGE.Set(false)
 	if i.exhaustedBounds == -1 {
-		panic("Prev called even though exhausted lower bound")
+		panic(errors.AssertionFailedf("Prev called even though exhausted lower bound"))
 	}
 	i.exhaustedBounds = 0
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
@@ -1700,7 +1700,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) skipForward(
 				// We checked that i.index was at a valid entry, so
 				// loadBlockFailed could not have happened due to i.index
 				// being exhausted, and must be due to an error.
-				panic("loadDataBlock should not have failed with no error")
+				panic(errors.AssertionFailedf("loadDataBlock should not have failed with no error"))
 			}
 			// result == loadBlockIrrelevant. Enforce the upper bound here since
 			// don't want to bother moving to the next block if upper bound is
@@ -1790,7 +1790,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) skipBackward() *base.InternalKV {
 				// We checked that i.index was at a valid entry, so
 				// loadBlockFailed could not have happened due to to i.index
 				// being exhausted, and must be due to an error.
-				panic("loadDataBlock should not have failed with no error")
+				panic(errors.AssertionFailedf("loadDataBlock should not have failed with no error"))
 			}
 			// result == loadBlockIrrelevant. Enforce the lower bound here
 			// since don't want to bother moving to the previous block if lower
@@ -1861,7 +1861,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) Close() error {
 
 func (i *singleLevelIterator[I, PI, D, PD]) closeInternal() error {
 	if invariants.Enabled && i.inPool {
-		panic("Close called on interator in pool")
+		panic(errors.AssertionFailedf("Close called on interator in pool"))
 	}
 
 	if i.closeHook != nil {

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -103,7 +103,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) loadSecondLevelIndexBlock(dir int8) loa
 // `blockIntersects` or `blockExcluded`.
 func (i *twoLevelIterator[I, PI, D, PD]) resolveMaybeExcluded(dir int8) intersectsResult {
 	if invariants.Enabled && !i.topLevelIndexLoaded {
-		panic("pebble: resolveMaybeExcluded called without loaded top-level index")
+		panic(errors.AssertionFailedf("pebble: resolveMaybeExcluded called without loaded top-level index"))
 	}
 
 	// This iterator is configured with a bound-limited block property filter.
@@ -710,7 +710,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) seekPrefixGE(
 // virtualLast should only be called if i.secondLevel.readBlockEnv.Virtual != nil.
 func (i *twoLevelIterator[I, PI, D, PD]) virtualLast() *base.InternalKV {
 	if i.secondLevel.readEnv.Virtual == nil {
-		panic("pebble: invalid call to virtualLast")
+		panic(errors.AssertionFailedf("pebble: invalid call to virtualLast"))
 	}
 	if !i.secondLevel.endKeyInclusive {
 		// Trivial case.
@@ -729,7 +729,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) virtualLastSeekLE() *base.InternalKV {
 	// TODO(bananabrick): We can optimize this check away for the level iter
 	// if necessary.
 	if !i.secondLevel.endKeyInclusive {
-		panic("unexpected virtualLastSeekLE with exclusive upper bounds")
+		panic(errors.AssertionFailedf("unexpected virtualLastSeekLE with exclusive upper bounds"))
 	}
 	key := i.secondLevel.upper
 
@@ -973,7 +973,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) Last() (kv *base.InternalKV) {
 	}
 
 	if i.secondLevel.upper != nil {
-		panic("twoLevelIterator.Last() used despite upper bound")
+		panic(errors.AssertionFailedf("twoLevelIterator.Last() used despite upper bound"))
 	}
 	i.secondLevel.exhaustedBounds = 0
 	i.secondLevel.err = nil // clear cached iteration error
@@ -1047,7 +1047,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) nextInternal(
 		// filter miss, the data block should not have been invalidated. This assertion
 		// ensures the optimization to preserve loaded blocks is working correctly.
 		if PD(&i.secondLevel.data).IsDataInvalidated() {
-			panic("pebble: data block was invalidated after SeekPrefixGE returned nil due to bloom filter miss")
+			panic(errors.AssertionFailedf("pebble: data block was invalidated after SeekPrefixGE returned nil due to bloom filter miss"))
 		}
 	}
 	i.lastOpWasSeekPrefixGE.Set(false)
@@ -1080,7 +1080,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) NextPrefix(succKey []byte) (kv *base.In
 	}
 	i.lastOpWasSeekPrefixGE.Set(false)
 	if i.secondLevel.exhaustedBounds == +1 {
-		panic("Next called even though exhausted upper bound")
+		panic(errors.AssertionFailedf("Next called even though exhausted upper bound"))
 	}
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.secondLevel.boundsCmp = 0
@@ -1340,7 +1340,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) ensureTopLevelIndexLoaded() bool {
 // Close implements internalIterator.Close, as documented in the pebble package.
 func (i *twoLevelIterator[I, PI, D, PD]) Close() error {
 	if invariants.Enabled && i.secondLevel.pool != nil {
-		panic("twoLevelIterator's singleLevelIterator has its own non-nil pool")
+		panic(errors.AssertionFailedf("twoLevelIterator's singleLevelIterator has its own non-nil pool"))
 	}
 	pool := i.pool
 	err := i.secondLevel.closeInternal()

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -161,7 +162,7 @@ func (i *fragmentIter) applySpanTransforms() error {
 		i.startKeyBuf = append(i.startKeyBuf[:0], i.span.Start...)
 		i.span.Start = i.startKeyBuf
 		if invariants.Enabled && !bytes.Equal(syntheticPrefix, i.endKeyBuf[:len(syntheticPrefix)]) {
-			panic("pebble: invariant violation: synthetic prefix mismatch")
+			panic(errors.AssertionFailedf("pebble: invariant violation: synthetic prefix mismatch"))
 		}
 		i.endKeyBuf = append(i.endKeyBuf[:len(syntheticPrefix)], i.span.End...)
 		i.span.End = i.endKeyBuf
@@ -340,7 +341,7 @@ func (i *fragmentIter) Next() (*keyspan.Span, error) {
 		if x, err := i.gatherForward(i.blockIter.Next()); err != nil {
 			return nil, err
 		} else if invariants.Enabled && !x.Valid() {
-			panic("pebble: invariant violation: next entry unexpectedly invalid")
+			panic(errors.AssertionFailedf("pebble: invariant violation: next entry unexpectedly invalid"))
 		}
 		i.dir = +1
 	}
@@ -376,7 +377,7 @@ func (i *fragmentIter) Prev() (*keyspan.Span, error) {
 		if x, err := i.gatherBackward(i.blockIter.Prev()); err != nil {
 			return nil, err
 		} else if invariants.Enabled && !x.Valid() {
-			panic("pebble: invariant violation: previous entry unexpectedly invalid")
+			panic(errors.AssertionFailedf("pebble: invariant violation: previous entry unexpectedly invalid"))
 		}
 		i.dir = -1
 	}

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -431,7 +431,7 @@ func (i *Iter) readFirstKey() error {
 		ptr = unsafe.Add(ptr, 1)
 	} else {
 		// The shared length is != 0, which is invalid.
-		panic("first key in block must have zero shared length")
+		panic(errors.AssertionFailedf("first key in block must have zero shared length"))
 	}
 
 	var unshared uint32
@@ -732,7 +732,7 @@ func (i *Iter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 // pebble package.
 func (i *Iter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	// This should never be called as prefix iteration is handled by sstable.Iterator.
-	panic("pebble: SeekPrefixGE unimplemented")
+	panic(errors.AssertionFailedf("pebble: SeekPrefixGE unimplemented"))
 }
 
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
@@ -1616,7 +1616,7 @@ func (i *Iter) Close() error {
 // always be handled the by the parent sstable iterator.
 func (i *Iter) SetBounds(lower, upper []byte) {
 	// This should never be called as bounds are handled by sstable.Iterator.
-	panic("pebble: SetBounds unimplemented")
+	panic(errors.AssertionFailedf("pebble: SetBounds unimplemented"))
 }
 
 // SetContext implements base.InternalIterator.

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -349,10 +349,10 @@ func (i *indexBlockBuf) estimatedSize() uint64 {
 	// Make sure that the size estimation works as expected.
 	if invariants.Enabled {
 		if i.size.estimate.inflightSize != 0 {
-			panic("unexpected inflight entry in index block size estimation")
+			panic(errors.AssertionFailedf("unexpected inflight entry in index block size estimation"))
 		}
 		if i.size.estimate.size() != uint64(i.block.EstimatedSize()) {
-			panic("index block size estimation is incorrect")
+			panic(errors.AssertionFailedf("index block size estimation is incorrect"))
 		}
 	}
 	return i.size.estimate.size()
@@ -378,7 +378,7 @@ func (d *dataBlockEstimates) dataBlockCompressed(compressedSize int, inflightSiz
 func (d *dataBlockEstimates) size() uint64 {
 	if invariants.Enabled {
 		if d.estimate.inflightSize != 0 {
-			panic("unexpected inflight entry in data block size estimation")
+			panic(errors.AssertionFailedf("unexpected inflight entry in data block size estimation"))
 		}
 	}
 	return d.estimate.size()

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -300,7 +300,7 @@ type copyFilterWriter struct {
 
 var _ base.TableFilterWriter = (*copyFilterWriter)(nil)
 
-func (copyFilterWriter) AddKey(key []byte) { panic("unimplemented") }
+func (copyFilterWriter) AddKey(key []byte) { panic(errors.AssertionFailedf("unimplemented")) }
 
 func (c *copyFilterWriter) Finish() (_ []byte, _ base.TableFilterFamily, ok bool) {
 	data, family := c.data, c.family
@@ -453,7 +453,7 @@ func newMemReader(b []byte) *memReader {
 func (m *memReader) ReadAt(_ context.Context, p []byte, off int64) error {
 	n, err := m.r.ReadAt(p, off)
 	if invariants.Enabled && err == nil && n != len(p) {
-		panic("short read")
+		panic(errors.AssertionFailedf("short read"))
 	}
 	return err
 }

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -432,7 +432,7 @@ func (f footer) encode(buf []byte) []byte {
 		case block.ChecksumTypeXXHash64:
 			buf[0] = byte(block.ChecksumTypeXXHash64)
 		default:
-			panic("unknown checksum type")
+			panic(errors.AssertionFailedf("unknown checksum type"))
 		}
 		n := 1
 		n += f.metaindexBH.EncodeVarints(buf[n:])
@@ -457,7 +457,7 @@ func (f footer) encode(buf []byte) []byte {
 		}
 
 	default:
-		panic("sstable: unspecified table format version")
+		panic(errors.AssertionFailedf("sstable: unspecified table format version"))
 	}
 
 	return buf
@@ -471,6 +471,6 @@ func supportsTwoLevelIndex(format TableFormat) bool {
 		TableFormatPebblev5, TableFormatPebblev6, TableFormatPebblev7:
 		return true
 	default:
-		panic("sstable: unspecified table format version")
+		panic(errors.AssertionFailedf("sstable: unspecified table format version"))
 	}
 }

--- a/sstable/tablefilters/binaryfuse/bitpacking/bitpacking.go
+++ b/sstable/tablefilters/binaryfuse/bitpacking/bitpacking.go
@@ -13,6 +13,7 @@ import (
 	"encoding/binary"
 	"unsafe"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/invariants"
 )
 
@@ -38,7 +39,7 @@ func EncodedSize(n int, bpv int) int {
 	case 16:
 		return n * 2
 	default:
-		panic("unsupported bpv")
+		panic(errors.AssertionFailedf("unsupported bpv"))
 	}
 }
 
@@ -62,7 +63,7 @@ func Encode8(input []uint8, bpv int, output []byte) {
 	case 8:
 		copy(output[:len(input)], input)
 	default:
-		panic("unsupported bpv")
+		panic(errors.AssertionFailedf("unsupported bpv"))
 	}
 }
 
@@ -117,7 +118,7 @@ func Encode16(input []uint16, bpv int, output []byte) {
 	case 16:
 		encode16bpv(input, output)
 	default:
-		panic("unsupported bpv")
+		panic(errors.AssertionFailedf("unsupported bpv"))
 	}
 }
 
@@ -293,7 +294,7 @@ func Decode(data []byte, i uint, bpv int) uint16 {
 		shift := (i & 1) * 12
 		return uint16((w >> shift) & 0xFFF)
 	default:
-		panic("unsupported bpv")
+		panic(errors.AssertionFailedf("unsupported bpv"))
 	}
 }
 
@@ -343,7 +344,7 @@ func Decode3(data []byte, i1, i2, i3 uint, bpv int) (uint16, uint16, uint16) {
 		shift3 := (i3 & 1) * 12
 		return uint16((w1 >> shift1) & 0xFFF), uint16((w2 >> shift2) & 0xFFF), uint16((w3 >> shift3) & 0xFFF)
 	default:
-		panic("unsupported bpv")
+		panic(errors.AssertionFailedf("unsupported bpv"))
 	}
 }
 

--- a/sstable/tablefilters/binaryfuse/filter.go
+++ b/sstable/tablefilters/binaryfuse/filter.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/FastFilter/xorfilter"
 	"github.com/cockroachdb/crlib/fifo"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/sstable/tablefilters/binaryfuse/bitpacking"
 )
 
@@ -139,7 +140,7 @@ func build[T uint8 | uint16](bld *builder, fpBits int) (data []byte, ok bool) {
 	case []uint16:
 		bitpacking.Encode16(fingerprints, fpBits, data)
 	default:
-		panic("unsupported fingerprints type")
+		panic(errors.AssertionFailedf("unsupported fingerprints type"))
 	}
 
 	data = binary.LittleEndian.AppendUint64(data, filter.Seed)

--- a/sstable/tablefilters/bloom/bits.go
+++ b/sstable/tablefilters/bloom/bits.go
@@ -7,6 +7,8 @@ package bloom
 import (
 	"encoding/binary"
 	"unsafe"
+
+	"github.com/cockroachdb/errors"
 )
 
 const cacheLineSize = 64
@@ -96,7 +98,7 @@ func mayContain(filter []byte, h uint32) bool {
 	nProbes := filter[n]
 	nLines := binary.LittleEndian.Uint32(filter[n+1:])
 	if 8*(uint32(n)/nLines) != cacheLineBits {
-		panic("bloom filter: unexpected cache line size")
+		panic(errors.AssertionFailedf("bloom filter: unexpected cache line size"))
 	}
 	bits := aliasFilterBits(filter, nLines)
 	return bits.probe(nProbes, h)

--- a/sstable/test_utils.go
+++ b/sstable/test_utils.go
@@ -405,7 +405,7 @@ func (w *testingBloomFilterWriter) AddKey(key []byte) { w.bloom.AddKey(key) }
 func (w *testingBloomFilterWriter) Finish() ([]byte, base.TableFilterFamily, bool) {
 	data, _, ok := w.bloom.Finish()
 	if !ok {
-		panic("no filter")
+		panic(errors.AssertionFailedf("no filter"))
 	}
 	return data, w.family, true
 }

--- a/sstable/testdata/make-table.go
+++ b/sstable/testdata/make-table.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -20,7 +21,7 @@ func main() {
 		panic(err)
 	}
 	if filepath.Base(dir) != "testdata" {
-		panic("This program must be run from sstable/testdata")
+		panic(errors.AssertionFailedf("This program must be run from sstable/testdata"))
 	}
 	if err := os.Chdir(filepath.Dir(dir)); err != nil {
 		panic(err)

--- a/sstable/valblk/writer.go
+++ b/sstable/valblk/writer.go
@@ -72,7 +72,7 @@ func (w *Writer) AddValue(v []byte) (Handle, error) {
 		// big, so finish this block.
 		w.compressAndFlush()
 		if invariants.Enabled && w.buf.Size() != 0 {
-			panic("buffer should be empty when starting new block")
+			panic(errors.AssertionFailedf("buffer should be empty when starting new block"))
 		}
 	}
 	vh := Handle{
@@ -162,7 +162,7 @@ func (w *Writer) writeValueBlocksIndex(layout LayoutWriter, h IndexHandle) (Inde
 		b = b[int(h.BlockLengthByteLength):]
 	}
 	if len(b) != 0 {
-		panic("incorrect length calculation")
+		panic(errors.AssertionFailedf("incorrect length calculation"))
 	}
 	pb := w.physBlockMaker.Make(w.buf.Data(), blockkind.Metadata, block.DontCompress)
 	if _, err := layout.WriteValueIndexBlock(pb.Take(), h); err != nil {

--- a/table_stats.go
+++ b/table_stats.go
@@ -826,7 +826,7 @@ func estimateDiskUsageInTableAndBlobReferences(
 func maybeSetStatsFromProperties(meta *manifest.TableMetadata, props *sstable.Properties) bool {
 	meta.TableBacking.PopulateProperties(props)
 	if invariants.Enabled && meta.Virtual {
-		panic("table expected to be physical")
+		panic(errors.AssertionFailedf("table expected to be physical"))
 	}
 	// If a table contains any deletions, we defer the stats collection. There
 	// are two main reasons for this:

--- a/valsep/value_separator.go
+++ b/valsep/value_separator.go
@@ -351,7 +351,7 @@ func (vs *ValueSeparator) preserveBlobReference(
 		})
 	}
 	if invariants.Enabled && vs.currPendingReferences[refID].blobFileID != fileID {
-		panic("wrong reference index")
+		panic(errors.AssertionFailedf("wrong reference index"))
 	}
 
 	handleSuffix := blob.DecodeHandleSuffix(lv.ValueOrHandle)
@@ -439,7 +439,7 @@ func (vs *ValueSeparator) maybeCheckInvariants() {
 				if ref.preserved {
 					totalValueSize += ref.valueSize
 				} else {
-					panic("no new references should exist in preserveAllHotBlobReferences mode")
+					panic(errors.AssertionFailedf("no new references should exist in preserveAllHotBlobReferences mode"))
 				}
 			}
 			accumulatedPreservedValueSize := vs.blobTiers[base.HotTier].totalPreservedValueSize

--- a/version_set.go
+++ b/version_set.go
@@ -784,7 +784,7 @@ func (vs *versionSet) incrementCompactions(
 
 	default:
 		if invariants.Enabled {
-			panic("unhandled compaction kind")
+			panic(errors.AssertionFailedf("unhandled compaction kind"))
 		}
 
 	}
@@ -912,7 +912,7 @@ func (vs *versionSet) getNextDiskFileNum() base.DiskFileNum {
 
 func (vs *versionSet) append(v *manifest.Version) {
 	if v.Refs() != 0 {
-		panic("pebble: version should be unreferenced")
+		panic(errors.AssertionFailedf("pebble: version should be unreferenced"))
 	}
 	if !vs.versions.Empty() {
 		vs.versions.Back().UnrefLocked()

--- a/vfs/disk_health.go
+++ b/vfs/disk_health.go
@@ -384,11 +384,11 @@ func (d *diskHealthCheckingFile) timeDiskOp(
 	delta := start.Sub(d.createTime)
 	packed := pack(delta, writeSizeInBytes, opType)
 	if d.lastWritePacked.Swap(packed) != 0 {
-		panic("concurrent write operations detected on file")
+		panic(errors.AssertionFailedf("concurrent write operations detected on file"))
 	}
 	defer func() {
 		if d.lastWritePacked.Swap(0) != packed {
-			panic("concurrent write operations detected on file")
+			panic(errors.AssertionFailedf("concurrent write operations detected on file"))
 		}
 	}()
 	op()
@@ -409,7 +409,7 @@ func pack(delta time.Duration, writeSizeInBytes int64, opType OpType) uint64 {
 	// of effective monitoring time before the uint wraps around, at millisecond
 	// precision.
 	if deltaMillis > 1<<deltaBits-1 {
-		panic("vfs: last write delta would result in integer wraparound")
+		panic(errors.AssertionFailedf("vfs: last write delta would result in integer wraparound"))
 	}
 
 	// See writeSizePrecision to get the unit of writeSize. As of 1/26/2023, the unit is KBs.

--- a/vfs/errorfs/errorfs.go
+++ b/vfs/errorfs/errorfs.go
@@ -129,10 +129,10 @@ var WriteOps = MakeOpKinds(OpCreate, OpLink, OpRemove, OpRemoveAll, OpRename, Op
 
 func init() {
 	if ReadOps&WriteOps != 0 {
-		panic("some op is both read and write")
+		panic(errors.AssertionFailedf("some op is both read and write"))
 	}
 	if ReadOps|WriteOps != (OpKinds(1)<<numOpKinds - 1) {
-		panic("some op is neither read nor write")
+		panic(errors.AssertionFailedf("some op is neither read nor write"))
 	}
 }
 

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -139,7 +139,7 @@ type CrashCloneCfg struct {
 // latter is controlled by CrashCloneCfg.
 func (y *MemFS) CrashClone(cfg CrashCloneCfg) *MemFS {
 	if !y.crashable {
-		panic("not a crashable MemFS")
+		panic(errors.AssertionFailedf("not a crashable MemFS"))
 	}
 	// Block all modification operations while we clone.
 	y.cloneMu.Lock()
@@ -552,7 +552,7 @@ func (y *MemFS) List(dirname string) ([]string, error) {
 	err := y.walk(dirname, func(dir *memNode, frag string, final bool) error {
 		if final {
 			if frag != "" {
-				panic("unreachable")
+				panic(errors.AssertionFailedf("unreachable"))
 			}
 			ret = make([]string, 0, len(dir.children))
 			for s := range dir.children {
@@ -804,7 +804,7 @@ func (f *memFile) Write(p []byte) (int, error) {
 	if f.pos+len(p) <= len(f.n.mu.data) {
 		n := copy(f.n.mu.data[f.pos:f.pos+len(p)], p)
 		if n != len(p) {
-			panic("stuff")
+			panic(errors.AssertionFailedf("stuff"))
 		}
 	} else {
 		if grow := f.pos - len(f.n.mu.data); grow > 0 {
@@ -845,7 +845,7 @@ func (f *memFile) WriteAt(p []byte, ofs int64) (int, error) {
 
 	n := copy(f.n.mu.data[int(ofs):int(ofs)+len(p)], p)
 	if n != len(p) {
-		panic("stuff")
+		panic(errors.AssertionFailedf("stuff"))
 	}
 
 	return len(p), nil

--- a/vfs/syncing_file.go
+++ b/vfs/syncing_file.go
@@ -213,5 +213,5 @@ func (fs *syncingFS) ReuseForWrite(
 	oldname, newname string, category DiskWriteCategory,
 ) (File, error) {
 	// TODO(radu): implement this if needed.
-	panic("unimplemented")
+	panic(errors.AssertionFailedf("unimplemented"))
 }

--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -194,7 +194,7 @@ func (p *dirProber) probeLoop() {
 					return failedProbeDuration
 				}
 				if n != len(p.buf) {
-					panic("invariant violation")
+					panic(errors.AssertionFailedf("invariant violation"))
 				}
 				err = f.Sync()
 				if err != nil {
@@ -248,9 +248,9 @@ func (p *dirProber) getMeanMax(interval time.Duration) (time.Duration, time.Dura
 	numSamples := p.mu.nextProbeIndex - p.mu.firstProbeIndex
 	samplesNeeded := int((interval + p.interval - 1) / p.interval)
 	if samplesNeeded == 0 {
-		panic("interval is too short")
+		panic(errors.AssertionFailedf("interval is too short"))
 	} else if samplesNeeded > probeHistoryLength {
-		panic("interval is too long")
+		panic(errors.AssertionFailedf("interval is too long"))
 	}
 	if samplesNeeded > numSamples {
 		// Not enough samples, so assume not yet healthy.
@@ -353,7 +353,7 @@ func (m *failoverMonitor) newWriter(writerCreateFunc func(dir dirAndFileHandle) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.mu.writer != nil {
-		panic("previous writer not closed")
+		panic(errors.AssertionFailedf("previous writer not closed"))
 	}
 	m.mu.writer = writerCreateFunc(m.opts.dirs[m.mu.dirIndex])
 }
@@ -746,7 +746,7 @@ func (wm *failoverManager) Create(wn NumWAL, jobID int) (Writer, error) {
 		wm.mu.Lock()
 		defer wm.mu.Unlock()
 		if wm.mu.ww != nil {
-			panic("previous wal.Writer not closed")
+			panic(errors.AssertionFailedf("previous wal.Writer not closed"))
 		}
 	}()
 	fwOpts := failoverWriterOpts{


### PR DESCRIPTION
Previously, the linter only caught panic(fmt.Sprintf(...)) and required errors.AssertionFailedf instead. However, panic("string literal") was not caught, meaning these panic messages would be fully redacted in CockroachDB logs (the entire string is treated as unsafe and replaced with ‹×›).

Combine the existing TestPanicFmtSprintf rule with a new check for panic("...") into a single TestPanicArgs lint rule that catches both patterns in non-test files. Convert all existing string literal panic occurrences to use errors.AssertionFailedf, ensuring panic messages are preserved in redacted log output.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>