### PR TITLE
compact: fix EncodeSpan error check in range delete path

### DIFF
--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -280,7 +280,7 @@ func (r *Runner) writeKeysToTable(
 		case base.InternalKeyKindRangeDelete:
 			// The previous span (if any) must end at or before this key, since the
 			// spans we receive are non-overlapping.
-			if err := tw.EncodeSpan(r.lastRangeDelSpan); r.err != nil {
+			if err := tw.EncodeSpan(r.lastRangeDelSpan); err != nil {
 				return nil, err
 			}
 			r.lastRangeDelSpan.CopyFrom(r.iter.Span())


### PR DESCRIPTION
When flushing the previous range delete span with `EncodeSpan`, the code checked `r.err` instead of the error returned from `EncodeSpan`, so failures from `EncodeSpan` were not propagated to the caller.