### PR TITLE
sstable: treat NumDeletionsThreshold as inclusive for tombstone-dense blocks

### DIFF
--- a/sstable/colblk_writer.go
+++ b/sstable/colblk_writer.go
@@ -805,7 +805,7 @@ func (w *RawColumnWriter) flushDataBlockWithoutNextKey(nextKey []byte) error {
 // Invariant: w.dataBlockBuf.uncompressed must already be populated.
 func (w *RawColumnWriter) maybeIncrementTombstoneDenseBlocks(uncompressedLen int) {
 	minSize := w.opts.DeletionSizeRatioThreshold * float32(uncompressedLen)
-	if w.dataBlock.numDeletions > w.opts.NumDeletionsThreshold || float32(w.dataBlock.deletionSize) > minSize {
+	if w.dataBlock.numDeletions >= w.opts.NumDeletionsThreshold || float32(w.dataBlock.deletionSize) > minSize {
 		w.props.NumTombstoneDenseBlocks++
 	}
 	w.dataBlock.numDeletions = 0

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -986,7 +986,7 @@ func (w *RawRowWriter) maybeAddToFilter(key []byte) {
 // Invariant: w.dataBlockBuf.uncompressed must already be populated.
 func (w *RawRowWriter) maybeIncrementTombstoneDenseBlocks() {
 	minSize := w.deletionSizeRatioThreshold * float32(len(w.dataBlockBuf.uncompressed))
-	if w.dataBlockBuf.numDeletions > w.numDeletionsThreshold || float32(w.dataBlockBuf.deletionSize) > minSize {
+	if w.dataBlockBuf.numDeletions >= w.numDeletionsThreshold || float32(w.dataBlockBuf.deletionSize) > minSize {
 		w.props.NumTombstoneDenseBlocks++
 	}
 	w.dataBlockBuf.numDeletions = 0


### PR DESCRIPTION
Previously `maybeIncrementTombstoneDenseBlocks` in both writers compared `numDeletions > NumDeletionsThreshold`, so a block with exactly `NumDeletionsThreshold` point tombstones was not counted toward `NumTombstoneDenseBlocks`.

Use `>=` so behavior matches the documented definition ("at least `N` point tombstones") in `docs/RFCS/20240701_tombstone_density_heuristic.md`, `sstable/properties.go`, and `Options.Experimental.NumDeletionsThreshold`.