### PR TITLE
iterv2: improve mergingIterV2 debugability

### DIFF
--- a/internal/itertest/datadriven.go
+++ b/internal/itertest/datadriven.go
@@ -227,6 +227,11 @@ func RunInternalIterCmdWriter(
 			i := iter.(interface{ IsLowerBound(key []byte) bool })
 			fmt.Fprintf(w, "%v\n", i.IsLowerBound([]byte(parts[1])))
 			continue
+		case "print":
+			if s, ok := iter.(fmt.Stringer); ok {
+				fmt.Fprintln(w, s.String())
+			}
+			continue
 		default:
 			t.Fatalf("unknown op: %s", parts[0])
 		}

--- a/internal/iterv2/iter.go
+++ b/internal/iterv2/iter.go
@@ -210,15 +210,15 @@ func (s *Span) String() string {
 	default:
 		return "<invalid BoundaryType>"
 	}
+	b.WriteString(":{")
 	if len(s.Keys) > 0 {
-		b.WriteString(" {")
 		for i, k := range s.Keys {
 			if i > 0 {
 				b.WriteByte(' ')
 			}
 			b.WriteString(k.String())
 		}
-		b.WriteByte('}')
 	}
+	b.WriteByte('}')
 	return b.String()
 }

--- a/internal/iterv2/testdata/interleaving_iter
+++ b/internal/iterv2/testdata/interleaving_iter
@@ -37,24 +37,24 @@ next
 prev
 seek-lt a
 ----
-first:     z#inf,BDRY [?, z)
+first:     z#inf,BDRY [?, z):{}
 next:      .
-prev:      a#inf,BDRY [a, ?)
+prev:      a#inf,BDRY [a, ?):{}
 prev:      .
-last:      a#inf,BDRY [a, ?)
+last:      a#inf,BDRY [a, ?):{}
 prev:      .
-next:      z#inf,BDRY [?, z)
+next:      z#inf,BDRY [?, z):{}
 next:      .
-seek-ge x: z#inf,BDRY [?, z)
+seek-ge x: z#inf,BDRY [?, z):{}
 next:      .
-prev:      a#inf,BDRY [a, ?)
+prev:      a#inf,BDRY [a, ?):{}
 prev:      .
 seek-ge z: .
-seek-lt b: a#inf,BDRY [a, ?)
+seek-lt b: a#inf,BDRY [a, ?):{}
 prev:      .
-next:      z#inf,BDRY [?, z)
+next:      z#inf,BDRY [?, z):{}
 next:      .
-prev:      a#inf,BDRY [a, ?)
+prev:      a#inf,BDRY [a, ?):{}
 seek-lt a: .
 
 iter start=a end=z lower=b upper=u
@@ -70,16 +70,16 @@ next
 prev
 seek-lt b
 ----
-seek-ge p: u#inf,BDRY [?, u)
+seek-ge p: u#inf,BDRY [?, u):{}
 next:      .
-prev:      b#inf,BDRY [b, ?)
+prev:      b#inf,BDRY [b, ?):{}
 prev:      .
 seek-ge u: .
-seek-lt d: b#inf,BDRY [b, ?)
+seek-lt d: b#inf,BDRY [b, ?):{}
 prev:      .
-next:      u#inf,BDRY [?, u)
+next:      u#inf,BDRY [?, u):{}
 next:      .
-prev:      b#inf,BDRY [b, ?)
+prev:      b#inf,BDRY [b, ?):{}
 seek-lt b: .
 
 # Points only, no spans.
@@ -104,14 +104,14 @@ prev
 prev
 prev
 ----
-first: b#10,SET [?, ∞)
-next:  c#8,SET [?, ∞)
-next:  d#5,SET [?, ∞)
+first: b#10,SET [?, ∞):{}
+next:  c#8,SET [?, ∞):{}
+next:  d#5,SET [?, ∞):{}
 next:  .
 next:  .
-prev:  d#5,SET [-∞, ?)
-prev:  c#8,SET [-∞, ?)
-prev:  b#10,SET [-∞, ?)
+prev:  d#5,SET [-∞, ?):{}
+prev:  c#8,SET [-∞, ?):{}
+prev:  b#10,SET [-∞, ?):{}
 prev:  .
 
 iter start=a end=z
@@ -125,15 +125,15 @@ prev
 prev
 prev
 ----
-first: b#10,SET [?, z)
-next:  c#8,SET [?, z)
-next:  d#5,SET [?, z)
-next:  z#inf,BDRY [?, z)
+first: b#10,SET [?, z):{}
+next:  c#8,SET [?, z):{}
+next:  d#5,SET [?, z):{}
+next:  z#inf,BDRY [?, z):{}
 next:  .
-prev:  d#5,SET [a, ?)
-prev:  c#8,SET [a, ?)
-prev:  b#10,SET [a, ?)
-prev:  a#inf,BDRY [a, ?)
+prev:  d#5,SET [a, ?):{}
+prev:  c#8,SET [a, ?):{}
+prev:  b#10,SET [a, ?):{}
+prev:  a#inf,BDRY [a, ?):{}
 
 iter start=b end=e
 first
@@ -146,15 +146,15 @@ prev
 prev
 prev
 ----
-first: b#10,SET [?, e)
-next:  c#8,SET [?, e)
-next:  d#5,SET [?, e)
-next:  e#inf,BDRY [?, e)
+first: b#10,SET [?, e):{}
+next:  c#8,SET [?, e):{}
+next:  d#5,SET [?, e):{}
+next:  e#inf,BDRY [?, e):{}
 next:  .
-prev:  d#5,SET [b, ?)
-prev:  c#8,SET [b, ?)
-prev:  b#10,SET [b, ?)
-prev:  b#inf,BDRY [b, ?)
+prev:  d#5,SET [b, ?):{}
+prev:  c#8,SET [b, ?):{}
+prev:  b#10,SET [b, ?):{}
+prev:  b#inf,BDRY [b, ?):{}
 
 iter lower=bb
 seek-ge bb
@@ -165,12 +165,12 @@ prev
 prev
 prev
 ----
