### PR TITLE
sstable: check bloom filter before generating synthetic key

### DIFF
--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -934,6 +934,12 @@ func (i *singleLevelIterator[I, PI, D, PD]) seekGEHelper(
 // previous SeekPrefixGE returned nil due to a bloom filter miss, since the
 // iterator was not repositioned in that case.
 //
+// Ordering invariant: the bloom filter is consulted before any synthetic key
+// is materialized via the maximum-suffix-property optimization. A bloom filter
+// miss is a stronger signal of absence than the table-wide max suffix, so
+// returning nil up front avoids needlessly armed synthetic keys and the heap
+// comparisons they would force. See issue #5638.
+//
 // Note: SeekPrefixGE only checks the upper bound. It is up to the caller to
 // ensure that key is greater than or equal to the lower bound.
 func (i *singleLevelIterator[I, PI, D, PD]) SeekPrefixGE(
@@ -966,6 +972,14 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 		if i.cmp(key, i.lower) < 0 {
 			key = i.lower
 		}
+	}
+	var (
+		previousErr error
+		ok          bool
+	)
+	flags, previousErr, ok = i.prepareSeekPrefixGE(prefix, flags)
+	if !ok || i.err != nil {
+		return kv
 	}
 	// If there's a maximum suffix property configured and the seek key contains
 	// a suffix (len(key) > len(prefix)), we might be able to defer actually
@@ -1022,28 +1036,25 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 				// to still be open by the time singleLevelIterator.Next is called
 				// and we use the seek key to actually perform the seek.
 				i.synthetic.seekKey = append(i.synthetic.seekKey[:0], key...)
-				// Clear any stale error from previous operations before returning
-				// a valid key. The seekPrefixGE helper clears i.err, but this
-				// early return bypasses it.
-				i.err = nil
+				// i.err was already cleared by prepareSeekPrefixGE above; the
+				// previous error (returned in previousErr) is intentionally
+				// dropped because the synthetic key represents a valid kv that
+				// supersedes the deferred seek's previous failure.
 				return &i.synthetic.kv
 			}
 		}
 	}
-	kv, _ = i.seekPrefixGE(prefix, key, flags, false /* shouldReturnMeta */)
+	kv, _ = i.seekPrefixGEAfterBloomFilter(key, flags, previousErr, false /* shouldReturnMeta */)
 	return kv
 }
 
