### PR TITLE
Makefile: hardcode crossversion-meta and stress-crossversion for 26.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ stressmeta: override TESTS = TestMeta$$
 stressmeta: stress
 
 .PHONY: crossversion-meta
+crossversion-meta: LATEST_RELEASE := crl-release-26.1
 crossversion-meta:
-	$(eval LATEST_RELEASE := $(shell git fetch origin && git branch -r --list '*/crl-release-*' | grep -o 'crl-release-.*$$' | sort | tail -1))
 	git checkout ${LATEST_RELEASE}; \
 		${GO} test -c ./internal/metamorphic -o './internal/metamorphic/crossversion/${LATEST_RELEASE}.test'; \
 		git checkout -; \
@@ -81,7 +81,7 @@ crossversion-meta:
 
 .PHONY: stress-crossversion
 stress-crossversion:
-	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-24.3 crl-release-25.1 crl-release-25.2 crl-release-25.3 crl-release-25.4 crl-release-26.1 master
+	STRESS=1 ./scripts/run-crossversion-meta.sh crl-release-24.3 crl-release-25.1 crl-release-25.2 crl-release-25.3 crl-release-25.4 crl-release-26.1 crl-release-26.2
 
 .PHONY: test-s390x-qemu
 test-s390x-qemu: TAGS += slowbuild


### PR DESCRIPTION
Hardcode LATEST_RELEASE to crl-release-26.1 for the crossversion-meta target, replacing the dynamic branch resolution. Update stress-crossversion to end with crl-release-26.2 instead of master.