-seek-ge bb: c#8,SET [?, ∞)
-next:       d#5,SET [?, ∞)
+seek-ge bb: c#8,SET [?, ∞):{}
+next:       d#5,SET [?, ∞):{}
 next:       .
-prev:       d#5,SET [bb, ?)
-prev:       c#8,SET [bb, ?)
-prev:       bb#inf,BDRY [bb, ?)
+prev:       d#5,SET [bb, ?):{}
+prev:       c#8,SET [bb, ?):{}
+prev:       bb#inf,BDRY [bb, ?):{}
 prev:       .
 
 iter upper=d
@@ -182,12 +182,12 @@ next
 next
 next
 ----
-seek-lt d: c#8,SET [-∞, ?)
-prev:      b#10,SET [-∞, ?)
+seek-lt d: c#8,SET [-∞, ?):{}
+prev:      b#10,SET [-∞, ?):{}
 prev:      .
-next:      b#10,SET [?, d)
-next:      c#8,SET [?, d)
-next:      d#inf,BDRY [?, d)
+next:      b#10,SET [?, d):{}
+next:      c#8,SET [?, d):{}
+next:      d#inf,BDRY [?, d):{}
 next:      .
 
 iter lower=c upper=dd
@@ -200,13 +200,13 @@ prev
 prev
 prev
 ----
-seek-ge c: c#8,SET [?, dd)
-next:      d#5,SET [?, dd)
-next:      dd#inf,BDRY [?, dd)
+seek-ge c: c#8,SET [?, dd):{}
+next:      d#5,SET [?, dd):{}
+next:      dd#inf,BDRY [?, dd):{}
 next:      .
-prev:      d#5,SET [c, ?)
-prev:      c#8,SET [c, ?)
-prev:      c#inf,BDRY [c, ?)
+prev:      d#5,SET [c, ?):{}
+prev:      c#8,SET [c, ?):{}
+prev:      c#inf,BDRY [c, ?):{}
 prev:      .
 
 # Spans only, no points.
@@ -230,15 +230,15 @@ seek-ge e
 next
 prev
 ----
-first:     c#inf,BDRY [?, c)
-next:      g#inf,BDRY [?, g) {(#5,RANGEDEL)}
+first:     c#inf,BDRY [?, c):{}
+next:      g#inf,BDRY [?, g):{(#5,RANGEDEL)}
 next:      .
-prev:      g#inf,BDRY [g, ?)
-prev:      c#inf,BDRY [c, ?) {(#5,RANGEDEL)}
+prev:      g#inf,BDRY [g, ?):{}
+prev:      c#inf,BDRY [c, ?):{(#5,RANGEDEL)}
 prev:      .
-seek-ge e: g#inf,BDRY [?, g) {(#5,RANGEDEL)}
+seek-ge e: g#inf,BDRY [?, g):{(#5,RANGEDEL)}
 next:      .
-prev:      g#inf,BDRY [g, ?)
+prev:      g#inf,BDRY [g, ?):{}
 
 iter start=a end=z
 first
@@ -251,15 +251,15 @@ seek-ge e
 next
 prev
 ----
-first:     c#inf,BDRY [?, c)
-next:      g#inf,BDRY [?, g) {(#5,RANGEDEL)}
-next:      z#inf,BDRY [?, z)
-prev:      g#inf,BDRY [g, ?)
-prev:      c#inf,BDRY [c, ?) {(#5,RANGEDEL)}
-prev:      a#inf,BDRY [a, ?)
-seek-ge e: g#inf,BDRY [?, g) {(#5,RANGEDEL)}
-next:      z#inf,BDRY [?, z)
-prev:      g#inf,BDRY [g, ?)
+first:     c#inf,BDRY [?, c):{}
+next:      g#inf,BDRY [?, g):{(#5,RANGEDEL)}
+next:      z#inf,BDRY [?, z):{}
+prev:      g#inf,BDRY [g, ?):{}
+prev:      c#inf,BDRY [c, ?):{(#5,RANGEDEL)}
+prev:      a#inf,BDRY [a, ?):{}
+seek-ge e: g#inf,BDRY [?, g):{(#5,RANGEDEL)}
+next:      z#inf,BDRY [?, z):{}
+prev:      g#inf,BDRY [g, ?):{}
 
 iter start=c end=g
 first
@@ -267,9 +267,9 @@ next
 last
 prev
 ----
-first: g#inf,BDRY [?, g) {(#5,RANGEDEL)}
+first: g#inf,BDRY [?, g):{(#5,RANGEDEL)}
 next:  .
-last:  c#inf,BDRY [c, ?) {(#5,RANGEDEL)}
+last:  c#inf,BDRY [c, ?):{(#5,RANGEDEL)}
 prev:  .
 
 iter lower=b upper=d
@@ -284,8 +284,8 @@ prev
 seek-ge e: .
 next:      .
 next:      .
-prev:      c#inf,BDRY [c, ?) {(#5,RANGEDEL)}
-prev:      b#inf,BDRY [b, ?)
+prev:      c#inf,BDRY [c, ?):{(#5,RANGEDEL)}
+prev:      b#inf,BDRY [b, ?):{}
 prev:      .
 prev:      .
 
@@ -295,9 +295,9 @@ next
 prev
 prev
 ----
-seek-ge e: f#inf,BDRY [?, f) {(#5,RANGEDEL)}
+seek-ge e: f#inf,BDRY [?, f):{(#5,RANGEDEL)}
 next:      .
-prev:      e#inf,BDRY [e, ?) {(#5,RANGEDEL)}
+prev:      e#inf,BDRY [e, ?):{(#5,RANGEDEL)}
 prev:      .
 
 # Mixed points and spans, forward iteration.
@@ -330,16 +330,16 @@ next
 next
 next
 ----
