### PR TITLE
record: speed up slow tests

### DIFF
--- a/record/log_writer_test.go
+++ b/record/log_writer_test.go
@@ -56,7 +56,7 @@ func TestSyncQueue(t *testing.T) {
 	var doneWG sync.WaitGroup
 	for range SyncConcurrency {
 		doneWG.Go(func() {
-			for range 1000 {
+			for range 100 {
 				wg := &sync.WaitGroup{}
 				wg.Add(1)
 				// syncQueue is a single-producer, single-consumer queue. We need to

--- a/record/record.go
+++ b/record/record.go
@@ -232,6 +232,12 @@ var (
 	ErrUnexpectedEOF = errors.New("pebble/record: unexpected EOF")
 )
 
+// disableBitFlipCheckForTesting, when true, causes the reader to skip the
+// (expensive) bit-flip diagnostic on a checksum mismatch and just return
+// ErrInvalidChunk. Used by tests that exercise the corruption path on large
+// chunks.
+var disableBitFlipCheckForTesting bool
+
 // IsInvalidRecord returns true if the error matches one of the error types
 // returned for invalid records. These are treated in a way similar to io.EOF
 // in recovery code.
@@ -377,13 +383,15 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 			}
 			data := r.buf[r.begin-headerSize+6 : r.end]
 			if checksum != crc.New(data).Value() {
-				computeChecksum := func(data []byte) uint32 { return crc.New(data).Value() }
-				// Check if there was a bit flip.
-				found, indexFound, bitFound := bitflip.CheckSliceForBitFlip(data, computeChecksum, checksum)
 				err := ErrInvalidChunk
-				if found {
-					err = errors.WithSafeDetails(err, ". bit flip found: block num %d. wal offset %d. byte index %d. got: 0x%x. want: 0x%x.",
-						errors.Safe(r.blockNum), errors.Safe(r.invalidOffset), errors.Safe(indexFound), errors.Safe(data[indexFound]), errors.Safe(data[indexFound]^(1<<bitFound)))
+				if !disableBitFlipCheckForTesting {
+					computeChecksum := func(data []byte) uint32 { return crc.New(data).Value() }
+					// Check if there was a bit flip.
+					found, indexFound, bitFound := bitflip.CheckSliceForBitFlip(data, computeChecksum, checksum)
+					if found {
+						err = errors.WithSafeDetails(err, ". bit flip found: block num %d. wal offset %d. byte index %d. got: 0x%x. want: 0x%x.",
+							errors.Safe(r.blockNum), errors.Safe(r.invalidOffset), errors.Safe(indexFound), errors.Safe(data[indexFound]), errors.Safe(data[indexFound]^(1<<bitFound)))
+					}
 				}
 
 				r.invalidOffset = uint64(r.blockNum)*blockSize + uint64(r.begin)

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -908,6 +908,9 @@ func (l *readerLogger) logf(format string, args ...interface{}) {
 }
 
 func TestWALSync(t *testing.T) {
+	defer func(prev bool) { disableBitFlipCheckForTesting = prev }(disableBitFlipCheckForTesting)
+	disableBitFlipCheckForTesting = true
+
 	var buffer bytes.Buffer
 	result := make([]byte, 0)
 	corruptChunkNumbers := make([]int, 0)

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -160,9 +160,9 @@ func TestBasic(t *testing.T) {
 }
 
 func TestBoundary(t *testing.T) {
-	for i := blockSize - 16; i < blockSize+16; i++ {
+	for i := blockSize - 4; i < blockSize+4; i++ {
 		s0 := big("abcd", i)
-		for j := blockSize - 16; j < blockSize+16; j++ {
+		for j := blockSize - 4; j < blockSize+4; j++ {
 			s1 := big("ABCDE", j)
 			testLiterals(t, []string{s0, s1})
 			testLiterals(t, []string{s0, "", s1})


### PR DESCRIPTION
```
  ┌───────────────┬────────┬───────┐                                                                                                                             
  │     Test      │ Before │ After │                                                                                                                             
  ├───────────────┼────────┼───────┤                                                                                                                             
  │ TestSyncQueue │ 3.1s   │ 0.9s  │                                                                                                                           
  ├───────────────┼────────┼───────┤                                                                                                                           
  │ TestBoundary  │ 2.8s   │ 0.7s  │                                                                                                                             
  ├───────────────┼────────┼───────┤                                                                                                                             
  │ TestWALSync   │ 5.7s   │ 0.65s │                                                                                                                             
  └───────────────┴────────┴───────┘
```

#### record: speed up TestSyncQueue

Reduce per-goroutine push iterations from 1000 to 100. The test still
spawns SyncConcurrency (4096) producers, which is what stresses the
single-producer/single-consumer queue; we don't need 4M total ops.

Test runtime drops from ~3.1s to ~0.9s.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### record: speed up TestBoundary

Narrow the boundary scan window from blockSize±16 to blockSize±4. The
test still covers immediate boundary transitions on either side of
blockSize (which is the interesting region for chunk splitting), with
16x fewer (i,j) pairs.

Test runtime drops from ~2.8s to ~0.7s.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### record: speed up TestWALSync

The bulk of TestWALSync's runtime was spent inside
bitflip.CheckSliceForBitFlip, an O(N^2) brute-force CRC scan invoked on
every checksum mismatch. The test exercises many corruption scenarios on
~32KB chunks but only asserts that ErrInvalidChunk is returned; the
bit-flip diagnostic (a "did corruption come from a single bit flip?"
hint embedded in the error message) is irrelevant to the assertions.

Add an unexported disableBitFlipCheckForTesting flag in the record
package that short-circuits that diagnostic, and set it from
TestWALSync.

Test runtime drops from ~5.7s to ~0.65s.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>