### PR TITLE
crl-release-26.2: db: ensure manifest, catalog durable before marker creation

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -604,6 +604,15 @@ func (d *DB) writeCheckpointManifest(
 	if err != nil {
 		return err
 	}
+	// Sync the directory to ensure the MANIFEST file is durable before creating
+	// the marker that references it. This prevents a crash from leaving the
+	// marker pointing to a non-existent MANIFEST. Without this sync, both the
+	// MANIFEST and marker files would be unsynced until Move() completes,
+	// creating a race where a crash could include the marker but not the
+	// MANIFEST on filesystems with unordered metadata updates.
+	if err := manifestMarker.SyncDir(); err != nil {
+		return err
+	}
 	if err := manifestMarker.Move(base.MakeFilename(base.FileTypeManifest, manifestFileNum)); err != nil {
 		return err
 	}

--- a/objstorage/objstorageprovider/remoteobjcat/catalog.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog.go
@@ -395,6 +395,15 @@ func (c *Catalog) Checkpoint(fs vfs.FS, dir string) error {
 	if err != nil {
 		return err
 	}
+	// Sync the directory to ensure the catalog file is durable before creating
+	// the marker that references it. This prevents a crash from leaving the
+	// marker pointing to a non-existent catalog file. Without this sync, both
+	// the catalog and marker files would be unsynced until Move() completes,
+	// creating a race where a crash could include the marker but not the
+	// catalog on filesystems with unordered metadata updates.
+	if err := catalogMarker.SyncDir(); err != nil {
+		return err
+	}
 	if err := catalogMarker.Move(c.mu.catalogFilename); err != nil {
 		return err
 	}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -14,6 +14,7 @@ open-dir: db
 open-dir: db
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
@@ -751,6 +752,7 @@ close: checkpoints/checkpoint5/000019.sst
 sync: checkpoints/checkpoint5
 get-disk-usage: checkpoints/checkpoint5
 create: checkpoints/checkpoint5/MANIFEST-000020
+sync: checkpoints/checkpoint5
 sync: checkpoints/checkpoint5/MANIFEST-000020
 create: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000020
 sync: checkpoints/checkpoint5/marker.manifest.000002.MANIFEST-000020
@@ -855,6 +857,7 @@ close: checkpoints/checkpoint6/000019.sst
 sync: checkpoints/checkpoint6
 get-disk-usage: checkpoints/checkpoint6
 create: checkpoints/checkpoint6/MANIFEST-000020
+sync: checkpoints/checkpoint6
 sync: checkpoints/checkpoint6/MANIFEST-000020
 create: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000020
 sync: checkpoints/checkpoint6/marker.manifest.000002.MANIFEST-000020
@@ -929,6 +932,7 @@ open-dir: valsepdb
 open-dir: valsepdb
 create: valsepdb/MANIFEST-000001
 sync: valsepdb/MANIFEST-000001
+sync: valsepdb
 create: valsepdb/marker.manifest.000001.MANIFEST-000001
 sync: valsepdb/marker.manifest.000001.MANIFEST-000001
 close: valsepdb/marker.manifest.000001.MANIFEST-000001

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -183,6 +183,7 @@ sync-data: checkpoints/checkpoint1/MANIFEST-000001
 close: checkpoints/checkpoint1/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
+sync: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
@@ -226,6 +227,7 @@ sync-data: checkpoints/checkpoint2/MANIFEST-000001
 close: checkpoints/checkpoint2/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
+sync: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
@@ -266,6 +268,7 @@ sync-data: checkpoints/checkpoint3/MANIFEST-000001
 close: checkpoints/checkpoint3/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint3
+sync: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
@@ -596,6 +599,7 @@ sync-data: checkpoints/checkpoint4/MANIFEST-000001
 close: checkpoints/checkpoint4/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint4
+sync: checkpoints/checkpoint4
 create: checkpoints/checkpoint4/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint4/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint4/marker.manifest.000001.MANIFEST-000001
@@ -706,6 +710,7 @@ sync-data: checkpoints/checkpoint5/MANIFEST-000001
 close: checkpoints/checkpoint5/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint5
+sync: checkpoints/checkpoint5
 create: checkpoints/checkpoint5/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint5/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint5/marker.manifest.000001.MANIFEST-000001
@@ -811,6 +816,7 @@ sync-data: checkpoints/checkpoint6/MANIFEST-000001
 close: checkpoints/checkpoint6/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint6
+sync: checkpoints/checkpoint6
 create: checkpoints/checkpoint6/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint6/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint6/marker.manifest.000001.MANIFEST-000001
@@ -1082,6 +1088,7 @@ sync-data: checkpoints/checkpoint8/MANIFEST-000001
 close: checkpoints/checkpoint8/MANIFEST-000001
 close: valsepdb/MANIFEST-000001
 open-dir: checkpoints/checkpoint8
+sync: checkpoints/checkpoint8
 create: checkpoints/checkpoint8/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint8/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint8/marker.manifest.000001.MANIFEST-000001
@@ -1198,6 +1205,7 @@ sync-data: checkpoints/checkpoint9/MANIFEST-000001
 close: checkpoints/checkpoint9/MANIFEST-000001
 close: valsepdb/MANIFEST-000001
 open-dir: checkpoints/checkpoint9
+sync: checkpoints/checkpoint9
 create: checkpoints/checkpoint9/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint9/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint9/marker.manifest.000001.MANIFEST-000001

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -179,6 +179,7 @@ sync-data: checkpoints/checkpoint1/REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint1/REMOTE-OBJ-CATALOG-000001
 close: db/REMOTE-OBJ-CATALOG-000001
 open-dir: checkpoints/checkpoint1
+sync: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync-data: checkpoints/checkpoint1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -233,6 +234,7 @@ sync-data: checkpoints/checkpoint2/REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint2/REMOTE-OBJ-CATALOG-000001
 close: db/REMOTE-OBJ-CATALOG-000001
 open-dir: checkpoints/checkpoint2
+sync: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync-data: checkpoints/checkpoint2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -283,6 +285,7 @@ sync-data: checkpoints/checkpoint3/REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint3/REMOTE-OBJ-CATALOG-000001
 close: db/REMOTE-OBJ-CATALOG-000001
 open-dir: checkpoints/checkpoint3
+sync: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync-data: checkpoints/checkpoint3/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: checkpoints/checkpoint3/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -167,6 +167,7 @@ sync-data: checkpoints/checkpoint1/MANIFEST-000001
 close: checkpoints/checkpoint1/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint1
+sync: checkpoints/checkpoint1
 create: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint1/marker.manifest.000001.MANIFEST-000001
@@ -220,6 +221,7 @@ sync-data: checkpoints/checkpoint2/MANIFEST-000001
 close: checkpoints/checkpoint2/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint2
+sync: checkpoints/checkpoint2
 create: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint2/marker.manifest.000001.MANIFEST-000001
@@ -269,6 +271,7 @@ sync-data: checkpoints/checkpoint3/MANIFEST-000001
 close: checkpoints/checkpoint3/MANIFEST-000001
 close: db/MANIFEST-000001
 open-dir: checkpoints/checkpoint3
+sync: checkpoints/checkpoint3
 create: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 sync-data: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001
 close: checkpoints/checkpoint3/marker.manifest.000001.MANIFEST-000001

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -14,6 +14,7 @@ open-dir: db
 open-dir: db
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -21,6 +21,7 @@ open-dir: db
 open-dir: db
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
@@ -158,6 +159,7 @@ open-dir: db1
 open-dir: db1
 create: db1/MANIFEST-000001
 sync: db1/MANIFEST-000001
+sync: db1
 create: db1/marker.manifest.000001.MANIFEST-000001
 sync: db1/marker.manifest.000001.MANIFEST-000001
 close: db1/marker.manifest.000001.MANIFEST-000001
@@ -273,6 +275,7 @@ remove: db1/000345.blob
 sync: db1
 get-disk-usage: db1
 create: db1/MANIFEST-000459
+sync: db1
 sync: db1/MANIFEST-000459
 create: db1/marker.manifest.000002.MANIFEST-000459
 sync: db1/marker.manifest.000002.MANIFEST-000459

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -20,6 +20,7 @@ open-dir: db
 open-dir: db
 create: db/MANIFEST-000001
 sync: db/MANIFEST-000001
+sync: db
 create: db/marker.manifest.000001.MANIFEST-000001
 sync: db/marker.manifest.000001.MANIFEST-000001
 close: db/marker.manifest.000001.MANIFEST-000001
@@ -148,6 +149,7 @@ sync: db
 get-disk-usage: db
 create: db/MANIFEST-000006
 close: db/MANIFEST-000001
+sync: db
 sync: db/MANIFEST-000006
 create: db/marker.manifest.000002.MANIFEST-000006
 sync: db/marker.manifest.000002.MANIFEST-000006
@@ -174,6 +176,7 @@ sync: db
 get-disk-usage: db
 create: db/MANIFEST-000009
 close: db/MANIFEST-000006
+sync: db
 sync: db/MANIFEST-000009
 create: db/marker.manifest.000003.MANIFEST-000009
 sync: db/marker.manifest.000003.MANIFEST-000009
@@ -209,6 +212,7 @@ sync: db
 get-disk-usage: db
 create: db/MANIFEST-000011
 close: db/MANIFEST-000009
+sync: db
 sync: db/MANIFEST-000011
 create: db/marker.manifest.000004.MANIFEST-000011
 sync: db/marker.manifest.000004.MANIFEST-000011
@@ -246,6 +250,7 @@ sync: db
 get-disk-usage: db
 create: db/MANIFEST-000014
 close: db/MANIFEST-000011
+sync: db
 sync: db/MANIFEST-000014
 create: db/marker.manifest.000005.MANIFEST-000014
 sync: db/marker.manifest.000005.MANIFEST-000014
@@ -275,6 +280,7 @@ link: ext/0 -> db/000015.sst
 sync: db
 create: db/MANIFEST-000016
 close: db/MANIFEST-000014
+sync: db
 sync: db/MANIFEST-000016
 create: db/marker.manifest.000006.MANIFEST-000016
 sync: db/marker.manifest.000006.MANIFEST-000016
@@ -443,6 +449,7 @@ sync: db/MANIFEST-000016
 [JOB 16] flushing 2 ingested tables
 create: db/MANIFEST-000023
 close: db/MANIFEST-000016
+sync: db
 sync: db/MANIFEST-000023
 create: db/marker.manifest.000007.MANIFEST-000023
 sync: db/marker.manifest.000007.MANIFEST-000023

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -603,6 +603,7 @@ sync-data: checkpoint/MANIFEST-000023
 close: checkpoint/MANIFEST-000023
 close: db/MANIFEST-000023
 open-dir: checkpoint
+sync: checkpoint
 create: checkpoint/marker.manifest.000001.MANIFEST-000023
 sync-data: checkpoint/marker.manifest.000001.MANIFEST-000023
 close: checkpoint/marker.manifest.000001.MANIFEST-000023

--- a/version_set.go
+++ b/version_set.go
@@ -218,7 +218,21 @@ func (vs *versionSet) initNewDB(
 		}
 	}
 	if err == nil {
-		// NB: Move() is responsible for syncing the data directory.
+		// Sync the directory to make the MANIFEST file durable before creating
+		// the marker that points to it. This prevents a crash from leaving the
+		// marker pointing to a non-existent MANIFEST. Without this sync, both
+		// the MANIFEST and marker files would be unsynced until Move() completes,
+		// creating a race where a crash could include the marker but not the
+		// MANIFEST on filesystems with unordered metadata updates.
+		if err = vs.manifestMarker.SyncDir(); err != nil {
+			vs.opts.Logger.Fatalf("MANIFEST directory sync failed: %v", err)
+		}
+	}
+	if err == nil {
+		// NB: Move() syncs the directory again after creating the marker file,
+		// making the marker itself durable. The two directory syncs ensure that
+		// MANIFEST is durable before marker creation, and marker is durable
+		// after creation, eliminating any race window.
 		if err = vs.manifestMarker.Move(base.MakeFilename(base.FileTypeManifest, vs.manifestFileNum)); err != nil {
 			vs.opts.Logger.Fatalf("MANIFEST set current failed: %v", err)
 		}
@@ -494,6 +508,15 @@ func (vs *versionSet) UpdateVersionLocked(
 				})
 				return errors.Wrap(err, "MANIFEST create failed")
 			}
