### PR TITLE
lint: don't pass -all to go vet

### DIFF
--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -89,7 +89,7 @@ func TestLint(t *testing.T) {
 	t.Run("TestGoVet", func(t *testing.T) {
 		if err := stream.ForEach(
 			stream.Sequence(
-				dirCmd(t, pkg.Dir, "go", "vet", "-all", "./..."),
+				dirCmd(t, pkg.Dir, "go", "vet", "./..."),
 				stream.GrepNot(`^#`), // ignore comment lines
 				ignoreGoMod(),
 			), func(s string) {


### PR DESCRIPTION
The `-all` flag is deprecated and has no effect.