### PR TITLE
db: use full path when stat-ing obsolete MANIFEST and OPTIONS files

### DIFF
--- a/obsolete_files.go
+++ b/obsolete_files.go
@@ -145,14 +145,15 @@ func (d *DB) scanObsoleteFiles(list []string, flushableIngests []*ingestedFlusha
 			continue
 		}
 		makeObsoleteFile := func() deletepacer.ObsoleteFile {
+			path := d.opts.FS.PathJoin(d.dirname, filename)
 			of := deletepacer.ObsoleteFile{
 				FileType:  fileType,
 				FS:        d.opts.FS,
-				Path:      d.opts.FS.PathJoin(d.dirname, filename),
+				Path:      path,
 				FileNum:   diskFileNum,
 				Placement: base.Local,
 			}
-			if stat, err := d.opts.FS.Stat(filename); err == nil {
+			if stat, err := d.opts.FS.Stat(path); err == nil {
 				of.FileSize = uint64(stat.Size())
 			}
 			return of

--- a/obsolete_files_test.go
+++ b/obsolete_files_test.go
@@ -19,6 +19,95 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestScanObsoleteFilesUsesFullPath verifies that scanObsoleteFiles uses
+// directory-qualified paths when Stat-ing obsolete MANIFEST and OPTIONS files.
+// Regression test for a bug where bare filenames (e.g. "MANIFEST-000001") were
+// passed to FS.Stat instead of the full path (e.g. "db/MANIFEST-000001"),
+// causing the Stat to resolve against the wrong directory on non-local
+// filesystems.
+func TestScanObsoleteFilesUsesFullPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	mem := vfs.NewMem()
+	dir := "db" // non-root dirname to exercise the path joining
+
+	// Open a DB, write some data, and flush to force MANIFEST rotation.
+	d, err := Open(dir, &Options{
+		FS:                 mem,
+		FormatMajorVersion: FormatNewest,
+		Logger:             testutils.Logger{T: t},
+	})
+	require.NoError(t, err)
+	require.NoError(t, d.Set([]byte("a"), []byte("1"), Sync))
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Set([]byte("b"), []byte("2"), Sync))
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Close())
+
+	// The directory should now contain at least one obsolete MANIFEST or
+	// OPTIONS file from the rotations above.
+	listing, err := mem.List(dir)
+	require.NoError(t, err)
+	var hasOldManifest, hasOldOptions bool
+	for _, name := range listing {
+		ft, _, ok := base.ParseFilename(mem, name)
+		if !ok {
+			continue
+		}
+		if ft == base.FileTypeManifest {
+			hasOldManifest = true
+		}
+		if ft == base.FileTypeOptions {
+			hasOldOptions = true
+		}
+	}
+	// Sanity check: we should have at least some MANIFEST/OPTIONS files.
+	require.True(t, hasOldManifest || hasOldOptions,
+		"expected at least one MANIFEST or OPTIONS file in %v", listing)
+
+	// Wrap the FS with a statTrackingFS that records all Stat calls and
+	// fails the test if any Stat is called with a bare filename (without
+	// the "db/" directory prefix).
+	tracker := &statTrackingFS{FS: mem, dir: dir, t: t}
+
+	// Reopen the DB — this triggers scanObsoleteFiles during Open.
+	d, err = Open(dir, &Options{
+		FS:                 tracker,
+		FormatMajorVersion: FormatNewest,
+		Logger:             testutils.Logger{T: t},
+		DisableTableStats:  true,
+	})
+	require.NoError(t, err)
+	d.TestOnlyWaitForCleaning()
+
+	// Verify we actually observed some Stat calls (the test is meaningful).
+	require.True(t, tracker.statCount > 0, "expected at least one Stat call")
+	require.NoError(t, d.Close())
+}
+
+// statTrackingFS wraps a vfs.FS and verifies that all Stat calls for MANIFEST
+// and OPTIONS files use directory-qualified paths.
+type statTrackingFS struct {
+	vfs.FS
+	dir       string
+	t         *testing.T
+	statCount int
+}
+
+func (fs *statTrackingFS) Stat(name string) (vfs.FileInfo, error) {
+	// Check if this is a MANIFEST or OPTIONS file by looking at the basename.
+	baseName := fs.FS.PathBase(name)
+	if strings.HasPrefix(baseName, "MANIFEST-") || strings.HasPrefix(baseName, "OPTIONS-") {
+		fs.statCount++
+		// The name must be prefixed with the database directory. A bare
+		// filename like "MANIFEST-000001" indicates the bug.
+		if !strings.HasPrefix(name, fs.dir+"/") {
+			fs.t.Errorf("Stat called with bare filename %q; expected %s/%s", name, fs.dir, baseName)
+		}
+	}
+	return fs.FS.Stat(name)
+}
+
 func TestCleaner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	dbs := make(map[string]*DB)


### PR DESCRIPTION
scanObsoleteFiles was calling FS.Stat with bare filenames (e.g. "MANIFEST-000001") instead of directory-qualified paths (e.g. "db/MANIFEST-000001"). On local disk this was harmless because the error was silently swallowed—FileSize stayed 0 but the file was still deleted. On non-local VFS implementations, the bare filename resolved against the wrong directory, producing spurious NotFound errors and wasted gRPC round-trips.

Fixes the Stat call to use the already-computed full path.