### PR TITLE
crl-release-26.1: db: fix additional goroutine leaks in tests

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -3319,6 +3319,7 @@ func TestTombstoneDensityCompactionMoveOptimization(t *testing.T) {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
+	defer opts.private.fsCloser.Close()
 
 	// Create a file with high tombstone density.
 	meta := &manifest.TableMetadata{
@@ -3421,6 +3422,7 @@ func TestTombstoneDensityCompactionMoveOptimization_NoMoveWithOverlap(t *testing
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
+	defer opts.private.fsCloser.Close()
 
 	// Create a file with high tombstone density in L4.
 	metaL4 := &manifest.TableMetadata{
@@ -3505,6 +3507,7 @@ func TestTombstoneDensityCompactionMoveOptimization_GrandparentOverlapTooLarge(t
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
+	defer opts.private.fsCloser.Close()
 
 	// File in L4 with high tombstone density.
 	metaL4 := &manifest.TableMetadata{
@@ -3573,6 +3576,7 @@ func TestTombstoneDensityCompactionMoveOptimization_BelowDensityThreshold(t *tes
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
+	defer opts.private.fsCloser.Close()
 
 	meta := &manifest.TableMetadata{
 		TableNum: 1,
@@ -3625,6 +3629,7 @@ func TestTombstoneDensityCompactionMoveOptimization_InvalidStats(t *testing.T) {
 		return NewConcurrencyLimitSchedulerWithNoPeriodicGrantingForTest()
 	}
 	opts.WithFSDefaults()
+	defer opts.private.fsCloser.Close()
 
 	meta := &manifest.TableMetadata{
 		TableNum: 1,

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -115,6 +115,7 @@ func TestIngestLoad(t *testing.T) {
 			}
 			var bv blobtest.Values
 			w := sstable.NewRawWriter(objstorageprovider.NewFileWritable(f), writerOpts)
+			defer w.Close()
 			for data := range crstrings.LinesSeq(td.Input) {
 				if strings.HasPrefix(data, "Span: ") {
 					data = strings.TrimPrefix(data, "Span: ")
@@ -154,6 +155,7 @@ func TestIngestLoad(t *testing.T) {
 				FS:         mem,
 			}
 			opts.WithFSDefaults()
+			defer opts.private.fsCloser.Close()
 			getNextFileNum := func() base.DiskFileNum { return 1 }
 			localFiles := LocalSSTables([]LocalSST{{Path: "ext"}})
 			lr, err := ingestLoad(context.Background(), opts, dbVersion, localFiles, nil, nil, nil, nil, getNextFileNum)
@@ -266,6 +268,7 @@ func TestIngestLoadRand(t *testing.T) {
 		FS:       mem,
 	}
 	opts.WithFSDefaults()
+	defer opts.private.fsCloser.Close()
 	opts.EnsureDefaults()
 	lr, err := ingestLoad(context.Background(), opts, version, paths, nil, nil, nil, nil, fileNumAllocator.nextFileNum)
 	require.NoError(t, err)
@@ -432,6 +435,7 @@ func TestIngestLoadInvalid(t *testing.T) {
 		FS:       mem,
 	}
 	opts.WithFSDefaults()
+	defer opts.private.fsCloser.Close()
 	getNextFileNum := func() base.DiskFileNum { return 1 }
 	localFiles := LocalSSTables([]LocalSST{{Path: "invalid"}})
 	if _, err := ingestLoad(context.Background(), opts, internalFormatNewest, localFiles, nil, nil, nil, nil, getNextFileNum); err == nil {
@@ -1683,6 +1687,7 @@ func TestIngestMemtableOverlaps(t *testing.T) {
 					}
 					opts.EnsureDefaults()
 					opts.WithFSDefaults()
+					defer opts.private.fsCloser.Close()
 					if len(d.CmdArgs) > 1 {
 						return fmt.Sprintf("%s expects at most 1 argument", d.Cmd)
 					}


### PR DESCRIPTION
Fix some additional goroutine leaks:

- Close diskHealthCheckingFS in tests that call WithFSDefaults() without opening a DB: TestIngestLoad, TestIngestLoadRand, TestIngestLoadInvalid, TestIngestMemtableOverlaps, and the five TestTombstoneDensity* tests.

- Close sstable writer on error paths in TestIngestLoad, where early returns (malformed input, Add/EncodeSpan errors) abandoned the writer without calling Close(), leaking the writeQueue goroutine.

Fixes #5902