### PR TITLE
db: mark rowblk-format sstables for compaction at new format version

### DIFF
--- a/format_major_version.go
+++ b/format_major_version.go
@@ -677,53 +677,18 @@ func (d *DB) markFilesForCompactionLocked(findFn findFilesFunc) error {
 	}
 	jobID := d.newJobIDLocked()
 
-	// Acquire a read state to have a view of the LSM and a guarantee that none
-	// of the referenced files will be deleted until we've unreferenced the read
-	// state. Some findFilesFuncs may read the files, requiring they not be
-	// deleted.
-	rs := d.loadReadState()
-	var (
-		found bool
-		files [numLevels][]*manifest.TableMetadata
-		err   error
-	)
-	func() {
-		defer rs.unrefLocked()
-		// Note the unusual locking: unlock, defer Lock(). The scan of the files in
-		// the version does not need to block other operations that require the
-		// DB.mu. Drop it for the scan, before re-acquiring it.
-		d.mu.Unlock()
-		defer d.mu.Lock()
-		found, files, err = findFn(rs.current)
-	}()
-	if err != nil {
-		return err
-	}
-
-	// The database lock has been acquired again by the defer within the above
-	// anonymous function.
-	if !found {
-		// Nothing to do.
-		return nil
-	}
-
-	// After scanning, if we found files to mark, we fetch the current state of
-	// the LSM (which may have changed) and build the list of tables to mark for
-	// compaction.
-
-	// Lock the manifest for a coherent view of the LSM. The database lock has
-	// been re-acquired by the defer within the above anonymous function.
-	_, err = d.mu.versions.UpdateVersionLocked(func() (versionUpdate, error) {
-		var ve manifest.VersionEdit
+	// Run the scan and the version edit under the same DB.mu/manifest lock so
+	// they observe the same Version. This call site is a one-time format major
+	// version upgrade, so holding DB.mu across the scan is acceptable.
+	_, err := d.mu.versions.UpdateVersionLocked(func() (versionUpdate, error) {
 		vers := d.mu.versions.currentVersion()
+		found, files, err := findFn(vers)
+		if err != nil || !found {
+			return versionUpdate{}, err
+		}
+		var ve manifest.VersionEdit
 		for level, filesToMark := range files {
 			for _, f := range filesToMark {
-				// Ignore files to be marked that have already been compacted or marked.
-				if f.CompactionState == manifest.CompactionStateCompacted ||
-					vers.MarkedForCompaction.Contains(f, level) {
-					continue
-				}
-				// Else, mark the file for compaction in this version.
 				ve.TablesMarkedForCompaction = append(ve.TablesMarkedForCompaction, manifest.TableMarkedForCompactionEntry{
 					TableNum: f.TableNum,
 					Level:    level,

--- a/format_major_version.go
+++ b/format_major_version.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/blob"
+	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/atomicfs"
 )
@@ -257,6 +259,14 @@ const (
 	// ingesting blob files as part of local ingestions.
 	FormatIngestBlobFiles
 
+	// FormatRowblkMarkedForCompaction is a format major version that guarantees
+	// that all sstables with a row-based (pre-Pebblev5) data block format are
+	// marked for compaction in the manifest. Ratcheting to this version will
+	// block (without holding mutexes) until the LSM scan completes and the
+	// marks are persisted. A subsequent format major version will require all
+	// such marked tables to have been compacted.
+	FormatRowblkMarkedForCompaction
+
 	// -- Add new versions here --
 
 	// FormatNewest is the most recent format major version.
@@ -404,6 +414,12 @@ var formatMajorVersionMigrations = map[FormatMajorVersion]func(*DB) error{
 	},
 	FormatIngestBlobFiles: func(d *DB) error {
 		return d.finalizeFormatVersUpgrade(FormatIngestBlobFiles)
+	},
+	FormatRowblkMarkedForCompaction: func(d *DB) error {
+		if err := d.markFilesForCompactionLocked(findFilesRowblk(d)); err != nil {
+			return err
+		}
+		return d.finalizeFormatVersUpgrade(FormatRowblkMarkedForCompaction)
 	},
 }
 
@@ -616,6 +632,36 @@ func (d *DB) compactMarkedFilesLocked() error {
 		}
 	}
 	return nil
+}
+
+// findFilesRowblk returns a findFilesFunc that locates every sstable in the
+// LSM whose on-disk table format uses row-based (non-columnar) data blocks.
+// Virtual sstables are inspected via their backing physical file.
+func findFilesRowblk(d *DB) findFilesFunc {
+	return func(v *manifest.Version) (found bool, files [numLevels][]*manifest.TableMetadata, _ error) {
+		ctx := context.Background()
+		for l := range v.Levels {
+			for f := range v.Levels[l].All() {
+				var isRowblk bool
+				if err := d.fileCache.withReader(ctx, block.NoReadEnv, f,
+					func(r *sstable.Reader, _ sstable.ReadEnv) error {
+						format, err := r.TableFormat()
+						if err != nil {
+							return err
+						}
+						isRowblk = !format.BlockColumnar()
+						return nil
+					}); err != nil {
+					return false, files, err
+				}
+				if isRowblk {
+					files[l] = append(files[l], f)
+					found = true
+				}
+			}
+		}
+		return found, files, nil
+	}
 }
 
 // findFilesFunc scans the LSM for files, returning true if at least one

--- a/format_major_version_test.go
+++ b/format_major_version_test.go
@@ -41,11 +41,12 @@ func TestFormatMajorVersionStableValues(t *testing.T) {
 	require.Equal(t, FormatBackingValueSize, FormatMajorVersion(27))
 	require.Equal(t, FormatMarkForCompactionInVersionEdit, FormatMajorVersion(28))
 	require.Equal(t, FormatIngestBlobFiles, FormatMajorVersion(29))
+	require.Equal(t, FormatRowblkMarkedForCompaction, FormatMajorVersion(30))
 
 	// When we add a new version, we should add a check for the new version above
 	// in addition to updating the expected values below.
-	require.Equal(t, FormatNewest, FormatMajorVersion(29))
-	require.Equal(t, internalFormatNewest, FormatMajorVersion(29))
+	require.Equal(t, FormatNewest, FormatMajorVersion(30))
+	require.Equal(t, internalFormatNewest, FormatMajorVersion(30))
 }
 
 func TestFormatMajorVersion_MigrationDefined(t *testing.T) {
@@ -241,6 +242,7 @@ func TestFormatMajorVersions_TableFormat(t *testing.T) {
 		FormatBackingValueSize:                      {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 		FormatMarkForCompactionInVersionEdit:        {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 		FormatIngestBlobFiles:                       {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
+		FormatRowblkMarkedForCompaction:             {sstable.TableFormatPebblev1, sstable.TableFormatPebblev7},
 	}
 
 	// Valid versions.
@@ -270,6 +272,7 @@ func TestFormatMajorVersions_BlobFileFormat(t *testing.T) {
 		FormatBackingValueSize:               blob.FileFormatV2,
 		FormatMarkForCompactionInVersionEdit: blob.FileFormatV2,
 		FormatIngestBlobFiles:                blob.FileFormatV2,
+		FormatRowblkMarkedForCompaction:      blob.FileFormatV2,
 	}
 
 	// Valid versions.

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -990,12 +990,6 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 		blockFlush = false
 	)
 	cache := NewCache(0)
-	defer func() {
-		if d != nil && !closed {
-			require.NoError(t, d.Close())
-		}
-		cache.Unref()
-	}()
 	var fsLog struct {
 		sync.Mutex
 		buf bytes.Buffer
@@ -1171,6 +1165,10 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}
 	})
+	if d != nil && !closed {
+		require.NoError(t, d.Close())
+	}
+	cache.Unref()
 }
 
 func testIngestSharedImpl(

--- a/open_test.go
+++ b/open_test.go
@@ -579,7 +579,7 @@ func TestNewDBFilenames(t *testing.T) {
 			"LOCK",
 			"MANIFEST-000001",
 			"OPTIONS-000002",
-			"marker.format-version.000016.029",
+			fmt.Sprintf("marker.format-version.%06d.%03d", internalFormatNewest-FormatMinSupported, internalFormatNewest),
 			"marker.manifest.000001.MANIFEST-000001",
 		},
 	}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -106,6 +106,11 @@ sync: db/marker.format-version.000016.029
 close: db/marker.format-version.000016.029
 remove: db/marker.format-version.000015.028
 sync: db
+create: db/marker.format-version.000017.030
+sync: db/marker.format-version.000017.030
+close: db/marker.format-version.000017.030
+remove: db/marker.format-version.000016.029
+sync: db
 get-disk-usage: db
 
 batch db
@@ -170,9 +175,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000002
 close: checkpoints/checkpoint1/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.029
-close: checkpoints/checkpoint1/marker.format-version.000001.029
+create: checkpoints/checkpoint1/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.030
+close: checkpoints/checkpoint1/marker.format-version.000001.030
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 link: db/000005.sst -> checkpoints/checkpoint1/000005.sst
@@ -215,9 +220,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000002
 close: checkpoints/checkpoint2/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.029
-close: checkpoints/checkpoint2/marker.format-version.000001.029
+create: checkpoints/checkpoint2/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.030
+close: checkpoints/checkpoint2/marker.format-version.000001.030
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 link: db/000007.sst -> checkpoints/checkpoint2/000007.sst
@@ -255,9 +260,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000002
 close: checkpoints/checkpoint3/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.029
-close: checkpoints/checkpoint3/marker.format-version.000001.029
+create: checkpoints/checkpoint3/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.030
+close: checkpoints/checkpoint3/marker.format-version.000001.030
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 link: db/000005.sst -> checkpoints/checkpoint3/000005.sst
@@ -344,7 +349,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000002
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 list checkpoints/checkpoint1
@@ -354,7 +359,7 @@ list checkpoints/checkpoint1
 000007.sst
 MANIFEST-000001
 OPTIONS-000002
-marker.format-version.000001.029
+marker.format-version.000001.030
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint1 readonly
@@ -422,7 +427,7 @@ list checkpoints/checkpoint2
 000007.sst
 MANIFEST-000001
 OPTIONS-000002
-marker.format-version.000001.029
+marker.format-version.000001.030
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint2 readonly
@@ -465,7 +470,7 @@ list checkpoints/checkpoint3
 000007.sst
 MANIFEST-000001
 OPTIONS-000002
-marker.format-version.000001.029
+marker.format-version.000001.030
 marker.manifest.000001.MANIFEST-000001
 
 open checkpoints/checkpoint3 readonly
@@ -585,9 +590,9 @@ sync-data: checkpoints/checkpoint4/OPTIONS-000002
 close: checkpoints/checkpoint4/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint4
-create: checkpoints/checkpoint4/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint4/marker.format-version.000001.029
-close: checkpoints/checkpoint4/marker.format-version.000001.029
+create: checkpoints/checkpoint4/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint4/marker.format-version.000001.030
+close: checkpoints/checkpoint4/marker.format-version.000001.030
 sync: checkpoints/checkpoint4
 close: checkpoints/checkpoint4
 link: db/000010.sst -> checkpoints/checkpoint4/000010.sst
@@ -677,7 +682,7 @@ list db
 LOCK
 MANIFEST-000001
 OPTIONS-000002
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 
@@ -696,9 +701,9 @@ sync-data: checkpoints/checkpoint5/OPTIONS-000002
 close: checkpoints/checkpoint5/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint5
-create: checkpoints/checkpoint5/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint5/marker.format-version.000001.029
-close: checkpoints/checkpoint5/marker.format-version.000001.029
+create: checkpoints/checkpoint5/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint5/marker.format-version.000001.030
+close: checkpoints/checkpoint5/marker.format-version.000001.030
 sync: checkpoints/checkpoint5
 close: checkpoints/checkpoint5
 link: db/000010.sst -> checkpoints/checkpoint5/000010.sst
@@ -803,9 +808,9 @@ sync-data: checkpoints/checkpoint6/OPTIONS-000002
 close: checkpoints/checkpoint6/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint6
-create: checkpoints/checkpoint6/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint6/marker.format-version.000001.029
-close: checkpoints/checkpoint6/marker.format-version.000001.029
+create: checkpoints/checkpoint6/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint6/marker.format-version.000001.030
+close: checkpoints/checkpoint6/marker.format-version.000001.030
 sync: checkpoints/checkpoint6
 close: checkpoints/checkpoint6
 link: db/000011.sst -> checkpoints/checkpoint6/000011.sst
@@ -1030,6 +1035,11 @@ sync: valsepdb/marker.format-version.000016.029
 close: valsepdb/marker.format-version.000016.029
 remove: valsepdb/marker.format-version.000015.028
 sync: valsepdb
+create: valsepdb/marker.format-version.000017.030
+sync: valsepdb/marker.format-version.000017.030
+close: valsepdb/marker.format-version.000017.030
+remove: valsepdb/marker.format-version.000016.029
+sync: valsepdb
 get-disk-usage: valsepdb
 
 batch valsepdb
@@ -1075,9 +1085,9 @@ sync-data: checkpoints/checkpoint8/OPTIONS-000002
 close: checkpoints/checkpoint8/OPTIONS-000002
 close: valsepdb/OPTIONS-000002
 open-dir: checkpoints/checkpoint8
-create: checkpoints/checkpoint8/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint8/marker.format-version.000001.029
-close: checkpoints/checkpoint8/marker.format-version.000001.029
+create: checkpoints/checkpoint8/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint8/marker.format-version.000001.030
+close: checkpoints/checkpoint8/marker.format-version.000001.030
 sync: checkpoints/checkpoint8
 close: checkpoints/checkpoint8
 link: valsepdb/000006.blob -> checkpoints/checkpoint8/000006.blob
@@ -1192,9 +1202,9 @@ sync-data: checkpoints/checkpoint9/OPTIONS-000002
 close: checkpoints/checkpoint9/OPTIONS-000002
 close: valsepdb/OPTIONS-000002
 open-dir: checkpoints/checkpoint9
-create: checkpoints/checkpoint9/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint9/marker.format-version.000001.029
-close: checkpoints/checkpoint9/marker.format-version.000001.029
+create: checkpoints/checkpoint9/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint9/marker.format-version.000001.030
+close: checkpoints/checkpoint9/marker.format-version.000001.030
 sync: checkpoints/checkpoint9
 close: checkpoints/checkpoint9
 link: valsepdb/000006.blob -> checkpoints/checkpoint9/000006.blob

--- a/testdata/checkpoint_shared
+++ b/testdata/checkpoint_shared
@@ -91,6 +91,11 @@ sync: db/marker.format-version.000013.029
 close: db/marker.format-version.000013.029
 remove: db/marker.format-version.000012.028
 sync: db
+create: db/marker.format-version.000014.030
+sync: db/marker.format-version.000014.030
+close: db/marker.format-version.000014.030
+remove: db/marker.format-version.000013.029
+sync: db
 get-disk-usage: db
 create: db/REMOTE-OBJ-CATALOG-000001
 sync: db/REMOTE-OBJ-CATALOG-000001
@@ -157,9 +162,9 @@ sync-data: checkpoints/checkpoint1/OPTIONS-000002
 close: checkpoints/checkpoint1/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint1
-create: checkpoints/checkpoint1/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint1/marker.format-version.000001.029
-close: checkpoints/checkpoint1/marker.format-version.000001.029
+create: checkpoints/checkpoint1/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint1/marker.format-version.000001.030
+close: checkpoints/checkpoint1/marker.format-version.000001.030
 sync: checkpoints/checkpoint1
 close: checkpoints/checkpoint1
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -212,9 +217,9 @@ sync-data: checkpoints/checkpoint2/OPTIONS-000002
 close: checkpoints/checkpoint2/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint2
-create: checkpoints/checkpoint2/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint2/marker.format-version.000001.029
-close: checkpoints/checkpoint2/marker.format-version.000001.029
+create: checkpoints/checkpoint2/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint2/marker.format-version.000001.030
+close: checkpoints/checkpoint2/marker.format-version.000001.030
 sync: checkpoints/checkpoint2
 close: checkpoints/checkpoint2
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -263,9 +268,9 @@ sync-data: checkpoints/checkpoint3/OPTIONS-000002
 close: checkpoints/checkpoint3/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoints/checkpoint3
-create: checkpoints/checkpoint3/marker.format-version.000001.029
-sync-data: checkpoints/checkpoint3/marker.format-version.000001.029
-close: checkpoints/checkpoint3/marker.format-version.000001.029
+create: checkpoints/checkpoint3/marker.format-version.000001.030
+sync-data: checkpoints/checkpoint3/marker.format-version.000001.030
+close: checkpoints/checkpoint3/marker.format-version.000001.030
 sync: checkpoints/checkpoint3
 close: checkpoints/checkpoint3
 open: db/MANIFEST-000001 (options: *vfs.sequentialReadsOption)
@@ -326,7 +331,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000002
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000013.029
+marker.format-version.000014.030
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -336,7 +341,7 @@ list checkpoints/checkpoint1
 MANIFEST-000001
 OPTIONS-000002
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.029
+marker.format-version.000001.030
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 
@@ -389,7 +394,7 @@ list checkpoints/checkpoint2
 MANIFEST-000001
 OPTIONS-000002
 REMOTE-OBJ-CATALOG-000001
-marker.format-version.000001.029
+marker.format-version.000001.030
 marker.manifest.000001.MANIFEST-000001
 marker.remote-obj-catalog.000001.REMOTE-OBJ-CATALOG-000001
 

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -130,6 +130,12 @@ close: db/marker.format-version.000016.029
 remove: db/marker.format-version.000015.028
 sync: db
 upgraded to format version: 029
+create: db/marker.format-version.000017.030
+sync: db/marker.format-version.000017.030
+close: db/marker.format-version.000017.030
+remove: db/marker.format-version.000016.029
+sync: db
+upgraded to format version: 030
 get-disk-usage: db
 
 flush
@@ -139,10 +145,10 @@ sync-data: wal/000003.log
 close: wal/000003.log
 create: wal/000004.log
 sync: wal
-[JOB 2] WAL created 000004
-[JOB 3] flushing 1 memtable (100B) to L0
+[JOB 3] WAL created 000004
+[JOB 4] flushing 1 memtable (100B) to L0
 create: db/000005.sst
-[JOB 3] flushing: sstable created 000005
+[JOB 4] flushing: sstable created 000005
 sync-data: db/000005.sst
 close: db/000005.sst
 sync: db
@@ -156,8 +162,8 @@ sync: db/marker.manifest.000002.MANIFEST-000006
 close: db/marker.manifest.000002.MANIFEST-000006
 remove: db/marker.manifest.000001.MANIFEST-000001
 sync: db
-[JOB 3] MANIFEST created 000006
-[JOB 3] flushed 1 memtable (100B) to L0 [000005] (688B), in 1.0s (3.0s total), output rate 688B/s
+[JOB 4] MANIFEST created 000006
+[JOB 4] flushed 1 memtable (100B) to L0 [000005] (688B), in 1.0s (3.0s total), output rate 688B/s
 
 compact
 ----
@@ -166,10 +172,10 @@ sync-data: wal/000004.log
 close: wal/000004.log
 reuseForWrite: wal/000003.log -> wal/000007.log
 sync: wal
-[JOB 4] WAL created 000007 (recycled 000003)
-[JOB 5] flushing 1 memtable (100B) to L0
+[JOB 5] WAL created 000007 (recycled 000003)
+[JOB 6] flushing 1 memtable (100B) to L0
 create: db/000008.sst
-[JOB 5] flushing: sstable created 000008
+[JOB 6] flushing: sstable created 000008
 sync-data: db/000008.sst
 close: db/000008.sst
 sync: db
@@ -183,11 +189,11 @@ sync: db/marker.manifest.000003.MANIFEST-000009
 close: db/marker.manifest.000003.MANIFEST-000009
 remove: db/marker.manifest.000002.MANIFEST-000006
 sync: db
-[JOB 5] MANIFEST created 000009
-[JOB 5] flushed 1 memtable (100B) to L0 [000008] (688B), in 1.0s (3.0s total), output rate 688B/s
+[JOB 6] MANIFEST created 000009
+[JOB 6] flushed 1 memtable (100B) to L0 [000008] (688B), in 1.0s (3.0s total), output rate 688B/s
 remove: db/MANIFEST-000001
-[JOB 5] MANIFEST deleted 000001
-[JOB 6] compacting(default) L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00; OverlappingRatio: Single 0.00, Multi 0.00
+[JOB 6] MANIFEST deleted 000001
+[JOB 7] compacting(default) L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00; OverlappingRatio: Single 0.00, Multi 0.00
 open: db/000005.sst (options: *vfs.randomReadsOption)
 read-at(627, 61): db/000005.sst
 read-at(577, 50): db/000005.sst
@@ -205,7 +211,7 @@ read-at(0, 78): db/000008.sst
 close: db/000008.sst
 close: db/000005.sst
 create: db/000010.sst
-[JOB 6] compacting: sstable created 000010
+[JOB 7] compacting: sstable created 000010
 sync-data: db/000010.sst
 close: db/000010.sst
 sync: db
@@ -219,16 +225,16 @@ sync: db/marker.manifest.000004.MANIFEST-000011
 close: db/marker.manifest.000004.MANIFEST-000011
 remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
-[JOB 6] MANIFEST created 000011
-[JOB 6] compacted(default) write-blobs-input-depth-zero L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (683B), in 1.0s (4.0s total), output rate 683B/s
+[JOB 7] MANIFEST created 000011
+[JOB 7] compacted(default) write-blobs-input-depth-zero L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (683B), in 1.0s (4.0s total), output rate 683B/s
 close: db/000005.sst
 close: db/000008.sst
 remove: db/MANIFEST-000006
-[JOB 6] MANIFEST deleted 000006
+[JOB 7] MANIFEST deleted 000006
 remove: db/000005.sst
-[JOB 6] sstable deleted 000005
+[JOB 7] sstable deleted 000005
 remove: db/000008.sst
-[JOB 6] sstable deleted 000008
+[JOB 7] sstable deleted 000008
 
 disable-file-deletions
 ----
@@ -240,10 +246,10 @@ sync-data: wal/000007.log
 close: wal/000007.log
 reuseForWrite: wal/000004.log -> wal/000012.log
 sync: wal
-[JOB 7] WAL created 000012 (recycled 000004)
-[JOB 8] flushing 1 memtable (100B) to L0
+[JOB 8] WAL created 000012 (recycled 000004)
+[JOB 9] flushing 1 memtable (100B) to L0
 create: db/000013.sst
-[JOB 8] flushing: sstable created 000013
+[JOB 9] flushing: sstable created 000013
 sync-data: db/000013.sst
 close: db/000013.sst
 sync: db
@@ -257,13 +263,13 @@ sync: db/marker.manifest.000005.MANIFEST-000014
 close: db/marker.manifest.000005.MANIFEST-000014
 remove: db/marker.manifest.000004.MANIFEST-000011
 sync: db
-[JOB 8] MANIFEST created 000014
-[JOB 8] flushed 1 memtable (100B) to L0 [000013] (688B), in 1.0s (3.0s total), output rate 688B/s
+[JOB 9] MANIFEST created 000014
+[JOB 9] flushed 1 memtable (100B) to L0 [000013] (688B), in 1.0s (3.0s total), output rate 688B/s
 
 enable-file-deletions
 ----
 remove: db/MANIFEST-000009
-[JOB 9] MANIFEST deleted 000009
+[JOB 10] MANIFEST deleted 000009
 
 ingest
 ----
@@ -276,7 +282,7 @@ read-at(81, 41): ext/0
 read-at(0, 81): ext/0
 close: ext/0
 link: ext/0 -> db/000015.sst
-[JOB 10] ingesting: sstable created 000015
+[JOB 11] ingesting: sstable created 000015
 sync: db
 create: db/MANIFEST-000016
 close: db/MANIFEST-000014
@@ -287,11 +293,11 @@ sync: db/marker.manifest.000006.MANIFEST-000016
 close: db/marker.manifest.000006.MANIFEST-000016
 remove: db/marker.manifest.000005.MANIFEST-000014
 sync: db
-[JOB 10] MANIFEST created 000016
+[JOB 11] MANIFEST created 000016
 remove: db/MANIFEST-000011
-[JOB 10] MANIFEST deleted 000011
+[JOB 11] MANIFEST deleted 000011
 remove: ext/0
-[JOB 10] ingested L0:000015 (652B); manifest update took 0.1s; block reads took 0.3s with 7.7KB block bytes read
+[JOB 11] ingested L0:000015 (652B); manifest update took 0.1s; block reads took 0.3s with 7.7KB block bytes read
 
 metrics
 ----
@@ -414,39 +420,39 @@ read-at(81, 41): ext/b
 read-at(0, 81): ext/b
 close: ext/b
 link: ext/a -> db/000017.sst
-[JOB 11] ingesting: sstable created 000017
+[JOB 12] ingesting: sstable created 000017
 link: ext/b -> db/000018.sst
-[JOB 11] ingesting: sstable created 000018
+[JOB 12] ingesting: sstable created 000018
 sync: db
 sync-data: wal/000012.log
 close: wal/000012.log
 reuseForWrite: wal/000007.log -> wal/000019.log
 sync: wal
-[JOB 12] WAL created 000019 (recycled 000007)
+[JOB 13] WAL created 000019 (recycled 000007)
 sync-data: wal/000019.log
 sync-data: wal/000019.log
 close: wal/000019.log
 create: wal/000020.log
 sync: wal
-[JOB 13] WAL created 000020
+[JOB 14] WAL created 000020
 remove: ext/a
 remove: ext/b
-[JOB 11] ingested as flushable, memtable flushes took 0.2s: 000017 (652B), 000018 (652B); manifest update took 0.1s; block reads took 0.3s with 7.7KB block bytes read
+[JOB 12] ingested as flushable, memtable flushes took 0.2s: 000017 (652B), 000018 (652B); manifest update took 0.1s; block reads took 0.3s with 7.7KB block bytes read
 sync-data: wal/000020.log
 close: wal/000020.log
 create: wal/000021.log
 sync: wal
-[JOB 14] WAL created 000021
-[JOB 15] flushing 1 memtable (100B) to L0
+[JOB 15] WAL created 000021
+[JOB 16] flushing 1 memtable (100B) to L0
 create: db/000022.sst
-[JOB 15] flushing: sstable created 000022
+[JOB 16] flushing: sstable created 000022
 sync-data: db/000022.sst
 close: db/000022.sst
 sync: db
 get-disk-usage: db
 sync: db/MANIFEST-000016
-[JOB 15] flushed 1 memtable (100B) to L0 [000022] (688B), in 1.0s (3.0s total), output rate 688B/s
-[JOB 16] flushing 2 ingested tables
+[JOB 16] flushed 1 memtable (100B) to L0 [000022] (688B), in 1.0s (3.0s total), output rate 688B/s
+[JOB 17] flushing 2 ingested tables
 create: db/MANIFEST-000023
 close: db/MANIFEST-000016
 sync: db
@@ -456,14 +462,14 @@ sync: db/marker.manifest.000007.MANIFEST-000023
 close: db/marker.manifest.000007.MANIFEST-000023
 remove: db/marker.manifest.000006.MANIFEST-000016
 sync: db
-[JOB 16] MANIFEST created 000023
-[JOB 16] flushed 2 ingested flushables L0:000017 (652B) + L6:000018 (652B) in 1.0s (3.0s total), output rate 1.3KB/s
+[JOB 17] MANIFEST created 000023
+[JOB 17] flushed 2 ingested flushables L0:000017 (652B) + L6:000018 (652B) in 1.0s (3.0s total), output rate 1.3KB/s
 remove: db/MANIFEST-000014
-[JOB 16] MANIFEST deleted 000014
-[JOB 17] flushing 1 memtable (100B) to L0
+[JOB 17] MANIFEST deleted 000014
+[JOB 18] flushing 1 memtable (100B) to L0
 get-disk-usage: db
 sync: db/MANIFEST-000023
-[JOB 17] flush error: pebble: empty table
+[JOB 18] flush error: pebble: empty table
 
 metrics
 ----
@@ -586,9 +592,9 @@ sync-data: checkpoint/OPTIONS-000002
 close: checkpoint/OPTIONS-000002
 close: db/OPTIONS-000002
 open-dir: checkpoint
-create: checkpoint/marker.format-version.000001.029
-sync-data: checkpoint/marker.format-version.000001.029
-close: checkpoint/marker.format-version.000001.029
+create: checkpoint/marker.format-version.000001.030
+sync-data: checkpoint/marker.format-version.000001.030
+close: checkpoint/marker.format-version.000001.030
 sync: checkpoint
 close: checkpoint
 link: db/000013.sst -> checkpoint/000013.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -38,7 +38,7 @@ ext
 ext1
 ext2
 ext3
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 # Ingest can complete despite the flush being blocked.
@@ -62,7 +62,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000002
 ext
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 allowFlush
@@ -96,7 +96,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000002
 ext
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 # Test basic WAL replay
@@ -117,7 +117,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000002
 ext
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -210,7 +210,7 @@ MANIFEST-000001
 OPTIONS-000002
 ext
 ext5
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 allowFlush
@@ -440,7 +440,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000002
 ext
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -460,7 +460,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000002
 ext
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 open
@@ -493,7 +493,7 @@ MANIFEST-000001
 MANIFEST-000012
 OPTIONS-000010
 ext
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000002.MANIFEST-000012
 
 # Make sure that the new mutable memtable can accept writes.
@@ -636,7 +636,7 @@ LOCK
 MANIFEST-000001
 OPTIONS-000002
 ext
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 close
@@ -655,7 +655,7 @@ MANIFEST-000001
 OPTIONS-000002
 ext
 ext1
-marker.format-version.000016.029
+marker.format-version.000017.030
 marker.manifest.000001.MANIFEST-000001
 
 open

--- a/tool/db.go
+++ b/tool/db.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/record"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/cockroachdb/pebble/tool/logs"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/spf13/cobra"
@@ -372,6 +373,7 @@ func (d *dbT) loadOptions(dir string) error {
 		return nil
 	}
 
+	var dbOpts pebble.Options
 	hooks := &pebble.ParseHooks{
 		NewComparer: func(name string) (*pebble.Comparer, error) {
 			if c := d.comparers[name]; c != nil {
@@ -385,13 +387,28 @@ func (d *dbT) loadOptions(dir string) error {
 			}
 			return nil, errors.Errorf("unknown merger %q", errors.Safe(name))
 		},
+		NewKeySchema: func(name string) (pebble.KeySchema, error) {
+			if s, ok := d.opts.KeySchemas[name]; ok {
+				return *s, nil
+			}
+			// Fall back to a default key schema for the comparer loaded
+			// from OPTIONS. This mirrors what pebble.Options.ensureDefaults
+			// would do if no KeySchema were configured.
+			cmp := dbOpts.Comparer
+			if cmp == nil {
+				cmp = d.opts.Comparer
+			}
+			if cmp == nil {
+				cmp = base.DefaultComparer
+			}
+			return colblk.DefaultKeySchema(cmp, 16 /* bundleSize */), nil
+		},
 	}
 
 	// TODO(peter): RocksDB sometimes leaves multiple OPTIONS files in
 	// existence. We parse all of them as the comparer and merger shouldn't be
 	// changing. We could parse only the first or the latest. Not clear if this
 	// matters.
-	var dbOpts pebble.Options
 	for _, filename := range ls {
 		ft, _, ok := base.ParseFilename(d.opts.FS, filename)
 		if !ok {
@@ -428,6 +445,17 @@ func (d *dbT) loadOptions(dir string) error {
 	if dbOpts.Merger != nil {
 		d.opts.Merger = dbOpts.Merger
 	}
+	if dbOpts.KeySchema != "" {
+		d.opts.KeySchema = dbOpts.KeySchema
+	}
+	for name, schema := range dbOpts.KeySchemas {
+		if d.opts.KeySchemas == nil {
+			d.opts.KeySchemas = make(map[string]*pebble.KeySchema)
+		}
+		if _, ok := d.opts.KeySchemas[name]; !ok {
+			d.opts.KeySchemas[name] = schema
+		}
+	}
 	return nil
 }
 
@@ -461,6 +489,13 @@ func (d *dbT) openDBInternal(dir string, openOptions ...OpenOption) (*pebble.DB,
 	}
 	opts.Cache = nil
 	opts.CacheSize = 128 * 1024 * 1024
+	// If the configured KeySchema isn't registered, clear it so that
+	// pebble.Options.ensureDefaults derives a DefaultKeySchema for the
+	// configured Comparer.
+	if _, ok := opts.KeySchemas[opts.KeySchema]; !ok {
+		opts.KeySchema = ""
+		opts.KeySchemas = nil
+	}
 	return pebble.Open(dir, &opts)
 }
 

--- a/tool/testdata/db_upgrade
+++ b/tool/testdata/db_upgrade
@@ -27,7 +27,7 @@ db get foo yellow
 db upgrade foo
 ----
 ----
-Upgrading DB from internal version 16 to 29.
+Upgrading DB from internal version 16 to 30.
 WARNING!!!
 This DB will not be usable with older versions of Pebble!
 
@@ -43,7 +43,7 @@ Continue? [Y/N] Error: EOF
 
 db upgrade foo --yes
 ----
-Upgrading DB from internal version 16 to 29.
+Upgrading DB from internal version 16 to 30.
 Upgrade complete.
 
 db get foo blue
@@ -56,4 +56,4 @@ db get foo yellow
 
 db upgrade foo
 ----
-DB is already at internal version 29.
+DB is already at internal version 30.


### PR DESCRIPTION
Pebble has supported the columnar (`colblk`) sstable data block format
since `FormatColumnarBlocks` (`TableFormatPebblev5`); the older
row-based (`rowblk`) format is now considered deprecated.

This change adds `FormatRowblkMarkedForCompaction`, whose ratchet
migration marks every existing `rowblk` sstable for compaction so that
normal background rewrite compactions rewrite them in the columnar
format. A follow-up format major version (planned later) will block the
ratchet until the marked set is empty, at which point `rowblk` support
can be removed.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>