### PR TITLE
vfs: fix multiple bugs

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -292,6 +292,7 @@ func (d *DB) Checkpoint(
 		// the filesystem.
 		ckErr = versionMarker.Move(formatVers.String())
 		if ckErr != nil {
+			_ = versionMarker.Close()
 			return ckErr
 		}
 		ckErr = versionMarker.Close()
@@ -614,6 +615,7 @@ func (d *DB) writeCheckpointManifest(
 		return err
 	}
 	if err := manifestMarker.Move(base.MakeFilename(base.FileTypeManifest, manifestFileNum)); err != nil {
+		_ = manifestMarker.Close()
 		return err
 	}
 	return manifestMarker.Close()

--- a/objstorage/objstorageprovider/remoteobjcat/catalog.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog.go
@@ -404,6 +404,7 @@ func (c *Catalog) Checkpoint(fs vfs.FS, dir string) error {
 		return err
 	}
 	if err := catalogMarker.Move(c.mu.catalogFilename); err != nil {
+		_ = catalogMarker.Close()
 		return err
 	}
 	return catalogMarker.Close()

--- a/version_set.go
+++ b/version_set.go
@@ -1090,7 +1090,8 @@ func findCurrentManifest(
 	var ok bool
 	_, manifestNum, ok = base.ParseFilename(fs, filename)
 	if !ok {
-		return marker, 0, false, base.CorruptionErrorf("pebble: MANIFEST name %q is malformed", errors.Safe(filename))
+		_ = marker.Close()
+		return nil, 0, false, base.CorruptionErrorf("pebble: MANIFEST name %q is malformed", errors.Safe(filename))
 	}
 	return marker, manifestNum, true, nil
 }

--- a/vfs/disk_full.go
+++ b/vfs/disk_full.go
@@ -437,11 +437,21 @@ func (f *enospcFile) Sync() error {
 }
 
 func (f *enospcFile) SyncData() error {
-	return f.inner.SyncData()
+	gen := f.fs.waitUntilReady()
+	err := f.inner.SyncData()
+	if err != nil && isENOSPC(err) {
+		f.fs.handleENOSPC(gen)
+	}
+	return err
 }
 
 func (f *enospcFile) SyncTo(length int64) (fullSync bool, err error) {
-	return f.inner.SyncTo(length)
+	gen := f.fs.waitUntilReady()
+	fullSync, err = f.inner.SyncTo(length)
+	if err != nil && isENOSPC(err) {
+		f.fs.handleENOSPC(gen)
+	}
+	return fullSync, err
 }
 
 func (f *enospcFile) Fd() uintptr {

--- a/vfs/errorfs/errorfs.go
+++ b/vfs/errorfs/errorfs.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/dsl"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -335,15 +334,11 @@ func (fs *FS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
 	if err := fs.inj.MaybeError(Op{Kind: OpOpen, Path: name}); err != nil {
 		return nil, err
 	}
-	f, err := fs.fs.Open(name)
+	f, err := fs.fs.Open(name, opts...)
 	if err != nil {
 		return nil, err
 	}
-	ef := &errorFile{name, f, fs.inj}
-	for _, opt := range opts {
-		opt.Apply(ef)
-	}
-	return ef, nil
+	return &errorFile{name, f, fs.inj}, nil
 }
 
 // OpenReadWrite implements FS.OpenReadWrite.
@@ -353,15 +348,11 @@ func (fs *FS) OpenReadWrite(
 	if err := fs.inj.MaybeError(Op{Kind: OpOpen, Path: name}); err != nil {
 		return nil, err
 	}
-	f, err := fs.fs.OpenReadWrite(name, category)
+	f, err := fs.fs.OpenReadWrite(name, category, opts...)
 	if err != nil {
 		return nil, err
 	}
-	ef := &errorFile{name, f, fs.inj}
-	for _, opt := range opts {
-		opt.Apply(ef)
-	}
-	return ef, nil
+	return &errorFile{name, f, fs.inj}, nil
 }
 
 // OpenDir implements FS.OpenDir.
@@ -401,10 +392,6 @@ func (fs *FS) PathJoin(elem ...string) string {
 
 // Remove implements FS.Remove.
 func (fs *FS) Remove(name string) error {
-	if _, err := fs.fs.Stat(name); oserror.IsNotExist(err) {
-		return nil
-	}
-
 	if err := fs.inj.MaybeError(Op{Kind: OpRemove, Path: name}); err != nil {
 		return err
 	}
@@ -434,7 +421,11 @@ func (fs *FS) ReuseForWrite(
 	if err := fs.inj.MaybeError(Op{Kind: OpReuseForWrite, Path: oldname}); err != nil {
 		return nil, err
 	}
-	return fs.fs.ReuseForWrite(oldname, newname, category)
+	f, err := fs.fs.ReuseForWrite(oldname, newname, category)
+	if err != nil {
+		return nil, err
+	}
+	return &errorFile{newname, f, fs.inj}, nil
 }
 
 // MkdirAll implements FS.MkdirAll.

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -788,12 +788,12 @@ func (f *memFile) ReadAt(p []byte, off int64) (int, error) {
 }
 
 func (f *memFile) Write(p []byte) (int, error) {
+	if !f.write {
+		return 0, errors.New("pebble/vfs: file was not created for writing")
+	}
 	if f.fs.crashable {
 		f.fs.cloneMu.RLock()
 		defer f.fs.cloneMu.RUnlock()
-	}
-	if !f.write {
-		return 0, errors.New("pebble/vfs: file was not created for writing")
 	}
 	if f.n.isDir {
 		return 0, errors.New("pebble/vfs: cannot write a directory")
@@ -825,12 +825,12 @@ func (f *memFile) Write(p []byte) (int, error) {
 }
 
 func (f *memFile) WriteAt(p []byte, ofs int64) (int, error) {
+	if !f.write {
+		return 0, errors.New("pebble/vfs: file was not created for writing")
+	}
 	if f.fs.crashable {
 		f.fs.cloneMu.RLock()
 		defer f.fs.cloneMu.RUnlock()
-	}
-	if !f.write {
-		return 0, errors.New("pebble/vfs: file was not created for writing")
 	}
 	if f.n.isDir {
 		return 0, errors.New("pebble/vfs: cannot write a directory")

--- a/vfs/vfstest/open_files_test.go
+++ b/vfs/vfstest/open_files_test.go
@@ -39,7 +39,7 @@ func TestOpenFiles(t *testing.T) {
 			return f
 		}},
 		{name: "OpenReadWrite", fn: func() vfs.File {
-			f, err := fs.Open("foo")
+			f, err := fs.OpenReadWrite("foo", vfs.WriteCategoryUnspecified)
 			require.NoError(t, err)
 			return f
 		}},

--- a/wal/testdata/dir_prober
+++ b/wal/testdata/dir_prober
@@ -1,5 +1,6 @@
-# First write to probe file has error.
-init interval=200ms inject-errors=((ErrInjected (And Writes (PathMatch "foo") (OnIndex 0))))
+# First create of probe file has error. OnIndex 1 skips the Remove call
+# (index 0) and targets Create (index 1).
+init interval=200ms inject-errors=((ErrInjected (And Writes (PathMatch "foo") (OnIndex 1))))
 ----
 
 enable wait


### PR DESCRIPTION
Fix several bugs found by auditing:

- vfs/disk_full.go: enospcFile.SyncData and SyncTo now call
  waitUntilReady()/handleENOSPC(), matching the pattern in Sync(). No
  retry is attempted per fsyncgate.

- vfs/errorfs/errorfs.go: ReuseForWrite now wraps the returned file in
  errorFile so error injection applies to subsequent I/O. Open and
  OpenReadWrite now forward opts to the inner FS instead of applying
  them manually on the wrapper. Remove no longer swallows ErrNotExist.

- vfs/vfstest/open_files_test.go: Fix copy-paste error where the
  "OpenReadWrite" test case was calling Open instead of OpenReadWrite.

- vfs/mem_fs.go: Move the \!f.write check before f.fs.crashable access
  in Write and WriteAt to prevent nil pointer panic on NewMemFile files
  (which have fs: nil).

- checkpoint.go: Close versionMarker and manifestMarker on Move failure
  to prevent FD leaks.

- remoteobjcat/catalog.go: Close catalogMarker on Move failure in
  Checkpoint to prevent FD leak.

- version_set.go: findCurrentManifest now closes the marker before
  returning an error on malformed MANIFEST name, preventing the caller
  from leaking it.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>