-func (i *singleLevelIterator[I, PI, D, PD]) seekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags, shouldReturnMeta bool,
-) (kv *base.InternalKV, kvMeta base.KVMeta) {
-	// NOTE: prefix is only used for bloom filter checking and not later work in
-	// this method. Hence, we can use the existing iterator position if the last
-	// SeekPrefixGE did not fail bloom filter matching.
-
-	// Clear the tracking flag initially; will be set later if bloom filter returns false
+func (i *singleLevelIterator[I, PI, D, PD]) prepareSeekPrefixGE(
+	prefix []byte, flags base.SeekGEFlags,
+) (_ base.SeekGEFlags, previousErr error, ok bool) {
+	// Clear the tracking flag initially; it will be set again below if the bloom
+	// filter proves that the requested prefix is absent from the table.
 	i.lastOpWasSeekPrefixGE.Set(false)
-	err := i.err
+	previousErr = i.err
 	i.err = nil // clear cached iteration error
 	if i.useFilterBlock {
 		if !i.lastBloomFilterMatched {
@@ -1057,12 +1068,14 @@ func (i *singleLevelIterator[I, PI, D, PD]) seekPrefixGE(
 			flags = flags.DisableTrySeekUsingNext()
 		}
 		i.lastBloomFilterMatched = false
-		// Check prefix bloom filter.
+		// Check prefix bloom filter before considering the synthetic key
+		// optimization. A bloom filter miss is a stronger signal than the
+		// table-wide maximum suffix property.
 		var mayContain bool
 		mayContain, i.err = i.bloomFilterMayContain(prefix)
 		if i.err != nil {
 			PD(&i.data).Invalidate()
-			return nil, base.KVMeta{}
+			return flags, previousErr, false
 		}
 		if !mayContain {
 			if treesteps.Enabled && treesteps.IsRecording(i) {
@@ -1072,24 +1085,47 @@ func (i *singleLevelIterator[I, PI, D, PD]) seekPrefixGE(
 			// We can avoid invalidating the already loaded block since the caller is
 			// not allowed to call Next when SeekPrefixGE returns nil.
 			i.lastOpWasSeekPrefixGE.Set(true)
-			return nil, base.KVMeta{}
+			return flags, previousErr, false
 		}
 		treesteps.UpdateLastOpf(i, "bloom filter matched")
 		i.lastBloomFilterMatched = true
 	}
+	return flags, previousErr, true
+}
+
+func (i *singleLevelIterator[I, PI, D, PD]) seekPrefixGE(
+	prefix, key []byte, flags base.SeekGEFlags, shouldReturnMeta bool,
+) (kv *base.InternalKV, kvMeta base.KVMeta) {
+	// NOTE: prefix is only used for bloom filter checking and not later work in
+	// this method. Hence, we can use the existing iterator position if the last
+	// SeekPrefixGE did not fail bloom filter matching.
+	var (
+		previousErr error
+		ok          bool
+	)
+	flags, previousErr, ok = i.prepareSeekPrefixGE(prefix, flags)
+	if !ok || i.err != nil {
+		return nil, base.KVMeta{}
+	}
+	return i.seekPrefixGEAfterBloomFilter(key, flags, previousErr, shouldReturnMeta)
+}
+
+func (i *singleLevelIterator[I, PI, D, PD]) seekPrefixGEAfterBloomFilter(
+	key []byte, flags base.SeekGEFlags, previousErr error, shouldReturnMeta bool,
+) (kv *base.InternalKV, kvMeta base.KVMeta) {
 	if flags.TrySeekUsingNext() {
 		// The i.exhaustedBounds comparison indicates that the upper bound was
 		// reached. The i.data.isDataInvalidated() indicates that the sstable was
 		// exhausted.
-		if (i.exhaustedBounds == exhaustedUpperBound || PD(&i.data).IsDataInvalidated()) && err == nil {
+		if (i.exhaustedBounds == exhaustedUpperBound || PD(&i.data).IsDataInvalidated()) && previousErr == nil {
 			// Already exhausted, so return nil.
 			return nil, base.KVMeta{}
 		}
-		if err != nil {
+		if previousErr != nil {
 			// The current iterator position cannot be used.
 			flags = flags.DisableTrySeekUsingNext()
 		}
-		// INVARIANT: flags.TrySeekUsingNext() => err == nil &&
+		// INVARIANT: flags.TrySeekUsingNext() => previousErr == nil &&
 		// !i.exhaustedBounds==+1 && !i.data.isDataInvalidated(). That is,
 		// data-exhausted and bounds-exhausted, as defined earlier, are both
 		// false. Ths makes it safe to clear out i.exhaustedBounds and i.err
@@ -1594,7 +1630,14 @@ func (i *singleLevelIterator[I, PI, D, PD]) nextInternal(
 		// The synthetic key is no longer relevant and must be cleared.
 		// Perform the actual seek since the synthetic key is on top of the heap and must be resolved.
 		i.synthetic.atSyntheticKey = false
-		return i.seekPrefixGE(i.reader.Comparer.Split.Prefix(i.synthetic.seekKey), i.synthetic.seekKey, base.SeekGEFlagsNone, shouldReturnMeta)
+		// SeekPrefixGE already consulted the bloom filter (and matched) before
+		// emitting the synthetic key, and lastBloomFilterMatched is still true.
+		// Skip prepareSeekPrefixGE to avoid a redundant bloom filter probe and
+		// drive the deferred seek directly.
+		i.lastOpWasSeekPrefixGE.Set(false)
+		previousErr := i.err
+		i.err = nil
+		return i.seekPrefixGEAfterBloomFilter(i.synthetic.seekKey, base.SeekGEFlagsNone, previousErr, shouldReturnMeta)
 	}
 
 	if invariants.Enabled && i.lastOpWasSeekPrefixGE.Get() {

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/testkeys"
 	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable/block"
@@ -804,6 +805,56 @@ func createTestSSTWithOptions(
 	}
 }
 
+func createTestKeysSSTWithOptions(
+	t *testing.T,
+	keys []string,
+	filterPolicy base.TableFilterPolicy,
+	filterDecoder base.TableFilterDecoder,
+	forceTwoLevel bool,
+) (*Reader, func()) {
+	mem := vfs.NewMem()
+
+	f, err := mem.Create("testkeys.sst", vfs.WriteCategoryUnspecified)
+	require.NoError(t, err)
+
+	writerOpts := WriterOptions{
+		Comparer:     testkeys.Comparer,
+		MergerName:   base.DefaultMerger.Name,
+		FilterPolicy: filterPolicy,
+		BlockPropertyCollectors: []func() BlockPropertyCollector{
+			NewTestKeysBlockPropertyCollector,
+		},
+	}
+	if forceTwoLevel {
+		writerOpts.BlockSize = 128
+		writerOpts.IndexBlockSize = 16
+	}
+	w := NewWriter(objstorageprovider.NewFileWritable(f), writerOpts)
+
+	for _, key := range keys {
+		require.NoError(t, w.Set([]byte(key), []byte("value-"+key)))
+	}
+	require.NoError(t, w.Close())
+
+	f, err = mem.Open("testkeys.sst")
+	require.NoError(t, err)
+
+	readerOpts := ReaderOptions{
+		Comparer: testkeys.Comparer,
+		Merger:   base.DefaultMerger,
+	}
+	if filterDecoder != nil {
+		readerOpts.FilterDecoders = []base.TableFilterDecoder{filterDecoder}
+	}
+
+	reader, err := newReader(f, readerOpts)
+	require.NoError(t, err)
+
+	return reader, func() {
+		reader.Close()
+	}
+}
+
 // TestBloomFilterOptimizationSingleLevel tests the bloom filter optimization
 // in single-level iterators where data blocks are not invalidated when bloom
 // filter returns false with no error.
@@ -1006,6 +1057,88 @@ func TestBloomFilterOptimizationTwoLevel(t *testing.T) {
 
 		require.NoError(t, iter.Error())
 	})
+}
+
+func TestSeekPrefixGEBloomMissPrecedesSyntheticKeySingleLevel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	filterPolicy, filterDecoder := newControllableFilterPolicy("test-filter-synthetic-miss", false, nil)
+	reader, cleanup := createTestKeysSSTWithOptions(t,
+		[]string{"a@10", "c@1"},
+		filterPolicy, filterDecoder, false)
+	defer cleanup()
+
+	var pool block.BufferPool
+	pool.Init(5, block.ForCompaction)
+	defer pool.Release()
+
+	var stats base.InternalIteratorStats
+	iter, err := newRowBlockSingleLevelIterator(context.Background(), reader, IterOptions{
+		Transforms:            NoTransforms,
+		FilterBlockSizeLimit:  AlwaysUseFilterBlock,
+		Env:                   ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &pool}},
+		ReaderProvider:        MakeTrivialReaderProvider(reader),
+		MaximumSuffixProperty: MaxTestKeysSuffixProperty{},
+	})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	preload := iter.SeekGE([]byte("c@1"), base.SeekGEFlagsNone)
+	require.NotNil(t, preload)
+	require.True(t, iter.data.Valid())
+	require.False(t, iter.data.IsDataInvalidated())
+
+	kv := iter.SeekPrefixGE([]byte("b"), []byte("b@15"), base.SeekGEFlagsNone)
+	require.Nil(t, kv, "bloom miss should prevent synthetic key generation")
+	require.False(t, iter.synthetic.atSyntheticKey, "synthetic key should not be armed after bloom miss")
+	require.False(t, iter.lastBloomFilterMatched, "bloom miss should leave lastBloomFilterMatched unset")
+	require.False(t, iter.data.IsDataInvalidated(), "bloom miss should not invalidate the preloaded block")
+	require.NotNil(t, iter.SeekGE([]byte("c@1"), base.SeekGEFlagsNone), "iterator should remain usable after bloom miss")
+	require.NoError(t, iter.Error())
+}
+
+func TestSeekPrefixGEBloomMissPrecedesSyntheticKeyTwoLevel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	filterPolicy, filterDecoder := newControllableFilterPolicy("test-filter-synthetic-2lvl-miss", false, nil)
+	keys := make([]string, 0, 129)
+	keys = append(keys, "a@10")
+	for i := 0; i < 128; i++ {
+		keys = append(keys, fmt.Sprintf("c%03d@1", i))
+	}
+	reader, cleanup := createTestKeysSSTWithOptions(t, keys, filterPolicy, filterDecoder, true)
+	defer cleanup()
+
+	require.True(t, reader.Attributes.Has(AttributeTwoLevelIndex),
+		"test requires two-level index structure to be created")
+
+	var pool block.BufferPool
+	pool.Init(5, block.ForCompaction)
+	defer pool.Release()
+
+	var stats base.InternalIteratorStats
+	iter, err := newRowBlockTwoLevelIterator(context.Background(), reader, IterOptions{
+		Transforms:            NoTransforms,
+		FilterBlockSizeLimit:  AlwaysUseFilterBlock,
+		Env:                   ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &pool}},
+		ReaderProvider:        MakeTrivialReaderProvider(reader),
+		MaximumSuffixProperty: MaxTestKeysSuffixProperty{},
+	})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	preload := iter.SeekGE([]byte("c064@1"), base.SeekGEFlagsNone)
+	require.NotNil(t, preload)
+	require.True(t, iter.secondLevel.data.Valid())
+	require.False(t, iter.secondLevel.data.IsDataInvalidated())
+
+	kv := iter.SeekPrefixGE([]byte("b"), []byte("b@15"), base.SeekGEFlagsNone)
+	require.Nil(t, kv, "bloom miss should prevent synthetic key generation")
+	require.False(t, iter.secondLevel.synthetic.atSyntheticKey, "synthetic key should not be armed after bloom miss")
+	require.False(t, iter.lastBloomFilterMatched, "bloom miss should leave lastBloomFilterMatched unset")
+	require.False(t, iter.secondLevel.data.IsDataInvalidated(), "bloom miss should not invalidate the preloaded block")
+	require.NotNil(t, iter.SeekGE([]byte("c127@1"), base.SeekGEFlagsNone), "iterator should remain usable after bloom miss")
+	require.NoError(t, iter.Error())
 }
 
 // TestBloomFilterOptimizationEdgeCases tests edge cases for the bloom filter

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -450,6 +450,12 @@ func (i *twoLevelIterator[I, PI, D, PD]) internalSeekGE(
 // SeekPrefixGE implements internalIterator.SeekPrefixGE, as documented in the
 // pebble package. Note that SeekPrefixGE only checks the upper bound. It is up
 // to the caller to ensure that key is greater than or equal to the lower bound.
+//
+// Ordering invariant: the bloom filter is consulted before any synthetic key
+// is materialized via the maximum-suffix-property optimization. A bloom filter
+// miss is a stronger signal of absence than the table-wide max suffix, so
+// returning nil up front avoids needlessly armed synthetic keys and the heap
+// comparisons they would force. See issue #5638.
 func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 	prefix, key []byte, flags base.SeekGEFlags,
 ) (kv *base.InternalKV) {
@@ -459,10 +465,9 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 			op.Finishf("= %s", kv.String())
 		}()
 	}
