### PR TITLE
tombspan: fix sort order in pending tombstone list

### DIFF
--- a/internal/tombspan/testdata/partial_promotion
+++ b/internal/tombspan/testdata/partial_promotion
@@ -1,0 +1,44 @@
+# Test that UpdateWithEarliestSnapshot correctly promotes only tombstones
+# whose HighestSeqNum is less than the earliest snapshot, even when there
+# are other pending tombstones with higher sequence numbers.
+
+define-version
+L2
+000001:[a#50,SET-d#50,SET] seqnums:[#50-#50]
+000002:[e#50,SET-h#50,SET] seqnums:[#50-#50]
+----
+v0:
+L2:
+  000001:[a#50,SET-d#50,SET] seqnums:[#50-#50] points:[a#50,SET-d#50,SET]
+  000002:[e#50,SET-h#50,SET] seqnums:[#50-#50] points:[e#50,SET-h#50,SET]
+
+# Add two tombstones with different sequence numbers: one high (300) and one
+# low (100).
+
+add
+L0.000001 [a, d) seqnums{point=[#100-#100]}
+L0.000002 [e, h) seqnums{point=[#300-#300]}
+----
+Pending:
+  L0.000001 [a, d) seqnums{point=[#100-#100]}
+  L0.000002 [e, h) seqnums{point=[#300-#300]}
+
+# Update with a snapshot at 200. This should promote the tombstone with
+# seqnum 100 (since 200 > 100) but NOT the tombstone with seqnum 300
+# (since 200 <= 300).
+
+update-with-earliest-snapshot 200
+----
+Pending:
+  L0.000002 [e, h) seqnums{point=[#300-#300]}
+Tombstoned spans:
+[a, d) = {point=100}
+
+# After advancing the snapshot past 300, the remaining tombstone should be
+# promoted too.
+
+update-with-earliest-snapshot 400
+----
+Tombstoned spans:
+[a, d) = {point=100}
+[e, h) = {point=300}

--- a/internal/tombspan/tombspan.go
+++ b/internal/tombspan/tombspan.go
@@ -280,7 +280,7 @@ type Set struct {
 	// pending is the set of WideTombstones that cannot yet be used to schedule
 	// delete-only compactions, because at least one of their tombstones are not
 	// yet in the last snapshot stripe. Pending is sorted by HighestSeqNum() in
-	// descending order.
+	// ascending order.
 	//
 	// When UpdateWithEarliestSnapshot is called with a sufficiently high
 	// snapshot sequence number, a prefix of the pending WideTombstones are
@@ -363,7 +363,7 @@ func mergeTombstonedSpans(a, b tombstoneSeqNums) tombstoneSeqNums {
 func (fs *Set) AddTombstones(tombstones ...WideTombstone) {
 	fs.pending = append(fs.pending, tombstones...)
 	slices.SortFunc(fs.pending, func(a, b WideTombstone) int {
-		return cmp.Compare(b.HighestSeqNum(), a.HighestSeqNum())
+		return cmp.Compare(a.HighestSeqNum(), b.HighestSeqNum())
 	})
 }
 
@@ -379,13 +379,12 @@ func (ts *Set) UpdateWithEarliestSnapshot(earliestSnapshot base.SeqNum) {
 	// tombstones are recorded. The highest tombstone sequence number must be in
 	// the last snapshot stripe for the WideTombstone to be used to actually
 	// delete data.
-	for i, h := range ts.pending {
-		if earliestSnapshot <= h.HighestSeqNum() {
-			// All remaining WideTombstones are not yet in the last snapshot
-			// stripe.
-			ts.pending = append(ts.pending[:0], ts.pending[i:]...)
-			return
-		}
+	n := 0
+	for n < len(ts.pending) && ts.pending[n].HighestSeqNum() < earliestSnapshot {
+		n++
+	}
+	// The first n tombstones are now in the last snapshot stripe.
+	for _, h := range ts.pending[:n] {
 		// This WideTombstone's tombstones are now in the last snapshot stripe.
 		// Add a tombstoned span.
 		s := tombstoneSeqNums{
@@ -397,8 +396,7 @@ func (ts *Set) UpdateWithEarliestSnapshot(earliestSnapshot base.SeqNum) {
 				return mergeTombstonedSpans(curr, s)
 			})
 	}
-	// All WideTombstones were added to the tombstoned spans.
-	ts.pending = ts.pending[:0]
+	ts.pending = slices.Delete(ts.pending, 0, n)
 }
 
 // DeleteOnlyCompaction describes a picked delete-only compaction, applying to a

--- a/internal/tombspan/tombspan_test.go
+++ b/internal/tombspan/tombspan_test.go
@@ -18,6 +18,14 @@ import (
 )
 
 func TestSet(t *testing.T) {
+	runSetTest(t, "testdata/set")
+}
+
+func TestPartialPromotion(t *testing.T) {
+	runSetTest(t, "testdata/partial_promotion")
+}
+
+func runSetTest(t *testing.T, path string) {
 	tables := make(map[base.DiskFileNum]*manifest.TableMetadata)
 	set := Make(testkeys.Comparer)
 	var versions []*manifest.Version
@@ -53,7 +61,7 @@ func TestSet(t *testing.T) {
 		return h
 	}
 
-	datadriven.RunTest(t, "testdata/set", func(t *testing.T, td *datadriven.TestData) string {
+	datadriven.RunTest(t, path, func(t *testing.T, td *datadriven.TestData) string {
 		switch td.Cmd {
 		case "define-version":
 			l0Organizer := manifest.NewL0Organizer(testkeys.Comparer, 64*1024 /* flushSplitBytes */)


### PR DESCRIPTION
`AddTombstones` sorted the pending list in descending order of
`HighestSeqNum`. `UpdateWithEarliestSnapshot` iterates from the front and
returns early when it encounters a tombstone not yet in the last snapshot
stripe. With descending order, the highest seqnum tombstones were at the
front, causing the function to return before checking lower-seqnum
tombstones that were actually eligible for promotion.

Fix by sorting in ascending order so that eligible (lower seqnum)
tombstones are processed first and the early return correctly skips only
ineligible (higher seqnum) tombstones.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>