### PR TITLE
makefile: increase s390x QEMU test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ test-s390x-qemu:
 				lscpu | grep Endian && \
 				cd /pebble && \
 				go version && \
-				go test -tags '$(TAGS)' -timeout 30m ./..."
+				go test -tags '$(TAGS)' -timeout 60m ./..."
 
 .PHONY: gen-bazel
 gen-bazel:


### PR DESCRIPTION
Per Radu's suggestion (https://github.com/cockroachdb/pebble/issues/5686#issuecomment-3935025890), increase the s390x QEMU test timeout from 30m to 60m to accommodate the slowness of QEMU user-mode emulation.

Fixes #5833.