### PR TITLE
randvar: fix SkewedLatest.Max to return the effective max

### DIFF
--- a/internal/randvar/skewed_latest.go
+++ b/internal/randvar/skewed_latest.go
@@ -61,9 +61,9 @@ func (z *SkewedLatest) IncMax(delta uint64) {
 
 // Max returns max.
 func (z *SkewedLatest) Max() uint64 {
-	z.mu.Lock()
-	defer z.mu.Unlock()
-	return z.mu.zipf.Max()
+	z.mu.RLock()
+	defer z.mu.RUnlock()
+	return z.mu.max
 }
 
 // Uint64 returns a random Uint64 between min and max, where keys near max are

--- a/internal/randvar/skewed_latest_test.go
+++ b/internal/randvar/skewed_latest_test.go
@@ -66,3 +66,20 @@ func TestSkewedLatest(t *testing.T) {
 		dumpSamples(x)
 	}
 }
+
+func TestSkewedLatestMax(t *testing.T) {
+	const min, max uint64 = 10, 99
+	z, err := NewSkewedLatest(min, max, 0.99)
+	require.NoError(t, err)
+	require.Equal(t, max, z.Max())
+
+	z.IncMax(50)
+	require.Equal(t, max+50, z.Max())
+
+	rng := NewRand()
+	for i := 0; i < 1000; i++ {
+		v := z.Uint64(rng)
+		require.GreaterOrEqual(t, v, min)
+		require.LessOrEqual(t, v, z.Max())
+	}
+}


### PR DESCRIPTION
Before this change, SkewedLatest.Max() returned z.mu.zipf.Max(). The
inner Zipf is constructed as NewZipf(0, max-min, theta), so its Max()
is max-min, not max. As a result, SkewedLatest.Max() was off by min
whenever min > 0, violating the randvar.Dynamic.Max() contract ("Read
the current max value the variable will return."). Uint64() was
unaffected because it computes z.mu.max - zipf.Uint64(rng), so the
sampled distribution always stayed in [min, max].

This change makes Max() return z.mu.max, the field already maintained
by IncMax. The lock is downgraded to RLock since this is a read.

Existing in-tree callers either pass min=0 (metamorphic/config.go) or
do not call Max() (cmd/pebble/ycsb.go, internal/randvar/flag.go), so
no observable behavior changes today; the fix prevents a latent
foot-gun for future callers.

A new TestSkewedLatestMax pins the contract by constructing with
min=10, max=99, asserting Max()==99 before and Max()==149 after
IncMax(50), and verifying every sampled value stays in [min, Max()].

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>