### PR TITLE
manifest: speed up tests

### DIFF
--- a/internal/manifest/annotator_test.go
+++ b/internal/manifest/annotator_test.go
@@ -134,7 +134,7 @@ func TestNumFilesRangeAnnotationEmptyRanges(t *testing.T) {
 
 func TestNumFilesRangeAnnotationRandomized(t *testing.T) {
 	const count = 10_000
-	const numIterations = 10_000
+	const numIterations = 1_000
 
 	v, _ := makeTestVersion(count)
 

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -346,8 +346,8 @@ func TestIterCmpEdgeCases(t *testing.T) {
 }
 
 func TestIterCmpRand(t *testing.T) {
-	const itemCount = 65536
-	const iterCount = 1000
+	const itemCount = 8192
+	const iterCount = 200
 
 	var tr btree[*TableMetadata]
 	tr.bcmp = cmp

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -556,7 +556,7 @@ func TestRandomizedBTree(t *testing.T) {
 		// Reduce the number of ops in race mode so the test doesn't take very long.
 		numOps = 1_000 + rng.IntN(4_000)
 	} else {
-		numOps = 10_000 + rng.IntN(40_000)
+		numOps = 2_000 + rng.IntN(8_000)
 	}
 
 	var metadataAlloc [maxFileNum]TableMetadata

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -222,14 +222,22 @@ func TestBTree(t *testing.T) {
 	const count = 768
 	items := rang(0, count-1)
 
+	// shouldVerify gates the expensive O(N) tree walks (Verify and
+	// checkIter) so they run every 16th iteration and on the final one.
+	// This preserves boundary coverage (height transitions, near-empty/full
+	// tree, fan-out splits) while reducing per-phase work ~16x.
+	shouldVerify := func(i int) bool { return i%16 == 0 || i == count-1 }
+
 	// Add keys in sorted order.
 	for i := 0; i < count; i++ {
 		require.NoError(t, tr.Insert(items[i]))
-		tr.Verify(t)
 		if e := i + 1; e != tr.Count() {
 			t.Fatalf("expected length %d, but found %d", e, tr.Count())
 		}
-		checkIter(t, tableMetadataIter(&tr), 0, i+1, keyMemo)
+		if shouldVerify(i) {
+			tr.Verify(t)
+			checkIter(t, tableMetadataIter(&tr), 0, i+1, keyMemo)
+		}
 	}
 
 	// delete keys in sorted order.
@@ -239,21 +247,25 @@ func TestBTree(t *testing.T) {
 		if len(obsolete.TableBackings) == 0 {
 			t.Fatalf("expected item %d to be obsolete", i)
 		}
-		tr.Verify(t)
 		if e := count - (i + 1); e != tr.Count() {
 			t.Fatalf("expected length %d, but found %d", e, tr.Count())
 		}
-		checkIter(t, tableMetadataIter(&tr), i+1, count, keyMemo)
+		if shouldVerify(i) {
+			tr.Verify(t)
+			checkIter(t, tableMetadataIter(&tr), i+1, count, keyMemo)
+		}
 	}
 
 	// Add keys in reverse sorted order.
 	for i := 1; i <= count; i++ {
 		require.NoError(t, tr.Insert(items[count-i]))
-		tr.Verify(t)
 		if i != tr.Count() {
 			t.Fatalf("expected length %d, but found %d", i, tr.Count())
 		}
-		checkIter(t, tableMetadataIter(&tr), count-i, count, keyMemo)
+		if shouldVerify(i - 1) {
+			tr.Verify(t)
+			checkIter(t, tableMetadataIter(&tr), count-i, count, keyMemo)
+		}
 	}
 
 	// delete keys in reverse sorted order.
@@ -263,11 +275,13 @@ func TestBTree(t *testing.T) {
 		if len(obsolete.TableBackings) == 0 {
 			t.Fatalf("expected item %d to be obsolete", i)
 		}
-		tr.Verify(t)
 		if e := count - i; e != tr.Count() {
 			t.Fatalf("expected length %d, but found %d", e, tr.Count())
 		}
-		checkIter(t, tableMetadataIter(&tr), 0, count-i, keyMemo)
+		if shouldVerify(i - 1) {
+			tr.Verify(t)
+			checkIter(t, tableMetadataIter(&tr), 0, count-i, keyMemo)
+		}
 	}
 }
 

--- a/internal/manifest/btree_test.go
+++ b/internal/manifest/btree_test.go
@@ -286,7 +286,7 @@ func TestBTree(t *testing.T) {
 }
 
 func TestIterClone(t *testing.T) {
-	const count = 65536
+	const count = 8192
 
 	var tr btree[*TableMetadata]
 	tr.bcmp = cmp

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -53,7 +53,7 @@ func TestInuseKeyRangesRandomized(t *testing.T) {
 	ks := testkeys.Alpha(maxKeyLen)
 	smallest := make([]byte, maxKeyLen+testkeys.MaxSuffixLen)
 	largest := make([]byte, maxKeyLen+testkeys.MaxSuffixLen)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 200; i++ {
 		n := testkeys.WriteKeyAt(smallest[:cap(smallest)], ks, rng.Uint64N(ks.Count()), rng.Int64N(maxSuffix))
 		smallest = smallest[:n]
 		n = testkeys.WriteKeyAt(largest[:cap(largest)], ks, rng.Uint64N(ks.Count()), rng.Int64N(maxSuffix))


### PR DESCRIPTION

```
  ┌───────────────────────────────────────┬────────┬───────┐                                                                                                     
  │                 Test                  │ Before │ After │                                                                                                     
  ├───────────────────────────────────────┼────────┼───────┤                                                                                                     
  │ TestRandomizedBTree                   │ 6.61s  │ 0.15s │                                                                                                     
  ├───────────────────────────────────────┼────────┼───────┤                                                                                                   
  │ TestBTree                             │ 1.97s  │ 0.12s │                                                                                                     
  ├───────────────────────────────────────┼────────┼───────┤                                                                                                     
  │ TestNumFilesRangeAnnotationRandomized │ 1.74s  │ 0.19s │                                                                                                     
  ├───────────────────────────────────────┼────────┼───────┤                                                                                                     
  │ TestIterClone                         │ 0.95s  │ 0.02s │                                                                                                   
  ├───────────────────────────────────────┼────────┼───────┤                                                                                                     
  │ TestIterCmpRand                       │ 0.73s  │ 0.01s │                                                        
  ├───────────────────────────────────────┼────────┼───────┤                                                                                                     
  │ TestInuseKeyRangesRandomized          │ 0.31s  │ 0.13s │                                                        
  └───────────────────────────────────────┴────────┴───────┘                                                                                                                                                                                                                    
```


#### manifest: speed up TestRandomizedBTree

Reduce the operation count in the non-slow build path from
`10_000 + rand(40_000)` (avg 30k) to `2_000 + rand(8_000)` (avg 6k). The
test is randomized and run on every CI invocation; 6k operations still
exercise the insert/delete/iterate weight ratios many times over.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### manifest: speed up TestBTree

The test inserts/deletes 768 items four times and after each operation
called `tr.Verify` and `checkIter`, both of which walk the entire
tree. Total cost was O(N^2) per phase.

Gate the expensive walks behind a `shouldVerify(i)` predicate that
fires every 16th iteration plus the final one. Tree height transitions
and split/merge boundaries are still covered, but per-phase
verification work drops ~16x.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### manifest: speed up TestNumFilesRangeAnnotationRandomized

Reduce `numIterations` from 10,000 to 1,000. The loop asserts parity
between `v.Overlaps` and `NumFilesAnnotator.LevelRangeAnnotation` over
random bounds; 1,000 random ranges across 10,000 files still gives
broad coverage.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### manifest: speed up TestIterClone

Reduce the tree size from 65,536 to 8,192. The test clones the
iterator every 500 items and walks the remainder via
`checkIterRelative`, so total work scales as O(N^2/500). With 8,192
items the tree still spans multiple levels and produces ~16 clones at
varied depths.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### manifest: speed up TestIterCmpRand

Reduce the tree size from 65,536 to 8,192 items and the iterator count
from 1,000 to 200. The test exercises `cmpIter` consistency by sorting
positioned iterators two ways; 200 random positions across 8,192 items
still triggers the comparison logic many times.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### manifest: speed up TestInuseKeyRangesRandomized

Reduce the verification loop from 1,000 to 200 iterations. The
metamorphic database generation upstream is what gives the test
interesting state; 200 random spans is still plenty to validate
`CalculateInuseKeyRanges` covers `Overlaps`. Also dramatically reduces
noisy `t.Logf` output.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>