### PR TITLE
pebble: fix excise seqnum passed to ingestApply

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1990,9 +1990,11 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 
 		// If there's an excise being done atomically with the same ingest, we
 		// assign the lowest sequence number in the set of sequence numbers for this
-		// ingestion to the excise. Note that we've already allocated sstCount+1
-		// sequence numbers in this case.
+		// ingestion to the excise; the sstables get the seqnums above it. Note that
+		// we've already allocated sstCount+1 sequence numbers in this case.
+		var exciseSeqNum base.SeqNum
 		if args.ExciseSpan.Valid() {
+			exciseSeqNum = seqNum
 			seqNum++ // the first seqNum is reserved for the excise.
 		}
 		// Update the sequence numbers for all ingested sstables'
@@ -2024,7 +2026,7 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 		}
 		// Assign the sstables to the correct level in the LSM and apply the
 		// version edit.
-		ve, manifestUpdateDuration, err = d.ingestApply(ctx, jobID, loadResult, mut, args.ExciseSpan, args.ExciseBoundsPolicy, seqNum, args.SkipRemoteProbe)
+		ve, manifestUpdateDuration, err = d.ingestApply(ctx, jobID, loadResult, mut, args.ExciseSpan, args.ExciseBoundsPolicy, exciseSeqNum, args.SkipRemoteProbe)
 	}
 
 	// Only one ingest can occur at a time because if not, one would block waiting

--- a/ingest.go
+++ b/ingest.go
@@ -2500,7 +2500,22 @@ func (d *DB) ingestApply(
 	if exciseSpan.Valid() {
 		for s := d.mu.snapshots.root.next; s != &d.mu.snapshots.root; s = s.next {
 			// Skip non-EFOS snapshots, and also skip any EFOS that were created
-			// *after* the excise, or are already closed.
+			// *at or after* the excise, or are already closed.
+			//
+			// The boundary case efos.seqNum == exciseSeqNum is reachable: the
+			// commit pipeline's spin-wait in AllocateSeqNum makes
+			// visibleSeqNum == exciseSeqNum before prepare registers the excise
+			// in d.mu.snapshots.ongoingExcises, so a concurrent EFOS creator
+			// that grabs DB.mu in that window can observe snapshotSeqNum ==
+			// exciseSeqNum without seeing the excise. Such an EFOS sees the
+			// post-excise version of the LSM (the excise's seqnum is not
+			// visible to it, and any of its keys with that seqnum are equally
+			// invisible), so it is correct to skip it here. The
+			// exciseOverlapBounds machinery in prepare ensures that if such an
+			// EFOS is on snapshotList, the excise has already waited for the
+			// memtable flush that transitions it off the list, so in practice
+			// we don't expect to encounter one — but the predicate is written
+			// to handle it for safety.
 			//
 			// NB: this code can race with EventuallyFileOnlySnapshot.Close, which
 			// closes the channel that isClosed() reads, without holding DB.mu. This
@@ -2508,7 +2523,7 @@ func (d *DB) ingestApply(
 			// not closed until after the excise has already updated the LSM state.
 			// It is then fair to confirm that the EFOS did not overlap with the
 			// excise.
-			if s.efos == nil || base.Visible(exciseSeqNum, s.efos.seqNum, base.SeqNumMax) ||
+			if s.efos == nil || base.Visible(exciseSeqNum, s.efos.seqNum+1, base.SeqNumMax) ||
 				s.efos.isClosed() {
 				continue
 			}


### PR DESCRIPTION
When an ingest includes an excise, AllocateSeqNum allocates sstCount+1
sequence numbers and the lowest one is reserved for the excise; the
sstables take the seqnums above it. The apply callback's seqNum++
correctly advances past the excise's seqnum so ingestUpdateSeqNum
assigns the right values to sstables, but the post-increment seqNum
was then also passed to ingestApply as the exciseSeqNum parameter. So
inside ingestApply, exciseSeqNum was actually the first sstable's
seqnum (assignedSeqNum+1), not the excise's seqnum (assignedSeqNum --
the value prepare registers in d.mu.snapshots.ongoingExcises and that
removeFromOngoingExcises later removes).

This had two consequences:

  1. The ExciseBoundsRecord written to the manifest stored the wrong
     seqnum (one higher than the excise's actual seqnum). The
     flushable-ingest path records the correct value (set in prepare
     from the pre-increment seqnum), so the two ingest paths
     disagreed for the same logical operation.

  2. The post-apply EFOS scan computed visibility against the wrong
     seqnum. This is harmless in practice: visibleSeqNum is published
     atomically from N to N+sstCount+1 by AllocateSeqNum, so a
     concurrent EFOS can never observe an efos.seqNum that falls
     strictly inside the allocation range. The cases the off-by-one
     would actually misclassify are unreachable. Still, the predicate
     was nominally comparing the wrong value.

Fix: introduce a separate exciseSeqNum local in apply, set to seqNum
before the increment, and pass it to ingestApply.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>
