### PR TITLE
github: add nightly workflow and crossversion stress for 26.2

### DIFF
--- a/.github/workflows/nightlies-26.2.yaml
+++ b/.github/workflows/nightlies-26.2.yaml
@@ -1,0 +1,60 @@
+name: Nightlies (crl-release-26.2)
+
+on:
+  schedule:
+    - cron: '30 10 * * * ' # 10:30am UTC daily
+  workflow_dispatch:
+
+env:
+  BRANCH: crl-release-26.2
+
+jobs:
+  resolve-sha:
+    runs-on: ubuntu-latest
+    outputs:
+      # This output only exists so we can interpolate it.
+      branch: ${{ steps.get_sha.outputs.branch }}
+      sha: ${{ steps.get_sha.outputs.sha }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get SHA for ${{ env.BRANCH }}
+        id: get_sha
+        run: |
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse origin/$BRANCH)" >> "$GITHUB_OUTPUT"
+
+  tests:
+    needs: resolve-sha
+    uses: ./.github/workflows/tests.yaml
+    with:
+      sha: ${{ needs.resolve-sha.outputs.sha }}
+      file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
+      go_version: 1.25
+
+  s390x:
+    needs: resolve-sha
+    uses: ./.github/workflows/s390x.yaml
+    with:
+      sha: ${{ needs.resolve-sha.outputs.sha }}
+      file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
+      go_version: 1.25
+
+  stress:
+    needs: resolve-sha
+    uses: ./.github/workflows/stress.yaml
+    with:
+      sha: ${{ needs.resolve-sha.outputs.sha }}
+      file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
+      go_version: 1.25
+
+  instrumented:
+    needs: resolve-sha
+    uses: ./.github/workflows/instrumented.yaml
+    with:
+      sha: ${{ needs.resolve-sha.outputs.sha }}
+      file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
+      go_version: 1.25

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ crossversion-meta:
 
 .PHONY: stress-crossversion
 stress-crossversion:
-	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-24.3 crl-release-25.1 crl-release-25.2 crl-release-25.3 crl-release-25.4 crl-release-26.1 master
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-24.3 crl-release-25.1 crl-release-25.2 crl-release-25.3 crl-release-25.4 crl-release-26.1 crl-release-26.2 master
 
 .PHONY: test-s390x-qemu
 test-s390x-qemu: TAGS += slowbuild


### PR DESCRIPTION
https://github.com/cockroachdb/pebble/tree/crl-release-26.2 has been created. This PR:

* Add nightlies-26.2.yaml targeting the crl-release-26.2 branch.
* Add crl-release-26.2 to the stress-crossversion Makefile target.