-	i.lastOpWasSeekPrefixGE.Set(false)
 	// Store the prefix on the second-level iterator for strict prefix
 	// iteration. The prefix slice is stable for the duration of prefix
-	// iteration.
+	// iteration. lastOpWasSeekPrefixGE is reset by prepareSeekPrefixGE below.
 	i.secondLevel.prefix = prefix
 
 	if i.secondLevel.synthetic.atSyntheticKey {
@@ -483,6 +488,14 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 		if i.secondLevel.cmp(key, i.secondLevel.lower) < 0 {
 			key = i.secondLevel.lower
 		}
+	}
+	var (
+		previousErr error
+		ok          bool
+	)
+	flags, previousErr, ok = i.prepareSeekPrefixGE(prefix, flags)
+	if !ok || i.secondLevel.err != nil {
+		return nil
 	}
 	// If there's a maximum suffix property configured and the seek key contains
 	// a suffix (len(key) > len(prefix)), we might be able to defer actually
@@ -538,29 +551,59 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 				// to still be open by the time singleLevelIterator.Next is called
 				// and we use the seek key to actually perform the seek.
 				i.secondLevel.synthetic.seekKey = append(i.secondLevel.synthetic.seekKey[:0], key...)
-				// Clear any stale error from previous operations before returning
-				// a valid key. The seekPrefixGE helper clears i.secondLevel.err,
-				// but this early return bypasses it.
-				i.secondLevel.err = nil
+				// i.secondLevel.err was already cleared by prepareSeekPrefixGE
+				// above; the previous error (returned in previousErr) is
+				// intentionally dropped because the synthetic key represents a
+				// valid kv that supersedes the deferred seek's previous failure.
 				return &i.secondLevel.synthetic.kv
 			}
 		}
 	}
 
