### PR TITLE
iterv2: test code cleanup

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -746,6 +746,21 @@ func (kv *InternalKV) String() string {
 	return kv.K.String()
 }
 
+// FormatKeys returns a string representation of the keys in the given slice of
+// InternalKVs, in the form "[a#6,DEL b#1,SET c#3,SET]".
+func FormatKeys(kvs []InternalKV) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := range kvs {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(kvs[i].K.String())
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
 // AtomicSeqNum is an atomic SeqNum.
 type AtomicSeqNum struct {
 	value atomic.Uint64

--- a/internal/iterv2/interleaving_iter_rand_test.go
+++ b/internal/iterv2/interleaving_iter_rand_test.go
@@ -106,10 +106,24 @@ func runRandomTest(t *testing.T, seed uint64) {
 			t.Logf("cfg: %+v", cfg)
 			t.Logf("start, end: %q %q", startKey, endKey)
 			t.Logf("lower, upper: %q %q", lower, upper)
-			t.Logf("points: %v", points)
+			t.Logf("points: %s", base.FormatKeys(points))
 			t.Logf("spans: %v", spans)
 		}
 	}()
 
-	CheckIter(t, rng, cmp, cfg, AllTestOps, points, spans, &interleavingIter, startKey, endKey, lower, upper, numOps)
+	checkCfg := CheckIterConfig{
+		Comparer:     cmp,
+		KeyGenConfig: cfg,
+		OpWeights:    AllTestOps,
+		NumOps:       numOps,
+	}
+	expected := TestIterData{
+		Points:   points,
+		Spans:    spans,
+		StartKey: startKey,
+		EndKey:   endKey,
+		Lower:    lower,
+		Upper:    upper,
+	}
+	CheckIter(t, rng, checkCfg, expected, &interleavingIter)
 }

