### PR TITLE
vfs/atomicfs: ensure manifest durable before marker creation

### DIFF
--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -14,6 +14,7 @@ open-dir: db
 open-dir: db
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
@@ -751,6 +752,7 @@ close: checkpoints/checkpoint5/000019.sst
 sync: checkpoints/checkpoint5
 get-disk-usage: checkpoints/checkpoint5
 create: checkpoints/checkpoint5/MANIFEST-000020
+sync: checkpoints/checkpoint5
 sync: checkpoints/checkpoint5/MANIFEST-000020
 create: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000020
 sync: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000020
@@ -855,6 +857,7 @@ close: checkpoints/checkpoint6/000019.sst
 sync: checkpoints/checkpoint6
 get-disk-usage: checkpoints/checkpoint6
 create: checkpoints/checkpoint6/MANIFEST-000020
+sync: checkpoints/checkpoint6
 sync: checkpoints/checkpoint6/MANIFEST-000020
 create: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000020
 sync: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000020
@@ -929,6 +932,7 @@ open-dir: valsepdb
 open-dir: valsepdb
 create: valsepdb/MANIFEST-000001
 sync: valsepdb/MANIFEST-000001
+sync: valsepdb
 create: valsepdb/marker.manifest.000001.MANIFEST-000001
 sync: valsepdb/marker.manifest.000001.MANIFEST-000001
 close: valsepdb/marker.manifest.000001.MANIFEST-000001

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -14,6 +14,7 @@ open-dir: db
 open-dir: db
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -21,6 +21,7 @@ open-dir: db
 open-dir: db
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
@@ -158,6 +159,7 @@ open-dir: db1
 open-dir: db1
 create: db1/MANIFEST-000001
 sync: db1/MANIFEST-000001
+sync: db1
 create: db1/marker.manifest.000001.MANIFEST-000001
 sync: db1/marker.manifest.000001.MANIFEST-000001
 close: db1/marker.manifest.000001.MANIFEST-000001
@@ -273,6 +275,7 @@ remove: db1/000345.blob
 sync: db1
 get-disk-usage: db1
 create: db1/MANIFEST-000459
+sync: db1
 sync: db1/MANIFEST-000459
 create: db1/marker.manifest.000002.MANIFEST-000459
 sync: db1/marker.manifest.000002.MANIFEST-000459

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -20,6 +20,7 @@ open-dir: db
 open-dir: db
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
@@ -148,6 +149,7 @@ sync: db
 get-disk-usage: db
 create: db/MANIFEST-000006
 close: db/MANIFEST-000001
+sync: db
 sync: db/MANIFEST-000006
 create: db/marker.manifest.000002.MANIFEST-000006
 sync: db/marker.manifest.000002.MANIFEST-000006
@@ -174,6 +176,7 @@ sync: db
 get-disk-usage: db
 create: db/MANIFEST-000009
 close: db/MANIFEST-000006
+sync: db
 sync: db/MANIFEST-000009
 create: db/marker.manifest.000003.MANIFEST-000009
 sync: db/marker.manifest.000003.MANIFEST-000009
@@ -209,6 +212,7 @@ sync: db
 get-disk-usage: db
 create: db/MANIFEST-000011
 close: db/MANIFEST-000009
+sync: db
 sync: db/MANIFEST-000011
 create: db/marker.manifest.000004.MANIFEST-000011
 sync: db/marker.manifest.000004.MANIFEST-000011
@@ -246,6 +250,7 @@ sync: db
 get-disk-usage: db
 create: db/MANIFEST-000014
 close: db/MANIFEST-000011
+sync: db
 sync: db/MANIFEST-000014
 create: db/marker.manifest.000005.MANIFEST-000014
 sync: db/marker.manifest.000005.MANIFEST-000014
@@ -275,6 +280,7 @@ link: ext/0 -> db/000015.sst
 sync: db
 create: db/MANIFEST-000016
 close: db/MANIFEST-000014
+sync: db
 sync: db/MANIFEST-000016
 create: db/marker.manifest.000006.MANIFEST-000016
 sync: db/marker.manifest.000006.MANIFEST-000016
@@ -443,6 +449,7 @@ sync: db/MANIFEST-000016
 [JOB 16] flushing 2 ingested tables
 create: db/MANIFEST-000023
 close: db/MANIFEST-000016
+sync: db
 sync: db/MANIFEST-000023
 create: db/marker.manifest.000007.MANIFEST-000023
 sync: db/marker.manifest.000007.MANIFEST-000023

