### PR TITLE
.claude: avoid auto invocation

### DIFF
--- a/.claude/agents/bug-confirmer.md
+++ b/.claude/agents/bug-confirmer.md
@@ -1,6 +1,6 @@
 ---
 name: bug-confirmer
-description: Independently validate one candidate bug and assign severity, optimized for subtle semantic issues in Pebble/CRDB-style Go code.
+description: Internal helper used only by the bug-catcher skill. Do not invoke directly. Independently validates one candidate bug from the bug-catcher pipeline and assigns severity.
 tools: Read, Grep, Glob, Bash, LS, Write, Edit
 model: opus
 ---

--- a/.claude/agents/candidate-generator.md
+++ b/.claude/agents/candidate-generator.md
@@ -1,6 +1,6 @@
 ---
 name: candidate-generator
-description: Generate candidate bugs from a package understanding artifact and direct source inspection, optimized for Pebble/CRDB-style Go code.
+description: Internal helper used only by the bug-catcher skill. Do not invoke directly. Generates candidate bugs from a package-understanding artifact for the bug-catcher pipeline.
 tools: Read, Grep, Glob, Bash, LS, Write
 model: opus
 ---

--- a/.claude/agents/package-understander.md
+++ b/.claude/agents/package-understander.md
@@ -1,6 +1,6 @@
 ---
 name: package-understander
-description: Build a durable understanding of a Go package and how the repository relies on it, optimized for Pebble/CRDB-style invariants and semantics.
+description: Internal helper used only by the bug-catcher skill. Do not invoke directly. Builds a durable package-understanding artifact for the bug-catcher pipeline.
 tools: Read, Grep, Glob, Bash, LS, Write
 model: opus
 ---

--- a/.claude/skills/bug-catcher/SKILL.md
+++ b/.claude/skills/bug-catcher/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: bug-catcher
 description: Audit a Go package in this repository for subtle correctness bugs, including both bugs inside the package and bugs in how the rest of the repository uses it. Optimized for Pebble- and CockroachDB-style code where invariants, iterator semantics, ownership, and API contracts matter more than style issues.
+disable-model-invocation: true
 ---
 
 You are running a multi-stage audit of a Go package.


### PR DESCRIPTION
Disable/discourage auto invocation of bug catcher skill and subagents.
I noticed the bug-confirmer being used in other contexts.