### PR TITLE
testutils: fix Logger.Fatalf to terminate process like DefaultLogger

### DIFF
--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -4,7 +4,12 @@
 
 package testutils
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
 
 // Logger is a logger that writes to a testing.TB.
 type Logger struct {
@@ -20,6 +25,15 @@ func (l Logger) Errorf(format string, args ...interface{}) {
 }
 
 func (l Logger) Fatalf(format string, args ...interface{}) {
-	l.T.Helper()
-	l.T.Fatalf(format, args...)
+	// Print the error and all goroutine stacks, then terminate the process.
+	// This matches DefaultLogger.Fatalf (which calls os.Exit) rather than using
+	// t.Fatalf (which calls runtime.Goexit). Goexit only terminates the calling
+	// goroutine; when Logger.Fatalf is called from a background goroutine
+	// (compaction, flush), this silently kills that goroutine without cleaning
+	// up DB state, causing Close to hang indefinitely. See #5780.
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	fmt.Fprintf(os.Stderr, "testutils.Logger.Fatalf(%s): %s\n%s\n",
+		l.T.Name(), fmt.Sprintf(format, args...), buf[:n])
+	os.Exit(1)
 }


### PR DESCRIPTION
## Summary

Ref #5780.

`testutils.Logger.Fatalf` called `t.Fatalf()`, which invokes
`runtime.Goexit()`. Goexit only terminates the calling goroutine. When
Logger.Fatalf is called from a background goroutine (compaction, flush), this
silently kills that goroutine without cleaning up DB state, causing Close to
hang on `cond.Wait` indefinitely.

Change Logger.Fatalf to print the error with all goroutine stacks to stderr
and call `os.Exit(1)`, matching `DefaultLogger.Fatalf` behavior.

This does not fix the underlying invariant violation that triggers
Logger.Fatalf. It makes that violation visible with a stack trace instead of
masking it as an unrelated timeout.