-seek-ge a: a#10,SET [?, c)
-next:      b#8,SET [?, c)
-next:      c#inf,BDRY [?, c)
-next:      c#5,SET [?, g) {(#5,RANGEDEL)}
-next:      d#4,SET [?, g) {(#5,RANGEDEL)}
-next:      e#2,SET [?, g) {(#5,RANGEDEL)}
-next:      g#inf,BDRY [?, g) {(#5,RANGEDEL)}
-next:      h#6,SET [?, z)
-next:      i#1,SET [?, z)
-next:      z#inf,BDRY [?, z)
+seek-ge a: a#10,SET [?, c):{}
+next:      b#8,SET [?, c):{}
+next:      c#inf,BDRY [?, c):{}
+next:      c#5,SET [?, g):{(#5,RANGEDEL)}
+next:      d#4,SET [?, g):{(#5,RANGEDEL)}
+next:      e#2,SET [?, g):{(#5,RANGEDEL)}
+next:      g#inf,BDRY [?, g):{(#5,RANGEDEL)}
+next:      h#6,SET [?, z):{}
+next:      i#1,SET [?, z):{}
+next:      z#inf,BDRY [?, z):{}
 
 # Mixed points and spans, backward iteration.
 
@@ -355,16 +355,16 @@ prev
 prev
 prev
 ----
-seek-lt z: i#1,SET [g, ?)
-prev:      h#6,SET [g, ?)
-prev:      g#inf,BDRY [g, ?)
-prev:      e#2,SET [c, ?) {(#5,RANGEDEL)}
-prev:      d#4,SET [c, ?) {(#5,RANGEDEL)}
-prev:      c#5,SET [c, ?) {(#5,RANGEDEL)}
-prev:      c#inf,BDRY [c, ?) {(#5,RANGEDEL)}
-prev:      b#8,SET [a, ?)
-prev:      a#10,SET [a, ?)
-prev:      a#inf,BDRY [a, ?)
+seek-lt z: i#1,SET [g, ?):{}
+prev:      h#6,SET [g, ?):{}
+prev:      g#inf,BDRY [g, ?):{}
+prev:      e#2,SET [c, ?):{(#5,RANGEDEL)}
+prev:      d#4,SET [c, ?):{(#5,RANGEDEL)}
+prev:      c#5,SET [c, ?):{(#5,RANGEDEL)}
+prev:      c#inf,BDRY [c, ?):{(#5,RANGEDEL)}
+prev:      b#8,SET [a, ?):{}
+prev:      a#10,SET [a, ?):{}
+prev:      a#inf,BDRY [a, ?):{}
 
 # Contiguous (abutting) fragment spans.
 
@@ -391,13 +391,13 @@ next
 next
 next
 ----
-seek-ge a: a#10,SET [?, c)
-next:      c#inf,BDRY [?, c)
-next:      d#4,SET [?, f) {(#5,RANGEDEL)}
-next:      f#inf,BDRY [?, f) {(#5,RANGEDEL)}
-next:      h#6,SET [?, j) {(#3,RANGEKEYDEL)}
-next:      j#inf,BDRY [?, j) {(#3,RANGEKEYDEL)}
-next:      z#inf,BDRY [?, z)
+seek-ge a: a#10,SET [?, c):{}
+next:      c#inf,BDRY [?, c):{}
+next:      d#4,SET [?, f):{(#5,RANGEDEL)}
+next:      f#inf,BDRY [?, f):{(#5,RANGEDEL)}
+next:      h#6,SET [?, j):{(#3,RANGEKEYDEL)}
+next:      j#inf,BDRY [?, j):{(#3,RANGEKEYDEL)}
+next:      z#inf,BDRY [?, z):{}
 
 iter lower=a upper=z
 seek-lt z
@@ -408,13 +408,13 @@ prev
 prev
 prev
 ----
-seek-lt z: j#inf,BDRY [j, ?)
-prev:      h#6,SET [f, ?) {(#3,RANGEKEYDEL)}
-prev:      f#inf,BDRY [f, ?) {(#3,RANGEKEYDEL)}
-prev:      d#4,SET [c, ?) {(#5,RANGEDEL)}
-prev:      c#inf,BDRY [c, ?) {(#5,RANGEDEL)}
-prev:      a#10,SET [a, ?)
-prev:      a#inf,BDRY [a, ?)
+seek-lt z: j#inf,BDRY [j, ?):{}
+prev:      h#6,SET [f, ?):{(#3,RANGEKEYDEL)}
+prev:      f#inf,BDRY [f, ?):{(#3,RANGEKEYDEL)}
+prev:      d#4,SET [c, ?):{(#5,RANGEDEL)}
+prev:      c#inf,BDRY [c, ?):{(#5,RANGEDEL)}
+prev:      a#10,SET [a, ?):{}
+prev:      a#inf,BDRY [a, ?):{}
 
 # Points exactly at span boundaries.
 
@@ -436,11 +436,11 @@ next
 next
 next
 ----
-seek-ge a: c#inf,BDRY [?, c)
-next:      c#5,SET [?, g) {(#10,RANGEDEL)}
-next:      g#inf,BDRY [?, g) {(#10,RANGEDEL)}
-next:      g#3,SET [?, z)
-next:      z#inf,BDRY [?, z)
+seek-ge a: c#inf,BDRY [?, c):{}
+next:      c#5,SET [?, g):{(#10,RANGEDEL)}
+next:      g#inf,BDRY [?, g):{(#10,RANGEDEL)}
+next:      g#3,SET [?, z):{}
+next:      z#inf,BDRY [?, z):{}
 
 iter lower=a upper=z
 seek-lt z
@@ -449,11 +449,11 @@ prev
 prev
 prev
 ----
-seek-lt z: g#3,SET [g, ?)
-prev:      g#inf,BDRY [g, ?)
-prev:      c#5,SET [c, ?) {(#10,RANGEDEL)}
-prev:      c#inf,BDRY [c, ?) {(#10,RANGEDEL)}
-prev:      a#inf,BDRY [a, ?)
+seek-lt z: g#3,SET [g, ?):{}
+prev:      g#inf,BDRY [g, ?):{}
+prev:      c#5,SET [c, ?):{(#10,RANGEDEL)}
+prev:      c#inf,BDRY [c, ?):{(#10,RANGEDEL)}
+prev:      a#inf,BDRY [a, ?):{}
 
 # Direction changes.
 
@@ -480,13 +480,13 @@ next
 next
 prev
 ----
