### PR TITLE
checkpoint, remoteobjcat: fix marker races

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -604,6 +604,15 @@ func (d *DB) writeCheckpointManifest(
 	if err != nil {
 		return err
 	}
+	// Sync the directory to ensure the MANIFEST file is durable before creating
+	// the marker that references it. This prevents a crash from leaving the
+	// marker pointing to a non-existent MANIFEST. Without this sync, both the
+	// MANIFEST and marker files would be unsynced until Move() completes,
+	// creating a race where a crash could include the marker but not the
+	// MANIFEST on filesystems with unordered metadata updates.
+	if err := manifestMarker.SyncDir(); err != nil {
+		return err
+	}
 	if err := manifestMarker.Move(base.MakeFilename(base.FileTypeManifest, manifestFileNum)); err != nil {
 		return err
 	}

--- a/objstorage/objstorageprovider/remoteobjcat/catalog.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog.go
@@ -395,6 +395,15 @@ func (c *Catalog) Checkpoint(fs vfs.FS, dir string) error {
 	if err != nil {
 		return err
 	}
+	// Sync the directory to ensure the catalog file is durable before creating
+	// the marker that references it. This prevents a crash from leaving the
+	// marker pointing to a non-existent catalog file. Without this sync, both
+	// the catalog and marker files would be unsynced until Move() completes,
+	// creating a race where a crash could include the marker but not the
+	// catalog on filesystems with unordered metadata updates.
+	if err := catalogMarker.SyncDir(); err != nil {
+		return err
+	}
 	if err := catalogMarker.Move(c.mu.catalogFilename); err != nil {
 		return err
 	}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -183,6 +183,7 @@ sync-data: checkpoints/checkpoint1/MANIFEST-000001
 close: checkpoints/checkpoint1/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
+sync: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
@@ -226,6 +227,7 @@ sync-data: checkpoints/checkpoint2/MANIFEST-000001
 close: checkpoints/checkpoint2/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
+sync: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
@@ -266,6 +268,7 @@ sync-data: checkpoints/checkpoint3/MANIFEST-000001
 close: checkpoints/checkpoint3/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint3
+sync: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
@@ -596,6 +599,7 @@ sync-data: checkpoints/checkpoint4/MANIFEST-000001
 close: checkpoints/checkpoint4/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint4
+sync: checkpoints/checkpoint4
 create: checkpoints/checkpoint4/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint4/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint4/marker.manifest.000001.MANIFEST-000001
@@ -706,6 +710,7 @@ sync-data: checkpoints/checkpoint5/MANIFEST-000001
 close: checkpoints/checkpoint5/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint5
+sync: checkpoints/checkpoint5
 create: checkpoints/checkpoint5/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint5/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint5/marker.manifest.000001.MANIFEST-000001
@@ -811,6 +816,7 @@ sync-data: checkpoints/checkpoint6/MANIFEST-000001
 close: checkpoints/checkpoint6/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint6
+sync: checkpoints/checkpoint6
 create: checkpoints/checkpoint6/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint6/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint6/marker.manifest.000001.MANIFEST-000001
@@ -1082,6 +1088,7 @@ sync-data: checkpoints/checkpoint8/MANIFEST-000001
 close: checkpoints/checkpoint8/MANIFEST-000001
 close: valsepdb/MANIFEST-000001
 open-dir: checkpoints/checkpoint8
+sync: checkpoints/checkpoint8
 create: checkpoints/checkpoint8/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint8/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint8/marker.manifest.000001.MANIFEST-000001
@@ -1198,6 +1205,7 @@ sync-data: checkpoints/checkpoint9/MANIFEST-000001
 close: checkpoints/checkpoint9/MANIFEST-000001
 close: valsepdb/MANIFEST-000001
 open-dir: checkpoints/checkpoint9
+sync: checkpoints/checkpoint9
 create: checkpoints/checkpoint9/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint9/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint9/marker.manifest.000001.MANIFEST-000001

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -179,6 +179,7 @@ sync-data: checkpoints/checkpoint1/REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint1/REMOTE-OBJ-CATALOG-000001
 close: db/REMOTE-OBJ-CATALOG-000001
 open-dir: checkpoints/checkpoint1
+sync: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync-data: checkpoints/checkpoint1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -233,6 +234,7 @@ sync-data: checkpoints/checkpoint2/REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint2/REMOTE-OBJ-CATALOG-000001
 close: db/REMOTE-OBJ-CATALOG-000001
 open-dir: checkpoints/checkpoint2
+sync: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync-data: checkpoints/checkpoint2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -283,6 +285,7 @@ sync-data: checkpoints/checkpoint3/REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint3/REMOTE-OBJ-CATALOG-000001
 close: db/REMOTE-OBJ-CATALOG-000001
 open-dir: checkpoints/checkpoint3
+sync: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync-data: checkpoints/checkpoint3/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint3/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -167,6 +167,7 @@ sync-data: checkpoints/checkpoint1/MANIFEST-000001
 close: checkpoints/checkpoint1/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
+sync: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
@@ -220,6 +221,7 @@ sync-data: checkpoints/checkpoint2/MANIFEST-000001
 close: checkpoints/checkpoint2/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
+sync: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
@@ -269,6 +271,7 @@ sync-data: checkpoints/checkpoint3/MANIFEST-000001
 close: checkpoints/checkpoint3/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint3
+sync: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -603,6 +603,7 @@ sync-data: checkpoint/MANIFEST-000023
 close: checkpoint/MANIFEST-000023
 close: db/MANIFEST-000023
 open-dir: checkpoint
+sync: checkpoint
 create: checkpoint/marker.manifest.000001.MANIFEST-000023
 sync-data: checkpoint/marker.manifest.000001.MANIFEST-000023
 close: checkpoint/marker.manifest.000001.MANIFEST-000023


### PR DESCRIPTION
See individual commits for details.
