### PR TITLE
compaction: fix TestCompaction Close hang under race detector

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -894,12 +894,10 @@ func runCompactionTest(
 	defer leaktest.AfterTest(t)()
 
 	var d *DB
-	defer func() {
-		if d != nil {
-			require.NoError(t, closeAllSnapshots(d))
-			require.NoError(t, d.Close())
-		}
-	}()
+	// NB: d is closed explicitly at the end of this function, not via
+	// defer. If deferred, a td.Fatalf (runtime.Goexit) would run Close()
+	// while a compaction goroutine is still in flight, causing Close() to
+	// hang in cond.Wait(). See #5780.
 
 	seed := uint64(time.Now().UnixNano())
 	rng := rand.New(rand.NewPCG(0, seed))
@@ -1582,6 +1580,10 @@ func runCompactionTest(
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}
 	})
+	if d != nil {
+		require.NoError(t, closeAllSnapshots(d))
+		require.NoError(t, d.Close())
+	}
 }
 
 // TestCompaction tests compaction mechanics. It is a datadriven test, with

--- a/data_test.go
+++ b/data_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/blobtest"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -796,8 +797,14 @@ func runCompactCmdFn(
 
 func runCompactCmd(t *testing.T, td *datadriven.TestData, d *DB) error {
 	ctx := context.Background()
-	// Set up a 1-minute deadline to detect stuck compactions.
-	ctx, cancelFn := context.WithDeadline(ctx, time.Now().Add(time.Minute))
+	// Set up a deadline to detect stuck compactions. Use a longer timeout
+	// for slow builds (race detector) where compactions take significantly
+	// longer.
+	timeout := time.Minute
+	if buildtags.SlowBuild {
+		timeout = 5 * time.Minute
+	}
+	ctx, cancelFn := context.WithDeadline(ctx, time.Now().Add(timeout))
 	defer cancelFn()
 	compactFunc := runCompactCmdFn(ctx, t, td, d)
 	err := compactFunc()


### PR DESCRIPTION
## Summary

- Move `d.Close()` in `runCompactionTest` from `defer` to end of function,
  so it doesn't run during `runtime.Goexit()` while a compaction is in flight.
- Increase the compact deadline from 1 minute to 5 minutes for slow builds
  (race detector), preventing the spurious timeout that triggers the hang.

Fixes #5780.

## Root cause

`runCompactCmd` has a 1-minute deadline. Under the race detector, compactions
can exceed it. `td.Fatalf("compaction took too long")` calls `runtime.Goexit()`
on the test goroutine. The deferred `d.Close()` runs during Goexit, but the
compaction goroutine is still alive. `Close()` waits on `compactingCount > 0`
forever.

The CI goroutine dump from the [failing run](https://github.com/cockroachdb/pebble/actions/runs/21983890172) confirms: `Close()` stuck in `cond.Wait()` with `runtime.Goexit()` visible in the stack, triggered by `td.Fatalf` at `data_test.go:804`.