### PR TITLE
pebble: fix semaphore leaks on commitPipeline.Commit prepare error

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -140,6 +140,14 @@ type commitEnv struct {
 	// and err != nil, a failure to persist the WAL will populate *err. Returns
 	// the memtable the batch should be applied to. Serial execution enforced by
 	// commitPipeline.mu.
+	//
+	// Contract on error: if write returns a non-nil error, it must not have
+	// enqueued anything in the WAL sync queue (i.e. the logSyncQSem slot
+	// reserved by the caller is the caller's to release), and it must not
+	// have signaled wg or written to err. The current production
+	// implementation (DB.commitWrite) satisfies this trivially because its
+	// only failure points are mem.prepare / makeRoomForWrite, which run
+	// before WriteRecord; WriteRecord errors panic.
 	write func(b *Batch, wg *sync.WaitGroup, err *error) (*memTable, error)
 }
 
@@ -315,12 +323,37 @@ func (p *commitPipeline) Commit(b *Batch, syncWAL bool, noSyncWait bool) error {
 	//
 	// NB: We set Batch.commitErr on error so that the batch won't be a candidate
 	// for reuse. See Batch.release().
-	mem, err := p.prepare(b, syncWAL, noSyncWait)
+	mem, enqueued, err := p.prepare(b, syncWAL, noSyncWait)
 	if err != nil {
 		b.db = nil // prevent batch reuse on error
-		// NB: we are not doing <-p.commitQueueSem since the batch is still
-		// sitting in the pending queue. We should consider fixing this by also
-		// removing the batch from the pending queue.
+		if !enqueued {
+			// The batch was rejected before being enqueued in the pending
+			// queue and before env.write was called (e.g. ErrInvalidBatch).
+			// No batch state to clean up; just release the semaphore slots
+			// reserved above. Otherwise repeated failures would exhaust the
+			// bounded semaphores and deadlock the commit pipeline.
+			<-p.commitQueueSem
+			if syncWAL {
+				<-p.logSyncQSem
+			}
+		} else {
+			// env.write returned an error after the batch was enqueued in
+			// p.pending. We cannot drain commitQueueSem because the batch
+			// still occupies a slot in the lock-free pending queue, and
+			// commitQueue does not support out-of-order removal. (Same
+			// situation as the apply-error branch below.) Per the
+			// commitEnv.write contract, env.write did not enqueue into the
+			// WAL sync queue on error, so we must drain the logSyncQSem
+			// slot ourselves; nothing else will.
+			//
+			// The DB is effectively unrecoverable at this point: this batch
+			// will block publish() of all subsequent batches forever. In
+			// production DB.commitInternal turns any Commit error into a
+			// Fatalf, which is how this asymmetry is tolerated.
+			if syncWAL {
+				<-p.logSyncQSem
+			}
+		}
 		return err
 	}
 
@@ -329,7 +362,9 @@ func (p *commitPipeline) Commit(b *Batch, syncWAL bool, noSyncWait bool) error {
 		b.db = nil // prevent batch reuse on error
 		// NB: we are not doing <-p.commitQueueSem since the batch is still
 		// sitting in the pending queue. We should consider fixing this by also
-		// removing the batch from the pending queue.
+		// removing the batch from the pending queue. logSyncQSem does not
+		// leak here because WriteRecord successfully enqueued the record and
+		// it will be drained on sync queue pop.
 		return err
 	}
 
@@ -427,10 +462,23 @@ func (p *commitPipeline) AllocateSeqNum(
 	<-p.commitQueueSem
 }
 
-func (p *commitPipeline) prepare(b *Batch, syncWAL bool, noSyncWait bool) (*memTable, error) {
+// prepare enqueues the batch in the pending queue, assigns it a sequence
+// number, and writes it to the WAL via p.env.write.
+//
+// The returned enqueued bool indicates whether the batch was added to the
+// pending queue before the error occurred. This dictates how the caller
+// must clean up:
+//   - enqueued=false: nothing was done; caller releases both semaphore slots.
+//   - enqueued=true: the batch is in p.pending and has a sequence number;
+//     caller must NOT release commitQueueSem (the slot is still in use)
+//     but must release logSyncQSem (env.write's contract guarantees the
+//     WAL sync queue was not enqueued on error).
+func (p *commitPipeline) prepare(
+	b *Batch, syncWAL bool, noSyncWait bool,
+) (mem *memTable, enqueued bool, err error) {
 	n := uint64(b.Count())
 	if n == invalidBatchCount {
-		return nil, ErrInvalidBatch
+		return nil, false, ErrInvalidBatch
 	}
 	var syncWG *sync.WaitGroup
 	var syncErr *error
@@ -459,6 +507,7 @@ func (p *commitPipeline) prepare(b *Batch, syncWAL bool, noSyncWait bool) (*memT
 	// is lock-free, we want the order of batches to be the same as the sequence
 	// number order.
 	p.pending.enqueue(b)
+	enqueued = true
 
 	// Assign the batch a sequence number. Note that we use atomic operations
 	// here to handle concurrent reads of logSeqNum. commitPipeline.mu provides
@@ -466,11 +515,11 @@ func (p *commitPipeline) prepare(b *Batch, syncWAL bool, noSyncWait bool) (*memT
 	b.setSeqNum(p.env.logSeqNum.Add(base.SeqNum(n)) - base.SeqNum(n))
 
 	// Write the data to the WAL.
-	mem, err := p.env.write(b, syncWG, syncErr)
+	mem, err = p.env.write(b, syncWG, syncErr)
 
 	p.mu.Unlock()
 
-	return mem, err
+	return mem, enqueued, err
 }
 
 func (p *commitPipeline) publish(b *Batch) {

--- a/commit.go
+++ b/commit.go
@@ -318,9 +318,16 @@ func (p *commitPipeline) Commit(b *Batch, syncWAL bool, noSyncWait bool) error {
 	mem, err := p.prepare(b, syncWAL, noSyncWait)
 	if err != nil {
 		b.db = nil // prevent batch reuse on error
-		// NB: we are not doing <-p.commitQueueSem since the batch is still
-		// sitting in the pending queue. We should consider fixing this by also
-		// removing the batch from the pending queue.
+		// The only error prepare can return is ErrInvalidBatch, which is
+		// returned before the batch is enqueued in the pending queue and
+		// before the WAL write. Release the semaphore slots acquired above;
+		// otherwise repeated failures would exhaust the bounded semaphores
+		// (logSyncQSem in particular has no other drain path here, since
+		// WriteRecord never ran) and deadlock the commit pipeline.
+		<-p.commitQueueSem
+		if syncWAL {
+			<-p.logSyncQSem
+		}
 		return err
 	}
 
@@ -329,7 +336,9 @@ func (p *commitPipeline) Commit(b *Batch, syncWAL bool, noSyncWait bool) error {
 		b.db = nil // prevent batch reuse on error
 		// NB: we are not doing <-p.commitQueueSem since the batch is still
 		// sitting in the pending queue. We should consider fixing this by also
-		// removing the batch from the pending queue.
+		// removing the batch from the pending queue. logSyncQSem does not
+		// leak here because WriteRecord successfully enqueued the record and
+		// it will be drained on sync queue pop.
 		return err
 	}
 

--- a/commit_test.go
+++ b/commit_test.go
@@ -354,6 +354,48 @@ func TestCommitPipelineLogDataSeqNum(t *testing.T) {
 	wg.Wait()
 }
 
+// TestCommitPipelineInvalidBatchLeak is a regression test for a bug where
+// Commit leaked the commitQueueSem and logSyncQSem slots when prepare
+// returned ErrInvalidBatch. Each failed commit permanently consumed one slot
+// from each semaphore; after record.SyncConcurrency-1 such failures,
+// subsequent commits would block forever.
+func TestCommitPipelineInvalidBatchLeak(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	makeBadBatch := func() *Batch {
+		b := &Batch{}
+		require.NoError(t, b.Set([]byte("foo"), []byte("bar"), nil))
+		// Force the batch's count to invalidBatchCount so prepare returns
+		// ErrInvalidBatch before enqueueing the batch or writing to the WAL.
+		b.setCount(invalidBatchCount)
+		return b
+	}
+
+	for _, syncWAL := range []bool{false, true} {
+		t.Run(fmt.Sprintf("syncWAL=%t", syncWAL), func(t *testing.T) {
+			var e testCommitEnv
+			p := newCommitPipeline(e.env())
+			e.queueSemChan = p.logSyncQSem
+
+			// Submit more failing commits than the semaphore capacity. Without
+			// the fix, the loop would deadlock once the semaphores filled.
+			for i := 0; i < 2*record.SyncConcurrency; i++ {
+				err := p.Commit(makeBadBatch(), syncWAL, false /* noSyncWait */)
+				require.ErrorIs(t, err, ErrInvalidBatch)
+				require.Equal(t, 0, len(p.commitQueueSem),
+					"commitQueueSem leaked on iteration %d", i)
+				require.Equal(t, 0, len(p.logSyncQSem),
+					"logSyncQSem leaked on iteration %d", i)
+			}
+
+			// A subsequent valid commit should succeed without blocking.
+			b := &Batch{}
+			require.NoError(t, b.Set([]byte("ok"), []byte("v"), nil))
+			require.NoError(t, p.Commit(b, syncWAL, false /* noSyncWait */))
+		})
+	}
+}
+
 func BenchmarkCommitPipeline(b *testing.B) {
 	for _, noSyncWait := range []bool{false, true} {
 		for _, parallelism := range []int{1, 2, 4, 8, 16, 32, 64, 128} {

--- a/commit_test.go
+++ b/commit_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/crlib/testutils/leaktest"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/arenaskl"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/buildtags"
@@ -33,6 +34,10 @@ type testCommitEnv struct {
 		buf []uint64
 	}
 	queueSemChan chan struct{}
+	// If non-nil, write returns this error without registering anything in
+	// the WAL sync queue (i.e. without consuming queueSemChan), matching
+	// the commitEnv.write contract for the error case.
+	writeErr error
 }
 
 func (e *testCommitEnv) env() commitEnv {
@@ -53,6 +58,9 @@ func (e *testCommitEnv) apply(b *Batch, mem *memTable) error {
 
 func (e *testCommitEnv) write(b *Batch, wg *sync.WaitGroup, _ *error) (*memTable, error) {
 	e.writeCount.Add(1)
+	if e.writeErr != nil {
+		return nil, e.writeErr
+	}
 	if wg != nil {
 		wg.Done()
 		<-e.queueSemChan
@@ -352,6 +360,116 @@ func TestCommitPipelineLogDataSeqNum(t *testing.T) {
 		require.NoError(t, p.Commit(b, false /* sync */, false))
 	})
 	wg.Wait()
+}
+
+// TestCommitPipelinePrepareErrorLeak exercises commitPipeline.Commit's
+// cleanup on the two distinct prepare error paths:
+//
+//   - "invalid-batch": prepare returns ErrInvalidBatch before the batch is
+//     enqueued in the pending queue and before env.write runs. Both
+//     semaphore slots reserved by Commit must be released, and the
+//     pipeline must remain usable for subsequent commits.
+//
+//   - "write-error": env.write returns an error after the batch has been
+//     enqueued in the pending queue. The batch occupies a pending-queue
+//     slot indefinitely (commitQueue does not support out-of-order
+//     removal), so commitQueueSem cannot be released; but logSyncQSem
+//     must be released by Commit, since env.write's contract guarantees
+//     it did not enqueue into the WAL sync queue. After commitQueueSem
+//     fills with stuck batches, further Commits must block (this
+//     documents the known "DB is horked" failure mode that
+//     DB.commitInternal converts into Fatalf).
+func TestCommitPipelinePrepareErrorLeak(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Run("invalid-batch", func(t *testing.T) {
+		makeBadBatch := func() *Batch {
+			b := &Batch{}
+			require.NoError(t, b.Set([]byte("foo"), []byte("bar"), nil))
+			// Force the batch's count to invalidBatchCount so prepare
+			// returns ErrInvalidBatch before enqueueing the batch or
+			// calling env.write.
+			b.setCount(invalidBatchCount)
+			return b
+		}
+
+		for _, syncWAL := range []bool{false, true} {
+			t.Run(fmt.Sprintf("syncWAL=%t", syncWAL), func(t *testing.T) {
+				var e testCommitEnv
+				p := newCommitPipeline(e.env())
+				e.queueSemChan = p.logSyncQSem
+
+				// Submit more failing commits than the semaphore capacity.
+				// Without the fix, the loop would deadlock once the
+				// semaphores filled.
+				for i := 0; i < 2*record.SyncConcurrency; i++ {
+					err := p.Commit(makeBadBatch(), syncWAL, false /* noSyncWait */)
+					require.ErrorIs(t, err, ErrInvalidBatch)
+					require.Equal(t, 0, len(p.commitQueueSem),
+						"commitQueueSem leaked on iteration %d", i)
+					require.Equal(t, 0, len(p.logSyncQSem),
+						"logSyncQSem leaked on iteration %d", i)
+				}
+
+				// A subsequent valid commit should succeed without blocking.
+				b := &Batch{}
+				require.NoError(t, b.Set([]byte("ok"), []byte("v"), nil))
+				require.NoError(t, p.Commit(b, syncWAL, false /* noSyncWait */))
+			})
+		}
+	})
+
+	t.Run("write-error", func(t *testing.T) {
+		writeErr := errors.New("simulated WAL write error")
+
+		for _, syncWAL := range []bool{false, true} {
+			t.Run(fmt.Sprintf("syncWAL=%t", syncWAL), func(t *testing.T) {
+				var e testCommitEnv
+				e.writeErr = writeErr
+				p := newCommitPipeline(e.env())
+				e.queueSemChan = p.logSyncQSem
+
+				// Each failed commit consumes one commitQueueSem slot
+				// (batch stuck in p.pending) but must release logSyncQSem.
+				// Fill the commitQueueSem capacity exactly.
+				cap := record.SyncConcurrency - 1
+				for i := 0; i < cap; i++ {
+					b := &Batch{}
+					require.NoError(t, b.Set([]byte("foo"), []byte("bar"), nil))
+					err := p.Commit(b, syncWAL, false /* noSyncWait */)
+					require.ErrorIs(t, err, writeErr)
+					require.Equal(t, i+1, len(p.commitQueueSem),
+						"commitQueueSem unexpectedly drained on iteration %d", i)
+					require.Equal(t, 0, len(p.logSyncQSem),
+						"logSyncQSem leaked on iteration %d", i)
+				}
+
+				// commitQueueSem is now full of stuck batches. The next
+				// Commit must block on the semaphore acquisition. Verify
+				// via a short timeout instead of literally hanging.
+				done := make(chan error, 1)
+				go func() {
+					b := &Batch{}
+					_ = b.Set([]byte("blocked"), []byte("v"), nil)
+					done <- p.Commit(b, syncWAL, false /* noSyncWait */)
+				}()
+				select {
+				case err := <-done:
+					t.Fatalf("Commit unexpectedly returned %v; expected to block", err)
+				case <-time.After(50 * time.Millisecond):
+					// Expected: Commit is blocked on commitQueueSem.
+				}
+				// Drain the goroutine so it doesn't leak past this test:
+				// release one commitQueueSem slot so the blocked Commit
+				// proceeds, then itself errors out (consuming a slot of
+				// its own; that final leak is intrinsic to the documented
+				// failure mode and exits with the pipeline).
+				<-p.commitQueueSem
+				err := <-done
+				require.ErrorIs(t, err, writeErr)
+			})
+		}
+	})
 }
 
 func BenchmarkCommitPipeline(b *testing.B) {


### PR DESCRIPTION
`commitPipeline.Commit` acquires `commitQueueSem` and (when `syncWAL`)
`logSyncQSem` before calling `prepare`. Previously, when `prepare`
returned an error the function returned without draining either
semaphore. The pre-existing `TODO` comment justified this on the
grounds that the batch was "still sitting in the pending queue", but
that premise only holds for one of two error paths.

`prepare` can fail in two distinct places:

  1. `ErrInvalidBatch` from the count check at the top of `prepare`,
     before the batch is enqueued and before `p.env.write` runs.
     This is a bug indicator (caller-side corruption of
     `Batch.count`), not a normal failure.

  2. An error returned by `p.env.write`, after the batch has been
     enqueued in `p.pending` and assigned a sequence number. In
     production today, `db.commitWrite` panics on `WriteRecord`
     errors, but the function's signature promises errors and any
     future loosening would surface them here. This is the realistic
     failure mode.

The two paths require different cleanup. On the `ErrInvalidBatch`
path, both semaphore slots must be released; otherwise `logSyncQSem`
in particular has no other drain path and after
`record.SyncConcurrency-1` failures every subsequent `Commit` blocks
forever. On the write-error path the batch occupies a slot in the
lock-free `commitQueue` (which does not support out-of-order
removal), so `commitQueueSem` cannot be released; but `logSyncQSem`
must be drained by `Commit` itself, since per the (now-documented)
`commitEnv.write` contract, `env.write` did not enqueue into the WAL
sync queue on error. The batch will block `publish()` of all
subsequent batches forever; in production `DB.commitInternal` turns
the returned error into `Fatalf`, which is how this asymmetry is
tolerated.

Restructure `prepare` to return an `enqueued` bool so `Commit` can
distinguish the two paths. The apply-error path is left unchanged:
`WriteRecord` did succeed by then, so `logSyncQSem` drains naturally
on the sync queue pop.

`TestCommitPipelinePrepareErrorLeak` covers both paths.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>
