### PR TITLE
checkpoint: fix flaky TestCheckpointFlushableIngest

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -516,6 +516,13 @@ func TestCheckpointFlushableIngest(t *testing.T) {
 	require.NoError(t, w.Set([]byte("b"), []byte("ingested")))
 	require.NoError(t, w.Close())
 
+	// Prevent automatic flushes from draining the flushable queue before we
+	// can verify the ingestedFlushable and take a checkpoint.
+	// DisableAutomaticCompactions does not disable flushes.
+	d.mu.Lock()
+	d.mu.compact.flushing = true
+	d.mu.Unlock()
+
 	// Ingest the SSTable. Because it overlaps with the memtable key "b", it is
 	// added to the flushable queue as an ingestedFlushable rather than being
 	// placed directly into L0.
@@ -536,6 +543,12 @@ func TestCheckpointFlushableIngest(t *testing.T) {
 	// Checkpoint without flushing first. The checkpoint must copy the
 	// ingestedFlushable SSTable files so that WAL replay on open succeeds.
 	require.NoError(t, d.Checkpoint("checkpoint"))
+
+	// Re-enable flushing so Close does not deadlock.
+	d.mu.Lock()
+	d.mu.compact.flushing = false
+	d.mu.Unlock()
+
 	require.NoError(t, d.Close())
 
 	// Opening the checkpoint previously failed with:


### PR DESCRIPTION
## Summary

Fix race in `TestCheckpointFlushableIngest` that causes intermittent failures under stress testing.

### Root Cause

The test sets `DisableAutomaticCompactions: true` expecting it to prevent background work from interfering, but this flag only gates compaction picking in `pickAnyCompaction`. It does not affect `maybeScheduleFlush`.

During `handleIngestAsFlushable`, after the `ingestedFlushable` is appended to the memtable queue, `maybeScheduleFlush` is called which starts a background flush goroutine (`go d.flush()`). This goroutine is blocked on `d.mu` while the `prepare` callback holds it, but once `prepare`'s deferred `d.mu.Unlock()` fires (before `Ingest` returns to the caller), the flush goroutine can acquire `d.mu` and begin flushing.

Two flush cycles then drain the queue: first the rotated immutable memtable, then the `ingestedFlushable` itself (since `ingestedFlushable.readyForFlush()` always returns true). Under stress with 16 parallel processes, both flushes complete before the test acquires `d.mu` at line 525 to check the queue. The test then sees only `[*pebble.memTable]` in the queue and the assertion fails.

### Fix

Block flush scheduling before the ingest by setting `d.mu.compact.flushing = true`. This is the established pattern for preventing flush interference in tests, used in `ingest_test.go` (`blockFlush`/`allowFlush` commands), `excise_test.go`, `open_test.go`, `event_listener_test.go`, and `metrics_test.go`. The flag is reset before `Close` to avoid deadlocking at the `d.mu.compact.flushing` wait loop in `db.go:Close`.

Fixes #5860.