### PR TITLE
iterv2: improvements to mergingIterV2

### DIFF
--- a/cockroachkvs/blockproperties.go
+++ b/cockroachkvs/blockproperties.go
@@ -9,7 +9,6 @@ import (
 	"math"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
 )
 
@@ -17,8 +16,8 @@ const mvccWallTimeIntervalCollector = "MVCCTimeInterval"
 
 // BlockPropertyCollectors is a list of constructors for block-property
 // collectors used by CockroachDB.
-var BlockPropertyCollectors = []func() pebble.BlockPropertyCollector{
-	func() pebble.BlockPropertyCollector {
+var BlockPropertyCollectors = []func() sstable.BlockPropertyCollector{
+	func() sstable.BlockPropertyCollector {
 		return sstable.NewBlockIntervalCollector(
 			mvccWallTimeIntervalCollector,
 			pebbleIntervalMapper{},
@@ -92,7 +91,7 @@ var _ sstable.IntervalMapper = pebbleIntervalMapper{}
 
 // MapPointKey is part of the sstable.IntervalMapper interface.
 func (pebbleIntervalMapper) MapPointKey(
-	key pebble.InternalKey, value []byte,
+	key sstable.InternalKey, value []byte,
 ) (sstable.BlockInterval, error) {
 	return mapSuffixToInterval(key.UserKey)
 }

--- a/merging_iter_v2.go
+++ b/merging_iter_v2.go
@@ -917,7 +917,18 @@ func (h *mergingIterV2Heap) Reset() {
 }
 
 func (h *mergingIterV2Heap) less(i, j int) bool {
-	return h.items[i].level.Compare(h.cmp, h.items[j].level) == h.lessCmp
+	li := h.items[i].level
+	lj := h.items[j].level
+	if cmp := li.Compare(h.cmp, lj); cmp != 0 {
+		return cmp == h.lessCmp
+	}
+	// When multiple levels have the same key, put higher levels (smaller index)
+	// at the top. This can only happen for boundary keys (real internal keys with
+	// the same user key must have different seq nums).
+	if invariants.Enabled && h.items[i].level.iterKV.Kind() != base.InternalKeyKindSpanBoundary {
+		panic(errors.AssertionFailedf("duplicate non-boundary key"))
+	}
+	return li.index < lj.index
 }
 
 func (h *mergingIterV2Heap) swap(i, j int) {
@@ -935,7 +946,7 @@ func (h *mergingIterV2Heap) Init(lessCmp int) {
 	h.lessCmp = lessCmp
 	n := h.Len()
 	for i := n/2 - 1; i >= 0; i-- {
-		h.down(i, n)
+		h.down(i)
 	}
 }
 
@@ -944,17 +955,18 @@ func (h *mergingIterV2Heap) Top() *mergingIterV2Level {
 }
 
 func (h *mergingIterV2Heap) FixTop() {
-	h.down(0, h.Len())
+	h.down(0)
 }
 
 func (h *mergingIterV2Heap) PopTop() {
 	n := h.Len() - 1
 	h.swap(0, n)
-	h.down(0, n)
 	h.items = h.items[:n]
+	h.down(0)
 }
 
-func (h *mergingIterV2Heap) down(i, n int) {
+func (h *mergingIterV2Heap) down(i int) {
+	n := len(h.items)
 	for {
 		j1 := 2*i + 1
 		if j1 >= n || j1 < 0 {

--- a/merging_iter_v2.go
+++ b/merging_iter_v2.go
@@ -456,21 +456,43 @@ func (m *mergingIterV2) advanceSlabForward() {
 		return
 	}
 
-	// Mark all levels at the slab boundary. The actual Next() call is deferred to
-	// the Build loop below, where we can skip it for levels that become parked
-	// (avoiding unnecessary file opens in level iterators).
-	top.atBoundary = true
-	m.heap.PopTop()
-	for m.heap.Len() > 0 {
-		level := m.heap.Top()
-		if level.iterKV.K.Kind() != base.InternalKeyKindSpanBoundary {
-			break
+	// Optimization: when a single level has a boundary here, and the current span
+	// on that level has no span keys, try to advance without rebuilding the slab.
+	// TODO(radu): we can relax these conditions to cover more cases.
+	if len(top.span.Keys) == 0 && !m.heap.MultipleLevelsAtSameBoundary() {
+		top.iterKV = top.iter.Next()
+		if top.iterKV == nil {
+			if m.levelHasError(top) {
+				return
+			}
+			m.heap.PopTop()
+		} else {
+			m.heap.FixTop()
 		}
-		if m.slab.cmp(level.iterKV.K.UserKey, boundaryKey) != 0 {
-			break
+		if len(top.span.Keys) == 0 {
+			// This was a spurious boundary: no keys before, no keys after. Nothing
+			// else in the slab has changed.
+			m.slab.calcNextBoundary(+1)
+			return
 		}
-		level.atBoundary = true
+		// We have to rebuild the slab in case some levels become parked.
+	} else {
+		// Mark all levels at the slab boundary. The actual Next() call is deferred to
+		// the Build loop below, where we can skip it for levels that become parked
+		// (avoiding unnecessary file opens in level iterators).
+		top.atBoundary = true
 		m.heap.PopTop()
+		for m.heap.Len() > 0 {
+			level := m.heap.Top()
+			if level.iterKV.K.Kind() != base.InternalKeyKindSpanBoundary {
+				break
+			}
+			if m.slab.cmp(level.iterKV.K.UserKey, boundaryKey) != 0 {
+				break
+			}
+			level.atBoundary = true
+			m.heap.PopTop()
+		}
 	}
 
 	// If some levels are parked, we will need the boundaryKey after potentially
@@ -661,22 +683,44 @@ func (m *mergingIterV2) advanceSlabBackward() {
 	top := m.heap.Top()
 	boundaryKey := top.iterKV.K.UserKey
 
-	// Mark all levels at the slab boundary (see advanceSlabForward). The actual
-	// Prev() call is deferred to the Build loop below, where we can skip it for
-	// levels that become parked (avoiding unnecessary file opens in level
-	// iterators).
-	top.atBoundary = true
-	m.heap.PopTop()
-	for m.heap.Len() > 0 {
-		level := m.heap.Top()
-		if level.iterKV.K.Kind() != base.InternalKeyKindSpanBoundary {
-			break
+	// Optimization: when a single level has a boundary here, and the current span
+	// on that level has no span keys, try to advance without rebuilding the slab.
+	// TODO(radu): we can relax these conditions to cover more cases.
+	if len(top.span.Keys) == 0 && !m.heap.MultipleLevelsAtSameBoundary() {
+		top.iterKV = top.iter.Prev()
+		if top.iterKV == nil {
+			if m.levelHasError(top) {
+				return
+			}
+			m.heap.PopTop()
+		} else {
+			m.heap.FixTop()
 		}
-		if m.slab.cmp(level.iterKV.K.UserKey, boundaryKey) != 0 {
-			break
+		if len(top.span.Keys) == 0 {
+			// This was a spurious boundary: no keys before, no keys after. Nothing
+			// else in the slab has changed.
+			m.slab.calcNextBoundary(-1)
+			return
 		}
-		level.atBoundary = true
+		// We have to rebuild the slab in case some levels become parked.
+	} else {
+		// Mark all levels at the slab boundary (see advanceSlabForward). The actual
+		// Prev() call is deferred to the Build loop below, where we can skip it for
+		// levels that become parked (avoiding unnecessary file opens in level
+		// iterators).
+		top.atBoundary = true
 		m.heap.PopTop()
+		for m.heap.Len() > 0 {
+			level := m.heap.Top()
+			if level.iterKV.K.Kind() != base.InternalKeyKindSpanBoundary {
+				break
+			}
+			if m.slab.cmp(level.iterKV.K.UserKey, boundaryKey) != 0 {
+				break
+			}
+			level.atBoundary = true
+			m.heap.PopTop()
+		}
 	}
 
 	// Unless some levels are parked, we are only using boundary in the first loop
@@ -947,6 +991,39 @@ func (h *mergingIterV2Heap) Init(lessCmp int) {
 
 func (h *mergingIterV2Heap) Top() *mergingIterV2Level {
 	return h.items[0].level
+}
+
+// MultipleLevelsAtSameBoundary returns true if the "second best" in the heap is at
+// the same boundary key as the top.
+func (h *mergingIterV2Heap) MultipleLevelsAtSameBoundary() bool {
+	if invariants.Enabled && h.Top().iterKV.Kind() != base.InternalKeyKindSpanBoundary {
+		panic(errors.AssertionFailedf("not at boundary"))
+	}
+
+	if h.Len() < 2 {
+		return false
+	}
+	secondBest := h.items[1].level
+	if h.Len() > 2 {
+		if h.items[0].winnerChild == winnerChildUnknown {
+			if h.less(2, 1) {
+				h.items[0].winnerChild = winnerChildRight
+			} else {
+				h.items[0].winnerChild = winnerChildLeft
+			}
+		}
+		if h.items[0].winnerChild == winnerChildRight {
+			secondBest = h.items[2].level
+		}
+	}
+	top := h.items[0].level
+	// Note: the index comparison is just an optimization: we know that if there
+	// are multiple levels with the same key, the smallest index is on top. We
+	// expect the bottom level to have the most boundaries, so it can save some
+	// comparisons.
+	return secondBest.index > top.index &&
+		secondBest.iterKV.Kind() == base.InternalKeyKindSpanBoundary &&
+		h.cmp(secondBest.iterKV.K.UserKey, top.iterKV.K.UserKey) == 0
 }
 
 func (h *mergingIterV2Heap) FixTop() {

--- a/merging_iter_v2.go
+++ b/merging_iter_v2.go
@@ -105,8 +105,7 @@ import (
 // The slab ends at the nearest unshadowed span boundary across all levels.
 // The slab state — per-level [minSeqNum, maxSeqNum) ranges, the next
 // boundary, and which levels are parked — is computed by
-// slabState.BuildForward / slabState.BuildBackward (see
-// merging_iter_v2_slab.go).
+// slabState.Build (see merging_iter_v2_slab.go).
 //
 // # Worked Example
 //
@@ -161,18 +160,15 @@ import (
 // When a slab boundary is reached (handleBoundaryForward /
 // handleBoundaryBackward), the merging iterator performs a slab transition:
 //
-//  1. Drain all co-located boundary keys at the same user key from the heap,
-//     advancing each level past its boundary. Multiple levels may have span
-//     boundaries at the same user key.
-//  2. Recompute the slab state via BuildForward / BuildBackward. This reads
-//     each level's updated span (the stashed span pointer is updated in
-//     place by the level iterator), finds visible RANGEDELs, sets per-level
-//     visibility ranges, and computes the next slab boundary.
-//  3. Unpark levels that were previously parked but are no longer shadowed
-//     (seek them to the slab boundary via SeekGE / SeekLT).
-//  4. Park levels that are now fully shadowed (clear their iterKV and
-//     exclude them from the heap).
-//  5. Rebuild the heap.
+//  1. Mark all co-located boundary keys at the same user key, removing them
+//     from the heap. The Next()/Prev() call to cross each boundary is
+//     deferred to avoid unnecessary file opens in level iterators.
+//  2. Recompute the slab state via Build. For each level, advance past the
+//     boundary (via Next()/Prev()) only if the level is not parked. Parked
+//     levels skip the call entirely — this is the key optimization. Unpark
+//     levels that were previously parked but are no longer shadowed by seeking
+//     them to the slab boundary.
+//  3. Rebuild the heap.
 //
 // # Parked Levels
 //
@@ -234,6 +230,10 @@ type mergingIterV2Level struct {
 	// RANGEDEL. A parked level's iterator is not positioned and produces
 	// no keys until unparked.
 	parked bool
+	// atBoundary is true when this level has a boundary key at the current
+	// slab boundary. The Next()/Prev() to cross it is deferred until we
+	// know whether the level will be parked.
+	atBoundary bool
 }
 
 func (level *mergingIterV2Level) Compare(cmp base.Compare, other *mergingIterV2Level) int {
@@ -321,7 +321,7 @@ func (m *mergingIterV2) First() (kv *base.InternalKV) {
 	}
 	m.err = nil
 	m.prefix = nil
-	for levelIdx, parked := range m.slab.BuildForward() {
+	for levelIdx, parked := range m.slab.Build(+1) {
 		level := &m.levels[levelIdx]
 		level.parked = parked
 		if parked {
@@ -345,7 +345,7 @@ func (m *mergingIterV2) seekGE(key []byte, flags base.SeekGEFlags) {
 	}
 	// TODO(radu): support TrySeekUsingNext.
 	flags = flags.DisableTrySeekUsingNext()
-	for levelIdx, parked := range m.slab.BuildForward() {
+	for levelIdx, parked := range m.slab.Build(+1) {
 		level := &m.levels[levelIdx]
 		level.parked = parked
 		if parked {
@@ -407,7 +407,8 @@ func (m *mergingIterV2) findNextEntry() *base.InternalKV {
 
 		// Handle boundary keys from level iters.
 		if level.iterKV.K.Kind() == base.InternalKeyKindSpanBoundary {
-			m.handleBoundaryForward(level)
+			m.slab.assertNextBoundary(level.iterKV.K.UserKey)
+			m.advanceSlabForward()
 			continue
 		}
 
@@ -438,56 +439,16 @@ func (m *mergingIterV2) addLevelStats(l *mergingIterV2Level) {
 	}
 }
 
-// handleBoundaryForward processes a boundary key at the top of the heap.
-// The boundary always matches the slab boundary, triggering a slab transition.
-func (m *mergingIterV2) handleBoundaryForward(level *mergingIterV2Level) {
-	if invariants.Enabled {
-		if m.slab.nextBoundary == nil || m.slab.cmp(level.iterKV.K.UserKey, m.slab.nextBoundary) != 0 {
-			panic(errors.AssertionFailedf(
-				"mergingIterV2: boundary key %s does not match slab boundary %v",
-				level.iterKV.K, m.slab.nextBoundary,
-			))
-		}
-	}
-	m.advanceSlabForward()
-}
-
 // advanceSlabForward handles a slab transition during forward iteration.
 func (m *mergingIterV2) advanceSlabForward() {
-	// Copy the slab boundary into a stable buffer. BuildForward below will
-	// reuse slab.nextBoundaryBuf, invalidating slab.nextBoundary.
-	m.keyBuf = append(m.keyBuf[:0], m.slab.nextBoundary...)
-	slabBoundary := m.keyBuf
+	top := m.heap.Top()
+	boundaryKey := top.iterKV.K.UserKey
 
-	// Drain all level boundary keys at slabBoundary from the heap.
-	for m.heap.Len() > 0 {
-		level := m.heap.Top()
-		if level.iterKV.K.Kind() != base.InternalKeyKindSpanBoundary {
-			break
-		}
-		if m.slab.cmp(level.iterKV.K.UserKey, slabBoundary) != 0 {
-			break
-		}
-		// Advance this level past its boundary. The level's stashed span
-		// pointer (level.span) is updated in-place by the iterator.
-		// TODO(radu): if the level becomes parked, this Next() call is not
-		// necessary and it can cause opening a new file in a level iterator.
-		level.iterKV = level.iter.Next()
-		if level.iterKV == nil {
-			if m.levelHasError(level) {
-				return
-			}
-			m.heap.PopTop()
-		} else {
-			m.heap.FixTop()
-		}
-	}
-
-	// If in prefix mode and the slab boundary is past the prefix, exhaust
+	// If in prefix mode and the boundary key is past the prefix, exhaust
 	// all levels. All matching-prefix keys have been returned. Don't seek
 	// any level past the prefix (preserves TrySeekUsingNext correctness
 	// for future seeks to different prefixes).
-	if m.prefix != nil && !bytes.Equal(m.prefix, m.split.Prefix(slabBoundary)) {
+	if m.prefix != nil && !bytes.Equal(m.prefix, m.split.Prefix(boundaryKey)) {
 		for i := range m.levels {
 			m.levels[i].iterKV = nil
 		}
@@ -495,33 +456,63 @@ func (m *mergingIterV2) advanceSlabForward() {
 		return
 	}
 
-	// Recompute the slab via BuildForward. Levels that were previously
-	// parked are unparked and seeked to the slab boundary; newly parked
-	// levels have their iterKV cleared.
-	for levelIdx, parked := range m.slab.BuildForward() {
+	// Mark all levels at the slab boundary. The actual Next() call is deferred to
+	// the Build loop below, where we can skip it for levels that become parked
+	// (avoiding unnecessary file opens in level iterators).
+	top.atBoundary = true
+	m.heap.PopTop()
+	for m.heap.Len() > 0 {
+		level := m.heap.Top()
+		if level.iterKV.K.Kind() != base.InternalKeyKindSpanBoundary {
+			break
+		}
+		if m.slab.cmp(level.iterKV.K.UserKey, boundaryKey) != 0 {
+			break
+		}
+		level.atBoundary = true
+		m.heap.PopTop()
+	}
+
+	// If some levels are parked, we will need the boundaryKey after potentially
+	// moving the iterator that produced it; make a copy.
+	if m.anyLevelParked() {
+		m.keyBuf = append(m.keyBuf[:0], boundaryKey...)
+		boundaryKey = m.keyBuf
+	}
+
+	// Recompute the slab. For levels at the boundary, call Next() to cross it
+	// (updating the span in place) only if the level is not parked. Parked levels
+	// skip the Next() entirely.
+	for levelIdx, parked := range m.slab.Build(+1) {
 		level := &m.levels[levelIdx]
 		wasParked := level.parked
 		level.parked = parked
 		if parked {
 			level.iterKV = nil
+			level.atBoundary = false
+		} else if level.atBoundary {
+			// Cross the boundary via Next(). This updates the level's
+			// stashed span pointer in place.
+			level.atBoundary = false
+			level.iterKV = level.iter.Next()
+			if level.iterKV == nil && m.levelHasError(level) {
+				return
+			}
 		} else if wasParked {
 			// Unpark: seek to slab boundary.
 			if m.prefix != nil {
 				// TODO(radu): use TrySeekUsingNext (we'll have to keep track of whether
 				// the iteration direction has changed).
-				level.iterKV = level.iter.SeekPrefixGE(
-					m.prefix, slabBoundary, base.SeekGEFlagsNone,
-				)
+				level.iterKV = level.iter.SeekPrefixGE(m.prefix, boundaryKey, base.SeekGEFlagsNone)
 			} else {
-				level.iterKV = level.iter.SeekGE(
-					slabBoundary, base.SeekGEFlagsNone,
-				)
+				level.iterKV = level.iter.SeekGE(boundaryKey, base.SeekGEFlagsNone)
 			}
 			if level.iterKV == nil && m.levelHasError(level) {
 				return
 			}
 		}
-		// else: level was active and stays active; span already current.
+		// else: level was active, not at boundary, stays active; span
+		// already current.
 	}
 
 	// Rebuild the heap.
@@ -570,7 +561,7 @@ func (m *mergingIterV2) seekLT(key []byte, flags base.SeekLTFlags) {
 	if invariants.Enabled && flags.RelativeSeek() {
 		panic(errors.AssertionFailedf("invalid use of relative seek"))
 	}
-	for levelIdx, parked := range m.slab.BuildBackward() {
+	for levelIdx, parked := range m.slab.Build(-1) {
 		level := &m.levels[levelIdx]
 		level.parked = parked
 		if parked {
@@ -595,7 +586,7 @@ func (m *mergingIterV2) Last() (kv *base.InternalKV) {
 	}
 	m.err = nil
 	m.prefix = nil
-	for levelIdx, parked := range m.slab.BuildBackward() {
+	for levelIdx, parked := range m.slab.Build(-1) {
 		level := &m.levels[levelIdx]
 		level.parked = parked
 		if parked {
@@ -646,7 +637,8 @@ func (m *mergingIterV2) findPrevEntry() *base.InternalKV {
 
 		// Handle boundary keys from level iters.
 		if level.iterKV.K.Kind() == base.InternalKeyKindSpanBoundary {
-			m.handleBoundaryBackward(level)
+			m.slab.assertNextBoundary(level.iterKV.K.UserKey)
+			m.advanceSlabBackward()
 			continue
 		}
 
@@ -664,71 +656,62 @@ func (m *mergingIterV2) findPrevEntry() *base.InternalKV {
 	return nil
 }
 
-// handleBoundaryBackward processes a boundary key at the top of the heap
-// during backward iteration. The boundary always matches the slab boundary,
-// triggering a slab transition.
-func (m *mergingIterV2) handleBoundaryBackward(level *mergingIterV2Level) {
-	if invariants.Enabled {
-		if m.slab.nextBoundary == nil || m.slab.cmp(level.iterKV.K.UserKey, m.slab.nextBoundary) != 0 {
-			panic(errors.AssertionFailedf(
-				"mergingIterV2: boundary key %s does not match slab boundary %v",
-				level.iterKV.K, m.slab.nextBoundary,
-			))
-		}
-	}
-	m.advanceSlabBackward()
-}
-
 // advanceSlabBackward handles a slab transition during backward iteration.
 func (m *mergingIterV2) advanceSlabBackward() {
-	// Copy the slab boundary into a stable buffer. BuildBackward below will
-	// reuse slab.nextBoundaryBuf, invalidating slab.nextBoundary.
-	m.keyBuf = append(m.keyBuf[:0], m.slab.nextBoundary...)
-	lastSlabBoundary := m.keyBuf
+	top := m.heap.Top()
+	boundaryKey := top.iterKV.K.UserKey
 
-	// Drain all level boundary keys at slabBoundary from the heap.
+	// Mark all levels at the slab boundary (see advanceSlabForward). The actual
+	// Prev() call is deferred to the Build loop below, where we can skip it for
+	// levels that become parked (avoiding unnecessary file opens in level
+	// iterators).
+	top.atBoundary = true
+	m.heap.PopTop()
 	for m.heap.Len() > 0 {
 		level := m.heap.Top()
 		if level.iterKV.K.Kind() != base.InternalKeyKindSpanBoundary {
 			break
 		}
-		if m.slab.cmp(level.iterKV.K.UserKey, lastSlabBoundary) != 0 {
+		if m.slab.cmp(level.iterKV.K.UserKey, boundaryKey) != 0 {
 			break
 		}
-		// Advance this level past its boundary (backward). The level's
-		// stashed span pointer (level.span) is updated in-place by the
-		// iterator.
-		// TODO(radu): if the level becomes parked, this Prev() call is not
-		// necessary and it can cause opening a new file in a level iterator.
-		level.iterKV = level.iter.Prev()
-		if level.iterKV == nil {
-			if m.levelHasError(level) {
-				return
-			}
-			m.heap.PopTop()
-		} else {
-			m.heap.FixTop()
-		}
+		level.atBoundary = true
+		m.heap.PopTop()
 	}
 
-	// Recompute the slab via BuildBackward. Levels that were previously
-	// parked are unparked and seeked to the slab boundary; newly parked
-	// levels have their iterKV cleared.
-	for level, parked := range m.slab.BuildBackward() {
-		wasParked := m.levels[level].parked
-		m.levels[level].parked = parked
+	// Unless some levels are parked, we are only using boundary in the first loop
+	// below (before messing with the iterator).
+	if m.anyLevelParked() {
+		m.keyBuf = append(m.keyBuf[:0], boundaryKey...)
+		boundaryKey = m.keyBuf
+	}
+
+	// Recompute the slab. For levels at the boundary, call Prev() to cross it
+	// only if the level is not parked.
+	for levelIdx, parked := range m.slab.Build(-1) {
+		level := &m.levels[levelIdx]
+		wasParked := level.parked
+		level.parked = parked
 		if parked {
-			m.levels[level].iterKV = nil
+			level.iterKV = nil
+			level.atBoundary = false
+		} else if level.atBoundary {
+			// Cross the boundary via Prev(). This updates the level's
+			// stashed span pointer in place.
+			level.atBoundary = false
+			level.iterKV = level.iter.Prev()
+			if level.iterKV == nil && m.levelHasError(level) {
+				return
+			}
 		} else if wasParked {
 			// Unpark: seek to before slab boundary.
-			m.levels[level].iterKV = m.levels[level].iter.SeekLT(
-				lastSlabBoundary, base.SeekLTFlagsNone,
-			)
-			if m.levels[level].iterKV == nil && m.levelHasError(&m.levels[level]) {
+			level.iterKV = level.iter.SeekLT(boundaryKey, base.SeekLTFlagsNone)
+			if level.iterKV == nil && m.levelHasError(level) {
 				return
 			}
 		}
-		// else: level was active and stays active; span already current.
+		// else: level was active, not at boundary, stays active; span
+		// already current.
 	}
 
 	// Rebuild the heap.
@@ -752,7 +735,7 @@ func (m *mergingIterV2) switchToMinHeapAndNext() *base.InternalKV {
 	key.UserKey = m.keyBuf
 
 	// Recompute slab for forward iteration.
-	for levelIdx, parked := range m.slab.BuildForward() {
+	for levelIdx, parked := range m.slab.Build(+1) {
 		level := &m.levels[levelIdx]
 		if parked {
 			level.parked = true
@@ -799,7 +782,7 @@ func (m *mergingIterV2) switchToMaxHeapAndPrev() *base.InternalKV {
 	key.UserKey = m.keyBuf
 
 	// Recompute slab for backward iteration.
-	for levelIdx, parked := range m.slab.BuildBackward() {
+	for levelIdx, parked := range m.slab.Build(-1) {
 		level := &m.levels[levelIdx]
 		if parked {
 			level.parked = true
@@ -881,9 +864,21 @@ func (m *mergingIterV2) TreeStepsNode() treesteps.NodeInfo {
 	return info
 }
 
+func (m *mergingIterV2) anyLevelParked() bool {
+	for i := range m.levels {
+		if m.levels[i].parked {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *mergingIterV2) levelHasError(level *mergingIterV2Level) bool {
 	if err := level.iter.Error(); err != nil {
 		m.err = err
+		for i := range m.levels {
+			m.levels[i].atBoundary = false
+		}
 		m.heap.Reset()
 		return true
 	}

--- a/merging_iter_v2_bench_test.go
+++ b/merging_iter_v2_bench_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/cockroachdb/pebble/cockroachkvs"
+	"github.com/cockroachdb/pebble/internal/base"
+)
+
+func BenchmarkMergingIterV2Heap(b *testing.B) {
+	// 8 is a typical number of levels: 6 levels plus one L0 sublevel plus a
+	// memtable.
+	const numLevels = 8
+
+	type keyConfig struct {
+		name string
+		cfg  cockroachkvs.KeyGenConfig
+	}
+	configs := []keyConfig{
+		{name: "short", cfg: cockroachkvs.KeyGenConfig{
+			PrefixAlphabetLen: 8, RoachKeyLen: 10, PrefixLenShared: 2,
+			AvgKeysPerPrefix: 2, BaseWallTime: 1e18,
+		}},
+		{name: "long", cfg: cockroachkvs.KeyGenConfig{
+			PrefixAlphabetLen: 20, RoachKeyLen: 512, PrefixLenShared: 64,
+			AvgKeysPerPrefix: 2, BaseWallTime: 1e18,
+		}},
+	}
+
+	for _, tc := range configs {
+		b.Run(tc.name, func(b *testing.B) {
+			rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
+			levels := make([]mergingIterV2Level, numLevels)
+			for l := range levels {
+				levels[l].index = l
+			}
+
+			// Init measures the time to initialize the heap.
+			b.Run("Init", func(b *testing.B) {
+				var heap mergingIterV2Heap
+				heap.cmp = cockroachkvs.Comparer.Compare
+				heap.items = make([]mergingIterV2HeapItem, 0, numLevels)
+
+				const numKVs = 1024
+				keys, _ := cockroachkvs.RandomKVs(rng, numKVs, tc.cfg, 0)
+				rand.Shuffle(len(keys), func(i, j int) {
+					keys[i], keys[j] = keys[j], keys[i]
+				})
+				levelKVs := make([]base.InternalKV, numLevels)
+				p := 0
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					heap.Reset()
+					for l := range levels {
+						levelKVs[l].K = base.MakeInternalKey(keys[(p+l)%numKVs], 1, base.InternalKeyKindSet)
+						p++
+						levels[l].iterKV = &levelKVs[l]
+						heap.Append(&levels[l])
+					}
+					p += numLevels
+					heap.Init(+1)
+				}
+			})
+
+			b.Run("FixTop", func(b *testing.B) {
+				// Generate a shared pool of keys and distribute them to levels
+				// with exponential bias (lower levels get more keys), mimicking
+				// a real LSM.
+				const totalKeys = 100_000
+				allKeys, _ := cockroachkvs.RandomKVs(rng, totalKeys, tc.cfg, 0)
+
+				var heap mergingIterV2Heap
+				heap.cmp = cockroachkvs.Comparer.Compare
+				heap.items = make([]mergingIterV2HeapItem, 0, numLevels)
+
+				b.ResetTimer()
+				for done := 0; done < b.N; {
+					b.StopTimer()
+					levelKVs := make([][]base.InternalKV, numLevels)
+					for _, k := range allKeys {
+						// Each level has ~4x more keys than the next level.
+						l := 0
+						for ; l < numLevels-1 && rng.IntN(4) == 1; l++ {
+						}
+						levelKVs[l] = append(levelKVs[l], base.InternalKV{
+							K: base.MakeInternalKey(k, 1, base.InternalKeyKindSet),
+						})
+					}
+					pos := make([]int, numLevels)
+					heap.Reset()
+					for l := range levels {
+						if len(levelKVs[l]) == 0 {
+							continue
+						}
+						levels[l].iterKV = &levelKVs[l][0]
+						heap.Append(&levels[l])
+					}
+					heap.Init(+1)
+					b.StartTimer()
+
+					for heap.Len() > 0 && done < b.N {
+						top := heap.Top()
+						l := top.index
+						pos[l]++
+						if pos[l] >= len(levelKVs[l]) {
+							heap.PopTop()
+							top.iterKV = nil
+						} else {
+							top.iterKV = &levelKVs[l][pos[l]]
+							heap.FixTop()
+						}
+						done++
+					}
+				}
+			})
+		})
+	}
+}

--- a/merging_iter_v2_rand_test.go
+++ b/merging_iter_v2_rand_test.go
@@ -115,9 +115,20 @@ func randMergingTestLevels(
 		lvlCfg.MinSeqNum = minSeq
 		lvlCfg.MaxSeqNum = maxSeq
 
+		// Generate random spurious boundaries (0-3 per level).
+		numExtra := rng.IntN(4)
+		var extraBoundaries [][]byte
+		if numExtra > 0 {
+			extraBoundaries = make([][]byte, numExtra)
+			for j := range numExtra {
+				extraBoundaries[j] = cfg.RandKey(rng)
+			}
+		}
+
 		levels[i] = mergingTestLevel{
-			points: iterv2.RandPointKeys(rng, lvlCfg, maxPointsPerLevel),
-			spans:  iterv2.RandSpans(rng, lvlCfg, maxSpansPerLevel),
+			points:          iterv2.RandPointKeys(rng, lvlCfg, maxPointsPerLevel),
+			spans:           iterv2.RandSpans(rng, lvlCfg, maxSpansPerLevel),
+			extraBoundaries: extraBoundaries,
 		}
 	}
 	return levels

--- a/merging_iter_v2_slab.go
+++ b/merging_iter_v2_slab.go
@@ -51,6 +51,7 @@ type slabState struct {
 // smaller seqnum than any higher-level RANGEDEL.
 func (s *slabState) Build(dir int8) iter.Seq2[int, bool] {
 	return func(yield func(int, bool) bool) {
+		// INVARIANT: highestRangeDelSeqNum > 0 <=> parked
 		highestRangeDelSeqNum := base.SeqNum(0)
 
 		parked := false

--- a/merging_iter_v2_slab.go
+++ b/merging_iter_v2_slab.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"iter"
+	"slices"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -17,9 +18,7 @@ import (
 
 // slabState manages the per-level span state, the per-level visibility ranges
 // ([minSeqNum, maxSeqNum) on each level), and the slab boundary for the
-// merging iterator. It is direction-aware: BuildForward uses span.Boundary
-// (which is the exclusive End during forward iteration); BuildBackward uses
-// span.Boundary (which is the inclusive Start during backward iteration).
+// merging iterator.
 type slabState struct {
 	cmp base.Compare
 	// snapshot is the SeqNum at which we are reading; only point/span keys with
@@ -32,33 +31,26 @@ type slabState struct {
 	// level index (0 = highest / most recent level).
 	levels []mergingIterV2Level
 
-	// nextBoundary is the user key where the current slab ends (forward
-	// iteration) or starts (backward iteration). It is the nearest
-	// unshadowed span.Boundary across all levels. nil means no boundary
-	// was found (the slab extends to the iterator bound).
-	nextBoundary    []byte
-	nextBoundaryBuf []byte
+	// nextBoundary is the nearest unshadowed span.Boundary across all
+	// non-parked levels. Only computed and used in invariant builds, for
+	// assertion checking in handleBoundaryForward / handleBoundaryBackward.
+	nextBoundary invariants.Value[[]byte]
 }
 
-// BuildForward returns an iterator over (levelIdx, parked) pairs for levels
-// 0 through len(s.levels)-1. For each yielded level, the caller must position
-// the level's iterator (which updates the stashed span) before continuing the
-// loop, unless parked is true (in which case the iterator should not be
-// positioned). The caller should also set the level's parked field accordingly.
+// Build returns an iterator over (levelIdx, parked) pairs for levels 0 through
+// len(s.levels)-1. For each yielded level, the caller must position the level's
+// iterator (which updates the stashed span) before continuing the loop, unless
+// parked is true (in which case the iterator should not be positioned). The
+// caller should also set the level's parked field accordingly.
 //
-// After the caller continues, BuildForward reads the level's span, detects
-// visible RANGEDELs, sets the level's [minSeqNum, maxSeqNum) visibility range,
-// updates the nextBoundary, and computes whether the next level should be
-// parked.
+// After the caller continues, Build reads the level's span, detects visible
+// RANGEDELs, sets the level's [minSeqNum, maxSeqNum) visibility range, and
+// computes whether the next level should be parked.
 //
 // Under invariants, asserts that a lower-level RANGEDEL has a strictly
 // smaller seqnum than any higher-level RANGEDEL.
-//
-// TODO(radu): avoid building and maintaining the slab in the common case where
-// no levels have any spans.
-func (s *slabState) BuildForward() iter.Seq2[int, bool] {
+func (s *slabState) Build(dir int8) iter.Seq2[int, bool] {
 	return func(yield func(int, bool) bool) {
-		s.nextBoundary = nil
 		highestRangeDelSeqNum := base.SeqNum(0)
 
 		parked := false
@@ -94,83 +86,40 @@ func (s *slabState) BuildForward() iter.Seq2[int, bool] {
 			}
 			sl.minSeqNum = highestRangeDelSeqNum
 
-			// Incremental nextBoundary: minimum span.Boundary across all
-			// active (non-parked) levels. During forward iteration,
-			// span.Boundary is the exclusive End of the span.
-			if boundary := sl.span.Boundary; boundary != nil {
-				if s.nextBoundary == nil || s.cmp(boundary, s.nextBoundary) < 0 {
-					s.nextBoundaryBuf = append(s.nextBoundaryBuf[:0], boundary...)
-					s.nextBoundary = s.nextBoundaryBuf
-				}
-			}
-
 			// All lower levels are parked if we have any visible RANGEDEL.
 			parked = highestRangeDelSeqNum > 0
 		}
+		s.calcNextBoundary(dir)
 	}
 }
 
-// BuildBackward is the backward-iteration counterpart of BuildForward. It
-// returns an iterator over (levelIdx, parked) pairs. For each yielded level,
-// the caller must position the level's iterator (which updates the stashed
-// span) before continuing the loop, unless parked is true. During backward
-// iteration, span.Boundary is the inclusive Start of the span.
+// calcNextBoundary computes the nearest unshadowed span boundary across all
+// non-parked levels and stores it in s.nextBoundary. Only does work in
+// invariant builds; in production builds this is a no-op.
 //
-// After the caller continues, BuildBackward reads the level's span, detects
-// visible RANGEDELs, sets the level's [minSeqNum, maxSeqNum) visibility range,
-// updates the nextBoundary, and computes whether the next level should be
-// parked.
-//
-// The nextBoundary is the maximum span.Boundary across all non-parked levels
-// (the nearest boundary in the backward direction).
-func (s *slabState) BuildBackward() iter.Seq2[int, bool] {
-	return func(yield func(int, bool) bool) {
-		s.nextBoundary = nil
-		highestRangeDelSeqNum := base.SeqNum(0)
-
-		parked := false
-		for levelIdx := range s.levels {
-			if !yield(levelIdx, parked) {
-				return
-			}
-			// After yield, the caller has positioned the level's iterator
-			// (updating the span) or left it unpositioned if parked.
-
-			if parked {
-				continue
-			}
-
-			sl := &s.levels[levelIdx]
-			// Set maxSeqNum: batch level uses batchSnapshot, others use snapshot.
-			if levelIdx == 0 && s.batchSnapshot != 0 {
-				sl.maxSeqNum = s.batchSnapshot
-			} else {
-				sl.maxSeqNum = s.snapshot
-			}
-
-			if highestRangeDelSeqNum == 0 {
-				highestRangeDelSeqNum = visibleRangeDelSeqNum(sl.span, sl.maxSeqNum)
-			} else if invariants.Enabled {
-				rdSeqNum := visibleRangeDelSeqNum(sl.span, sl.maxSeqNum)
-				if rdSeqNum >= highestRangeDelSeqNum {
-					panic(errors.AssertionFailedf("lower level has visible RANGEDEL with seqnum >= higher level's"))
-				}
-			}
-			sl.minSeqNum = highestRangeDelSeqNum
-
-			// Incremental nextBoundary: maximum span.Boundary across all
-			// active (non-parked) levels. During backward iteration,
-			// span.Boundary is the inclusive Start of the span.
-			if boundary := sl.span.Boundary; boundary != nil {
-				if s.nextBoundary == nil || s.cmp(boundary, s.nextBoundary) > 0 {
-					s.nextBoundaryBuf = append(s.nextBoundaryBuf[:0], boundary...)
-					s.nextBoundary = s.nextBoundaryBuf
-				}
-			}
-
-			// All lower levels are parked if we have any visible RANGEDEL.
-			parked = highestRangeDelSeqNum > 0
+// dir indicates the comparison direction: +1 for forward iteration (minimum
+// boundary), -1 for backward iteration (maximum boundary).
+func (s *slabState) calcNextBoundary(dir int8) {
+	if !invariants.Enabled {
+		return
+	}
+	var nb []byte
+	for i := range s.levels {
+		if s.levels[i].parked {
+			continue
 		}
+		if boundary := s.levels[i].span.Boundary; boundary != nil {
+			if nb == nil || s.cmp(boundary, nb) == -int(dir) {
+				nb = boundary
+			}
+		}
+	}
+	s.nextBoundary.Set(slices.Clone(nb))
+}
+
+func (s *slabState) assertNextBoundary(key []byte) {
+	if invariants.Enabled && s.cmp(s.nextBoundary.Get(), key) != 0 {
+		panic(errors.AssertionFailedf("boundary key %s does not match slab boundary %v", key, s.nextBoundary))
 	}
 }
 

--- a/merging_iter_v2_test.go
+++ b/merging_iter_v2_test.go
@@ -24,8 +24,9 @@ import (
 // mergingTestLevel represents a single level of a merging iterator test, with
 // sorted point keys and non-overlapping range deletion spans.
 type mergingTestLevel struct {
-	points []base.InternalKV // sorted by InternalCompare
-	spans  []keyspan.Span    // non-overlapping, sorted by Start
+	points          []base.InternalKV // sorted by InternalCompare
+	spans           []keyspan.Span    // non-overlapping, sorted by Start
+	extraBoundaries [][]byte          // additional boundary keys (for spurious boundaries)
 }
 
 // mergeLevels returns the surviving point keys after applying range deletion
@@ -92,7 +93,7 @@ func newMergingIterV2FromLevels(
 ) *mergingIterV2 {
 	iters := make([]iterv2.Iter, len(levels))
 	for i, lvl := range levels {
-		iters[i] = iterv2.NewTestIter(lvl.points, lvl.spans, nil, nil, nil, nil, nil)
+		iters[i] = iterv2.NewTestIter(lvl.points, lvl.spans, lvl.extraBoundaries, nil, nil, nil, nil)
 		if rand.IntN(2) == 0 {
 			iters[i] = iterv2.NewInvalidating(iters[i])
 		}


### PR DESCRIPTION
This PR is for the top 3 commits.

#### iterv2: minor changes to mergingIterV2Heap

Break boundary key ties by index. This will be helpful with some
optimizations later.

Also add a benchmark:

```
name                               time/op
MergingIterV2Heap/short/Init-10     117ns ±12%
MergingIterV2Heap/short/FixTop-10  10.1ns ±17%
MergingIterV2Heap/long/Init-10      144ns ± 3%
MergingIterV2Heap/long/FixTop-10   21.1ns ±10%
```

#### iterv2: mergingIterV2: defer boundary Next/Prev to avoid unnecessary file opens

Previously, when the merging iterator hit a slab boundary, it would
immediately call Next()/Prev() on every level with a boundary key at that
position before rebuilding the slab. This could cause unnecessary file opens
in level iterators for levels that become parked in the new slab.

This change defers the Next()/Prev() call: levels at the boundary are marked
with atBoundary=true and removed from the heap. During the slab Build loop,
Next()/Prev() is only called for levels that remain active (not parked).
Parked levels skip the call entirely.

Other changes:
 - Merge BuildForward/BuildBackward into a single Build(dir) method.
 - Remove handleBoundaryForward/handleBoundaryBackward (inlined).
 - Make nextBoundary tracking invariant-only (used for assertion checking).
 - Add anyLevelParked() helper to avoid unnecessary key copies.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### iterv2: mergingIterV2: fast path to avoid slab rebuild

When a single level hits a spurious boundary (a span boundary with no span
keys before and after), skip the full slab rebuild and just recalculate the
next boundary. This avoids unnecessary work for the common case of empty
range deletion spans.

Add MultipleLevelsAtSameBoundary() to efficiently detect when the fast path
is applicable (only one level at the boundary). Add test infrastructure for
generating random spurious boundaries to exercise this code path.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>