### PR TITLE
strparse: validate # prefix in HashSeqNum

### DIFF
--- a/internal/strparse/strparse.go
+++ b/internal/strparse/strparse.go
@@ -236,9 +236,15 @@ func (p *Parser) SeqNum() base.SeqNum {
 	return base.ParseSeqNum(p.Next())
 }
 
-// Uint64 parses the next token as a sequence number with a "#" prefix.
+// HashSeqNum parses the next token as a sequence number with a "#" prefix.
 func (p *Parser) HashSeqNum() base.SeqNum {
 	tok := p.Next()
+	if !strings.HasPrefix(tok, "#") {
+		p.Errf("expected sequence number with %q prefix, got %q", "#", tok)
+	}
+	if len(tok) < 2 {
+		p.Errf("expected sequence number after %q prefix, got %q", "#", tok)
+	}
 	return base.ParseSeqNum(tok[1:])
 }
 

--- a/internal/strparse/strparse_test.go
+++ b/internal/strparse/strparse_test.go
@@ -5,8 +5,10 @@
 package strparse
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,4 +52,54 @@ func TestParserOffsets(t *testing.T) {
 		p := MakeParser(test.sep, test.input)
 		require.Equal(t, test.want, p.tokens)
 	}
+}
+
+func TestHashSeqNum(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		p := MakeParser("[]-", "#42")
+		require.Equal(t, base.SeqNum(42), p.HashSeqNum())
+	})
+
+	// Each invalid case should produce an Errf-style panic that includes the
+	// original input, rather than panicking on out-of-bounds inside ParseSeqNum.
+	invalidCases := []struct {
+		name      string
+		separator string
+		input     string
+		wantSub   string
+	}{
+		{name: "missing prefix", separator: "[]-", input: "123", wantSub: `expected sequence number with "#" prefix`},
+		{name: "empty number", separator: "[]-", input: "#", wantSub: `expected sequence number after "#" prefix`},
+		{name: "wrong token", separator: "[]-", input: "]", wantSub: `expected sequence number with "#" prefix`},
+	}
+	for _, tc := range invalidCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := MakeParser(tc.separator, tc.input)
+			defer func() {
+				r := recover()
+				require.NotNil(t, r, "expected panic")
+				err, ok := r.(error)
+				require.True(t, ok, "expected error panic, got %T", r)
+				msg := err.Error()
+				require.Contains(t, msg, tc.wantSub)
+				require.Contains(t, msg, tc.input, "error should reference original input")
+			}()
+			_ = p.HashSeqNum()
+		})
+	}
+}
+
+func TestSeqNumRangeMalformed(t *testing.T) {
+	// Malformed range "[#1-]" should produce an Errf-style panic, not an
+	// out-of-bounds panic from ParseSeqNum("").
+	p := MakeParser("[]-", "[#1-]")
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "expected panic")
+		err, ok := r.(error)
+		require.True(t, ok, "expected error panic, got %T", r)
+		require.True(t, strings.Contains(err.Error(), "error parsing"),
+			"expected Errf-formatted error, got %q", err.Error())
+	}()
+	_ = p.SeqNumRange()
 }


### PR DESCRIPTION
Previously, Parser.HashSeqNum unconditionally sliced off the first byte
of the next token and forwarded the result to base.ParseSeqNum. There
was no check that the token began with "#", and no check that the token
was non-empty. The doc comment was also a stale copy of Uint64's
("Uint64 parses ..."). This produced two failure modes reachable from
ParseTableMetadataDebug, ParseVersionEditDebug (excise-op seqnum), and
Parser.SeqNumRange:

  1. A token like "123" (missing the "#" prefix) was silently parsed as
     "23", yielding a wrong seqnum with no error.

  2. A missing or unexpected token (e.g. malformed "[#1-]" range, where
     HashSeqNum sees "]") caused base.ParseSeqNum to be called with ""
     or "" after slicing, panicking on s[0] index-out-of-range. The
     panic bypassed Parser.Errf, so callers that recover Errf-style
     panics lost the parser's context (original input and last token).

This change validates strings.HasPrefix(tok, "#") and len(tok) > 1,
routing failures through p.Errf the same way Parser.BlobFileID
validates its "B" prefix. The doc comment is also corrected to refer
to HashSeqNum.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>