-seek-ge a: a#10,SET [?, c)
-next:      b#8,SET [?, c)
-prev:      a#10,SET [a, ?)
-next:      b#8,SET [?, c)
-next:      c#inf,BDRY [?, c)
-next:      c#5,SET [?, g) {(#5,RANGEDEL)}
-prev:      c#inf,BDRY [c, ?) {(#5,RANGEDEL)}
+seek-ge a: a#10,SET [?, c):{}
+next:      b#8,SET [?, c):{}
+prev:      a#10,SET [a, ?):{}
+next:      b#8,SET [?, c):{}
+next:      c#inf,BDRY [?, c):{}
+next:      c#5,SET [?, g):{(#5,RANGEDEL)}
+prev:      c#inf,BDRY [c, ?):{(#5,RANGEDEL)}
 
 # SeekGE and SeekLT.
 
@@ -509,10 +509,10 @@ next
 next
 next
 ----
-seek-ge d: e#2,SET [?, g) {(#5,RANGEDEL)}
-next:      g#inf,BDRY [?, g) {(#5,RANGEDEL)}
-next:      h#6,SET [?, z)
-next:      z#inf,BDRY [?, z)
+seek-ge d: e#2,SET [?, g):{(#5,RANGEDEL)}
+next:      g#inf,BDRY [?, g):{(#5,RANGEDEL)}
+next:      h#6,SET [?, z):{}
+next:      z#inf,BDRY [?, z):{}
 
 iter lower=a upper=z
 seek-lt g
@@ -520,10 +520,10 @@ prev
 prev
 prev
 ----
-seek-lt g: e#2,SET [c, ?) {(#5,RANGEDEL)}
-prev:      c#5,SET [c, ?) {(#5,RANGEDEL)}
-prev:      c#inf,BDRY [c, ?) {(#5,RANGEDEL)}
-prev:      a#10,SET [a, ?)
+seek-lt g: e#2,SET [c, ?):{(#5,RANGEDEL)}
+prev:      c#5,SET [c, ?):{(#5,RANGEDEL)}
+prev:      c#inf,BDRY [c, ?):{(#5,RANGEDEL)}
+prev:      a#10,SET [a, ?):{}
 
 # SetBounds + re-seek.
 
@@ -535,9 +535,9 @@ next
 next
 ----
 set-bounds c g: ok
-seek-ge c:      c#5,SET [?, g) {(#5,RANGEDEL)}
-next:           e#2,SET [?, g) {(#5,RANGEDEL)}
-next:           g#inf,BDRY [?, g) {(#5,RANGEDEL)}
+seek-ge c:      c#5,SET [?, g):{(#5,RANGEDEL)}
+next:           e#2,SET [?, g):{(#5,RANGEDEL)}
+next:           g#inf,BDRY [?, g):{(#5,RANGEDEL)}
 next:           .
 
 # SetBounds with nil bounds (unbounded).
@@ -547,8 +547,8 @@ seek-ge a
 next
 ----
 set-bounds . .: ok
-seek-ge a:      a#10,SET [?, c)
-next:           c#inf,BDRY [?, c)
+seek-ge a:      a#10,SET [?, c):{}
+next:           c#inf,BDRY [?, c):{}
 
 # Point exhaustion with remaining boundaries.
 
@@ -569,9 +569,9 @@ seek-ge a
 next
 next
 ----
-seek-ge a: a#10,SET [?, c)
-next:      c#inf,BDRY [?, c)
-next:      g#inf,BDRY [?, g) {(#5,RANGEDEL)}
+seek-ge a: a#10,SET [?, c):{}
+next:      c#inf,BDRY [?, c):{}
+next:      g#inf,BDRY [?, g):{(#5,RANGEDEL)}
 
 # Direction change from backward-exhausted with lower bound.
 # After SetBounds(m, .), SeekLT(a) returns nil (backward-exhausted).
@@ -596,7 +596,7 @@ next
 ----
 set-bounds m .: ok
 seek-lt a:      .
-next:           p#5,SET [?, ∞)
+next:           p#5,SET [?, ∞):{}
 
 # Direction change from forward-exhausted with upper bound.
 # After SetBounds(., m), SeekGE(z) returns nil (forward-exhausted).
@@ -610,7 +610,7 @@ prev
 ----
 set-bounds . m: ok
 seek-ge z:      .
-prev:           a#10,SET [-∞, ?)
+prev:           a#10,SET [-∞, ?):{}
 
 # Backward gap span end clamped to upper bound.
 # With upper=h, the span [c,j) is above upper. When going backward from
@@ -634,7 +634,7 @@ prev
 ----
 set-bounds . h: ok
 seek-ge z:      .
-prev:           d#4,SET [c, ?) {(#5,RANGEDEL)}
+prev:           d#4,SET [c, ?):{(#5,RANGEDEL)}
 
 # Stale fragment state after SeekGE/SeekLT returns nil.
 # When SeekGE or SeekLT exhausts points, the fragment iterator state
@@ -659,7 +659,7 @@ seek-ge a
 seek-ge z
 next
 ----
-seek-ge a: b#8,SET [?, c)
+seek-ge a: b#8,SET [?, c):{}
 seek-ge z: .
 next:      .
 
@@ -670,7 +670,7 @@ seek-lt z
 seek-lt a
 prev
 ----
-seek-lt z: g#inf,BDRY [g, ?)
+seek-lt z: g#inf,BDRY [g, ?):{}
 seek-lt a: .
 prev:      .
 
@@ -696,8 +696,8 @@ first
 next
 ----
 set-bounds . h: ok
-first:          c#inf,BDRY [?, c)
-next:           d#4,SET [?, h) {(#5,RANGEDEL)}
+first:          c#inf,BDRY [?, c):{}
+next:           d#4,SET [?, h):{(#5,RANGEDEL)}
 
 # Same test but backward: no spurious boundary at lower bound.
 # With nil upper from set-bounds, the last gap is unbounded above.
@@ -707,8 +707,8 @@ last
 prev
 ----
 set-bounds d .: ok
