### PR TITLE
crl-release-26.2: remoteobjcat: sync directory before marker move in createNewCatalogFi…

### DIFF
--- a/objstorage/objstorageprovider/remoteobjcat/catalog.go
+++ b/objstorage/objstorageprovider/remoteobjcat/catalog.go
@@ -351,7 +351,15 @@ func (c *Catalog) createNewCatalogFileLocked() (outErr error) {
 		if err := writeRecord(&ve, file, recWriter); err != nil {
 			return err
 		}
-
+		// Sync the directory to ensure the catalog file is durable before creating
+		// the marker that references it. This prevents a crash from leaving the
+		// marker pointing to a non-existent catalog file. Without this sync, both
+		// the catalog and marker files would be unsynced until Move() completes,
+		// creating a race where a crash could include the marker but not the
+		// catalog on filesystems with unordered metadata updates.
+		if err := c.mu.marker.SyncDir(); err != nil {
+			return err
+		}
 		// Move the marker to the new filename. Move handles syncing the data
 		// directory as well.
 		if err := c.mu.marker.Move(filename); err != nil {

--- a/objstorage/objstorageprovider/remoteobjcat/testdata/catalog
+++ b/objstorage/objstorageprovider/remoteobjcat/testdata/catalog
@@ -9,6 +9,7 @@ add 1 10 100
 ----
 create: test/REMOTE-OBJ-CATALOG-000001
 sync: test/REMOTE-OBJ-CATALOG-000001
+sync: test
 create: test/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync: test/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: test/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -80,6 +81,7 @@ add 8 80 80
 ----
 create: test/REMOTE-OBJ-CATALOG-000002
 sync: test/REMOTE-OBJ-CATALOG-000002
+sync: test
 create: test/marker.remote-obj-catalog.000002.REMOTE-OBJ-CATALOG-000002
 sync: test/marker.remote-obj-catalog.000002.REMOTE-OBJ-CATALOG-000002
 close: test/marker.remote-obj-catalog.000002.REMOTE-OBJ-CATALOG-000002
@@ -117,6 +119,7 @@ add 5 50 500
 ----
 create: other-path/REMOTE-OBJ-CATALOG-000001
 sync: other-path/REMOTE-OBJ-CATALOG-000001
+sync: other-path
 create: other-path/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync: other-path/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: other-path/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -163,6 +166,7 @@ random-batches n=20 size=2000
 ----
 create: test/REMOTE-OBJ-CATALOG-000003
 sync: test/REMOTE-OBJ-CATALOG-000003
+sync: test
 create: test/marker.remote-obj-catalog.000003.REMOTE-OBJ-CATALOG-000003
 sync: test/marker.remote-obj-catalog.000003.REMOTE-OBJ-CATALOG-000003
 close: test/marker.remote-obj-catalog.000003.REMOTE-OBJ-CATALOG-000003
@@ -189,6 +193,7 @@ sync: test/REMOTE-OBJ-CATALOG-000003
 close: test/REMOTE-OBJ-CATALOG-000003
 create: test/REMOTE-OBJ-CATALOG-000004
 sync: test/REMOTE-OBJ-CATALOG-000004
+sync: test
 create: test/marker.remote-obj-catalog.000004.REMOTE-OBJ-CATALOG-000004
 sync: test/marker.remote-obj-catalog.000004.REMOTE-OBJ-CATALOG-000004
 close: test/marker.remote-obj-catalog.000004.REMOTE-OBJ-CATALOG-000004
@@ -223,6 +228,7 @@ sync: test/REMOTE-OBJ-CATALOG-000004
 close: test/REMOTE-OBJ-CATALOG-000004
 create: test/REMOTE-OBJ-CATALOG-000005
 sync: test/REMOTE-OBJ-CATALOG-000005
+sync: test
 create: test/marker.remote-obj-catalog.000005.REMOTE-OBJ-CATALOG-000005
 sync: test/marker.remote-obj-catalog.000005.REMOTE-OBJ-CATALOG-000005
 close: test/marker.remote-obj-catalog.000005.REMOTE-OBJ-CATALOG-000005
@@ -248,6 +254,7 @@ sync: test/REMOTE-OBJ-CATALOG-000005
 close: test/REMOTE-OBJ-CATALOG-000005
 create: test/REMOTE-OBJ-CATALOG-000006
 sync: test/REMOTE-OBJ-CATALOG-000006
+sync: test
 create: test/marker.remote-obj-catalog.000006.REMOTE-OBJ-CATALOG-000006
 sync: test/marker.remote-obj-catalog.000006.REMOTE-OBJ-CATALOG-000006
 close: test/marker.remote-obj-catalog.000006.REMOTE-OBJ-CATALOG-000006
@@ -259,6 +266,7 @@ sync: test/REMOTE-OBJ-CATALOG-000006
 close: test/REMOTE-OBJ-CATALOG-000006
 create: test/REMOTE-OBJ-CATALOG-000007
 sync: test/REMOTE-OBJ-CATALOG-000007
+sync: test
 create: test/marker.remote-obj-catalog.000007.REMOTE-OBJ-CATALOG-000007
 sync: test/marker.remote-obj-catalog.000007.REMOTE-OBJ-CATALOG-000007
 close: test/marker.remote-obj-catalog.000007.REMOTE-OBJ-CATALOG-000007
@@ -272,6 +280,7 @@ sync: test/REMOTE-OBJ-CATALOG-000007
 close: test/REMOTE-OBJ-CATALOG-000007
 create: test/REMOTE-OBJ-CATALOG-000008
 sync: test/REMOTE-OBJ-CATALOG-000008
+sync: test
 create: test/marker.remote-obj-catalog.000008.REMOTE-OBJ-CATALOG-000008
 sync: test/marker.remote-obj-catalog.000008.REMOTE-OBJ-CATALOG-000008
 close: test/marker.remote-obj-catalog.000008.REMOTE-OBJ-CATALOG-000008

--- a/objstorage/objstorageprovider/testdata/provider/local_readahead
+++ b/objstorage/objstorageprovider/testdata/provider/local_readahead
@@ -5,6 +5,7 @@ open dir=p1 creator-id=1
 <local fs> open-dir: p1
 <local fs> create: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p1
 <local fs> create: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach
@@ -8,6 +8,7 @@ open dir=p1 creator-id=1
 <local fs> open-dir: p1
 <local fs> create: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p1
 <local fs> create: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -77,6 +78,7 @@ open dir=p2 creator-id=2
 <local fs> open-dir: p2
 <local fs> create: p2/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p2
 <local fs> create: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach_after_unref
@@ -7,6 +7,7 @@ open dir=p5 creator-id=5
 <local fs> open-dir: p5
 <local fs> create: p5/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p5/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p5
 <local fs> create: p5/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p5/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p5/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -34,6 +35,7 @@ open dir=p6 creator-id=6
 <local fs> open-dir: p6
 <local fs> create: p6/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p6/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p6
 <local fs> create: p6/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p6/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p6/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/objstorage/objstorageprovider/testdata/provider/shared_attach_multi
+++ b/objstorage/objstorageprovider/testdata/provider/shared_attach_multi
@@ -7,6 +7,7 @@ open dir=p1 creator-id=1
 <local fs> open-dir: p1
 <local fs> create: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p1
 <local fs> create: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -30,6 +31,7 @@ open dir=p2 creator-id=2
 <local fs> open-dir: p2
 <local fs> create: p2/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p2
 <local fs> create: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/objstorage/objstorageprovider/testdata/provider/shared_basic
+++ b/objstorage/objstorageprovider/testdata/provider/shared_basic
@@ -7,6 +7,7 @@ open dir=p1 creator-id=1
 <local fs> open-dir: p1
 <local fs> create: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p1
 <local fs> create: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -123,6 +124,7 @@ close
 <local fs> sync: p1
 <local fs> create: p1/REMOTE-OBJ-CATALOG-000002
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000002
+<local fs> sync: p1
 <local fs> create: p1/marker.remote-obj-catalog.000002.REMOTE-OBJ-CATALOG-000002
 <local fs> sync: p1/marker.remote-obj-catalog.000002.REMOTE-OBJ-CATALOG-000002
 <local fs> close: p1/marker.remote-obj-catalog.000002.REMOTE-OBJ-CATALOG-000002

--- a/objstorage/objstorageprovider/testdata/provider/shared_no_ref
+++ b/objstorage/objstorageprovider/testdata/provider/shared_no_ref
@@ -7,6 +7,7 @@ open dir=p1 creator-id=1
 <local fs> open-dir: p1
 <local fs> create: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p1
 <local fs> create: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -134,6 +135,7 @@ open dir=p2 creator-id=2
 <local fs> open-dir: p2
 <local fs> create: p2/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p2
 <local fs> create: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/objstorage/objstorageprovider/testdata/provider/shared_readahead
+++ b/objstorage/objstorageprovider/testdata/provider/shared_readahead
@@ -5,6 +5,7 @@ open dir=p1 creator-id=1
 <local fs> open-dir: p1
 <local fs> create: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p1
 <local fs> create: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/objstorage/objstorageprovider/testdata/provider/shared_remove
+++ b/objstorage/objstorageprovider/testdata/provider/shared_remove
@@ -5,6 +5,7 @@ open dir=p1 creator-id=1
 <local fs> open-dir: p1
 <local fs> create: p1/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p1
 <local fs> create: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p1/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
@@ -45,6 +46,7 @@ open dir=p2 creator-id=2
 <local fs> open-dir: p2
 <local fs> create: p2/REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p2/REMOTE-OBJ-CATALOG-000001
+<local fs> sync: p2
 <local fs> create: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> sync: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 <local fs> close: p2/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -94,6 +94,7 @@ sync: db
 get-disk-usage: db
 create: db/REMOTE-OBJ-CATALOG-000001
 sync: db/REMOTE-OBJ-CATALOG-000001
+sync: db
 create: db/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 sync: db/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 close: db/marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001


### PR DESCRIPTION
…leLocked

Without a directory sync before the marker move, a crash could leave the marker pointing to a non-existent catalog file on filesystems with unordered metadata updates.