### PR TITLE
github: revert go change for 26.x nightlies

### DIFF
--- a/.github/workflows/nightlies-26.1.yaml
+++ b/.github/workflows/nightlies-26.1.yaml
@@ -33,7 +33,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
-      go_version: 1.26
+      go_version: 1.25
 
   s390x:
     needs: resolve-sha
@@ -41,7 +41,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
-      go_version: 1.26
+      go_version: 1.25
 
   stress:
     needs: resolve-sha
@@ -49,7 +49,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
-      go_version: 1.26
+      go_version: 1.25
 
   instrumented:
     needs: resolve-sha
@@ -57,4 +57,4 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
-      go_version: 1.26
+      go_version: 1.25

--- a/.github/workflows/nightlies-26.2.yaml
+++ b/.github/workflows/nightlies-26.2.yaml
@@ -33,7 +33,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
-      go_version: 1.26
+      go_version: 1.25
 
   s390x:
     needs: resolve-sha
@@ -41,7 +41,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
-      go_version: 1.26
+      go_version: 1.25
 
   stress:
     needs: resolve-sha
@@ -49,7 +49,7 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
-      go_version: 1.26
+      go_version: 1.25
 
   instrumented:
     needs: resolve-sha
@@ -57,4 +57,4 @@ jobs:
     with:
       sha: ${{ needs.resolve-sha.outputs.sha }}
       file_issue_branch: ${{ needs.resolve-sha.outputs.branch }}
-      go_version: 1.26
+      go_version: 1.25


### PR DESCRIPTION
We do not want to run existing releases against go 1.26. This reverts
the changes to `nightlies-26.*.yaml` from #5923.

Fixes #5944
Fixes #5955