### PR TITLE
sstable/colblk,cockroachkvs: fix equalPrefix in KeySeeker.SeekGE

### DIFF
--- a/cockroachkvs/cockroachkvs.go
+++ b/cockroachkvs/cockroachkvs.go
@@ -881,7 +881,7 @@ func (ks *cockroachKeySeeker) SeekGE(
 	si := Split(key)
 	row, eq := ks.roachKeys.Search(key[:si-1])
 	if eq {
-		return ks.seekGEOnSuffix(row, key[si:]), true
+		return ks.seekGEOnSuffix(row, key[si:])
 	}
 	return row, false
 }
@@ -889,8 +889,12 @@ func (ks *cockroachKeySeeker) SeekGE(
 // seekGEOnSuffix is a helper function for SeekGE when a seek key's prefix
 // exactly matches a row. seekGEOnSuffix finds the first row at index or later
 // with the same prefix as index and a suffix greater than or equal to [suffix],
-// or if no such row exists, the next row with a different prefix.
-func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row int) {
+// or if no such row exists, the next row with a different prefix. equalPrefix
+// reports whether the returned row still has the same prefix as the seek key
+// (false when the search walked past the prefix group).
+func (ks *cockroachKeySeeker) seekGEOnSuffix(
+	index int, seekSuffix []byte,
+) (row int, equalPrefix bool) {
 	// We have three common cases:
 	// 1. The seek key has no suffix.
 	// 2. We are seeking to an MVCC timestamp in a block where all keys have
@@ -902,7 +906,7 @@ func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row 
 		// The search key has no suffix, so it's the smallest possible key with its
 		// prefix. Return the row. This is a common case where the user is seeking
 		// to the most-recent row and just wants the smallest key with the prefix.
-		return index
+		return index, true
 	}
 
 	const withWall = 9
@@ -924,15 +928,16 @@ func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row 
 		// the most common case.
 		if latestWallTime := ks.mvccWallTimes.At(index); latestWallTime < seekWallTime ||
 			(latestWallTime == seekWallTime && uint32(ks.mvccLogical.At(index)) <= seekLogicalTime) {
-			return index
+			return index, true
 		}
 
 		// Binary search between [index+1, prefixChanged.SeekSetBitGE(index+1)].
 		//
 		// Define f(i) = true iff key at i is >= seek key.
 		// Invariant: f(l-1) == false, f(u) == true.
+		nextPrefixRow := ks.roachKeyChanged.SeekSetBitGE(index + 1)
 		l := index + 1
-		u := ks.roachKeyChanged.SeekSetBitGE(index + 1)
+		u := nextPrefixRow
 
 		for l < u {
 			m := int(uint(l+u) >> 1) // avoid overflow when computing m
@@ -945,7 +950,7 @@ func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row 
 				l = m + 1 // preserves f(l-1) = false
 			}
 		}
-		return l
+		return l, l < nextPrefixRow
 	}
 
 	// Remove the terminator byte, which we know is equal to len(seekSuffix)
@@ -959,8 +964,9 @@ func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row 
 	//
 	// Define f(i) = true iff key at i is >= seek key (i.e. suffix at i is <= seek suffix).
 	// Invariant: f(l-1) == false, f(u) == true.
+	nextPrefixRow := ks.roachKeyChanged.SeekSetBitGE(index + 1)
 	l := index
-	u := ks.roachKeyChanged.SeekSetBitGE(index + 1)
+	u := nextPrefixRow
 	for l < u {
 		m := int(uint(l+u) >> 1) // avoid overflow when computing m
 		// l ≤ m < u
@@ -995,7 +1001,7 @@ func (ks *cockroachKeySeeker) seekGEOnSuffix(index int, seekSuffix []byte) (row 
 			l = m + 1 // preserves f(l-1) == false
 		}
 	}
-	return l
+	return l, l < nextPrefixRow
 }
 
 // MaterializeUserKey is part of the KeySeeker interface.

--- a/cockroachkvs/testdata/key_schema_key_seeker
+++ b/cockroachkvs/testdata/key_schema_key_seeker
@@ -101,18 +101,18 @@ zoo @ 9000000000,0
 ----
 SeekGE(apple @ 2000000000,0, boundRow=-1, searchDir=0) = (row=0, equalPrefix=false) [hex:6261720000000000b2d05e00000000010d]
 SeekGE(bar @ 4000000000,0, boundRow=-1, searchDir=0) = (row=0, equalPrefix=true) [hex:6261720000000000b2d05e00000000010d]
-SeekGE(bar @ 3000000000,0, boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00000000010d]
-SeekGE(bar @ 2000000000,0, boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00000000010d]
+SeekGE(bar @ 3000000000,0, boundRow=-1, searchDir=0) = (row=1, equalPrefix=false) [hex:6261780000000000b2d05e00000000010d]
+SeekGE(bar @ 2000000000,0, boundRow=-1, searchDir=0) = (row=1, equalPrefix=false) [hex:6261780000000000b2d05e00000000010d]
 SeekGE(bax @ 3000000000,1, boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00000000010d]
