### PR TITLE
manifest: track regions containing range key sets

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -2533,6 +2533,7 @@ func (d *DB) runCopyCompaction(
 	}
 	if inputMeta.HasRangeKeys {
 		newMeta.ExtendRangeKeyBounds(c.comparer.Compare,
+			inputMeta.RangeKeyKinds,
 			inputMeta.RangeKeyBounds.Smallest(),
 			inputMeta.RangeKeyBounds.Largest())
 	}
@@ -3006,7 +3007,11 @@ func (c *tableCompaction) makeVersionEdit(result compact.Result) (*manifest.Vers
 				t.WriterMeta.LargestRangeDel)
 		}
 		if t.WriterMeta.HasRangeKeys {
-			fileMeta.ExtendRangeKeyBounds(c.comparer.Compare,
+			kinds := manifest.AnyRangeKeys
+			if t.WriterMeta.Properties.NumRangeKeySets == 0 {
+				kinds = manifest.OnlyRangeKeyUnsetAndDelete
+			}
+			fileMeta.ExtendRangeKeyBounds(c.comparer.Compare, kinds,
 				t.WriterMeta.SmallestRangeKey,
 				t.WriterMeta.LargestRangeKey)
 		}

--- a/excise.go
+++ b/excise.go
@@ -277,7 +277,7 @@ func looseLeftTableBounds(
 		if largestRangeKey.IsUpperBoundFor(cmp, exciseSpanStart) {
 			largestRangeKey = base.MakeExclusiveSentinelKey(InternalKeyKindRangeKeyMin, exciseSpanStart)
 		}
-		leftTable.ExtendRangeKeyBounds(cmp, originalTable.RangeKeyBounds.Smallest(), largestRangeKey)
+		leftTable.ExtendRangeKeyBounds(cmp, originalTable.RangeKeyKinds, originalTable.RangeKeyBounds.Smallest(), largestRangeKey)
 	}
 }
 
@@ -305,7 +305,7 @@ func looseRightTableBounds(
 		if !smallestRangeKey.IsUpperBoundFor(cmp, exciseSpanEnd) {
 			smallestRangeKey = base.MakeInternalKey(exciseSpanEnd, 0, base.InternalKeyKindRangeKeyMax)
 		}
-		rightTable.ExtendRangeKeyBounds(cmp, smallestRangeKey, originalTable.RangeKeyBounds.Largest())
+		rightTable.ExtendRangeKeyBounds(cmp, originalTable.RangeKeyKinds, smallestRangeKey, originalTable.RangeKeyBounds.Largest())
 	}
 }
 
@@ -354,7 +354,7 @@ func determineLeftTableBounds(
 				// The key is owned by the range key iter, so we need to copy it.
 				lastRangeKey = slices.Clone(rkey.End)
 			}
-			leftTable.ExtendRangeKeyBounds(cmp, originalTable.RangeKeyBounds.Smallest(),
+			leftTable.ExtendRangeKeyBounds(cmp, originalTable.RangeKeyKinds, originalTable.RangeKeyBounds.Smallest(),
 				base.MakeExclusiveSentinelKey(rkey.LargestKey().Kind(), lastRangeKey))
 		}
 	}
@@ -417,7 +417,7 @@ func determineRightTableBounds(
 			} else if exciseSpanEnd.Kind != base.Exclusive {
 				return base.AssertionFailedf("cannot truncate range key during excise with an inclusive upper bound")
 			}