-last:           j#inf,BDRY [j, ?)
-prev:           d#4,SET [d, ?) {(#5,RANGEDEL)}
+last:           j#inf,BDRY [j, ?):{}
+prev:           d#4,SET [d, ?):{(#5,RANGEDEL)}
 
 # NextPrefix is equivalent to SeekGE(succKey).
 
@@ -732,9 +732,9 @@ next
 next
 next
 ----
-seek-ge a:   a#10,SET [?, c)
-next-prefix: c#inf,BDRY [?, c)
-next:        d#4,SET [?, g) {(#5,RANGEDEL)}
-next:        g#inf,BDRY [?, g) {(#5,RANGEDEL)}
-next:        h#6,SET [?, z)
-next:        z#inf,BDRY [?, z)
+seek-ge a:   a#10,SET [?, c):{}
+next-prefix: c#inf,BDRY [?, c):{}
+next:        d#4,SET [?, g):{(#5,RANGEDEL)}
+next:        g#inf,BDRY [?, g):{(#5,RANGEDEL)}
+next:        h#6,SET [?, z):{}
+next:        z#inf,BDRY [?, z):{}

--- a/merging_iter_v2.go
+++ b/merging_iter_v2.go
@@ -7,7 +7,12 @@ package pebble
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"iter"
+	"slices"
+	"strings"
 
