### PR TITLE
tombspan: minor cleanup of canDeleteOrExciseTable

### DIFF
--- a/internal/tombspan/testdata/set
+++ b/internal/tombspan/testdata/set
@@ -80,3 +80,55 @@ pick-compaction v=1 exciseAllowed
 ----
 none
 (none)
+
+# A tombstone span whose only candidates require excise is dropped when
+# pick-compaction is called while excise is currently disallowed. This is
+# intentional: EnableDeleteOnlyCompactionExcises may be persistently false,
+# and preserving such spans across calls would let tombstonedSpans grow
+# unboundedly. If excise is re-enabled later, a future WideTombstone for the
+# same keyspace will need to re-add the span.
+#
+# Define v2 with a new wide tombstone source table 000040 and two L4 tables
+# (000041 and 000042) that only partially overlap the tombstone bounds (so
+# they're eligible for excise but not for outright deletion).
+
+define-version
+L0
+000040:[c#100,RANGEDEL-m#inf,RANGEDEL] seqnums:[#100-#100]
+L4
+000041:[a#5,SET-d#5,SET] seqnums:[#5-#5]
+000042:[k#5,SET-p#5,SET] seqnums:[#5-#5]
+----
+v2:
+L0.0:
+  000040:[c#100,RANGEDEL-m#inf,RANGEDEL] seqnums:[#100-#100] points:[c#100,RANGEDEL-m#inf,RANGEDEL]
+L4:
+  000041:[a#5,SET-d#5,SET] seqnums:[#5-#5] points:[a#5,SET-d#5,SET]
+  000042:[k#5,SET-p#5,SET] seqnums:[#5-#5] points:[k#5,SET-p#5,SET]
+
+add
+L0.000040 [c, m) seqnums{point=[#100-#100]}
+----
+Pending:
+  L0.000040 [c, m) seqnums{point=[#100-#100]}
+
+update-with-earliest-snapshot 200
+----
+Tombstoned spans:
+[c, m) = {point=100}
+
+# With excise disallowed, no compaction is picked AND the span is cleared
+# (by design — see comment above).
+
+pick-compaction v=2
+----
+none
+(none)
+
+# A subsequent call with excise allowed therefore also returns none: the
+# span has already been forgotten.
+
+pick-compaction v=2 exciseAllowed
+----
+none
+(none)

--- a/internal/tombspan/tombspan.go
+++ b/internal/tombspan/tombspan.go
@@ -453,21 +453,46 @@ func (ts *Set) PickCompaction(
 					continue
 				}
 
-				eligibility := canDeleteOrExciseTable(ts.comparer.Compare, tombBounds, m.UserKeyBounds(), isExciseAllowed)
-				if eligibility == tableEligibilityDelete {
+				eligibility := canDeleteOrExciseTable(ts.comparer.Compare, tombBounds, m.UserKeyBounds())
+				switch eligibility {
+				case tableEligibilityDelete:
 					return DeleteOnlyCompaction{
 						Level:  level,
 						Table:  iter.Take(),
 						Bounds: tombBounds,
 						Excise: false,
 					}, true /* ok */
-				} else if eligibility == tableEligibilityExcise && isExciseAllowed {
-					return DeleteOnlyCompaction{
-						Level:  level,
-						Table:  iter.Take(),
-						Bounds: tombBounds,
-						Excise: true,
-					}, true /* ok */
+				case tableEligibilityExcise:
+					if isExciseAllowed {
+						return DeleteOnlyCompaction{
+							Level:  level,
+							Table:  iter.Take(),
+							Bounds: tombBounds,
+							Excise: true,
+						}, true /* ok */
+					}
+					// The table is structurally eligible for excise, but
+					// excise is not currently allowed (the
+					// EnableDeleteOnlyCompactionExcises option is false).
+					// That option is set from a function-valued hook and may
+					// remain false indefinitely (e.g. an operator-controlled
+					// CockroachDB cluster setting that is left off). We
+					// deliberately do NOT mark the span as transiently
+					// skipped here: if we did, every wide tombstone whose
+					// only LSM candidates require excise would accumulate in
+					// tombstonedSpans for the lifetime of the process and
+					// be re-evaluated on every PickCompaction call,
+					// unboundedly growing the region tree.
+					//
+					// Instead we treat this candidate as not picked. If no
+					// other candidate is found below, the span will be
+					// cleared and disk-space reclamation for these tables
+					// will fall back to regular compactions. If excise is
+					// later re-enabled, a future WideTombstone covering the
+					// same keyspace (e.g. produced when the next table-stats
+					// scan re-observes the originating RANGEDEL) will
+					// re-add the span. This forgets the current span on
+					// purpose; do not "fix" it by preserving the span here.
 				}
 			}
 		}
@@ -522,8 +547,10 @@ const (
 	tableEligibilityExcise
 )
 
+// canDeleteOrExciseTable returns the eligibility of a table for deletion or
+// excise, given the tombstone bounds and the table bounds.
 func canDeleteOrExciseTable(
-	cmp base.Compare, tombBounds, tableBounds base.UserKeyBounds, isExciseAllowed bool,
+	cmp base.Compare, tombBounds, tableBounds base.UserKeyBounds,
 ) tableEligibility {
 	if tombBounds.ContainsBounds(cmp, tableBounds) {
 		// The table is completely contained within the tombstone's
@@ -533,13 +560,6 @@ func canDeleteOrExciseTable(
 		//	    |--------sstable--------|
 		//
 		return tableEligibilityDelete
-	}
-
-	// We can't delete the table outright. If excise is enabled and
-	// allowed by the format major version, we can try to excise the
-	// table. Otherwise, we can continue to the next table.
-	if !isExciseAllowed {
-		return tableEligibilityNone
 	}
 
 	if cmp(tombBounds.Start, tableBounds.Start) <= 0 ||


### PR DESCRIPTION
Better document that dropping tombstones that require excise while
excise is disabled is intended behavior.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>
