### PR TITLE
internal/keyspan: pass left and right to ShouldDefragment in checkEqual

### DIFF
--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -454,7 +454,7 @@ func (i *DefragmentingIter) Prev() (*Span, error) {
 // DefragmentMethod and ensures both spans are NOT empty; not defragmenting empty
 // spans is an optimization that lets us load fewer sstable blocks.
 func (i *DefragmentingIter) checkEqual(left, right *Span) bool {
-	return (!left.Empty() && !right.Empty()) && i.method.ShouldDefragment(i.comparer.CompareRangeSuffixes, i.iterSpan, &i.curr)
+	return (!left.Empty() && !right.Empty()) && i.method.ShouldDefragment(i.comparer.CompareRangeSuffixes, left, right)
 }
 
 // defragmentForward defragments spans in the forward direction, starting from


### PR DESCRIPTION
checkEqual compared `left` and `right` for emptiness but called `ShouldDefragment` with `i.iterSpan` and `i.curr` instead of the two spans being checked, so defragmentation decisions could be wrong.