-SeekGE(bax @ 3000000000,0, boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00000000010d]
+SeekGE(bax @ 3000000000,0, boundRow=-1, searchDir=0) = (row=2, equalPrefix=false) [hex:666f6f0000000000b2d05e00000000010d]
 SeekGE(fax @ 9000000000,0, boundRow=-1, searchDir=0) = (row=2, equalPrefix=false) [hex:666f6f0000000000b2d05e00000000010d]
 SeekGE(foo @ 3000000000,2, boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00000000010d]
 SeekGE(foo @ 3000000000,1, boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00000000010d]
-SeekGE(foo @ 3000000000,0, boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00000000010d]
+SeekGE(foo @ 3000000000,0, boundRow=-1, searchDir=0) = (row=3, equalPrefix=false) [hex:6d6f6f0000000000b2d05e00000000010d]
 SeekGE(moo @ 3000000001,0, boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00000000010d]
 SeekGE(moo @ 3000000000,2, boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00000000010d]
 SeekGE(moo @ 3000000000,1, boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00000000010d]
-SeekGE(moo @ 3000000000,0, boundRow=-1, searchDir=0) = (row=4, equalPrefix=true)
+SeekGE(moo @ 3000000000,0, boundRow=-1, searchDir=0) = (row=4, equalPrefix=false)
 SeekGE(zoo @ 9000000000,0, boundRow=-1, searchDir=0) = (row=4, equalPrefix=false)
 
 materialize-user-key

--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -386,7 +386,7 @@ func (ks *defaultKeySeeker) SeekGE(
 	si := ks.comparer.Split(key)
 	row, eq := ks.prefixes.Search(key[:si])
 	if eq {
-		return ks.seekGEOnSuffix(row, key[si:]), true
+		return ks.seekGEOnSuffix(row, key[si:])
 	}
 	return row, false
 }
@@ -394,20 +394,23 @@ func (ks *defaultKeySeeker) SeekGE(
 // seekGEOnSuffix is a helper function for SeekGE when a seek key's prefix
 // exactly matches a row. seekGEOnSuffix finds the first row at index or later
 // with the same prefix as index and a suffix greater than or equal to [suffix],
-// or if no such row exists, the next row with a different prefix.
-func (ks *defaultKeySeeker) seekGEOnSuffix(index int, suffix []byte) (row int) {
+// or if no such row exists, the next row with a different prefix. equalPrefix
+// reports whether the returned row still has the same prefix as the seek key
+// (false when the search walked past the prefix group).
+func (ks *defaultKeySeeker) seekGEOnSuffix(index int, suffix []byte) (row int, equalPrefix bool) {
 	// The search key's prefix exactly matches the prefix of the row at index.
 	// If the row at index has a suffix >= [suffix], then return the row.
 	if ks.comparer.ComparePointSuffixes(ks.suffixes.At(index), suffix) >= 0 {
-		return index
+		return index, true
 	}
 	// Otherwise, the row at [index] sorts before the search key and we need to
 	// search forward. Binary search between [index+1, prefixChanged.SeekSetBitGE(index+1)].
 	//
 	// Define f(l-1) == false and f(u) == true.
 	// Invariant: f(l-1) == false, f(u) == true.
+	nextPrefixRow := ks.decoder.prefixChanged.SeekSetBitGE(index + 1)
 	l := index + 1
-	u := ks.decoder.prefixChanged.SeekSetBitGE(index + 1)
+	u := nextPrefixRow
 	for l < u {
 		h := int(uint(l+u) >> 1) // avoid overflow when computing h
 		// l ≤ h < u
@@ -417,7 +420,9 @@ func (ks *defaultKeySeeker) seekGEOnSuffix(index int, suffix []byte) (row int) {
 			l = h + 1 // preserves f(l-1) == false
 		}
 	}
-	return l
+	// If l == nextPrefixRow, no row in the prefix group satisfied the suffix
+	// constraint and we have walked into the next prefix group (or past maxRow).
+	return l, l < nextPrefixRow
 }
 
 // MaterializeUserKey is part of the colblk.KeySeeker interface.


### PR DESCRIPTION
Separating this from #5928

Both defaultKeySeeker.SeekGE (sstable/colblk) and cockroachKeySeeker.SeekGE
(cockroachkvs) unconditionally returned equalPrefix=true whenever the seek
key's prefix matched a row in the prefix-bytes column. The helper
seekGEOnSuffix, however, may walk past the matched prefix's last row when
no row in that prefix group has a suffix >= the seek suffix; in that case
it returns the first row of the next prefix group (or one past maxRow).
The caller mislabeled such results as having an equal prefix.

This commit changes seekGEOnSuffix in both keySeekers to also return
whether the resulting row still belongs to the seek key's prefix group
(i.e. whether the binary search stayed strictly below the next prefix
boundary), and propagates that value out of SeekGE.

In existing code, this return value is only used in a specific case
(synthetic suffix), where we pass a bare prefix (which cannot exercise
the bug).