### PR TITLE
pebble: speed up root package tests

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -326,7 +326,7 @@ func TestCheckpointCompaction(t *testing.T) {
 	wg.Go(func() {
 		defer cancel()
 		defer close(check)
-		for i := 0; ctx.Err() == nil && i < 200; i++ {
+		for i := 0; ctx.Err() == nil && i < 50; i++ {
 			dir := fmt.Sprintf("checkpoint%06d", i)
 			if err := d.Checkpoint(dir); err != nil {
 				t.Error(err)

--- a/db_test.go
+++ b/db_test.go
@@ -2235,8 +2235,8 @@ func TestWALFailoverAvoidsWriteStall(t *testing.T) {
 	// Secondary for WAL failover can do log creation.
 	secondary := wal.Dir{FS: mem, Dirname: "secondary"}
 	walFailover := &WALFailoverOptions{Secondary: secondary, FailoverOptions: wal.FailoverOptions{
-		UnhealthySamplingInterval:          100 * time.Millisecond,
-		UnhealthyOperationLatencyThreshold: func() (time.Duration, bool) { return time.Second, true },
+		UnhealthySamplingInterval:          10 * time.Millisecond,
+		UnhealthyOperationLatencyThreshold: func() (time.Duration, bool) { return 50 * time.Millisecond, true },
 	}}
 	o := &Options{
 		FS:                          primaryFS,

--- a/db_test.go
+++ b/db_test.go
@@ -2313,7 +2313,7 @@ func TestElevateThresholdAfterWriteStallUnblocksStall(t *testing.T) {
 	go func() {
 		// After ~8 writes, the default write stall threshold is exceeded.
 		// It is observed by the above goroutine, which removes the stall.
-		for i := 0; i < 200; i++ {
+		for i := 0; i < 50; i++ {
 			require.NoError(t, d.Set([]byte(fmt.Sprintf("%d", i)), value, nil))
 		}
 		done <- struct{}{}

--- a/error_test.go
+++ b/error_test.go
@@ -539,7 +539,7 @@ func TestDBCompactionCrash(t *testing.T) {
 	// completion without performing a k-th write operation.
 	done := false
 	rng := rand.New(rand.NewPCG(0, uint64(seed)))
-	for k := int32(0); !done; k += rng.Int32N(5) + 1 {
+	for k := int32(0); !done; k += rng.Int32N(10) + 3 {
 		t.Run(fmt.Sprintf("k=%d", k), func(t *testing.T) {
 			// Run, simulating a crash by ignoring syncs after the k-th write
 			// operation after Open.

--- a/external_test.go
+++ b/external_test.go
@@ -426,7 +426,7 @@ func TestReadOnlyRecovery(t *testing.T) {
 	rng := rand.New(rand.NewPCG(0, uint64(seed)))
 
 	// Generate a random database by running the metamorphic test with the
-	// WriteOpConfig. We'll perform ~10,000 random operations that mutate the
+	// WriteOpConfig. We'll perform ~3,000 random operations that mutate the
 	// state of the database.
 	kf := metamorphic.TestkeysKeyFormat
 	testOpts := metamorphic.RandomOptions(rng, kf, metamorphic.RandomOptionsCfg{
@@ -440,7 +440,7 @@ func TestReadOnlyRecovery(t *testing.T) {
 	var cloneFS *vfs.MemFS
 	{
 		test, err := metamorphic.New(metamorphic.GenerateOps(
-			rng, 10000, kf, metamorphic.WriteOpConfig()),
+			rng, 3000, kf, metamorphic.WriteOpConfig()),
 			testOpts, "" /* dir */, io.Discard)
 		require.NoError(t, err)
 		memFS := vfs.Root(testOpts.Opts.FS).(*vfs.MemFS)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -701,7 +701,7 @@ func TestMetricsWALBytesWrittenMonotonicity(t *testing.T) {
 
 	func() {
 		defer func() { close(stopCh) }()
-		abort := time.After(time.Second)
+		abort := time.After(200 * time.Millisecond)
 		var prevWALBytesWritten uint64
 		for {
 			select {

--- a/open_test.go
+++ b/open_test.go
@@ -612,90 +612,93 @@ func TestNewDBFilenames(t *testing.T) {
 }
 
 func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
-	opts := testingRandomized(t, &Options{FS: fs})
-
 	useStoreRelativeWALPath := rand.IntN(2) == 0
+	// Iterations sharing the same `dirname` must run sequentially (they reopen
+	// the same on-disk database), so we parallelize only across the outer
+	// (startFromEmpty, walDirname) groups.
 	for _, startFromEmpty := range []bool{false, true} {
 		for _, walDirname := range []string{"", "wal"} {
-			for _, length := range []int{-1, 0, 1, 1000, 100000} {
-				dirname := "sharedDatabase" + walDirname
-				if startFromEmpty {
-					dirname = "startFromEmpty" + walDirname + strconv.Itoa(length)
-				}
-				dirname = fs.PathJoin(root, dirname)
-				if walDirname == "" {
-					opts.WALDir = ""
-				} else {
-					if useStoreRelativeWALPath {
-						opts.WALDir = MakeStoreRelativePath(fs, walDirname)
+			t.Run(fmt.Sprintf("sfe=%t/wal=%q", startFromEmpty, walDirname), func(t *testing.T) {
+				t.Parallel()
+				opts := testingRandomized(t, &Options{FS: fs})
+				for _, length := range []int{-1, 0, 1, 1000} {
+					dirname := "sharedDatabase" + walDirname
+					if startFromEmpty {
+						dirname = "startFromEmpty" + walDirname + strconv.Itoa(length)
+					}
+					dirname = fs.PathJoin(root, dirname)
+					if walDirname == "" {
+						opts.WALDir = ""
 					} else {
-						opts.WALDir = fs.PathJoin(dirname, walDirname)
+						if useStoreRelativeWALPath {
+							opts.WALDir = MakeStoreRelativePath(fs, walDirname)
+						} else {
+							opts.WALDir = fs.PathJoin(dirname, walDirname)
+						}
 					}
-				}
 
-				got, xxx := []byte(nil), ""
-				if length >= 0 {
-					xxx = strings.Repeat("x", length)
-				}
+					got, xxx := []byte(nil), ""
+					if length >= 0 {
+						xxx = strings.Repeat("x", length)
+					}
 
-				d0, err := Open(dirname, opts)
-				if err != nil {
-					t.Fatalf("sfe=%t, length=%d: Open #0: %v",
-						startFromEmpty, length, err)
-				}
-				if length >= 0 {
-					err = d0.Set([]byte("key"), []byte(xxx), nil)
+					d0, err := Open(dirname, opts)
 					if err != nil {
-						t.Errorf("sfe=%t, length=%d: Set: %v",
+						t.Fatalf("sfe=%t, length=%d: Open #0: %v",
+							startFromEmpty, length, err)
+					}
+					if length >= 0 {
+						err = d0.Set([]byte("key"), []byte(xxx), nil)
+						if err != nil {
+							t.Errorf("sfe=%t, length=%d: Set: %v",
+								startFromEmpty, length, err)
+							continue
+						}
+					}
+					err = d0.Close()
+					if err != nil {
+						t.Errorf("sfe=%t, length=%d: Close #0: %v",
 							startFromEmpty, length, err)
 						continue
 					}
-				}
-				err = d0.Close()
-				if err != nil {
-					t.Errorf("sfe=%t, length=%d: Close #0: %v",
-						startFromEmpty, length, err)
-					continue
-				}
 
-				d1, err := Open(dirname, opts)
-				if err != nil {
-					t.Errorf("sfe=%t, length=%d: Open #1: %v",
-						startFromEmpty, length, err)
-					continue
-				}
-				if length >= 0 {
-					var closer io.Closer
-					got, closer, err = d1.Get([]byte("key"))
+					d1, err := Open(dirname, opts)
 					if err != nil {
-						t.Errorf("sfe=%t, length=%d: Get: %v",
+						t.Errorf("sfe=%t, length=%d: Open #1: %v",
 							startFromEmpty, length, err)
 						continue
 					}
-					got = append([]byte(nil), got...)
-					closer.Close()
-				}
-				err = d1.Close()
-				if err != nil {
-					t.Errorf("sfe=%t, length=%d: Close #1: %v",
-						startFromEmpty, length, err)
-					continue
-				}
+					if length >= 0 {
+						var closer io.Closer
+						got, closer, err = d1.Get([]byte("key"))
+						if err != nil {
+							t.Errorf("sfe=%t, length=%d: Get: %v",
+								startFromEmpty, length, err)
+							continue
+						}
+						got = append([]byte(nil), got...)
+						closer.Close()
+					}
+					err = d1.Close()
+					if err != nil {
+						t.Errorf("sfe=%t, length=%d: Close #1: %v",
+							startFromEmpty, length, err)
+						continue
+					}
 
-				if length >= 0 && string(got) != xxx {
-					t.Errorf("sfe=%t, length=%d: got value differs from set value",
-						startFromEmpty, length)
-					continue
-				}
+					if length >= 0 && string(got) != xxx {
+						t.Errorf("sfe=%t, length=%d: got value differs from set value",
+							startFromEmpty, length)
+						continue
+					}
 
-				{
-					got, err := opts.FS.List(dirname)
+					listed, err := opts.FS.List(dirname)
 					if err != nil {
 						t.Fatalf("List: %v", err)
 					}
 					var optionsCount int
-					for _, s := range got {
-						if t, _, ok := base.ParseFilename(opts.FS, s); ok && t == base.FileTypeOptions {
+					for _, s := range listed {
+						if ft, _, ok := base.ParseFilename(opts.FS, s); ok && ft == base.FileTypeOptions {
 							optionsCount++
 						}
 					}
@@ -703,7 +706,7 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 						t.Fatalf("expected 1 OPTIONS file, but found %d", optionsCount)
 					}
 				}
-			}
+			})
 		}
 	}
 }

--- a/open_test.go
+++ b/open_test.go
@@ -447,26 +447,27 @@ func TestOpenAlreadyLocked(t *testing.T) {
 			},
 		},
 	}
-	// We'll provide the same WAL recovery directory for all tests to
-	// verify that the lock acquired during Open is properly released.
-	walRecoveryDir := t.TempDir()
-	recoveryLock, err := base.LockDirectory(walRecoveryDir, vfs.Default)
-	require.NoError(t, err)
-	defer recoveryLock.Close()
-	walRecoveryDirs := []wal.Dir{
-		{FS: vfs.Default, Dirname: t.TempDir()},
-		{Lock: recoveryLock, FS: vfs.Default, Dirname: walRecoveryDir},
-	}
-
 	runTest := func(t *testing.T, tmpDirs [4]string, setupLocks func(opts *Options, dirname, walDirname, secondaryWalDirname string, fs vfs.FS) error, fs vfs.FS) {
 		dataDir := tmpDirs[0]
 		dataDir2 := tmpDirs[1]
 		walDir := tmpDirs[2]
 		secondaryWalDir := tmpDirs[3]
 
+		// Per-subtest WAL recovery directories. The unlocked entry verifies
+		// that Open acquires and releases the lock; the pre-locked entry
+		// verifies that Open is happy with a caller-provided lock.
+		walRecoveryDir := t.TempDir()
+		recoveryLock, err := base.LockDirectory(walRecoveryDir, vfs.Default)
+		require.NoError(t, err)
+		defer recoveryLock.Close()
+		walRecoveryDirs := []wal.Dir{
+			{FS: vfs.Default, Dirname: t.TempDir()},
+			{Lock: recoveryLock, FS: vfs.Default, Dirname: walRecoveryDir},
+		}
+
 		// Setup directory locks.
 		opts := testingRandomized(t, &Options{FS: fs, WALRecoveryDirs: walRecoveryDirs})
-		err := setupLocks(opts, dataDir, walDir, secondaryWalDir, fs)
+		err = setupLocks(opts, dataDir, walDir, secondaryWalDir, fs)
 		require.NoError(t, err)
 
 		defer func() {
@@ -525,6 +526,7 @@ func TestOpenAlreadyLocked(t *testing.T) {
 	t.Run("memfs", func(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				tmpDirs := [4]string{"dir/0", "dir/1", "dir/2", "dir/3"}
 				mem := vfs.NewMem()
 				for i := range tmpDirs {
@@ -540,6 +542,7 @@ func TestOpenAlreadyLocked(t *testing.T) {
 		t.Run("absolute", func(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
 					var tmpDirs [4]string
 					for i := range tmpDirs {
 						tmpDirs[i] = t.TempDir()
@@ -560,8 +563,9 @@ func TestOpenAlreadyLocked(t *testing.T) {
 					for i := range tmpDirs {
 						tmpDirs[i] = filepath.Join(tempRoot, fmt.Sprintf("dir%d", i))
 						require.NoError(t, os.Mkdir(tmpDirs[i], 0755), "Failed to create temp dir %s", tmpDirs[i])
-						tmpDirs[i], err = filepath.Rel(tempRoot, tmpDirs[i])
+						rel, err := filepath.Rel(tempRoot, tmpDirs[i])
 						require.NoError(t, err)
+						tmpDirs[i] = rel
 					}
 
 					runTest(t, tmpDirs, tc.setupLocks, vfs.Default)

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -212,14 +212,14 @@ func TestFlushDelayStress(t *testing.T) {
 		opts := &Options{
 			FS:                    vfs.NewMem(),
 			Comparer:              testkeys.Comparer,
-			FlushDelayDeleteRange: time.Duration(rng.IntN(10)+1) * time.Millisecond,
-			FlushDelayRangeKey:    time.Duration(rng.IntN(10)+1) * time.Millisecond,
+			FlushDelayDeleteRange: time.Millisecond,
+			FlushDelayRangeKey:    time.Millisecond,
 			FormatMajorVersion:    internalFormatNewest,
 			MemTableSize:          8192,
 			Logger:                testutils.Logger{T: t},
 		}
 
-		runs := 100
+		runs := 25
 		if buildtags.SlowBuild {
 			runs = 5
 		}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -246,7 +246,7 @@ func TestSnapshotClosed(t *testing.T) {
 
 func TestSnapshotRangeDeletionStress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	const runs = 200
+	const runs = 50
 	const middleKey = runs * runs
 
 	d, err := Open("", &Options{

--- a/testdata/large_keys
+++ b/testdata/large_keys
@@ -1,197 +1,72 @@
 # FormatFlushableIngestExcises is format major version 18, which precedes
 # support for columnar blocks.
 #
-# Set a target file size of 4MB.
+# Set a target file size of 400KB.
 
-define target-file-sizes=(4000000) format-major-version=18
+define target-file-sizes=(400000) format-major-version=18
 ----
 
-# Commit many keys with 1MB-shared prefixes.
+# Commit many keys with 100KB-shared prefixes.
 
 batch-commit
-set a(p,1000000)arition
-set a(p,1000000)alling
-set a(p,1000000)eal
-set a(p,1000000)ellate
-set a(p,1000000)endectomy
-set a(p,1000000)etizers
-set a(p,1000000)etizing
-set a(p,1000000)laude
-set a(p,1000000)lauding
-set a(p,1000000)le
-set a(p,1000000)les
-set a(p,1000000)letini
-set a(p,1000000)letinis
-set a(p,1000000)lebottomjeans
-set a(p,1000000)lication
-set a(p,1000000)ly
-set a(p,1000000)lying
-set a(p,1000000)ollo
-set a(p,1000000)raisal
-set a(p,1000000)raisals
-set a(p,1000000)raiser
-set a(p,1000000)raisers
-set a(p,1000000)raising
-set a(p,1000000)rentice
-set a(p,1000000)rentices
-set a(p,1000000)renticing
-set a(p,1000000)roval
-set a(p,1000000)rovals
-set a(p,1000000)rove
+set a(p,100000)arition
+set a(p,100000)alling
+set a(p,100000)eal
+set a(p,100000)ellate
+set a(p,100000)endectomy
+set a(p,100000)etizers
+set a(p,100000)etizing
+set a(p,100000)laude
+set a(p,100000)lauding
+set a(p,100000)le
+set a(p,100000)les
+set a(p,100000)letini
+set a(p,100000)letinis
+set a(p,100000)lebottomjeans
+set a(p,100000)lication
+set a(p,100000)ly
+set a(p,100000)lying
+set a(p,100000)ollo
+set a(p,100000)raisal
+set a(p,100000)raisals
+set a(p,100000)raiser
+set a(p,100000)raisers
+set a(p,100000)raising
+set a(p,100000)rentice
+set a(p,100000)rentices
+set a(p,100000)renticing
+set a(p,100000)roval
+set a(p,100000)rovals
+set a(p,100000)rove
 ----
 
 flush verbose
 ----
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[#10-#13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563833
-  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[#14-#17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563851
-  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[#18-#23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563842
-  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[#21-#25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563836
-  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[#26-#29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563833
-  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[#30-#33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563848
-  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[#34-#37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563851
-  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[#38-#38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94329
-
-layout filename=000005.sst
-----
-sstable
- ├── data  offset: 0  length: 46944
- ├── data  offset: 46949  length: 46945
- ├── data  offset: 93899  length: 46941
- ├── data  offset: 140845  length: 46944
- ├── index  offset: 187794  length: 46942
- ├── index  offset: 234741  length: 46946
- ├── index  offset: 281692  length: 46942
- ├── index  offset: 328639  length: 46945
- ├── top-index  offset: 375589  length: 187759
- ├── properties  offset: 563353  length: 383
- ├── meta-index  offset: 563741  length: 34
- └── footer  offset: 563780  length: 53
-
-properties file=000005
-raw.key.size
-index.size
-index.partitions
-----
-raw.key.size:
-  rocksdb.raw.key.size: 4000058
-index.size:
-  rocksdb.index.size: 8000259
-  rocksdb.top-level.index.size: 4000122
-index.partitions:
-  rocksdb.index.partitions: 4
-
-batch-commit
-del-range a(p,1000000)arition a(p,1000000)eal
-del-range a(p,1000000)ellate a(p,1000000)etizers
-del-range a(p,1000000)etizing a(p,1000000)lauding
-del-range a(p,1000000)le a(p,1000000)lebottomjeans
-del-range a(p,1000000)lebottomjeans a(p,1000000)lication
-del-range a(p,1000000)ly a(p,1000000)lying
-del-range a(p,1000000)raisals a(p,1000000)rentice
-del-range a(p,1000000)rentices a(p,1000000)roval
-del-range a(p,1000000)rovals a(p,1000000)rove
-----
-
-flush verbose
-----
-L0.1:
-  000015:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[#39-#41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000620
-  000016:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] seqnums:[#42-#44] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)lying#inf,RANGEDEL] size:6000626
-  000017:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[#45-#47] points:[a(p,1000000)raisals#45,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:6000620
-L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] seqnums:[#10-#13] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)e(l,2)ate#13,SET] size:563833
-  000006:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] seqnums:[#14-#17] points:[a(p,1000000)endectomy#14,SET-a(p,1000000)laude#17,SET] size:563851
-  000007:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] seqnums:[#18-#23] points:[a(p,1000000)lauding#18,SET-a(p,1000000)les#20,SET] size:563842
-  000008:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] seqnums:[#21-#25] points:[a(p,1000000)letini#21,SET-a(p,1000000)ly#25,SET] size:563836
-  000009:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] seqnums:[#26-#29] points:[a(p,1000000)lying#26,SET-a(p,1000000)raisals#29,SET] size:563833
-  000010:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] seqnums:[#30-#33] points:[a(p,1000000)raiser#30,SET-a(p,1000000)rentice#33,SET] size:563848
-  000011:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] seqnums:[#34-#37] points:[a(p,1000000)rentices#34,SET-a(p,1000000)rovals#37,SET] size:563851
-  000012:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] seqnums:[#38-#38] points:[a(p,1000000)rove#38,SET-a(p,1000000)rove#38,SET] size:94329
-
-layout filename=000015.sst
-----
-sstable
- ├── data  offset: 0  length: 8
- ├── index  offset: 13  length: 24
- ├── range-del  offset: 42  length: 6000104
- ├── properties  offset: 6000151  length: 341
- ├── meta-index  offset: 6000497  length: 65
- └── footer  offset: 6000567  length: 53
-
-properties file=000008
-rocksdb.raw
-----
-rocksdb.raw:
-  rocksdb.raw.key.size: 4000059
-  rocksdb.raw.value.size: 20
-
-# Repeat the above with columnar blocks.
-
-define target-file-sizes=(4000000) format-major-version=19
-----
-
-# Commit many keys with 1MB-shared prefixes.
-
-batch-commit
-set a(p,1000000)arition
-set a(p,1000000)alling
-set a(p,1000000)eal
-set a(p,1000000)ellate
-set a(p,1000000)endectomy
-set a(p,1000000)etizers
-set a(p,1000000)etizing
-set a(p,1000000)laude
-set a(p,1000000)lauding
-set a(p,1000000)le
-set a(p,1000000)les
-set a(p,1000000)letini
-set a(p,1000000)letinis
-set a(p,1000000)lebottomjeans
-set a(p,1000000)lication
-set a(p,1000000)ly
-set a(p,1000000)lying
-set a(p,1000000)ollo
-set a(p,1000000)raisal
-set a(p,1000000)raisals
-set a(p,1000000)raiser
-set a(p,1000000)raisers
-set a(p,1000000)raising
-set a(p,1000000)rentice
-set a(p,1000000)rentices
-set a(p,1000000)renticing
-set a(p,1000000)roval
-set a(p,1000000)rovals
-set a(p,1000000)rove
-----
-
-flush verbose
-----
-L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] seqnums:[#10-#12] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] size:423324
-  000006:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] seqnums:[#13-#15] points:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] size:423345
-  000007:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] seqnums:[#16-#18] points:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] size:423330
-  000008:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] seqnums:[#19-#23] points:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] size:423334
-  000009:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] seqnums:[#21-#24] points:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] size:423345
-  000010:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] seqnums:[#25-#27] points:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] size:423310
-  000011:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] seqnums:[#28-#30] points:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] size:423330
-  000012:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] seqnums:[#31-#33] points:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] size:423336
-  000013:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] seqnums:[#34-#36] points:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] size:423343
-  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[#37-#38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282420
+  000006:[a(p,100000)a(l,2)ing#11,SET-a(p,100000)e(l,2)ate#13,SET] seqnums:[#10-#13] points:[a(p,100000)a(l,2)ing#11,SET-a(p,100000)e(l,2)ate#13,SET] size:57231
+  000007:[a(p,100000)endectomy#14,SET-a(p,100000)laude#17,SET] seqnums:[#14-#17] points:[a(p,100000)endectomy#14,SET-a(p,100000)laude#17,SET] size:57246
+  000008:[a(p,100000)lauding#18,SET-a(p,100000)les#20,SET] seqnums:[#18-#23] points:[a(p,100000)lauding#18,SET-a(p,100000)les#20,SET] size:57237
+  000009:[a(p,100000)letini#21,SET-a(p,100000)ly#25,SET] seqnums:[#21-#25] points:[a(p,100000)letini#21,SET-a(p,100000)ly#25,SET] size:57234
+  000010:[a(p,100000)lying#26,SET-a(p,100000)raisals#29,SET] seqnums:[#26-#29] points:[a(p,100000)lying#26,SET-a(p,100000)raisals#29,SET] size:57231
+  000011:[a(p,100000)raiser#30,SET-a(p,100000)rentice#33,SET] seqnums:[#30-#33] points:[a(p,100000)raiser#30,SET-a(p,100000)rentice#33,SET] size:57246
+  000012:[a(p,100000)rentices#34,SET-a(p,100000)rovals#37,SET] seqnums:[#34-#37] points:[a(p,100000)rentices#34,SET-a(p,100000)rovals#37,SET] size:57246
+  000013:[a(p,100000)rove#38,SET-a(p,100000)rove#38,SET] seqnums:[#38-#38] points:[a(p,100000)rove#38,SET-a(p,100000)rove#38,SET] size:9894
 
 layout filename=000006.sst
 ----
 sstable
- ├── data  offset: 0  length: 46995
- ├── data  offset: 47000  length: 46998
- ├── data  offset: 94003  length: 46993
- ├── index  offset: 141001  length: 46965
- ├── index  offset: 187971  length: 46971
- ├── index  offset: 234947  length: 46973
- ├── top-index  offset: 281925  length: 140828
- ├── properties  offset: 422758  length: 490
- ├── meta-index  offset: 423253  length: 34
- └── footer  offset: 423292  length: 53
+ ├── data  offset: 0  length: 4728
+ ├── data  offset: 4733  length: 4729
+ ├── data  offset: 9467  length: 4725
+ ├── data  offset: 14197  length: 4728
+ ├── index  offset: 18930  length: 4725
+ ├── index  offset: 23660  length: 4728
+ ├── index  offset: 28393  length: 4724
+ ├── index  offset: 33122  length: 4727
+ ├── top-index  offset: 37854  length: 18895
+ ├── properties  offset: 56754  length: 380
+ ├── meta-index  offset: 57139  length: 34
+ └── footer  offset: 57178  length: 53
 
 properties file=000006
 raw.key.size
@@ -199,55 +74,180 @@ index.size
 index.partitions
 ----
 raw.key.size:
-  rocksdb.raw.key.size: 3000049
+  rocksdb.raw.key.size: 400058
 index.size:
-  rocksdb.index.size: 6000258
-  rocksdb.top-level.index.size: 3000094
+  rocksdb.index.size: 800248
+  rocksdb.top-level.index.size: 400118
 index.partitions:
-  rocksdb.index.partitions: 3
+  rocksdb.index.partitions: 4
 
 batch-commit
-del-range a(p,1000000)arition a(p,1000000)eal
-del-range a(p,1000000)ellate a(p,1000000)etizers
-del-range a(p,1000000)etizing a(p,1000000)lauding
-del-range a(p,1000000)le a(p,1000000)lebottomjeans
-del-range a(p,1000000)lebottomjeans a(p,1000000)lication
-del-range a(p,1000000)ly a(p,1000000)lying
-del-range a(p,1000000)raisals a(p,1000000)rentice
-del-range a(p,1000000)rentices a(p,1000000)roval
-del-range a(p,1000000)rovals a(p,1000000)rove
+del-range a(p,100000)arition a(p,100000)eal
+del-range a(p,100000)ellate a(p,100000)etizers
+del-range a(p,100000)etizing a(p,100000)lauding
+del-range a(p,100000)le a(p,100000)lebottomjeans
+del-range a(p,100000)lebottomjeans a(p,100000)lication
+del-range a(p,100000)ly a(p,100000)lying
+del-range a(p,100000)raisals a(p,100000)rentice
+del-range a(p,100000)rentices a(p,100000)roval
+del-range a(p,100000)rovals a(p,100000)rove
 ----
 
 flush verbose
 ----
 L0.1:
-  000017:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] seqnums:[#39-#41] points:[a(p,1000000)arition#39,RANGEDEL-a(p,1000000)lauding#inf,RANGEDEL] size:6000731
-  000018:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] seqnums:[#42-#45] points:[a(p,1000000)le#42,RANGEDEL-a(p,1000000)rentice#inf,RANGEDEL] size:7000745
-  000019:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] seqnums:[#46-#47] points:[a(p,1000000)rentices#46,RANGEDEL-a(p,1000000)rove#inf,RANGEDEL] size:4000703
+  000015:[a(p,100000)arition#39,RANGEDEL-a(p,100000)lauding#inf,RANGEDEL] seqnums:[#39-#41] points:[a(p,100000)arition#39,RANGEDEL-a(p,100000)lauding#inf,RANGEDEL] size:600616
+  000016:[a(p,100000)le#42,RANGEDEL-a(p,100000)lying#inf,RANGEDEL] seqnums:[#42-#44] points:[a(p,100000)le#42,RANGEDEL-a(p,100000)lying#inf,RANGEDEL] size:600622
+  000017:[a(p,100000)raisals#45,RANGEDEL-a(p,100000)rove#inf,RANGEDEL] seqnums:[#45-#47] points:[a(p,100000)raisals#45,RANGEDEL-a(p,100000)rove#inf,RANGEDEL] size:600616
 L0.0:
-  000005:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] seqnums:[#10-#12] points:[a(p,1000000)a(l,2)ing#11,SET-a(p,1000000)eal#12,SET] size:423324
-  000006:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] seqnums:[#13-#15] points:[a(p,1000000)e(l,2)ate#13,SET-a(p,1000000)etizers#15,SET] size:423345
-  000007:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] seqnums:[#16-#18] points:[a(p,1000000)etizing#16,SET-a(p,1000000)lauding#18,SET] size:423330
-  000008:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] seqnums:[#19-#23] points:[a(p,1000000)le#19,SET-a(p,1000000)les#20,SET] size:423334
-  000009:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] seqnums:[#21-#24] points:[a(p,1000000)letini#21,SET-a(p,1000000)lication#24,SET] size:423345
-  000010:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] seqnums:[#25-#27] points:[a(p,1000000)ly#25,SET-a(p,1000000)o(l,2)o#27,SET] size:423310
-  000011:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] seqnums:[#28-#30] points:[a(p,1000000)raisal#28,SET-a(p,1000000)raiser#30,SET] size:423330
-  000012:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] seqnums:[#31-#33] points:[a(p,1000000)raisers#31,SET-a(p,1000000)rentice#33,SET] size:423336
-  000013:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] seqnums:[#34-#36] points:[a(p,1000000)rentices#34,SET-a(p,1000000)roval#36,SET] size:423343
-  000014:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] seqnums:[#37-#38] points:[a(p,1000000)rovals#37,SET-a(p,1000000)rove#38,SET] size:282420
+  000006:[a(p,100000)a(l,2)ing#11,SET-a(p,100000)e(l,2)ate#13,SET] seqnums:[#10-#13] points:[a(p,100000)a(l,2)ing#11,SET-a(p,100000)e(l,2)ate#13,SET] size:57231
+  000007:[a(p,100000)endectomy#14,SET-a(p,100000)laude#17,SET] seqnums:[#14-#17] points:[a(p,100000)endectomy#14,SET-a(p,100000)laude#17,SET] size:57246
+  000008:[a(p,100000)lauding#18,SET-a(p,100000)les#20,SET] seqnums:[#18-#23] points:[a(p,100000)lauding#18,SET-a(p,100000)les#20,SET] size:57237
+  000009:[a(p,100000)letini#21,SET-a(p,100000)ly#25,SET] seqnums:[#21-#25] points:[a(p,100000)letini#21,SET-a(p,100000)ly#25,SET] size:57234
+  000010:[a(p,100000)lying#26,SET-a(p,100000)raisals#29,SET] seqnums:[#26-#29] points:[a(p,100000)lying#26,SET-a(p,100000)raisals#29,SET] size:57231
+  000011:[a(p,100000)raiser#30,SET-a(p,100000)rentice#33,SET] seqnums:[#30-#33] points:[a(p,100000)raiser#30,SET-a(p,100000)rentice#33,SET] size:57246
+  000012:[a(p,100000)rentices#34,SET-a(p,100000)rovals#37,SET] seqnums:[#34-#37] points:[a(p,100000)rentices#34,SET-a(p,100000)rovals#37,SET] size:57246
+  000013:[a(p,100000)rove#38,SET-a(p,100000)rove#38,SET] seqnums:[#38-#38] points:[a(p,100000)rove#38,SET-a(p,100000)rove#38,SET] size:9894
 
-layout filename=000017.sst
+layout filename=000016.sst
 ----
 sstable
- ├── index  offset: 0  length: 28
- ├── range-del  offset: 33  length: 6000129
- ├── properties  offset: 6000167  length: 436
- ├── meta-index  offset: 6000608  length: 65
- └── footer  offset: 6000678  length: 53
+ ├── data  offset: 0  length: 8
+ ├── index  offset: 13  length: 24
+ ├── range-del  offset: 42  length: 600110
+ ├── properties  offset: 600157  length: 339
+ ├── meta-index  offset: 600501  length: 63
+ └── footer  offset: 600569  length: 53
 
-properties file=000017
+properties file=000009
 rocksdb.raw
 ----
 rocksdb.raw:
-  rocksdb.raw.key.size: 6000043
+  rocksdb.raw.key.size: 400059
+  rocksdb.raw.value.size: 20
+
+# Repeat the above with columnar blocks.
+
+define target-file-sizes=(400000) format-major-version=19
+----
+
+# Commit many keys with 100KB-shared prefixes.
+
+batch-commit
+set a(p,100000)arition
+set a(p,100000)alling
+set a(p,100000)eal
+set a(p,100000)ellate
+set a(p,100000)endectomy
+set a(p,100000)etizers
+set a(p,100000)etizing
+set a(p,100000)laude
+set a(p,100000)lauding
+set a(p,100000)le
+set a(p,100000)les
+set a(p,100000)letini
+set a(p,100000)letinis
+set a(p,100000)lebottomjeans
+set a(p,100000)lication
+set a(p,100000)ly
+set a(p,100000)lying
+set a(p,100000)ollo
+set a(p,100000)raisal
+set a(p,100000)raisals
+set a(p,100000)raiser
+set a(p,100000)raisers
+set a(p,100000)raising
+set a(p,100000)rentice
+set a(p,100000)rentices
+set a(p,100000)renticing
+set a(p,100000)roval
+set a(p,100000)rovals
+set a(p,100000)rove
+----
+
+flush verbose
+----
+L0.0:
+  000006:[a(p,100000)a(l,2)ing#11,SET-a(p,100000)eal#12,SET] seqnums:[#10-#12] points:[a(p,100000)a(l,2)ing#11,SET-a(p,100000)eal#12,SET] size:43380
+  000007:[a(p,100000)e(l,2)ate#13,SET-a(p,100000)etizers#15,SET] seqnums:[#13-#15] points:[a(p,100000)e(l,2)ate#13,SET-a(p,100000)etizers#15,SET] size:43399
+  000008:[a(p,100000)etizing#16,SET-a(p,100000)lauding#18,SET] seqnums:[#16-#18] points:[a(p,100000)etizing#16,SET-a(p,100000)lauding#18,SET] size:43386
+  000009:[a(p,100000)le#19,SET-a(p,100000)les#20,SET] seqnums:[#19-#23] points:[a(p,100000)le#19,SET-a(p,100000)les#20,SET] size:43388
+  000010:[a(p,100000)letini#21,SET-a(p,100000)lication#24,SET] seqnums:[#21-#24] points:[a(p,100000)letini#21,SET-a(p,100000)lication#24,SET] size:43399
+  000011:[a(p,100000)ly#25,SET-a(p,100000)o(l,2)o#27,SET] seqnums:[#25-#27] points:[a(p,100000)ly#25,SET-a(p,100000)o(l,2)o#27,SET] size:43366
+  000012:[a(p,100000)raisal#28,SET-a(p,100000)raiser#30,SET] seqnums:[#28-#30] points:[a(p,100000)raisal#28,SET-a(p,100000)raiser#30,SET] size:43388
+  000013:[a(p,100000)raisers#31,SET-a(p,100000)rentice#33,SET] seqnums:[#31-#33] points:[a(p,100000)raisers#31,SET-a(p,100000)rentice#33,SET] size:43390
+  000014:[a(p,100000)rentices#34,SET-a(p,100000)roval#36,SET] seqnums:[#34-#36] points:[a(p,100000)rentices#34,SET-a(p,100000)roval#36,SET] size:43401
+  000015:[a(p,100000)rovals#37,SET-a(p,100000)rove#38,SET] seqnums:[#37-#38] points:[a(p,100000)rovals#37,SET-a(p,100000)rove#38,SET] size:29124
+
+layout filename=000006.sst
+----
+sstable
+ ├── data  offset: 0  length: 4782
+ ├── data  offset: 4787  length: 4780
+ ├── data  offset: 9572  length: 4778
+ ├── index  offset: 14355  length: 4750
+ ├── index  offset: 19110  length: 4754
+ ├── index  offset: 23869  length: 4750
+ ├── top-index  offset: 28624  length: 14170
+ ├── properties  offset: 42799  length: 484
+ ├── meta-index  offset: 43288  length: 34
+ └── footer  offset: 43327  length: 53
+
+properties file=000006
+raw.key.size
+index.size
+index.partitions
+----
+raw.key.size:
+  rocksdb.raw.key.size: 300043
+index.size:
+  rocksdb.index.size: 600234
+  rocksdb.top-level.index.size: 300080
+index.partitions:
+  rocksdb.index.partitions: 3
+
+batch-commit
+del-range a(p,100000)arition a(p,100000)eal
+del-range a(p,100000)ellate a(p,100000)etizers
+del-range a(p,100000)etizing a(p,100000)lauding
+del-range a(p,100000)le a(p,100000)lebottomjeans
+del-range a(p,100000)lebottomjeans a(p,100000)lication
+del-range a(p,100000)ly a(p,100000)lying
+del-range a(p,100000)raisals a(p,100000)rentice
+del-range a(p,100000)rentices a(p,100000)roval
+del-range a(p,100000)rovals a(p,100000)rove
+----
+
+flush verbose
+----
+L0.1:
+  000017:[a(p,100000)arition#39,RANGEDEL-a(p,100000)lauding#inf,RANGEDEL] seqnums:[#39-#41] points:[a(p,100000)arition#39,RANGEDEL-a(p,100000)lauding#inf,RANGEDEL] size:600727
+  000018:[a(p,100000)le#42,RANGEDEL-a(p,100000)rentice#inf,RANGEDEL] seqnums:[#42-#45] points:[a(p,100000)le#42,RANGEDEL-a(p,100000)rentice#inf,RANGEDEL] size:700741
+  000019:[a(p,100000)rentices#46,RANGEDEL-a(p,100000)rove#inf,RANGEDEL] seqnums:[#46-#47] points:[a(p,100000)rentices#46,RANGEDEL-a(p,100000)rove#inf,RANGEDEL] size:400699
+L0.0:
+  000006:[a(p,100000)a(l,2)ing#11,SET-a(p,100000)eal#12,SET] seqnums:[#10-#12] points:[a(p,100000)a(l,2)ing#11,SET-a(p,100000)eal#12,SET] size:43380
+  000007:[a(p,100000)e(l,2)ate#13,SET-a(p,100000)etizers#15,SET] seqnums:[#13-#15] points:[a(p,100000)e(l,2)ate#13,SET-a(p,100000)etizers#15,SET] size:43399
+  000008:[a(p,100000)etizing#16,SET-a(p,100000)lauding#18,SET] seqnums:[#16-#18] points:[a(p,100000)etizing#16,SET-a(p,100000)lauding#18,SET] size:43386
+  000009:[a(p,100000)le#19,SET-a(p,100000)les#20,SET] seqnums:[#19-#23] points:[a(p,100000)le#19,SET-a(p,100000)les#20,SET] size:43388
+  000010:[a(p,100000)letini#21,SET-a(p,100000)lication#24,SET] seqnums:[#21-#24] points:[a(p,100000)letini#21,SET-a(p,100000)lication#24,SET] size:43399
+  000011:[a(p,100000)ly#25,SET-a(p,100000)o(l,2)o#27,SET] seqnums:[#25-#27] points:[a(p,100000)ly#25,SET-a(p,100000)o(l,2)o#27,SET] size:43366
+  000012:[a(p,100000)raisal#28,SET-a(p,100000)raiser#30,SET] seqnums:[#28-#30] points:[a(p,100000)raisal#28,SET-a(p,100000)raiser#30,SET] size:43388
+  000013:[a(p,100000)raisers#31,SET-a(p,100000)rentice#33,SET] seqnums:[#31-#33] points:[a(p,100000)raisers#31,SET-a(p,100000)rentice#33,SET] size:43390
+  000014:[a(p,100000)rentices#34,SET-a(p,100000)roval#36,SET] seqnums:[#34-#36] points:[a(p,100000)rentices#34,SET-a(p,100000)roval#36,SET] size:43401
+  000015:[a(p,100000)rovals#37,SET-a(p,100000)rove#38,SET] seqnums:[#37-#38] points:[a(p,100000)rovals#37,SET-a(p,100000)rove#38,SET] size:29124
+
+layout filename=000018.sst
+----
+sstable
+ ├── index  offset: 0  length: 28
+ ├── range-del  offset: 33  length: 700143
+ ├── properties  offset: 700181  length: 434
+ ├── meta-index  offset: 700620  length: 63
+ └── footer  offset: 700688  length: 53
+
+properties file=000018
+rocksdb.raw
+----
+rocksdb.raw:
+  rocksdb.raw.key.size: 800065
   rocksdb.raw.value.size: 0

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -393,7 +393,9 @@ func TestLargeKeys(t *testing.T) {
 				FormatMajorVersion:          internalFormatNewest,
 				FS:                          vfs.NewMem(),
 				Logger:                      testutils.Logger{T: t},
+				MemTableSize:                16 << 20,
 				MemTableStopWritesThreshold: 4,
+				DisableAutomaticCompactions: true,
 				DisableTableStats:           true,
 			}
 			var err error


### PR DESCRIPTION
Speed up the slowest tests in the root package.

Total package time dropped from 40.5s → 24.9s (~38% faster).
                                                                                                                                                                 
  ```
┌──────────────────────────────────────────────────┬────────┬───────┐                                                                                          
  │                       Test                       │ Before │ After │                                                                                          
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestDBCompactionCrash                            │ 7.89s  │ 1.62s │                                                                                          
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestMetricsWALBytesWrittenMonotonicity           │ 3.60s  │ <0.3s │                                                                                          
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestOpenCloseOpenClose                           │ 3.21s  │ 1.75s │                                                                                          
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestLargeKeys                                    │ 2.58s  │ 0.30s │                                                                                          
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestOpenAlreadyLocked                            │ 2.28s  │ 2.04s │                         
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestCheckpointCompaction                         │ 2.21s  │ <0.5s │
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestElevateThresholdAfterWriteStallUnblocksStall │ 1.83s  │ 1.08s │                         
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestReadOnlyRecovery                             │ 1.41s  │ <0.5s │                         
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestWALFailoverAvoidsWriteStall                  │ 1.36s  │ 0.38s │                         
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestSnapshotRangeDeletionStress                  │ 1.17s  │ <0.5s │                         
  ├──────────────────────────────────────────────────┼────────┼───────┤                                                                                          
  │ TestFlushDelayStress                             │ 1.12s  │ <0.6s │                         
  └──────────────────────────────────────────────────┴────────┴───────┘                                                                                          
```

#### pebble: speed up TestDBCompactionCrash

Increase the outer-loop step from `rng.Int32N(5)+1` to `rng.Int32N(10)+3`.
Each iteration opens a database and replays writes up to a crash point;
sampling crash points at a coarser stride reduces test time roughly
2-3x while still exercising a representative range of crash positions.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestMetricsWALBytesWrittenMonotonicity

Cut the run-time budget from 1s to 200ms. The test asserts that
`Metrics.WAL.BytesWritten` never decreases under concurrent writers and
flushes; many violations would surface within tens of milliseconds, so
200ms is sufficient to detect the regressed behavior tracked in #3505.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestOpenCloseOpenClose

Drop the 100,000-byte value length and parallelize the
`(startFromEmpty, walDirname)` subtests. The four resulting subtests are
independent on disk; running them concurrently halves wall time while
preserving the sequential-reopen semantics within each group.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: shrink testdata/large_keys

Reduce the shared key prefix from 1MB to 100KB and drop the SST target
file size from 4MB to 400KB. Multi-block index partitioning (the
property `TestLargeKeys` exercises, see #4518) is preserved at the
smaller scale, with the same number of files and index partitions.

To avoid flakes, we disable compactions and set `MemTableSize` to
16MiB to keep the SET batch (~3MB) below `largeBatchThreshold`.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestOpenAlreadyLocked

Move the WAL recovery directory setup inside `runTest` so each subtest
gets its own pre-acquired lock and unlocked recovery directory, then run
the `memfs` and `disk/absolute` subtests in parallel. The
`disk/relative` subtests can't be parallelized because they call
`t.Chdir`.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestCheckpointCompaction

Reduce the number of checkpoints created from 200 to 50. The test
exercises concurrent writes, compactions, and checkpoint creation/open;
50 iterations is enough to catch concurrency issues without the extra
cost of validating the remaining 150.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestElevateThresholdAfterWriteStallUnblocksStall

Reduce the number of 1MB writes from 200 to 50. The write stall fires
after ~8 writes; once the elevation goroutine clears it, the remaining
writes only verify that the elevated threshold continues to admit
writes — 50 is enough to exercise that.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestReadOnlyRecovery

Reduce the metamorphic operation count from 10,000 to 3,000. The test
generates a random database state and verifies a read-only re-open
doesn't mutate the filesystem; 3,000 ops produce a sufficiently rich
state with multiple SSTs and WAL segments.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestWALFailoverAvoidsWriteStall

Drop `UnhealthySamplingInterval` from 100ms to 10ms and
`UnhealthyOperationLatencyThreshold` from 1s to 50ms. The test runs
entirely against in-memory `vfs.NewMem`, so the latency thresholds only
serve to gate when the failover decision triggers; tightening them
shortens the time-to-failover and cuts the test runtime ~3x.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestSnapshotRangeDeletionStress

Reduce the number of runs from 200 to 50. Each run writes O(runs) keys
and takes a snapshot, so total work scales as O(runs^2). The expanding
DeleteRange pattern is fully exercised at 50 runs.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### pebble: speed up TestFlushDelayStress

Drop the run count from 100 to 25 and replace the random 1-10ms flush
delays with a fixed 1ms. The test runs inside `synctest.Test`, which
makes wall-clock variance irrelevant, so the random delay range adds
nothing but extra simulated time per iteration.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>