--- a/internal/iterv2/test_iter.go
+++ b/internal/iterv2/test_iter.go
@@ -65,33 +65,34 @@ type TestIter struct {
 
 var _ Iter = (*TestIter)(nil)
 
+// TestIterData contains the data that is presented by a TestIter.
+type TestIterData struct {
+	// Point keys to return.
+	Points []base.InternalKV
+	// Span definitions.
+	Spans []keyspan.Span
+	// ExtraBoundaries contains additional boundary keys to inject (to induce
+	// spurious boundaries in gaps between spans).
+	ExtraBoundaries [][]byte
+	// StartKey, EndKey are the overall ("static") bounds of the iterator's range
+	// (can be nil).
+	StartKey, EndKey []byte
+	// Lower, Upper are the initial "dynamic" bounds (can be nil, see
+	// Iter.SetBounds).
+	Lower, Upper []byte
+}
+
 // NewTestIter creates a TestIter.
-//
-// Parameters:
-//   - points: point keys to include.
-//   - spans: span definitions.
-//   - extraBoundaries: additional boundary keys to inject (to induce
-//     spurious boundaries in gaps between spans).
-//   - startKey: the overall start key of the iterator's range (can be nil).
-//   - endKey: the overall exclusive end key of the iterator's range (can be
-//     nil).
-//   - lower: the initial lower bound (nil for unbounded below).
-//   - upper: the initial exclusive upper bound (nil for unbounded above).
-func NewTestIter(
-	points []base.InternalKV,
-	spans []keyspan.Span,
-	extraBoundaries [][]byte,
-	startKey, endKey, lower, upper []byte,
-) *TestIter {
+func NewTestIter(cfg TestIterData) *TestIter {
 	t := &TestIter{
-		points:          points,
-		spans:           spans,
-		extraBoundaries: extraBoundaries,
-		startKey:        startKey,
-		endKey:          endKey,
+		points:          cfg.Points,
+		spans:           cfg.Spans,
+		extraBoundaries: cfg.ExtraBoundaries,
+		startKey:        cfg.StartKey,
+		endKey:          cfg.EndKey,
 		idx:             -1,
 	}
-	t.init(lower, upper)
+	t.init(cfg.Lower, cfg.Upper)
 	return t
 }
 

--- a/internal/iterv2/test_iter_test.go
+++ b/internal/iterv2/test_iter_test.go
@@ -71,7 +71,14 @@ func TestTestIter(t *testing.T) {
 				}
 				return []byte(s)
 			}
-			iter = NewTestIter(points, spans, nil, key(start), key(end), key(lower), key(upper))
+			iter = NewTestIter(TestIterData{
+				Points:   points,
+				Spans:    spans,
+				StartKey: key(start),
+				EndKey:   key(end),
+				Lower:    key(lower),
+				Upper:    key(upper),
+			})
 			return runIterOps(t, iter, d.Input)
 
 		default:

--- a/internal/iterv2/test_utils.go
+++ b/internal/iterv2/test_utils.go
@@ -60,36 +60,35 @@ var AllTestOps = TestOpWeights{
 	TestOpSetBounds:    5,
 }
 
+// CheckIterConfig contains parameters for CheckIter.
+type CheckIterConfig struct {
+	Comparer     *base.Comparer
+	KeyGenConfig KeyGenConfig
+	OpWeights    TestOpWeights
+	NumOps       int
+}
+
 // CheckIter constructs a TestIter with the given points and spans and runs
 // numOps random positioning operations on TestIter and iter, comparing their
 // outputs after each operation. The TestIter is wrapped in an OpCheckIter and
 // iter is wrapped in a LoggingIter. On mismatch, the operation history is
 // logged and t.Fatalf is called.
-func CheckIter(
-	t TB,
-	rng *rand.Rand,
-	cmp *base.Comparer,
-	cfg KeyGenConfig,
-	weights TestOpWeights,
-	points []base.InternalKV,
-	spans []keyspan.Span,
-	iter Iter,
-	startKey, endKey []byte,
-	lower, upper []byte,
-	numOps int,
-) {
+func CheckIter(t TB, rng *rand.Rand, cfg CheckIterConfig, expected TestIterData, iter Iter) {
+	startKey, endKey := expected.StartKey, expected.EndKey
+	lower, upper := expected.Lower, expected.Upper
+	cmp := cfg.Comparer
 	if startKey != nil && endKey != nil && cmp.Compare(startKey, endKey) >= 0 {
 		panic(errors.AssertionFailedf("invalid range [%q, %q)", startKey, endKey))
 	}
 	var totalWeight int
-	for _, w := range weights {
+	for _, w := range cfg.OpWeights {
 		totalWeight += w
 	}
 	if totalWeight == 0 {
 		panic(errors.AssertionFailedf("CheckIter: all weights are zero"))
 	}
 
-	testIter := NewTestIter(points, spans, nil, startKey, endKey, lower, upper)
+	testIter := NewTestIter(expected)
 	checkIter := NewOpCheckIter(testIter, cmp, lower, upper)
 	logIter := NewLoggingIter(iter)
 	defer func() {
@@ -98,19 +97,76 @@ func CheckIter(
 	}()
 
 	var lastKV *base.InternalKV
-	for range numOps {
+	for range cfg.NumOps {
 		// Pick a random operation based on weights.
 		r := rng.IntN(totalWeight)
 		var op TestOp
 		for op = 0; op < NumTestOps-1; op++ {
-			r -= weights[op]
+			r -= cfg.OpWeights[op]
 			if r < 0 {
 				break
 			}
 		}
 
-		var refKV, intKV *base.InternalKV
+		var opKey []byte
 
+		// Initialize doOp to perform the selected operation on any Iter.
+		var doOp func(iter Iter) *base.InternalKV
+		switch op {
+		case TestOpFirst:
+			doOp = func(iter Iter) *base.InternalKV { return iter.First() }
+
+		case TestOpLast:
+			doOp = func(iter Iter) *base.InternalKV { return iter.Last() }
+
+		case TestOpSeekGE:
+			opKey = cfg.KeyGenConfig.RandKey(rng)
+			doOp = func(iter Iter) *base.InternalKV {
+				return iter.SeekGE(opKey, base.SeekGEFlagsNone)
+			}
+
+		case TestOpSeekPrefixGE:
+			opKey = cfg.KeyGenConfig.RandKey(rng)
+			prefix := cmp.Split.Prefix(opKey)
+			doOp = func(iter Iter) *base.InternalKV {
+				return iter.SeekPrefixGE(prefix, opKey, base.SeekGEFlagsNone)
+			}
+
+		case TestOpSeekLT:
+			key := cfg.KeyGenConfig.RandKey(rng)
+			doOp = func(iter Iter) *base.InternalKV {
+				return iter.SeekLT(key, base.SeekLTFlagsNone)
+			}
+
+		case TestOpNext:
+			doOp = func(iter Iter) *base.InternalKV { return iter.Next() }
+
+		case TestOpPrev:
+			doOp = func(iter Iter) *base.InternalKV { return iter.Prev() }
+
+		case TestOpNextPrefix:
+			if lastKV == nil || lastKV.Kind() == base.InternalKeyKindSpanBoundary {
+				// NextPrefix not applicable.
+				continue
+			}
+			succKey := cmp.ImmediateSuccessor(nil, cmp.Split.Prefix(lastKV.K.UserKey))
+			doOp = func(iter Iter) *base.InternalKV {
+				return iter.NextPrefix(succKey)
+			}
+
+		case TestOpSetBounds:
+			lower, upper = RandBounds(rng, cfg.KeyGenConfig, startKey, endKey)
+			doOp = func(iter Iter) *base.InternalKV {
+				iter.SetBounds(lower, upper)
+				return nil
+			}
+
+		default:
+			t.Fatalf("unknown op %d", op)
+		}
+
+		// Run doOp on checkIter, catching illegal ops.
+		var refKV, intKV *base.InternalKV
 		illegal := false
 		func() {
 			defer func() {
@@ -123,60 +179,15 @@ func CheckIter(
 					panic(r)
 				}
 			}()
-
-			switch op {
-			case TestOpFirst:
-				refKV = checkIter.First()
-				intKV = logIter.First()
-
-			case TestOpLast:
-				refKV = checkIter.Last()
-				intKV = logIter.Last()
-
-			case TestOpSeekGE:
-				key := cfg.RandKey(rng)
-				refKV = checkIter.SeekGE(key, base.SeekGEFlagsNone)
-				intKV = logIter.SeekGE(key, base.SeekGEFlagsNone)
-
-			case TestOpSeekPrefixGE:
-				key := cfg.RandKey(rng)
-				prefix := cmp.Split.Prefix(key)
-				refKV = checkIter.SeekPrefixGE(prefix, key, base.SeekGEFlagsNone)
-				intKV = logIter.SeekPrefixGE(prefix, key, base.SeekGEFlagsNone)
-
-			case TestOpSeekLT:
-				key := cfg.RandKey(rng)
-				refKV = checkIter.SeekLT(key, base.SeekLTFlagsNone)
-				intKV = logIter.SeekLT(key, base.SeekLTFlagsNone)
-
-			case TestOpNext:
-				refKV = checkIter.Next()
-				intKV = logIter.Next()
-
-			case TestOpPrev:
-				refKV = checkIter.Prev()
-				intKV = logIter.Prev()
-
-			case TestOpNextPrefix:
-				if lastKV == nil || lastKV.Kind() == base.InternalKeyKindSpanBoundary {
-					// NextPrefix not applicable.
-					illegal = true
-					return
-				}
-				succKey := cmp.ImmediateSuccessor(nil, cmp.Split.Prefix(lastKV.K.UserKey))
-				refKV = checkIter.NextPrefix(succKey)
-				intKV = logIter.NextPrefix(succKey)
-
-			case TestOpSetBounds:
-				lower, upper = RandBounds(rng, cfg, startKey, endKey)
-				checkIter.SetBounds(lower, upper)
-				logIter.SetBounds(lower, upper)
-			}
+			refKV = doOp(checkIter)
 		}()
-
 		if illegal {
 			continue
 		}
+
+		// Run doOp on logIter; any illegal op here fails the test.
+		intKV = doOp(logIter)
+
 		lastKV = refKV
 
 		// Check for mismatches.

--- a/level_iter_v2_rand_test.go
+++ b/level_iter_v2_rand_test.go
@@ -153,12 +153,8 @@ func runLevelIterV2RandomTest(t *testing.T, seed uint64) {
 			t.Logf("cfg: %+v", cfg)
 			t.Logf("initial bounds: %q %q", lower, upper)
 			for i, m := range metas {
-				p := make([]base.InternalKey, len(filePointKeys[i]))
-				for j := range p {
-					p[j] = filePointKeys[i][j].K
-				}
 				t.Logf("file %d (%s - %s):", i, m.PointKeyBounds.Smallest(), m.PointKeyBounds.Largest())
-				t.Logf("  points: %v", p)
+				t.Logf("  points: %s", base.FormatKeys(filePointKeys[i]))
 				t.Logf("  spans: %v", fileSpans[i])
 			}
 		}
@@ -168,10 +164,21 @@ func runLevelIterV2RandomTest(t *testing.T, seed uint64) {
 	slices.SortFunc(allSpans, func(a, b keyspan.Span) int {
 		return cmp.Compare(a.Start, b.Start)
 	})
-	ops := iterv2.AllTestOps
+	checkCfg := iterv2.CheckIterConfig{
+		Comparer:     cmp,
+		KeyGenConfig: cfg,
+		OpWeights:    iterv2.AllTestOps,
+		NumOps:       500,
+	}
 	// TODO(radu): implement NextPrefix.
-	ops[iterv2.TestOpNextPrefix] = 0
-	iterv2.CheckIter(t, rng, cmp, cfg, ops /* iterv2.AllTestOps*/, points, allSpans, li, nil, nil, lower, upper, 500)
+	checkCfg.OpWeights[iterv2.TestOpNextPrefix] = 0
+	expected := iterv2.TestIterData{
+		Points: points,
+		Spans:  allSpans,
+		Lower:  lower,
+		Upper:  upper,
+	}
+	iterv2.CheckIter(t, rng, checkCfg, expected, li)
 }
 
 // pickFileBoundaries generates sorted, deduplicated file boundaries

--- a/merging_iter_v2_rand_test.go
+++ b/merging_iter_v2_rand_test.go
@@ -42,7 +42,7 @@ func runMergingIterV2RandomTest(t *testing.T, seed uint64) {
 	}
 
 	// TODO(radu): support initial lower/upper bounds.
-	iter := newMergingIterV2FromLevels(cmp, levels, snapshot)
+	iter := newMergingIterV2FromLevels(rng, cmp, levels, snapshot)
 	expectedPoints := mergeLevels(cmp, levels, snapshot)
 
 	// On failure, log seed and configuration.
@@ -53,12 +53,8 @@ func runMergingIterV2RandomTest(t *testing.T, seed uint64) {
 			fmt.Printf("cfg: %+v\n", cfg)
 			for levelIdx, l := range levels {
 				fmt.Printf("L%d:\n", levelIdx)
-				p := make([]base.InternalKey, len(l.points))
-				for j := range p {
-					p[j] = l.points[j].K
-				}
-				fmt.Printf("  points: %v\n", p)
-				fmt.Printf("  spans: %v\n", l.spans)
+				fmt.Printf("  points: %s\n", base.FormatKeys(l.Points))
+				fmt.Printf("  spans: %v\n", l.Spans)
 			}
 		}
 	}()
@@ -68,14 +64,23 @@ func runMergingIterV2RandomTest(t *testing.T, seed uint64) {
 	// infrastructure.
 	var interleaving iterv2.InterleavingIter
 	interleaving.Init(cmp, iter, nil, nil, nil, nil, nil)
-	iterv2.CheckIter(t, rng, cmp, cfg, iterv2.AllTestOps, expectedPoints, nil, &interleaving, nil, nil, nil, nil, 500)
+	checkCfg := iterv2.CheckIterConfig{
+		Comparer:     cmp,
+		KeyGenConfig: cfg,
+		OpWeights:    iterv2.AllTestOps,
+		NumOps:       500,
+	}
+	expected := iterv2.TestIterData{
+		Points: expectedPoints,
+	}
+	iterv2.CheckIter(t, rng, checkCfg, expected, &interleaving)
 }
 
 // randMergingTestLevels generates random merging test levels with seqnum ranges
 // partitioned so that level 0 (topmost) gets the highest seqnums.
 func randMergingTestLevels(
 	rng *rand.Rand, cfg iterv2.KeyGenConfig, maxLevels, maxPointsPerLevel, maxSpansPerLevel int,
-) []mergingTestLevel {
+) []iterv2.TestIterData {
 	numLevels := 1 + rng.IntN(maxLevels)
 
 	// Partition [cfg.MinSeqNum, cfg.MaxSeqNum] into numLevels non-overlapping
@@ -103,7 +108,7 @@ func randMergingTestLevels(
 	cuts = append(cuts, totalSeqNums)
 	slices.Sort(cuts)
 
-	levels := make([]mergingTestLevel, numLevels)
+	levels := make([]iterv2.TestIterData, numLevels)
 	for i := range numLevels {
 		// Level 0 is the topmost (highest seqnums). Partitions are assigned in
 		// reverse order: level 0 gets the last partition.
@@ -125,10 +130,10 @@ func randMergingTestLevels(
 			}
 		}
 
-		levels[i] = mergingTestLevel{
-			points:          iterv2.RandPointKeys(rng, lvlCfg, maxPointsPerLevel),
-			spans:           iterv2.RandSpans(rng, lvlCfg, maxSpansPerLevel),
-			extraBoundaries: extraBoundaries,
+		levels[i] = iterv2.TestIterData{
+			Points:          iterv2.RandPointKeys(rng, lvlCfg, maxPointsPerLevel),
+			Spans:           iterv2.RandSpans(rng, lvlCfg, maxSpansPerLevel),
+			ExtraBoundaries: extraBoundaries,
 		}
 	}
 	return levels

--- a/merging_iter_v2_test.go
+++ b/merging_iter_v2_test.go
@@ -21,20 +21,12 @@ import (
 	"github.com/cockroachdb/pebble/internal/testkeys"
 )
 
-// mergingTestLevel represents a single level of a merging iterator test, with
-// sorted point keys and non-overlapping range deletion spans.
-type mergingTestLevel struct {
-	points          []base.InternalKV // sorted by InternalCompare
-	spans           []keyspan.Span    // non-overlapping, sorted by Start
-	extraBoundaries [][]byte          // additional boundary keys (for spurious boundaries)
-}
-
 // mergeLevels returns the surviving point keys after applying range deletion
 // filtering across all levels. A point is "surviving" if it is visible at the
 // given snapshot and not shadowed by any visible RANGEDEL with a strictly
 // greater sequence number.
 func mergeLevels(
-	cmp *base.Comparer, levels []mergingTestLevel, snapshot base.SeqNum,
+	cmp *base.Comparer, levels []iterv2.TestIterData, snapshot base.SeqNum,
 ) []base.InternalKV {
 	// Collect all visible range deletions from all levels.
 	type rangeDel struct {
@@ -43,7 +35,7 @@ func mergeLevels(
 	}
 	var rangeDels []rangeDel
 	for _, lvl := range levels {
-		for _, span := range lvl.spans {
+		for _, span := range lvl.Spans {
 			for _, k := range span.Keys {
 				if k.Trailer.SeqNum() < snapshot {
 					rangeDels = append(rangeDels, rangeDel{
@@ -60,7 +52,7 @@ func mergeLevels(
 	// deletions.
 	var surviving []base.InternalKV
 	for _, lvl := range levels {
-		for _, p := range lvl.points {
+		for _, p := range lvl.Points {
 			if p.SeqNum() >= snapshot {
 				continue
 			}
@@ -89,25 +81,27 @@ func mergeLevels(
 // newMergingIterV2FromLevels builds a mergingIterV2 from test levels by
 // wrapping each level's data in an iterv2.TestIter.
 func newMergingIterV2FromLevels(
-	cmp *base.Comparer, levels []mergingTestLevel, snapshot base.SeqNum,
+	rng *rand.Rand, cmp *base.Comparer, levels []iterv2.TestIterData, snapshot base.SeqNum,
 ) *mergingIterV2 {
 	iters := make([]iterv2.Iter, len(levels))
-	for i, lvl := range levels {
-		iters[i] = iterv2.NewTestIter(lvl.points, lvl.spans, lvl.extraBoundaries, nil, nil, nil, nil)
-		if rand.IntN(2) == 0 {
+	for i := range levels {
+		iters[i] = iterv2.NewTestIter(levels[i])
+		if rng.IntN(2) == 0 {
 			iters[i] = iterv2.NewInvalidating(iters[i])
+		}
+		if rng.IntN(2) == 0 {
+			iters[i] = iterv2.NewOpCheckIter(iters[i], cmp, nil, nil)
 		}
 	}
 	return newMergingIterV2(cmp.Compare, cmp.Split, snapshot, iters...)
 }
 
-// parseMergingTestLevels parses a define block into a slice of
-// mergingTestLevel. Each level starts with an "L" line, followed by point keys
-// (in "key#seq,KIND" format) and range deletion spans (in
-// "start-end:{(#seq,RANGEDEL) ...}" format, as understood by
+// parseMergingTestLevels parses a define block. Each level starts with an "L"
+// line, followed by point keys (in "key#seq,KIND" format) and range deletion
+// spans (in "start-end:{(#seq,RANGEDEL) ...}" format, as understood by
 // keyspan.ParseSpan).
-func parseMergingTestLevels(input string) []mergingTestLevel {
-	var levels []mergingTestLevel
+func parseMergingTestLevels(input string) []iterv2.TestIterData {
+	var levels []iterv2.TestIterData
 	curLevel := -1
 	for line := range crstrings.LinesSeq(input) {
 		line = strings.TrimSpace(line)
@@ -115,7 +109,7 @@ func parseMergingTestLevels(input string) []mergingTestLevel {
 			continue
 		}
 		if line == "L" {
-			levels = append(levels, mergingTestLevel{})
+			levels = append(levels, iterv2.TestIterData{})
 			curLevel++
 			continue
 		}
@@ -125,12 +119,12 @@ func parseMergingTestLevels(input string) []mergingTestLevel {
 		// If the line contains a "-" followed by ":{", it's a span.
 		if strings.Contains(line, ":{") || strings.Contains(line, "-") && strings.Contains(line, "RANGEDEL") {
 			span := keyspan.ParseSpan(line)
-			levels[curLevel].spans = append(levels[curLevel].spans, span)
+			levels[curLevel].Spans = append(levels[curLevel].Spans, span)
 		} else {
 			// Parse space-separated point keys.
 			for field := range strings.FieldsSeq(line) {
 				k := base.ParseInternalKey(field)
-				levels[curLevel].points = append(levels[curLevel].points, base.MakeInternalKV(k, nil))
+				levels[curLevel].Points = append(levels[curLevel].Points, base.MakeInternalKV(k, nil))
 			}
 		}
 	}
@@ -138,14 +132,14 @@ func parseMergingTestLevels(input string) []mergingTestLevel {
 }
 
 // formatMergingTestLevels formats levels for display in define output.
-func formatMergingTestLevels(levels []mergingTestLevel) string {
+func formatMergingTestLevels(levels []iterv2.TestIterData) string {
 	var buf strings.Builder
 	for i, lvl := range levels {
 		fmt.Fprintf(&buf, "L%d\n", i)
-		for _, p := range lvl.points {
+		for _, p := range lvl.Points {
 			fmt.Fprintf(&buf, "  %s\n", p.K)
 		}
-		for _, s := range lvl.spans {
+		for _, s := range lvl.Spans {
 			fmt.Fprintf(&buf, "  %s\n", s)
 		}
 	}
@@ -169,9 +163,10 @@ func formatMergingTestLevels(levels []mergingTestLevel) string {
 //	  seek-ge <key>
 //	  ...
 func TestMergingIterV2(t *testing.T) {
-	var levels []mergingTestLevel
+	var levels []iterv2.TestIterData
 	var snapshot base.SeqNum
 
+	rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 	datadriven.RunTest(t, "testdata/merging_iter_v2", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "define":
@@ -186,7 +181,7 @@ func TestMergingIterV2(t *testing.T) {
 			return formatMergingTestLevels(levels)
 
 		case "iter":
-			iter := newMergingIterV2FromLevels(testkeys.Comparer, levels, snapshot)
+			iter := newMergingIterV2FromLevels(rng, testkeys.Comparer, levels, snapshot)
 			defer iter.Close()
 			return itertest.RunInternalIterCmd(t, d, iter, itertest.Verbose)
 


### PR DESCRIPTION
Replace long lists of arguments with configuration structs.

Sometimes wrap `mergingIterV2` inputs in `OpCheckIter` (which ensures
that `mergingIterV2` strictly respects the `iterv2.Iter` semantics as
a caller).