### PR TITLE
arenaskl, batch: enforce strict prefix iteration, stop enforcing in iterv2

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1722,7 +1722,9 @@ func (b *Batch) CommitStats() BatchCommitStats {
 }
 
 // Note: batchIter mirrors the implementation of flushableBatchIter. Keep the
-// two in sync.
+// two in sync. Note that flushFlushableBatchIter does not implement prefix
+// iteration: its SeekPrefixGE panics, so the prefix-mode logic below is
+// intentionally absent there.
 type batchIter struct {
 	batch *Batch
 	iter  batchskl.Iterator
@@ -1733,6 +1735,10 @@ type batchIter struct {
 	// encodes an offset within the batch. Only batch entries earlier than the
 	// offset are visible during iteration.
 	snapshot base.SeqNum
+	// prefix, when non-nil, restricts iteration to keys whose split prefix
+	// equals prefix. Set by SeekPrefixGE; cleared by SeekGE/SeekLT/First/Last/
+	// NextPrefix/SetBounds.
+	prefix []byte
 }
 
 // batchIter implements the base.InternalIterator interface.
@@ -1749,6 +1755,7 @@ func (i *batchIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV 
 	}
 
 	i.err = nil // clear cached iteration error
+	i.prefix = nil
 	ikey := i.iter.SeekGE(key, flags)
 	for ikey != nil && ikey.SeqNum() >= i.snapshot {
 		ikey = i.iter.Next()
@@ -1763,11 +1770,13 @@ func (i *batchIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV 
 }
 
 func (i *batchIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	// SeekGE clears i.prefix, so any TrySeekUsingNext path inside it operates
+	// without prefix gating. Re-apply prefix afterward and check the result.
 	kv := i.SeekGE(key, flags)
+	i.prefix = prefix
 	if kv == nil {
 		return nil
 	}
-	// If the key doesn't have the sought prefix, return nil.
 	if !bytes.Equal(i.batch.comparer.Split.Prefix(kv.K.UserKey), prefix) {
 		i.kv = base.InternalKV{}
 		return nil
@@ -1777,6 +1786,7 @@ func (i *batchIter) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *ba
 
 func (i *batchIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	i.err = nil // clear cached iteration error
+	i.prefix = nil
 	ikey := i.iter.SeekLT(key)
 	for ikey != nil && ikey.SeqNum() >= i.snapshot {
 		ikey = i.iter.Prev()
@@ -1792,6 +1802,7 @@ func (i *batchIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV 
 
 func (i *batchIter) First() *base.InternalKV {
 	i.err = nil // clear cached iteration error
+	i.prefix = nil
 	ikey := i.iter.First()
 	for ikey != nil && ikey.SeqNum() >= i.snapshot {
 		ikey = i.iter.Next()
@@ -1807,6 +1818,7 @@ func (i *batchIter) First() *base.InternalKV {
 
 func (i *batchIter) Last() *base.InternalKV {
 	i.err = nil // clear cached iteration error
+	i.prefix = nil
 	ikey := i.iter.Last()
 	for ikey != nil && ikey.SeqNum() >= i.snapshot {
 		ikey = i.iter.Prev()
@@ -1829,12 +1841,16 @@ func (i *batchIter) Next() *base.InternalKV {
 		i.kv = base.InternalKV{}
 		return nil
 	}
+	if i.prefix != nil && !bytes.Equal(i.batch.comparer.Split.Prefix(ikey.UserKey), i.prefix) {
+		return nil
+	}
 	i.kv.K = *ikey
 	i.kv.V = base.MakeInPlaceValue(i.value())
 	return &i.kv
 }
 
 func (i *batchIter) NextPrefix(succKey []byte) *base.InternalKV {
+	i.prefix = nil
 	// Because NextPrefix was invoked `succKey` must be ≥ the key at i's current
 	// position. Seek the arena iterator using TrySeekUsingNext.
 	ikey := i.iter.SeekGE(succKey, base.SeekGEFlagsNone.EnableTrySeekUsingNext())
@@ -1897,6 +1913,7 @@ func (i *batchIter) Close() error {
 
 func (i *batchIter) SetBounds(lower, upper []byte) {
 	i.iter.SetBounds(lower, upper)
+	i.prefix = nil
 }
 
 func (i *batchIter) SetContext(_ context.Context) {}
@@ -2214,6 +2231,11 @@ type flushableBatchIter struct {
 	// Optionally initialize to bounds of iteration, if any.
 	lower []byte
 	upper []byte
+
+	// prefix, when non-nil, restricts iteration to keys whose split prefix
+	// equals prefix. Set by SeekPrefixGE; cleared by SeekGE/SeekLT/First/Last/
+	// NextPrefix/SetBounds.
+	prefix []byte
 }
 
 // flushableBatchIter implements the base.InternalIterator interface.
@@ -2228,6 +2250,7 @@ func (i *flushableBatchIter) String() string {
 // optimization to provide much benefit here at the moment.
 func (i *flushableBatchIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	i.err = nil // clear cached iteration error
+	i.prefix = nil
 	ikey := base.MakeSearchKey(key)
 	i.index = sort.Search(len(i.offsets), func(j int) bool {
 		return base.InternalCompare(i.cmp, ikey, i.getKey(j)) <= 0
@@ -2248,11 +2271,12 @@ func (i *flushableBatchIter) SeekGE(key []byte, flags base.SeekGEFlags) *base.In
 func (i *flushableBatchIter) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
 ) *base.InternalKV {
+	// SeekGE clears i.prefix; re-apply prefix afterward and check the result.
 	kv := i.SeekGE(key, flags)
+	i.prefix = prefix
 	if kv == nil {
 		return nil
 	}
-	// If the key doesn't have the sought prefix, return nil.
 	if !bytes.Equal(i.batch.comparer.Split.Prefix(kv.K.UserKey), prefix) {
 		return nil
 	}
@@ -2263,6 +2287,7 @@ func (i *flushableBatchIter) SeekPrefixGE(
 // package.
 func (i *flushableBatchIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
 	i.err = nil // clear cached iteration error
+	i.prefix = nil
 	ikey := base.MakeSearchKey(key)
 	i.index = sort.Search(len(i.offsets), func(j int) bool {
 		return base.InternalCompare(i.cmp, ikey, i.getKey(j)) <= 0
@@ -2283,6 +2308,7 @@ func (i *flushableBatchIter) SeekLT(key []byte, flags base.SeekLTFlags) *base.In
 // package.
 func (i *flushableBatchIter) First() *base.InternalKV {
 	i.err = nil // clear cached iteration error
+	i.prefix = nil
 	if len(i.offsets) == 0 {
 		return nil
 	}
@@ -2299,6 +2325,7 @@ func (i *flushableBatchIter) First() *base.InternalKV {
 // package.
 func (i *flushableBatchIter) Last() *base.InternalKV {
 	i.err = nil // clear cached iteration error
+	i.prefix = nil
 	if len(i.offsets) == 0 {
 		return nil
 	}
@@ -2311,8 +2338,10 @@ func (i *flushableBatchIter) Last() *base.InternalKV {
 	return kv
 }
 
-// Note: flushFlushableBatchIter.Next mirrors the implementation of
+// Note: flushFlushableBatchIter.Next mirrors the structure of
 // flushableBatchIter.Next due to performance. Keep the two in sync.
+// flushFlushableBatchIter.Next omits the bounds and prefix checks because the
+// flush iterator never has bounds or prefix mode set.
 func (i *flushableBatchIter) Next() *base.InternalKV {
 	if i.index == len(i.offsets) {
 		return nil
@@ -2323,6 +2352,13 @@ func (i *flushableBatchIter) Next() *base.InternalKV {
 	}
 	kv := i.getKV(i.index)
 	if i.upper != nil && i.cmp(kv.K.UserKey, i.upper) >= 0 {
+		i.index = len(i.offsets)
+		return nil
+	}
+	if i.prefix != nil && !bytes.Equal(i.batch.comparer.Split.Prefix(kv.K.UserKey), i.prefix) {
+		// Explicitly exhaust the iterator by setting i.index past the end. This
+		// is safe because TrySeekUsingNext is ignored by flushableBatchIter, so
+		// a subsequent SeekPrefixGE will reposition the iterator from scratch.
 		i.index = len(i.offsets)
 		return nil
 	}
@@ -2348,6 +2384,7 @@ func (i *flushableBatchIter) Prev() *base.InternalKV {
 // Note: flushFlushableBatchIter.NextPrefix mirrors the implementation of
 // flushableBatchIter.NextPrefix due to performance. Keep the two in sync.
 func (i *flushableBatchIter) NextPrefix(succKey []byte) *base.InternalKV {
+	// SeekGE clears i.prefix.
 	return i.SeekGE(succKey, base.SeekGEFlagsNone.EnableTrySeekUsingNext())
 }
 
@@ -2408,6 +2445,7 @@ func (i *flushableBatchIter) Close() error {
 func (i *flushableBatchIter) SetBounds(lower, upper []byte) {
 	i.lower = lower
 	i.upper = upper
+	i.prefix = nil
 }
 
 func (i *flushableBatchIter) SetContext(_ context.Context) {}
@@ -2453,8 +2491,11 @@ func (i *flushFlushableBatchIter) NextPrefix(succKey []byte) *base.InternalKV {
 	panic(errors.AssertionFailedf("pebble: Prev unimplemented"))
 }
 
-// Note: flushFlushableBatchIter.Next mirrors the implementation of
-// flushableBatchIter.Next due to performance. Keep the two in sync.
+// Note: flushFlushableBatchIter.Next mirrors the structure of
+// flushableBatchIter.Next due to performance. Keep the two in sync. The
+// bounds and prefix-mode checks are intentionally omitted: the flush iterator
+// is not used with bounds and never enters prefix mode (its SeekPrefixGE
+// panics).
 func (i *flushFlushableBatchIter) Next() *base.InternalKV {
 	if i.index == len(i.offsets) {
 		return nil

--- a/batch_test.go
+++ b/batch_test.go
@@ -1105,6 +1105,127 @@ func TestBatchIter(t *testing.T) {
 	}
 }
 
+// TestBatchIterStrictPrefix verifies the strict prefix iteration behavior of
+// batchIter.SeekPrefixGE and Next using testkeys.Comparer (which has a
+// non-trivial Split that splits at '@' and orders suffixes in reverse:
+// a@3 < a@2 < a@1 < b@2 < b@1).
+func TestBatchIterStrictPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	newIter := func() *batchIter {
+		b := newIndexedBatch(nil, testkeys.Comparer)
+		for _, k := range []string{"a@1", "a@2", "a@3", "b@1", "b@2"} {
+			require.NoError(t, b.Set([]byte(k), []byte("v"+k), nil))
+		}
+		return b.newInternalIter(nil)
+	}
+
+	requireKey := func(t *testing.T, kv *base.InternalKV, want string) {
+		t.Helper()
+		require.NotNil(t, kv)
+		require.Equal(t, want, string(kv.K.UserKey))
+	}
+
+	t.Run("Next stops at prefix boundary", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.Next(), "a@2")
+		requireKey(t, iter.Next(), "a@1")
+		require.Nil(t, iter.Next())
+	})
+
+	t.Run("no matching prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		require.Nil(t, iter.SeekPrefixGE([]byte("c"), []byte("c"), base.SeekGEFlagsNone))
+	})
+
+	t.Run("seek past matching suffixes", func(t *testing.T) {
+		// testkeys reverse-suffix ordering: the first key >= "a@0" is b@2.
+		iter := newIter()
+		defer iter.Close()
+		require.Nil(t, iter.SeekPrefixGE([]byte("a"), []byte("a@0"), base.SeekGEFlagsNone))
+	})
+
+	t.Run("SeekGE clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		require.Nil(t, iter.SeekPrefixGE([]byte("a"), []byte("a@0"), base.SeekGEFlagsNone))
+		requireKey(t, iter.SeekGE([]byte("b@2"), base.SeekGEFlagsNone), "b@2")
+		requireKey(t, iter.Next(), "b@1")
+	})
+
+	t.Run("SeekPrefixGE with TrySeekUsingNext crosses prefix", func(t *testing.T) {
+		// Load-bearing case for the clear-then-set ordering in SeekPrefixGE: if
+		// SeekGE saw a non-nil i.prefix during its TrySeekUsingNext path, an
+		// inner Next() could short-circuit on prefix mismatch.
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.SeekPrefixGE([]byte("b"), []byte("b@2"),
+			base.SeekGEFlagsNone.EnableTrySeekUsingNext()), "b@2")
+	})
+
+	t.Run("First clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.First(), "a@3")
+		requireKey(t, iter.Next(), "a@2")
+		requireKey(t, iter.Next(), "a@1")
+		requireKey(t, iter.Next(), "b@2")
+		requireKey(t, iter.Next(), "b@1")
+		require.Nil(t, iter.Next())
+	})
+
+	t.Run("Last clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.Last(), "b@1")
+	})
+
+	t.Run("SeekLT clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.SeekLT([]byte("c"), base.SeekLTFlagsNone), "b@1")
+	})
+
+	t.Run("SetBounds clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		iter.SetBounds(nil, nil)
+		requireKey(t, iter.SeekGE([]byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.Next(), "a@2")
+		requireKey(t, iter.Next(), "a@1")
+		requireKey(t, iter.Next(), "b@2")
+	})
+
+	t.Run("snapshot interaction", func(t *testing.T) {
+		// Construct a batch where the snapshot loop in Next must skip an
+		// invisible key with the matching prefix and land on a visible key
+		// with a different prefix; verify the prefix check fires.
+		b := newIndexedBatch(nil, testkeys.Comparer)
+		require.NoError(t, b.Set([]byte("a@2"), []byte("v"), nil))
+		// Capture the snapshot here: subsequent Sets are invisible.
+		snap := b.nextSeqNum()
+		require.NoError(t, b.Set([]byte("a@1"), []byte("v"), nil))
+		require.NoError(t, b.Set([]byte("b@1"), []byte("v"), nil))
+
+		iter := b.newInternalIter(nil)
+		defer iter.Close()
+		iter.snapshot = snap
+
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@2")
+		// iter.Next() advances to a@1 (invisible), snapshot loop skips to b@1
+		// (visible), prefix check fails; result is nil.
+		require.Nil(t, iter.Next())
+	})
+}
+
 func TestBatchRangeOps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var b *Batch
@@ -1225,6 +1346,102 @@ func TestFlushableBatchIter(t *testing.T) {
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
 		}
+	})
+}
+
+// TestFlushableBatchIterStrictPrefix verifies the strict prefix iteration
+// behavior of flushableBatchIter (mirrors TestBatchIterStrictPrefix).
+func TestFlushableBatchIterStrictPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	newIter := func() internalIterator {
+		batch := newBatch(nil)
+		for _, k := range []string{"a@1", "a@2", "a@3", "b@1", "b@2"} {
+			require.NoError(t, batch.Set([]byte(k), []byte("v"+k), nil))
+		}
+		fb, err := newFlushableBatch(batch, testkeys.Comparer)
+		require.NoError(t, err)
+		return fb.newIter(nil)
+	}
+
+	requireKey := func(t *testing.T, kv *base.InternalKV, want string) {
+		t.Helper()
+		require.NotNil(t, kv)
+		require.Equal(t, want, string(kv.K.UserKey))
+	}
+
+	t.Run("Next stops at prefix boundary", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.Next(), "a@2")
+		requireKey(t, iter.Next(), "a@1")
+		require.Nil(t, iter.Next())
+	})
+
+	t.Run("no matching prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		require.Nil(t, iter.SeekPrefixGE([]byte("c"), []byte("c"), base.SeekGEFlagsNone))
+	})
+
+	t.Run("seek past matching suffixes", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		require.Nil(t, iter.SeekPrefixGE([]byte("a"), []byte("a@0"), base.SeekGEFlagsNone))
+	})
+
+	t.Run("SeekGE clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		require.Nil(t, iter.SeekPrefixGE([]byte("a"), []byte("a@0"), base.SeekGEFlagsNone))
+		requireKey(t, iter.SeekGE([]byte("b@2"), base.SeekGEFlagsNone), "b@2")
+		requireKey(t, iter.Next(), "b@1")
+	})
+
+	t.Run("SeekPrefixGE with TrySeekUsingNext crosses prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.SeekPrefixGE([]byte("b"), []byte("b@2"),
+			base.SeekGEFlagsNone.EnableTrySeekUsingNext()), "b@2")
+	})
+
+	t.Run("First clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.First(), "a@3")
+		requireKey(t, iter.Next(), "a@2")
+		requireKey(t, iter.Next(), "a@1")
+		requireKey(t, iter.Next(), "b@2")
+		requireKey(t, iter.Next(), "b@1")
+		require.Nil(t, iter.Next())
+	})
+
+	t.Run("Last clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.Last(), "b@1")
+	})
+
+	t.Run("SeekLT clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.SeekLT([]byte("c"), base.SeekLTFlagsNone), "b@1")
+	})
+
+	t.Run("SetBounds clears prefix", func(t *testing.T) {
+		iter := newIter()
+		defer iter.Close()
+		requireKey(t, iter.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone), "a@3")
+		iter.SetBounds(nil, nil)
+		requireKey(t, iter.SeekGE([]byte("a"), base.SeekGEFlagsNone), "a@3")
+		requireKey(t, iter.Next(), "a@2")
+		requireKey(t, iter.Next(), "a@1")
+		requireKey(t, iter.Next(), "b@2")
 	})
 }
 

--- a/flushable.go
+++ b/flushable.go
@@ -290,7 +290,7 @@ func (s *ingestedFlushable) newItersV2(
 		iiter := &iterv2.InterleavingIter{}
 		iiter.Init(
 			s.comparer,
-			base.NewFakeIterWithCmp(s.comparer.Compare, nil),
+			base.NewFakeIter(s.comparer, nil),
 			keyspan.NewIter(s.comparer.Compare, []keyspan.Span{rdel}),
 			nil, nil, nil, nil,
 		)

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -18,6 +18,7 @@
 package arenaskl
 
 import (
+	"bytes"
 	"context"
 	"sync"
 
@@ -40,6 +41,8 @@ func (s *splice) init(prev, next *node) {
 // simply value copying the struct. All iterator methods are thread-safe.
 type Iterator struct {
 	list  *Skiplist
+	split base.Split
+
 	nd    *node
 	kv    base.InternalKV
 	lower []byte
@@ -58,6 +61,11 @@ type Iterator struct {
 	// comparisons are necessary.
 	lowerNode *node
 	upperNode *node
+
+	// prefix, when non-nil, restricts iteration to keys whose split prefix
+	// equals prefix. Set by SeekPrefixGE; cleared by SeekGE/SeekLT/First/Last/
+	// SetBounds.
+	prefix []byte
 }
 
 // Iterator implements the base.InternalIterator interface.
@@ -91,6 +99,7 @@ func (it *Iterator) Error() error {
 // It is up to the caller to ensure that key is greater than or equal to the
 // lower bound.
 func (it *Iterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
+	it.prefix = nil
 	if flags.TrySeekUsingNext() {
 		if it.nd == it.list.tail || it.nd == it.upperNode {
 			// Iterator is done.
@@ -128,11 +137,25 @@ func (it *Iterator) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV 
 }
 
 // SeekPrefixGE moves the iterator to the first entry whose key is greater than
-// or equal to the given key. This method is equivalent to SeekGE and is
-// provided so that an arenaskl.Iterator implements the
-// internal/base.InternalIterator interface.
+// or equal to the given key, restricted to keys with the given prefix.
+// Subsequent calls to Next return nil once the iterator advances to a key
+// whose prefix differs from prefix.
+//
+// NB: SeekPrefixGE in terms of positioning the iterator behaves exactly like
+// SeekGE. The prefix parameter is only used to decide whether to return the
+// InternalKV it landed on (if the prefix matches) or nil (if the prefix does
+// not match). Since it doesn't change positioning behavior, TrySeekUsingNext
+// works with no special casing for earlier prefix iteration.
 func (it *Iterator) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *base.InternalKV {
-	return it.SeekGE(key, flags)
+	// SeekGE clears it.prefix, so the TrySeekUsingNext loop's calls to
+	// it.Next() use non-prefix semantics. We re-apply prefix afterward and
+	// check the result.
+	kv := it.SeekGE(key, flags)
+	it.prefix = prefix
+	if kv != nil && !bytes.Equal(it.split.Prefix(kv.K.UserKey), prefix) {
+		return nil
+	}
+	return kv
 }
 
 // SeekLT moves the iterator to the last entry whose key is less than the given
@@ -140,6 +163,7 @@ func (it *Iterator) SeekPrefixGE(prefix, key []byte, flags base.SeekGEFlags) *ba
 // nil otherwise. Note that SeekLT only checks the lower bound. It is up to the
 // caller to ensure that key is less than the upper bound.
 func (it *Iterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV {
+	it.prefix = nil
 	// NB: the top-level Iterator has already adjusted key based on
 	// the upper-bound.
 	it.nd, _ = it.seekForBaseSplice(key)
@@ -160,6 +184,7 @@ func (it *Iterator) SeekLT(key []byte, flags base.SeekLTFlags) *base.InternalKV 
 // only checks the upper bound. It is up to the caller to ensure that key is
 // greater than or equal to the lower bound (e.g. via a call to SeekGE(lower)).
 func (it *Iterator) First() *base.InternalKV {
+	it.prefix = nil
 	it.nd = it.list.getNext(it.list.head, 0)
 	if it.nd == it.list.tail || it.nd == it.upperNode {
 		return nil
@@ -178,6 +203,7 @@ func (it *Iterator) First() *base.InternalKV {
 // checks the lower bound. It is up to the caller to ensure that key is less
 // than the upper bound (e.g. via a call to SeekLT(upper)).
 func (it *Iterator) Last() *base.InternalKV {
+	it.prefix = nil
 	it.nd = it.list.getPrev(it.list.tail, 0)
 	if it.nd == it.list.head || it.nd == it.lowerNode {
 		return nil
@@ -205,7 +231,14 @@ func (it *Iterator) Next() *base.InternalKV {
 		it.upperNode = it.nd
 		return nil
 	}
+	// Set it.kv.V before the prefix check so that it.kv stays internally
+	// consistent. A subsequent SeekGE/SeekPrefixGE with TrySeekUsingNext may
+	// land on this same node via the fast path that returns &it.kv directly,
+	// which would otherwise expose the previous key's value.
 	it.kv.V = base.MakeInPlaceValue(it.value())
+	if it.prefix != nil && !bytes.Equal(it.split.Prefix(it.kv.K.UserKey), it.prefix) {
+		return nil
+	}
 	return &it.kv
 }
 
@@ -244,6 +277,7 @@ func (it *Iterator) SetBounds(lower, upper []byte) {
 	it.upper = upper
 	it.lowerNode = nil
 	it.upperNode = nil
+	it.prefix = nil
 }
 
 // SetContext implements base.InternalIterator.

--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -299,15 +299,18 @@ func (s *Skiplist) addInternal(key base.InternalKey, value []byte, ins *Inserter
 	return nil
 }
 
-// NewIter returns a new Iterator object. The lower and upper bound parameters
-// control the range of keys the iterator will return. Specifying for nil for
-// lower or upper bound disables the check for that boundary. Note that lower
-// bound is not checked on {SeekGE,First} and upper bound is not check on
-// {SeekLT,Last}. The user is expected to perform that check. Note that it is
-// safe for an iterator to be copied by value.
-func (s *Skiplist) NewIter(lower, upper []byte) *Iterator {
+// NewIter returns a new Iterator object. The split function is used to extract
+// the prefix of a user key for strict prefix iteration via SeekPrefixGE; it
+// must be non-nil (callers without a meaningful Split function should pass
+// base.DefaultSplit). The lower and upper bound parameters control the range
+// of keys the iterator will return. Specifying for nil for lower or upper
+// bound disables the check for that boundary. Note that lower bound is not
+// checked on {SeekGE,First} and upper bound is not check on {SeekLT,Last}.
+// The user is expected to perform that check. Note that it is safe for an
+// iterator to be copied by value.
+func (s *Skiplist) NewIter(split base.Split, lower, upper []byte) *Iterator {
 	it := iterPool.Get().(*Iterator)
-	*it = Iterator{list: s, nd: s.head, lower: lower, upper: upper}
+	*it = Iterator{list: s, nd: s.head, lower: lower, upper: upper, split: split}
 	return it
 }
 

--- a/internal/arenaskl/skl_bench_test.go
+++ b/internal/arenaskl/skl_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkCockroachKeysSeekPrefixGE(b *testing.B) {
 	for _, skip := range []int{1, 2, 4, 8, 16} {
 		for _, useNext := range []bool{false, true} {
 			b.Run(fmt.Sprintf("skip=%d/use-next=%t", skip, useNext), func(b *testing.B) {
-				it := l.NewIter(nil, nil)
+				it := l.NewIter(cockroachkvs.Split, nil, nil)
 				j := 0
 				b.ResetTimer()
 				it.SeekPrefixGE(prefixes[j], keys[j], base.SeekGEFlagsNone)

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -64,7 +64,7 @@ func makeInserterAdd(s *Skiplist) func(key base.InternalKey, value []byte) error
 // length iterates over skiplist to give exact size.
 func length(s *Skiplist) int {
 	count := 0
-	it := s.NewIter(nil, nil)
+	it := s.NewIter(base.DefaultSplit, nil, nil)
 	for kv := it.First(); kv != nil; kv = it.Next() {
 		count++
 	}
@@ -74,7 +74,7 @@ func length(s *Skiplist) int {
 // length iterates over skiplist in reverse order to give exact size.
 func lengthRev(s *Skiplist) int {
 	count := 0
-	it := s.NewIter(nil, nil)
+	it := s.NewIter(base.DefaultSplit, nil, nil)
 	for kv := it.Last(); kv != nil; kv = it.Prev() {
 		count++
 	}
@@ -93,7 +93,7 @@ func TestNoPointers(t *testing.T) {
 func TestEmpty(t *testing.T) {
 	key := makeKey("aaa")
 	l := NewSkiplist(newArena(arenaSize), bytes.Compare)
-	it := l.NewIter(nil, nil)
+	it := l.NewIter(base.DefaultSplit, nil, nil)
 	require.Nil(t, it.First())
 	require.Nil(t, it.Last())
 	require.Nil(t, it.SeekGE(key, base.SeekGEFlagsNone))
@@ -128,7 +128,7 @@ func TestBasic(t *testing.T) {
 	for _, inserter := range []bool{false, true} {
 		t.Run(fmt.Sprintf("inserter=%t", inserter), func(t *testing.T) {
 			l := NewSkiplist(newArena(arenaSize), bytes.Compare)
-			it := l.NewIter(nil, nil)
+			it := l.NewIter(base.DefaultSplit, nil, nil)
 
 			add := l.Add
 			if inserter {
@@ -220,7 +220,7 @@ func TestConcurrentBasic(t *testing.T) {
 			// Check values. Concurrent reads.
 			for i := range n {
 				wg.Go(func() {
-					it := l.NewIter(nil, nil)
+					it := l.NewIter(base.DefaultSplit, nil, nil)
 					kv := it.SeekGE(makeKey(fmt.Sprintf("%05d", i)), base.SeekGEFlagsNone)
 					require.NotNil(t, kv)
 					require.EqualValues(t, fmt.Sprintf("%05d", i), kv.K.UserKey)
@@ -269,7 +269,7 @@ func TestConcurrentOneKey(t *testing.T) {
 			var sawValue atomic.Int32
 			for range n {
 				wg.Go(func() {
-					it := l.NewIter(nil, nil)
+					it := l.NewIter(base.DefaultSplit, nil, nil)
 					kv := it.SeekGE(key, base.SeekGEFlagsNone)
 					require.NotNil(t, kv)
 					require.True(t, bytes.Equal(key, kv.K.UserKey))
@@ -292,7 +292,7 @@ func TestSkiplistAdd(t *testing.T) {
 	for _, inserter := range []bool{false, true} {
 		t.Run(fmt.Sprintf("inserter=%t", inserter), func(t *testing.T) {
 			l := NewSkiplist(newArena(arenaSize), bytes.Compare)
-			it := l.NewIter(nil, nil)
+			it := l.NewIter(base.DefaultSplit, nil, nil)
 
 			add := l.Add
 			if inserter {
@@ -308,7 +308,7 @@ func TestSkiplistAdd(t *testing.T) {
 			require.EqualValues(t, []byte{}, mustGetValue(t, kv.V))
 
 			l = NewSkiplist(newArena(arenaSize), bytes.Compare)
-			it = l.NewIter(nil, nil)
+			it = l.NewIter(base.DefaultSplit, nil, nil)
 
 			add = l.Add
 			if inserter {
@@ -385,7 +385,7 @@ func TestConcurrentAdd(t *testing.T) {
 
 			for f := 0; f < 2; f++ {
 				go func(f int) {
-					it := l.NewIter(nil, nil)
+					it := l.NewIter(base.DefaultSplit, nil, nil)
 					add := l.Add
 					if inserter {
 						add = makeInserterAdd(l)
@@ -421,7 +421,7 @@ func TestConcurrentAdd(t *testing.T) {
 func TestIteratorNext(t *testing.T) {
 	const n = 100
 	l := NewSkiplist(newArena(arenaSize), bytes.Compare)
-	it := l.NewIter(nil, nil)
+	it := l.NewIter(base.DefaultSplit, nil, nil)
 
 	require.Nil(t, it.First())
 	for i := n - 1; i >= 0; i-- {
@@ -442,7 +442,7 @@ func TestIteratorNext(t *testing.T) {
 func TestIteratorPrev(t *testing.T) {
 	const n = 100
 	l := NewSkiplist(newArena(arenaSize), bytes.Compare)
-	it := l.NewIter(nil, nil)
+	it := l.NewIter(base.DefaultSplit, nil, nil)
 
 	require.Nil(t, it.Last())
 	var ins Inserter
@@ -481,7 +481,7 @@ func mustSeekPrefixGEKV(
 func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 	const n = 100
 	l := NewSkiplist(newArena(arenaSize), bytes.Compare)
-	it := l.NewIter(nil, nil)
+	it := l.NewIter(base.DefaultSplit, nil, nil)
 
 	require.Nil(t, it.First())
 	// 1000, 1010, 1020, ..., 1990.
@@ -518,7 +518,9 @@ func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 		mustSeekGEKV(t, it, makeKey("01100"), base.SeekGEFlagsNone, "01100", "v01100")
 	}
 
-	// Test SeekPrefixGE with trySeekUsingNext optimization.
+	// Test SeekPrefixGE with trySeekUsingNext optimization. With base.DefaultSplit
+	// the prefix is the whole key, so strict prefix iteration is equivalent to
+	// exact-match iteration.
 	{
 		mustSeekPrefixGEKV(t, it, makeKey("01000"), base.SeekGEFlagsNone, "01000", "v01000")
 
@@ -531,11 +533,18 @@ func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 		// Seeking to a key that cannot be reached using Next.
 		mustSeekPrefixGEKV(t, it, makeKey("01200"), base.SeekGEFlagsNone.EnableTrySeekUsingNext(), "01200", "v01200")
 
-		// Seeking to an earlier key, but the caller lies. Incorrect result.
-		mustSeekPrefixGEKV(t, it, makeKey("01100"), base.SeekGEFlagsNone.EnableTrySeekUsingNext(), "01200", "v01200")
+		// Seeking to an earlier key, but the caller lies. Under strict prefix
+		// iteration, the result key "01200" doesn't match the prefix "01100",
+		// so SeekPrefixGE returns nil.
+		require.Nil(t, it.SeekPrefixGE(makeKey("01100"), makeKey("01100"),
+			base.SeekGEFlagsNone.EnableTrySeekUsingNext()))
 
 		// Telling the truth works.
 		mustSeekPrefixGEKV(t, it, makeKey("01100"), base.SeekGEFlagsNone, "01100", "v01100")
+
+		// After SeekPrefixGE("01100"), Next() returns nil because the next key
+		// "01110" has a different prefix under DefaultSplit.
+		require.Nil(t, it.Next())
 	}
 
 	// Test seek for empty key.
@@ -543,10 +552,120 @@ func TestIteratorSeekGEAndSeekPrefixGE(t *testing.T) {
 	mustSeekGEKV(t, it, makeKey(""), base.SeekGEFlagsNone, "", "")
 }
 
+// TestIteratorStrictPrefix verifies the strict prefix iteration behavior of
+// SeekPrefixGE and Next using a Comparer with a non-trivial Split function
+// (testkeys.Comparer splits at '@').
+func TestIteratorStrictPrefix(t *testing.T) {
+	l := NewSkiplist(newArena(arenaSize), testkeys.Comparer.Compare)
+	// testkeys orders suffixes in reverse: a@3 < a@2 < a@1 < b@2 < b@1.
+	keys := []string{"a@1", "a@2", "a@3", "b@1", "b@2"}
+	var ins Inserter
+	for _, k := range keys {
+		require.NoError(t, ins.Add(l, makeIkey(k), []byte("v"+k)))
+	}
+
+	it := l.NewIter(testkeys.Comparer.Split, nil, nil)
+	defer it.Close()
+
+	// SeekPrefixGE("a", "a") returns the smallest key with prefix "a", which
+	// in testkeys order is a@3. Next steps through a@2, a@1, then nil because
+	// the next key (b@2) has a different prefix.
+	kv := it.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone)
+	require.NotNil(t, kv)
+	require.EqualValues(t, "a@3", string(kv.K.UserKey))
+	kv = it.Next()
+	require.NotNil(t, kv)
+	require.EqualValues(t, "a@2", string(kv.K.UserKey))
+	kv = it.Next()
+	require.NotNil(t, kv)
+	require.EqualValues(t, "a@1", string(kv.K.UserKey))
+	require.Nil(t, it.Next())
+
+	// SeekPrefixGE with no matching key after the seek key.
+	require.Nil(t, it.SeekPrefixGE([]byte("c"), []byte("c"), base.SeekGEFlagsNone))
+
+	// SeekPrefixGE past all "a" keys lands on a key with a different prefix,
+	// so the prefix check returns nil. testkeys reverse-suffix ordering means
+	// a@0 > a@1 > a@2 > a@3, so "a@0" is past all "a@x" keys in sorted order
+	// and the first key >= "a@0" is b@2.
+	require.Nil(t, it.SeekPrefixGE([]byte("a"), []byte("a@0"), base.SeekGEFlagsNone))
+
+	// After an exhausted prefix iteration, SeekGE clears prefix mode and
+	// regular iteration resumes.
+	kv = it.SeekGE([]byte("b@2"), base.SeekGEFlagsNone)
+	require.NotNil(t, kv)
+	require.EqualValues(t, "b@2", string(kv.K.UserKey))
+	kv = it.Next()
+	require.NotNil(t, kv)
+	require.EqualValues(t, "b@1", string(kv.K.UserKey))
+
+	// Switching prefixes via SeekPrefixGE with TrySeekUsingNext.
+	// Going forward to b@2 after a@... is the load-bearing case.
+	kv = it.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone)
+	require.NotNil(t, kv)
+	require.EqualValues(t, "a@3", string(kv.K.UserKey))
+	kv = it.SeekPrefixGE([]byte("b"), []byte("b@2"),
+		base.SeekGEFlagsNone.EnableTrySeekUsingNext())
+	require.NotNil(t, kv)
+	require.EqualValues(t, "b@2", string(kv.K.UserKey))
+
+	// Last clears prefix mode.
+	kv = it.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone)
+	require.NotNil(t, kv)
+	kv = it.Last()
+	require.NotNil(t, kv)
+	require.EqualValues(t, "b@1", string(kv.K.UserKey))
+}
+
+// TestIteratorPrefixExhaustedTrySeekUsingNext exercises the case where Next
+// returns nil due to a prefix change, and a subsequent SeekPrefixGE with
+// TrySeekUsingNext lands on exactly the node where Next stopped. The
+// TrySeekUsingNext fast path returns &it.kv directly without re-fetching the
+// value, so it.kv.V must already reflect the current node — otherwise the
+// returned value is the previous (different prefix) key's stale value.
+func TestIteratorPrefixExhaustedTrySeekUsingNext(t *testing.T) {
+	l := NewSkiplist(newArena(arenaSize), testkeys.Comparer.Compare)
+	keys := []string{"a@1", "a@2", "a@3", "b@1", "b@2"}
+	var ins Inserter
+	for _, k := range keys {
+		require.NoError(t, ins.Add(l, makeIkey(k), []byte("v"+k)))
+	}
+
+	it := l.NewIter(testkeys.Comparer.Split, nil, nil)
+	defer it.Close()
+
+	// Walk the "a" prefix to its end.
+	kv := it.SeekPrefixGE([]byte("a"), []byte("a"), base.SeekGEFlagsNone)
+	require.NotNil(t, kv)
+	require.EqualValues(t, "a@3", string(kv.K.UserKey))
+	require.EqualValues(t, "va@3", string(kv.V.InPlaceValue()))
+	kv = it.Next()
+	require.NotNil(t, kv)
+	require.EqualValues(t, "a@2", string(kv.K.UserKey))
+	require.EqualValues(t, "va@2", string(kv.V.InPlaceValue()))
+	kv = it.Next()
+	require.NotNil(t, kv)
+	require.EqualValues(t, "a@1", string(kv.K.UserKey))
+	require.EqualValues(t, "va@1", string(kv.V.InPlaceValue()))
+
+	// This Next advances to "b@2" (different prefix) and returns nil. The
+	// iterator's underlying node is now positioned at "b@2".
+	require.Nil(t, it.Next())
+
+	// SeekPrefixGE with TrySeekUsingNext lands on the same "b@2" node via the
+	// fast path. The returned value must be "b@2"'s value, not the stale
+	// "a@1" value left behind by the previous Next.
+	kv = it.SeekPrefixGE([]byte("b"), []byte("b@2"),
+		base.SeekGEFlagsNone.EnableTrySeekUsingNext())
+	require.NotNil(t, kv)
+	require.EqualValues(t, "b@2", string(kv.K.UserKey))
+	require.EqualValues(t, "vb@2", string(kv.V.InPlaceValue()))
+}
+
 func TestIteratorSeekLT(t *testing.T) {
 	const n = 100
 	l := NewSkiplist(newArena(arenaSize), bytes.Compare)
-	it := l.NewIter(nil, nil)
+	it := l.NewIter(base.DefaultSplit, nil, nil)
 
 	require.Nil(t, it.First())
 	// 1000, 1010, 1020, ..., 1990.
@@ -599,7 +718,7 @@ func TestIteratorBounds(t *testing.T) {
 		return makeIntKey(i).UserKey
 	}
 
-	it := l.NewIter(key(3), key(7))
+	it := l.NewIter(base.DefaultSplit, key(3), key(7))
 
 	// SeekGE within the lower and upper bound succeeds.
 	for i := 3; i <= 6; i++ {
@@ -768,7 +887,7 @@ func BenchmarkReadWrite(b *testing.B) {
 			b.ResetTimer()
 			var count int
 			b.RunParallel(func(pb *testing.PB) {
-				it := l.NewIter(nil, nil)
+				it := l.NewIter(base.DefaultSplit, nil, nil)
 				rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
 				buf := make([]byte, 8)
 
@@ -815,7 +934,7 @@ func BenchmarkIterNext(b *testing.B) {
 		}
 	}
 
-	it := l.NewIter(nil, nil)
+	it := l.NewIter(base.DefaultSplit, nil, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		kv := it.Next()
@@ -836,7 +955,7 @@ func BenchmarkIterPrev(b *testing.B) {
 		}
 	}
 
-	it := l.NewIter(nil, nil)
+	it := l.NewIter(base.DefaultSplit, nil, nil)
 	_ = it.Last()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -863,7 +982,7 @@ func BenchmarkSeekPrefixGE(b *testing.B) {
 	for _, skip := range []int{1, 2, 4, 8, 16} {
 		for _, useNext := range []bool{false, true} {
 			b.Run(fmt.Sprintf("skip=%d/use-next=%t", skip, useNext), func(b *testing.B) {
-				it := l.NewIter(nil, nil)
+				it := l.NewIter(base.DefaultSplit, nil, nil)
 				j := 0
 				var k []byte
 				makeKey := func() {

--- a/internal/base/test_utils.go
+++ b/internal/base/test_utils.go
@@ -5,6 +5,7 @@
 package base
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"strconv"
@@ -74,16 +75,11 @@ func fakeIkey(s string) InternalKey {
 	return MakeInternalKey([]byte(s[:j]), SeqNum(seqNum), InternalKeyKindSet)
 }
 
-// NewFakeIter returns an iterator over the given KVs, using the default
-// comparer.
-func NewFakeIter(kvs []InternalKV) *FakeIter {
-	return NewFakeIterWithCmp(DefaultComparer.Compare, kvs)
-}
-
-// NewFakeIterWithCmp returns an iterator over the given KVs.
-func NewFakeIterWithCmp(cmp Compare, kvs []InternalKV) *FakeIter {
+// NewFakeIter returns an iterator over the given KVs.
+func NewFakeIter(cmp *Comparer, kvs []InternalKV) *FakeIter {
 	return &FakeIter{
-		cmp:   cmp,
+		cmp:   cmp.Compare,
+		split: cmp.Split,
 		kvs:   kvs,
 		index: 0,
 	}
@@ -91,11 +87,16 @@ func NewFakeIterWithCmp(cmp Compare, kvs []InternalKV) *FakeIter {
 
 // FakeIter is an iterator over a fixed set of KVs.
 type FakeIter struct {
-	cmp      Compare
-	lower    []byte
-	upper    []byte
-	kvs      []InternalKV
-	index    int
+	cmp   Compare
+	split Split
+	lower []byte
+	upper []byte
+	kvs   []InternalKV
+	index int
+	// prefix, when non-nil, restricts iteration to keys whose split prefix
+	// equals prefix. Set by SeekPrefixGE; cleared by any other absolute
+	// positioning method (SeekGE, SeekLT, First, Last, SetBounds).
+	prefix   []byte
 	closeErr error
 }
 
@@ -113,6 +114,7 @@ func (f *FakeIter) String() string {
 
 // SeekGE is part of the InternalIterator interface.
 func (f *FakeIter) SeekGE(key []byte, flags SeekGEFlags) *InternalKV {
+	f.prefix = nil
 	if flags.TrySeekUsingNext() {
 		// Note that f.index could be len(f.kvs) here (iterator exhausted), and that
 		// is ok.
@@ -135,11 +137,18 @@ func (f *FakeIter) SeekGE(key []byte, flags SeekGEFlags) *InternalKV {
 
 // SeekPrefixGE is part of the InternalIterator interface.
 func (f *FakeIter) SeekPrefixGE(prefix, key []byte, flags SeekGEFlags) *InternalKV {
-	return f.SeekGE(key, flags)
+	// SeekGE clears f.prefix, so we re-apply it after.
+	kv := f.SeekGE(key, flags)
+	f.prefix = prefix
+	if kv != nil && !bytes.Equal(f.split.Prefix(kv.K.UserKey), prefix) {
+		return nil
+	}
+	return kv
 }
 
 // SeekLT is part of the InternalIterator interface.
 func (f *FakeIter) SeekLT(key []byte, flags SeekLTFlags) *InternalKV {
+	f.prefix = nil
 	for f.index = len(f.kvs) - 1; f.index >= 0; f.index-- {
 		if f.cmp(key, f.key().UserKey) > 0 {
 			if f.lower != nil && f.cmp(f.lower, f.key().UserKey) > 0 {
@@ -153,12 +162,14 @@ func (f *FakeIter) SeekLT(key []byte, flags SeekLTFlags) *InternalKV {
 
 // First is part of the InternalIterator interface.
 func (f *FakeIter) First() *InternalKV {
+	f.prefix = nil
 	f.index = -1
 	return f.Next()
 }
 
 // Last is part of the InternalIterator interface.
 func (f *FakeIter) Last() *InternalKV {
+	f.prefix = nil
 	f.index = len(f.kvs)
 	return f.Prev()
 }
@@ -173,6 +184,9 @@ func (f *FakeIter) Next() *InternalKV {
 		return nil
 	}
 	if f.upper != nil && f.cmp(f.upper, f.key().UserKey) <= 0 {
+		return nil
+	}
+	if f.prefix != nil && !bytes.Equal(f.split.Prefix(f.key().UserKey), f.prefix) {
 		return nil
 	}
 	return &f.kvs[f.index]
@@ -217,6 +231,7 @@ func (f *FakeIter) Close() error {
 func (f *FakeIter) SetBounds(lower, upper []byte) {
 	f.lower = lower
 	f.upper = upper
+	f.prefix = nil
 }
 
 // SetContext is part of the InternalIterator interface.

--- a/internal/compact/iterator_test.go
+++ b/internal/compact/iterator_test.go
@@ -365,7 +365,7 @@ func makeInputIters(
 	// SSTables are not released while iterating, and therefore not
 	// susceptible to use-after-free bugs, we skip the zeroing of
 	// RangeDelete keys.
-	return base.NewFakeIter(points),
+	return base.NewFakeIter(base.DefaultComparer, points),
 		keyspan.NewIter(base.DefaultComparer.Compare, rangeDels),
 		keyspan.NewIter(base.DefaultComparer.Compare, rangeKeys)
 }

--- a/internal/iterv2/interleaving_iter.go
+++ b/internal/iterv2/interleaving_iter.go
@@ -384,9 +384,8 @@ func (i *InterleavingIter) SeekPrefixGE(
 	}
 	kv := i.pointIter.SeekPrefixGE(prefix, key, flags)
 	i.checkPoint(kv)
-	// TODO(radu): make SeekPrefixGE strict in InternalIterator.
-	if kv != nil && !i.cmp.HasPrefix(kv.K.UserKey, prefix) {
-		kv = nil
+	if invariants.Enabled && kv != nil && !i.cmp.HasPrefix(kv.K.UserKey, prefix) {
+		panic(errors.AssertionFailedf("pointIter %T did not enforce strict prefix iteration", i.pointIter))
 	}
 	i.prefix = prefix
 	i.dir = +1
@@ -529,9 +528,8 @@ func (i *InterleavingIter) Next() *base.InternalKV {
 				i.setError(err)
 				return nil
 			}
-		} else if i.prefix != nil && !i.cmp.HasPrefix(i.pointKV.K.UserKey, i.prefix) {
-			// TODO(radu): make SeekPrefixGE strict in InternalIterator.
-			i.pointKV = nil
+		} else if invariants.Enabled && i.prefix != nil && !i.cmp.HasPrefix(i.pointKV.K.UserKey, i.prefix) {
+			panic(errors.AssertionFailedf("pointIter %T did not enforce strict prefix iteration", i.pointIter))
 		}
 		// If pointKV is outside the current span, we will emit a boundary in
 		// resolveForward.

--- a/internal/iterv2/interleaving_iter_rand_test.go
+++ b/internal/iterv2/interleaving_iter_rand_test.go
@@ -72,7 +72,7 @@ func runRandomTest(t *testing.T, seed uint64) {
 	lower, upper := RandBounds(rng, cfg, startKey, endKey)
 
 	var pointIter base.InternalIterator
-	pointIter = base.NewFakeIterWithCmp(cmp.Compare, points)
+	pointIter = base.NewFakeIter(cmp, points)
 	if lower != nil || upper != nil {
 		pointIter.SetBounds(lower, upper)
 	}

--- a/internal/iterv2/interleaving_iter_test.go
+++ b/internal/iterv2/interleaving_iter_test.go
@@ -72,7 +72,7 @@ func TestInterleavingIter(t *testing.T) {
 				}
 				return []byte(s)
 			}
-			pointIter := base.NewFakeIterWithCmp(testkeys.Comparer.Compare, points)
+			pointIter := base.NewFakeIter(testkeys.Comparer, points)
 			spanIter := keyspan.NewIter(testkeys.Comparer.Compare, spans)
 			iter.Init(
 				testkeys.Comparer,

--- a/internal/overlap/checker_test.go
+++ b/internal/overlap/checker_test.go
@@ -193,7 +193,7 @@ func (tt *testTables) Points(
 	if len(t.points) == 0 && rand.IntN(2) == 0 {
 		return nil, nil
 	}
-	return base.NewFakeIter(t.points), nil
+	return base.NewFakeIter(base.DefaultComparer, t.points), nil
 }
 
 func (tt *testTables) RangeDels(

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -62,7 +62,7 @@ func testIterator(
 	splitFunc func(r *rand.Rand) [][]string,
 ) {
 	fakeIterWithCloseErr := func(kvs []base.InternalKV, errorMsg string) *base.FakeIter {
-		f := base.NewFakeIter(kvs)
+		f := base.NewFakeIter(base.DefaultComparer, kvs)
 		f.SetCloseErr(errors.New(errorMsg))
 		return f
 	}
@@ -77,31 +77,31 @@ func testIterator(
 		{
 			"one sub-iterator",
 			[]internalIterator{
-				base.NewFakeIter(base.FakeKVs("e:1", "w:2")),
+				base.NewFakeIter(base.DefaultComparer, base.FakeKVs("e:1", "w:2")),
 			},
 			"<e:1><w:2>.",
 		},
 		{
 			"two sub-iterators",
 			[]internalIterator{
-				base.NewFakeIter(base.FakeKVs("a0:0")),
-				base.NewFakeIter(base.FakeKVs("b1:1", "b2:2")),
+				base.NewFakeIter(base.DefaultComparer, base.FakeKVs("a0:0")),
+				base.NewFakeIter(base.DefaultComparer, base.FakeKVs("b1:1", "b2:2")),
 			},
 			"<a0:0><b1:1><b2:2>.",
 		},
 		{
 			"empty sub-iterators",
 			[]internalIterator{
-				base.NewFakeIter(nil),
-				base.NewFakeIter(nil),
-				base.NewFakeIter(nil),
+				base.NewFakeIter(base.DefaultComparer, nil),
+				base.NewFakeIter(base.DefaultComparer, nil),
+				base.NewFakeIter(base.DefaultComparer, nil),
 			},
 			".",
 		},
 		{
 			"sub-iterator errors",
 			[]internalIterator{
-				base.NewFakeIter(base.FakeKVs("a0:0", "a1:1")),
+				base.NewFakeIter(base.DefaultComparer, base.FakeKVs("a0:0", "a1:1")),
 				fakeIterWithCloseErr(base.FakeKVs("b2:2", "b3:3", "b4:4"), "the sky is falling"),
 				fakeIterWithCloseErr(base.FakeKVs("c5:5", "c6:6"), "run for your lives"),
 			},
@@ -132,7 +132,7 @@ func testIterator(
 		splits := splitFunc(r)
 		iters := make([]internalIterator, len(splits))
 		for i, split := range splits {
-			iters[i] = base.NewFakeIter(base.FakeKVs(split...))
+			iters[i] = base.NewFakeIter(base.DefaultComparer, base.FakeKVs(split...))
 		}
 		iter := invalidating.NewIter(newFunc(iters...))
 		kv := iter.First()
@@ -190,7 +190,7 @@ func TestIterator(t *testing.T) {
 			merge:    wrappedMerge,
 		}
 		// NB: Use a mergingIter to filter entries newer than seqNum.
-		fakeIter := base.NewFakeIter(kvs)
+		fakeIter := base.NewFakeIter(base.DefaultComparer, kvs)
 		fakeIter.SetBounds(opts.GetLowerBound(), opts.GetUpperBound())
 		iter := newMergingIter(nil /* logger */, &it.stats.InternalStats, it.cmp, it.comparer.Split, fakeIter)
 		iter.snapshot = seqNum
@@ -862,7 +862,7 @@ func TestIteratorSeekOptErrors(t *testing.T) {
 
 	var errorIter errorSeekIter
 	newIter := func(opts IterOptions) *Iterator {
-		iter := base.NewFakeIter(kvs)
+		iter := base.NewFakeIter(base.DefaultComparer, kvs)
 		iter.SetBounds(opts.GetLowerBound(), opts.GetUpperBound())
 		errorIter = errorSeekIter{internalIterator: invalidating.NewIter(iter)}
 		// NB: This Iterator cannot be cloned since it is not constructed

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -46,7 +46,7 @@ func TestLevelIter(t *testing.T) {
 	newIters := func(
 		_ context.Context, file *manifest.TableMetadata, opts *IterOptions, _ internalIterOpts, _ iterKinds,
 	) (iterSet, error) {
-		f := base.NewFakeIter(iterKVs[file.TableNum])
+		f := base.NewFakeIter(base.DefaultComparer, iterKVs[file.TableNum])
 		f.SetBounds(opts.GetLowerBound(), opts.GetUpperBound())
 		return iterSet{point: f}, nil
 	}

--- a/level_iter_v2_test.go
+++ b/level_iter_v2_test.go
@@ -60,7 +60,7 @@ func TestLevelIterV2(t *testing.T) {
 		fi := files[f.TableNum]
 		var set iterSet
 		if kinds.Point() {
-			it := base.NewFakeIterWithCmp(cmp.Compare, fi.points)
+			it := base.NewFakeIter(cmp, fi.points)
 			it.SetBounds(opts.GetLowerBound(), opts.GetUpperBound())
 			set.point = it
 		}

--- a/mem_table.go
+++ b/mem_table.go
@@ -65,6 +65,7 @@ var memTableEmptySize = func() uint32 {
 // It is safe to call get, apply, newIter, and newRangeDelIter concurrently.
 type memTable struct {
 	cmp         Compare
+	split       base.Split
 	formatKey   base.FormatKey
 	equal       Equal
 	arenaBuf    manual.Buf
@@ -135,6 +136,7 @@ func (m *memTable) init(opts memTableOptions) {
 	}
 	*m = memTable{
 		cmp:                          opts.Comparer.Compare,
+		split:                        opts.Comparer.Split,
 		formatKey:                    opts.Comparer.FormatKey,
 		equal:                        opts.Comparer.Equal,
 		arenaBuf:                     opts.arenaBuf,
@@ -260,7 +262,7 @@ func (m *memTable) apply(batch *Batch, seqNum base.SeqNum) error {
 // unpositioned (Iterator.Valid() will return false). The iterator can be
 // positioned via a call to SeekGE, SeekLT, First or Last.
 func (m *memTable) newIter(o *IterOptions) internalIterator {
-	return m.skl.NewIter(o.GetLowerBound(), o.GetUpperBound())
+	return m.skl.NewIter(m.split, o.GetLowerBound(), o.GetUpperBound())
 }
 
 // newFlushIter is part of the flushable interface.
@@ -387,7 +389,7 @@ func (f *keySpanFrags) get(
 				f.spans = append(f.spans, fragmented)
 			},
 		}
-		it := skl.NewIter(nil, nil)
+		it := skl.NewIter(base.DefaultSplit, nil, nil)
 		var keysDst []keyspan.Key
 		for kv := it.First(); kv != nil; kv = it.Next() {
 			s, err := constructSpan(kv.K, kv.InPlaceValue(), keysDst)

--- a/mem_table_test.go
+++ b/mem_table_test.go
@@ -30,7 +30,7 @@ import (
 // get gets the value for the given key. It returns ErrNotFound if the DB does
 // not contain the key.
 func (m *memTable) get(key []byte) (value []byte, err error) {
-	it := m.skl.NewIter(nil, nil)
+	it := m.skl.NewIter(m.split, nil, nil)
 	defer it.Close()
 	kv := it.SeekGE(key, base.SeekGEFlagsNone)
 	if kv == nil {

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -75,7 +75,7 @@ func TestMergingIterSeek(t *testing.T) {
 					kv := base.ParseInternalKV(f)
 					kvs = append(kvs, kv)
 				}
-				iters = append(iters, base.NewFakeIter(kvs))
+				iters = append(iters, base.NewFakeIter(base.DefaultComparer, kvs))
 			}
 
 			var stats base.InternalIteratorStats
@@ -134,7 +134,7 @@ func TestMergingIterNextPrev(t *testing.T) {
 							j := strings.Index(key, ":")
 							kvs = append(kvs, base.MakeInternalKV(base.ParseInternalKey(key[:j]), []byte(key[j+1:])))
 						}
-						iters[i] = base.NewFakeIter(kvs)
+						iters[i] = base.NewFakeIter(base.DefaultComparer, kvs)
 					}
 
 					var stats base.InternalIteratorStats

--- a/scan_internal_test.go
+++ b/scan_internal_test.go
@@ -638,7 +638,7 @@ func TestPointCollapsingIter(t *testing.T) {
 					kvs = append(kvs, base.MakeInternalKV(k, v))
 				}
 			}
-			f := base.NewFakeIter(kvs)
+			f := base.NewFakeIter(base.DefaultComparer, kvs)
 
 			ksIter := keyspan.NewIter(base.DefaultComparer.Compare, spans)
 			pcIter := &pointCollapsingIterator{

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -159,7 +159,7 @@ seek-prefix-ge a
 next
 ----
 a#1,SET:1
-b#2,SET:2
+.
 
 iter
 seek-prefix-ge d


### PR DESCRIPTION
#### arenaskl: enforce strict prefix iteration

`arenaskl.Iterator.SeekPrefixGE` previously delegated to `SeekGE`,
returning any key >= the seek key regardless of prefix. With this
change, the iterator enforces prefix matching directly: `SeekPrefixGE`
returns nil if the result key has a different prefix, and subsequent
`Next()` calls return nil once a key with a different prefix is
encountered. This matches the strict prefix iteration recently added to
sstable iterators.

The iterator stores the active prefix (set in `SeekPrefixGE`, cleared
in any other absolute positioning method) and a `base.Split` function
used to extract a key's prefix. `SeekPrefixGE` clears the prefix before
calling the underlying `SeekGE` and re-applies it after, which avoids
polluting the `TrySeekUsingNext` loop with prefix checks that would
short-circuit prematurely when the iterator is repositioned across
prefixes.

The `Skiplist.NewIter` signature changes to take a `base.Split` as the
first argument; callers without a meaningful Split pass
`base.DefaultSplit`.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### batch: enforce strict prefix iteration

`batchIter` and `flushableBatchIter` previously checked the prefix only
on the initial result of `SeekPrefixGE`; subsequent `Next()` calls
could return keys past the prefix boundary. They now enforce prefix
matching during iteration: after `SeekPrefixGE`, `Next()` returns nil
once a key with a different prefix is encountered. This matches the
strict prefix iteration recently added to `arenaskl.Iterator` and
sstable iterators.

Each iterator stores the active prefix (set in `SeekPrefixGE`, cleared
in any other absolute positioning method including `SetBounds` and
`NextPrefix`). `SeekPrefixGE` clears the prefix before calling the
underlying `SeekGE` and re-applies it after, matching the
defensive-ordering pattern from `arenaskl`.

`flushFlushableBatchIter` is intentionally untouched: its
`SeekPrefixGE` panics, so prefix mode is unreachable; the existing
"keep in sync" comments are updated to document this.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### base: enforce strict prefix iteration in FakeIter

`FakeIter.SeekPrefixGE` previously delegated to `SeekGE`, returning
any key >= the seek key regardless of prefix. With this change, the
iterator enforces prefix matching: `SeekPrefixGE` returns nil if the
result key has a different prefix, and subsequent `Next()` calls
return nil once a key with a different prefix is encountered. This
matches the strict prefix iteration recently added to sstable,
`arenaskl`, batch and memtable iterators, and is required by
`InterleavingIter`'s new invariant assertion.

A new `NewFakeIterWithComparer(*Comparer, kvs)` constructor wires the
comparer's `Split` through, for callers (the iterv2 and level-iter-v2
tests) that use a comparer with a non-trivial Split. The existing
`NewFakeIterWithCmp(Compare, kvs)` constructor keeps working with
`base.DefaultSplit`, under which strict prefix iteration is
equivalent to exact-match iteration on the whole key.

The single test-data expectation in `testdata/level_iter` that relied
on the old non-strict semantics (`seek-prefix-ge a; next` returning
`b#2,SET`) is updated to reflect the new strict behavior.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### iterv2: assert strict prefix iteration in InterleavingIter

`InterleavingIter.SeekPrefixGE` and `Next` previously discarded any
point key returned by the wrapped point iterator that did not match
the active prefix, working around the historical non-strict semantics
of `InternalIterator.SeekPrefixGE`. Now that sstable, batch and
memtable iterators all enforce strict prefix iteration themselves,
that defensive filter is dead weight: replace it with an
`invariants`-only assertion that the point iterator is honoring the
strict semantics, and drop the corresponding `TODO`s.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>