### PR TITLE
blob: fix math.MaxUint32 overflow on 32-bit platforms

### DIFF
--- a/sstable/blob/blocks.go
+++ b/sstable/blob/blocks.go
@@ -163,7 +163,7 @@ func (d *indexBlockDecoder) Init(data []byte) {
 	d.bd.Init(data, indexBlockCustomHeaderSize)
 	d.virtualBlocks = colblk.DecodeColumn(&d.bd, indexBlockColumnVirtualBlocksIdx,
 		uint32(d.virtualBlockCount), colblk.DataTypeUint, colblk.DecodeUnsafeUints)
-	if d.bd.Rows() == math.MaxUint32 {
+	if uint32(d.bd.Rows()) == math.MaxUint32 {
 		panic(errors.AssertionFailedf("invalid row count"))
 	}
 	// Decode the offsets column. We pass rows+1 because an index block encoding


### PR DESCRIPTION
## Summary

- Commit 0ce8e60f added a guard comparing `d.bd.Rows()` (`int`) against
  `math.MaxUint32` to prevent overflow, but the comparison itself doesn't
  compile on 32-bit platforms where `int` is 32 bits.
- Fix by casting to `uint32` before comparing. The round-trip
  `uint32 → int → uint32` preserves the original header value on both
  32-bit and 64-bit.

Fixes #5858
Fixes #5859