### PR TITLE
options: flatten Experimental substruct into Options

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -48,11 +48,11 @@ func testCheckpointImpl(t *testing.T, ddFile string, createOnShared bool) {
 			DisableAutomaticCompactions: true,
 			Logger:                      testutils.Logger{T: t},
 		}
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): remoteMem,
 		})
 		if createOnShared {
-			opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+			opts.CreateOnShared = remote.CreateOnSharedAll
 		}
 		opts.DisableTableStats = true
 		opts.private.testingAlwaysWaitForCleanup = true

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -49,11 +49,11 @@ func testCheckpointImpl(t *testing.T, ddFile string, createOnShared bool) {
 			DisableAutomaticCompactions: true,
 			Logger:                      testutils.Logger{T: t},
 		}
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): remoteMem,
 		})
 		if createOnShared {
-			opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+			opts.CreateOnShared = remote.CreateOnSharedAll
 		}
 		opts.DisableTableStats = true
 		opts.private.testingAlwaysWaitForCleanup = true

--- a/close_test.go
+++ b/close_test.go
@@ -33,7 +33,7 @@ func TestCloseWithBlockedRemoteIO(t *testing.T) {
 		L0CompactionThreshold: 100,
 		L0StopWritesThreshold: 100,
 	}
-	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		remote.MakeLocator("blocking"): storage,
 	})
 

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -78,7 +78,7 @@ func newPebbleDB(dir string) DB {
 	// Enable value separation. Note the minimum size of 512 means that only the
 	// variant of the ycsb benchmarks that uses 1024 values will result in any
 	// value separation.
-	opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 		return pebble.ValueSeparationPolicy{
 			Enabled:                  true,
 			MinimumSize:              512,
@@ -91,7 +91,7 @@ func newPebbleDB(dir string) DB {
 	}
 
 	// Running the tool should not start compactions due to garbage.
-	opts.Experimental.CompactionGarbageFractionForMaxConcurrency = func() float64 {
+	opts.CompactionGarbageFractionForMaxConcurrency = func() float64 {
 		return -1.0
 	}
 	for i := 0; i < len(opts.Levels); i++ {
@@ -114,13 +114,13 @@ func newPebbleDB(dir string) DB {
 	}
 
 	if pathToLocalSharedStorage != "" {
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			// Store all shared objects on local disk, for convenience.
 			remote.MakeLocator(""): remote.NewLocalFS(pathToLocalSharedStorage, vfs.Default),
 		})
-		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+		opts.CreateOnShared = remote.CreateOnSharedAll
 		if secondaryCacheSize != 0 {
-			opts.Experimental.SecondaryCacheSizeBytes = secondaryCacheSize
+			opts.SecondaryCacheSizeBytes = secondaryCacheSize
 		}
 	}
 

--- a/compaction.go
+++ b/compaction.go
@@ -1517,7 +1517,7 @@ func (d *DB) runIngestFlush(c *tableCompaction) (*manifest.VersionEdit, error) {
 	var ingestSplitFiles []ingestSplitFile
 	ingestFlushable := c.flush.flushables[0].flushable.(*ingestedFlushable)
 
-	suggestSplit := d.opts.Experimental.IngestSplit != nil && d.opts.Experimental.IngestSplit() &&
+	suggestSplit := d.opts.IngestSplit != nil && d.opts.IngestSplit() &&
 		d.FormatMajorVersion() >= FormatVirtualSSTables
 
 	if suggestSplit || ingestFlushable.exciseSpan.Valid() {
@@ -2246,7 +2246,7 @@ func (d *DB) pickManualCompaction(env compactionEnv) (pc pickedCompaction) {
 
 // compact runs one compaction and maybe schedules another call to compact.
 func (d *DB) compact(c compaction, errChannel chan error) {
-	pprof.Do(d.bgCtx, c.PprofLabels(d.opts.Experimental.UserKeyCategories), func(context.Context) {
+	pprof.Do(d.bgCtx, c.PprofLabels(d.opts.UserKeyCategories), func(context.Context) {
 		func() {
 			d.mu.Lock()
 			defer d.mu.Unlock()
@@ -2869,7 +2869,7 @@ func (d *DB) compactAndWrite(
 		firstKey := runner.FirstKey()
 		if !spanPolicySet || !spanPolicy.StillCovers(d.cmp, firstKey) {
 			var err error
-			spanPolicy, err = d.opts.Experimental.SpanPolicyFunc(base.UserKeyBounds{
+			spanPolicy, err = d.opts.SpanPolicyFunc(base.UserKeyBounds{
 				Start: firstKey,
 				End:   c.bounds.End,
 			})

--- a/compaction.go
+++ b/compaction.go
@@ -1517,7 +1517,7 @@ func (d *DB) runIngestFlush(c *tableCompaction) (*manifest.VersionEdit, error) {
 	var ingestSplitFiles []ingestSplitFile
 	ingestFlushable := c.flush.flushables[0].flushable.(*ingestedFlushable)
 
-	suggestSplit := d.opts.Experimental.IngestSplit != nil && d.opts.Experimental.IngestSplit() &&
+	suggestSplit := d.opts.IngestSplit != nil && d.opts.IngestSplit() &&
 		d.FormatMajorVersion() >= FormatVirtualSSTables
 
 	if suggestSplit || ingestFlushable.exciseSpan.Valid() {
@@ -2246,7 +2246,7 @@ func (d *DB) pickManualCompaction(env compactionEnv) (pc pickedCompaction) {
 
 // compact runs one compaction and maybe schedules another call to compact.
 func (d *DB) compact(c compaction, errChannel chan error) {
-	pprof.Do(d.bgCtx, c.PprofLabels(d.opts.Experimental.UserKeyCategories), func(context.Context) {
+	pprof.Do(d.bgCtx, c.PprofLabels(d.opts.UserKeyCategories), func(context.Context) {
 		func() {
 			d.mu.Lock()
 			defer d.mu.Unlock()
@@ -2870,7 +2870,7 @@ func (d *DB) compactAndWrite(
 		firstKey := runner.FirstKey()
 		if !spanPolicySet || !spanPolicy.StillCovers(d.cmp, firstKey) {
 			var err error
-			spanPolicy, err = d.opts.Experimental.SpanPolicyFunc(base.UserKeyBounds{
+			spanPolicy, err = d.opts.SpanPolicyFunc(base.UserKeyBounds{
 				Start: firstKey,
 				End:   c.bounds.End,
 			})

--- a/compaction_delete.go
+++ b/compaction_delete.go
@@ -32,8 +32,8 @@ func (d *DB) tryScheduleDeleteOnlyCompaction() bool {
 	}
 	v := d.mu.versions.currentVersion()
 	isExciseAllowed := d.FormatMajorVersion() >= FormatVirtualSSTables &&
-		d.opts.Experimental.EnableDeleteOnlyCompactionExcises != nil &&
-		d.opts.Experimental.EnableDeleteOnlyCompactionExcises()
+		d.opts.EnableDeleteOnlyCompactionExcises != nil &&
+		d.opts.EnableDeleteOnlyCompactionExcises()
 
 	picked, ok := d.mu.compact.wideTombstones.PickCompaction(v, isExciseAllowed)
 	if !ok {

--- a/compaction_delete_test.go
+++ b/compaction_delete_test.go
@@ -71,7 +71,7 @@ func TestCompactionDeleteOnlyHints(t *testing.T) {
 			CompactionConcurrencyRange: func() (lower, upper int) { return 1, 1 },
 		}
 		opts.WithFSDefaults()
-		opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool { return true }
+		opts.EnableDeleteOnlyCompactionExcises = func() bool { return true }
 		return opts, nil
 	}
 

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -878,11 +878,11 @@ func calculateLevelSizes(
 		levelMaxBytes[level] = math.MaxInt64
 	}
 
-	bottomLevelSize := dbSize - dbSize/uint64(opts.Experimental.LevelMultiplier)
+	bottomLevelSize := dbSize - dbSize/uint64(opts.LevelMultiplier)
 
 	curLevelSize := bottomLevelSize
 	for level := numLevels - 2; level >= firstNonEmptyLevel; level-- {
-		curLevelSize /= uint64(opts.Experimental.LevelMultiplier)
+		curLevelSize /= uint64(opts.LevelMultiplier)
 	}
 
 	// Compute base level (where L0 data is compacted to).
@@ -890,7 +890,7 @@ func calculateLevelSizes(
 	baseLevel = firstNonEmptyLevel
 	for baseLevel > 1 && curLevelSize > baseBytesMax {
 		baseLevel--
-		curLevelSize /= uint64(opts.Experimental.LevelMultiplier)
+		curLevelSize /= uint64(opts.LevelMultiplier)
 	}
 
 	smoothedLevelMultiplier := 1.0
@@ -904,14 +904,14 @@ func calculateLevelSizes(
 	}
 
 	levelSize := float64(baseBytesMax)
-	if smoothedLevelMultiplier > float64(opts.Experimental.LevelMultiplier) {
+	if smoothedLevelMultiplier > float64(opts.LevelMultiplier) {
 		// Don't let the multiplier grow beyond the configured level multiplier.
 		// Instead, grow all levels proportionally by allowing a larger L1.
 		//
 		// TODO(radu): revisit this decision, as it could result in much more
 		// expensive L0->L1 compactions. Consider increasing the memtable size
 		// proportionally.
-		smoothedLevelMultiplier = float64(opts.Experimental.LevelMultiplier)
+		smoothedLevelMultiplier = float64(opts.LevelMultiplier)
 		levelSize = float64(curLevelSize)
 	}
 
@@ -1088,7 +1088,7 @@ func (p *compactionPickerByScore) calculateLevelScores(
 		// and attempting to pick L0 compactions may result in intra-L0
 		// compactions.
 		const compensatedScoreThreshold = 1.0
-		if (level == 0 || p.opts.Experimental.UseDeprecatedCompensatedScore()) &&
+		if (level == 0 || p.opts.UseDeprecatedCompensatedScore()) &&
 			compensatedScore < compensatedScoreThreshold {
 			// No need to compact this level; score stays 0.
 			continue
@@ -1332,31 +1332,31 @@ func (p *compactionPickerByScore) getCompactionConcurrency() int {
 	// Let n be the number of in-progress compactions.
 	//
 	// l0ReadAmp >= ccSignal1 then can run another compaction, where
-	// ccSignal1 = n * p.opts.Experimental.L0CompactionConcurrency
+	// ccSignal1 = n * p.opts.L0CompactionConcurrency
 	// Rearranging,
-	// n <= l0ReadAmp / p.opts.Experimental.L0CompactionConcurrency.
+	// n <= l0ReadAmp / p.opts.L0CompactionConcurrency.
 	// So we can run up to
-	// l0ReadAmp / p.opts.Experimental.L0CompactionConcurrency extra compactions.
+	// l0ReadAmp / p.opts.L0CompactionConcurrency extra compactions.
 	l0ReadAmpCompactions := 0
-	if p.opts.Experimental.L0CompactionConcurrency > 0 {
+	if p.opts.L0CompactionConcurrency > 0 {
 		l0ReadAmp := p.latestVersionState.l0Organizer.MaxDepthAfterOngoingCompactions()
-		l0ReadAmpCompactions = (l0ReadAmp / p.opts.Experimental.L0CompactionConcurrency)
+		l0ReadAmpCompactions = (l0ReadAmp / p.opts.L0CompactionConcurrency)
 	}
 	// compactionDebt >= ccSignal2 then can run another compaction, where
-	// ccSignal2 = uint64(n) * p.opts.Experimental.CompactionDebtConcurrency
+	// ccSignal2 = uint64(n) * p.opts.CompactionDebtConcurrency
 	// Rearranging,
-	// n <= compactionDebt / p.opts.Experimental.CompactionDebtConcurrency
+	// n <= compactionDebt / p.opts.CompactionDebtConcurrency
 	// So we can run up to
-	// compactionDebt / p.opts.Experimental.CompactionDebtConcurrency extra
+	// compactionDebt / p.opts.CompactionDebtConcurrency extra
 	// compactions.
 	compactionDebtCompactions := 0
-	if p.opts.Experimental.CompactionDebtConcurrency > 0 {
+	if p.opts.CompactionDebtConcurrency > 0 {
 		compactionDebt := p.estimatedCompactionDebt()
-		compactionDebtCompactions = int(compactionDebt / p.opts.Experimental.CompactionDebtConcurrency)
+		compactionDebtCompactions = int(compactionDebt / p.opts.CompactionDebtConcurrency)
 	}
 
 	compactableGarbageCompactions := 0
-	garbageFractionLimit := p.opts.Experimental.CompactionGarbageFractionForMaxConcurrency()
+	garbageFractionLimit := p.opts.CompactionGarbageFractionForMaxConcurrency()
 	if garbageFractionLimit > 0 && p.dbSizeBytes > 0 {
 		delBytes := deletionBytesAnnotator.MultiLevelAnnotation(p.vers.Levels[:])
 		compactableGarbageBytes := delBytes.PointDels + delBytes.RangeDels
@@ -1736,7 +1736,7 @@ func (p *compactionPickerByScore) pickVirtualRewriteCompaction(
 	// picked again, since the space amp will increase.
 	referencedDataPct, _, vtablesByLevel := p.latestVersionState.virtualBackings.ReplacementCandidate()
 
-	if 1-referencedDataPct < p.opts.Experimental.VirtualTableRewriteUnreferencedFraction() {
+	if 1-referencedDataPct < p.opts.VirtualTableRewriteUnreferencedFraction() {
 		return nil
 	}
 
@@ -1760,7 +1760,7 @@ func (p *compactionPickerByScore) pickVirtualRewriteCompaction(
 func (p *compactionPickerByScore) pickBlobFileRewriteCompactionHighPriority(
 	env compactionEnv,
 ) (pc *pickedBlobFileCompaction) {
-	policy := p.opts.Experimental.ValueSeparationPolicy()
+	policy := p.opts.ValueSeparationPolicy()
 	if policy.GarbageRatioHighPriority >= 1.0 {
 		// High-priority blob file rewrite compactions are disabled.
 		return nil
@@ -1795,7 +1795,7 @@ func (p *compactionPickerByScore) pickBlobFileRewriteCompactionLowPriority(
 		// No blob files with any garbage to rewrite.
 		return nil
 	}
-	policy := p.opts.Experimental.ValueSeparationPolicy()
+	policy := p.opts.ValueSeparationPolicy()
 	if policy.GarbageRatioLowPriority >= 1.0 {
 		// Blob file rewrite compactions are disabled.
 		return nil
@@ -1838,12 +1838,12 @@ func (p *compactionPickerByScore) pickBlobFileRewriteCandidate(
 // pickTombstoneDensityCompaction looks for a compaction that eliminates
 // regions of extremely high point tombstone density. For each level, it picks
 // a file where the ratio of tombstone-dense blocks is at least
-// options.Experimental.MinTombstoneDenseRatio, prioritizing compaction of
+// options.MinTombstoneDenseRatio, prioritizing compaction of
 // files with higher ratios of tombstone-dense blocks.
 func (p *compactionPickerByScore) pickTombstoneDensityCompaction(
 	env compactionEnv,
 ) (pc *pickedTableCompaction) {
-	threshold := p.opts.Experimental.TombstoneDenseCompactionThreshold()
+	threshold := p.opts.TombstoneDenseCompactionThreshold()
 	if threshold <= 0 {
 		// Tombstone density compactions are disabled.
 		return nil
@@ -1947,7 +1947,7 @@ func (pc *pickedTableCompaction) maybeAddLevel(
 		// as they could block compactions from L0.
 		return pc
 	}
-	if !opts.Experimental.MultiLevelCompactionHeuristic().allowL0() && pc.startLevel.level == 0 {
+	if !opts.MultiLevelCompactionHeuristic().allowL0() && pc.startLevel.level == 0 {
 		return pc
 	}
 	targetFileSize := opts.TargetFileSize(pc.outputLevel.level, pc.baseLevel)
@@ -1955,7 +1955,7 @@ func (pc *pickedTableCompaction) maybeAddLevel(
 		// Don't add a level if the current compaction exceeds the compaction size limit
 		return pc
 	}
-	return opts.Experimental.MultiLevelCompactionHeuristic().pick(pc, opts, env)
+	return opts.MultiLevelCompactionHeuristic().pick(pc, opts, env)
 }
 
 // MultiLevelHeuristic evaluates whether to add files from the next level into the compaction.

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -368,7 +368,7 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 					return 1, maxConcurrentCompactions
 				}
 				if d.HasArg("compaction-debt-concurrency") {
-					d.ScanArgs(t, "compaction-debt-concurrency", &opts.Experimental.CompactionDebtConcurrency)
+					d.ScanArgs(t, "compaction-debt-concurrency", &opts.CompactionDebtConcurrency)
 				}
 				if errMsg != "" {
 					return errMsg
@@ -562,7 +562,7 @@ func TestCompactionPickerEstimatedCompactionDebt(t *testing.T) {
 func TestCompactionPickerL0(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	opts := DefaultOptions()
-	opts.Experimental.L0CompactionConcurrency = 1
+	opts.L0CompactionConcurrency = 1
 
 	parseMeta := func(s string) (*manifest.TableMetadata, error) {
 		parts := strings.Split(s, ":")
@@ -733,7 +733,7 @@ const noSharedStorage = false
 func TestCompactionPickerConcurrency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	opts := DefaultOptions()
-	opts.Experimental.L0CompactionConcurrency = 1
+	opts.L0CompactionConcurrency = 1
 	lowerConcurrencyLimit, upperConcurrencyLimit := 1, 4
 	opts.CompactionConcurrencyRange = func() (int, int) { return lowerConcurrencyLimit, upperConcurrencyLimit }
 
@@ -798,8 +798,8 @@ func TestCompactionPickerConcurrency(t *testing.T) {
 
 		case "pick-auto":
 			td.MaybeScanArgs(t, "l0_compaction_threshold", &opts.L0CompactionThreshold)
-			td.MaybeScanArgs(t, "l0_compaction_concurrency", &opts.Experimental.L0CompactionConcurrency)
-			td.MaybeScanArgs(t, "compaction_debt_concurrency", &opts.Experimental.CompactionDebtConcurrency)
+			td.MaybeScanArgs(t, "l0_compaction_concurrency", &opts.L0CompactionConcurrency)
+			td.MaybeScanArgs(t, "compaction_debt_concurrency", &opts.CompactionDebtConcurrency)
 			td.MaybeScanArgs(t, "concurrency", &lowerConcurrencyLimit, &upperConcurrencyLimit)
 
 			env := compactionEnv{
@@ -1136,7 +1136,7 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 	}
 
 	t.Logf("Test basic setup inputs behavior without multi level compactions")
-	opts.Experimental.MultiLevelCompactionHeuristic = OptionNoMultiLevel
+	opts.MultiLevelCompactionHeuristic = OptionNoMultiLevel
 	datadriven.RunTest(t, "testdata/compaction_setup_inputs",
 		setupInputTest)
 
@@ -1146,12 +1146,12 @@ func TestPickedCompactionSetupInputs(t *testing.T) {
 		// multilevel compactions to be picked.
 		return 1, 2
 	}
-	opts.Experimental.MultiLevelCompactionHeuristic = optionAlwaysMultiLevel
+	opts.MultiLevelCompactionHeuristic = optionAlwaysMultiLevel
 	datadriven.RunTest(t, "testdata/compaction_setup_inputs_multilevel_dummy",
 		setupInputTest)
 
 	t.Logf("Try Write-Amp Heuristic")
-	opts.Experimental.MultiLevelCompactionHeuristic = OptionWriteAmpHeuristic
+	opts.MultiLevelCompactionHeuristic = OptionWriteAmpHeuristic
 	datadriven.RunTest(t, "testdata/compaction_setup_inputs_multilevel_write_amp",
 		setupInputTest)
 }
@@ -1371,7 +1371,7 @@ func TestCompactionPickerPickFile(t *testing.T) {
 				Logger:                      testutils.Logger{T: t},
 				DisableAutomaticCompactions: true,
 			}
-			opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+			opts.CompactionScheduler = func() CompactionScheduler {
 				return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 			}
 
@@ -1539,7 +1539,7 @@ func TestCompactionPickerScores(t *testing.T) {
 				FormatMajorVersion:          FormatNewest,
 				Logger:                      testutils.Logger{T: t},
 			}
-			opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+			opts.CompactionScheduler = func() CompactionScheduler {
 				return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 			}
 			var err error

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -961,7 +961,7 @@ func runCompactionTest(
 			},
 		}
 		opts.WithFSDefaults()
-		opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+		opts.CompactionScheduler = func() CompactionScheduler {
 			return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 		}
 		return opts
@@ -1576,7 +1576,7 @@ func runCompactionTest(
 				}
 				spanPolicies = append(spanPolicies, policy)
 			}
-			d.opts.Experimental.SpanPolicyFunc = MakeStaticSpanPolicyFunc(d.cmp, spanPolicies...)
+			d.opts.SpanPolicyFunc = MakeStaticSpanPolicyFunc(d.cmp, spanPolicies...)
 			return ""
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
@@ -1798,11 +1798,11 @@ func TestCompactionTombstones(t *testing.T) {
 					Logger:             testutils.Logger{T: t},
 				}
 				opts.WithFSDefaults()
-				opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool { return true }
-				opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+				opts.EnableDeleteOnlyCompactionExcises = func() bool { return true }
+				opts.CompactionScheduler = func() CompactionScheduler {
 					return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 				}
-				opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+				opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 					return ValueSeparationPolicy{
 						Enabled: false,
 					}
@@ -2722,7 +2722,7 @@ func TestMarkedForCompaction(t *testing.T) {
 				t = t.Add(time.Second)
 				return t
 			}
-			opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+			opts.CompactionScheduler = func() CompactionScheduler {
 				return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 			}
 			var err error
@@ -2943,10 +2943,10 @@ func TestSharedObjectDeletePacing(t *testing.T) {
 
 	var opts Options
 	opts.FS = vfs.NewMem()
-	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		remote.MakeLocator(""): remote.NewInMem(),
 	})
-	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+	opts.CreateOnShared = remote.CreateOnSharedAll
 	opts.DeletionPacing.BaselineRate = func() uint64 { return 1 }
 	opts.Logger = testutils.Logger{T: t}
 
@@ -3159,7 +3159,7 @@ func TestCompactionCorruption(t *testing.T) {
 	}
 	opts.WithFSDefaults()
 	remoteStorage := remote.NewInMem()
-	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		remote.MakeLocator("external-locator"): remoteStorage,
 	})
 	d, err := Open("", opts)
@@ -3350,9 +3350,9 @@ func TestTombstoneDensityCompactionMoveOptimization(t *testing.T) {
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
@@ -3452,9 +3452,9 @@ func TestTombstoneDensityCompactionMoveOptimization_NoMoveWithOverlap(t *testing
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
@@ -3536,9 +3536,9 @@ func TestTombstoneDensityCompactionMoveOptimization_GrandparentOverlapTooLarge(t
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
@@ -3604,9 +3604,9 @@ func TestTombstoneDensityCompactionMoveOptimization_BelowDensityThreshold(t *tes
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.9 } // Set high threshold
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.9 } // Set high threshold
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
@@ -3656,9 +3656,9 @@ func TestTombstoneDensityCompactionMoveOptimization_InvalidStats(t *testing.T) {
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -959,7 +959,7 @@ func runCompactionTest(
 			},
 		}
 		opts.WithFSDefaults()
-		opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+		opts.CompactionScheduler = func() CompactionScheduler {
 			return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 		}
 		return opts
@@ -1574,7 +1574,7 @@ func runCompactionTest(
 				}
 				spanPolicies = append(spanPolicies, policy)
 			}
-			d.opts.Experimental.SpanPolicyFunc = MakeStaticSpanPolicyFunc(d.cmp, spanPolicies...)
+			d.opts.SpanPolicyFunc = MakeStaticSpanPolicyFunc(d.cmp, spanPolicies...)
 			return ""
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
@@ -1800,11 +1800,11 @@ func TestCompactionTombstones(t *testing.T) {
 					Logger:             testutils.Logger{T: t},
 				}
 				opts.WithFSDefaults()
-				opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool { return true }
-				opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+				opts.EnableDeleteOnlyCompactionExcises = func() bool { return true }
+				opts.CompactionScheduler = func() CompactionScheduler {
 					return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 				}
-				opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+				opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 					return ValueSeparationPolicy{
 						Enabled: false,
 					}
@@ -2724,7 +2724,7 @@ func TestMarkedForCompaction(t *testing.T) {
 				t = t.Add(time.Second)
 				return t
 			}
-			opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+			opts.CompactionScheduler = func() CompactionScheduler {
 				return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 			}
 			var err error
@@ -2945,10 +2945,10 @@ func TestSharedObjectDeletePacing(t *testing.T) {
 
 	var opts Options
 	opts.FS = vfs.NewMem()
-	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		remote.MakeLocator(""): remote.NewInMem(),
 	})
-	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+	opts.CreateOnShared = remote.CreateOnSharedAll
 	opts.DeletionPacing.BaselineRate = func() uint64 { return 1 }
 	opts.Logger = testutils.Logger{T: t}
 
@@ -3161,7 +3161,7 @@ func TestCompactionCorruption(t *testing.T) {
 	}
 	opts.WithFSDefaults()
 	remoteStorage := remote.NewInMem()
-	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		remote.MakeLocator("external-locator"): remoteStorage,
 	})
 	d, err := Open("", opts)
@@ -3352,9 +3352,9 @@ func TestTombstoneDensityCompactionMoveOptimization(t *testing.T) {
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
@@ -3455,9 +3455,9 @@ func TestTombstoneDensityCompactionMoveOptimization_NoMoveWithOverlap(t *testing
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 } // Lower for test
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
@@ -3540,9 +3540,9 @@ func TestTombstoneDensityCompactionMoveOptimization_GrandparentOverlapTooLarge(t
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
@@ -3609,9 +3609,9 @@ func TestTombstoneDensityCompactionMoveOptimization_BelowDensityThreshold(t *tes
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.9 } // Set high threshold
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.9 } // Set high threshold
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
@@ -3662,9 +3662,9 @@ func TestTombstoneDensityCompactionMoveOptimization_InvalidStats(t *testing.T) {
 	)
 
 	opts := DefaultOptions()
-	opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
-	opts.Experimental.NumDeletionsThreshold = 1
-	opts.Experimental.CompactionScheduler = func() CompactionScheduler {
+	opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.5 }
+	opts.NumDeletionsThreshold = 1
+	opts.CompactionScheduler = func() CompactionScheduler {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()

--- a/compaction_value_separation.go
+++ b/compaction_value_separation.go
@@ -26,10 +26,10 @@ func (d *DB) determineCompactionValueSeparation(
 	jobID JobID, c *tableCompaction,
 ) valsep.ValueSeparation {
 	if d.FormatMajorVersion() < FormatValueSeparation ||
-		d.opts.Experimental.ValueSeparationPolicy == nil {
+		d.opts.ValueSeparationPolicy == nil {
 		return valsep.NeverSeparateValues{}
 	}
-	policy := d.opts.Experimental.ValueSeparationPolicy()
+	policy := d.opts.ValueSeparationPolicy()
 	if !policy.Enabled {
 		return valsep.NeverSeparateValues{}
 	}
@@ -42,7 +42,7 @@ func (d *DB) determineCompactionValueSeparation(
 		// For flushes, c.version is nil.
 		blobFileSet = uniqueInputBlobMetadatas(&c.version.BlobFiles, c.inputs)
 	}
-	if writeBlobs, outputBlobReferenceDepth := shouldWriteBlobFiles(c, policy, d.opts.Experimental.SpanPolicyFunc, d.cmp); !writeBlobs {
+	if writeBlobs, outputBlobReferenceDepth := shouldWriteBlobFiles(c, policy, d.opts.SpanPolicyFunc, d.cmp); !writeBlobs {
 		// This compaction should preserve existing blob references.
 		return valsep.NewPreserveAllHotBlobReferences(
 			blobFileSet,
@@ -64,7 +64,7 @@ func (d *DB) determineCompactionValueSeparation(
 		policy.MinimumMVCCGarbageSize,
 		valsep.WriteNewBlobFilesOptions{
 			InputBlobPhysicalFiles: blobFileSet,
-			ShortAttrExtractor:     d.opts.Experimental.ShortAttributeExtractor,
+			ShortAttrExtractor:     d.opts.ShortAttributeExtractor,
 			InvalidValueCallback: func(userKey []byte, value []byte, err error) {
 				// The value may not be safe, so it will be redacted when redaction
 				// is enabled.

--- a/data_test.go
+++ b/data_test.go
@@ -919,8 +919,8 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 	valueSeparator.pbr = valsep.NewPreserveAllHotBlobReferences(
 		valueSeparator.metas,
 		0, /* outputreference depth */
-		d.opts.Experimental.ValueSeparationPolicy().MinimumSize,
-		d.opts.Experimental.ValueSeparationPolicy().MinimumMVCCGarbageSize,
+		d.opts.ValueSeparationPolicy().MinimumSize,
+		d.opts.ValueSeparationPolicy().MinimumMVCCGarbageSize,
 	)
 
 	var mem *memTable
@@ -1713,7 +1713,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 			}
 			opts.Cache = NewCache(size)
 		case "disable-multi-level":
-			opts.Experimental.MultiLevelCompactionHeuristic = OptionNoMultiLevel
+			opts.MultiLevelCompactionHeuristic = OptionNoMultiLevel
 		case "enable-table-stats":
 			enable, err := strconv.ParseBool(cmdArg.Vals[0])
 			if err != nil {
@@ -1884,7 +1884,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 					}
 				}
 			}
-			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+			opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return policy
 			}
 		case "wal-failover":
@@ -1899,7 +1899,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 		}
 	}
 	if len(spanPolicies) > 0 {
-		opts.Experimental.SpanPolicyFunc = MakeStaticSpanPolicyFunc(opts.Comparer.Compare, spanPolicies...)
+		opts.SpanPolicyFunc = MakeStaticSpanPolicyFunc(opts.Comparer.Compare, spanPolicies...)
 	}
 	return nil
 }

--- a/data_test.go
+++ b/data_test.go
@@ -926,8 +926,8 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 	valueSeparator.pbr = valsep.NewPreserveAllHotBlobReferences(
 		valueSeparator.metas,
 		0, /* outputreference depth */
-		d.opts.Experimental.ValueSeparationPolicy().MinimumSize,
-		d.opts.Experimental.ValueSeparationPolicy().MinimumMVCCGarbageSize,
+		d.opts.ValueSeparationPolicy().MinimumSize,
+		d.opts.ValueSeparationPolicy().MinimumMVCCGarbageSize,
 	)
 
 	var mem *memTable
@@ -1720,7 +1720,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 			}
 			opts.Cache = NewCache(size)
 		case "disable-multi-level":
-			opts.Experimental.MultiLevelCompactionHeuristic = OptionNoMultiLevel
+			opts.MultiLevelCompactionHeuristic = OptionNoMultiLevel
 		case "enable-table-stats":
 			enable, err := strconv.ParseBool(cmdArg.Vals[0])
 			if err != nil {
@@ -1891,7 +1891,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 					}
 				}
 			}
-			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+			opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return policy
 			}
 		case "wal-failover":
@@ -1906,7 +1906,7 @@ func parseDBOptionsArgs(opts *Options, args []datadriven.CmdArg) error {
 		}
 	}
 	if len(spanPolicies) > 0 {
-		opts.Experimental.SpanPolicyFunc = MakeStaticSpanPolicyFunc(opts.Comparer.Compare, spanPolicies...)
+		opts.SpanPolicyFunc = MakeStaticSpanPolicyFunc(opts.Comparer.Compare, spanPolicies...)
 	}
 	return nil
 }

--- a/db.go
+++ b/db.go
@@ -2820,7 +2820,7 @@ func firstError(err0, err1 error) error {
 // Does nothing if SharedStorage was not set in the options when the DB was
 // opened or if the DB is in read-only mode.
 func (d *DB) SetCreatorID(creatorID uint64) error {
-	if d.opts.Experimental.RemoteStorage == nil || d.opts.ReadOnly {
+	if d.opts.RemoteStorage == nil || d.opts.ReadOnly {
 		return nil
 	}
 	return d.objProvider.SetCreatorID(objstorage.CreatorID(creatorID))

--- a/db.go
+++ b/db.go
@@ -2720,7 +2720,7 @@ func firstError(err0, err1 error) error {
 // Does nothing if SharedStorage was not set in the options when the DB was
 // opened or if the DB is in read-only mode.
 func (d *DB) SetCreatorID(creatorID uint64) error {
-	if d.opts.Experimental.RemoteStorage == nil || d.opts.ReadOnly {
+	if d.opts.RemoteStorage == nil || d.opts.ReadOnly {
 		return nil
 	}
 	return d.objProvider.SetCreatorID(objstorage.CreatorID(creatorID))

--- a/db_test.go
+++ b/db_test.go
@@ -1677,7 +1677,7 @@ func TestMemtableIngestInversion(t *testing.T) {
 	}
 	tel := TeeEventListener(MakeLoggingEventListener(testutils.Logger{T: t}), el)
 	opts.EventListener = &tel
-	opts.Experimental.L0CompactionConcurrency = 1
+	opts.L0CompactionConcurrency = 1
 	d, err := Open("", opts)
 	require.NoError(t, err)
 	defer func() {
@@ -2383,7 +2383,7 @@ func TestDeterminism(t *testing.T) {
 						FormatMajorVersion:          FormatNewest,
 						DisableAutomaticCompactions: true,
 					}
-					opts.Experimental.IngestSplit = func() bool { return rand.IntN(2) == 1 }
+					opts.IngestSplit = func() bool { return rand.IntN(2) == 1 }
 					if d != nil {
 						require.NoError(t, d.Close())
 					}

--- a/disk_usage_test.go
+++ b/disk_usage_test.go
@@ -52,7 +52,7 @@ func TestEstimateDiskUsageDataDriven(t *testing.T) {
 				d = nil
 			}
 			opts := &Options{FS: fs, FormatMajorVersion: FormatExciseBoundsRecord, DisableAutomaticCompactions: true}
-			opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+			opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 				remote.MakeLocator("external-locator"): remoteStorage,
 			})
 			require.NoError(t, parseDBOptionsArgs(opts, td.CmdArgs))

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -643,7 +643,7 @@ func TestBlobCorruptionEvent(t *testing.T) {
 				},
 				DisableAutomaticCompactions: true,
 			}
-			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+			opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return ValueSeparationPolicy{
 					Enabled:                true,
 					MinimumSize:            1,

--- a/excise_test.go
+++ b/excise_test.go
@@ -87,16 +87,16 @@ func TestExcise(t *testing.T) {
 			opts.Levels[0].BlockSize = blockSize
 			opts.Levels[0].IndexBlockSize = 32 << 10
 		}
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator("external-locator"): remoteStorage,
 		})
-		opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
+		opts.CreateOnShared = remote.CreateOnSharedNone
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts.DisableAutomaticCompactions = true
 		// Set this to true to add some testing for the virtual sstable validation
 		// code paths.
-		opts.Experimental.ValidateOnIngest = true
+		opts.ValidateOnIngest = true
 
 		var err error
 		d, err = Open("", opts)
@@ -452,23 +452,23 @@ func TestConcurrentExcise(t *testing.T) {
 		lel := MakeLoggingEventListener(testutils.Logger{T: t})
 		tel := TeeEventListener(lel, el)
 		opts1.EventListener = &tel
-		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts1.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): sstorage,
 		})
-		opts1.Experimental.CreateOnShared = remote.CreateOnSharedAll
-		opts1.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
+		opts1.CreateOnShared = remote.CreateOnSharedAll
+		opts1.CreateOnSharedLocator = remote.MakeLocator("")
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts1.DisableAutomaticCompactions = true
-		opts1.Experimental.MultiLevelCompactionHeuristic = OptionNoMultiLevel
+		opts1.MultiLevelCompactionHeuristic = OptionNoMultiLevel
 
 		opts2 := &Options{}
 		*opts2 = *opts1
-		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts2.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): sstorage,
 		})
-		opts2.Experimental.CreateOnShared = remote.CreateOnSharedAll
-		opts2.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
+		opts2.CreateOnShared = remote.CreateOnSharedAll
+		opts2.CreateOnSharedLocator = remote.MakeLocator("")
 		opts2.FS = mem2
 
 		var err error

--- a/external_test.go
+++ b/external_test.go
@@ -200,7 +200,7 @@ func buildSeparatedValuesDB(
 		MemTableSize:            2 << 20,
 		L0CompactionThreshold:   2,
 	}
-	o.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+	o.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 		return pebble.ValueSeparationPolicy{
 			Enabled:               true,
 			MinimumSize:           50,

--- a/file_cache.go
+++ b/file_cache.go
@@ -819,7 +819,7 @@ func SetupBlobReaderProvider(
 
 	fileCacheSize := FileCacheSize(opts.MaxOpenFiles)
 	if opts.FileCache == nil {
-		fc = NewFileCache(opts.Experimental.FileCacheShards, fileCacheSize)
+		fc = NewFileCache(opts.FileCacheShards, fileCacheSize)
 	} else {
 		fc = opts.FileCache
 		fc.Ref()

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -486,7 +486,7 @@ func (d *DB) TableFormat() sstable.TableFormat {
 		// value blocks were conditional on an experimental setting. In format
 		// major versions with maximum table formats of Pebblev4 and higher,
 		// value blocks are always enabled.
-		if d.opts.Experimental.EnableValueBlocks == nil || !d.opts.Experimental.EnableValueBlocks() {
+		if d.opts.EnableValueBlocks == nil || !d.opts.EnableValueBlocks() {
 			f = sstable.TableFormatPebblev2
 		}
 	}
@@ -502,7 +502,7 @@ func (d *DB) BlobFileFormat() blob.FileFormat {
 // shouldCreateShared returns true if the database should use shared objects
 // when creating new objects on the given level.
 func (d *DB) shouldCreateShared(targetLevel int) bool {
-	return remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, targetLevel) &&
+	return remote.ShouldCreateShared(d.opts.CreateOnShared, targetLevel) &&
 		d.FormatMajorVersion() >= FormatMinForSharedObjects
 }
 

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -470,7 +470,7 @@ func (d *DB) TableFormat() sstable.TableFormat {
 		// value blocks were conditional on an experimental setting. In format
 		// major versions with maximum table formats of Pebblev4 and higher,
 		// value blocks are always enabled.
-		if d.opts.Experimental.EnableValueBlocks == nil || !d.opts.Experimental.EnableValueBlocks() {
+		if d.opts.EnableValueBlocks == nil || !d.opts.EnableValueBlocks() {
 			f = sstable.TableFormatPebblev2
 		}
 	}
@@ -486,7 +486,7 @@ func (d *DB) BlobFileFormat() blob.FileFormat {
 // shouldCreateShared returns true if the database should use shared objects
 // when creating new objects on the given level.
 func (d *DB) shouldCreateShared(targetLevel int) bool {
-	return remote.ShouldCreateShared(d.opts.Experimental.CreateOnShared, targetLevel) &&
+	return remote.ShouldCreateShared(d.opts.CreateOnShared, targetLevel) &&
 		d.FormatMajorVersion() >= FormatMinForSharedObjects
 }
 

--- a/ingest.go
+++ b/ingest.go
@@ -659,7 +659,7 @@ func ingestLoad(
 	// true, as that means we could have suffixed RangeKeyDels or Unsets in the local
 	// files that won't ever be surfaced, even if there are no shared or external files
 	// in the ingestion.
-	shouldDisableRangeKeyChecks := len(shared) > 0 || len(external) > 0 || opts.Experimental.CreateOnShared != remote.CreateOnSharedNone
+	shouldDisableRangeKeyChecks := len(shared) > 0 || len(external) > 0 || opts.CreateOnShared != remote.CreateOnSharedNone
 	for _, p := range local {
 		f, err := opts.FS.Open(p.Path)
 		if err != nil {
@@ -1452,7 +1452,7 @@ func (d *DB) IngestExternalFiles(
 	if d.opts.ReadOnly {
 		return IngestOperationStats{}, ErrReadOnly
 	}
-	if d.opts.Experimental.RemoteStorage == nil {
+	if d.opts.RemoteStorage == nil {
 		return IngestOperationStats{}, errors.New("pebble: cannot ingest external files without shared storage configured")
 	}
 	// SkipRemoteProbe avoids opening remote-backed LSM files to probe for data
@@ -1726,7 +1726,7 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 	local := args.Local
 	shared := args.Shared
 	external := args.External
-	if len(shared) > 0 && d.opts.Experimental.RemoteStorage == nil {
+	if len(shared) > 0 && d.opts.RemoteStorage == nil {
 		panic(errors.AssertionFailedf("cannot ingest shared sstables with nil SharedStorage"))
 	}
 	if (args.ExciseSpan.Valid() || len(shared) > 0 || len(external) > 0) && d.FormatMajorVersion() < FormatVirtualSSTables {
@@ -1929,7 +1929,7 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 			// of this problem.
 			(len(d.mu.mem.queue) < d.opts.MemTableStopWritesThreshold ||
 				d.mu.log.manager.ElevateWriteStallThresholdForFailover()) &&
-			!d.opts.Experimental.DisableIngestAsFlushable() && !hasRemoteFiles &&
+			!d.opts.DisableIngestAsFlushable() && !hasRemoteFiles &&
 			(!args.ExciseSpan.Valid() || d.FormatMajorVersion() >= FormatFlushableIngestExcises)
 		if !canIngestFlushable {
 			// We're not able to ingest as a flushable,
@@ -2259,7 +2259,7 @@ func (d *DB) ingestApply(
 	ve := &manifest.VersionEdit{
 		NewTables: make([]manifest.NewTableEntry, lr.sstCount()),
 	}
-	if exciseSpan.Valid() || (d.opts.Experimental.IngestSplit != nil && d.opts.Experimental.IngestSplit()) {
+	if exciseSpan.Valid() || (d.opts.IngestSplit != nil && d.opts.IngestSplit()) {
 		ve.DeletedTables = map[manifest.DeletedTableEntry]*manifest.TableMetadata{}
 	}
 	var metrics levelMetricsDelta
@@ -2293,8 +2293,8 @@ func (d *DB) ingestApply(
 			objProvider:     d.objProvider,
 			skipRemoteProbe: skipRemoteProbe,
 		}
-		shouldIngestSplit := d.opts.Experimental.IngestSplit != nil &&
-			d.opts.Experimental.IngestSplit() && d.FormatMajorVersion() >= FormatVirtualSSTables
+		shouldIngestSplit := d.opts.IngestSplit != nil &&
+			d.opts.IngestSplit() && d.FormatMajorVersion() >= FormatVirtualSSTables
 		baseLevel := d.mu.versions.picker.getBaseLevel()
 		// filesToSplit is a list where each element is a pair consisting of a file
 		// being ingested and a file being split to make room for an ingestion into
@@ -2563,7 +2563,7 @@ func (d *DB) ingestApply(
 // DB.mu must be locked when calling.
 func (d *DB) maybeValidateSSTablesLocked(newFiles []manifest.NewTableEntry) {
 	// Only add to the validation queue when the feature is enabled.
-	if !d.opts.Experimental.ValidateOnIngest {
+	if !d.opts.ValidateOnIngest {
 		return
 	}
 
@@ -2578,7 +2578,7 @@ func (d *DB) maybeValidateSSTablesLocked(newFiles []manifest.NewTableEntry) {
 func (d *DB) shouldValidateSSTablesLocked() bool {
 	return !d.mu.tableValidation.validating &&
 		d.closed.Load() == nil &&
-		d.opts.Experimental.ValidateOnIngest &&
+		d.opts.ValidateOnIngest &&
 		len(d.mu.tableValidation.pending) > 0
 }
 

--- a/ingest.go
+++ b/ingest.go
@@ -664,7 +664,7 @@ func ingestLoad(
 	// true, as that means we could have suffixed RangeKeyDels or Unsets in the local
 	// files that won't ever be surfaced, even if there are no shared or external files
 	// in the ingestion.
-	shouldDisableRangeKeyChecks := len(shared) > 0 || len(external) > 0 || opts.Experimental.CreateOnShared != remote.CreateOnSharedNone
+	shouldDisableRangeKeyChecks := len(shared) > 0 || len(external) > 0 || opts.CreateOnShared != remote.CreateOnSharedNone
 	for _, p := range local {
 		f, err := opts.FS.Open(p.Path)
 		if err != nil {
@@ -1457,7 +1457,7 @@ func (d *DB) IngestExternalFiles(
 	if d.opts.ReadOnly {
 		return IngestOperationStats{}, ErrReadOnly
 	}
-	if d.opts.Experimental.RemoteStorage == nil {
+	if d.opts.RemoteStorage == nil {
 		return IngestOperationStats{}, errors.New("pebble: cannot ingest external files without shared storage configured")
 	}
 	// SkipRemoteProbe avoids opening remote-backed LSM files to probe for data
@@ -1731,7 +1731,7 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 	local := args.Local
 	shared := args.Shared
 	external := args.External
-	if len(shared) > 0 && d.opts.Experimental.RemoteStorage == nil {
+	if len(shared) > 0 && d.opts.RemoteStorage == nil {
 		panic(errors.AssertionFailedf("cannot ingest shared sstables with nil SharedStorage"))
 	}
 	if (args.ExciseSpan.Valid() || len(shared) > 0 || len(external) > 0) && d.FormatMajorVersion() < FormatVirtualSSTables {
@@ -1934,7 +1934,7 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 			// of this problem.
 			(len(d.mu.mem.queue) < d.opts.MemTableStopWritesThreshold ||
 				d.mu.log.manager.ElevateWriteStallThresholdForFailover()) &&
-			!d.opts.Experimental.DisableIngestAsFlushable() && !hasRemoteFiles &&
+			!d.opts.DisableIngestAsFlushable() && !hasRemoteFiles &&
 			(!args.ExciseSpan.Valid() || d.FormatMajorVersion() >= FormatFlushableIngestExcises)
 		if !canIngestFlushable {
 			// We're not able to ingest as a flushable,
@@ -2264,7 +2264,7 @@ func (d *DB) ingestApply(
 	ve := &manifest.VersionEdit{
 		NewTables: make([]manifest.NewTableEntry, lr.sstCount()),
 	}
-	if exciseSpan.Valid() || (d.opts.Experimental.IngestSplit != nil && d.opts.Experimental.IngestSplit()) {
+	if exciseSpan.Valid() || (d.opts.IngestSplit != nil && d.opts.IngestSplit()) {
 		ve.DeletedTables = map[manifest.DeletedTableEntry]*manifest.TableMetadata{}
 	}
 	var metrics levelMetricsDelta
@@ -2298,8 +2298,8 @@ func (d *DB) ingestApply(
 			objProvider:     d.objProvider,
 			skipRemoteProbe: skipRemoteProbe,
 		}
-		shouldIngestSplit := d.opts.Experimental.IngestSplit != nil &&
-			d.opts.Experimental.IngestSplit() && d.FormatMajorVersion() >= FormatVirtualSSTables
+		shouldIngestSplit := d.opts.IngestSplit != nil &&
+			d.opts.IngestSplit() && d.FormatMajorVersion() >= FormatVirtualSSTables
 		baseLevel := d.mu.versions.picker.getBaseLevel()
 		// filesToSplit is a list where each element is a pair consisting of a file
 		// being ingested and a file being split to make room for an ingestion into
@@ -2568,7 +2568,7 @@ func (d *DB) ingestApply(
 // DB.mu must be locked when calling.
 func (d *DB) maybeValidateSSTablesLocked(newFiles []manifest.NewTableEntry) {
 	// Only add to the validation queue when the feature is enabled.
-	if !d.opts.Experimental.ValidateOnIngest {
+	if !d.opts.ValidateOnIngest {
 		return
 	}
 
@@ -2583,7 +2583,7 @@ func (d *DB) maybeValidateSSTablesLocked(newFiles []manifest.NewTableEntry) {
 func (d *DB) shouldValidateSSTablesLocked() bool {
 	return !d.mu.tableValidation.validating &&
 		d.closed.Load() == nil &&
-		d.opts.Experimental.ValidateOnIngest &&
+		d.opts.ValidateOnIngest &&
 		len(d.mu.tableValidation.pending) > 0
 }
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -437,7 +437,7 @@ func TestFlushableIngestWithBlobs(t *testing.T) {
 		// Set a high stop-writes threshold to ensure we can use flushable ingests.
 		MemTableStopWritesThreshold: 10,
 	}
-	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
 			Enabled:                true,
 			MinimumSize:            4,
@@ -466,7 +466,7 @@ func TestFlushableIngestWithBlobs(t *testing.T) {
 	}
 	writerOpts := valsep.SSTBlobWriterOptions{
 		SSTWriterOpts:          sstWriterOpts,
-		ValueSeparationMinSize: opts.Experimental.ValueSeparationPolicy().MinimumSize,
+		ValueSeparationMinSize: opts.ValueSeparationPolicy().MinimumSize,
 	}
 	writerOpts.NewBlobFileFn = func() (objstorage.Writable, error) {
 		path := fmt.Sprintf("blob%d", fileCount)
@@ -588,7 +588,7 @@ func TestFlushableIngestWithBlobsWALRecovery(t *testing.T) {
 		// Set a high stop-writes threshold to ensure we can use flushable ingests.
 		MemTableStopWritesThreshold: 10,
 	}
-	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
 			Enabled:                true,
 			MinimumSize:            4,
@@ -610,7 +610,7 @@ func TestFlushableIngestWithBlobsWALRecovery(t *testing.T) {
 	}
 	writerOpts := valsep.SSTBlobWriterOptions{
 		SSTWriterOpts:          sstWriterOpts,
-		ValueSeparationMinSize: opts.Experimental.ValueSeparationPolicy().MinimumSize,
+		ValueSeparationMinSize: opts.ValueSeparationPolicy().MinimumSize,
 	}
 	writerOpts.NewBlobFileFn = func() (objstorage.Writable, error) {
 		path := fs.PathJoin(dir, fmt.Sprintf("blob%d", fileCount))
@@ -1218,22 +1218,22 @@ func testIngestSharedImpl(
 		}
 		lel := MakeLoggingEventListener(testutils.Logger{T: t})
 		opts1.EventListener = &lel
-		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts1.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): sstorage,
 		})
-		opts1.Experimental.CreateOnShared = createOnShared
-		opts1.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
+		opts1.CreateOnShared = createOnShared
+		opts1.CreateOnSharedLocator = remote.MakeLocator("")
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts1.DisableAutomaticCompactions = true
 
 		opts2 = &Options{}
 		*opts2 = *opts1
-		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts2.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): sstorage,
 		})
-		opts2.Experimental.CreateOnShared = createOnShared
-		opts2.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
+		opts2.CreateOnShared = createOnShared
+		opts2.CreateOnSharedLocator = remote.MakeLocator("")
 		opts2.FS = mem2
 
 		var err error
@@ -1587,9 +1587,9 @@ func TestSimpleIngestShared(t *testing.T) {
 			L0StopWritesThreshold: 100,
 			Logger:                testutils.Logger{T: t},
 		}
-		opts.Experimental.RemoteStorage = providerSettings.Remote.StorageFactory
-		opts.Experimental.CreateOnShared = providerSettings.Remote.CreateOnShared
-		opts.Experimental.CreateOnSharedLocator = providerSettings.Remote.CreateOnSharedLocator
+		opts.RemoteStorage = providerSettings.Remote.StorageFactory
+		opts.CreateOnShared = providerSettings.Remote.CreateOnShared
+		opts.CreateOnSharedLocator = providerSettings.Remote.CreateOnSharedLocator
 
 		var err error
 		d, err = Open("", opts)
@@ -1701,11 +1701,11 @@ func TestIngestExternal(t *testing.T) {
 			FormatMajorVersion: majorVersion,
 			Logger:             testutils.Logger{T: t},
 		}
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator("external-locator"): remoteStorage,
 		})
-		opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
-		opts.Experimental.IngestSplit = func() bool {
+		opts.CreateOnShared = remote.CreateOnSharedNone
+		opts.IngestSplit = func() bool {
 			return true
 		}
 		// Disable automatic compactions because otherwise we'll race with
@@ -2234,7 +2234,7 @@ func TestIngest(t *testing.T) {
 			}},
 			FormatMajorVersion: internalFormatNewest,
 		}
-		opts.Experimental.IngestSplit = func() bool {
+		opts.IngestSplit = func() bool {
 			return split
 		}
 		// Disable automatic compactions because otherwise we'll race with
@@ -3568,7 +3568,7 @@ func TestIngestValidation(t *testing.T) {
 					},
 				},
 			}
-			opts.Experimental.ValidateOnIngest = true
+			opts.ValidateOnIngest = true
 			d, err := Open("", opts)
 			require.NoError(t, err)
 			defer func() { require.NoError(t, d.Close()) }()

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -440,7 +440,7 @@ func TestFlushableIngestWithBlobs(t *testing.T) {
 		// Set a high stop-writes threshold to ensure we can use flushable ingests.
 		MemTableStopWritesThreshold: 10,
 	}
-	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
 			Enabled:                true,
 			MinimumSize:            4,
@@ -469,7 +469,7 @@ func TestFlushableIngestWithBlobs(t *testing.T) {
 	}
 	writerOpts := valsep.SSTBlobWriterOptions{
 		SSTWriterOpts:          sstWriterOpts,
-		ValueSeparationMinSize: opts.Experimental.ValueSeparationPolicy().MinimumSize,
+		ValueSeparationMinSize: opts.ValueSeparationPolicy().MinimumSize,
 	}
 	writerOpts.NewBlobFileFn = func() (objstorage.Writable, error) {
 		path := fmt.Sprintf("blob%d", fileCount)
@@ -591,7 +591,7 @@ func TestFlushableIngestWithBlobsWALRecovery(t *testing.T) {
 		// Set a high stop-writes threshold to ensure we can use flushable ingests.
 		MemTableStopWritesThreshold: 10,
 	}
-	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
 			Enabled:                true,
 			MinimumSize:            4,
@@ -613,7 +613,7 @@ func TestFlushableIngestWithBlobsWALRecovery(t *testing.T) {
 	}
 	writerOpts := valsep.SSTBlobWriterOptions{
 		SSTWriterOpts:          sstWriterOpts,
-		ValueSeparationMinSize: opts.Experimental.ValueSeparationPolicy().MinimumSize,
+		ValueSeparationMinSize: opts.ValueSeparationPolicy().MinimumSize,
 	}
 	writerOpts.NewBlobFileFn = func() (objstorage.Writable, error) {
 		path := fs.PathJoin(dir, fmt.Sprintf("blob%d", fileCount))
@@ -1220,22 +1220,22 @@ func testIngestSharedImpl(
 		}
 		lel := MakeLoggingEventListener(testutils.Logger{T: t})
 		opts1.EventListener = &lel
-		opts1.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts1.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): sstorage,
 		})
-		opts1.Experimental.CreateOnShared = createOnShared
-		opts1.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
+		opts1.CreateOnShared = createOnShared
+		opts1.CreateOnSharedLocator = remote.MakeLocator("")
 		// Disable automatic compactions because otherwise we'll race with
 		// delete-only compactions triggered by ingesting range tombstones.
 		opts1.DisableAutomaticCompactions = true
 
 		opts2 = &Options{}
 		*opts2 = *opts1
-		opts2.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts2.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): sstorage,
 		})
-		opts2.Experimental.CreateOnShared = createOnShared
-		opts2.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
+		opts2.CreateOnShared = createOnShared
+		opts2.CreateOnSharedLocator = remote.MakeLocator("")
 		opts2.FS = mem2
 
 		var err error
@@ -1589,9 +1589,9 @@ func TestSimpleIngestShared(t *testing.T) {
 			L0StopWritesThreshold: 100,
 			Logger:                testutils.Logger{T: t},
 		}
-		opts.Experimental.RemoteStorage = providerSettings.Remote.StorageFactory
-		opts.Experimental.CreateOnShared = providerSettings.Remote.CreateOnShared
-		opts.Experimental.CreateOnSharedLocator = providerSettings.Remote.CreateOnSharedLocator
+		opts.RemoteStorage = providerSettings.Remote.StorageFactory
+		opts.CreateOnShared = providerSettings.Remote.CreateOnShared
+		opts.CreateOnSharedLocator = providerSettings.Remote.CreateOnSharedLocator
 
 		var err error
 		d, err = Open("", opts)
@@ -1703,11 +1703,11 @@ func TestIngestExternal(t *testing.T) {
 			FormatMajorVersion: majorVersion,
 			Logger:             testutils.Logger{T: t},
 		}
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator("external-locator"): remoteStorage,
 		})
-		opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
-		opts.Experimental.IngestSplit = func() bool {
+		opts.CreateOnShared = remote.CreateOnSharedNone
+		opts.IngestSplit = func() bool {
 			return true
 		}
 		// Disable automatic compactions because otherwise we'll race with
@@ -2234,7 +2234,7 @@ func TestIngest(t *testing.T) {
 			}},
 			FormatMajorVersion: internalFormatNewest,
 		}
-		opts.Experimental.IngestSplit = func() bool {
+		opts.IngestSplit = func() bool {
 			return split
 		}
 		// Disable automatic compactions because otherwise we'll race with
@@ -3572,7 +3572,7 @@ func TestIngestValidation(t *testing.T) {
 					},
 				},
 			}
-			opts.Experimental.ValidateOnIngest = true
+			opts.ValidateOnIngest = true
 			d, err := Open("", opts)
 			require.NoError(t, err)
 			defer func() { require.NoError(t, d.Close()) }()

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -128,7 +128,7 @@ func replayManifest(
 	}
 	l0Organizer := manifest.NewL0Organizer(cmp, opts.FlushSplitBytes)
 	emptyVersion := manifest.NewInitialVersion(cmp)
-	v, err := bve.Apply(emptyVersion, opts.Experimental.ReadCompactionRate)
+	v, err := bve.Apply(emptyVersion, opts.ReadCompactionRate)
 	require.NoError(t, err)
 	l0Organizer.PerformUpdate(l0Organizer.PrepareUpdate(&bve, v), v)
 	return v, l0Organizer

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1382,7 +1382,7 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 		var sm, la *TableMetadata
 		for _, f := range addedTables {
 			// NB: allowedSeeks is used for read triggered compactions. It is set using
-			// Options.Experimental.ReadCompactionRate which defaults to 32KB.
+			// Options.ReadCompactionRate which defaults to 32KB.
 			var allowedSeeks int64
 			if readCompactionRate != 0 {
 				allowedSeeks = int64(f.Size) / readCompactionRate

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1424,7 +1424,7 @@ func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Versi
 		var sm, la *TableMetadata
 		for _, f := range addedTables {
 			// NB: allowedSeeks is used for read triggered compactions. It is set using
-			// Options.Experimental.ReadCompactionRate which defaults to 32KB.
+			// Options.ReadCompactionRate which defaults to 32KB.
 			var allowedSeeks int64
 			if readCompactionRate != 0 {
 				allowedSeeks = int64(f.Size) / readCompactionRate

--- a/iterator.go
+++ b/iterator.go
@@ -840,7 +840,7 @@ func (i *Iterator) maybeSampleRead() {
 		i.sampleRead()
 		return
 	}
-	samplingPeriod := int32(int64(readBytesPeriod) * i.readState.db.opts.Experimental.ReadSamplingMultiplier)
+	samplingPeriod := int32(int64(readBytesPeriod) * i.readState.db.opts.ReadSamplingMultiplier)
 	if samplingPeriod <= 0 {
 		return
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -841,7 +841,7 @@ func (i *Iterator) maybeSampleRead() {
 		i.sampleRead()
 		return
 	}
-	samplingPeriod := int32(int64(readBytesPeriod) * i.readState.db.opts.Experimental.ReadSamplingMultiplier)
+	samplingPeriod := int32(int64(readBytesPeriod) * i.readState.db.opts.ReadSamplingMultiplier)
 	if samplingPeriod <= 0 {
 		return
 	}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1432,7 +1432,7 @@ func TestIteratorValueRetrievalProfile(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	opts := &Options{}
 	opts.FormatMajorVersion = internalFormatNewest
-	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
 			Enabled:                true,
 			MinimumSize:            1,
@@ -2570,7 +2570,7 @@ func BenchmarkIteratorScanNextPrefix(b *testing.B) {
 			FormatMajorVersion: FormatNewest,
 		}
 		opts.DisableAutomaticCompactions = true
-		opts.Experimental.EnableValueBlocks = func() bool { return enableValueBlocks }
+		opts.EnableValueBlocks = func() bool { return enableValueBlocks }
 		d, err := Open("", opts)
 		require.NoError(b, err)
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1439,7 +1439,7 @@ func TestIteratorValueRetrievalProfile(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	opts := &Options{}
 	opts.FormatMajorVersion = internalFormatNewest
-	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
 			Enabled:                true,
 			MinimumSize:            1,
@@ -2577,7 +2577,7 @@ func BenchmarkIteratorScanNextPrefix(b *testing.B) {
 			FormatMajorVersion: FormatNewest,
 		}
 		opts.DisableAutomaticCompactions = true
-		opts.Experimental.EnableValueBlocks = func() bool { return enableValueBlocks }
+		opts.EnableValueBlocks = func() bool { return enableValueBlocks }
 		d, err := Open("", opts)
 		require.NoError(b, err)
 

--- a/metamorphic/build.go
+++ b/metamorphic/build.go
@@ -144,7 +144,7 @@ func buildForIngest(
 	// If value separation is enabled and the format major version supports
 	// ingesting blob files, use SSTBlobWriter to potentially create blob files.
 	// Blob files don't support shared storage yet, so skip when it's enabled.
-	if t.opts.Experimental.ValueSeparationPolicy().Enabled &&
+	if t.opts.ValueSeparationPolicy().Enabled &&
 		db.FormatMajorVersion() >= pebble.FormatIngestBlobFiles &&
 		!t.testOpts.sharedStorageEnabled {
 		return buildForIngestWithBlobs(t, dbID, b, i, path, f, db)
@@ -175,7 +175,7 @@ func buildForIngestWithBlobs(
 	blobFileCount := 0
 
 	// Get the value separation policy to determine the minimum value size.
-	policy := t.opts.Experimental.ValueSeparationPolicy()
+	policy := t.opts.ValueSeparationPolicy()
 
 	writerOpts := valsep.SSTBlobWriterOptions{
 		SSTWriterOpts:                     t.opts.MakeWriterOptions(0, db.FormatMajorVersion().MaxTableFormat()),

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -110,21 +110,21 @@ func parseOptions(
 				}
 			case "TestOptions.enable_value_blocks":
 				opts.enableValueBlocks = true
-				opts.Opts.Experimental.EnableValueBlocks = func() bool { return true }
+				opts.Opts.EnableValueBlocks = func() bool { return true }
 			case "TestOptions.disable_value_blocks_for_ingest_sstables":
 				opts.disableValueBlocksForIngestSSTables = true
 			case "TestOptions.async_apply_to_db":
 				opts.asyncApplyToDB = true
 			case "TestOptions.shared_storage_enabled":
 				opts.sharedStorageEnabled = true
-				if opts.Opts.Experimental.CreateOnShared == remote.CreateOnSharedNone {
-					opts.Opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+				if opts.Opts.CreateOnShared == remote.CreateOnSharedNone {
+					opts.Opts.CreateOnShared = remote.CreateOnSharedAll
 				}
 			case "TestOptions.external_storage_enabled":
 				opts.externalStorageEnabled = true
 			case "TestOptions.secondary_cache_enabled":
 				opts.secondaryCacheEnabled = true
-				opts.Opts.Experimental.SecondaryCacheSizeBytes = 1024 * 1024 * 32 // 32 MBs
+				opts.Opts.SecondaryCacheSizeBytes = 1024 * 1024 * 32 // 32 MBs
 			case "TestOptions.seed_efos":
 				v, err := strconv.ParseUint(value, 10, 64)
 				if err != nil {
@@ -152,7 +152,7 @@ func parseOptions(
 			case "TestOptions.ingest_split":
 				// TODO(radu): this should be on by default.
 				opts.ingestSplit = true
-				opts.Opts.Experimental.IngestSplit = func() bool {
+				opts.Opts.IngestSplit = func() bool {
 					return true
 				}
 			case "TestOptions.use_shared_replicate":
@@ -164,7 +164,7 @@ func parseOptions(
 				opts.useExcise = true
 			case "TestOptions.use_delete_only_compaction_excises":
 				opts.useDeleteOnlyCompactionExcises = true
-				opts.Opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool {
+				opts.Opts.EnableDeleteOnlyCompactionExcises = func() bool {
 					return opts.useDeleteOnlyCompactionExcises
 				}
 			case "TestOptions.disable_downloads":
@@ -309,9 +309,9 @@ func defaultOptions(kf KeyFormat) *pebble.Options {
 		BlockPropertyCollectors: kf.BlockPropertyCollectors,
 	}
 	opts.Levels[0].TableFilterPolicy = func() pebble.TableFilterPolicy { return bloom.FilterPolicy(10) }
-	opts.Experimental.IngestSplit = func() bool { return false }
+	opts.IngestSplit = func() bool { return false }
 
-	opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 		return pebble.ValueSeparationPolicy{
 			Enabled:                  true,
 			MinimumSize:              5,
@@ -671,11 +671,11 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	opts.FormatMajorVersion = minimumFormatMajorVersion
 	n := int(newestFormatMajorVersionToTest - opts.FormatMajorVersion)
 	opts.FormatMajorVersion += pebble.FormatMajorVersion(rng.IntN(n + 1))
-	opts.Experimental.L0CompactionConcurrency = 1 + rng.IntN(4)          // 1-4
-	opts.Experimental.LevelMultiplier = 5 * int(randPowerOf2(rng, 0, 6)) // 5 - 320
-	targetByteDeletionRate := randPowerOf2(rng, 20, 30)                  // 1MB - 1GB
+	opts.L0CompactionConcurrency = 1 + rng.IntN(4)          // 1-4
+	opts.LevelMultiplier = 5 * int(randPowerOf2(rng, 0, 6)) // 5 - 320
+	targetByteDeletionRate := randPowerOf2(rng, 20, 30)     // 1MB - 1GB
 	opts.DeletionPacing.BaselineRate = func() uint64 { return targetByteDeletionRate }
-	opts.Experimental.ValidateOnIngest = rng.IntN(2) != 0
+	opts.ValidateOnIngest = rng.IntN(2) != 0
 	opts.L0CompactionThreshold = 1 + rng.IntN(100)                 // 1 - 100
 	opts.L0CompactionFileThreshold = int(randPowerOf2(rng, 0, 10)) // 1 - 1024
 	opts.L0StopWritesThreshold = randInRange(rng, 50, 150)         // 50 - 150
@@ -693,7 +693,7 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	}
 	// [-0.2, 0.4], in steps of 0.2.
 	garbageFrac := float64(rng.IntN(5))/5.0 - 0.2
-	opts.Experimental.CompactionGarbageFractionForMaxConcurrency = func() float64 {
+	opts.CompactionGarbageFractionForMaxConcurrency = func() float64 {
 		return garbageFrac
 	}
 	maxConcurrentDownloads := rng.IntN(3) + 1 // 1-3
@@ -741,7 +741,7 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 		}
 	}
 	if rng.IntN(2) == 0 {
-		opts.Experimental.DisableIngestAsFlushable = func() bool { return true }
+		opts.DisableIngestAsFlushable = func() bool { return true }
 	}
 
 	// We either use no multilevel compactions, multilevel compactions with the
@@ -750,15 +750,15 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	// ohterwise would.
 	switch rng.IntN(3) {
 	case 0:
-		opts.Experimental.MultiLevelCompactionHeuristic = pebble.OptionNoMultiLevel
+		opts.MultiLevelCompactionHeuristic = pebble.OptionNoMultiLevel
 	case 1:
-		opts.Experimental.MultiLevelCompactionHeuristic = pebble.OptionWriteAmpHeuristic
+		opts.MultiLevelCompactionHeuristic = pebble.OptionWriteAmpHeuristic
 	default:
 		writeAmpHeuristic := &pebble.WriteAmpHeuristic{
 			AddPropensity: rng.Float64() * float64(rng.IntN(3)), // [0,3.0)
 			AllowL0:       rng.IntN(4) == 1,                     // 25% of the time
 		}
-		opts.Experimental.MultiLevelCompactionHeuristic = func() pebble.MultiLevelHeuristic {
+		opts.MultiLevelCompactionHeuristic = func() pebble.MultiLevelHeuristic {
 			return writeAmpHeuristic
 		}
 	}
@@ -855,7 +855,7 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	}
 	testOpts.enableValueBlocks = rng.IntN(2) != 0
 	if testOpts.enableValueBlocks {
-		testOpts.Opts.Experimental.EnableValueBlocks = func() bool { return true }
+		testOpts.Opts.EnableValueBlocks = func() bool { return true }
 	}
 	testOpts.disableValueBlocksForIngestSSTables = rng.IntN(2) == 0
 	testOpts.asyncApplyToDB = rng.IntN(2) != 0
@@ -867,15 +867,15 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 		}
 		// If shared storage is enabled, pick between writing all files on shared
 		// vs. lower levels only, 50% of the time.
-		testOpts.Opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
+		testOpts.Opts.CreateOnShared = remote.CreateOnSharedAll
 		if rng.IntN(2) == 0 {
-			testOpts.Opts.Experimental.CreateOnShared = remote.CreateOnSharedLower
+			testOpts.Opts.CreateOnShared = remote.CreateOnSharedLower
 		}
 		// If shared storage is enabled, enable secondary cache 20% of the time.
 		if rng.IntN(100) < 20 {
 			testOpts.secondaryCacheEnabled = true
 			// TODO(josh): Randomize various secondary cache settings.
-			testOpts.Opts.Experimental.SecondaryCacheSizeBytes = 1024 * 1024 * 32 // 32 MBs
+			testOpts.Opts.SecondaryCacheSizeBytes = 1024 * 1024 * 32 // 32 MBs
 		}
 		// 50% of the time, enable shared replication.
 		testOpts.useSharedReplicate = rng.IntN(2) == 0
@@ -895,7 +895,7 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	//  - 50% of the time (n = 2,3), enable value separation and randomize parameters.
 	if n := rng.IntN(4); n == 1 {
 		// 25% of the time, disable value separation.
-		opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+		opts.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 			return pebble.ValueSeparationPolicy{Enabled: false}
 		}
 	} else if n > 1 {
@@ -912,19 +912,19 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 			GarbageRatioLowPriority:  lowPri,
 			GarbageRatioHighPriority: lowPri + rng.Float64()*(1.0-lowPri), // [lowPri, 1.0)
 		}
-		opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+		opts.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 			return policy
 		}
 	}
 
 	if rng.IntN(2) == 0 {
-		opts.Experimental.IteratorTracking.PollInterval = 100 * time.Millisecond
-		opts.Experimental.IteratorTracking.MaxAge = 10 * time.Second
+		opts.IteratorTracking.PollInterval = 100 * time.Millisecond
+		opts.IteratorTracking.MaxAge = 10 * time.Second
 	}
 
 	testOpts.seedEFOS = rng.Uint64()
 	testOpts.ingestSplit = rng.IntN(2) == 0
-	opts.Experimental.IngestSplit = func() bool { return testOpts.ingestSplit }
+	opts.IngestSplit = func() bool { return testOpts.ingestSplit }
 	testOpts.useExcise = rng.IntN(2) == 0
 	if testOpts.useExcise {
 		if testOpts.Opts.FormatMajorVersion < pebble.FormatVirtualSSTables {
@@ -932,7 +932,7 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 		}
 	}
 	testOpts.useDeleteOnlyCompactionExcises = rng.IntN(2) == 0
-	opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool {
+	opts.EnableDeleteOnlyCompactionExcises = func() bool {
 		return testOpts.useDeleteOnlyCompactionExcises
 	}
 	testOpts.disableDownloads = rng.IntN(2) == 0

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -70,24 +70,24 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"FS:",
 		"KeySchemas[",
 		"FileCache:",
-		"Experimental.CompactionScheduler",
+		"CompactionScheduler",
 		// Function pointers
 		"BlockPropertyCollectors:",
 		"EventListener:",
 		"CompactionConcurrencyRange:",
 		"MaxConcurrentDownloads:",
 		"DeletionPacing.BaselineRate:",
-		"Experimental.CompactionGarbageFractionForMaxConcurrency:",
-		"Experimental.DisableIngestAsFlushable:",
-		"Experimental.EnableColumnarBlocks:",
-		"Experimental.EnableValueBlocks:",
-		"Experimental.IneffectualSingleDeleteCallback:",
-		"Experimental.IngestSplit:",
-		"Experimental.RemoteStorage:",
-		"Experimental.SingleDeleteInvariantViolationCallback:",
-		"Experimental.EnableDeleteOnlyCompactionExcises:",
-		"Experimental.TombstoneDenseCompactionThreshold:",
-		"Experimental.ValueSeparationPolicy:",
+		"CompactionGarbageFractionForMaxConcurrency:",
+		"DisableIngestAsFlushable:",
+		"EnableColumnarBlocks:",
+		"EnableValueBlocks:",
+		"IneffectualSingleDeleteCallback:",
+		"IngestSplit:",
+		"RemoteStorage:",
+		"SingleDeleteInvariantViolationCallback:",
+		"EnableDeleteOnlyCompactionExcises:",
+		"TombstoneDenseCompactionThreshold:",
+		"ValueSeparationPolicy:",
 		"Levels[0].Compression:",
 		"Levels[0].TableFilterPolicy:",
 		"Levels[1].Compression:",
@@ -104,9 +104,9 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"Levels[6].TableFilterPolicy:",
 		"WALFailover.FailoverOptions.UnhealthyOperationLatencyThreshold:",
 		// Floating points
-		"Experimental.PointTombstoneWeight:",
-		"Experimental.MultiLevelCompactionHeuristic.AddPropensity",
-		"Experimental.MultiLevelCompactionHeuristic",
+		"PointTombstoneWeight:",
+		"MultiLevelCompactionHeuristic.AddPropensity",
+		"MultiLevelCompactionHeuristic",
 	}
 
 	checkOptions := func(t *testing.T, o *TestOptions) {
@@ -121,12 +121,12 @@ func TestOptionsRoundtrip(t *testing.T) {
 
 		// In some options, the closure obscures the underlying value. Check
 		// that the return values are equal.
-		expectEqualFn(t, o.Opts.Experimental.EnableValueBlocks, parsed.Opts.Experimental.EnableValueBlocks)
-		expectEqualFn(t, o.Opts.Experimental.DisableIngestAsFlushable, parsed.Opts.Experimental.DisableIngestAsFlushable)
-		expectEqualFn(t, o.Opts.Experimental.IngestSplit, parsed.Opts.Experimental.IngestSplit)
-		expectEqualFn(t, o.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency, parsed.Opts.Experimental.CompactionGarbageFractionForMaxConcurrency)
-		expectEqualFn(t, o.Opts.Experimental.TombstoneDenseCompactionThreshold, parsed.Opts.Experimental.TombstoneDenseCompactionThreshold)
-		expectEqualFn(t, o.Opts.Experimental.ValueSeparationPolicy, parsed.Opts.Experimental.ValueSeparationPolicy)
+		expectEqualFn(t, o.Opts.EnableValueBlocks, parsed.Opts.EnableValueBlocks)
+		expectEqualFn(t, o.Opts.DisableIngestAsFlushable, parsed.Opts.DisableIngestAsFlushable)
+		expectEqualFn(t, o.Opts.IngestSplit, parsed.Opts.IngestSplit)
+		expectEqualFn(t, o.Opts.CompactionGarbageFractionForMaxConcurrency, parsed.Opts.CompactionGarbageFractionForMaxConcurrency)
+		expectEqualFn(t, o.Opts.TombstoneDenseCompactionThreshold, parsed.Opts.TombstoneDenseCompactionThreshold)
+		expectEqualFn(t, o.Opts.ValueSeparationPolicy, parsed.Opts.ValueSeparationPolicy)
 		expectEqualFn(t, o.Opts.DeletionPacing.BaselineRate, parsed.Opts.DeletionPacing.BaselineRate)
 		for i := range o.Opts.Levels {
 			expectEqualFn(t, o.Opts.Levels[i].Compression, parsed.Opts.Levels[i].Compression)

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -268,7 +268,7 @@ func (t *Test) init(
 func (t *Test) finalizeOptions() pebble.Options {
 	o := *t.opts
 	// Give each DB its own CompactionScheduler.
-	o.Experimental.CompactionScheduler = func() pebble.CompactionScheduler {
+	o.CompactionScheduler = func() pebble.CompactionScheduler {
 		return pebble.NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 
@@ -297,7 +297,7 @@ func (t *Test) finalizeOptions() pebble.Options {
 		m[remote.MakeLocator("external")] = t.externalStorage
 	}
 	if len(m) > 0 {
-		o.Experimental.RemoteStorage = remote.MakeSimpleFactory(m)
+		o.RemoteStorage = remote.MakeSimpleFactory(m)
 	}
 	return o
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -271,9 +271,9 @@ func TestMetrics(t *testing.T) {
 		}
 		// Fix FileCacheShards to avoid non-determinism in disk usage (the option is
 		// written to the OPTIONS file).
-		opts.Experimental.FileCacheShards = 10
-		opts.Experimental.EnableValueBlocks = func() bool { return true }
-		opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+		opts.FileCacheShards = 10
+		opts.EnableValueBlocks = func() bool { return true }
+		opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 			return ValueSeparationPolicy{
 				Enabled:                true,
 				MinimumSize:            3,
@@ -292,13 +292,13 @@ func TestMetrics(t *testing.T) {
 		// ingests.
 		opts.MemTableStopWritesThreshold = 4
 
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): remoteStorage,
 		})
 		if createOnSharedLower {
-			opts.Experimental.CreateOnShared = remote.CreateOnSharedLower
+			opts.CreateOnShared = remote.CreateOnSharedLower
 		} else {
-			opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
+			opts.CreateOnShared = remote.CreateOnSharedNone
 		}
 		var err error
 		d, err = Open("", opts)

--- a/open.go
+++ b/open.go
@@ -114,7 +114,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		// We will initialize the store at the minimum possible format, then upgrade
 		// the format to the desired one. This helps test the format upgrade code.
 		formatVersion = FormatMinSupported
-		if opts.Experimental.CreateOnShared != remote.CreateOnSharedNone {
+		if opts.CreateOnShared != remote.CreateOnSharedNone {
 			formatVersion = FormatMinForSharedObjects
 		}
 		// There is no format version marker file. There are three cases:
@@ -168,12 +168,12 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	d.mu.versions = &versionSet{}
 	d.diskAvailBytes.Store(math.MaxUint64)
 	d.problemSpans.Init(manifest.NumLevels, opts.Comparer.Compare)
-	if opts.Experimental.CompactionScheduler != nil {
-		d.compactionScheduler = opts.Experimental.CompactionScheduler()
+	if opts.CompactionScheduler != nil {
+		d.compactionScheduler = opts.CompactionScheduler()
 	} else {
 		d.compactionScheduler = newConcurrencyLimitScheduler(defaultTimeSource{})
 	}
-	if iterTrackOpts := opts.Experimental.IteratorTracking; iterTrackOpts.PollInterval > 0 && iterTrackOpts.MaxAge > 0 {
+	if iterTrackOpts := opts.IteratorTracking; iterTrackOpts.PollInterval > 0 && iterTrackOpts.MaxAge > 0 {
 		d.iterTracker = inflight.NewPollingTracker(iterTrackOpts.PollInterval, iterTrackOpts.MaxAge, func(report string) {
 			d.opts.Logger.Infof("Long-lived iterators detected:\n%s", report)
 		})
@@ -253,7 +253,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		// Create a fresh version set and create an initial manifest file.
 		blobRewriteHeuristic := manifest.BlobRewriteHeuristic{
 			CurrentTime: d.opts.private.timeNow,
-			MinimumAge:  opts.Experimental.ValueSeparationPolicy().RewriteMinimumAge,
+			MinimumAge:  opts.ValueSeparationPolicy().RewriteMinimumAge,
 		}
 		if err := d.mu.versions.initNewDB(
 			jobID, dirname, d.objProvider, opts, rs.manifestMarker, d.FormatMajorVersion, blobRewriteHeuristic, &d.mu.Mutex); err != nil {
@@ -358,7 +358,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 
 	fileCacheSize := FileCacheSize(opts.MaxOpenFiles)
 	if opts.FileCache == nil {
-		opts.FileCache = NewFileCache(opts.Experimental.FileCacheShards, fileCacheSize)
+		opts.FileCache = NewFileCache(opts.FileCacheShards, fileCacheSize)
 		defer opts.FileCache.Unref()
 	}
 	fileCacheReaderOpts := d.opts.MakeReaderOptions()

--- a/open_test.go
+++ b/open_test.go
@@ -1781,8 +1781,8 @@ func TestOpenRatchetsNextFileNum(t *testing.T) {
 	memShared := remote.NewInMem()
 
 	opts := &Options{FS: mem, Logger: testutils.Logger{T: t}}
-	opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
-	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+	opts.CreateOnShared = remote.CreateOnSharedAll
+	opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 		remote.MakeLocator(""): memShared,
 	})
 	d, err := Open("", opts)

--- a/options.go
+++ b/options.go
@@ -50,16 +50,20 @@ const (
 
 // Type aliases for types moved to internal/base package.
 // These provide public access to internal types needed by external users.
-type SpanPolicy = base.SpanPolicy
-type ValueStoragePolicyAdjustment = base.ValueStoragePolicyAdjustment
-type TieringPolicy = base.TieringPolicy
-type TieringSpanID = base.TieringSpanID
-type TieringAttribute = base.TieringAttribute
-type TieringPolicyAndExtractor = base.TieringPolicyAndExtractor
-type UserKeyBounds = base.UserKeyBounds
+type (
+	SpanPolicy                   = base.SpanPolicy
+	ValueStoragePolicyAdjustment = base.ValueStoragePolicyAdjustment
+	TieringPolicy                = base.TieringPolicy
+	TieringSpanID                = base.TieringSpanID
+	TieringAttribute             = base.TieringAttribute
+	TieringPolicyAndExtractor    = base.TieringPolicyAndExtractor
+	UserKeyBounds                = base.UserKeyBounds
+)
 
-type TableFilterPolicy = base.TableFilterPolicy
-type TableFilterDecoder = base.TableFilterDecoder
+type (
+	TableFilterPolicy  = base.TableFilterPolicy
+	TableFilterDecoder = base.TableFilterDecoder
+)
 
 var NoFilterPolicy = base.NoFilterPolicy
 
@@ -603,224 +607,246 @@ type Options struct {
 	// flushes, compactions, and table deletion.
 	EventListener *EventListener
 
-	// Experimental contains experimental options which are off by default.
-	// These options are temporary and will eventually either be deleted, moved
-	// out of the experimental group, or made the non-adjustable default. These
-	// options may change at any time, so do not rely on them.
-	Experimental struct {
-		// The threshold of L0 read-amplification at which compaction concurrency
-		// is enabled (if CompactionDebtConcurrency was not already exceeded).
-		// Every multiple of this value enables another concurrent
-		// compaction up to CompactionConcurrencyRange.
-		L0CompactionConcurrency int
+	// L0CompactionConcurrency is the threshold of L0 read-amplification at
+	// which compaction concurrency is enabled (if CompactionDebtConcurrency
+	// was not already exceeded). Every multiple of this value enables another
+	// concurrent compaction up to CompactionConcurrencyRange.
+	L0CompactionConcurrency int
 
-		// CompactionDebtConcurrency controls the threshold of compaction debt
-		// at which additional compaction concurrency slots are added. For every
-		// multiple of this value in compaction debt bytes, an additional
-		// concurrent compaction is added. This works "on top" of
-		// L0CompactionConcurrency, so the higher of the count of compaction
-		// concurrency slots as determined by the two options is chosen.
-		CompactionDebtConcurrency uint64
+	// CompactionDebtConcurrency controls the threshold of compaction debt
+	// at which additional compaction concurrency slots are added. For every
+	// multiple of this value in compaction debt bytes, an additional
+	// concurrent compaction is added. This works "on top" of
+	// L0CompactionConcurrency, so the higher of the count of compaction
+	// concurrency slots as determined by the two options is chosen.
+	CompactionDebtConcurrency uint64
 
-		// CompactionGarbageFractionForMaxConcurrency is the fraction of garbage
-		// due to DELs and RANGEDELs that causes MaxConcurrentCompactions to be
-		// allowed. Concurrent compactions are allowed in a linear manner upto
-		// this limit being reached. A value <= 0.0 disables adding concurrency
-		// due to garbage.
-		CompactionGarbageFractionForMaxConcurrency func() float64
+	// CompactionGarbageFractionForMaxConcurrency is the fraction of garbage
+	// due to DELs and RANGEDELs that causes MaxConcurrentCompactions to be
+	// allowed. Concurrent compactions are allowed in a linear manner upto
+	// this limit being reached. A value <= 0.0 disables adding concurrency
+	// due to garbage.
+	CompactionGarbageFractionForMaxConcurrency func() float64
 
-		// UseDeprecatedCompensatedScore is a temporary option to revert the
-		// compaction picker to the previous behavior of only considering
-		// compaction out of a level if its compensated fill factor divided by
-		// the next level's fill factor is >= 1.0. The details of this setting
-		// are documented within its use within the compaction picker.
+	// UseDeprecatedCompensatedScore is a temporary option to revert the
+	// compaction picker to the previous behavior of only considering
+	// compaction out of a level if its compensated fill factor divided by
+	// the next level's fill factor is >= 1.0. The details of this setting
+	// are documented within its use within the compaction picker.
+	//
+	// The default value is false.
+	UseDeprecatedCompensatedScore func() bool
+
+	// IngestSplit, if it returns true, allows for ingest-time splitting of
+	// existing sstables into two virtual sstables to allow ingestion sstables to
+	// slot into a lower level than they otherwise would have.
+	IngestSplit func() bool
+
+	// ReadCompactionRate controls the frequency of read triggered
+	// compactions by adjusting `AllowedSeeks` in manifest.TableMetadata:
+	//
+	// AllowedSeeks = FileSize / ReadCompactionRate
+	//
+	// From LevelDB:
+	// ```
+	// We arrange to automatically compact this file after
+	// a certain number of seeks. Let's assume:
+	//   (1) One seek costs 10ms
+	//   (2) Writing or reading 1MB costs 10ms (100MB/s)
+	//   (3) A compaction of 1MB does 25MB of IO:
+	//         1MB read from this level
+	//         10-12MB read from next level (boundaries may be misaligned)
+	//         10-12MB written to next level
+	// This implies that 25 seeks cost the same as the compaction
+	// of 1MB of data.  I.e., one seek costs approximately the
+	// same as the compaction of 40KB of data.  We are a little
+	// conservative and allow approximately one seek for every 16KB
+	// of data before triggering a compaction.
+	// ```
+	ReadCompactionRate int64
+
+	// ReadSamplingMultiplier is a multiplier for the readSamplingPeriod in
+	// iterator.maybeSampleRead() to control the frequency of read sampling
+	// to trigger a read triggered compaction. A value of -1 prevents sampling
+	// and disables read triggered compactions. The default is 1 << 4. which
+	// gets multiplied with a constant of 1 << 16 to yield 1 << 20 (1MB).
+	ReadSamplingMultiplier int64
+
+	// NumDeletionsThreshold defines the minimum number of point tombstones
+	// that must be present in a single data block for that block to be
+	// considered tombstone-dense for the purposes of triggering a
+	// tombstone density compaction. Data blocks may also be considered
+	// tombstone-dense if they meet the criteria defined by
+	// DeletionSizeRatioThreshold below. Tombstone-dense blocks are identified
+	// when sstables are written, and so this is effectively an option for
+	// sstable writers.
+	//
+	// The default value is 100.
+	NumDeletionsThreshold int
+
+	// DeletionSizeRatioThreshold defines the minimum ratio of the size of
+	// point tombstones to the size of a data block that must be reached
+	// for that block to be considered tombstone-dense for the purposes of
+	// triggering a tombstone density compaction. Data blocks may also be
+	// considered tombstone-dense if they meet the criteria defined by
+	// NumDeletionsThreshold above. Tombstone-dense blocks are identified
+	// when sstables are written, and so this is effectively an option for
+	// sstable writers.
+	//
+	// The default value is 0.5.
+	DeletionSizeRatioThreshold float32
+
+	// TombstoneDenseCompactionThreshold is a function that returns the minimum
+	// percent of data blocks in a table that must be tombstone-dense for that
+	// table to be eligible for a tombstone density compaction. The value should
+	// be defined as a ratio out of 1. The default value is 0.10.
+	//
+	// If multiple tables are eligible for a tombstone density compaction, then
+	// tables with a higher percent of tombstone-dense blocks are still
+	// prioritized for compaction.
+	//
+	// Using a function allows for dynamic reconfiguration of the threshold based
+	// on workload characteristics. A zero or negative value disables tombstone
+	// density compactions.
+	TombstoneDenseCompactionThreshold func() float64
+
+	// FileCacheShards is the number of shards per file cache.
+	// Reducing the value can reduce the number of idle goroutines per DB
+	// instance which can be useful in scenarios with a lot of DB instances
+	// and a large number of CPUs, but doing so can lead to higher contention
+	// in the file cache and reduced performance.
+	//
+	// The default value is the number of logical CPUs, which can be
+	// limited by runtime.GOMAXPROCS.
+	FileCacheShards int
+
+	// ValidateOnIngest schedules validation of sstables after they have
+	// been ingested.
+	//
+	// By default, this value is false.
+	//
+	// Experimental.
+	ValidateOnIngest bool
+
+	// LevelMultiplier configures the size multiplier used to determine the
+	// desired size of each level of the LSM. Defaults to 10.
+	LevelMultiplier int
+
+	// MultiLevelCompactionHeuristic determines whether to add an additional
+	// level to a conventional two level compaction.
+	//
+	// Experimental.
+	MultiLevelCompactionHeuristic func() MultiLevelHeuristic
+
+	// EnableValueBlocks is used to decide whether to enable writing
+	// TableFormatPebblev3 sstables. This setting is only respected by a
+	// specific subset of format major versions: FormatSSTableValueBlocks,
+	// FormatFlushableIngest and FormatPrePebblev1MarkedCompacted. In lower
+	// format major versions, value blocks are never enabled. In higher
+	// format major versions, value blocks are always enabled.
+	EnableValueBlocks func() bool
+
+	// ShortAttributeExtractor is used iff EnableValueBlocks() returns true
+	// (else ignored). If non-nil, a ShortAttribute can be extracted from the
+	// value and stored with the key, when the value is stored elsewhere.
+	ShortAttributeExtractor ShortAttributeExtractor
+
+	// DisableIngestAsFlushable disables lazy ingestion of sstables through
+	// a WAL write and memtable rotation. Only effectual if the format
+	// major version is at least `FormatFlushableIngest`.
+	DisableIngestAsFlushable func() bool
+
+	// RemoteStorage enables use of remote storage (e.g. S3) for storing
+	// sstables. Setting this option enables use of CreateOnShared option and
+	// allows ingestion of external files.
+	//
+	// Experimental.
+	RemoteStorage remote.StorageFactory
+
+	// If CreateOnShared is non-zero, new sstables are created on remote storage
+	// (using CreateOnSharedLocator and with the appropriate
+	// CreateOnSharedStrategy). These sstables can be shared between different
+	// Pebble instances; the lifecycle of such objects is managed by the
+	// remote.Storage constructed by options.RemoteStorage.
+	//
+	// Can only be used when RemoteStorage is set (and recognizes
+	// CreateOnSharedLocator).
+	//
+	// Experimental.
+	CreateOnShared        remote.CreateOnSharedStrategy
+	CreateOnSharedLocator remote.Locator
+
+	// CacheSizeBytesBytes is the size of the on-disk block cache for objects
+	// on shared storage in bytes. If it is 0, no cache is used.
+	//
+	// Experimental.
+	SecondaryCacheSizeBytes int64
+
+	// EnableDeleteOnlyCompactionExcises enables delete-only compactions to also
+	// apply delete-only compaction hints on sstables that partially overlap
+	// with it. This application happens through an excise, similar to
+	// the excise phase of IngestAndExcise.
+	//
+	// Experimental.
+	EnableDeleteOnlyCompactionExcises func() bool
+
+	// CompactionScheduler, if set, is used to create a scheduler to limit
+	// concurrent compactions as well as to pace compactions already chosen. If
+	// nil, a default scheduler is created and used.
+	//
+	// Experimental.
+	CompactionScheduler func() CompactionScheduler
+
+	// Experimental.
+	UserKeyCategories UserKeyCategories
+
+	// ValueSeparationPolicy controls the policy for separating values into
+	// external blob files. If nil, value separation defaults to disabled.
+	// The value separation policy is ignored if EnableColumnarBlocks() is
+	// false.
+	//
+	// Experimental.
+	ValueSeparationPolicy func() ValueSeparationPolicy
+
+	// SpanPolicyFunc is used to determine the SpanPolicy for a key region.
+	//
+	// Experimental.
+	SpanPolicyFunc SpanPolicyFunc
+
+	// VirtualTableRewriteUnreferencedFraction configures the minimum fraction of
+	// unreferenced data in a backing table required to trigger a virtual table
+	// rewrite compaction. This is calculated as the ratio of unreferenced
+	// data size to total backing file size. A value of 0.0 triggers
+	// rewrites for any amount of unreferenced data. A value of 1.0 disables
+	// virtual table rewrite compactions entirely. The default value is 0.30
+	// (rewrite when >= 30% of backing data is unreferenced).
+	//
+	// Experimental.
+	VirtualTableRewriteUnreferencedFraction func() float64
+
+	// IteratorTracking configures periodic logging of iterators held open for
+	// too long.
+	//
+	// Experimental.
+	IteratorTracking struct {
+		// PollInterval is the interval at which to log a report of long-lived
+		// iterators. If zero, disables iterator tracking.
 		//
-		// The default value is false.
-		UseDeprecatedCompensatedScore func() bool
+		// The default value is 0 (disabled).
+		PollInterval time.Duration
 
-		// IngestSplit, if it returns true, allows for ingest-time splitting of
-		// existing sstables into two virtual sstables to allow ingestion sstables to
-		// slot into a lower level than they otherwise would have.
-		IngestSplit func() bool
-
-		// ReadCompactionRate controls the frequency of read triggered
-		// compactions by adjusting `AllowedSeeks` in manifest.TableMetadata:
+		// MaxAge is the age above which iterators are considered long-lived. If
+		// zero, disables iterator tracking.
 		//
-		// AllowedSeeks = FileSize / ReadCompactionRate
-		//
-		// From LevelDB:
-		// ```
-		// We arrange to automatically compact this file after
-		// a certain number of seeks. Let's assume:
-		//   (1) One seek costs 10ms
-		//   (2) Writing or reading 1MB costs 10ms (100MB/s)
-		//   (3) A compaction of 1MB does 25MB of IO:
-		//         1MB read from this level
-		//         10-12MB read from next level (boundaries may be misaligned)
-		//         10-12MB written to next level
-		// This implies that 25 seeks cost the same as the compaction
-		// of 1MB of data.  I.e., one seek costs approximately the
-		// same as the compaction of 40KB of data.  We are a little
-		// conservative and allow approximately one seek for every 16KB
-		// of data before triggering a compaction.
-		// ```
-		ReadCompactionRate int64
+		// The default value is 0 (disabled).
+		MaxAge time.Duration
+	}
 
-		// ReadSamplingMultiplier is a multiplier for the readSamplingPeriod in
-		// iterator.maybeSampleRead() to control the frequency of read sampling
-		// to trigger a read triggered compaction. A value of -1 prevents sampling
-		// and disables read triggered compactions. The default is 1 << 4. which
-		// gets multiplied with a constant of 1 << 16 to yield 1 << 20 (1MB).
-		ReadSamplingMultiplier int64
-
-		// NumDeletionsThreshold defines the minimum number of point tombstones
-		// that must be present in a single data block for that block to be
-		// considered tombstone-dense for the purposes of triggering a
-		// tombstone density compaction. Data blocks may also be considered
-		// tombstone-dense if they meet the criteria defined by
-		// DeletionSizeRatioThreshold below. Tombstone-dense blocks are identified
-		// when sstables are written, and so this is effectively an option for
-		// sstable writers. The default value is 100.
-		NumDeletionsThreshold int
-
-		// DeletionSizeRatioThreshold defines the minimum ratio of the size of
-		// point tombstones to the size of a data block that must be reached
-		// for that block to be considered tombstone-dense for the purposes of
-		// triggering a tombstone density compaction. Data blocks may also be
-		// considered tombstone-dense if they meet the criteria defined by
-		// NumDeletionsThreshold above. Tombstone-dense blocks are identified
-		// when sstables are written, and so this is effectively an option for
-		// sstable writers. The default value is 0.5.
-		DeletionSizeRatioThreshold float32
-
-		// TombstoneDenseCompactionThreshold is a function that returns the minimum
-		// percent of data blocks in a table that must be tombstone-dense for that
-		// table to be eligible for a tombstone density compaction. The value should
-		// be defined as a ratio out of 1. The default value is 0.10.
-		//
-		// If multiple tables are eligible for a tombstone density compaction, then
-		// tables with a higher percent of tombstone-dense blocks are still
-		// prioritized for compaction.
-		//
-		// Using a function allows for dynamic reconfiguration of the threshold based
-		// on workload characteristics. A zero or negative value disables tombstone
-		// density compactions.
-		TombstoneDenseCompactionThreshold func() float64
-
-		// FileCacheShards is the number of shards per file cache.
-		// Reducing the value can reduce the number of idle goroutines per DB
-		// instance which can be useful in scenarios with a lot of DB instances
-		// and a large number of CPUs, but doing so can lead to higher contention
-		// in the file cache and reduced performance.
-		//
-		// The default value is the number of logical CPUs, which can be
-		// limited by runtime.GOMAXPROCS.
-		FileCacheShards int
-
-		// ValidateOnIngest schedules validation of sstables after they have
-		// been ingested.
-		//
-		// By default, this value is false.
-		ValidateOnIngest bool
-
-		// LevelMultiplier configures the size multiplier used to determine the
-		// desired size of each level of the LSM. Defaults to 10.
-		LevelMultiplier int
-
-		// MultiLevelCompactionHeuristic determines whether to add an additional
-		// level to a conventional two level compaction.
-		MultiLevelCompactionHeuristic func() MultiLevelHeuristic
-
-		// EnableValueBlocks is used to decide whether to enable writing
-		// TableFormatPebblev3 sstables. This setting is only respected by a
-		// specific subset of format major versions: FormatSSTableValueBlocks,
-		// FormatFlushableIngest and FormatPrePebblev1MarkedCompacted. In lower
-		// format major versions, value blocks are never enabled. In higher
-		// format major versions, value blocks are always enabled.
-		EnableValueBlocks func() bool
-
-		// ShortAttributeExtractor is used iff EnableValueBlocks() returns true
-		// (else ignored). If non-nil, a ShortAttribute can be extracted from the
-		// value and stored with the key, when the value is stored elsewhere.
-		ShortAttributeExtractor ShortAttributeExtractor
-
-		// DisableIngestAsFlushable disables lazy ingestion of sstables through
-		// a WAL write and memtable rotation. Only effectual if the format
-		// major version is at least `FormatFlushableIngest`.
-		DisableIngestAsFlushable func() bool
-
-		// RemoteStorage enables use of remote storage (e.g. S3) for storing
-		// sstables. Setting this option enables use of CreateOnShared option and
-		// allows ingestion of external files.
-		RemoteStorage remote.StorageFactory
-
-		// If CreateOnShared is non-zero, new sstables are created on remote storage
-		// (using CreateOnSharedLocator and with the appropriate
-		// CreateOnSharedStrategy). These sstables can be shared between different
-		// Pebble instances; the lifecycle of such objects is managed by the
-		// remote.Storage constructed by options.RemoteStorage.
-		//
-		// Can only be used when RemoteStorage is set (and recognizes
-		// CreateOnSharedLocator).
-		CreateOnShared        remote.CreateOnSharedStrategy
-		CreateOnSharedLocator remote.Locator
-
-		// CacheSizeBytesBytes is the size of the on-disk block cache for objects
-		// on shared storage in bytes. If it is 0, no cache is used.
-		SecondaryCacheSizeBytes int64
-
-		// EnableDeleteOnlyCompactionExcises enables delete-only compactions to also
-		// apply delete-only compaction hints on sstables that partially overlap
-		// with it. This application happens through an excise, similar to
-		// the excise phase of IngestAndExcise.
-		EnableDeleteOnlyCompactionExcises func() bool
-
-		// CompactionScheduler, if set, is used to create a scheduler to limit
-		// concurrent compactions as well as to pace compactions already chosen. If
-		// nil, a default scheduler is created and used.
-		CompactionScheduler func() CompactionScheduler
-
-		UserKeyCategories UserKeyCategories
-
-		// ValueSeparationPolicy controls the policy for separating values into
-		// external blob files. If nil, value separation defaults to disabled.
-		// The value separation policy is ignored if EnableColumnarBlocks() is
-		// false.
-		ValueSeparationPolicy func() ValueSeparationPolicy
-
-		// SpanPolicyFunc is used to determine the SpanPolicy for a key region.
-		SpanPolicyFunc SpanPolicyFunc
-
-		// VirtualTableRewriteUnreferencedFraction configures the minimum fraction of
-		// unreferenced data in a backing table required to trigger a virtual table
-		// rewrite compaction. This is calculated as the ratio of unreferenced
-		// data size to total backing file size. A value of 0.0 triggers
-		// rewrites for any amount of unreferenced data. A value of 1.0 disables
-		// virtual table rewrite compactions entirely. The default value is 0.30
-		// (rewrite when >= 30% of backing data is unreferenced).
-		VirtualTableRewriteUnreferencedFraction func() float64
-
-		// IteratorTracking configures periodic logging of iterators held open for
-		// too long.
-		IteratorTracking struct {
-			// PollInterval is the interval at which to log a report of long-lived
-			// iterators. If zero, disables iterator tracking.
-			//
-			// The default value is 0 (disabled).
-			PollInterval time.Duration
-
-			// MaxAge is the age above which iterators are considered long-lived. If
-			// zero, disables iterator tracking.
-			//
-			// The default value is 0 (disabled).
-			MaxAge time.Duration
-		}
-
-		Tiering struct {
-			// NowFn can be used to override the current time used to decide if data
-			// belongs in the cold or hot tier.
-			NowFn func() time.Time
-		}
+	// Experimental.
+	Tiering struct {
+		// NowFn can be used to override the current time used to decide if data
+		// belongs in the cold or hot tier.
+		NowFn func() time.Time
 	}
 
 	// TableFilterDecoders contains the available table filter decoders.
@@ -1588,22 +1614,22 @@ func (o *Options) EnsureDefaults() {
 	}
 	o.DeletionPacing.EnsureDefaults()
 
-	if o.Experimental.DisableIngestAsFlushable == nil {
-		o.Experimental.DisableIngestAsFlushable = func() bool { return false }
+	if o.DisableIngestAsFlushable == nil {
+		o.DisableIngestAsFlushable = func() bool { return false }
 	}
-	if o.Experimental.L0CompactionConcurrency <= 0 {
-		o.Experimental.L0CompactionConcurrency = 10
+	if o.L0CompactionConcurrency <= 0 {
+		o.L0CompactionConcurrency = 10
 	}
-	if o.Experimental.CompactionDebtConcurrency <= 0 {
-		o.Experimental.CompactionDebtConcurrency = 1 << 30 // 1 GB
+	if o.CompactionDebtConcurrency <= 0 {
+		o.CompactionDebtConcurrency = 1 << 30 // 1 GB
 	}
-	if o.Experimental.CompactionGarbageFractionForMaxConcurrency == nil {
+	if o.CompactionGarbageFractionForMaxConcurrency == nil {
 		// When 40% of the DB is garbage, the compaction concurrency is at the
 		// maximum permitted.
-		o.Experimental.CompactionGarbageFractionForMaxConcurrency = func() float64 { return 0.4 }
+		o.CompactionGarbageFractionForMaxConcurrency = func() float64 { return 0.4 }
 	}
-	if o.Experimental.ValueSeparationPolicy == nil {
-		o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+	if o.ValueSeparationPolicy == nil {
+		o.ValueSeparationPolicy = func() ValueSeparationPolicy {
 			return ValueSeparationPolicy{
 				Enabled:                  true,
 				MinimumSize:              256,     // 256 bytes
@@ -1706,7 +1732,7 @@ func (o *Options) EnsureDefaults() {
 
 	if o.FormatMajorVersion == FormatDefault {
 		o.FormatMajorVersion = FormatMinSupported
-		if o.Experimental.CreateOnShared != remote.CreateOnSharedNone {
+		if o.CreateOnShared != remote.CreateOnSharedNone {
 			o.FormatMajorVersion = FormatMinForSharedObjects
 		}
 	}
@@ -1720,41 +1746,41 @@ func (o *Options) EnsureDefaults() {
 	if o.WALFailover != nil {
 		o.WALFailover.FailoverOptions.EnsureDefaults()
 	}
-	if o.Experimental.UseDeprecatedCompensatedScore == nil {
-		o.Experimental.UseDeprecatedCompensatedScore = func() bool { return false }
+	if o.UseDeprecatedCompensatedScore == nil {
+		o.UseDeprecatedCompensatedScore = func() bool { return false }
 	}
-	if o.Experimental.LevelMultiplier <= 0 {
-		o.Experimental.LevelMultiplier = defaultLevelMultiplier
+	if o.LevelMultiplier <= 0 {
+		o.LevelMultiplier = defaultLevelMultiplier
 	}
-	if o.Experimental.ReadCompactionRate == 0 {
-		o.Experimental.ReadCompactionRate = 16000
+	if o.ReadCompactionRate == 0 {
+		o.ReadCompactionRate = 16000
 	}
-	if o.Experimental.ReadSamplingMultiplier == 0 {
-		o.Experimental.ReadSamplingMultiplier = 1 << 4
+	if o.ReadSamplingMultiplier == 0 {
+		o.ReadSamplingMultiplier = 1 << 4
 	}
-	if o.Experimental.NumDeletionsThreshold == 0 {
-		o.Experimental.NumDeletionsThreshold = sstable.DefaultNumDeletionsThreshold
+	if o.NumDeletionsThreshold == 0 {
+		o.NumDeletionsThreshold = sstable.DefaultNumDeletionsThreshold
 	}
-	if o.Experimental.DeletionSizeRatioThreshold == 0 {
-		o.Experimental.DeletionSizeRatioThreshold = sstable.DefaultDeletionSizeRatioThreshold
+	if o.DeletionSizeRatioThreshold == 0 {
+		o.DeletionSizeRatioThreshold = sstable.DefaultDeletionSizeRatioThreshold
 	}
-	if o.Experimental.TombstoneDenseCompactionThreshold == nil {
-		o.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.10 }
+	if o.TombstoneDenseCompactionThreshold == nil {
+		o.TombstoneDenseCompactionThreshold = func() float64 { return 0.10 }
 	}
-	if o.Experimental.FileCacheShards <= 0 {
-		o.Experimental.FileCacheShards = runtime.GOMAXPROCS(0)
+	if o.FileCacheShards <= 0 {
+		o.FileCacheShards = runtime.GOMAXPROCS(0)
 	}
-	if o.Experimental.MultiLevelCompactionHeuristic == nil {
-		o.Experimental.MultiLevelCompactionHeuristic = OptionWriteAmpHeuristic
+	if o.MultiLevelCompactionHeuristic == nil {
+		o.MultiLevelCompactionHeuristic = OptionWriteAmpHeuristic
 	}
-	if o.Experimental.SpanPolicyFunc == nil {
-		o.Experimental.SpanPolicyFunc = func(bounds base.UserKeyBounds) (base.SpanPolicy, error) { return base.SpanPolicy{}, nil }
+	if o.SpanPolicyFunc == nil {
+		o.SpanPolicyFunc = func(bounds base.UserKeyBounds) (base.SpanPolicy, error) { return base.SpanPolicy{}, nil }
 	}
-	if o.Experimental.VirtualTableRewriteUnreferencedFraction == nil {
-		o.Experimental.VirtualTableRewriteUnreferencedFraction = func() float64 { return defaultVirtualTableUnreferencedFraction }
+	if o.VirtualTableRewriteUnreferencedFraction == nil {
+		o.VirtualTableRewriteUnreferencedFraction = func() float64 { return defaultVirtualTableUnreferencedFraction }
 	}
-	if o.Experimental.Tiering.NowFn == nil {
-		o.Experimental.Tiering.NowFn = time.Now
+	if o.Tiering.NowFn == nil {
+		o.Tiering.NowFn = time.Now
 	}
 	if o.private.timeNow == nil {
 		o.private.timeNow = time.Now
@@ -1828,12 +1854,12 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  bytes_per_sync=%d\n", o.BytesPerSync)
 	fmt.Fprintf(&buf, "  cache_size=%d\n", cacheSize)
 	fmt.Fprintf(&buf, "  cleaner=%s\n", o.Cleaner)
-	fmt.Fprintf(&buf, "  compaction_debt_concurrency=%d\n", o.Experimental.CompactionDebtConcurrency)
+	fmt.Fprintf(&buf, "  compaction_debt_concurrency=%d\n", o.CompactionDebtConcurrency)
 	fmt.Fprintf(&buf, "  compaction_garbage_fraction_for_max_concurrency=%.2f\n",
-		o.Experimental.CompactionGarbageFractionForMaxConcurrency())
+		o.CompactionGarbageFractionForMaxConcurrency())
 	fmt.Fprintf(&buf, "  comparer=%s\n", o.Comparer.Name)
 	fmt.Fprintf(&buf, "  disable_wal=%t\n", o.DisableWAL)
-	if o.Experimental.DisableIngestAsFlushable != nil && o.Experimental.DisableIngestAsFlushable() {
+	if o.DisableIngestAsFlushable != nil && o.DisableIngestAsFlushable() {
 		fmt.Fprintf(&buf, "  disable_ingest_as_flushable=%t\n", true)
 	}
 	fmt.Fprintf(&buf, "  flush_delay_delete_range=%s\n", o.FlushDelayDeleteRange)
@@ -1841,13 +1867,13 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  flush_split_bytes=%d\n", o.FlushSplitBytes)
 	fmt.Fprintf(&buf, "  format_major_version=%d\n", o.FormatMajorVersion)
 	fmt.Fprintf(&buf, "  key_schema=%s\n", o.KeySchema)
-	fmt.Fprintf(&buf, "  l0_compaction_concurrency=%d\n", o.Experimental.L0CompactionConcurrency)
+	fmt.Fprintf(&buf, "  l0_compaction_concurrency=%d\n", o.L0CompactionConcurrency)
 	fmt.Fprintf(&buf, "  l0_compaction_file_threshold=%d\n", o.L0CompactionFileThreshold)
 	fmt.Fprintf(&buf, "  l0_compaction_threshold=%d\n", o.L0CompactionThreshold)
 	fmt.Fprintf(&buf, "  l0_stop_writes_threshold=%d\n", o.L0StopWritesThreshold)
 	fmt.Fprintf(&buf, "  lbase_max_bytes=%d\n", o.LBaseMaxBytes)
-	if o.Experimental.LevelMultiplier != defaultLevelMultiplier {
-		fmt.Fprintf(&buf, "  level_multiplier=%d\n", o.Experimental.LevelMultiplier)
+	if o.LevelMultiplier != defaultLevelMultiplier {
+		fmt.Fprintf(&buf, "  level_multiplier=%d\n", o.LevelMultiplier)
 	}
 	lower, upper := o.CompactionConcurrencyRange()
 	fmt.Fprintf(&buf, "  concurrent_compactions=%d\n", lower)
@@ -1862,29 +1888,29 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  free_space_timeframe=%s\n", o.DeletionPacing.FreeSpaceTimeframe.String())
 	fmt.Fprintf(&buf, "  obsolete_bytes_timeframe=%s\n", o.DeletionPacing.BacklogTimeframe.String())
 	fmt.Fprintf(&buf, "  merger=%s\n", o.Merger.Name)
-	if o.Experimental.MultiLevelCompactionHeuristic != nil {
-		fmt.Fprintf(&buf, "  multilevel_compaction_heuristic=%s\n", o.Experimental.MultiLevelCompactionHeuristic().String())
+	if o.MultiLevelCompactionHeuristic != nil {
+		fmt.Fprintf(&buf, "  multilevel_compaction_heuristic=%s\n", o.MultiLevelCompactionHeuristic().String())
 	}
-	fmt.Fprintf(&buf, "  read_compaction_rate=%d\n", o.Experimental.ReadCompactionRate)
-	fmt.Fprintf(&buf, "  read_sampling_multiplier=%d\n", o.Experimental.ReadSamplingMultiplier)
-	fmt.Fprintf(&buf, "  num_deletions_threshold=%d\n", o.Experimental.NumDeletionsThreshold)
-	fmt.Fprintf(&buf, "  deletion_size_ratio_threshold=%f\n", o.Experimental.DeletionSizeRatioThreshold)
-	fmt.Fprintf(&buf, "  tombstone_dense_compaction_threshold=%f\n", o.Experimental.TombstoneDenseCompactionThreshold())
+	fmt.Fprintf(&buf, "  read_compaction_rate=%d\n", o.ReadCompactionRate)
+	fmt.Fprintf(&buf, "  read_sampling_multiplier=%d\n", o.ReadSamplingMultiplier)
+	fmt.Fprintf(&buf, "  num_deletions_threshold=%d\n", o.NumDeletionsThreshold)
+	fmt.Fprintf(&buf, "  deletion_size_ratio_threshold=%f\n", o.DeletionSizeRatioThreshold)
+	fmt.Fprintf(&buf, "  tombstone_dense_compaction_threshold=%f\n", o.TombstoneDenseCompactionThreshold())
 	// We no longer care about strict_wal_tail, but set it to true in case an
 	// older version reads the options.
 	fmt.Fprintf(&buf, "  strict_wal_tail=%t\n", true)
-	fmt.Fprintf(&buf, "  table_cache_shards=%d\n", o.Experimental.FileCacheShards)
-	fmt.Fprintf(&buf, "  validate_on_ingest=%t\n", o.Experimental.ValidateOnIngest)
+	fmt.Fprintf(&buf, "  table_cache_shards=%d\n", o.FileCacheShards)
+	fmt.Fprintf(&buf, "  validate_on_ingest=%t\n", o.ValidateOnIngest)
 	fmt.Fprintf(&buf, "  wal_dir=%s\n", o.WALDir)
 	fmt.Fprintf(&buf, "  wal_bytes_per_sync=%d\n", o.WALBytesPerSync)
-	fmt.Fprintf(&buf, "  secondary_cache_size_bytes=%d\n", o.Experimental.SecondaryCacheSizeBytes)
-	fmt.Fprintf(&buf, "  create_on_shared=%d\n", o.Experimental.CreateOnShared)
+	fmt.Fprintf(&buf, "  secondary_cache_size_bytes=%d\n", o.SecondaryCacheSizeBytes)
+	fmt.Fprintf(&buf, "  create_on_shared=%d\n", o.CreateOnShared)
 
-	if o.Experimental.IteratorTracking.PollInterval != 0 {
-		fmt.Fprintf(&buf, "  iterator_tracking_poll_interval=%s\n", o.Experimental.IteratorTracking.PollInterval)
+	if o.IteratorTracking.PollInterval != 0 {
+		fmt.Fprintf(&buf, "  iterator_tracking_poll_interval=%s\n", o.IteratorTracking.PollInterval)
 	}
-	if o.Experimental.IteratorTracking.MaxAge != 0 {
-		fmt.Fprintf(&buf, "  iterator_tracking_max_age=%s\n", o.Experimental.IteratorTracking.MaxAge)
+	if o.IteratorTracking.MaxAge != 0 {
+		fmt.Fprintf(&buf, "  iterator_tracking_max_age=%s\n", o.IteratorTracking.MaxAge)
 	}
 
 	// Private options.
@@ -1903,8 +1929,8 @@ func (o *Options) String() string {
 		fmt.Fprintln(&buf, "  disable_lazy_combined_iteration=true")
 	}
 
-	if o.Experimental.ValueSeparationPolicy != nil {
-		policy := o.Experimental.ValueSeparationPolicy()
+	if o.ValueSeparationPolicy != nil {
+		policy := o.ValueSeparationPolicy()
 		fmt.Fprintln(&buf)
 		fmt.Fprintln(&buf, "[Value Separation]")
 		fmt.Fprintf(&buf, "  enabled=%t\n", policy.Enabled)
@@ -2114,13 +2140,12 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 					o.Comparer = comparer
 				}
 			case "compaction_debt_concurrency":
-				o.Experimental.CompactionDebtConcurrency, err = strconv.ParseUint(value, 10, 64)
+				o.CompactionDebtConcurrency, err = strconv.ParseUint(value, 10, 64)
 			case "compaction_garbage_fraction_for_max_concurrency":
 				var frac float64
 				frac, err = strconv.ParseFloat(value, 64)
 				if err == nil {
-					o.Experimental.CompactionGarbageFractionForMaxConcurrency =
-						func() float64 { return frac }
+					o.CompactionGarbageFractionForMaxConcurrency = func() float64 { return frac }
 				}
 			case "delete_range_flush_delay":
 				// NB: This is a deprecated serialization of the
@@ -2134,7 +2159,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				var v bool
 				v, err = strconv.ParseBool(value)
 				if err == nil {
-					o.Experimental.DisableIngestAsFlushable = func() bool { return v }
+					o.DisableIngestAsFlushable = func() bool { return v }
 				}
 			case "disable_lazy_combined_iteration":
 				o.private.disableLazyCombinedIteration, err = strconv.ParseBool(value)
@@ -2201,7 +2226,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 					}
 				}
 			case "l0_compaction_concurrency":
-				o.Experimental.L0CompactionConcurrency, err = strconv.Atoi(value)
+				o.L0CompactionConcurrency, err = strconv.Atoi(value)
 			case "l0_compaction_file_threshold":
 				o.L0CompactionFileThreshold, err = strconv.Atoi(value)
 			case "l0_compaction_threshold":
@@ -2211,7 +2236,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "lbase_max_bytes":
 				o.LBaseMaxBytes, err = strconv.ParseInt(value, 10, 64)
 			case "level_multiplier":
-				o.Experimental.LevelMultiplier, err = strconv.Atoi(value)
+				o.LevelMultiplier, err = strconv.Atoi(value)
 			case "concurrent_compactions":
 				concurrencyLimit.lowerSet = true
 				concurrencyLimit.lower, err = strconv.Atoi(value)
@@ -2249,9 +2274,9 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 			case "multilevel_compaction_heuristic":
 				switch {
 				case value == "none":
-					o.Experimental.MultiLevelCompactionHeuristic = OptionNoMultiLevel
+					o.MultiLevelCompactionHeuristic = OptionNoMultiLevel
 				case strings.HasPrefix(value, "wamp"):
-					o.Experimental.MultiLevelCompactionHeuristic = OptionWriteAmpHeuristic
+					o.MultiLevelCompactionHeuristic = OptionWriteAmpHeuristic
 					fields := strings.FieldsFunc(strings.TrimPrefix(value, "wamp"), func(r rune) bool {
 						return unicode.IsSpace(r) || r == ',' || r == '(' || r == ')'
 					})
@@ -2268,7 +2293,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 
 					if err == nil {
 						if h.AllowL0 || h.AddPropensity != 0 {
-							o.Experimental.MultiLevelCompactionHeuristic = func() MultiLevelHeuristic {
+							o.MultiLevelCompactionHeuristic = func() MultiLevelHeuristic {
 								return &h
 							}
 						}
@@ -2299,23 +2324,23 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 					}
 				}
 			case "read_compaction_rate":
-				o.Experimental.ReadCompactionRate, err = strconv.ParseInt(value, 10, 64)
+				o.ReadCompactionRate, err = strconv.ParseInt(value, 10, 64)
 			case "read_sampling_multiplier":
-				o.Experimental.ReadSamplingMultiplier, err = strconv.ParseInt(value, 10, 64)
+				o.ReadSamplingMultiplier, err = strconv.ParseInt(value, 10, 64)
 			case "num_deletions_threshold":
-				o.Experimental.NumDeletionsThreshold, err = strconv.Atoi(value)
+				o.NumDeletionsThreshold, err = strconv.Atoi(value)
 			case "deletion_size_ratio_threshold":
 				val, parseErr := strconv.ParseFloat(value, 32)
-				o.Experimental.DeletionSizeRatioThreshold = float32(val)
+				o.DeletionSizeRatioThreshold = float32(val)
 				err = parseErr
 			case "tombstone_dense_compaction_threshold":
 				var threshold float64
 				threshold, err = strconv.ParseFloat(value, 64)
 				if err == nil {
-					o.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return threshold }
+					o.TombstoneDenseCompactionThreshold = func() float64 { return threshold }
 				}
 			case "table_cache_shards":
-				o.Experimental.FileCacheShards, err = strconv.Atoi(value)
+				o.FileCacheShards, err = strconv.Atoi(value)
 			case "table_format":
 				switch value {
 				case "leveldb":
@@ -2328,21 +2353,21 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 					return nil
 				}
 			case "validate_on_ingest":
-				o.Experimental.ValidateOnIngest, err = strconv.ParseBool(value)
+				o.ValidateOnIngest, err = strconv.ParseBool(value)
 			case "wal_dir":
 				o.WALDir = value
 			case "wal_bytes_per_sync":
 				o.WALBytesPerSync, err = strconv.Atoi(value)
 			case "secondary_cache_size_bytes":
-				o.Experimental.SecondaryCacheSizeBytes, err = strconv.ParseInt(value, 10, 64)
+				o.SecondaryCacheSizeBytes, err = strconv.ParseInt(value, 10, 64)
 			case "create_on_shared":
 				var createOnSharedInt int64
 				createOnSharedInt, err = strconv.ParseInt(value, 10, 64)
-				o.Experimental.CreateOnShared = remote.CreateOnSharedStrategy(createOnSharedInt)
+				o.CreateOnShared = remote.CreateOnSharedStrategy(createOnSharedInt)
 			case "iterator_tracking_poll_interval":
-				o.Experimental.IteratorTracking.PollInterval, err = time.ParseDuration(value)
+				o.IteratorTracking.PollInterval, err = time.ParseDuration(value)
 			case "iterator_tracking_max_age":
-				o.Experimental.IteratorTracking.MaxAge, err = time.ParseDuration(value)
+				o.IteratorTracking.MaxAge, err = time.ParseDuration(value)
 			default:
 				if hooks != nil && hooks.OnUnknown != nil {
 					hooks.OnUnknown(section+"."+key, value)
@@ -2506,7 +2531,7 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 		return err
 	}
 	if valSepPolicySet {
-		o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy { return valSepPolicy }
+		o.ValueSeparationPolicy = func() ValueSeparationPolicy { return valSepPolicy }
 	}
 	if concurrencyLimit.lowerSet || concurrencyLimit.upperSet {
 		if !concurrencyLimit.lowerSet {
@@ -2662,9 +2687,9 @@ func (o *Options) Validate() error {
 	// is no need to check for zero values.
 
 	var buf strings.Builder
-	if o.Experimental.L0CompactionConcurrency < 1 {
+	if o.L0CompactionConcurrency < 1 {
 		fmt.Fprintf(&buf, "L0CompactionConcurrency (%d) must be >= 1\n",
-			o.Experimental.L0CompactionConcurrency)
+			o.L0CompactionConcurrency)
 	}
 	if o.L0StopWritesThreshold < o.L0CompactionThreshold {
 		fmt.Fprintf(&buf, "L0StopWritesThreshold (%d) must be >= L0CompactionThreshold (%d)\n",
@@ -2682,7 +2707,7 @@ func (o *Options) Validate() error {
 		fmt.Fprintf(&buf, "FormatMajorVersion (%d) must be between %d and %d\n",
 			o.FormatMajorVersion, FormatMinSupported, internalFormatNewest)
 	}
-	if o.Experimental.CreateOnShared != remote.CreateOnSharedNone && o.FormatMajorVersion < FormatMinForSharedObjects {
+	if o.CreateOnShared != remote.CreateOnSharedNone && o.FormatMajorVersion < FormatMinForSharedObjects {
 		fmt.Fprintf(&buf, "FormatMajorVersion (%d) when CreateOnShared is set must be at least %d\n",
 			o.FormatMajorVersion, FormatMinForSharedObjects)
 	}
@@ -2694,7 +2719,7 @@ func (o *Options) Validate() error {
 			fmt.Fprintf(&buf, "KeySchema %q not found in KeySchemas\n", o.KeySchema)
 		}
 	}
-	if policy := o.Experimental.ValueSeparationPolicy(); policy.Enabled {
+	if policy := o.ValueSeparationPolicy(); policy.Enabled {
 		if policy.MinimumSize <= 0 {
 			fmt.Fprintf(&buf, "ValueSeparationPolicy.MinimumSize (%d) must be > 0\n", policy.MinimumSize)
 		}
@@ -2745,8 +2770,8 @@ func (o *Options) MakeWriterOptions(level int, format sstable.TableFormat) sstab
 		Comparer:                   o.Comparer,
 		BlockPropertyCollectors:    o.BlockPropertyCollectors,
 		AllocatorSizeClasses:       o.AllocatorSizeClasses,
-		NumDeletionsThreshold:      o.Experimental.NumDeletionsThreshold,
-		DeletionSizeRatioThreshold: o.Experimental.DeletionSizeRatioThreshold,
+		NumDeletionsThreshold:      o.NumDeletionsThreshold,
+		DeletionSizeRatioThreshold: o.DeletionSizeRatioThreshold,
 	}
 	if o.Merger != nil {
 		writerOpts.MergerName = o.Merger.Name
@@ -2759,7 +2784,7 @@ func (o *Options) MakeWriterOptions(level int, format sstable.TableFormat) sstab
 		}
 	}
 	if format >= sstable.TableFormatPebblev3 {
-		writerOpts.ShortAttributeExtractor = o.Experimental.ShortAttributeExtractor
+		writerOpts.ShortAttributeExtractor = o.ShortAttributeExtractor
 		if format >= sstable.TableFormatPebblev4 && level == numLevels-1 {
 			writerOpts.WritingToLowestLevel = true
 		}
@@ -2810,10 +2835,10 @@ func (o *Options) MakeObjStorageProviderSettings(dirname string) objstorageprovi
 	s.Local.NoSyncOnClose = o.NoSyncOnClose
 	s.Local.BytesPerSync = o.BytesPerSync
 	s.Local.ReadaheadConfig = o.Local.ReadaheadConfig
-	s.Remote.StorageFactory = o.Experimental.RemoteStorage
-	s.Remote.CreateOnShared = o.Experimental.CreateOnShared
-	s.Remote.CreateOnSharedLocator = o.Experimental.CreateOnSharedLocator
-	s.Remote.CacheSizeBytes = o.Experimental.SecondaryCacheSizeBytes
+	s.Remote.StorageFactory = o.RemoteStorage
+	s.Remote.CreateOnShared = o.CreateOnShared
+	s.Remote.CreateOnSharedLocator = o.CreateOnSharedLocator
+	s.Remote.CacheSizeBytes = o.SecondaryCacheSizeBytes
 	return s
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -43,13 +43,13 @@ func (o *Options) randomizeForTesting(t testing.TB) {
 		t.Logf("Running %s with format major version %s", t.Name(), o.FormatMajorVersion.String())
 	}
 	// Randomize value separation if using a format major version that supports it.
-	if o.FormatMajorVersion >= FormatValueSeparation && o.Experimental.ValueSeparationPolicy == nil {
+	if o.FormatMajorVersion >= FormatValueSeparation && o.ValueSeparationPolicy == nil {
 		switch rand.IntN(4) {
 		case 0:
 			// 25% of the time, use defaults (leave nil for EnsureDefaults).
 		case 1:
 			// 25% of the time, disable value separation.
-			o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+			o.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return ValueSeparationPolicy{Enabled: false}
 			}
 		default:
@@ -65,12 +65,12 @@ func (o *Options) randomizeForTesting(t testing.TB) {
 				GarbageRatioLowPriority:  lowPri,
 				GarbageRatioHighPriority: lowPri + rand.Float64()*(1.0-lowPri), // [lowPri, 1.0)
 			}
-			o.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy { return policy }
+			o.ValueSeparationPolicy = func() ValueSeparationPolicy { return policy }
 		}
 	}
 	if rand.IntN(2) == 0 {
-		o.Experimental.IteratorTracking.PollInterval = 100 * time.Millisecond
-		o.Experimental.IteratorTracking.MaxAge = 10 * time.Second
+		o.IteratorTracking.PollInterval = 100 * time.Millisecond
+		o.IteratorTracking.MaxAge = 10 * time.Second
 	}
 	o.EnsureDefaults()
 }
@@ -486,22 +486,22 @@ func TestOptionsParse(t *testing.T) {
 			opts.Levels[0].BlockSize = 1024
 			opts.Levels[1].BlockSize = 2048
 			opts.Levels[2].BlockSize = 4096
-			opts.Experimental.CompactionDebtConcurrency = 100
+			opts.CompactionDebtConcurrency = 100
 			opts.FlushDelayDeleteRange = 10 * time.Second
 			opts.FlushDelayRangeKey = 11 * time.Second
-			opts.Experimental.LevelMultiplier = 5
+			opts.LevelMultiplier = 5
 			opts.DeletionPacing.BaselineRate = func() uint64 { return 200 }
 			opts.WALFailover = &WALFailoverOptions{
 				Secondary: wal.Dir{Dirname: "wal_secondary", FS: vfs.Default},
 			}
-			opts.Experimental.ReadCompactionRate = 300
-			opts.Experimental.ReadSamplingMultiplier = 400
-			opts.Experimental.NumDeletionsThreshold = 500
-			opts.Experimental.DeletionSizeRatioThreshold = 0.7
-			opts.Experimental.TombstoneDenseCompactionThreshold = func() float64 { return 0.2 }
-			opts.Experimental.FileCacheShards = 500
-			opts.Experimental.SecondaryCacheSizeBytes = 1024
-			opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+			opts.ReadCompactionRate = 300
+			opts.ReadSamplingMultiplier = 400
+			opts.NumDeletionsThreshold = 500
+			opts.DeletionSizeRatioThreshold = 0.7
+			opts.TombstoneDenseCompactionThreshold = func() float64 { return 0.2 }
+			opts.FileCacheShards = 500
+			opts.SecondaryCacheSizeBytes = 1024
+			opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 				return ValueSeparationPolicy{
 					Enabled:               true,
 					MinimumSize:           1024,

--- a/recovery.go
+++ b/recovery.go
@@ -384,7 +384,7 @@ func recoverVersion(
 	}
 
 	emptyVersion := manifest.NewInitialVersion(opts.Comparer)
-	newVersion, err := bve.Apply(emptyVersion, opts.Experimental.ReadCompactionRate)
+	newVersion, err := bve.Apply(emptyVersion, opts.ReadCompactionRate)
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +392,7 @@ func recoverVersion(
 	rv.latest.l0Organizer.InitCompactingFileInfo(nil /* in-progress compactions */)
 	rv.latest.blobFiles.Init(&bve, manifest.BlobRewriteHeuristic{
 		CurrentTime: opts.private.timeNow,
-		MinimumAge:  opts.Experimental.ValueSeparationPolicy().RewriteMinimumAge,
+		MinimumAge:  opts.ValueSeparationPolicy().RewriteMinimumAge,
 	})
 	rv.version = newVersion
 	return rv, nil

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -887,7 +887,7 @@ func (r *Runner) prepareWorkloadSteps(ctx context.Context) error {
 				}
 
 				// Apply the edit.
-				v, err = bve.Apply(v, r.Opts.Experimental.ReadCompactionRate)
+				v, err = bve.Apply(v, r.Opts.ReadCompactionRate)
 				if err != nil {
 					return err
 				}

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -97,7 +97,7 @@ func runReplayTest(t *testing.T, path string) {
 				FormatMajorVersion:        pebble.FormatMinSupported,
 				L0CompactionFileThreshold: 1,
 			}
-			setDefaultExperimentalOpts(opts)
+			setDefaultTestOpts(opts)
 			ct = datatest.NewCompactionTracker(opts)
 
 			r = Runner{
@@ -151,8 +151,8 @@ func runReplayTest(t *testing.T, path string) {
 	})
 }
 
-func setDefaultExperimentalOpts(opts *pebble.Options) {
-	opts.Experimental.FileCacheShards = 2
+func setDefaultTestOpts(opts *pebble.Options) {
+	opts.FileCacheShards = 2
 }
 
 func TestReplay(t *testing.T) {
@@ -187,7 +187,7 @@ func TestLoadFlushedSSTableKeys(t *testing.T) {
 		Comparer:           testkeys.Comparer,
 		FormatMajorVersion: pebble.FormatMinSupported,
 	}
-	setDefaultExperimentalOpts(opts)
+	setDefaultTestOpts(opts)
 	d, err := pebble.Open("", opts)
 	require.NoError(t, err)
 	defer d.Close()
@@ -333,7 +333,7 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 				FS:                          fs,
 				MaxManifestFileSize:         96,
 			}
-			setDefaultExperimentalOpts(opts)
+			setDefaultTestOpts(opts)
 			wc.Attach(opts)
 			var err error
 			d, err = pebble.Open("build", opts)
@@ -348,7 +348,7 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 				FS:                          fs,
 				MaxManifestFileSize:         96,
 			}
-			opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+			opts.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 				return pebble.ValueSeparationPolicy{
 					Enabled:                true,
 					MinimumSize:            3,
@@ -357,7 +357,7 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 					RewriteMinimumAge:      15 * time.Minute,
 				}
 			}
-			setDefaultExperimentalOpts(opts)
+			setDefaultTestOpts(opts)
 			wc.Attach(opts)
 			var err error
 			d, err = pebble.Open("build", opts)
@@ -372,7 +372,7 @@ func collectCorpus(t *testing.T, fs *vfs.MemFS, name string) {
 				FS:                          fs,
 				MaxManifestFileSize:         156,
 			}
-			setDefaultExperimentalOpts(opts)
+			setDefaultTestOpts(opts)
 			wc.Attach(opts)
 			var err error
 			d, err = pebble.Open("build", opts)
@@ -593,7 +593,7 @@ func TestCompactionsQuiesce(t *testing.T) {
 					LBaseMaxBytes:      1,
 				},
 			}
-			r.Opts.Experimental.LevelMultiplier = 2
+			r.Opts.LevelMultiplier = 2
 			require.NoError(t, r.Run(context.Background()))
 			defer r.Close()
 

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -72,11 +72,11 @@ func TestScanStatistics(t *testing.T) {
 				sstable.NewTestKeysBlockPropertyCollector,
 			},
 		}
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator(""): remote.NewInMem(),
 		})
-		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
-		opts.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
+		opts.CreateOnShared = remote.CreateOnSharedAll
+		opts.CreateOnSharedLocator = remote.MakeLocator("")
 		opts.DisableAutomaticCompactions = true
 		opts.EnsureDefaults()
 		opts.WithFSDefaults()
@@ -248,12 +248,12 @@ func TestScanInternal(t *testing.T) {
 				sstable.NewTestKeysBlockPropertyCollector,
 			},
 		}
-		opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
 			remote.MakeLocator("external-storage"): extStorage,
 			remote.MakeLocator(""):                 remote.NewInMem(),
 		})
-		opts.Experimental.CreateOnShared = remote.CreateOnSharedAll
-		opts.Experimental.CreateOnSharedLocator = remote.MakeLocator("")
+		opts.CreateOnShared = remote.CreateOnSharedAll
+		opts.CreateOnSharedLocator = remote.MakeLocator("")
 		opts.DisableAutomaticCompactions = true
 		opts.EnsureDefaults()
 		opts.WithFSDefaults()
@@ -313,7 +313,7 @@ func TestScanInternal(t *testing.T) {
 					return nil, err
 				}
 				if !v {
-					opts.Experimental.CreateOnShared = remote.CreateOnSharedNone
+					opts.CreateOnShared = remote.CreateOnSharedNone
 				}
 			}
 		}

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -227,7 +227,7 @@ type WriterOptions struct {
 	Checksum block.ChecksumType
 
 	// ShortAttributeExtractor mirrors
-	// Options.Experimental.ShortAttributeExtractor.
+	// Options.ShortAttributeExtractor.
 	ShortAttributeExtractor base.ShortAttributeExtractor
 
 	// TieringSpanIDGetter returns the tiering span ID for a key. The span ID
@@ -283,11 +283,11 @@ type WriterOptions struct {
 	// internal options can only be used from within the pebble package.
 	internal sstableinternal.WriterOptions
 
-	// NumDeletionsThreshold mirrors Options.Experimental.NumDeletionsThreshold.
+	// NumDeletionsThreshold mirrors Options.NumDeletionsThreshold.
 	NumDeletionsThreshold int
 
 	// DeletionSizeRatioThreshold mirrors
-	// Options.Experimental.DeletionSizeRatioThreshold.
+	// Options.DeletionSizeRatioThreshold.
 	DeletionSizeRatioThreshold float32
 
 	// disableObsoleteCollector is used to disable the obsolete key block property

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -57,11 +57,11 @@ type Properties struct {
 	// considered tombstone-dense.
 	//
 	// A block is considered tombstone dense if at least one of the following:
-	//  1. The block contains at least options.Experimental.NumDeletionsThreshold
+	//  1. The block contains at least options.NumDeletionsThreshold
 	//     point tombstones.
 	//  2. The ratio of the uncompressed size of point tombstones to the
 	//     uncompressed size of the block is at least
-	//     options.Experimental.DeletionSizeRatioThreshold.
+	//     options.DeletionSizeRatioThreshold.
 	//
 	// This statistic is used to determine eligibility for a tombstone density
 	// compaction.

--- a/tool/db.go
+++ b/tool/db.go
@@ -956,7 +956,7 @@ func (d *dbT) readCurrentVersion(dirname string) (*manifest.Version, error) {
 	}
 	l0Organizer := manifest.NewL0Organizer(cmp, d.opts.FlushSplitBytes)
 	emptyVersion := manifest.NewInitialVersion(cmp)
-	v, err := bve.Apply(emptyVersion, d.opts.Experimental.ReadCompactionRate)
+	v, err := bve.Apply(emptyVersion, d.opts.ReadCompactionRate)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/db.go
+++ b/tool/db.go
@@ -921,7 +921,7 @@ func (d *dbT) readCurrentVersion(dirname string) (*manifest.Version, error) {
 	}
 	l0Organizer := manifest.NewL0Organizer(cmp, d.opts.FlushSplitBytes)
 	emptyVersion := manifest.NewInitialVersion(cmp)
-	v, err := bve.Apply(emptyVersion, d.opts.Experimental.ReadCompactionRate)
+	v, err := bve.Apply(emptyVersion, d.opts.ReadCompactionRate)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/make_test_find_db_val_sep.go
+++ b/tool/make_test_find_db_val_sep.go
@@ -63,7 +63,7 @@ func main() {
 	for i := range opts.Levels {
 		opts.Levels[i].BlockSize = 100
 	}
-	opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
 		return pebble.ValueSeparationPolicy{
 			Enabled:               true,
 			MinimumSize:           minSizeForValSep,

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -169,7 +169,7 @@ func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 			if comparer != nil {
 				l0Organizer := manifest.NewL0Organizer(comparer, 0 /* flushSplitBytes */)
 				emptyVersion := manifest.NewInitialVersion(comparer)
-				v, err := bve.Apply(emptyVersion, m.opts.Experimental.ReadCompactionRate)
+				v, err := bve.Apply(emptyVersion, m.opts.ReadCompactionRate)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s\n", err)
 					return
@@ -548,7 +548,7 @@ func (m *manifestT) runCheck(cmd *cobra.Command, args []string) {
 					l0Organizer = manifest.NewL0Organizer(cmp, 0 /* flushSplitBytes */)
 					v = manifest.NewInitialVersion(cmp)
 				}
-				newv, err := bve.Apply(v, m.opts.Experimental.ReadCompactionRate)
+				newv, err := bve.Apply(v, m.opts.ReadCompactionRate)
 				if err != nil {
 					fmt.Fprintf(stdout, "%s: offset: %d err: %s\n",
 						arg, offset, err)

--- a/tool/testdata/make-fixtures.go
+++ b/tool/testdata/make-fixtures.go
@@ -28,8 +28,8 @@ func makeBrokenExternalDB() {
 		ErrorIfExists:               true,
 	}
 	store := remote.NewInMem()
-	opts.Experimental.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
-		"external": store,
+	opts.RemoteStorage = remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{
+		remote.MakeLocator("external"): store,
 	})
 	opts.EnsureDefaults()
 
@@ -88,7 +88,7 @@ func makeBrokenExternalDB() {
 	}
 
 	if _, err := db.IngestExternalFiles(context.Background(), []pebble.ExternalFile{{
-		Locator:     "external",
+		Locator:     remote.MakeLocator("external"),
 		ObjName:     "foo.sst",
 		Size:        123,
 		StartKey:    []byte("a25"),

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -206,9 +206,9 @@ func (t *T) ConfigureSharedStorage(
 	createOnShared remote.CreateOnSharedStrategy,
 	createOnSharedLocator remote.Locator,
 ) {
-	t.opts.Experimental.RemoteStorage = s
-	t.opts.Experimental.CreateOnShared = createOnShared
-	t.opts.Experimental.CreateOnSharedLocator = createOnSharedLocator
+	t.opts.RemoteStorage = s
+	t.opts.CreateOnShared = createOnShared
+	t.opts.CreateOnSharedLocator = createOnSharedLocator
 }
 
 // debugReaderProvider is a cache-less ReaderProvider meant for debugging blob

--- a/version_set.go
+++ b/version_set.go
@@ -534,7 +534,7 @@ func (vs *versionSet) UpdateVersionLocked(
 		if err != nil {
 			return errors.Wrap(err, "MANIFEST accumulate failed")
 		}
-		newVersion, err = bulkEdit.Apply(currentVersion, vs.opts.Experimental.ReadCompactionRate)
+		newVersion, err = bulkEdit.Apply(currentVersion, vs.opts.ReadCompactionRate)
 		if err != nil {
 			return errors.Wrap(err, "MANIFEST apply failed")
 		}

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -56,7 +56,7 @@ func TestVersionSet(t *testing.T) {
 		Comparer: base.DefaultComparer,
 		Logger:   testutils.Logger{T: t},
 	}
-	opts.Experimental.ValueSeparationPolicy = func() ValueSeparationPolicy {
+	opts.ValueSeparationPolicy = func() ValueSeparationPolicy {
 		return ValueSeparationPolicy{
 			Enabled:               true,
 			MinimumSize:           50,
@@ -70,7 +70,7 @@ func TestVersionSet(t *testing.T) {
 	}
 	blobRewriteHeuristic := manifest.BlobRewriteHeuristic{
 		CurrentTime: getCurrentTimeSecs,
-		MinimumAge:  opts.Experimental.ValueSeparationPolicy().RewriteMinimumAge,
+		MinimumAge:  opts.ValueSeparationPolicy().RewriteMinimumAge,
 	}
 
 	opts.EnsureDefaults()


### PR DESCRIPTION
The Options struct contained an Experimental substruct grouping ~30 fields. This was originally intended to signal instability, but many of these fields have been stable for years (e.g. L0CompactionConcurrency, LevelMultiplier, MultiLevelCompactionHeuristic). The grouping added unnecessary indirection (opts.Experimental.FieldName vs opts.FieldName) and was misleading about the stability of the options it contained.

Flatten all Experimental fields directly into the Options struct and remove the wrapper. Fields that are genuinely still experimental are annotated with an `// Experimental.` doc comment. No field names, types, defaults, or logic changed. The serialization format is unaffected since serialized keys (e.g. `l0_compaction_concurrency`) were already flat under the `[Options]` section.

Fixes [#5750](https://github.com/cockroachdb/pebble/issues/5750)

Release note: None