### PR TITLE
crl-release-26.2: vfs: fix MemFS cloneMu recursive RLock deadlock

### DIFF
--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -85,6 +85,11 @@ type MemFS struct {
 
 	// cloneMu is used to block all modification operations while we clone the
 	// filesystem. Only used when crashable is true.
+	//
+	// Methods holding cloneMu must not call other public MemFS methods that also
+	// acquire cloneMu; use the unexported variants (rename, create) instead.
+	// Go's sync.RWMutex is writer-preferring, so recursive RLock deadlocks when
+	// a writer (CrashClone) is waiting.
 	cloneMu sync.RWMutex
 
 	// lockFiles holds a map of open file locks. Presence in this map indicates
@@ -224,6 +229,12 @@ func (y *MemFS) Create(fullname string, category DiskWriteCategory) (File, error
 		y.cloneMu.RLock()
 		defer y.cloneMu.RUnlock()
 	}
+	return y.create(fullname, category)
+}
+
+// create is the lock-free internal implementation of Create. The caller must
+// hold cloneMu when crashable is true.
+func (y *MemFS) create(fullname string, category DiskWriteCategory) (File, error) {
 	var ret *memFile
 	err := y.walk(fullname, func(dir *memNode, frag string, final bool) error {
 		if final {
@@ -281,8 +292,6 @@ func (y *MemFS) Link(oldname, newname string) error {
 			if frag == "" {
 				return errors.New("pebble/vfs: empty file name")
 			}
-			y.cloneMu.RLock()
-			defer y.cloneMu.RUnlock()
 			if _, ok := dir.children[frag]; ok {
 				return &os.LinkError{
 					Op:  "link",
@@ -423,6 +432,12 @@ func (y *MemFS) Rename(oldname, newname string) error {
 		y.cloneMu.RLock()
 		defer y.cloneMu.RUnlock()
 	}
+	return y.rename(oldname, newname)
+}
+
+// rename is the lock-free internal implementation of Rename. The caller must
+// hold cloneMu when crashable is true.
+func (y *MemFS) rename(oldname, newname string) error {
 	var n *memNode
 	err := y.walk(oldname, func(dir *memNode, frag string, final bool) error {
 		if final {
@@ -461,7 +476,7 @@ func (y *MemFS) ReuseForWrite(oldname, newname string, category DiskWriteCategor
 		y.cloneMu.RLock()
 		defer y.cloneMu.RUnlock()
 	}
-	if err := y.Rename(oldname, newname); err != nil {
+	if err := y.rename(oldname, newname); err != nil {
 		return nil, err
 	}
 	f, err := y.Open(newname)
@@ -530,7 +545,7 @@ func (y *MemFS) Lock(fullname string) (io.Closer, error) {
 	// directory. Create the path so that we have the normal detection of
 	// non-existent directory paths, and make the lock visible when listing
 	// directory entries.
-	f, err := y.Create(fullname, WriteCategoryUnspecified)
+	f, err := y.create(fullname, WriteCategoryUnspecified)
 	if err != nil {
 		// "Release" the lock since we failed.
 		y.lockedFiles.Delete(fullname)

--- a/vfs/mem_fs_test.go
+++ b/vfs/mem_fs_test.go
@@ -5,13 +5,16 @@
 package vfs
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand/v2"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
@@ -138,6 +141,117 @@ func TestMemFile(t *testing.T) {
 	if got := string(buf); got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
+}
+
+// TestMemFSCrashCloneConcurrency exercises concurrent CrashClone (write lock)
+// against ReuseForWrite, Link, and Lock (all of which take read locks and call
+// other methods that also take read locks). Before the fix in this package,
+// these methods would recursively acquire cloneMu.RLock(), deadlocking when
+// CrashClone was waiting for the write lock (Go's sync.RWMutex is
+// writer-preferring, blocking new RLocks behind a pending Lock).
+func TestMemFSCrashCloneConcurrency(t *testing.T) {
+	const workers = 4
+	const duration = 5 * time.Second
+
+	fs := NewCrashableMem()
+	// Pre-create a directory and seed files for ReuseForWrite and Link.
+	require.NoError(t, fs.MkdirAll("/d", 0755))
+	for i := 0; i < workers; i++ {
+		name := fmt.Sprintf("/d/src-%d", i)
+		f, err := fs.Create(name, WriteCategoryUnspecified)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	var g sync.WaitGroup
+
+	// CrashClone goroutines (writer lock).
+	for i := 0; i < workers; i++ {
+		g.Add(1)
+		go func() {
+			defer g.Done()
+			rng := rand.New(rand.NewPCG(0, uint64(i)))
+			for ctx.Err() == nil {
+				fs.CrashClone(CrashCloneCfg{UnsyncedDataPercent: 50, RNG: rng})
+			}
+		}()
+	}
+
+	// ReuseForWrite goroutines.
+	for i := 0; i < workers; i++ {
+		g.Add(1)
+		go func() {
+			defer g.Done()
+			a := fmt.Sprintf("/d/reuse-a-%d", i)
+			b := fmt.Sprintf("/d/reuse-b-%d", i)
+			// Seed initial file.
+			f, err := fs.Create(a, WriteCategoryUnspecified)
+			if err != nil {
+				return
+			}
+			_ = f.Close()
+			useA := true
+			for ctx.Err() == nil {
+				var from, to string
+				if useA {
+					from, to = a, b
+				} else {
+					from, to = b, a
+				}
+				f, err := fs.ReuseForWrite(from, to, WriteCategoryUnspecified)
+				if err != nil {
+					// File may have been removed by CrashClone side effects;
+					// recreate and retry.
+					f2, err2 := fs.Create(a, WriteCategoryUnspecified)
+					if err2 == nil {
+						_ = f2.Close()
+					}
+					useA = true
+					continue
+				}
+				_ = f.Close()
+				useA = !useA
+			}
+		}()
+	}
+
+	// Link goroutines.
+	for i := 0; i < workers; i++ {
+		g.Add(1)
+		go func() {
+			defer g.Done()
+			src := fmt.Sprintf("/d/src-%d", i)
+			n := 0
+			for ctx.Err() == nil {
+				dst := fmt.Sprintf("/d/link-%d-%d", i, n)
+				_ = fs.Link(src, dst)
+				// Clean up to avoid unbounded growth.
+				_ = fs.Remove(dst)
+				n++
+			}
+		}()
+	}
+
+	// Lock goroutines.
+	for i := 0; i < workers; i++ {
+		g.Add(1)
+		go func() {
+			defer g.Done()
+			name := fmt.Sprintf("/d/lock-%d", i)
+			for ctx.Err() == nil {
+				closer, err := fs.Lock(name)
+				if err != nil {
+					continue
+				}
+				_ = closer.Close()
+			}
+		}()
+	}
+
+	g.Wait()
 }
 
 func TestMemFSLock(t *testing.T) {


### PR DESCRIPTION
Backport of #5993 to crl-release-26.2.

## Summary

Cherry-pick of b47118f1 (master). Three MemFS methods deadlock against concurrent CrashClone due to recursive `cloneMu.RLock()`. See #5993 for full details.

Fixes #5987.