### PR TITLE
tool: fix sstable check panic on blob references

### DIFF
--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -178,18 +178,21 @@ func (s *sstableT) runCheck(cmd *cobra.Command, args []string) {
 	s.foreachSstable(stderr, args, func(path string, r *sstable.Reader, props sstable.Properties) {
 		fmt.Fprintf(stdout, "%s\n", path)
 
+		if err := r.ValidateBlockChecksums(); err != nil {
+			fmt.Fprintf(stdout, "  checksum validation failed: %s\n", err)
+		}
+
 		// Update the internal formatter if this comparator has one specified.
 		s.fmtKey.setForComparer(props.ComparerName, s.comparers)
 		s.fmtValue.setForComparer(props.ComparerName, s.comparers)
 
-		iter, err := r.NewIter(sstable.NoTransforms, nil, nil, sstable.AssertNoBlobHandles)
+		iter, err := r.NewIter(sstable.NoTransforms, nil, nil, sstable.DebugHandlesBlobContext)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
 			return
 		}
 
-		// Verify that SeekPrefixGE can find every key in the table.
-		prefixIter, err := r.NewIter(sstable.NoTransforms, nil, nil, sstable.AssertNoBlobHandles)
+		prefixIter, err := r.NewIter(sstable.NoTransforms, nil, nil, sstable.DebugHandlesBlobContext)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s\n", err)
 			return

--- a/tool/testdata/sstable_check
+++ b/tool/testdata/sstable_check
@@ -50,3 +50,8 @@ sstable check
 testdata/bad-magic-sst/000015.sst
 ----
 000015.sst: pebble/table: invalid table 000015: (bad magic number: 0xf6cff485b741e288)
+
+sstable check
+testdata/find-val-sep-db/000005.sst
+----
+000005.sst


### PR DESCRIPTION
## Summary
- `sstable check` panics with "blob references not configured" when encountering SSTables containing blob value references.
- Switch blob context from `AssertNoBlobHandles` to `DebugHandlesBlobContext` so the iterator decodes blob handles as debug strings instead of panicking.
- Add `ValidateBlockChecksums()` as the first check, which the command's description ("verify checksums and metadata") promises but was not previously done.

## Test plan
- [x] Reproduced the panic using `tool/testdata/find-val-sep-db/000005.sst` (SST with blob references)
- [x] Verified the fix eliminates the panic
- [x] Added datadriven test case for `sstable check` on an SST with blob references
- [x] Existing `TestSSTable` tests pass

Fixes #5967