--- a/version_set.go
+++ b/version_set.go
@@ -218,7 +218,21 @@ func (vs *versionSet) initNewDB(
 		}
 	}
 	if err == nil {
-		// NB: Move() is responsible for syncing the data directory.
+		// Sync the directory to make the MANIFEST file durable before creating
+		// the marker that points to it. This prevents a crash from leaving the
+		// marker pointing to a non-existent MANIFEST. Without this sync, both
+		// the MANIFEST and marker files would be unsynced until Move() completes,
+		// creating a race where a crash could include the marker but not the
+		// MANIFEST on filesystems with unordered metadata updates.
+		if err = vs.manifestMarker.SyncDir(); err != nil {
+			vs.opts.Logger.Fatalf("MANIFEST directory sync failed: %v", err)
+		}
+	}
+	if err == nil {
+		// NB: Move() syncs the directory again after creating the marker file,
+		// making the marker itself durable. The two directory syncs ensure that
+		// MANIFEST is durable before marker creation, and marker is durable
+		// after creation, eliminating any race window.
 		if err = vs.manifestMarker.Move(base.MakeFilename(base.FileTypeManifest, vs.manifestFileNum)); err != nil {
 			vs.opts.Logger.Fatalf("MANIFEST set current failed: %v", err)
 		}
@@ -494,6 +508,15 @@ func (vs *versionSet) UpdateVersionLocked(
 				})
 				return errors.Wrap(err, "MANIFEST create failed")
 			}
+			// Sync the directory to make the MANIFEST file durable before creating
+			// the marker that points to it. This prevents a crash from leaving the
+			// marker pointing to a non-existent MANIFEST. Without this sync, both
+			// the MANIFEST and marker files would be unsynced until Move() completes,
+			// creating a race where a crash could include the marker but not the
+			// MANIFEST on filesystems with unordered metadata updates.
+			if err := vs.manifestMarker.SyncDir(); err != nil {
+				return errors.Wrap(err, "MANIFEST directory sync failed")
+			}
 		}
 
 		// Call ApplyAndUpdateVersionEdit before accumulating the version edit.
@@ -537,7 +560,10 @@ func (vs *versionSet) UpdateVersionLocked(
 			return errors.Wrap(err, "MANIFEST sync failed")
 		}
 		if newManifestFileNum != 0 {
-			// NB: Move() is responsible for syncing the data directory.
+			// NB: Move() syncs the directory again after creating the marker file,
+			// making the marker itself durable. The two directory syncs ensure that
+			// MANIFEST is durable before marker creation, and marker is durable
+			// after creation, eliminating any race window.
 			if err := vs.manifestMarker.Move(base.MakeFilename(base.FileTypeManifest, newManifestFileNum)); err != nil {
 				return errors.Wrap(err, "MANIFEST set current failed")
 			}

--- a/vfs/atomicfs/marker.go
+++ b/vfs/atomicfs/marker.go
@@ -259,3 +259,16 @@ func (a *Marker) RemoveObsolete() error {
 	a.obsoleteFiles = nil
 	return nil
 }
+
+// SyncDir syncs the directory to ensure that any file creations or removals
+// within the directory are durable. This can be used to ensure atomicity
+// when multiple files need to be created before updating the marker.
+func (a *Marker) SyncDir() error {
+	if err := a.dirFD.Sync(); err != nil {
+		// Fsync errors are unrecoverable.
+		// See https://wiki.postgresql.org/wiki/Fsync_Errors and
+		// https://danluu.com/fsyncgate.
+		panic(errors.WithStack(err))
+	}
+	return nil
+}


### PR DESCRIPTION
Previously, when rotating the manifest, both the new MANIFEST file and its marker file were created in the directory before a single directory sync made them both visible atomically. If a crash occurred after both files were created but before the directory sync, the filesystem could include the marker file without the MANIFEST file it references, particularly on filesystems with unordered metadata updates or under high I/O load.

This patch adds a SyncDir() method to atomicfs.Marker and calls it after creating a new MANIFEST file but before creating the marker that references it. This ensures two atomic operations: first the MANIFEST becomes durable, then the marker becomes durable. A crash at any point leaves the system in a consistent state where markers only reference existing MANIFEST files.

Fixes a race condition that could cause recovery to fail with "could not open manifest file: file does not exist".

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

Fixes: #5825