+	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/invariants"
@@ -234,6 +239,10 @@ type mergingIterV2Level struct {
 	// slab boundary. The Next()/Prev() to cross it is deferred until we
 	// know whether the level will be parked.
 	atBoundary bool
+}
+
+func (level *mergingIterV2Level) Name() string {
+	return string('A' + byte(level.index))
 }
 
 func (level *mergingIterV2Level) Compare(cmp base.Compare, other *mergingIterV2Level) int {
@@ -896,14 +905,72 @@ func (m *mergingIterV2) SetContext(ctx context.Context) {
 
 // String implements fmt.Stringer.
 func (m *mergingIterV2) String() string {
-	return "merging-v2"
+	var buf strings.Builder
+	buf.WriteString("merging-v2(")
+	if m.err != nil {
+		fmt.Fprintf(&buf, "err: %s", m.err)
+	} else if m.dir == 0 {
+		buf.WriteString("not positioned")
+	} else {
+		if m.dir > 0 {
+			buf.WriteString("fwd")
+		} else {
+			buf.WriteString("bwd")
+		}
+		buf.WriteString(", heap:")
+		for level := range m.heap.DebugItems() {
+			fmt.Fprintf(&buf, " %s:%s %s", level.Name(), level.iterKV.K, level.span)
+		}
+	}
+	buf.WriteByte(')')
+	return buf.String()
+}
+
+type treestepsV2DummyNode struct {
+	info treesteps.NodeInfo
+}
+
+func (d *treestepsV2DummyNode) TreeStepsNode() treesteps.NodeInfo {
+	return d.info
 }
 
 // TreeStepsNode implements treesteps.Node.
 func (m *mergingIterV2) TreeStepsNode() treesteps.NodeInfo {
-	info := treesteps.NodeInfof(m, "mergingIterV2(%p)", m)
+	info := treesteps.NodeInfof(m, "mergingIterV2")
+	if m.heap.Len() > 0 {
+		heapProp := crstrings.IfElse(m.heap.lessCmp == -1, "min heap", "max heap")
+		var str strings.Builder
+		for i, item := range m.heap.items {
+			if i > 0 {
+				str.WriteString(" ")
+			}
+			if item.level.iterKV != nil {
+				fmt.Fprintf(&str, "%s:%s", item.level.Name(), item.level.iterKV.K)
+			} else {
+				fmt.Fprintf(&str, "%s:<nil>", item.level.Name())
+			}
+		}
+		info.AddPropf(heapProp, "%s", str.String())
+	}
+	if m.prefix != nil {
+		info.AddPropf("prefix", "%s", m.prefix)
+	}
 	for i := range m.levels {
-		info.AddChildren(m.levels[i].iter)
+		l := &m.levels[i]
+		name := l.Name()
+		if l.iterKV != nil {
+			name = fmt.Sprintf("%s:%s", name, l.iterKV.K)
+		}
+		if l.parked {
+			name += " [parked]"
+		}
+		d := &treestepsV2DummyNode{}
+		if l.span != nil && l.span.Valid() {
+			name += fmt.Sprintf(" %s", l.span)
+		}
+		d.info = treesteps.NodeInfof(d, "%s", name)
+		d.info.AddChildren(l.iter)
+		info.AddChildren(d)
 	}
 	return info
 }
@@ -1068,5 +1135,26 @@ func (h *mergingIterV2Heap) down(i int) {
 		h.swap(i, j)
 		h.items[i].winnerChild = winnerChildUnknown
 		i = j
+	}
+}
+
+// DebugItems returns an iterator over the heap items in sorted order.
+func (h *mergingIterV2Heap) DebugItems() iter.Seq[*mergingIterV2Level] {
+	return func(yield func(*mergingIterV2Level) bool) {
+		indices := make([]int, len(h.items))
+		for i := range indices {
+			indices[i] = i
+		}
+		slices.SortFunc(indices, func(i, j int) int {
+			if h.less(i, j) {
+				return -1
+			}
+			return 1
+		})
+		for _, idx := range indices {
+			if !yield(h.items[idx].level) {
+				return
+			}
+		}
 	}
 }

--- a/testdata/merging_iter_v2
+++ b/testdata/merging_iter_v2
@@ -15,12 +15,14 @@ L1
 
 iter
 first
+print
 next
 next
 next
 next
 ----
 a#10,SET:
+merging-v2(fwd, heap: A:a#10,SET [?, ∞):{} B:b#5,SET [?, ∞):{})
 b#5,SET:
 c#9,SET:
 d#4,SET:
@@ -28,12 +30,14 @@ d#4,SET:
 
 iter
 last
+print
 prev
 prev
 prev
 prev
 ----
 d#4,SET:
+merging-v2(bwd, heap: B:d#4,SET [-∞, ?):{} A:c#9,SET [-∞, ?):{})
 c#9,SET:
 b#5,SET:
 a#10,SET:
@@ -214,17 +218,21 @@ L2
 
 iter
 first
+print
 next
 next
 next
+print
 next
 next
 next
 ----
 a#20,SET:
+merging-v2(fwd, heap: A:a#20,SET [?, ∞):{} B:a#10,SET [?, ∞):{} C:a#5,DEL [?, ∞):{})
 a#10,SET:
 a#5,DEL:
 b#15,SET:
+merging-v2(fwd, heap: B:b#15,SET [?, ∞):{} A:c#18,SET [?, ∞):{} C:d#1,SET [?, ∞):{})
 c#18,SET:
 d#1,SET:
 .

--- a/testdata/treesteps/level_iter_v2
+++ b/testdata/treesteps/level_iter_v2
@@ -1,0 +1,54 @@
+# Test treesteps recording for levelIterV2 SeekGE operation.
+# This test creates a DB with multiple sstables in L1 and performs a SeekGE
+# operation while recording the operation steps with treesteps.
+
+define
+L1
+  a#10,SET:va
+  b#10,SET:vb
+  c#10,SET:vc
+L1
+  d#5,SET:vd
+  d@10#5,SET:vd10
+  d@20#5,SET:vd20
+  e#5,SET:ve
+  f#5,SET:vf
+L1
+  g#1,SET:vg
+  h#1,SET:vh
+  i#1,SET:vi
+----
+L1:
+  000004:[a#10,SET-c#10,SET] seqnums:[#10-#10] points:[a#10,SET-c#10,SET] size:700
+  000005:[d#5,SET-f#5,SET] seqnums:[#5-#5] points:[d#5,SET-f#5,SET] size:831
+  000006:[g#1,SET-i#1,SET] seqnums:[#1-#1] points:[g#1,SET-i#1,SET] size:697
+
+level-iter-v2 depth=1
+seek-ge b
+next
+next
+next
+next
+next
+next
+next
+----
+b#10,SET:vb
+c#10,SET:vc
+d#inf,BDRY:
+d#5,SET:vd
+d@20#5,SET:vd20
+d@10#5,SET:vd10
+e#5,SET:ve
+f#5,SET:vf
+https://raduberinde.github.io/treesteps/decode.html#eNrUUk9L-0AQvf8-xTC9tLDQtPxyCRRELFKQHqwIYkrZmokurtuSHYIgQvHgxYuHfA4_VD6JZCtYNP45pOrOcefNm_d23g2O5RVhhEyWE8myyxmRZVrarqac9EwxZbO8jwInTMsKbTE6RWUUK6mrZ6LL_SEsDLiBEVN23AfLMmNKUKBZJLTZiiBVmiCo6j_ohUwcrJ4mVUbZCwcY0zV_vKWu-zPDn_kLX_39nsA_OjxdJ8qlaRNw0IsNlEVRFquyWMHIMGWaZK7MeYWIDYo3eIDy_hHWAWrHOI9RQNBpkOXOnTR6yewXxOCqfHj69g4YwLzVC8RkeLSNddUV2p3tMcMAzvyWn7SUScXu3uGJjwbeM4dNfk1Yf9jQC_U7_cBzAz2_DZDX6tMm1E9v_z0HAAD__7u7YYc=
+
+level-iter-v2 depth=1
+seek-prefix-ge d@10
+next
+next
+----
+d@10#5,SET:vd10
+g#inf,BDRY:
+.
+https://raduberinde.github.io/treesteps/decode.html#eNrUkc9KOzEQx--_pximlxYC3fZHLwsFEYsUpIgVQUwpwczWYExLMpaCCMWDFy8e9jl8qH0SSfSwiH9A3YNzmt35zHwz873BiboizJEpsFasuuyJAtMqdC2tyc4Nk5-v-yhwyrSKdMD8DI0zbJSNv4kuDz0VZrM_gqWD1DZm8id9CKw8k0aBbqmpXsqhMJYgizEAu1Q6YZ8NK4wz4SJhE9rwx1rvVX-nefZyhXSBOnDQkw6qsqzKbVVuYeyYvCW1Nm4RCelQvOEBqvtHqK_blqglCpCod3pZzLJOg1PvkgH5qwNfCEGK6uHp25owhPjRGojp6LiJB0Tf2p3mJsMQFi3jCrG7d3T6RxeQ11n2_9wZmxL6mdbs9t9zAAAA__9u8YMZ

--- a/testdata/treesteps/merging_iter_v2
+++ b/testdata/treesteps/merging_iter_v2
@@ -1,0 +1,131 @@
+define
+L1
+  a@1#10,SET:va1
+  b#10,SET:vb
+  e#10,SET:ve
+L2
+  a#5,SET:va
+  a@1#5,SET:va1b
+  b@2#5,SET:vb2
+  c#5,DEL:
+  d#5,SET:vd
+L3
+  c#1,SET:vc
+----
+L1:
+  000004:[a@1#10,SET-e#10,SET] seqnums:[#10-#10] points:[a@1#10,SET-e#10,SET] size:708
+L2:
+  000005:[a#5,SET-d#5,SET] seqnums:[#5-#5] points:[a#5,SET-d#5,SET] size:866
+L3:
+  000006:[c#1,SET-c#1,SET] seqnums:[#1-#1] points:[c#1,SET-c#1,SET] size:679
+
+merging-iter-v2 depth=2
+seek-ge a
+next
+next
+next
+next
+next
+next
+next
+----
+a#5,SET:va
+a@1#10,SET:va1
+a@1#5,SET:va1b
+b#10,SET:vb
+b@2#5,SET:vb2
+c#5,DEL:
+c#1,SET:vc
+d#5,SET:vd
+https://raduberinde.github.io/treesteps/decode.html#eNrsmU9r2z4Yx--_V_HgXBowNE5_2cEwlrUNY1B6WMdgNKU48ZNWLPFCrJVBKZQexmCXHXwcewl7UX4lI44SS4ndSIm62o58SizpkZ7vx8-fOLfWqTdCy7UohtT3qLdPJ4ghxXG4P8LJFQmuLgnFyeVN07KtM4rj6fzQcs8tEhBKvOH0NuKnNx34HABb8pbi5EMTQupNKPrCjCHe4JCND0hAwmvtE8RDcFNO8St97JTz8ZwdJIefentj3-BZtX8xi84kMoUp3QDi6Fcc3cfRPbxOvj0AAMRRxG7yG5446Yzkin_8ESwcrrXQzLEwn3zUDdhA9vqD-Xi62rJFnwDibz9hFvF7XcvrWjY06rvqKZy_ssFrO3X39m6919kW4eXUQo0EA_vw-N3Hqkjj8k6p6bROgsRa_P23lLVmvuq1ln3Web-8W_QAAzJEFxrTq1V5NV2mg5qqW6qWbNZnWz2qXy6-Ph8yG0m88gyMSADX6I1dTpUl6Y_cvhiqlUXEOSpPSxbFtKTu1Y3shZG97RRK-MVxNkj1MydZWdWR4p8biQoDWa2cDK2cxnqx_n8qdsVnlKVSCmzGYjaoQo-tUGJnEMmGkaFSTCo9RSa9jYgsRW_PZDipDJfbEnNNwgKIdmiGzmZtmyFSBCK9drMERNJTbtNfL6yUIrP18js3rhqlylQFWtn7A0OkEERQkQjq6NhQU8dWWVAZWTivGqFENUITRv-wPzBEikCkX2vZx52TQvOYn3Gbbo3ZqAij8mLRDCDdV-JvNO5hcJiKkHeSF8qVSHzCJGLM2XWSToanCpG0FTCDqayY_OwOojiYfA0vF3xdrxaeE56QaUWM6dGE31a826XEWLFoM5gMpvJjUuwOu18ajYN-QIbJB9SbEP3ctxWrdW1nwemOpYu7__4GAAD__6dCO2o=
+
+# This test verifies that the level iterators skips files 8:[d1-d2], 9:[e1-e2]
+# altogether. Ideally, we would skip 7:[c1-c2] as well, but we currently need to
+# read a key that's past the tombstone start before we consider the tombstone.
+define
+L1
+  c#10,RANGEDEL:f
+L2
+  a1#1,SET:va
+  a2#1,SET:va
+L2
+  b1#1,SET:va
+  b2#1,SET:va
+L2
+  c1#1,SET:va
+  c2#1,SET:va
+L2
+  d1#1,SET:va
+  d2#1,SET:va
+L2
+  e1#1,SET:va
+  e2#1,SET:va
+L2
+  f1#1,SET:va
+  f2#1,SET:va
+----
+L1:
+  000004:[c#10,RANGEDEL-f#inf,RANGEDEL] seqnums:[#10-#10] points:[c#10,RANGEDEL-f#inf,RANGEDEL] size:676
+L2:
+  000005:[a1#1,SET-a2#1,SET] seqnums:[#1-#1] points:[a1#1,SET-a2#1,SET] size:697
+  000006:[b1#1,SET-b2#1,SET] seqnums:[#1-#1] points:[b1#1,SET-b2#1,SET] size:697
+  000007:[c1#1,SET-c2#1,SET] seqnums:[#1-#1] points:[c1#1,SET-c2#1,SET] size:697
+  000008:[d1#1,SET-d2#1,SET] seqnums:[#1-#1] points:[d1#1,SET-d2#1,SET] size:697
+  000009:[e1#1,SET-e2#1,SET] seqnums:[#1-#1] points:[e1#1,SET-e2#1,SET] size:697
+  000010:[f1#1,SET-f2#1,SET] seqnums:[#1-#1] points:[f1#1,SET-f2#1,SET] size:697
+
+merging-iter-v2 depth=2
+first
+next
+next
+next
+next
+next
+next
+----
+a1#1,SET:va
+a2#1,SET:va
+b1#1,SET:va
+b2#1,SET:va
+f1#1,SET:va
+f2#1,SET:va
+.
+https://raduberinde.github.io/treesteps/decode.html#eNrsmM1q20AQx-99imF9sUEQadvmICglwW4oGB_iUiiWCZK8myyxVSNtQ8AEgg-l0EsPOpY-Qh9KT1K8tmutKlnaWLZqIp0Sze58_Jj_zloz1LMnBJmIk4CPbG6fcJ-QgJNpcDIh_jXzrq8YJ_7VHUYa6nMyXawPkDlAzGOc2WOkoXfMDzh89mC14z0n_kcMAbd9TkbxBWNyR8YrM2UeC24K2XvkvtB2OX6Kg6wEcwKkby_ff8XhKy4vw9wn5PaiU9PL8D9cylJIUlpieRCFP6PwMQof4Uz8NwcAiMJw9TIesGtsVogn-v5bvFkvPre8lSF9P17bN7uRJmcEEH39AUKtzdZRpQeDtxq4LXP2kJ-o5AbegNtgHtXO25efKi3B3OShUk1ezsKXbaycbU0_CcY24mSUK5vDhHlwQ-ypKVV3kLLNWPLCr6OAYKHoNQFD63c-yOWHc6BsTEzQF89rRTayWxmTSFuYqiG2DF0cVylclrRrFttZ4OpYYGUWSRnhEmWU5vW4adWdU7MooCInaxyXS-nwaBq61u50ly6fCCb3eDlVPl6c7CHtVDeYnPhgcneW1OnOkqpZxFhUd7w4WJlFst_xXlSUPaSPi1bdOTWLAipyiw3p3SnJgbawoS1z1mwYunZ51rvotDvdVuFvJH-ropmfSOSyXuUSdhM_y6tpuA0sy7qnadUVBGN90fWXrsfG4g-yIx0YTG3_loyG_wMadTkpV7voTgWRLT80Ny1ELaSBLhpzf3I7HAiTJkQRffv1hKOH5l-DDV15gNPsa7BkOiyuzSldkFWJUGoS20jgikhgdRLJTsd70U_2BfiYWNVd8zxIKGrm3_tPidJJu1wdDknZfTB8ePEnAAD__wCN3uo=
+
+define
+L1
+  b@20#5,SET:b20
+  b@10#5,SET:b10
+  c@20#5,SET:c20
+  c@10#5,SET:c10
+  d@20#5,SET:d20
+  d@10#5,SET:d10
+L2
+  a#4,RANGEDEL:c1
+L3
+  b@25#3,SET:b25
+  b@15#3,SET:b15
+  b@5#3,SET:b5
+  c@25#3,SET:c25
+  c@15#3,SET:c15
+  c@5#3,SET:c5
+  d@25#3,SET:d25
+  d@15#3,SET:d15
+  d@5#3,SET:d5
+----
+L1:
+  000004:[b@20#5,SET-d@10#5,SET] seqnums:[#5-#5] points:[b@20#5,SET-d@10#5,SET] size:839
+L2:
+  000005:[a#4,RANGEDEL-c1#inf,RANGEDEL] seqnums:[#4-#4] points:[a#4,RANGEDEL-c1#inf,RANGEDEL] size:678
+L3:
+  000006:[b@25#3,SET-d@5#3,SET] seqnums:[#3-#3] points:[b@25#3,SET-d@5#3,SET] size:873
+
+merging-iter-v2 depth=2
+seek-prefix-ge b
+seek-prefix-ge c try-seek-using-next
+seek-prefix-ge d try-seek-using-next
+----
+b@20#5,SET:b20
+c@20#5,SET:c20
+d@25#3,SET:d25
+https://raduberinde.github.io/treesteps/decode.html#eNrsls1q20AQgO99imF9sUEQWY57WChtnJhQCKYkpVAsE2TtOFkiq0LahoAJBB9KoZcedCx9hD6UnqRIVmyvI0WS7QT_SBfbmtn5-2ZnPCIdY4iEEoGeYIYwDoSL6Al0vIMhulfcvrrkAt3LW40o5EKgE-p7hHYJt7nghhW-Rrz55OKA35224ZsN8cGPAt0vGnjCcAWyBD0Lb9GKtQbc5t51EbUO3okCVuSgciu-VPRbFt5qWfQmrRO1jaSi2xD4fwL_IfAf4Cj6NQYACHw_fjnv-Kw-04ie4Nc_yUIr04KWYuFR-Vi3Y0Hy-cajfHaaKHJOAMGP3zBfmapO-jpRQK3tZb5jcCIBhb6cP3TfK9D_oKk1OrrPLka6o6k_eBfZq3B7oLROzr_udv2olGvBamaVJjJn1mt0VK0cKudHndP2Sfuslm1Zy8fJrKdS8scw4BZSUMOnuREIhtyGazQcCi36NPT8gIKff4t0e7jkqtO2bioX7c_PV-swi-t89MszXhEZdB3DvUHWe1l2SXWbgYzxRMLiVCfHCiEtyWWTM0Ny9VoJa7thmflgmQuwzCVhpUcXf0xWTjlDtxHuRsDK2WFr-1PzSnSTbsW-o95wcqy8l7sAi-WDxRZgsXVuSDaZX2w6v1i5IbcR7hphLbkJn3SS_l1VG6bNregL7gbJ5KQ2jOYrXCspm2d55B47zUojHjuQFtjb1eAu-pFJH9OZUGK3p5Dny1GAd1F-vfs3_wMAAP__trByMg==

--- a/treesteps_test.go
+++ b/treesteps_test.go
@@ -7,6 +7,7 @@
 package pebble
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -29,11 +30,15 @@ func TestTreeSteps(t *testing.T) {
 	if !treesteps.Enabled {
 		t.Skip("treesteps not available in this build")
 	}
-	if iterv2.Enabled {
-		t.Skip("treesteps output is specific to v1 iterator stack")
-	}
-
 	datadriven.Walk(t, "testdata/treesteps", func(t *testing.T, path string) {
+		isV2 := strings.HasSuffix(path, "_v2")
+		baseName := filepath.Base(path)
+		if isV2 && !iterv2.Enabled {
+			t.Skipf("skipping %s: iterv2 not enabled", baseName)
+		}
+		if !isV2 && iterv2.Enabled {
+			t.Skipf("skipping %s: iterv2 enabled", baseName)
+		}
 		var d *DB
 		defer func() {
 			if d != nil {
@@ -85,6 +90,36 @@ func TestTreeSteps(t *testing.T) {
 				miter.forceEnableSeekOpt = true
 				var stats base.InternalIteratorStats
 				miter.init(nil /* opts */, &stats, d.cmp, d.split, levelIters...)
+				defer miter.Close()
+				rec := treeStepsStartRecording(t, td, miter)
+				out := itertest.RunInternalIterCmd(t, td, miter, itertest.Verbose)
+				url := rec.Finish().URL()
+				return out + url.String()
+
+			case "level-iter-v2":
+				v := d.DebugCurrentVersion()
+				var opts IterOptions
+				iter := newLevelIterV2(t.Context(), opts, testkeys.Comparer, d.newIters,
+					v.Levels[1].Iter(), manifest.Level(1), internalIterOpts{})
+				defer iter.Close()
+				rec := treeStepsStartRecording(t, td, iter)
+				out := itertest.RunInternalIterCmd(t, td, iter, itertest.Verbose)
+				url := rec.Finish().URL()
+				return out + url.String()
+
+			case "merging-iter-v2":
+				v := d.DebugCurrentVersion()
+				var levelIters []iterv2.Iter
+				for l := 1; l < len(v.Levels); l++ {
+					if v.Levels[l].Empty() {
+						continue
+					}
+					var opts IterOptions
+					li := newLevelIterV2(t.Context(), opts, testkeys.Comparer, d.newIters,
+						v.Levels[l].Iter(), manifest.Level(l), internalIterOpts{})
+					levelIters = append(levelIters, li)
+				}
+				miter := newMergingIterV2(d.cmp, d.split, base.SeqNumMax, levelIters...)
 				defer miter.Close()
 				rec := treeStepsStartRecording(t, td, miter)
 				out := itertest.RunInternalIterCmd(t, td, miter, itertest.Verbose)


### PR DESCRIPTION
Implement informative `String()` and `TreeStepsNode()` for
`mergingIterV2` showing direction, heap contents, prefix, and
per-level state. Add a `print` command to `RunInternalIterCmd`
and treesteps tests for `levelIterV2` and `mergingIterV2`.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>