-	kv, _ = i.seekPrefixGE(prefix, key, flags, false /* shouldReturnMeta */)
+	kv, _ = i.seekPrefixGEAfterBloomFilter(prefix, key, flags, previousErr, false /* shouldReturnMeta */)
 	return kv
 }
 
-func (i *twoLevelIterator[I, PI, D, PD]) seekPrefixGE(
-	prefix, key []byte, flags base.SeekGEFlags, shouldReturnMeta bool,
-) (*base.InternalKV, base.KVMeta) {
-	// NOTE: prefix is only used for bloom filter checking and not later work in
-	// this method. Hence, we can use the existing iterator position if the last
-	// SeekPrefixGE did not fail bloom filter matching.
-
-	err := i.secondLevel.err
+func (i *twoLevelIterator[I, PI, D, PD]) prepareSeekPrefixGE(
+	prefix []byte, flags base.SeekGEFlags,
+) (_ base.SeekGEFlags, previousErr error, ok bool) {
+	i.lastOpWasSeekPrefixGE.Set(false)
+	previousErr = i.secondLevel.err
 	i.secondLevel.err = nil // clear cached iteration error
+	if i.useFilterBlock {
+		if !i.lastBloomFilterMatched {
+			// Iterator is not positioned based on last seek.
+			flags = flags.DisableTrySeekUsingNext()
+		}
+		i.lastBloomFilterMatched = false
+		// Check prefix bloom filter before considering the synthetic key
+		// optimization. A bloom filter miss is a stronger signal than the
+		// table-wide maximum suffix property.
+		var mayContain bool
+		mayContain, i.secondLevel.err = i.secondLevel.bloomFilterMayContain(prefix)
+		if i.secondLevel.err != nil {
+			PD(&i.secondLevel.data).Invalidate()
+			return flags, previousErr, false
+		}
+		if !mayContain {
+			if treesteps.Enabled && treesteps.IsRecording(i) {
+				treesteps.UpdateLastOpf(i, "pass bloom filter did not match")
+			}
+			// In the no-error bloom filter miss case, the key is definitely not in table.
+			// We can avoid invalidating the already loaded block since the caller is
+			// not allowed to call Next when SeekPrefixGE returns nil.
+			i.lastOpWasSeekPrefixGE.Set(true)
+			return flags, previousErr, false
+		}
+		treesteps.UpdateLastOpf(i, "bloom filter matched")
+		i.lastBloomFilterMatched = true
+	}
+	return flags, previousErr, true
+}
 
+func (i *twoLevelIterator[I, PI, D, PD]) seekPrefixGEAfterBloomFilter(
+	prefix, key []byte, flags base.SeekGEFlags, previousErr error, shouldReturnMeta bool,
+) (*base.InternalKV, base.KVMeta) {
 	if !i.ensureTopLevelIndexLoaded() {
 		return nil, base.KVMeta{}
 	}
@@ -571,36 +614,9 @@ func (i *twoLevelIterator[I, PI, D, PD]) seekPrefixGE(
 	filterUsedAndDidNotMatch := i.useFilterBlock && !i.lastBloomFilterMatched
 	if flags.TrySeekUsingNext() && !filterUsedAndDidNotMatch &&
 		(i.secondLevel.exhaustedBounds == exhaustedUpperBound || (PD(&i.secondLevel.data).IsDataInvalidated() && PI(&i.secondLevel.index).IsDataInvalidated())) &&
-		err == nil {
+		previousErr == nil {
 		// Already exhausted, so return nil.
 		return nil, base.KVMeta{}
-	}
-
-	// Check prefix bloom filter.
-	if i.useFilterBlock {
-		if !i.lastBloomFilterMatched {
-			// Iterator is not positioned based on last seek.
-			flags = flags.DisableTrySeekUsingNext()
-		}
-		i.lastBloomFilterMatched = false
-		var mayContain bool
-		mayContain, i.secondLevel.err = i.secondLevel.bloomFilterMayContain(prefix)
-		if i.secondLevel.err != nil {
-			PD(&i.secondLevel.data).Invalidate()
-			return nil, base.KVMeta{}
-		}
-		if !mayContain {
-			if treesteps.Enabled && treesteps.IsRecording(i) {
-				treesteps.UpdateLastOpf(i, "pass bloom filter did not match")
-			}
-			// In the no-error bloom filter miss case, the key is definitely not in table.
-			// We can avoid invalidating the already loaded block since the caller is
-			// not allowed to call Next when SeekPrefixGE returns nil.
-			i.lastOpWasSeekPrefixGE.Set(true)
-			return nil, base.KVMeta{}
-		}
-		treesteps.UpdateLastOpf(i, "bloom filter matched")
-		i.lastBloomFilterMatched = true
 	}
 
 	// Bloom filter matches.
@@ -618,7 +634,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) seekPrefixGE(
 	// block load.
 
 	var dontSeekWithinSingleLevelIter bool
-	if PI(&i.topLevelIndex).IsDataInvalidated() || !PI(&i.topLevelIndex).Valid() || PI(&i.secondLevel.index).IsDataInvalidated() || err != nil ||
+	if PI(&i.topLevelIndex).IsDataInvalidated() || !PI(&i.topLevelIndex).Valid() || PI(&i.secondLevel.index).IsDataInvalidated() || previousErr != nil ||
 		(i.secondLevel.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || PI(&i.topLevelIndex).SeparatorLT(key) {
 		// Slow-path: need to position the topLevelIndex.
 
@@ -662,7 +678,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) seekPrefixGE(
 			i.secondLevel.boundsCmp = 0
 		}
 	} else {
-		// INVARIANT: err == nil.
+		// INVARIANT: previousErr == nil.
 		//
 		// Else fast-path: There are two possible cases, from
 		// (i.boundsCmp > 0 || flags.TrySeekUsingNext()):
@@ -1050,8 +1066,16 @@ func (i *twoLevelIterator[I, PI, D, PD]) nextInternal(
 		// synthetic. Since SeekPrefixGE deferred this work during synthetic key generation.
 		// The synthetic key is no longer relevant and must be cleared.
 		i.secondLevel.synthetic.atSyntheticKey = false
-		return i.seekPrefixGE(i.secondLevel.reader.Comparer.Split.Prefix(i.secondLevel.synthetic.seekKey),
-			i.secondLevel.synthetic.seekKey, base.SeekGEFlagsNone, shouldReturnMeta)
+		// SeekPrefixGE already consulted the bloom filter (and matched) before
+		// emitting the synthetic key, and lastBloomFilterMatched is still true.
+		// Skip prepareSeekPrefixGE to avoid a redundant bloom filter probe and
+		// drive the deferred seek directly.
+		i.lastOpWasSeekPrefixGE.Set(false)
+		previousErr := i.secondLevel.err
+		i.secondLevel.err = nil
+		prefix := i.secondLevel.reader.Comparer.Split.Prefix(i.secondLevel.synthetic.seekKey)
+		return i.seekPrefixGEAfterBloomFilter(prefix, i.secondLevel.synthetic.seekKey,
+			base.SeekGEFlagsNone, previousErr, shouldReturnMeta)
 	}
 
 	if invariants.Enabled && i.lastOpWasSeekPrefixGE.Get() {

--- a/testdata/iter_histories/lazy_seekprefix_optimization
+++ b/testdata/iter_histories/lazy_seekprefix_optimization
@@ -304,3 +304,47 @@ s@8: (s@8, .)
 000007.Next() = (s@7#15,SET,"s@7")
 000007.Close() = nil
 000005.Close() = nil
+
+# Test that the bloom filter is checked before generating a synthetic key.
+#
+# The sstable contains keys with prefixes "a" and "c", but NOT "b".
+# The sstable's max suffix is @10 (oldest timestamp in the table).
+#
+# A SeekPrefixGE for "b@15" satisfies all synthetic key conditions:
+#   - maximumSuffixProperty is set
+#   - seek key has a suffix (b@15 > b)
+#   - seek suffix (@15) < table max suffix (@10) in testkeys ordering
+#     (larger number = older timestamp = sorts earlier)
+#   - prefix "b" is wholly within the sstable bounds (a < b < c)
+#
+# With the bug: synthetic key is generated before the bloom filter is checked,
+# so SeekPrefixGE returns (b@10#inf,SYNTHETIC) even though "b" is not in the table.
+# The Next() then performs the real seek and finds nothing (nil).
+#
+# Regression for issue #5638: the bloom filter should be checked first and
+# exclude the sstable, so SeekPrefixGE should return nil without generating a
+# synthetic key.
+
+reset bloom-bits-per-key=100
+----
+
+batch commit
+set a@10 a@10
+set c@1  c@1
+----
+committed 2 keys
+
+flush
+----
+
+lsm
+----
+L0.0:
+  000005:[a@10#10,SET-c@1#11,SET]
+
+combined-iter probe-points=(5,(Log "000005."))
+seek-prefix-ge b@15
+----
+.
+000005.SeekPrefixGE("b@15") = nil
+000005.Close() = nil


### PR DESCRIPTION
Previously SeekPrefixGE in both singleLevelIterator and twoLevelIterator
ran the maximum-suffix-property synthetic-key fast path before consulting
the bloom filter. When the bloom filter would have proved the prefix
absent, the iterator still materialized a synthetic key, pushed it onto
the merging-iterator heap, and forced the caller to Next() before
discovering the absence. The synthetic key and the comparisons it caused
were wasteful in that case.

Reorder the work so the bloom filter is consulted first. The bloom-filter
state setup and probe are factored out of seekPrefixGE into a new helper
prepareSeekPrefixGE that returns whether the seek should proceed. The
remainder of the seek work (top-level index loading and the exhausted-
bounds short-circuit in the two-level case, then the actual seek) lives
in seekPrefixGEAfterBloomFilter. SeekPrefixGE now calls
prepareSeekPrefixGE first and only enters the synthetic-key path on a
bloom-filter match; on a miss it returns nil without touching the
synthetic-key state, matching the documented contract that the iterator
is not positioned after a bloom-filter exclusion.

The synthetic-key Next path in nextInternal calls
seekPrefixGEAfterBloomFilter directly rather than re-entering
prepareSeekPrefixGE, so the bloom filter is still probed at most once
across the SeekPrefixGE/Next pair.

twoLevelIterator.seekPrefixGE had no remaining callers after this rewire
and is removed.

Add regression tests for both the single-level and two-level
iterators that arm a synthetic key, perform a SeekPrefixGE whose prefix
is not in the table, and assert that the synthetic key is never armed,
the preloaded data block is not invalidated, lastBloomFilterMatched is
left unset, and the iterator remains usable. Add a datadriven scenario
in testdata/iter_histories/lazy_seekprefix_optimization that exercises
the same path through the public iterator.

Fixes https://github.com/cockroachdb/pebble/issues/5638.
Release note: None