+			// Sync the directory to make the MANIFEST file durable before creating
+			// the marker that points to it. This prevents a crash from leaving the
+			// marker pointing to a non-existent MANIFEST. Without this sync, both
+			// the MANIFEST and marker files would be unsynced until Move() completes,
+			// creating a race where a crash could include the marker but not the
+			// MANIFEST on filesystems with unordered metadata updates.
+			if err := vs.manifestMarker.SyncDir(); err != nil {
+				return errors.Wrap(err, "MANIFEST directory sync failed")
+			}
 		}
 
 		// Call ApplyAndUpdateVersionEdit before accumulating the version edit.
@@ -537,7 +560,10 @@ func (vs *versionSet) UpdateVersionLocked(
 			return errors.Wrap(err, "MANIFEST sync failed")
 		}
 		if newManifestFileNum != 0 {
-			// NB: Move() is responsible for syncing the data directory.
+			// NB: Move() syncs the directory again after creating the marker file,
+			// making the marker itself durable. The two directory syncs ensure that
+			// MANIFEST is durable before marker creation, and marker is durable
+			// after creation, eliminating any race window.
 			if err := vs.manifestMarker.Move(base.MakeFilename(base.FileTypeManifest, newManifestFileNum)); err != nil {
 				return errors.Wrap(err, "MANIFEST set current failed")
 			}

--- a/vfs/atomicfs/marker.go
+++ b/vfs/atomicfs/marker.go
@@ -259,3 +259,16 @@ func (a *Marker) RemoveObsolete() error {
 	a.obsoleteFiles = nil
 	return nil
 }
+
+// SyncDir syncs the directory to ensure that any file creations or removals
+// within the directory are durable. This can be used to ensure atomicity
+// when multiple files need to be created before updating the marker.
+func (a *Marker) SyncDir() error {
+	if err := a.dirFD.Sync(); err != nil {
+		// Fsync errors are unrecoverable.
+		// See https://wiki.postgresql.org/wiki/Fsync_Errors and
+		// https://danluu.com/fsyncgate.
+		panic(errors.WithStack(err))
+	}
+	return nil
+}


### PR DESCRIPTION
See individual commits for details.