### PR TITLE
ackseq: minor bug fixes

### DIFF
--- a/internal/ackseq/ackseq.go
+++ b/internal/ackseq/ackseq.go
@@ -49,6 +49,12 @@ func (s *S) Next() uint64 {
 // returning the number of newly acknowledged sequence numbers.
 func (s *S) Ack(seqNum uint64) (int, error) {
 	s.mu.Lock()
+	if seqNum < s.mu.base || seqNum >= s.mu.base+windowSize {
+		defer s.mu.Unlock()
+		return 0, errors.Errorf(
+			"ack seqNum %d out of valid range [%d, %d)",
+			errors.Safe(seqNum), errors.Safe(s.mu.base), errors.Safe(s.mu.base+windowSize))
+	}
 	if s.getLocked(seqNum) {
 		defer s.mu.Unlock()
 		return 0, errors.Errorf(

--- a/internal/ackseq/ackseq.go
+++ b/internal/ackseq/ackseq.go
@@ -58,7 +58,7 @@ func (s *S) Ack(seqNum uint64) (int, error) {
 	if s.getLocked(seqNum) {
 		defer s.mu.Unlock()
 		return 0, errors.Errorf(
-			"pending acks exceeds window size: %d has been acked, but %d has not",
+			"sequence number %d already acked (base=%d)",
 			errors.Safe(seqNum), errors.Safe(s.mu.base))
 	}
 

--- a/internal/ackseq/ackseq_test.go
+++ b/internal/ackseq/ackseq_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package ackseq
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAckInOrder(t *testing.T) {
+	s := New(0)
+	for i := 0; i < 10; i++ {
+		seq := s.Next()
+		count, err := s.Ack(seq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("expected count 1, got %d", count)
+		}
+	}
+}
+
+func TestAckOutOfOrder(t *testing.T) {
+	s := New(0)
+	seqs := make([]uint64, 5)
+	for i := range seqs {
+		seqs[i] = s.Next()
+	}
+	// Ack in reverse order; only the last ack should advance the base.
+	for i := len(seqs) - 1; i > 0; i-- {
+		count, err := s.Ack(seqs[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Fatalf("expected count 0, got %d", count)
+		}
+	}
+	count, err := s.Ack(seqs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != len(seqs) {
+		t.Fatalf("expected count %d, got %d", len(seqs), count)
+	}
+}
+
+func TestAckDoubleAck(t *testing.T) {
+	s := New(0)
+	seq := s.Next()
+	if _, err := s.Ack(seq); err != nil {
+		t.Fatal(err)
+	}
+	seq = s.Next()
+	if _, err := s.Ack(seq); err != nil {
+		t.Fatal(err)
+	}
+	// Ack seq again (double ack, but base has advanced past it).
+	_, err := s.Ack(seq)
+	if err == nil {
+		t.Fatal("expected error for double ack")
+	}
+	if !strings.Contains(err.Error(), "out of valid range") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAckBelowBase(t *testing.T) {
+	s := New(5)
+	seq := s.Next() // returns 5
+	if _, err := s.Ack(seq); err != nil {
+		t.Fatal(err)
+	}
+	// Ack a seqNum below the initial base.
+	_, err := s.Ack(0)
+	if err == nil {
+		t.Fatal("expected error for seqNum below base")
+	}
+	if !strings.Contains(err.Error(), "out of valid range") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAckBeyondWindow(t *testing.T) {
+	s := New(0)
+	// Don't call Next() enough times; just try to ack a huge seqNum.
+	_, err := s.Ack(windowSize)
+	if err == nil {
+		t.Fatal("expected error for seqNum beyond window")
+	}
+	if !strings.Contains(err.Error(), "out of valid range") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/ackseq/ackseq_test.go
+++ b/internal/ackseq/ackseq_test.go
@@ -48,7 +48,7 @@ func TestAckOutOfOrder(t *testing.T) {
 	}
 }
 
-func TestAckDoubleAck(t *testing.T) {
+func TestAckDoubleAckAfterBaseAdvance(t *testing.T) {
 	s := New(0)
 	seq := s.Next()
 	if _, err := s.Ack(seq); err != nil {
@@ -65,6 +65,24 @@ func TestAckDoubleAck(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "out of valid range") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAckDoubleAckBeforeBaseAdvance(t *testing.T) {
+	s := New(0)
+	// Get two sequence numbers, ack the second one first.
+	s.Next()         // seq 0
+	seq1 := s.Next() // seq 1
+	if _, err := s.Ack(seq1); err != nil {
+		t.Fatal(err)
+	}
+	// Double-ack seq1 before base has advanced (base is still 0).
+	_, err := s.Ack(seq1)
+	if err == nil {
+		t.Fatal("expected error for double ack")
+	}
+	if !strings.Contains(err.Error(), "already acked") {
+		t.Fatalf("expected 'already acked' error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
#### ackseq: add range validation for seqNum in Ack

Previously, Ack had no validation that seqNum fell within the valid
range [base, base+windowSize). The only guard was a getLocked check
which tested the bit state, not the numeric range. This allowed two
classes of bugs:

1. Window overflow: when seqNum - base >= windowSize, the bit index
   aliased with a different sequence number (via windowMask), silently
   corrupting state and potentially advancing base incorrectly.

2. Below-base ack: when seqNum < base (e.g. due to a caller double-ack
   after base advanced), the bit could be set for an unrelated future
   sequence number, again corrupting state.

Add an explicit range check at the top of Ack that returns an error if
seqNum is outside [base, base+windowSize).

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### ackseq: fix misleading error message for double-ack

The error when getLocked(seqNum) returned true said "pending acks
exceeds window size" which was misleading. Now that we have an explicit
range check, the only way to reach this guard is a true double-ack
(same seqNum acked twice while base hasn't advanced past it). Update
the message to say "sequence number N already acked" which accurately
describes the situation.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>