### PR TITLE
base: fix UserKeyBounds.Union asymmetric handling of unset operand

### DIFF
--- a/internal/base/key_bounds.go
+++ b/internal/base/key_bounds.go
@@ -134,6 +134,8 @@ func (eb UserKeyBoundary) CompareUpperBounds(cmp Compare, other UserKeyBoundary)
 
 // UserKeyBounds is a user key interval with an inclusive start boundary and
 // with an end boundary that can be either inclusive or exclusive.
+//
+// Unset bounds are not valid (but can be used as the identity for Union).
 type UserKeyBounds struct {
 	Start []byte
 	End   UserKeyBoundary
@@ -175,9 +177,15 @@ func UserKeyBoundsFromInternal(smallest, largest InternalKey) UserKeyBounds {
 	return UserKeyBoundsEndExclusiveIf(smallest.UserKey, largest.UserKey, largest.IsExclusiveSentinel())
 }
 
+// IsUnset returns true if the bounds are the zero value (no start key and no
+// end key). Unset bounds are not Valid and act as the identity for Union.
+func (b *UserKeyBounds) IsUnset() bool {
+	return b.Start == nil && b.End.Key == nil
+}
+
 // Valid returns true if the bounds contain at least a user key.
 func (b *UserKeyBounds) Valid(cmp Compare) bool {
-	return b.End.IsUpperBoundFor(cmp, b.Start)
+	return !b.IsUnset() && b.End.IsUpperBoundFor(cmp, b.Start)
 }
 
 // Overlaps returns true if the bounds overlap.
@@ -231,10 +239,14 @@ func (b UserKeyBounds) Format(fmtKey FormatKey) string {
 // Union returns bounds that encompass both the receiver and the provided
 // bounds.
 //
-// If the receiver has nil bounds, the other bounds are returned.
+// If either operand is unset (see IsUnset), the other operand is returned
+// unchanged.
 func (b *UserKeyBounds) Union(cmp Compare, other UserKeyBounds) UserKeyBounds {
-	if b.Start == nil && b.End.Key == nil {
+	if b.IsUnset() {
 		return other
+	}
+	if other.IsUnset() {
+		return *b
 	}
 	union := *b
 	if cmp(union.Start, other.Start) > 0 {

--- a/internal/base/key_bounds.go
+++ b/internal/base/key_bounds.go
@@ -175,9 +175,15 @@ func UserKeyBoundsFromInternal(smallest, largest InternalKey) UserKeyBounds {
 	return UserKeyBoundsEndExclusiveIf(smallest.UserKey, largest.UserKey, largest.IsExclusiveSentinel())
 }
 
+// IsUnset returns true if the bounds are the zero value (no start key and no
+// end key). Unset bounds are not Valid and act as the identity for Union.
+func (b *UserKeyBounds) IsUnset() bool {
+	return b.Start == nil && b.End.Key == nil
+}
+
 // Valid returns true if the bounds contain at least a user key.
 func (b *UserKeyBounds) Valid(cmp Compare) bool {
-	return b.End.IsUpperBoundFor(cmp, b.Start)
+	return !b.IsUnset() && b.End.IsUpperBoundFor(cmp, b.Start)
 }
 
 // Overlaps returns true if the bounds overlap.
@@ -231,10 +237,14 @@ func (b UserKeyBounds) Format(fmtKey FormatKey) string {
 // Union returns bounds that encompass both the receiver and the provided
 // bounds.
 //
-// If the receiver has nil bounds, the other bounds are returned.
+// If either operand is unset (see IsUnset), the other operand is returned
+// unchanged.
 func (b *UserKeyBounds) Union(cmp Compare, other UserKeyBounds) UserKeyBounds {
-	if b.Start == nil && b.End.Key == nil {
+	if b.IsUnset() {
 		return other
+	}
+	if other.IsUnset() {
+		return *b
 	}
 	union := *b
 	if cmp(union.Start, other.Start) > 0 {

--- a/internal/base/key_bounds_test.go
+++ b/internal/base/key_bounds_test.go
@@ -67,6 +67,14 @@ func TestUserKeyBounds(t *testing.T) {
 	ade := UserKeyBoundsEndExclusive(a, d)
 	empty := UserKeyBounds{}
 
+	t.Run("IsUnset", func(t *testing.T) {
+		require.True(t, empty.IsUnset())
+		require.False(t, bb.IsUnset())
+		require.False(t, bdi.IsUnset())
+		require.False(t, bde.IsUnset())
+		require.False(t, aci.IsUnset())
+	})
+
 	t.Run("Valid", func(t *testing.T) {
 		require.True(t, bb.Valid(cmp))
 		require.True(t, bdi.Valid(cmp))
@@ -150,6 +158,9 @@ func TestUserKeyBounds(t *testing.T) {
 		require.Equal(t, ade, ace.Union(cmp, bde))
 		require.Equal(t, adi, ace.Union(cmp, bdi))
 
+		// Unset operand acts as the identity for Union, on either side.
 		require.Equal(t, bde, empty.Union(cmp, bde))
+		require.Equal(t, bde, bde.Union(cmp, empty))
+		require.Equal(t, empty, empty.Union(cmp, empty))
 	})
 }


### PR DESCRIPTION
UserKeyBounds.Union had a guard for an unset receiver (Start == nil &&
End.Key == nil → return other) but no symmetric guard for an unset
other. When the receiver was a real range like {Start:"b",
End:{"d", Exclusive}} and other was the zero value, the
cmp("b", nil) > 0 branch fired and silently rewrote union.Start to nil,
returning a corrupted bounds whose Start had effectively widened to
-infinity. Subsequent Overlaps / ContainsUserKey / ContainsBounds calls
would then report false positives.

All in-tree callers (manifest.KeyRange, manifest.ExtendKeyRange,
version_edit.go, compaction_picker_test.go) happen to pass non-empty
other derived from real TableMetadata.UserKeyBounds(), so the bug was
latent. The unit test only covered empty.Union(cmp, bde), never
bde.Union(cmp, empty), so the asymmetry never tripped CI.

This change introduces an IsUnset predicate on *UserKeyBounds that
returns true exactly when both Start and End.Key are nil. Valid now
short-circuits on IsUnset (which also avoids handing nil, nil to a
user-supplied comparator), and Union checks IsUnset on both operands so
that an unset operand on either side is treated as the identity. The
TestUserKeyBounds Union subtest is extended to cover bde.Union(empty)
and empty.Union(empty), and a new IsUnset subtest is added.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>