-			rightTable.ExtendRangeKeyBounds(cmp, base.InternalKey{
+			rightTable.ExtendRangeKeyBounds(cmp, originalTable.RangeKeyKinds, base.InternalKey{
 				UserKey: firstRangeKey,
 				Trailer: rkey.SmallestKey().Trailer,
 			}, originalTable.RangeKeyBounds.Largest())

--- a/excise_test.go
+++ b/excise_test.go
@@ -826,7 +826,7 @@ func TestExciseBounds(t *testing.T) {
 				m.ExtendPointKeyBounds(cmp, sstMeta.SmallestRangeDel, sstMeta.LargestRangeDel)
 			}
 			if sstMeta.HasRangeKeys {
-				m.ExtendRangeKeyBounds(cmp, sstMeta.SmallestRangeKey, sstMeta.LargestRangeKey)
+				m.ExtendRangeKeyBounds(cmp, manifest.AnyRangeKeys, sstMeta.SmallestRangeKey, sstMeta.LargestRangeKey)
 			}
 			printBounds("Bounds", m)
 

--- a/ingest.go
+++ b/ingest.go
@@ -114,7 +114,7 @@ func ingestSynthesizeShared(
 		// kinds here.
 		smallestRangeKey := base.MakeInternalKey(sm.SmallestRangeKey.UserKey, 0, base.InternalKeyKindRangeKeyMax)
 		largestRangeKey := base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeyMin, sm.LargestRangeKey.UserKey)
-		meta.ExtendRangeKeyBounds(opts.Comparer.Compare, smallestRangeKey, largestRangeKey)
+		meta.ExtendRangeKeyBounds(opts.Comparer.Compare, manifest.AnyRangeKeys, smallestRangeKey, largestRangeKey)
 	}
 
 	// For simplicity, we use the same number for both the FileNum and the
@@ -188,6 +188,7 @@ func ingestLoad1External(
 	if e.HasRangeKey {
 		meta.ExtendRangeKeyBounds(
 			opts.Comparer.Compare,
+			manifest.AnyRangeKeys,
 			base.MakeInternalKey(smallestCopy, 0, InternalKeyKindRangeKeyMax),
 			base.MakeExclusiveSentinelKey(InternalKeyKindRangeKeyMin, largestCopy),
 		)
@@ -464,7 +465,11 @@ func ingestLoad1(
 				// As range keys are fragmented, the end key of the last range key in
 				// the table provides the upper bound for the table.
 				largest := s.LargestKey().Clone()
-				meta.ExtendRangeKeyBounds(opts.Comparer.Compare, smallest, largest)
+				kinds := manifest.AnyRangeKeys
+				if props.NumRangeKeySets == 0 {
+					kinds = manifest.OnlyRangeKeyUnsetAndDelete
+				}
+				meta.ExtendRangeKeyBounds(opts.Comparer.Compare, kinds, smallest, largest)
 				res.lastRangeKey = s.Clone()
 			} else {
 				// s == nil.

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -3235,6 +3235,7 @@ func TestIngest_UpdateSequenceNumber(t *testing.T) {
 			if wm.HasRangeKeys {
 				m.ExtendRangeKeyBounds(
 					cmp,
+					manifest.AnyRangeKeys,
 					wm.SmallestRangeKey,
 					maybeUpdateUpperBound(wm.LargestRangeKey),
 				)

--- a/internal/keyspan/keyspanimpl/level_iter_test.go
+++ b/internal/keyspan/keyspanimpl/level_iter_test.go
@@ -300,7 +300,7 @@ func TestLevelIterEquivalence(t *testing.T) {
 				meta.RangeKeyBounds.SetInternalKeyBounds(
 					base.MakeInternalKey(file[0].Start, file[0].SmallestKey().SeqNum(), file[0].SmallestKey().Kind()),
 					base.MakeExclusiveSentinelKey(file[len(file)-1].LargestKey().Kind(), file[len(file)-1].End))
-				meta.ExtendRangeKeyBounds(base.DefaultComparer.Compare, meta.RangeKeyBounds.Smallest(), meta.RangeKeyBounds.Largest())
+				meta.ExtendRangeKeyBounds(base.DefaultComparer.Compare, manifest.AnyRangeKeys, meta.RangeKeyBounds.Smallest(), meta.RangeKeyBounds.Largest())
 				metas = append(metas, meta)
 			}
 
@@ -388,7 +388,7 @@ func TestLevelIter(t *testing.T) {
 							meta.ExtendPointKeyBounds(cmp, start, end)
 						case "range-key-bounds":
 							start, end := base.ParseInternalKeyRange(val)
-							meta.ExtendRangeKeyBounds(cmp, start, end)
+							meta.ExtendRangeKeyBounds(cmp, manifest.AnyRangeKeys, start, end)
 						default:
 							d.Fatalf(t, "unknown argument %q", arg)
 						}
@@ -405,7 +405,7 @@ func TestLevelIter(t *testing.T) {
 					f.meta.ExtendPointKeyBounds(cmp, smallest, largest)
 				} else {
 					f.rangeKeys = append(f.rangeKeys, span)
-					f.meta.ExtendRangeKeyBounds(cmp, smallest, largest)
+					f.meta.ExtendRangeKeyBounds(cmp, manifest.AnyRangeKeys, smallest, largest)
 				}
 			}
 			var strs []string

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -986,6 +986,7 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 				p.Expect(";", "nosets")
 				m.RangeKeyKinds = OnlyRangeKeyUnsetAndDelete
 			} else {
+				// Default: assume range key sets exist.
 				m.RangeKeyKinds = AnyRangeKeys
 			}
 

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -168,12 +168,26 @@ type TableMetadata struct {
 	// file must be part of a compaction to Lbase.
 	IsIntraL0Compacting bool
 	CompactionState     CompactionState
-	// HasPointKeys tracks whether the table contains point keys (including
-	// RANGEDELs). If a table contains only range deletions, HasPointsKeys is
-	// still true.
+	// HasPointKeys tracks whether the table (possibly) contains point keys
+	// (including RANGEDELs). If a table contains only range deletions,
+	// HasPointsKeys is still true.
+	//
+	// For virtual tables, it can be true even if no point keys are visible in the
+	// virtual table.
 	HasPointKeys bool
-	// HasRangeKeys tracks whether the table contains any range keys.
+	// HasRangeKeys tracks whether the table (possibly) contains any range keys.
+	//
+	// For virtual tables, it can be true even if no range keys are visible in the
+	// virtual table.
+	//
+	// Equivalent to RangeKeyKinds != NoRangeKeys; kept as a separate convenience
+	// field for symmetry with HasPointKeys.
 	HasRangeKeys bool
+	// RangeKeyKinds describes which kinds of range keys may be present in the
+	// table. In some cases (older manifests, external/virtual tables) we don't
+	// have full information; in those cases AnyRangeKeys is used as a defensive
+	// default whenever the table is known to have range keys.
+	RangeKeyKinds RangeKeyKinds
 	// Virtual is true if the TableMetadata belongs to a virtual sstable.
 	Virtual bool
 	// boundsSet track whether the overall bounds have been set.
@@ -188,6 +202,36 @@ type TableMetadata struct {
 	// SyntheticPrefix is used to prepend a prefix to all keys and/or override all
 	// suffixes in a table; used for some virtual tables.
 	SyntheticPrefixAndSuffix sstable.SyntheticPrefixAndSuffix
+}
+
+// RangeKeyKinds describes which kinds of range keys may be present in a table.
+type RangeKeyKinds uint8
+
+const (
+	// NoRangeKeys indicates that the table contains no range keys.
+	NoRangeKeys RangeKeyKinds = iota
+	// OnlyRangeKeyUnsetAndDelete indicates that the table contains range keys,
+	// but only of the RANGEKEYUNSET and RANGEKEYDELETE kinds (no
+	// RANGEKEYSETs).
+	OnlyRangeKeyUnsetAndDelete
+	// AnyRangeKeys indicates that the table may contain range keys of any
+	// kind, including RANGEKEYSETs. This is the default when we don't know
+	// for sure (e.g. older manifests, external/virtual tables).
+	AnyRangeKeys
+)
+
+// String implements fmt.Stringer.
+func (r RangeKeyKinds) String() string {
+	switch r {
+	case NoRangeKeys:
+		return "NoRangeKeys"
+	case OnlyRangeKeyUnsetAndDelete:
+		return "OnlyRangeKeyUnsetAndDelete"
+	case AnyRangeKeys:
+		return "AnyRangeKeys"
+	default:
+		return fmt.Sprintf("RangeKeyKinds(%d)", uint8(r))
+	}
 }
 
 // Ref increments the table's ref count. If this is the table's first reference,
@@ -628,18 +672,30 @@ func (m *TableMetadata) ExtendPointKeyBounds(
 // ExtendRangeKeyBounds attempts to extend the lower and upper range key bounds
 // and overall table bounds with the given smallest and largest keys. The
 // smallest and largest bounds may not be extended if the table already has a
-// bound that is smaller or larger, respectively. The receiver is returned.
+// bound that is smaller or larger, respectively. The kinds describe which
+// range key kinds are (potentially) present in the new bounds; the resulting
+// RangeKeyKinds field is the maximum of the existing and new values, so a
+// later call cannot downgrade an existing AnyRangeKeys. Callers without
+// precise information should pass AnyRangeKeys defensively. The receiver is
+// returned.
 // NB: calling this method should be preferred to manually setting the bounds by
 // manipulating the fields directly, to maintain certain invariants.
 func (m *TableMetadata) ExtendRangeKeyBounds(
-	cmp Compare, smallest, largest InternalKey,
+	cmp Compare, kinds RangeKeyKinds, smallest, largest InternalKey,
 ) *TableMetadata {
+	if invariants.Enabled && kinds == NoRangeKeys {
+		panic(errors.AssertionFailedf("ExtendRangeKeyBounds called with NoRangeKeys"))
+	}
 	// Update the range key bounds.
 	if !m.HasRangeKeys {
 		m.RangeKeyBounds = &InternalKeyBounds{}
 		m.RangeKeyBounds.SetInternalKeyBounds(smallest, largest)
 		m.HasRangeKeys = true
+		m.RangeKeyKinds = kinds
 	} else {
+		if kinds > m.RangeKeyKinds {
+			m.RangeKeyKinds = kinds
+		}
 		isSmallestRange := base.InternalCompare(cmp, smallest, m.RangeKeyBounds.Smallest()) < 0
 		isLargestRange := base.InternalCompare(cmp, largest, m.RangeKeyBounds.Largest()) > 0
 		if isSmallestRange && isLargestRange {
@@ -833,6 +889,9 @@ func (m *TableMetadata) DebugString(format base.FormatKey, verbose bool) string 
 	if m.HasRangeKeys {
 		fmt.Fprintf(&b, " ranges:[%s-%s]",
 			m.RangeKeyBounds.Smallest().Pretty(format), m.RangeKeyBounds.Largest().Pretty(format))
+		if m.RangeKeyKinds == OnlyRangeKeyUnsetAndDelete {
+			fmt.Fprintf(&b, ";nosets")
+		}
 	}
 	if m.Size != 0 {
 		fmt.Fprintf(&b, " size:%d", m.Size)
@@ -923,6 +982,12 @@ func ParseTableMetadataDebug(s string) (_ *TableMetadata, err error) {
 			m.RangeKeyBounds.SetInternalKeyBounds(smallest, p.InternalKey())
 			m.HasRangeKeys = true
 			p.Expect("]")
+			if !p.Done() && p.Peek() == ";" {
+				p.Expect(";", "nosets")
+				m.RangeKeyKinds = OnlyRangeKeyUnsetAndDelete
+			} else {
+				m.RangeKeyKinds = AnyRangeKeys
+			}
 
 		case "size":
 			m.Size = p.Uint64()
@@ -1036,6 +1101,15 @@ func (m *TableMetadata) Validate(cmp Compare, formatKey base.FormatKey) error {
 
 	// Range key validation.
 
+	if m.RangeKeyKinds > AnyRangeKeys {
+		return base.CorruptionErrorf("file %s has invalid RangeKeyKinds value %d",
+			errors.Safe(m.TableNum), uint8(m.RangeKeyKinds))
+	}
+	if m.HasRangeKeys != (m.RangeKeyKinds != NoRangeKeys) {
+		return base.CorruptionErrorf(
+			"file %s has inconsistent range key state: HasRangeKeys=%t, RangeKeyKinds=%s",
+			errors.Safe(m.TableNum), m.HasRangeKeys, m.RangeKeyKinds)
+	}
 	if m.HasRangeKeys {
 		if base.InternalCompare(cmp, m.RangeKeyBounds.Smallest(), m.RangeKeyBounds.Largest()) > 0 {
 			return base.CorruptionErrorf("file %s has inconsistent range key bounds: %s vs %s",

--- a/internal/manifest/table_metadata_test.go
+++ b/internal/manifest/table_metadata_test.go
@@ -78,7 +78,7 @@ func TestExtendBounds(t *testing.T) {
 			return format(m)
 		case "extend-range-key-bounds":
 			u, l := parseBounds(d.Input)
-			m.ExtendRangeKeyBounds(cmp, u, l)
+			m.ExtendRangeKeyBounds(cmp, AnyRangeKeys, u, l)
 			return format(m)
 		default:
 			return fmt.Sprintf("unknown command %s\n", d.Cmd)
@@ -192,7 +192,7 @@ func TestTableMetadataSize(t *testing.T) {
 		t.Skip("Test only supported on amd64 and arm64 architectures")
 	}
 
-	const tableMetadataSize = 208
+	const tableMetadataSize = 216
 	if structSize := unsafe.Sizeof(TableMetadata{}); structSize != tableMetadataSize {
 		t.Errorf("TableMetadata struct size (%d bytes) is not expected size (%d bytes)",
 			structSize, tableMetadataSize)

--- a/internal/manifest/testdata/version_check_ordering
+++ b/internal/manifest/testdata/version_check_ordering
@@ -239,6 +239,7 @@ L0 files 000001 and 000002 are not properly ordered: [#3-#inf] vs [#1-#inf]
 L0.0:
   000001:[a#3,RANGEKEYSET-b#inf,RANGEKEYSET] seqnums:[#3-#inf] ranges:[a#3,RANGEKEYSET-b#inf,RANGEKEYSET]
   000002:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[#1-#inf] ranges:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+Range key set regions: [a, b)=1 [c, d)=1
 
 check-ordering
 L1:
@@ -256,6 +257,7 @@ L1 files 000001 and 000002 are not properly ordered: [c#3,RANGEKEYSET-d#inf,RANG
 L1:
   000001:[c#3,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[#0-#0] ranges:[c#3,RANGEKEYSET-d#inf,RANGEKEYSET]
   000002:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET] seqnums:[#0-#0] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
+Range key set regions: [a, b)=1 [c, d)=1
 
 # Ordering considers tables with both point and range keys.
 
@@ -276,6 +278,7 @@ L0.1:
   000002:[c#1,RANGEKEYSET-e#2,SET] seqnums:[#1-#2] points:[d#3,SET-e#2,SET] ranges:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET]
 L0.0:
   000001:[a#1,RANGEKEYSET-c#4,SET] seqnums:[#1-#4] points:[b#1,SET-c#4,SET] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
+Range key set regions: [a, b)=1 [c, d)=1
 
 check-ordering
 L1:
@@ -293,3 +296,4 @@ L1 files 000001 and 000002 have overlapping ranges: [a#1,RANGEKEYSET-c#2,SET] vs
 L1:
   000001:[a#1,RANGEKEYSET-c#2,SET] seqnums:[#0-#0] points:[b#1,SET-c#2,SET] ranges:[a#1,RANGEKEYSET-b#inf,RANGEKEYSET]
   000002:[c#3,RANGEKEYSET-f#4,SET] seqnums:[#0-#0] points:[e#3,SET-f#4,SET] ranges:[c#3,RANGEKEYSET-e#inf,RANGEKEYSET]
+Range key set regions: [a, b)=1 [c, e)=1

--- a/internal/manifest/testdata/version_edit_apply
+++ b/internal/manifest/testdata/version_edit_apply
@@ -376,3 +376,135 @@ apply v12
   add-table: L2 000007:[f#3,SET-h#2,SET]
 ----
 pebble: internal error: L2 files 000007 and 000003 have overlapping ranges: [f#3,SET-h#2,SET] vs [f#1,SET-g#2,SET]
+
+# Range key set regions tests.
+
+# Define a version with tables that have range keys (default RangeKeyKinds=AnyRangeKeys).
+define rk1
+L1:
+  000001:[a#1,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[#1-#1] points:[a#1,SET-c#1,SET] ranges:[a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+----
+L1:
+  000001:[a#1,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[#1-#1] points:[a#1,SET-c#1,SET] ranges:[a#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+Range key set regions: [a, d)=1 [e, h)=1
+
+# Apply an edit replacing table 1 with another table with a shorter range key span.
+apply rk1 name=rk2
+  add-table: L1 000003:[b#3,RANGEKEYSET-c#inf,RANGEKEYSET] seqnums:[#3-#3] points:[b#3,SET-b#3,SET] ranges:[b#3,RANGEKEYSET-c#inf,RANGEKEYSET]
+  del-table: L1 000001
+----
+L1:
+  000003:[b#3,RANGEKEYSET-c#inf,RANGEKEYSET] seqnums:[#3-#3] points:[b#3,SET-b#3,SET] ranges:[b#3,RANGEKEYSET-c#inf,RANGEKEYSET]
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+Range key set regions: [b, c)=1 [e, h)=1
+
+apply rk2
+  del-table: L1 000002
+----
+L1:
+  000003:[b#3,RANGEKEYSET-c#inf,RANGEKEYSET] seqnums:[#3-#3] points:[b#3,SET-b#3,SET] ranges:[b#3,RANGEKEYSET-c#inf,RANGEKEYSET]
+Range key set regions: [b, c)=1
+
+apply rk2
+  del-table: L1 000003
+----
+L1:
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+Range key set regions: [e, h)=1
+
+# Tables with no range key sets do NOT contribute to the region tree.
+define rk3
+L1:
+  000001:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET] seqnums:[#1-#1] points:[a#1,SET-c#1,SET] ranges:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET];nosets
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+----
+L1:
+  000001:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET] seqnums:[#1-#1] points:[a#1,SET-c#1,SET] ranges:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET];nosets
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+Range key set regions: [e, h)=1
+
+# Adding a table with no range key sets does not affect the region tree.
+apply rk3 name=rk4
+  add-table: L1 000003:[i#3,RANGEKEYUNSET-k#inf,RANGEKEYUNSET] seqnums:[#3-#3] points:[i#3,SET-j#3,SET] ranges:[i#3,RANGEKEYUNSET-k#inf,RANGEKEYUNSET];nosets
+----
+L1:
+  000001:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET] seqnums:[#1-#1] points:[a#1,SET-c#1,SET] ranges:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET];nosets
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+  000003:[i#3,RANGEKEYUNSET-k#inf,RANGEKEYUNSET] seqnums:[#3-#3] points:[i#3,SET-j#3,SET] ranges:[i#3,RANGEKEYUNSET-k#inf,RANGEKEYUNSET];nosets
+Range key set regions: [e, h)=1
+
+# Removing a table without range key sets does not affect the region tree.
+apply rk4
+  del-table: L1 000001
+----
+L1:
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+  000003:[i#3,RANGEKEYUNSET-k#inf,RANGEKEYUNSET] seqnums:[#3-#3] points:[i#3,SET-j#3,SET] ranges:[i#3,RANGEKEYUNSET-k#inf,RANGEKEYUNSET];nosets
+Range key set regions: [e, h)=1
+
+# Replace a table that has range key sets with one that does not; region should disappear.
+apply rk3
+  del-table: L1 000002
+  add-table: L1 000004:[e#4,RANGEKEYUNSET-h#inf,RANGEKEYUNSET] seqnums:[#4-#4] points:[e#4,SET-f#4,SET] ranges:[e#4,RANGEKEYUNSET-h#inf,RANGEKEYUNSET];nosets
+----
+L1:
+  000001:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET] seqnums:[#1-#1] points:[a#1,SET-c#1,SET] ranges:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET];nosets
+  000004:[e#4,RANGEKEYUNSET-h#inf,RANGEKEYUNSET] seqnums:[#4-#4] points:[e#4,SET-f#4,SET] ranges:[e#4,RANGEKEYUNSET-h#inf,RANGEKEYUNSET];nosets
+
+# Replace a table without range key sets with one that has them.
+apply rk3
+  del-table: L1 000001
+  add-table: L1 000005:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[#5-#5] points:[a#5,SET-c#5,SET] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET]
+----
+L1:
+  000005:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[#5-#5] points:[a#5,SET-c#5,SET] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET]
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+Range key set regions: [a, d)=1 [e, h)=1
+
+# Add a table that adds overlapping regions.
+apply rk3 name=rk5
+  add-table: L2 000006: [a#2,RANGEKEYSET-u#inf,RANGEKEYSET] seqnums:[#2-#2] ranges:[a#5,RANGEKEYSET-u#inf,RANGEKEYSET]
+----
+L1:
+  000001:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET] seqnums:[#1-#1] points:[a#1,SET-c#1,SET] ranges:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET];nosets
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+L2:
+  000006:[#0,DEL-u#inf,RANGEKEYSET] seqnums:[#2-#2] ranges:[a#5,RANGEKEYSET-u#inf,RANGEKEYSET]
+Range key set regions: [a, e)=1 [e, h)=2 [h, u)=1
+
+# Add another table that adds overlapping regions.
+apply rk5 name=rk6
+  add-table: L3 000007: [f#1,RANGEKEYSET-z#inf,RANGEKEYSET] seqnums:[#1-#1] ranges:[f#5,RANGEKEYSET-z#inf,RANGEKEYSET]
+----
+L1:
+  000001:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET] seqnums:[#1-#1] points:[a#1,SET-c#1,SET] ranges:[a#1,RANGEKEYUNSET-d#inf,RANGEKEYUNSET];nosets
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+L2:
+  000006:[#0,DEL-u#inf,RANGEKEYSET] seqnums:[#2-#2] ranges:[a#5,RANGEKEYSET-u#inf,RANGEKEYSET]
+L3:
+  000007:[#0,DEL-z#inf,RANGEKEYSET] seqnums:[#1-#1] ranges:[f#5,RANGEKEYSET-z#inf,RANGEKEYSET]
+Range key set regions: [a, e)=1 [e, f)=2 [f, h)=3 [h, u)=2 [u, z)=1
+
+# Remove some tables.
+apply rk6 name=rk7
+  del-table: L1 000001
+  del-table: L3 000007
+----
+L1:
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+L2:
+  000006:[#0,DEL-u#inf,RANGEKEYSET] seqnums:[#2-#2] ranges:[a#5,RANGEKEYSET-u#inf,RANGEKEYSET]
+Range key set regions: [a, e)=1 [e, h)=2 [h, u)=1
+
+apply rk7 name=rk8
+  del-table: L2 000006
+----
+L1:
+  000002:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET] seqnums:[#2-#2] points:[e#2,SET-f#2,SET] ranges:[e#2,RANGEKEYSET-h#inf,RANGEKEYSET]
+Range key set regions: [e, h)=1
+
+apply rk8 name=rk9
+  del-table: L1 000002
+----

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/RaduBerinde/axisds/v3"
+	"github.com/RaduBerinde/axisds/v3/regiontree"
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -67,8 +69,9 @@ const NumLevels = 7
 // NewInitialVersion creates a version with no files. The L0Organizer should be freshly created.
 func NewInitialVersion(comparer *base.Comparer) *Version {
 	v := &Version{
-		cmp:       comparer,
-		BlobFiles: MakeBlobFileSet(nil),
+		cmp:                comparer,
+		BlobFiles:          MakeBlobFileSet(nil),
+		RangeKeySetRegions: makeRangeKeySetRegions(comparer),
 	}
 	for level := range v.Levels {
 		v.Levels[level] = MakeLevelMetadata(comparer.Compare, level, nil /* files */)
@@ -84,8 +87,9 @@ func NewVersionForTesting(
 	comparer *base.Comparer, l0Organizer *L0Organizer, files [7][]*TableMetadata,
 ) *Version {
 	v := &Version{
-		cmp:       comparer,
-		BlobFiles: MakeBlobFileSet(nil),
+		cmp:                comparer,
+		BlobFiles:          MakeBlobFileSet(nil),
+		RangeKeySetRegions: makeRangeKeySetRegions(comparer),
 	}
 	for l := range files {
 		// NB: We specifically insert `files` into the B-Tree in the order
@@ -100,11 +104,20 @@ func NewVersionForTesting(
 		} else {
 			v.Levels[l].tree.bcmp = btreeCmpSmallestKey(comparer.Compare)
 		}
+		v.RangeKeyLevels[l] = MakeLevelMetadata(comparer.Compare, l, nil)
 		for _, f := range files[l] {
 			v.Levels[l].totalTableSize += f.Size
 			v.Levels[l].totalRefSize += f.EstimatedReferenceSize()
 			if f.Virtual {
 				v.Levels[l].virtualTables.Inc(f.Size)
+			}
+			if f.HasRangeKeys {
+				if err := v.RangeKeyLevels[l].insert(f); err != nil {
+					panic(err)
+				}
+				if f.RangeKeyKinds == AnyRangeKeys {
+					addToRangeKeySetRegions(&v.RangeKeySetRegions, f)
+				}
 			}
 		}
 	}
@@ -158,6 +171,11 @@ type Version struct {
 	// MarkedForCompaction holds the set of tables that are marked for compaction.
 	MarkedForCompaction MarkedForCompactionSet
 
+	// RangeKeySetRegions tracks regions that may contain range-key-sets. The
+	// property is the number of tables with RangeKeyKinds=AnyRangeKeys whose
+	// range-key bounds overlap the region.
+	RangeKeySetRegions regiontree.T[[]byte, int]
+
 	// The callback to invoke when the last reference to a version is
 	// removed. Will be called with list.mu held.
 	Deleted func(obsolete ObsoleteFiles)
@@ -173,6 +191,39 @@ type Version struct {
 
 func (v *Version) Comparer() *base.Comparer {
 	return v.cmp
+}
+
+func makeRangeKeySetRegions(comparer *base.Comparer) regiontree.T[[]byte, int] {
+	return regiontree.Make(
+		axisds.CompareFn[[]byte](comparer.Compare),
+		func(a, b int) bool { return a == b },
+	)
+}
+
+// rangeKeySetRegionBounds returns the [start, end) user key bounds of a table's
+// range keys for use with the RangeKeySetRegions tree. The table must have range
+// keys (HasRangeKeys=true).
+func rangeKeySetRegionBounds(f *TableMetadata) (start, end []byte) {
+	bounds := f.UserKeyBoundsByType(KeyTypeRange)
+	// Range key bounds should always have an exclusive end.
+	if bounds.End.Kind != base.Exclusive {
+		panic(errors.AssertionFailedf("range key bounds have inclusive end for table %s", f.TableNum))
+	}
+	return bounds.Start, bounds.End.Key
+}
+
+// addToRangeKeySetRegions increments the RangeKeySetRegions tree for a table
+// with RangeKeyKinds=AnyRangeKeys.
+func addToRangeKeySetRegions(tree *regiontree.T[[]byte, int], f *TableMetadata) {
+	start, end := rangeKeySetRegionBounds(f)
+	tree.Update(start, end, func(p int) int { return p + 1 })
+}
+
+// removeFromRangeKeySetRegions decrements the RangeKeySetRegions tree for a
+// table with RangeKeyKinds=AnyRangeKeys.
+func removeFromRangeKeySetRegions(tree *regiontree.T[[]byte, int], f *TableMetadata) {
+	start, end := rangeKeySetRegionBounds(f)
+	tree.Update(start, end, func(p int) int { return p - 1 })
 }
 
 // String implements fmt.Stringer, printing the TableMetadata for each level in
@@ -232,6 +283,22 @@ func (v *Version) string(fmtKey base.FormatKey, verbose bool) string {
 		for f := range v.BlobFiles.All() {
 			fmt.Fprintf(&buf, "  %s\n", f.String())
 		}
+	}
+	if !v.RangeKeySetRegions.IsEmpty() {
+		iFmt := axisds.MakeIntervalFormatter(func(b []byte) string {
+			return fmt.Sprint(fmtKey(b))
+		})
+		fmt.Fprintf(&buf, "Range key set regions:")
+		n := 0
+		for interval, prop := range v.RangeKeySetRegions.All() {
+			if n >= 20 {
+				fmt.Fprintf(&buf, " ...")
+				break
+			}
+			fmt.Fprintf(&buf, " %s=%d", iFmt(interval), prop)
+			n++
+		}
+		fmt.Fprintln(&buf)
 	}
 	return buf.String()
 }

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -62,15 +62,30 @@ const (
 	tagRemovedBackingTable = 106
 	tagNewBlobFile         = 107
 	tagDeletedBlobFile     = 108
+)
 
-	// The custom tags sub-format used by tagNewFile4 and above. All tags less
-	// than customTagNonSafeIgnoreMask are safe to ignore and their format must be
-	// a single bytes field.
-	customTagTerminate         = 1
-	customTagNeedsCompaction   = 2
-	customTagCreationTime      = 6
-	customTagPathID            = 65
+// Custom tags used by tagNewFile4 and above.
+const (
+	// customTagTerminate is a sentinel value used to indicate the end of the
+	// custom tags section.
+	customTagTerminate = 1
+
+	// Flags with values below customTagNonSafeIgnoreMask are safe to ignore;
+	// their format is always a single bytes field.
+
+	// customTagNeedsCompaction is deprecated.
+	customTagNeedsCompaction = 2
+	// customTagCreationTime contains the file creation time. The bytes value
+	// contains a 64-bit uvarint. See TableMetadata.CreationTime.
+	customTagCreationTime = 6
+	// customTagNoRangeKeySets appears when a file has range keys but is known to
+	// have no RANGEKEYSETs. The bytes value is empty. See
+	// TableMatadata.RangeKeyKinds.
+	customTagNoRangeKeySets = 7
+
+	// All custom tags below are not safe to ignore.
 	customTagNonSafeIgnoreMask = 1 << 6
+	customTagPathID            = 65
 	customTagVirtual           = 66
 	customTagSyntheticPrefix   = 67
 	customTagSyntheticSuffix   = 68
@@ -405,6 +420,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				virtual        bool
 				backingFileNum uint64
 			}{}
+			var noRangeKeySets bool
 			var syntheticPrefix sstable.SyntheticPrefix
 			var syntheticSuffix sstable.SyntheticSuffix
 			var blobReferences BlobReferences
@@ -445,6 +461,16 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 						if n != len(field) {
 							return base.CorruptionErrorf("new-file4: invalid file creation time")
 						}
+
+					case customTagNoRangeKeySets:
+						field, err := d.readBytes()
+						if err != nil {
+							return err
+						}
+						if len(field) != 0 {
+							return base.CorruptionErrorf("new-file4: invalid no-range-key-sets value")
+						}
+						noRangeKeySets = true
 
 					case customTagPathID:
 						return base.CorruptionErrorf("new-file4: path-id field not supported")
@@ -543,6 +569,14 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				m.RangeKeyBounds.SetInternalKeyBounds(base.DecodeInternalKey(smallestRangeKey),
 					base.DecodeInternalKey(largestRangeKey))
 				m.HasRangeKeys = true
+				// Note that older encodings will not have the customTagNoRangeKeySets;
+				// in this case we have to assume that the table can contain any range
+				// keys (and accept the possibility of a false positive).
+				if noRangeKeySets {
+					m.RangeKeyKinds = OnlyRangeKeyUnsetAndDelete
+				} else {
+					m.RangeKeyKinds = AnyRangeKeys
+				}
 				// Set overall bounds (by default assume range keys).
 				m.boundTypeSmallest, m.boundTypeLargest = boundTypeRangeKey, boundTypeRangeKey
 				if boundsMarker&maskSmallest == maskSmallest {
@@ -884,7 +918,7 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 		e.writeUvarint(uint64(x.FileNum))
 	}
 	for _, x := range v.NewTables {
-		customFields := x.Meta.CreationTime != 0 || x.Meta.Virtual || len(x.Meta.BlobReferences) > 0
+		customFields := x.Meta.CreationTime != 0 || x.Meta.Virtual || len(x.Meta.BlobReferences) > 0 || x.Meta.RangeKeyKinds == OnlyRangeKeyUnsetAndDelete
 		var tag uint64
 		switch {
 		case x.Meta.HasRangeKeys:
@@ -934,6 +968,10 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 				var buf [binary.MaxVarintLen64]byte
 				n := binary.PutUvarint(buf[:], uint64(x.Meta.CreationTime))
 				e.writeBytes(buf[:n])
+			}
+			if x.Meta.RangeKeyKinds == OnlyRangeKeyUnsetAndDelete {
+				e.writeUvarint(customTagNoRangeKeySets)
+				e.writeBytes(nil)
 			}
 			if x.Meta.Virtual {
 				e.writeUvarint(customTagVirtual)

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1344,6 +1344,7 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 	v := &Version{
 		BlobFiles:           curr.BlobFiles.clone(),
 		MarkedForCompaction: curr.MarkedForCompaction.Clone(),
+		RangeKeySetRegions:  curr.RangeKeySetRegions.Clone(),
 		cmp:                 comparer,
 	}
 
@@ -1403,6 +1404,9 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 				}
 			}
 			v.RangeKeyLevels[level].remove(f)
+			if f.RangeKeyKinds == AnyRangeKeys {
+				removeFromRangeKeySetRegions(&v.RangeKeySetRegions, f)
+			}
 			v.MarkedForCompaction.Delete(f, level)
 		}
 
@@ -1455,6 +1459,9 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 				err = lmRange.insert(f)
 				if err != nil {
 					return nil, errors.Wrap(err, "pebble")
+				}
+				if f.RangeKeyKinds == AnyRangeKeys {
+					addToRangeKeySetRegions(&v.RangeKeySetRegions, f)
 				}
 			}
 			// Track the keys with the smallest and largest keys, so that we can

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -67,6 +67,7 @@ func TestVERoundTripAndAccumulate(t *testing.T) {
 		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindSet),
 	).ExtendRangeKeyBounds(
 		cmp,
+		AnyRangeKeys,
 		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
 		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
 	)
@@ -228,6 +229,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		CreationTime: 807050,
 	}).ExtendRangeKeyBounds(
 		cmp,
+		AnyRangeKeys,
 		base.MakeInternalKey([]byte("aaa"), 0, base.InternalKeyKindRangeKeySet),
 		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("zzz")),
 	)
@@ -245,6 +247,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindSet),
 	).ExtendRangeKeyBounds(
 		cmp,
+		AnyRangeKeys,
 		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
 		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
 	)
@@ -262,6 +265,7 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindSet),
 	).ExtendRangeKeyBounds(
 		cmp,
+		AnyRangeKeys,
 		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
 		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
 	)
@@ -279,10 +283,43 @@ func TestVersionEditRoundTrip(t *testing.T) {
 		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindSet),
 	).ExtendRangeKeyBounds(
 		cmp,
+		AnyRangeKeys,
 		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindRangeKeySet),
 		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeySet, []byte("z")),
 	)
 	m6.InitPhysicalBacking()
+
+	// Range-key-only table with RangeKeyTypes = OnlyRangeKeyUnsetAndDelete.
+	m7 := (&TableMetadata{
+		TableNum:     812,
+		Size:         8120,
+		CreationTime: 812070,
+	}).ExtendRangeKeyBounds(
+		cmp,
+		OnlyRangeKeyUnsetAndDelete,
+		base.MakeInternalKey([]byte("aaa"), 0, base.InternalKeyKindRangeKeyUnset),
+		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeyUnset, []byte("zzz")),
+	)
+	m7.InitPhysicalBacking()
+
+	// Table with both point and range keys with RangeKeyTypes = AnyRangeKeys.
+	m8 := (&TableMetadata{
+		TableNum:              813,
+		Size:                  8130,
+		CreationTime:          813080,
+		SeqNums:               base.SeqNumRange{Low: 12, High: 14},
+		LargestSeqNumAbsolute: 14,
+	}).ExtendPointKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("b"), 0, base.InternalKeyKindSet),
+		base.MakeInternalKey([]byte("n"), 0, base.InternalKeyKindSet),
+	).ExtendRangeKeyBounds(
+		cmp,
+		AnyRangeKeys,
+		base.MakeInternalKey([]byte("m"), 0, base.InternalKeyKindRangeKeyDelete),
+		base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeyDelete, []byte("y")),
+	)
+	m8.InitPhysicalBacking()
 
 	testCases := []VersionEdit{
 		// An empty version edit.
@@ -322,6 +359,14 @@ func TestVersionEditRoundTrip(t *testing.T) {
 				{
 					Level: 6,
 					Meta:  m4,
+				},
+				{
+					Level: 6,
+					Meta:  m7,
+				},
+				{
+					Level: 6,
+					Meta:  m8,
 				},
 			},
 		},

--- a/internal/overlap/checker_test.go
+++ b/internal/overlap/checker_test.go
@@ -81,6 +81,7 @@ func TestChecker(t *testing.T) {
 				if len(tt.rangeKeys) > 0 {
 					tt.meta.ExtendRangeKeyBounds(
 						bytes.Compare,
+						manifest.AnyRangeKeys,
 						base.MakeInternalKey(overrideBounds.Start, 0, base.InternalKeyKindRangeKeyMax),
 						base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeyMin, overrideBounds.End.Key),
 					)
@@ -95,7 +96,7 @@ func TestChecker(t *testing.T) {
 				}
 				if len(tt.rangeKeys) > 0 {
 					smallest, largest := boundsFromSpans(tt.rangeKeys)
-					tt.meta.ExtendRangeKeyBounds(bytes.Compare, smallest, largest)
+					tt.meta.ExtendRangeKeyBounds(bytes.Compare, manifest.AnyRangeKeys, smallest, largest)
 				}
 			}
 			tables.tables[tt.meta] = tt

--- a/level_checker.go
+++ b/level_checker.go
@@ -671,6 +671,64 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		return err
 	}
 
+	// Phase 4: Validate range key metadata (HasRangeKeys, RangeKeyTypes).
+	if err := checkRangeKeyMetadata(c, allTables); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// checkRangeKeyMetadata verifies that HasRangeKeys and RangeKeyTypes are
+// consistent with the actual range key contents of each table.
+func checkRangeKeyMetadata(c *checkConfig, allTables []*manifest.TableMetadata) error {
+	ctx := context.Background()
+	for _, file := range allTables {
+		iters, err := c.newIters(ctx, file, nil, internalIterOpts{}, iterRangeKeys)
+		if err != nil {
+			return err
+		}
+		rangeKeyIter := iters.rangeKey
+		if rangeKeyIter == nil {
+			// No range key iterator means no range keys in the table.
+			if file.HasRangeKeys {
+				return errors.Errorf("table %s has HasRangeKeys=true but no range key iterator", file.TableNum)
+			}
+			continue
+		}
+		hasRangeKeys := false
+		hasRangeKeySets := false
+		span, err := rangeKeyIter.First()
+		for ; span != nil; span, err = rangeKeyIter.Next() {
+			hasRangeKeys = true
+			for _, k := range span.Keys {
+				if k.Kind() == base.InternalKeyKindRangeKeySet {
+					hasRangeKeySets = true
+				}
+			}
+		}
+		rangeKeyIter.Close()
+		if err != nil {
+			return err
+		}
+		// For all tables, HasRangeKeys must be set if there are range keys; and
+		// RangeKeyKinds must be AnyRangeKeys if there are range key sets.
+		if hasRangeKeys && !file.HasRangeKeys {
+			return errors.Errorf("table %s has HasRangeKeys=false but contains range keys", file.TableNum)
+		}
+		if hasRangeKeySets && file.RangeKeyKinds != manifest.AnyRangeKeys {
+			return errors.Errorf("table %s has RangeKeyKinds!=AnyRangeKeys but contains RANGEKEYSETs", file.TableNum)
+		}
+		// For non-virtual tables, HasRangeKeys and RangeKeyKinds must exactly match reality.
+		if !file.Virtual {
+			if file.HasRangeKeys && !hasRangeKeys {
+				return errors.Errorf("table %s has HasRangeKeys=true but contains no range keys", file.TableNum)
+			}
+			if !hasRangeKeySets && file.RangeKeyKinds == manifest.AnyRangeKeys {
+				return errors.Errorf("table %s has RangeKeyKinds=AnyRangeKeys but does not contain RANGEKEYSETs", file.TableNum)
+			}
+		}
+	}
 	return nil
 }
 

--- a/level_checker.go
+++ b/level_checker.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/RaduBerinde/axisds/v3/regiontree"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/keyspan"
@@ -671,7 +672,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 		return err
 	}
 
-	// Phase 4: Validate range key metadata (HasRangeKeys, RangeKeyTypes).
+	// Phase 4: Validate range key metadata (HasRangeKeys, RangeKeyKinds).
 	if err := checkRangeKeyMetadata(c, allTables); err != nil {
 		return err
 	}
@@ -679,7 +680,7 @@ func checkLevelsInternal(c *checkConfig) (err error) {
 	return nil
 }
 
-// checkRangeKeyMetadata verifies that HasRangeKeys and RangeKeyTypes are
+// checkRangeKeyMetadata verifies that HasRangeKeys and RangeKeyKinds are
 // consistent with the actual range key contents of each table.
 func checkRangeKeyMetadata(c *checkConfig, allTables []*manifest.TableMetadata) error {
 	ctx := context.Background()
@@ -696,6 +697,7 @@ func checkRangeKeyMetadata(c *checkConfig, allTables []*manifest.TableMetadata) 
 			}
 			continue
 		}
+		current := c.readState.current
 		hasRangeKeys := false
 		hasRangeKeySets := false
 		span, err := rangeKeyIter.First()
@@ -704,6 +706,16 @@ func checkRangeKeyMetadata(c *checkConfig, allTables []*manifest.TableMetadata) 
 			for _, k := range span.Keys {
 				if k.Kind() == base.InternalKeyKindRangeKeySet {
 					hasRangeKeySets = true
+					// Verify that no subrange of this span has a zero count
+					// in the region tree.
+					if current.RangeKeySetRegions.Any(regiontree.GE(span.Start), regiontree.LT(span.End), func(count int) bool {
+						return count == 0
+					}) {
+						return errors.Errorf(
+							"table %s has RangeKeySet in span [%s, %s) but RangeKeySetRegions has zero-count subrange",
+							file.TableNum, c.comparer.FormatKey(span.Start), c.comparer.FormatKey(span.End),
+						)
+					}
 				}
 			}
 		}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -313,7 +313,7 @@ func (lt *levelIterTest) runBuild(d *datadriven.TestData) string {
 		m.ExtendPointKeyBounds(lt.cmp.Compare, meta.SmallestRangeDel, meta.LargestRangeDel)
 	}
 	if meta.HasRangeKeys {
-		m.ExtendRangeKeyBounds(lt.cmp.Compare, meta.SmallestRangeKey, meta.LargestRangeKey)
+		m.ExtendRangeKeyBounds(lt.cmp.Compare, manifest.AnyRangeKeys, meta.SmallestRangeKey, meta.LargestRangeKey)
 	}
 	m.InitPhysicalBacking()
 	lt.metas = append(lt.metas, m)

--- a/level_iter_v2_rand_test.go
+++ b/level_iter_v2_rand_test.go
@@ -341,7 +341,11 @@ func createSSTable(
 		m.ExtendPointKeyBounds(cmp.Compare, meta.SmallestRangeDel, meta.LargestRangeDel)
 	}
 	if meta.HasRangeKeys {
-		m.ExtendRangeKeyBounds(cmp.Compare, meta.SmallestRangeKey, meta.LargestRangeKey)
+		kinds := manifest.AnyRangeKeys
+		if meta.Properties.NumRangeKeySets == 0 {
+			kinds = manifest.OnlyRangeKeyUnsetAndDelete
+		}
+		m.ExtendRangeKeyBounds(cmp.Compare, kinds, meta.SmallestRangeKey, meta.LargestRangeKey)
 	}
 	m.InitPhysicalBacking()
 	return r, m

--- a/table_stats_test.go
+++ b/table_stats_test.go
@@ -241,7 +241,7 @@ func TestTableRangeDeletionIter(t *testing.T) {
 				m.ExtendPointKeyBounds(cmp.Compare, meta.SmallestRangeDel, meta.LargestRangeDel)
 			}
 			if meta.HasRangeKeys {
-				m.ExtendRangeKeyBounds(cmp.Compare, meta.SmallestRangeKey, meta.LargestRangeKey)
+				m.ExtendRangeKeyBounds(cmp.Compare, manifest.AnyRangeKeys, meta.SmallestRangeKey, meta.LargestRangeKey)
 			}
 			return m.DebugString(cmp.FormatKey, false /* verbose */)
 		case "spans":

--- a/testdata/compaction/l0_to_lbase_compaction
+++ b/testdata/compaction/l0_to_lbase_compaction
@@ -72,7 +72,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-   4 (1.2KB) |      90.0% |        0.0% |           0 |           0
+   4 (1.2KB) |      93.3% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote

--- a/testdata/compaction/range_keys
+++ b/testdata/compaction/range_keys
@@ -21,6 +21,7 @@ L2:
 L3:
   000006:[a#0,SET-c#inf,RANGEKEYSET] seqnums:[#0-#1] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
   000007:[c#0,SET-c#0,SET] seqnums:[#0-#0] points:[c#0,SET-c#0,SET]
+Range key set regions: [a, b)=1 [b, c)=2
 
 compact a-d L0 hide-size
 ----
@@ -31,6 +32,7 @@ L2:
 L3:
   000006:[a#0,SET-c#inf,RANGEKEYSET] seqnums:[#0-#1] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
   000007:[c#0,SET-c#0,SET] seqnums:[#0-#0] points:[c#0,SET-c#0,SET]
+Range key set regions: [a, b)=1 [b, c)=2
 
 compact a-d L1 hide-size
 ----
@@ -39,6 +41,7 @@ L2:
 L3:
   000006:[a#0,SET-c#inf,RANGEKEYSET] seqnums:[#0-#1] points:[a#0,SET-b#0,SET] ranges:[b#1,RANGEKEYSET-c#inf,RANGEKEYSET]
   000007:[c#0,SET-c#0,SET] seqnums:[#0-#0] points:[c#0,SET-c#0,SET]
+Range key set regions: [a, b)=1 [b, c)=2
 
 compact a-d L2 hide-size
 ----
@@ -46,3 +49,4 @@ L3:
   000010:[a#4,RANGEKEYSET-b#inf,RANGEKEYSET] seqnums:[#0-#4] points:[a#0,SET-a#0,SET] ranges:[a#4,RANGEKEYSET-b#inf,RANGEKEYSET]
   000011:[b#4,RANGEKEYSET-c#inf,RANGEKEYSET] seqnums:[#0-#4] points:[b#0,SET-b#0,SET] ranges:[b#4,RANGEKEYSET-c#inf,RANGEKEYSET]
   000007:[c#0,SET-c#0,SET] seqnums:[#0-#0] points:[c#0,SET-c#0,SET]
+Range key set regions: [a, c)=1

--- a/testdata/compaction/value_separation
+++ b/testdata/compaction/value_separation
@@ -190,7 +190,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    1 (424B) |      89.6% |        0.0% |           0 |           0
+    1 (424B) |      91.1% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote
@@ -519,7 +519,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    1 (544B) |      78.6% |        0.0% |           0 |           0
+    1 (544B) |      81.8% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote

--- a/testdata/compaction/virtual_rewrite
+++ b/testdata/compaction/virtual_rewrite
@@ -175,7 +175,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-   4 (1.2KB) |      91.9% |        0.0% |           0 |           0
+   4 (1.2KB) |      94.3% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -360,6 +360,7 @@ L6:
   XXXXXX:[r#16,RANGEKEYSET-t#16,SET]
   XXXXXX:[u#17,RANGEKEYSET-w#inf,RANGEKEYSET]
   XXXXXX:[x#18,SET-z#18,SET]
+Range key set regions: [a, c)=1 [d, f)=1 [i, k)=1 [l, n)=1 [r, t)=1 [u, w)=1
 
 get-hints
 ----
@@ -483,6 +484,7 @@ L0.0:
 L6:
   XXXXXX:[d#11,SET-i#11,SET]
   XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
+Range key set regions: [k, o)=1
 
 get-hints
 ----
@@ -507,6 +509,7 @@ L0.0:
   XXXXXX:[b#12,RANGEDEL-r#inf,RANGEDEL]
 L6:
   XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
+Range key set regions: [k, o)=1
 
 iter
 first
@@ -545,6 +548,7 @@ L0.0:
   XXXXXX:[b#11,RANGEKEYDEL-p#inf,RANGEDEL]
 L6:
   XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
+Range key set regions: [k, o)=1
 
 get-hints
 ----
@@ -575,6 +579,7 @@ L0.0:
   XXXXXX:[b#11,RANGEKEYDEL-p#inf,RANGEDEL]
 L6:
   XXXXXX:[l#10,RANGEKEYSET-m#inf,RANGEKEYSET]
+Range key set regions: [l, m)=1
 
 iter
 first
@@ -614,6 +619,7 @@ L0.0:
   XXXXXX:[l#11,RANGEKEYDEL-m#inf,RANGEDEL]
 L6:
   XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
+Range key set regions: [k, o)=1
 
 get-hints
 ----
@@ -642,6 +648,7 @@ L0.0:
   XXXXXX:[l#11,RANGEKEYDEL-m#inf,RANGEDEL]
 L6:
   XXXXXX:[k#10,RANGEKEYSET-o#10,SET]
+Range key set regions: [k, o)=1
 
 iter
 first

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -268,6 +268,7 @@ L6:
   000004:[a#1,RANGEKEYDEL-b#inf,RANGEKEYDEL]
   000005:[b#2,RANGEKEYUNSET-c#inf,RANGEKEYUNSET]
   000006:[c#3,RANGEKEYSET-d#inf,RANGEKEYSET]
+Range key set regions: [c, d)=1
 
 wait-pending-table-stats
 000004

--- a/testdata/excise
+++ b/testdata/excise
@@ -158,6 +158,7 @@ L0.0:
   000005:[b#11,SET-i#inf,RANGEDEL]
 L6:
   000004:[c#10,RANGEKEYSET-f#inf,RANGEKEYSET]
+Range key set regions: [c, f)=1
 
 excise-dryrun f g
 ----
@@ -210,6 +211,7 @@ lsm
 ----
 L0.0:
   000005:[a#10,SET-ee#inf,RANGEKEYSET]
+Range key set regions: [e, ee)=1
 
 build ext2
 set z z
@@ -225,6 +227,7 @@ L0.0:
   000008(000005):[d#12,SET-ee#inf,RANGEKEYSET]
 L6:
   000006:[z#15,SET-z#15,SET]
+Range key set regions: [e, ee)=1
 
 # Regression test for https://github.com/cockroachdb/pebble/issues/2947.
 reset
@@ -403,6 +406,7 @@ L0.0:
   000009:[bd#17,RANGEKEYSET-f#17,MERGE]
 L6:
   000008:[a@3#0,SET-z#0,SET]
+Range key set regions: [bd, f)=1
 
 build ext3
 set z updated
@@ -419,6 +423,7 @@ L0.0:
 L6:
   000012(000008):[a@3#0,SET-bbsomethinglong@4#0,SET]
   000013(000008):[d@6#0,SET-z#0,SET]
+Range key set regions: [cc, f)=1
 
 iter range-key-masking=@10
 first

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -67,7 +67,7 @@ ITERATORS
         file cache        |    filter   |    open     |    open
      entries |   hit rate | utilization |  sst iters  |  snapshots
 -------------+------------+-------------+-------------+------------
-    1 (304B) |      50.0% |        0.0% |           0 |           0
+    1 (304B) |      66.7% |        0.0% |           0 |           0
 
 FILES                 physical tables                 |                blob files
           |     local        shared        remote     |     local        shared        remote

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -783,6 +783,7 @@ lsm
 ----
 L6:
   000004:[d#10,RANGEKEYSET-g#inf,RANGEKEYSET]
+Range key set regions: [d, g)=1
 
 build ext2
 range-key-set b e 1 val2
@@ -797,6 +798,7 @@ L0.0:
   000005:[b#11,RANGEKEYSET-e#inf,RANGEKEYSET]
 L6:
   000004:[d#10,RANGEKEYSET-g#inf,RANGEKEYSET]
+Range key set regions: [b, d)=1 [d, e)=2 [e, g)=1
 
 build ext3
 range-key-del a c
@@ -814,6 +816,7 @@ L0.0:
   000005:[b#11,RANGEKEYSET-e#inf,RANGEKEYSET]
 L6:
   000004:[d#10,RANGEKEYSET-g#inf,RANGEKEYSET]
+Range key set regions: [b, d)=1 [d, e)=2 [e, g)=1
 
 build ext4
 set a a
@@ -832,6 +835,7 @@ L0.0:
   000005:[b#11,RANGEKEYSET-e#inf,RANGEKEYSET]
 L6:
   000004:[d#10,RANGEKEYSET-g#inf,RANGEKEYSET]
+Range key set regions: [b, d)=1 [d, e)=2 [e, g)=1
 
 compact a aa
 ----
@@ -842,6 +846,7 @@ lsm
 ----
 L6:
   000008:[a#0,SET-g#inf,RANGEKEYSET]
+Range key set regions: [c, g)=1
 
 # Shouldn't show results for the b-c range as it must be deleted.
 iter
@@ -886,6 +891,7 @@ lsm
 L6:
   000005:[a#11,RANGEKEYSET-c#inf,RANGEKEYSET]
   000004:[c#10,SET-e#10,SET]
+Range key set regions: [a, c)=1
 
 # The following test cases will test that files where the end bound is an
 # exclusive sentinel due to range keys are ingested into the correct levels.
@@ -903,6 +909,7 @@ L6:
   000005:[a#11,RANGEKEYSET-c#inf,RANGEKEYSET]
   000004:[c#10,SET-e#10,SET]
   000006:[f#12,SET-h#12,SET]
+Range key set regions: [a, c)=1
 
 
 build ext4
@@ -919,6 +926,7 @@ L6:
   000004:[c#10,SET-e#10,SET]
   000007:[eee#13,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
   000006:[f#12,SET-h#12,SET]
+Range key set regions: [a, c)=1
 
 build ext5
 range-key-set ee eee 1 val3
@@ -935,6 +943,7 @@ L6:
   000008:[ee#14,RANGEKEYSET-eee#inf,RANGEKEYSET]
   000007:[eee#13,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
   000006:[f#12,SET-h#12,SET]
+Range key set regions: [a, c)=1 [ee, eee)=1
 
 build ext6
 set x x
@@ -953,6 +962,7 @@ L6:
   000007:[eee#13,RANGEKEYUNSET-f#inf,RANGEKEYUNSET]
   000006:[f#12,SET-h#12,SET]
   000009:[x#15,SET-y#15,SET]
+Range key set regions: [a, c)=1 [ee, eee)=1
 
 build ext7
 range-key-del s x
@@ -971,6 +981,7 @@ L6:
   000006:[f#12,SET-h#12,SET]
   000010:[s#16,RANGEKEYDEL-x#inf,RANGEKEYDEL]
   000009:[x#15,SET-y#15,SET]
+Range key set regions: [a, c)=1 [ee, eee)=1
 
 reset enable-split
 ----

--- a/testdata/ingest_shared
+++ b/testdata/ingest_shared
@@ -512,6 +512,7 @@ lsm
 ----
 L6:
   000005:[a#10,RANGEKEYSET-e#12,SET]
+Range key set regions: [a, aaa)=1
 
 switch 2
 ----
@@ -543,6 +544,7 @@ L6:
   000008(000005):[a#10,RANGEKEYSET-aaa#inf,RANGEKEYSET]
   000007(000007):[b#14,DELSIZED-c#14,DEL]
   000009(000005):[d#11,SET-e#12,SET]
+Range key set regions: [a, aaa)=1
 
 iter
 first
@@ -689,6 +691,7 @@ L5:
   000006:[bb#14,RANGEKEYSET-g#inf,RANGEKEYSET]
 L6:
   000005:[a@3#10,SET-e#13,SET]
+Range key set regions: [bb, g)=1
 
 switch 2
 ----
@@ -724,6 +727,7 @@ L5:
 L6:
   000008(000008):[b@5#12,DELSIZED-e#12,DEL]
   000005:[ff#10,SET-ff#10,SET]
+Range key set regions: [bb, f)=1
 
 iter
 seek-ge b
@@ -1183,6 +1187,7 @@ lsm
 ----
 L6:
   000005:[c#10,RANGEKEYSET-h#inf,RANGEKEYSET]
+Range key set regions: [c, h)=1
 
 replicate 1 2 a f
 ----
@@ -1231,6 +1236,7 @@ lsm
 ----
 L6:
   000008:[c#12,RANGEKEYSET-e#inf,RANGEKEYSET]
+Range key set regions: [c, e)=1
 
 switch 1
 ----

--- a/testdata/ingest_shared_lower
+++ b/testdata/ingest_shared_lower
@@ -512,6 +512,7 @@ lsm
 ----
 L6:
   000006:[a#10,RANGEKEYSET-e#12,SET]
+Range key set regions: [a, aaa)=1
 
 switch 2
 ----
@@ -543,6 +544,7 @@ L6:
   000009(000006):[a#10,RANGEKEYSET-aaa#inf,RANGEKEYSET]
   000008(000008):[b#14,DELSIZED-c#14,DEL]
   000010(000006):[d#11,SET-e#12,SET]
+Range key set regions: [a, aaa)=1
 
 iter
 first
@@ -672,6 +674,7 @@ L5:
   000007:[bb#14,RANGEKEYSET-g#inf,RANGEKEYSET]
 L6:
   000006:[a@3#10,SET-e#13,SET]
+Range key set regions: [bb, g)=1
 
 switch 2
 ----
@@ -707,6 +710,7 @@ L5:
 L6:
   000009(000009):[b@5#12,DELSIZED-e#12,DEL]
   000006:[ff#10,SET-ff#10,SET]
+Range key set regions: [bb, f)=1
 
 iter
 seek-ge b

--- a/testdata/ingest_target_level
+++ b/testdata/ingest_target_level
@@ -228,6 +228,7 @@ L5
 ----
 L5:
   000004:[a#1,RANGEKEYSET-c#inf,RANGEKEYSET]
+Range key set regions: [a, c)=1
 
 target
 000000:[a#5,SET-c#5,SET] seqnums:[#5-#5]
@@ -241,6 +242,7 @@ L5
 ----
 L5:
   000004:[a#1,RANGEKEYSET-c#inf,RANGEKEYSET]
+Range key set regions: [a, c)=1
 
 target
 000000:[a#5,RANGEKEYDEL-c#inf,RANGEKEYDEL] seqnums:[#5-#5] ranges:[a#5,RANGEKEYDEL-c#inf,RANGEKEYDEL]

--- a/testdata/ingest_with_blobs
+++ b/testdata/ingest_with_blobs
@@ -36,6 +36,7 @@ L6:
 Blob files:
   B000010 physical:{000010 size:[93 (93B)] vals:[4 (4B)]}
   B000012 physical:{000012 size:[106 (106B)] vals:[17 (17B)]}
+Range key set regions: [e, j)=1
 
 
 
@@ -58,6 +59,7 @@ Blob files:
   B000010 physical:{000010 size:[93 (93B)] vals:[4 (4B)]}
   B000012 physical:{000012 size:[106 (106B)] vals:[17 (17B)]}
   B000014 physical:{000014 size:[93 (93B)] vals:[4 (4B)]}
+Range key set regions: [e, j)=1
 
 # Test excise.
 write-table ext4 value-separation-min-size=4
@@ -93,6 +95,7 @@ Blob files:
   B000014 physical:{000014 size:[93 (93B)] vals:[4 (4B)]}
   B000016 physical:{000016 size:[120 (120B)] vals:[30 (30B)]}
   B000018 physical:{000018 size:[104 (104B)] vals:[15 (15B)]}
+Range key set regions: [e, j)=1
 
 # Excise with no overlap.
 write-table ext6 value-separation-min-size=4
@@ -120,6 +123,7 @@ Blob files:
   B000016 physical:{000016 size:[120 (120B)] vals:[30 (30B)]}
   B000018 physical:{000018 size:[104 (104B)] vals:[15 (15B)]}
   B000023 physical:{000023 size:[114 (114B)] vals:[24 (24B)]}
+Range key set regions: [e, j)=1
 
 
 # Ingest with no blob files.
@@ -153,6 +157,7 @@ Blob files:
   B000016 physical:{000016 size:[120 (120B)] vals:[30 (30B)]}
   B000018 physical:{000018 size:[104 (104B)] vals:[15 (15B)]}
   B000023 physical:{000023 size:[114 (114B)] vals:[24 (24B)]}
+Range key set regions: [e, j)=1 [l, m)=1
 
 
 ingest file-dne

--- a/testdata/iter_histories/blob_references
+++ b/testdata/iter_histories/blob_references
@@ -213,6 +213,7 @@ L6:
   000004:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] seqnums:[#2-#5] points:[b#2,SETWITHDEL-b#2,SETWITHDEL] ranges:[a#5,RANGEKEYSET-d#inf,RANGEKEYSET] size:964 blobrefs:[(B000009: 7); depth:1]
 Blob files:
   B000009 physical:{000009 size:[96 (96B)] vals:[7 (7B)]}
+Range key set regions: [a, d)=1
 
 combined-iter
 seek-lt c

--- a/testdata/iter_histories/errors
+++ b/testdata/iter_histories/errors
@@ -74,6 +74,7 @@ L0
 ----
 L0.0:
   000004:[a#9,SET-e@2#2,SET]
+Range key set regions: [c, d)=1
 
 layout filename=000004.sst
 ----

--- a/testdata/iter_histories/iter_optimizations
+++ b/testdata/iter_histories/iter_optimizations
@@ -574,6 +574,7 @@ compact a-z
 ----
 L6:
   000005:[c#11,RANGEKEYSET-e#inf,RANGEKEYSET]
+Range key set regions: [c, e)=1
 
 batch commit
 set j k
@@ -588,6 +589,7 @@ compact a-z
 L6:
   000005:[c#11,RANGEKEYSET-e#inf,RANGEKEYSET]
   000007:[j#12,SET-j#12,SET]
+Range key set regions: [c, e)=1
 
 batch commit
 del-range c@2 d
@@ -614,6 +616,7 @@ L0.0:
 L6:
   000005:[c#11,RANGEKEYSET-e#inf,RANGEKEYSET]
   000007:[j#12,SET-j#12,SET]
+Range key set regions: [c, e)=1
 
 combined-iter upper=z@3 mask-suffix=@3 mask-filter use-l6-filter
 seek-prefix-ge b@2

--- a/testdata/iter_histories/lazy_combined_iteration
+++ b/testdata/iter_histories/lazy_combined_iteration
@@ -45,6 +45,7 @@ L0.1:
 L0.0:
   000005:[bar#10,SET-bar#10,SET]
   000007:[bax#11,RANGEKEYSET-zoo#inf,RANGEKEYSET]
+Range key set regions: [bax, foo)=1 [foo, zoo)=2
 
 # Assert that First correctly finds [bax,zoo), despite the discovery of
 # [foo,zoo) triggering the switch to combined iteration.
@@ -131,6 +132,7 @@ L0.0:
   000009:[d#12,RANGEKEYSET-e#inf,RANGEKEYSET]
   000011:[l#13,RANGEKEYSET-m#inf,RANGEKEYSET]
   000007:[z#11,SET-z#11,SET]
+Range key set regions: [d, e)=1 [l, m)=1
 
 combined-iter
 seek-ge k
@@ -246,6 +248,7 @@ L6:
   000004:[bax#9,DEL-bax#9,DEL]
   000005:[c#0,RANGEKEYSET-d#inf,RANGEKEYSET]
   000006:[d@2#2,SET-d@2#2,SET]
+Range key set regions: [c, d)=1
 
 combined-iter
 seek-prefix-ge bax
@@ -270,6 +273,7 @@ L6:
   000004:[bax#9,MERGE-bax#9,MERGE]
   000005:[c#0,RANGEKEYSET-d#inf,RANGEKEYSET]
   000006:[d@2#2,SET-d@2#2,SET]
+Range key set regions: [c, d)=1
 
 combined-iter
 seek-prefix-ge bax

--- a/testdata/iter_histories/prefix_iteration
+++ b/testdata/iter_histories/prefix_iteration
@@ -43,6 +43,7 @@ L0.0:
   000005:[a#10,RANGEKEYSET-c#inf,RANGEKEYSET]
   000007:[c#11,RANGEKEYSET-f#inf,RANGEKEYSET]
   000009:[f#12,RANGEKEYSET-m#inf,RANGEKEYSET]
+Range key set regions: [a, m)=1
 
 combined-iter
 seek-prefix-ge d@5
@@ -107,6 +108,7 @@ L0.0:
   000015:[d@0#20,SET-e#inf,RANGEKEYSET]
   000016:[y#21,RANGEKEYSET-z#inf,RANGEKEYSET]
   000017:[z#22,SET-z#22,SET]
+Range key set regions: [a, e)=1 [y, z)=1
 
 # The first seek-prefix-ge y@1 converts the iterator from lazy combined iterator
 # to combined iteration.
@@ -172,6 +174,7 @@ L6:
   000005:[a#10,RANGEKEYSET-c@8#inf,RANGEKEYSET]
   000006:[c@8#11,RANGEKEYSET-e#inf,RANGEKEYSET]
   000007:[y#12,RANGEKEYSET-z#12,SET]
+Range key set regions: [a, e)=1 [y, z)=1
 
 
 # The first seek-prefix-ge y@1 converts the iterator from lazy combined iterator
@@ -301,6 +304,7 @@ L0.0:
 L6:
   000004:[b@4#10,SET-b@4#10,SET]
   000005:[c#11,SET-f#inf,RANGEKEYSET]
+Range key set regions: [d, f)=1
 
 combined-iter
 seek-prefix-ge b@9

--- a/testdata/iter_histories/range_keys_simple
+++ b/testdata/iter_histories/range_keys_simple
@@ -352,6 +352,7 @@ L0.1:
   000008:[b#2120,RANGEKEYSET-z#inf,RANGEKEYSET]
 L0.0:
   000006:[a@100#12,SET-zz@1#2113,SET]
+Range key set regions: [b, e)=2 [e, z)=1
 
 scan-rangekeys
 ----
@@ -449,6 +450,7 @@ rangekey:b-d:{(#5,RANGEKEYSET,@2,foo)}
 ----
 L6:
   000004:[a#3,RANGEDEL-z#inf,RANGEDEL]
+Range key set regions: [b, d)=1
 
 combined-iter
 seek-lt apple

--- a/testdata/scan_internal
+++ b/testdata/scan_internal
@@ -91,11 +91,13 @@ compact a-z
 ----
 L6:
   000008:[a#10,RANGEKEYSET-e#13,SET]
+Range key set regions: [a, e)=1
 
 lsm
 ----
 L6:
   000008:[a#10,RANGEKEYSET-e#13,SET]
+Range key set regions: [a, e)=1
 
 scan-internal lower=a upper=z skip-shared snapshot=foo
 ----
@@ -134,6 +136,7 @@ compact a-z
 ----
 L6:
   000005:[a#10,RANGEKEYSET-e#inf,RANGEKEYSET]
+Range key set regions: [a, e)=1
 
 batch commit
 range-key-unset b d @6
@@ -165,6 +168,7 @@ L0.0:
   000007:[b#12,RANGEKEYUNSET-d#inf,RANGEKEYUNSET]
 L6:
   000005:[a#10,RANGEKEYSET-e#inf,RANGEKEYSET]
+Range key set regions: [a, e)=1
 
 scan-internal
 ----
@@ -300,6 +304,7 @@ compact a-z
 ----
 L6:
   000005:[a#11,RANGEKEYSET-e#inf,RANGEDEL]
+Range key set regions: [a, c)=1
 
 batch commit
 set f@8 baz
@@ -310,6 +315,7 @@ lsm
 ----
 L6:
   000005:[a#11,RANGEKEYSET-e#inf,RANGEDEL]
+Range key set regions: [a, c)=1
 
 scan-internal
 ----
@@ -372,11 +378,13 @@ compact a-z
 ----
 L6:
   000005:[a#10,SET-f#11,SET]
+Range key set regions: [e, ee)=1
 
 lsm
 ----
 L6:
   000005:[a#10,SET-f#11,SET]
+Range key set regions: [e, ee)=1
 
 scan-internal skip-shared lower=c upper=d
 ----
@@ -425,6 +433,7 @@ compact a-z
 ----
 L6:
   000005:[a#10,SET-ee#inf,RANGEKEYSET]
+Range key set regions: [e, ee)=1
 
 scan-internal skip-shared lower=a upper=ee
 ----
@@ -454,6 +463,7 @@ compact a-z
 ----
 L6:
   000005:[a#10,RANGEKEYSET-d#13,SET]
+Range key set regions: [a, aa)=1
 
 scan-internal skip-shared lower=b upper=e
 ----

--- a/testdata/table_stats
+++ b/testdata/table_stats
@@ -277,6 +277,7 @@ flush
 ----
 L0.0:
   000005:[a#12,RANGEKEYUNSET-b#inf,RANGEKEYSET]
+Range key set regions: [a, b)=1
 
 # Add a table that contains only point keys, to the right of the existing table.
 batch
@@ -288,12 +289,14 @@ flush
 L0.0:
   000005:[a#12,RANGEKEYUNSET-b#inf,RANGEKEYSET]
   000007:[c#13,SET-c#13,SET]
+Range key set regions: [a, b)=1
 
 compact a-c
 ----
 L6:
   000008:[a#11,RANGEKEYSET-b#inf,RANGEKEYSET]
   000009:[c#0,SET-c#0,SET]
+Range key set regions: [a, b)=1
 
 # Add a table that contains a RANGEKEYDEL covering the first table in L6.
 batch
@@ -307,6 +310,7 @@ L0.0:
 L6:
   000008:[a#11,RANGEKEYSET-b#inf,RANGEKEYSET]
   000009:[c#0,SET-c#0,SET]
+Range key set regions: [a, b)=1
 
 # Add one more table containing a RANGEDEL.
 batch
@@ -322,6 +326,7 @@ L0.0:
 L6:
   000008:[a#11,RANGEKEYSET-b#inf,RANGEKEYSET]
   000009:[c#0,SET-c#0,SET]
+Range key set regions: [a, b)=1
 
 # Compute stats on the table containing range key del. It should not show an
 # estimate for deleted point keys as there are no tables below it that contain
@@ -363,6 +368,7 @@ L0.0:
 L6:
   000008:[a#11,RANGEKEYSET-b#inf,RANGEKEYSET]
   000009:[c#0,SET-c#0,SET]
+Range key set regions: [a, b)=1
 
 compact a-z
 ----
@@ -466,6 +472,7 @@ L5:
   000005:[a#2,RANGEDEL-e#inf,RANGEDEL]
 L6:
   000006:[c#1,RANGEKEYSET-d#inf,RANGEKEYSET]
+Range key set regions: [c, d)=1
 
 # The table in L5 should not contain an estimate for the table below it, which
 # contains only range keys.
@@ -724,6 +731,7 @@ L0.0:
   000008(000005):[d#12,DEL-d#12,DEL]
 L6:
   000006:[f#14,SET-f#14,SET]
+Range key set regions: [e, ee)=1
 
 properties file=10
 rocksdb
@@ -774,6 +782,7 @@ L0.0:
 L6:
   000006:[f#14,SET-f#14,SET]
   000011:[z#20,SET-z#20,SET]
+Range key set regions: [e, ee)=1
 
 metadata-stats file=12
 ----
@@ -860,6 +869,7 @@ L6:
   000016:[e#18,RANGEKEYSET-ee#inf,RANGEKEYSET]
   000006:[f#14,SET-f#14,SET]
   000011:[z#20,SET-z#20,SET]
+Range key set regions: [e, ee)=1
 
 batch
 del-range a e
@@ -875,6 +885,7 @@ L6:
   000016:[e#18,RANGEKEYSET-ee#inf,RANGEKEYSET]
   000006:[f#14,SET-f#14,SET]
   000011:[z#20,SET-z#20,SET]
+Range key set regions: [e, ee)=1
 
 properties file=18
 rocksdb
@@ -919,6 +930,7 @@ L6:
   000006:[f#14,SET-f#14,SET]
   000011:[z#20,SET-z#20,SET]
   000019:[zz#23,SET-zz#23,SET]
+Range key set regions: [e, ee)=1
 
 properties file=20
 ----

--- a/tool/testdata/manifest_dump
+++ b/tool/testdata/manifest_dump
@@ -346,6 +346,7 @@ MANIFEST-000001
 EOF
 L0.0:
   000005:[a#38,RANGEKEYDEL-z@1#35,SET] seqnums:[#10-#38] points:[a@1#10,SET-z@1#35,SET] ranges:[a#38,RANGEKEYDEL-z#inf,RANGEKEYSET] size:1056
+Range key set regions: [a, z)=1
 
 manifest dump
 ./testdata/find-val-sep-db/MANIFEST-000001


### PR DESCRIPTION
#### manifest: add HasRangeKeySets

Add a flag that can tell us when a table has (or might have) range key
sets. This will be useful for lazy combined iteration (it currently
relies on table statistics for this information).

#### manifest: track regions containing range key sets

Add a RangeKeySetRegions field to Version, backed by a regiontree that
tracks the number of tables with HasRangeKeySets=true and range-key
bounds overlapping each region. The tree is maintained incrementally:
tables are added/removed during BulkVersionEdit.Apply and in
NewVersionForTesting.

This will be used for lazy combined iteration, allowing us to quickly
determine whether a given key range may contain range key sets without
relying on table statistics.

Also add a check in checkRangeKeyMetadata (level_checker) that verifies
the region tree is consistent with actual range key set spans.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>