### PR TITLE
sstable/rowblk: speed up multi-GiB overflow tests

### DIFF
--- a/sstable/rowblk/rowblk_64bit_test.go
+++ b/sstable/rowblk/rowblk_64bit_test.go
@@ -44,6 +44,9 @@ func TestSingularKVBlockRestartsOverflow(t *testing.T) {
 	largeValue := bytes.Repeat([]byte("v"), largeValueSize)
 
 	writer := &Writer{RestartInterval: 1}
+	// Pre-allocate the buffer to avoid repeated doubling/copying as the writer
+	// grows past multiple GiB.
+	writer.buf = make([]byte, 0, largeKeySize+largeValueSize+64)
 	require.NoError(t, writer.Add(base.InternalKey{UserKey: largeKey}, largeValue))
 	blockData := writer.Finish()
 	iter, err := NewIter(bytes.Compare, nil, nil, blockData, blockiter.NoTransforms)
@@ -99,6 +102,9 @@ func TestExceedingMaximumRestartOffset(t *testing.T) {
 		kvTestPairs[i] = KVTestPair{key: []byte(key), value: value4MB}
 	}
 	writer := &Writer{RestartInterval: 1}
+	// Pre-allocate the buffer to avoid repeated doubling/copying as the writer
+	// grows past 2 GiB.
+	writer.buf = make([]byte, 0, numKVs*valueSize+1<<20)
 	for _, KVPair := range kvTestPairs {
 		require.NoError(t, writer.Add(base.InternalKey{UserKey: KVPair.key}, KVPair.value))
 	}
@@ -148,6 +154,9 @@ func TestMultipleKVBlockRestartsOverflow(t *testing.T) {
 	}
 
 	writer := &Writer{RestartInterval: 1}
+	// Pre-allocate the buffer to avoid repeated doubling/copying as the writer
+	// grows past multiple GiB.
+	writer.buf = make([]byte, 0, numKVs*valueSize+fourGB+1<<20)
 	for _, KVPair := range kvTestPairs {
 		writer.Add(base.InternalKey{UserKey: KVPair.key}, KVPair.value)
 	}


### PR DESCRIPTION
The three 64-bit overflow tests in `rowblk_64bit_test.go` build row
blocks that grow into multiple GiB. The block writer doubles `w.buf`
on each grow, so each test was paying for many GiB-scale realloc/copy
passes as the buffer climbed from 1 KiB to its final size.

Pre-allocate `writer.buf` to the expected final size in each test:

- `TestExceedingMaximumRestartOffset`: 2.56s -> 0.39s
- `TestMultipleKVBlockRestartsOverflow`: 9.77s -> 5.90s
- `TestSingularKVBlockRestartsOverflow`: 11.06s -> 10.65s

Package wall time drops from ~24.2s to ~17.8s.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>