### PR TITLE
db: error when opening a database in format major version 1

### DIFF
--- a/open_test.go
+++ b/open_test.go
@@ -171,6 +171,39 @@ func TestErrorIfNotPristine(t *testing.T) {
 	}
 }
 
+// TestOpenFormatVersion1NotSupported verifies that opening a directory written
+// by a Pebble version that used FormatMostCompatible (format major version 1)
+// returns a clear error instead of silently treating the directory as a fresh
+// store and overwriting the data. See issue #5969.
+func TestOpenFormatVersion1NotSupported(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	writeFile := func(fs vfs.FS, name string) {
+		f, err := fs.Create(name, vfs.WriteCategoryUnspecified)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	for _, tc := range []struct {
+		name  string
+		files []string
+	}{
+		{name: "current-only", files: []string{"CURRENT"}},
+		{name: "current-and-manifest-and-sst", files: []string{"CURRENT", "MANIFEST-000001", "000002.sst"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := vfs.NewMem()
+			for _, f := range tc.files {
+				writeFile(fs, f)
+			}
+			_, err := Open("", &Options{FS: fs})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "format major version 1")
+			require.Contains(t, err.Error(), "no longer supported")
+		})
+	}
+}
+
 func TestOpen_WALFailover(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	filesystems := map[string]vfs.FS{}

--- a/recovery.go
+++ b/recovery.go
@@ -59,6 +59,20 @@ func (rs *recoveredState) init(opts *Options, dirname string) error {
 	if err != nil {
 		return errors.Wrapf(err, "pebble: database %q", dirname)
 	}
+	// If there is no format-version marker file, the directory must either be
+	// empty (a fresh store), have been written by a Pebble version that used
+	// FormatMostCompatible (format major version 1), or be a partially-created
+	// modern store that crashed before the format-version marker was synced.
+	// The legacy v1 case is recognizable by the presence of the `CURRENT` file
+	// (v1 used `CURRENT` rather than the atomic manifest marker, so
+	// `findCurrentManifest` would otherwise miss it and we would silently
+	// overwrite the existing data). The crashed-mid-create case is handled
+	// later via `ErrorIfNotPristine` in `Open`.
+	if rs.fmv == FormatDefault {
+		if err := checkForLegacyFormatVersion1(rs.ls, dirname); err != nil {
+			return err
+		}
+	}
 
 	// Open the object storage provider.
 	providerSettings := opts.MakeObjStorageProviderSettings(dirname)
@@ -230,6 +244,29 @@ func (rs *recoveredState) RemoveObsolete(opts *Options) error {
 		}
 	}
 	return err
+}
+
+// checkForLegacyFormatVersion1 returns an error if the directory listing
+// contains a `CURRENT` file, which indicates the store was written by a
+// Pebble version that used FormatMostCompatible (format major version 1).
+// v1 stores predate the `format-version` marker and use `CURRENT` rather
+// than the atomic `manifest` marker; absent this check we would treat the
+// directory as a fresh store and overwrite the existing data.
+//
+// We deliberately do not flag stores that have `MANIFEST-*` files but no
+// `CURRENT` file: real v1 stores always have `CURRENT`, while a modern
+// store can transiently have a manifest without a format-version marker if
+// it crashed mid-creation (the marker is written after the initial
+// manifest). That case is handled by `ErrorIfNotPristine` in `Open`.
+func checkForLegacyFormatVersion1(ls []string, dirname string) error {
+	for _, filename := range ls {
+		if filename == "CURRENT" {
+			return errors.Newf(
+				"pebble: database %q was written in format major version 1, which is no longer supported",
+				dirname)
+		}
+	}
+	return nil
 }
 
 // Close closes resources held by the RecoveredState, including open file


### PR DESCRIPTION
Format major version 1 (`FormatMostCompatible`) predates the
`format-version` marker file and uses a `CURRENT` file rather than the
atomic `manifest` marker. When opening such a database,
`lookupFormatMajorVersion` returned `FormatDefault` and
`findCurrentManifest` reported no manifest, so `Open` treated the
directory as a fresh store and overwrote the existing data.

The existing `ErrorIfNotPristine` safeguard only fires during WAL replay
or after a successful manifest recovery, neither of which happens for a
v1 store, so the safeguard was bypassed.

Detect the legacy state in `recoverState.init` by scanning the
directory listing for a `CURRENT` file when no `format-version` marker
is present, and return an error indicating that format major version 1
is no longer supported. The check runs before any destructive work.
`CURRENT` is the unambiguous v1 signal: real v1 stores always have it,
and modern Pebble never writes it. We deliberately do not flag
directories with `MANIFEST-*` but no `CURRENT`, because that state can
also occur transiently when a modern store crashes mid-creation
(`writeFormatVersionMarker` runs after `initNewDB`).

Fixes #5969.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>
