### PR TITLE
iterv2: lazy combined iteration using a trigger iterator

### DIFF
--- a/db.go
+++ b/db.go
@@ -1204,8 +1204,7 @@ func finishInitializingIter(ctx context.Context, buf *iterAlloc) *Iterator {
 		useLazyCombinedIteration := dbi.rangeKey == nil &&
 			dbi.opts.KeyTypes == IterKeyTypePointsAndRanges &&
 			(dbi.batch == nil || dbi.batch.batch.countRangeKeys == 0) &&
-			!dbi.opts.disableLazyCombinedIteration &&
-			!iterv2.Enabled
+			!dbi.opts.disableLazyCombinedIteration
 		if useLazyCombinedIteration {
 			// The user requested combined iteration, and there's no indexed
 			// batch currently containing range keys that would prevent lazy
@@ -1226,6 +1225,12 @@ func finishInitializingIter(ctx context.Context, buf *iterAlloc) *Iterator {
 				combinedIterState: combinedIterState{
 					initialized: false,
 				},
+			}
+			if iterv2.Enabled && !dbi.batchOnlyIter {
+				// The TriggerIter is the first level of mergingIterV2.
+				// Arm it so it fires when iteration enters a region with
+				// possible range-key sets.
+				dbi.triggerIter.Reset(&dbi.lazyCombinedIter.combinedIterState)
 			}
 			dbi.iter = &dbi.lazyCombinedIter
 			dbi.iter = invalidating.MaybeWrapIfInvariants(dbi.iter)
@@ -1443,6 +1448,25 @@ func (i *Iterator) constructPointIterV2(
 ) {
 	var v2iters []iterv2.Iter
 
+	var current *manifest.Version
+	if !i.batchOnlyIter {
+		if i.version != nil {
+			current = i.version
+		} else {
+			current = i.readState.current
+		}
+		// Always include the TriggerIter as the first level. It's a no-op
+		// unless armed; finishInitializingIter and SetOptions arm it via
+		// Reset() when lazy combined iteration is desired.
+		i.triggerIter.Init(
+			i.comparer.Compare,
+			&current.RangeKeySetRegions,
+			nil, /* trigger */
+			i.opts.LowerBound, i.opts.UpperBound,
+		)
+		v2iters = append(v2iters, &i.triggerIter)
+	}
+
 	// 1. Batch iterator (if any).
 	if i.batch != nil {
 		if i.batch.batch.index == nil {
@@ -1485,12 +1509,6 @@ func (i *Iterator) constructPointIterV2(
 		}
 
 		// 3. Level iterators: L0 sublevels followed by L1+.
-		var current *manifest.Version
-		if i.version != nil {
-			current = i.version
-		} else {
-			current = i.readState.current
-		}
 		i.opts.snapshotForHideObsoletePoints = buf.dbi.seqNum
 
 		addLevelIterV2 := func(files manifest.LevelIterator, layer manifest.Layer) {
@@ -1524,6 +1542,11 @@ func (i *Iterator) constructPointIterV2(
 	m.stats = &i.stats.InternalStats
 	if i.batch != nil {
 		m.slab.batchSnapshot = i.batch.batchSeqNum
+		// The batch follows the TriggerIter if one was inserted (i.e. when
+		// !batchOnlyIter); otherwise the batch is the first level.
+		if !i.batchOnlyIter {
+			m.slab.batchLevelIdx = 1
+		}
 	}
 	i.pointIter = invalidating.MaybeWrapIfInvariants(m).(topLevelIterator)
 	i.mergingV2 = m

--- a/internal/iterv2/testdata/trigger_iter
+++ b/internal/iterv2/testdata/trigger_iter
@@ -1,0 +1,413 @@
+# Single region [b, g). Tests SeekGE before, inside, and past the region.
+
+define
+[b, g)=1
+[m, p)=2
+----
+[b, g)=1
+[m, p)=2
+
+# SeekGE before a region: returns BOUNDARY at region start; Next triggers.
+iter
+seek-ge a
+----
+seek-ge a: b#inf,BDRY [?, b):{}
+
+continue
+next
+----
+next: .
+trigger: b(fwd)
+
+# SeekGE inside a region: immediate trigger, nil returned.
+iter
+seek-ge c
+----
+seek-ge c: .
+trigger: c(fwd)
+
+# SeekGE past all regions: nil.
+iter
+seek-ge z
+----
+seek-ge z: .
+
+# SeekGE between regions: BOUNDARY at second region start.
+iter
+seek-ge h
+next
+----
+seek-ge h: m#inf,BDRY [?, m):{}
+next:      .
+trigger: m(fwd)
+
+# SeekGE at exact region start: immediate trigger.
+iter
+seek-ge b
+----
+seek-ge b: .
+trigger: b(fwd)
+
+# SeekLT after a region: BOUNDARY at region end; Prev triggers.
+iter
+seek-lt h
+prev
+----
+seek-lt h: g#inf,BDRY [g, ?):{}
+prev:      .
+trigger: g(bwd)
+
+# SeekLT inside a region: immediate trigger.
+iter
+seek-lt d
+----
+seek-lt d: .
+trigger: d(bwd)
+
+# SeekLT before all regions: nil.
+iter
+seek-lt a
+----
+seek-lt a: .
+
+# First: returns boundary at first region start; Next triggers.
+iter
+first
+next
+----
+first: b#inf,BDRY [?, b):{}
+next:  .
+trigger: b(fwd)
+
+# SeekLT past all regions: BOUNDARY at last region end; Prev triggers.
+iter upper=z
+seek-lt z
+prev
+----
+seek-lt z: p#inf,BDRY [p, ?):{}
+prev:      .
+trigger: p(bwd)
+
+# Last with no upper bound.
+iter
+last
+prev
+----
+last: p#inf,BDRY [p, ?):{}
+prev: .
+trigger: p(bwd)
+
+# Multiple regions: only the nearest triggers.
+iter
+seek-ge a
+next
+----
+seek-ge a: b#inf,BDRY [?, b):{}
+next:      .
+trigger: b(fwd)
+
+# After trigger, all ops return nil.
+iter
+seek-ge c
+----
+seek-ge c: .
+trigger: c(fwd)
+
+continue
+first
+last
+seek-ge a
+seek-lt z
+next
+prev
+----
+first:     .
+last:      .
+seek-ge a: .
+seek-lt z: .
+next:      .
+prev:      .
+
+# SetBounds narrowing excludes regions.
+iter lower=h upper=k
+seek-ge h
+----
+seek-ge h: .
+
+# SetBounds that includes a region.
+iter lower=b upper=h
+seek-ge b
+----
+seek-ge b: .
+trigger: b(fwd)
+
+continue
+next
+----
+next: .
+
+# SetBounds between the two regions.
+iter lower=g upper=m
+seek-ge g
+----
+seek-ge g: .
+
+# SetBounds including only the second region.
+iter lower=l upper=q
+seek-ge l
+next
+----
+seek-ge l: m#inf,BDRY [?, m):{}
+next:      .
+trigger: m(fwd)
+
+# Re-seek before trigger fires (direction change).
+iter
+seek-ge a
+seek-lt z
+prev
+----
+seek-ge a: b#inf,BDRY [?, b):{}
+seek-lt z: p#inf,BDRY [p, ?):{}
+prev:      .
+trigger: p(bwd)
+
+# Re-seek in same direction before trigger fires.
+iter
+seek-ge a
+seek-ge h
+next
+----
+seek-ge a: b#inf,BDRY [?, b):{}
+seek-ge h: m#inf,BDRY [?, m):{}
+next:      .
+trigger: m(fwd)
+
+# Direction switch: backward to forward, no region ahead → nil.
+iter
+seek-lt z
+next
+----
+seek-lt z: p#inf,BDRY [p, ?):{}
+next:      .
+
+# Direction switch: forward to backward, no region behind → nil.
+iter
+seek-ge a
+prev
+----
+seek-ge a: b#inf,BDRY [?, b):{}
+prev:      .
+
+# Direction switch: backward to forward, region exists ahead.
+iter
+seek-lt h
+next
+next
+----
+seek-lt h: g#inf,BDRY [g, ?):{}
+next:      m#inf,BDRY [?, m):{}
+next:      .
+trigger: m(fwd)
+
+# Direction switch: forward to backward, region exists behind.
+iter
+seek-ge h
+prev
+prev
+----
+seek-ge h: m#inf,BDRY [?, m):{}
+prev:      g#inf,BDRY [g, ?):{}
+prev:      .
+trigger: g(bwd)
+
+# Next when unpositioned (seek found nothing): re-seeks from lower bound.
+iter
+seek-ge z
+next
+next
+----
+seek-ge z: .
+next:      b#inf,BDRY [?, b):{}
+next:      .
+trigger: b(fwd)
+
+# Prev when unpositioned (seek found nothing): re-seeks from upper bound.
+iter upper=z
+seek-lt a
+prev
+prev
+----
+seek-lt a: .
+prev:      p#inf,BDRY [p, ?):{}
+prev:      .
+trigger: p(bwd)
+
+# Next when unpositioned with bounds excluding all regions: nil.
+iter lower=h upper=k
+seek-ge h
+next
+----
+seek-ge h: .
+next:      .
+
+# Prev when unpositioned with bounds excluding all regions: nil.
+iter lower=h upper=k
+seek-lt k
+prev
+----
+seek-lt k: .
+prev:      .
+
+# SeekPrefixGE works like SeekGE.
+iter
+seek-ge c
+----
+seek-ge c: .
+trigger: c(fwd)
+
+# SeekGE inside a region (with bounds).
+iter lower=c upper=h
+seek-ge c
+----
+seek-ge c: .
+trigger: c(fwd)
+
+# SeekLT inside a region (with bounds).
+iter lower=b upper=d
+seek-lt d
+----
+seek-lt d: .
+trigger: d(bwd)
+
+# SeekGE with TrySeekUsingNext on a position before the next boundary:
+# returns the existing boundary kv without re-seeking.
+iter
+seek-ge a
+seek-ge a try-seek-using-next
+next
+----
+seek-ge a:                     b#inf,BDRY [?, b):{}
+seek-ge a try-seek-using-next: b#inf,BDRY [?, b):{}
+next:                          .
+trigger: b(fwd)
+
+# SeekGE with TrySeekUsingNext past the current boundary: falls through to
+# a real seek, finding the next boundary.
+iter
+seek-ge a
+seek-ge h try-seek-using-next
+next
+----
+seek-ge a:                     b#inf,BDRY [?, b):{}
+seek-ge h try-seek-using-next: m#inf,BDRY [?, m):{}
+next:                          .
+trigger: m(fwd)
+
+# SeekGE with TrySeekUsingNext past the current boundary, into a region:
+# immediate trigger.
+iter
+seek-ge a
+seek-ge n try-seek-using-next
+----
+seek-ge a:                     b#inf,BDRY [?, b):{}
+seek-ge n try-seek-using-next: .
+trigger: n(fwd)
+
+# SeekGE with TrySeekUsingNext past all regions; falls through to a real
+# seek which finds nothing. A subsequent TrySeekUsingNext on the now-exhausted
+# iterator is legal and returns nil.
+iter
+seek-ge a
+seek-ge z try-seek-using-next
+seek-ge zz try-seek-using-next
+----
+seek-ge a:                      b#inf,BDRY [?, b):{}
+seek-ge z try-seek-using-next:  .
+seek-ge zz try-seek-using-next: .
+
+# Bounds that exclude all regions: all ops return nil.
+iter lower=h upper=k
+first
+last
+seek-ge h
+seek-lt k
+next
+prev
+----
+first:     .
+last:      .
+seek-ge h: .
+seek-lt k: .
+next:      .
+prev:      .
+
+# Bounds that exclude all regions: set-bounds narrows to empty range.
+iter lower=b upper=z
+seek-ge b
+----
+seek-ge b: .
+trigger: b(fwd)
+
+continue
+set-bounds h k
+seek-ge h
+next
+----
+set-bounds h k: ok
+seek-ge h:      .
+next:           .
+
+# Bounds with lower only, no upper, no regions above lower.
+iter lower=q
+seek-ge q
+next
+----
+seek-ge q: .
+next:      .
+
+# Bounds with upper only, no lower, no regions below upper.
+iter upper=b
+seek-lt b
+prev
+----
+seek-lt b: .
+prev:      .
+
+# Bounds covering gap between regions.
+iter lower=g upper=m
+first
+last
+seek-ge g
+seek-lt m
+next
+prev
+----
+first:     .
+last:      .
+seek-ge g: .
+seek-lt m: .
+next:      .
+prev:      .
+
+# Region defined with suffixed start key.
+define
+[c@4, c@1)=1
+----
+[c@4, c@1)=1
+
+# Point before the region (c@5 < c@4): boundary at c@4.
+iter
+seek-ge c@5
+next
+----
+seek-ge c@5: c@4#inf,BDRY [?, c@4):{}
+next:        .
+trigger: c@4(fwd)
+
+# Point inside the region (c@4 < c@3 < c@1): immediate trigger.
+iter
+seek-ge c@3
+----
+seek-ge c@3: .
+trigger: c@3(fwd)

--- a/internal/iterv2/trigger_iter.go
+++ b/internal/iterv2/trigger_iter.go
@@ -1,0 +1,337 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package iterv2
+
+import (
+	"context"
+
+	"github.com/RaduBerinde/axisds/v3/regiontree"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/treesteps"
+)
+
+// BoundaryTrigger is called when the TriggerIter fires. The key is the
+// boundary position; dir is +1 (forward) or -1 (backward).
+type BoundaryTrigger interface {
+	// Trigger is called when a TriggerIter reaches a region in the regiontree.
+	// The key slice comes from the regiontree.
+	Trigger(key []byte, dir int8)
+}
+
+// TriggerIter is an iterv2.Iter that consults a regiontree to emit a synthetic
+// BOUNDARY key at the first position where iteration would touch a region with
+// a non-zero count. When the merging iterator reaches that boundary (calling
+// Next/Prev to advance past it), the TriggerIter fires its callback and
+// permanently exhausts itself.
+//
+// This is used for lazy combined iteration: the TriggerIter is placed as a
+// top-level child of the merging iterator to detect when point iteration
+// reaches a region that may contain range key sets.
+//
+// When bounds are set, the TriggerIter will check the entire region and elide
+// any work during iterator operations if there are no possible range key sets
+// within the bounds.
+type TriggerIter struct {
+	cmp     base.Compare
+	tree    *regiontree.T[[]byte, int]
+	trigger BoundaryTrigger // set to nil after firing
+	lower   []byte
+	upper   []byte
+
+	noRegions bool // true if no regions exist within [lower, upper)
+	dir       int8 // +1 forward, -1 backward, 0 unpositioned or exhausted.
+	// kv contains the closest boundary key in the iteration direction; empty if
+	// dir is 0.
+	kv base.InternalKV
+	// span is presented via Span(). It presents the same boundary in kv; empty if
+	// dir is 0.
+	span Span
+}
+
+var _ Iter = (*TriggerIter)(nil)
+
+// checkNoRegions sets noRegions to true if both bounds are set and there are no
+// regions with non-zero count within [lower, upper).
+func (t *TriggerIter) checkNoRegions() {
+	if t.trigger == nil {
+		t.noRegions = true
+		return
+	}
+	l := regiontree.Min[[]byte]()
+	if t.lower != nil {
+		l = regiontree.GE(t.lower)
+	}
+	u := regiontree.Max[[]byte]()
+	if t.upper != nil {
+		u = regiontree.LT(t.upper)
+	}
+	t.noRegions = !t.tree.Any(l, u, func(v int) bool { return v > 0 })
+}
+
+// Init initializes the TriggerIter.
+func (t *TriggerIter) Init(
+	cmp base.Compare, tree *regiontree.T[[]byte, int], trigger BoundaryTrigger, lower, upper []byte,
+) {
+	*t = TriggerIter{
+		cmp:     cmp,
+		tree:    tree,
+		trigger: trigger,
+		lower:   lower,
+		upper:   upper,
+	}
+	t.checkNoRegions()
+}
+
+// Reset the iterator and change the trigger. The trigger can be nil, in which
+// case the iterator will be exhausted for all operations until the next Reset.
+func (t *TriggerIter) Reset(trigger BoundaryTrigger) {
+	t.dir = 0
+	t.span = Span{}
+	t.trigger = trigger
+	t.kv = base.InternalKV{}
+	t.checkNoRegions()
+}
+
+// makeBoundaryKey creates a synthetic boundary key at the given user key.
+func makeBoundaryKey(key []byte) base.InternalKey {
+	return base.MakeInternalKey(key, base.SeqNumMax, base.InternalKeyKindSpanBoundary)
+}
+
+// upperBound returns the regiontree upper bound for queries.
+func (t *TriggerIter) upperBound() regiontree.UpperBound[[]byte] {
+	if t.upper != nil {
+		return regiontree.LT(t.upper)
+	}
+	return regiontree.Max[[]byte]()
+}
+
+// lowerBound returns the regiontree lower bound for queries.
+func (t *TriggerIter) lowerBound() regiontree.LowerBound[[]byte] {
+	if t.lower != nil {
+		return regiontree.GE(t.lower)
+	}
+	return regiontree.Min[[]byte]()
+}
+
+// exhaust sets the iterator to the exhausted state.
+func (t *TriggerIter) exhaust() {
+	t.dir = 0
+	t.span = Span{}
+	t.kv = base.InternalKV{}
+}
+
+// fire triggers the callback and permanently exhausts the iterator.
+func (t *TriggerIter) fire(key []byte, dir int8) {
+	t.trigger.Trigger(key, dir)
+	t.trigger = nil
+	t.noRegions = true
+	t.exhaust()
+}
+
+// seekForward implements the shared logic for SeekGE, First, SeekPrefixGE, and
+// NextPrefix. If seekKey is non-nil and the seek key lands inside a region, the
+// trigger fires immediately.
+func (t *TriggerIter) seekForward(
+	lower regiontree.LowerBound[[]byte], seekKey []byte,
+) *base.InternalKV {
+	if t.noRegions {
+		return nil
+	}
+	for interval := range t.tree.Enumerate(lower, t.upperBound()) {
+		// When seekKey is set, interval.Start is clipped to seekKey by
+		// Enumerate, so interval.Start == seekKey means the seek key is
+		// inside a region.
+		if seekKey != nil && t.cmp(interval.Start, seekKey) == 0 {
+			t.fire(seekKey, +1)
+			return nil
+		}
+		// Region is ahead of the starting position.
+		t.dir = +1
+		t.span = Span{
+			BoundaryType: BoundaryEnd,
+			Boundary:     interval.Start,
+		}
+		t.kv = base.InternalKV{K: makeBoundaryKey(interval.Start)}
+		return &t.kv
+	}
+	// No region found.
+	t.exhaust()
+	return nil
+}
+
+// seekBackward implements the shared logic for SeekLT and Last. If seekKey is
+// non-nil and the seek key lands inside a region, the trigger fires
+// immediately.
+func (t *TriggerIter) seekBackward(
+	upper regiontree.UpperBound[[]byte], seekKey []byte,
+) *base.InternalKV {
+	if t.noRegions {
+		return nil
+	}
+	for interval := range t.tree.EnumerateDesc(upper, t.lowerBound()) {
+		// When seekKey is set, interval.End is clipped to seekKey by EnumerateDesc,
+		// so interval.End == seekKey means that either the seek key is inside a
+		// region, or a region ends exactly at seekKey. In both cases, we should
+		// fire (we are doing reverse iteration so the seekKey is an exclusive upper
+		// bound).
+		if seekKey != nil && t.cmp(interval.End, seekKey) == 0 {
+			t.fire(seekKey, -1)
+			return nil
+		}
+		// Region is below the starting position.
+		t.dir = -1
+		t.span = Span{
+			BoundaryType: BoundaryStart,
+			Boundary:     interval.End,
+		}
+		t.kv = base.InternalKV{K: makeBoundaryKey(interval.End)}
+		return &t.kv
+	}
+	// No region found.
+	t.exhaust()
+	return nil
+}
+
+// First implements Iter. First must not be called when a lower bound is set;
+// use SeekGE(lower) instead.
+func (t *TriggerIter) First() *base.InternalKV {
+	return t.seekForward(regiontree.Min[[]byte](), nil)
+}
+
+// Last implements Iter. Last must not be called when an upper bound is set;
+// use SeekLT(upper) instead.
+func (t *TriggerIter) Last() *base.InternalKV {
+	return t.seekBackward(regiontree.Max[[]byte](), nil)
+}
+
+// SeekGE implements Iter.
+func (t *TriggerIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	if flags.TrySeekUsingNext() && invariants.Sometimes(50) {
+		if invariants.Enabled && t.dir == -1 {
+			panic(errors.AssertionFailedf("SeekGE with TrySeekUsingNext after backward positioning"))
+		}
+		if t.dir == 0 {
+			// Iterator already exhausted.
+			return nil
+		}
+		if t.cmp(key, t.kv.K.UserKey) <= 0 {
+			// Fast path: the seek did not reach the boundary.
+			return &t.kv
+		}
+		// Fall through.
+	}
+	return t.seekForward(regiontree.GE(key), key)
+}
+
+// SeekPrefixGE implements Iter.
+func (t *TriggerIter) SeekPrefixGE(_, key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	return t.SeekGE(key, flags)
+}
+
+// SeekLT implements Iter.
+func (t *TriggerIter) SeekLT(key []byte, _ base.SeekLTFlags) *base.InternalKV {
+	return t.seekBackward(regiontree.LT(key), key)
+}
+
+// Next implements Iter.
+func (t *TriggerIter) Next() *base.InternalKV {
+	if t.noRegions {
+		return nil
+	}
+	switch t.dir {
+	case +1:
+		// Positioned forward: advancing past the boundary fires the trigger.
+		t.fire(t.kv.K.UserKey, +1)
+		return nil
+	case -1:
+		// Was positioned backward; re-seek forward from the current boundary
+		// to handle direction switches correctly. t.kv.K.UserKey is the exclusive
+		// end key of the closest region before our position, and we know we are
+		// inside a gap (or we would have fired already). So seeking forward from
+		// this key will find the next boundary forward.
+		//
+		// For example, if we have regions [a, c) and [e, g) and last operation was
+		// SeekLT(d), the current boundary is c. seeking forward from c will find
+		// the [e, g) region.
+		return t.seekForward(regiontree.GE(t.kv.K.UserKey), nil)
+	default:
+		// Exhausted (e.g. a previous SeekLT found nothing). Seek forward from the
+		// lower bound.
+		return t.seekForward(t.lowerBound(), nil)
+	}
+}
+
+// NextPrefix implements Iter.
+func (t *TriggerIter) NextPrefix(succKey []byte) *base.InternalKV {
+	return t.SeekGE(succKey, base.SeekGEFlagsNone.EnableTrySeekUsingNext())
+}
+
+// Prev implements Iter.
+func (t *TriggerIter) Prev() *base.InternalKV {
+	if t.noRegions {
+		return nil
+	}
+	switch t.dir {
+	case -1:
+		// Positioned backward: advancing past the boundary fires the trigger.
+		t.fire(t.kv.K.UserKey, -1)
+		return nil
+	case +1:
+		// Was positioned forward; re-seek backward from before current boundary to
+		// handle direction switches correctly. t.kv.K.UserKey is the start key of
+		// the closest region after our position, and we know we are inside a gap
+		// (or we would have fired already). So seeking backward from this key will
+		// find the next boundary backward.
+		//
+		// For example, if we have regions [a, c) and [e, g) and last operation was
+		// SeekGE(d), the current boundary is e. seeking backward from e will find
+		// the [a, c) region.
+		return t.seekBackward(regiontree.LT(t.kv.K.UserKey), nil)
+	default:
+		// Exhausted (e.g. a previous SeekGE found nothing). Seek backward from the
+		// upper bound.
+		return t.seekBackward(t.upperBound(), nil)
+	}
+}
+
+// Span implements Iter.
+func (t *TriggerIter) Span() *Span {
+	return &t.span
+}
+
+// SetBounds implements Iter.
+func (t *TriggerIter) SetBounds(lower, upper []byte) {
+	t.lower = lower
+	t.upper = upper
+	t.dir = 0
+	t.span = Span{}
+	t.kv = base.InternalKV{}
+	t.checkNoRegions()
+}
+
+// Error implements Iter.
+func (t *TriggerIter) Error() error { return nil }
+
+// Close implements Iter.
+func (t *TriggerIter) Close() error { return nil }
+
+// SetContext implements Iter.
+func (t *TriggerIter) SetContext(_ context.Context) {}
+
+// String implements fmt.Stringer.
+func (t *TriggerIter) String() string { return "trigger-iter" }
+
+// TreeStepsNode implements treesteps.Node.
+func (t *TriggerIter) TreeStepsNode() treesteps.NodeInfo {
+	description := "TriggerIter"
+	if t.trigger == nil {
+		description += " (disabled)"
+	} else if t.noRegions {
+		description += " (no regions)"
+	}
+	return treesteps.NodeInfof(t, "%s", description)
+}

--- a/internal/iterv2/trigger_iter_test.go
+++ b/internal/iterv2/trigger_iter_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package iterv2
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/RaduBerinde/axisds/v3"
+	"github.com/RaduBerinde/axisds/v3/regiontree"
+	"github.com/cockroachdb/crlib/crstrings"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/testkeys"
+)
+
+// testTrigger records trigger events for testing.
+type testTrigger struct {
+	events []string
+}
+
+func (tt *testTrigger) Trigger(key []byte, dir int8) {
+	var dirStr string
+	if dir > 0 {
+		dirStr = "fwd"
+	} else {
+		dirStr = "bwd"
+	}
+	tt.events = append(tt.events, fmt.Sprintf("trigger: %s(%s)", key, dirStr))
+}
+
+func (tt *testTrigger) drain() string {
+	if len(tt.events) == 0 {
+		return ""
+	}
+	s := strings.Join(tt.events, "\n")
+	tt.events = tt.events[:0]
+	return s
+}
+
+func TestTriggerIter(t *testing.T) {
+	cmp := testkeys.Comparer.Compare
+	var tree regiontree.T[[]byte, int]
+	var iter TriggerIter
+	var tt testTrigger
+
+	datadriven.RunTest(t, "testdata/trigger_iter", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "define":
+			tree = regiontree.Make(
+				axisds.CompareFn[[]byte](cmp),
+				func(a, b int) bool { return a == b },
+			)
+			for line := range crstrings.LinesSeq(d.Input) {
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				// Parse "[start, end)=count".
+				line = strings.TrimPrefix(line, "[")
+				parts := strings.SplitN(line, ",", 2)
+				start := []byte(strings.TrimSpace(parts[0]))
+				rest := strings.TrimSpace(parts[1])
+				// rest is "end)=count"; split on ")=" to separate end from count.
+				parts2 := strings.SplitN(rest, ")=", 2)
+				end := []byte(strings.TrimSpace(parts2[0]))
+				var count int
+				fmt.Sscanf(strings.TrimSpace(parts2[1]), "%d", &count)
+				for range count {
+					tree.Update(start, end, func(p int) int { return p + 1 })
+				}
+			}
+			// Print the tree contents.
+			var buf strings.Builder
+			iFmt := axisds.MakeIntervalFormatter(func(b []byte) string {
+				return string(b)
+			})
+			n := 0
+			for interval, prop := range tree.All() {
+				if n > 0 {
+					buf.WriteString("\n")
+				}
+				fmt.Fprintf(&buf, "%s=%d", iFmt(interval), prop)
+				n++
+			}
+			if n == 0 {
+				return "<empty>"
+			}
+			return buf.String()
+
+		case "iter":
+			var lower, upper string
+			d.MaybeScanArgs(t, "lower", &lower)
+			d.MaybeScanArgs(t, "upper", &upper)
+			key := func(s string) []byte {
+				if s == "" {
+					return nil
+				}
+				return []byte(s)
+			}
+			iter.Init(cmp, &tree, &tt, key(lower), key(upper))
+			return RunIterOps(t, &iter, d.Input) + tt.drain()
+
+		case "continue":
+			return RunIterOps(t, &iter, d.Input) + tt.drain()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}

--- a/iterator.go
+++ b/iterator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/humanize"
 	"github.com/cockroachdb/pebble/internal/inflight"
 	"github.com/cockroachdb/pebble/internal/invariants"
+	"github.com/cockroachdb/pebble/internal/iterv2"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/keyspan/keyspanimpl"
 	"github.com/cockroachdb/pebble/internal/manifest"
@@ -283,8 +284,9 @@ type Iterator struct {
 	// appears here because key visibility is handled by the merging iterator.
 	// During SetOptions on an iterator over an indexed batch, this field is
 	// used to update the merging iterator's batch snapshot.
-	merging   *mergingIter
-	mergingV2 *mergingIterV2
+	merging     *mergingIter
+	mergingV2   *mergingIterV2
+	triggerIter iterv2.TriggerIter
 
 	// Keeping the bools here after all the 8 byte aligned fields shrinks the
 	// sizeof this struct by 24 bytes.
@@ -2809,6 +2811,17 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 	// lower level iterators should not trigger a switch to combined iteration.
 	i.lazyCombinedIter.combinedIterState = combinedIterState{
 		initialized: i.rangeKey != nil || !i.opts.rangeKeys(),
+	}
+	if iterv2.Enabled && i.mergingV2 != nil && !i.batchOnlyIter {
+		// Re-arm (or disarm) the TriggerIter living inside mergingIterV2 to
+		// match the new desired mode. Bounds didn't necessarily change yet,
+		// but Reset uses the iter's existing bounds; mergingIterV2.SetBounds
+		// (called below in the slow path) will propagate any new bounds.
+		var trigger iterv2.BoundaryTrigger
+		if !i.lazyCombinedIter.combinedIterState.initialized {
+			trigger = &i.lazyCombinedIter.combinedIterState
+		}
+		i.triggerIter.Reset(trigger)
 	}
 
 	boundsEqual := ((i.opts.LowerBound == nil) == (o.LowerBound == nil)) &&

--- a/merging_iter_v2_slab.go
+++ b/merging_iter_v2_slab.go
@@ -24,8 +24,11 @@ type slabState struct {
 	// snapshot is the SeqNum at which we are reading; only point/span keys with
 	// lower seq nums are visible.
 	snapshot base.SeqNum
-	// batchSnapshot is non-zero if and only if the first level is a batch.
+	// batchSnapshot is non-zero if and only if a level is the indexed batch.
 	batchSnapshot base.SeqNum
+	// batchLevelIdx is the index of the batch level; only meaningful when
+	// batchSnapshot != 0. Defaults to 0.
+	batchLevelIdx int
 
 	// levels aliases m.levels, sharing the same backing array. Indexed by
 	// level index (0 = highest / most recent level).
@@ -67,7 +70,7 @@ func (s *slabState) Build(dir int8) iter.Seq2[int, bool] {
 
 			sl := &s.levels[levelIdx]
 			// Set maxSeqNum: batch level uses batchSnapshot, others use snapshot.
-			if levelIdx == 0 && s.batchSnapshot != 0 {
+			if s.batchSnapshot != 0 && levelIdx == s.batchLevelIdx {
 				sl.maxSeqNum = s.batchSnapshot
 			} else {
 				sl.maxSeqNum = s.snapshot

--- a/range_keys.go
+++ b/range_keys.go
@@ -474,6 +474,14 @@ type combinedIterState struct {
 	initialized bool
 }
 
+// Trigger implements iterv2.BoundaryTrigger. It is invoked by an iterv2
+// TriggerIter at most once per iterator operation, so no key-merging logic
+// (cf. v1's levelIter.maybeTriggerCombinedIteration) is required here.
+func (c *combinedIterState) Trigger(key []byte, dir int8) {
+	c.triggered = true
+	c.key = key
+}
+
 // Assert that *lazyCombinedIter implements internalIterator.
 var _ internalIterator = (*lazyCombinedIter)(nil)
 


### PR DESCRIPTION
#### iterv2: add TriggerIter for lazy combined iteration

Add TriggerIter, an iterv2.Iter that consults a regiontree to emit a
synthetic boundary key at the first position where iteration would enter
a region that may contain range key sets.

Semantics:
- Forward seeks (SeekGE/First): if the seek key lands inside a region,
  the trigger fires immediately; otherwise a BOUNDARY key is returned at
  the region start.
- Backward seeks (SeekLT/Last): symmetric behavior with BOUNDARY at the
  region end.
- Next/Prev past a boundary: fires the trigger and returns nil.
- After firing, all operations return nil permanently.
- Re-seeking before the trigger fires is supported (resets position).

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### iterv2: wire TriggerIter into mergingIterV2 for lazy combined iteration

Always include a `TriggerIter` as the first level of `mergingIterV2`
(when a Version is available). The trigger is armed via `Reset` when
the iterator is configured for lazy combined iteration, and disarmed
otherwise, allowing the same iterator object to be reused across
`SetOptions`. `combinedIterState` implements `iterv2.BoundaryTrigger`
so the existing `lazyCombinedIter` machinery handles the switch to
combined iteration when the trigger fires. The slab logic now tracks
the batch level index explicitly, since the batch is no longer always
level 0.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>