### PR TITLE
iterv2: handle batch refresh in mergingIterV2

### DIFF
--- a/db.go
+++ b/db.go
@@ -1553,7 +1553,9 @@ func (i *Iterator) constructPointIterV2(
 		m.slab.batchSnapshot = i.batch.batchSeqNum
 		// The batch follows the TriggerIter if one was inserted (i.e. when
 		// !batchOnlyIter); otherwise the batch is the first level.
-		if !i.batchOnlyIter {
+		if i.batchOnlyIter {
+			m.slab.batchLevelIdx = 0
+		} else {
 			m.slab.batchLevelIdx = 1
 		}
 	}

--- a/internal/iterv2/interleaving_iter.go
+++ b/internal/iterv2/interleaving_iter.go
@@ -247,14 +247,18 @@ func (i *InterleavingIter) positionSpanIterForward(pos []byte, flags base.SeekGE
 		i.computeCurrentSpan()
 		return
 	}
-	// Try to avoid reseeking. We can do this in TrySeekUsingNext mode if pos is
-	// not beyond the current known span; otherwise we can do this if pos happens
-	// to be inside the known span.
 	var currentSpanOK bool
-	if flags.TrySeekUsingNext() {
-		currentSpanOK = i.span == nil || i.cmp.Compare(pos, i.span.End) < 0
-	} else {
-		currentSpanOK = i.span != nil && i.span.Contains(i.cmp.Compare, pos)
+	// Try to avoid reseeking the span iterator (unless the BatchJustRefreshed
+	// flag is set, in which case we always need to re-seek).
+	if !flags.BatchJustRefreshed() {
+		// Try to avoid reseeking. We can do this in TrySeekUsingNext mode if pos is
+		// not beyond the current known span; otherwise we can do this if pos
+		// happens to be inside the known span.
+		if flags.TrySeekUsingNext() {
+			currentSpanOK = i.span == nil || i.cmp.Compare(pos, i.span.End) < 0
+		} else {
+			currentSpanOK = i.span != nil && i.span.Contains(i.cmp.Compare, pos)
+		}
 	}
 	if !currentSpanOK {
 		i.nextSpan(i.spanIter.SeekGE(pos))

--- a/iterator.go
+++ b/iterator.go
@@ -2746,12 +2746,6 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 			// able to reuse the top-level Iterator state, because it may be
 			// incorrect after the inclusion of new batch mutations.
 			i.batchJustRefreshed = true
-			if i.mergingV2 != nil {
-				// V2: the batch point and range del iters are wrapped in an
-				// InterleavingIter. We can't update them in place, so force
-				// a full point iterator reconstruction.
-				reusePointIter = false
-			}
 			if reusePointIter && i.batch.batch.countRangeDels > 0 {
 				if i.batch.rangeDelIter.Count() == 0 {
 					// When we constructed this iterator, there were no

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -31,6 +32,7 @@ import (
 	"github.com/cockroachdb/pebble/internal/iterv2"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/testkeys"
+	"github.com/cockroachdb/pebble/internal/treesteps"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/sstable/block/blockkind"
@@ -1207,6 +1209,278 @@ func TestIteratorGuaranteedDurable(t *testing.T) {
 	})
 }
 
+// TestSetOptionsBatchRefreshSeekGE reproduces a sequence where Iterator.SeekGE
+// passes both BatchJustRefreshed and TrySeekUsingNext to mergingIterV2.SeekGE,
+// making it return an earlier key than before.
+func TestSetOptionsBatchRefreshSeekGE(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	mem := vfs.NewMem()
+	d, err := Open("", &Options{FS: mem})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, d.Close()) }()
+
+	// Write keys to the LSM and flush so that the batch iterator stack has
+	// a non-empty level beneath it. The new RANGEDELs added during the
+	// refresh below will hide "d" and "e"; "g" is left to be returned
+	// afterwards.
+	require.NoError(t, d.Set([]byte("d"), []byte("v"), nil))
+	require.NoError(t, d.Set([]byte("e"), []byte("v"), nil))
+	require.NoError(t, d.Set([]byte("g"), []byte("v"), nil))
+	require.NoError(t, d.Flush())
+
+	batch := d.NewIndexedBatch()
+	defer batch.Close()
+	require.NoError(t, batch.Set([]byte("c"), []byte("v"), nil))
+	// Add an inert RANGEDEL so that the batch's range-del iterator is wired
+	// into the InterleavingIter at iterator construction time. Without this,
+	// SetOptions below would close and rebuild pointIter (see iterator.go
+	// SetOptions), bypassing the BatchJustRefreshed+TSUN path under test.
+	require.NoError(t, batch.DeleteRange([]byte("y"), []byte("z"), nil))
+
+	iter, _ := batch.NewIter(nil)
+	defer iter.Close()
+	// Bypass the testingDisableSeekOpt randomization so that
+	// Iterator.SeekGE deterministically sets TrySeekUsingNext on the second
+	// seek below.
+	iter.forceEnableSeekOpt = true
+
+	// First SeekGE positions the iterator at "c" and records
+	// lastPositioningOp = seekGELastPositioningOp with prefixOrFullSeekKey = "a".
+	require.True(t, iter.SeekGE([]byte("a")))
+	require.Equal(t, []byte("c"), iter.Key())
+
+	// Mutate the batch by inserting a new key in (a, c) and two RANGEDELs.
+	// The first RANGEDEL is positioned between the iterator's current
+	// position ("c") and the second RANGEDEL ("e","f"); both shadow LSM
+	// keys ("d" and "e" respectively).
+	require.NoError(t, batch.Set([]byte("b"), []byte("v"), nil))
+	require.NoError(t, batch.DeleteRange([]byte("c0"), []byte("d0"), nil))
+	require.NoError(t, batch.DeleteRange([]byte("e"), []byte("f"), nil))
+
+	// SetOptions with identical IterOptions hits the SetOptions fast path:
+	// i.batchJustRefreshed becomes true, but lastPositioningOp is preserved
+	// (no invalidate()). Because the batch already had a range-del iterator
+	// in the stack, this updates it in place rather than rebuilding pointIter.
+	iter.SetOptions(&IterOptions{})
+
+	// SeekGE with a key strictly greater than the previous prefixOrFullSeekKey
+	// ("a"), and <= the current heap top ("c"). Iterator.SeekGE will pass
+	// BatchJustRefreshed AND TrySeekUsingNext to mergingIterV2.SeekGE, which
+	// takes the early-return path -- triggering the exploratory panic.
+	require.True(t, iter.SeekGE([]byte("a1")))
+	require.Equal(t, []byte("b"), iter.Key())
+
+	// Walk forward. "c" is the next batch key; the LSM key "e" must be
+	// hidden by the freshly added RANGEDEL, leaving "g" as the next visible
+	// key after "c".
+	require.True(t, iter.Next())
+	require.Equal(t, []byte("c"), iter.Key())
+	require.True(t, iter.Next())
+	require.Equal(t, []byte("g"), iter.Key())
+}
+
+// TestSetOptionsBatchRefreshRand is a randomized counterpart to
+// TestSetOptionsBatchRefreshSeekGE. Each iteration mutates an indexed batch,
+// calls SetOptions to refresh, and then compares the result of a seek on the
+// long-lived iterator (which may pass TrySeekUsingNext + BatchJustRefreshed to
+// the underlying merging iterator) against a freshly constructed iterator on
+// the same batch.
+//
+// The iteration randomly picks SeekGE, SeekPrefixGE, or SeekLT for each pass.
+// SeekLT does not currently propagate any TSUN/BatchJustRefreshed signal
+// through iterator.go (the optimization is gated on i.batch == nil), but we
+// still cover it to guard against regressions if InterleavingIter ever grows a
+// SeekLT fast path.
+func TestSetOptionsBatchRefreshRand(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Set to true to record treesteps for the BatchJustRefreshed seek on
+	// each iteration; on a failure the recording for the failing iteration
+	// is printed.
+	const recordTreeSteps = false
+
+	seed := uint64(time.Now().UnixNano())
+	rng := rand.New(rand.NewPCG(seed, seed))
+
+	mem := vfs.NewMem()
+	d, err := Open("", &Options{FS: mem, Comparer: testkeys.Comparer})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, d.Close()) }()
+
+	// Generate keys via iterv2.KeyGenConfig. A small prefix length and suffix
+	// range encourage collisions between batch and LSM keys.
+	keyCfg := iterv2.KeyGenConfig{MaxPrefixLen: 2, MaxSuffix: 3, MinSeqNum: 1, MaxSeqNum: 1}
+	prefixCfg := iterv2.KeyGenConfig{MaxPrefixLen: 2, MinSeqNum: 1, MaxSeqNum: 1}
+	randKey := func() []byte { return keyCfg.RandKey(rng) }
+	randPrefix := func() []byte { return prefixCfg.RandKey(rng) }
+
+	// Seed the LSM with multiple flushed sstables so the merging iterator has
+	// several non-batch levels beneath the batch. Each flush writes a random
+	// scattering of keys; the final memtable layer adds another level.
+	for f := 0; f < 3; f++ {
+		for k := 0; k < 8; k++ {
+			require.NoError(t, d.Set(randKey(), randValue(4, rng), nil))
+		}
+		require.NoError(t, d.Flush())
+	}
+	for k := 0; k < 8; k++ {
+		require.NoError(t, d.Set(randKey(), randValue(4, rng), nil))
+	}
+
+	batch := d.NewIndexedBatch()
+	defer batch.Close()
+
+	iter, _ := batch.NewIter(nil)
+	defer iter.Close()
+	// Bypass the testingDisableSeekOpt randomization so the second seek
+	// deterministically passes TrySeekUsingNext when its key permits it.
+	iter.forceEnableSeekOpt = true
+
+	// strictlyGreaterKey returns a key with a strictly greater prefix than
+	// min's. Under testkeys.Comparer, keys are compared by prefix bytewise
+	// first, so any byte appended to min's prefix yields a strictly greater
+	// key regardless of suffix choice.
+	strictlyGreaterKey := func(min []byte) []byte {
+		split := testkeys.Comparer.Split(min)
+		k := append(slices.Clone(min[:split]), byte('a')+byte(rng.IntN(8)))
+		if rng.IntN(2) == 0 {
+			return k
+		}
+		k = append(k, '@')
+		return strconv.AppendInt(k, int64(1+rng.IntN(3)), 10)
+	}
+
+	const (
+		opSeekGE = iota
+		opSeekPrefixGE
+		opSeekLT
+	)
+	opName := []string{"SeekGE", "SeekPrefixGE", "SeekLT"}
+
+	const iterations = 300
+	for it := 0; it < iterations; it++ {
+		op := rng.IntN(3)
+		seekKey := randKey()
+		switch op {
+		case opSeekGE:
+			iter.SeekGE(seekKey)
+		case opSeekPrefixGE:
+			iter.SeekPrefixGE(seekKey)
+		case opSeekLT:
+			iter.SeekLT(seekKey)
+		}
+
+		// Mutate the batch with a small random number of point/range writes.
+		nMutations := 1 + rng.IntN(3)
+		for j := 0; j < nMutations; j++ {
+			switch rng.IntN(2) {
+			case 0:
+				require.NoError(t, batch.Set(randKey(), randValue(4, rng), nil))
+			case 1:
+				// Range del bounds use bare prefixes so we don't have to deal
+				// with testkeys suffix encoding when extending the upper bound.
+				a := slices.Clone(randPrefix())
+				b := slices.Clone(randPrefix())
+				if bytes.Compare(a, b) > 0 {
+					a, b = b, a
+				}
+				if bytes.Equal(a, b) {
+					b = append(b, byte('a')+byte(rng.IntN(8)))
+				}
+				require.NoError(t, batch.DeleteRange(a, b, nil))
+			}
+		}
+
+		iter.SetOptions(&IterOptions{})
+
+		// Choose the new seek key. For SeekGE/SeekPrefixGE, make it strictly
+		// greater than the previous key/prefix so the iterator.go-level TSUN
+		// optimization fires (and the merging iterator sees TSUN +
+		// BatchJustRefreshed). SeekLT places no constraint.
+		var newSeekKey []byte
+		switch op {
+		case opSeekGE:
+			newSeekKey = strictlyGreaterKey(seekKey)
+		case opSeekPrefixGE:
+			newSeekKey = strictlyGreaterKey(seekKey)
+		case opSeekLT:
+			newSeekKey = randKey()
+		}
+
+		var rec *treesteps.Recording
+		if recordTreeSteps && treesteps.Enabled {
+			rec = treesteps.StartRecording(iter, fmt.Sprintf("iter %d: %s(%q)", it, opName[op], newSeekKey))
+		}
+
+		// Collect the seeked key plus a few step results. For SeekLT we step
+		// backwards via Prev; otherwise forward via Next. SeekPrefixGE
+		// terminates Next at the prefix boundary.
+		const numSteps = 3
+		collect := func(it *Iterator, valid bool, forward bool) (keys, vals [][]byte) {
+			for n := 0; valid && n <= numSteps; n++ {
+				keys = append(keys, slices.Clone(it.Key()))
+				v, err := it.ValueAndErr()
+				require.NoError(t, err)
+				vals = append(vals, slices.Clone(v))
+				if n == numSteps {
+					break
+				}
+				if forward {
+					valid = it.Next()
+				} else {
+					valid = it.Prev()
+				}
+			}
+			return keys, vals
+		}
+
+		var gotValid bool
+		switch op {
+		case opSeekGE:
+			gotValid = iter.SeekGE(newSeekKey)
+		case opSeekPrefixGE:
+			gotValid = iter.SeekPrefixGE(newSeekKey)
+		case opSeekLT:
+			gotValid = iter.SeekLT(newSeekKey)
+		}
+		gotKeys, gotVals := collect(iter, gotValid, op != opSeekLT)
+		var recSteps treesteps.Steps
+		if rec != nil {
+			recSteps = rec.Finish()
+		}
+
+		// Reference: a fresh iterator on the same batch performing the same
+		// seek + traversal.
+		ref, _ := batch.NewIter(nil)
+		var wantValid bool
+		switch op {
+		case opSeekGE:
+			wantValid = ref.SeekGE(newSeekKey)
+		case opSeekPrefixGE:
+			wantValid = ref.SeekPrefixGE(newSeekKey)
+		case opSeekLT:
+			wantValid = ref.SeekLT(newSeekKey)
+		}
+		wantKeys, wantVals := collect(ref, wantValid, op != opSeekLT)
+		require.NoError(t, ref.Close())
+
+		mismatch := wantValid != gotValid || len(wantKeys) != len(gotKeys)
+		for i := 0; !mismatch && i < len(wantKeys); i++ {
+			if !bytes.Equal(wantKeys[i], gotKeys[i]) || !bytes.Equal(wantVals[i], gotVals[i]) {
+				mismatch = true
+			}
+		}
+		if mismatch {
+			t.Logf("seed: %d", seed)
+			if rec != nil {
+				u := recSteps.URL()
+				t.Logf("treesteps recording:\n%s", u.String())
+			}
+			t.Fatalf("iter %d: op=%s seekKey=%q newSeekKey=%q\n got valid=%v keys=%q vals=%q\nwant valid=%v keys=%q vals=%q",
+				it, opName[op], seekKey, newSeekKey, gotValid, gotKeys, gotVals, wantValid, wantKeys, wantVals)
+		}
+	}
+}
+
 func TestIteratorBoundsLifetimes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
@@ -1594,7 +1868,7 @@ func testSetOptionsEquivalence(t *testing.T, seed uint64) {
 		longLivedBuf.Reset()
 		printIterState(&newIterBuf, newIter, newIterValidity, true /* printValidityState */)
 		printIterState(&longLivedBuf, longLivedIter, longLivedValidity, true /* printValidityState */)
-		fmt.Fprintf(&history, "%s = %s\n", iterOp.desc, newIterBuf.String())
+		fmt.Fprintf(&history, "%s = %s\n", iterOp.desc, longLivedBuf.String())
 
 		if newIterBuf.String() != longLivedBuf.String() {
 			t.Logf("history:\n%s\n", history.String())

--- a/level_iter_v2.go
+++ b/level_iter_v2.go
@@ -391,6 +391,9 @@ func (l *levelIterV2) SeekGE(key []byte, flags base.SeekGEFlags) (kv *base.Inter
 			op.Finishf("= %s", kv.String())
 		}()
 	}
+	if invariants.Enabled && flags.BatchJustRefreshed() {
+		panic(errors.AssertionFailedf("BatchJustRefreshed on level iter"))
+	}
 	if invariants.Enabled && l.lower != nil && l.comparer.Compare(key, l.lower) < 0 {
 		panic(errors.AssertionFailedf("levelIterV2 SeekGE to key %q violates lower bound %q", key, l.lower))
 	}
@@ -484,6 +487,9 @@ func (l *levelIterV2) SeekPrefixGE(
 		defer func() {
 			op.Finishf("= %s", kv.String())
 		}()
+	}
+	if invariants.Enabled && flags.BatchJustRefreshed() {
+		panic(errors.AssertionFailedf("BatchJustRefreshed on level iter"))
 	}
 	if invariants.Enabled && l.lower != nil && l.comparer.Compare(key, l.lower) < 0 {
 		panic(errors.AssertionFailedf("levelIterV2 SeekPrefixGE to key %q violates lower bound %q", key, l.lower))

--- a/merging_iter_v2.go
+++ b/merging_iter_v2.go
@@ -283,6 +283,7 @@ func newMergingIterV2(
 	m.heap.items = make([]mergingIterV2HeapItem, 0, len(iters))
 	m.slab.cmp = cmp
 	m.slab.snapshot = snapshot
+	m.slab.batchLevelIdx = -1
 	m.slab.levels = m.levels
 	return m
 }
@@ -397,6 +398,12 @@ func (m *mergingIterV2) seekGE(key []byte, flags base.SeekGEFlags) {
 				// an absolute seek.
 				levelFlags = levelFlags.DisableTrySeekUsingNext()
 			}
+			if levelIdx != m.slab.batchLevelIdx {
+				// The BatchJustRefreshed flag does something only for the batch level.
+				// We don't want to pass it to other levels since it disables some
+				// optimizations in InterleavingIters.
+				levelFlags = levelFlags.DisableBatchJustRefreshed()
+			}
 			m.prepareForLevelOp(level)
 			if m.prefix != nil {
 				level.iterKV = level.iter.SeekPrefixGE(m.prefix, key, levelFlags)
@@ -423,45 +430,123 @@ func (m *mergingIterV2) SeekGE(key []byte, flags base.SeekGEFlags) (kv *base.Int
 		if m.err != nil || m.dir != +1 || m.prefix != nil {
 			panic(errors.AssertionFailedf("invalid use of TrySeekUsingNext"))
 		}
-		if m.heap.Len() == 0 {
-			return nil
-		}
-		if top := m.heap.Top(); m.heap.cmp(key, top.iterKV.K.UserKey) <= 0 {
-			// The iterator is already at the right position.
-			//
-			// It is necessary to check for this case to avoid passing down
-			// TrySeekUsingNext incorrectly: it is possible multiple slab transitions
-			// are necessary between <key> and <iterKV.K>, which would mean some
-			// levels would go backwards if we seeked them at <key>.
-			//
-			// For example, consider two levels:
-			//  L1: a  [b, c):RANGEDEL d
-			//  L2:      b1
-			//
-			// A SeekGE(a1) on the merging iterator would cause slab transitions
-			// through boundaries b and c to produce the resulting key d. A subsequent
-			// SeekGE(b, TrySeekUsingNext) is legal because (from an external
-			// perspective) it doesn't move back the merging iterator. However, L1 is
-			// now positioned at d, so it would be illegal to re-seek it to b using
-			// TrySeekUsingNext.
-			return top.iterKV
-		}
-		// Try the single-level advance fast path.
-		if top := m.heap.Top(); m.shouldTrySingleLevelAdvance(top, key) {
-			m.prepareForLevelOp(top)
-			top.iterKV = top.iter.SeekGE(key, flags)
-			if m.finishSingleLevelAdvance(top) {
-				return m.findNextEntry()
+		// Note: SeekPrefixGE doesn't need analogous BatchJustRefreshed handling.
+		// A new prefix forces all levels to move forward, so the rewinding
+		// concern addressed by seekGEAfterBatchRefresh doesn't apply.
+		if flags.BatchJustRefreshed() {
+			var earlyExit bool
+			if flags, earlyExit = m.seekGEAfterBatchRefresh(key, flags); earlyExit {
+				return nil
 			}
-			// The top.span keys might have changed; fall through to the full slab
-			// rebuild below. m.seekGE will re-seek top with TSUN (a cheap no-op since
-			// top is now at >= key) before rebuilding.
+			// We fall back to rebuilding the entire slab, with the updated flags.
+			// TODO(radu): the batch level is already in the right place; we could
+			// avoid re-seeking it.
+		} else {
+			if m.heap.Len() == 0 {
+				return nil
+			}
+
+			if top := m.heap.Top(); m.heap.cmp(key, top.iterKV.K.UserKey) <= 0 {
+				// The iterator is already at the right position.
+				//
+				// It is necessary to check for this case to avoid passing down
+				// TrySeekUsingNext incorrectly: it is possible multiple slab transitions
+				// are necessary between <key> and <iterKV.K>, which would mean some
+				// levels would go backwards if we seeked them at <key>.
+				//
+				// For example, consider two levels:
+				//  L1: a  [b, c):RANGEDEL d
+				//  L2:      b1
+				//
+				// A SeekGE(a1) on the merging iterator would cause slab transitions
+				// through boundaries b and c to produce the resulting key d. A subsequent
+				// SeekGE(b, TrySeekUsingNext) is legal because (from an external
+				// perspective) it doesn't move back the merging iterator. However, L1 is
+				// now positioned at d, so it would be illegal to re-seek it to b using
+				// TrySeekUsingNext.
+				return top.iterKV
+			}
+			// Try the single-level advance fast path.
+			if top := m.heap.Top(); m.shouldTrySingleLevelAdvance(top, key) {
+				m.prepareForLevelOp(top)
+				top.iterKV = top.iter.SeekGE(key, flags)
+				if m.finishSingleLevelAdvance(top) {
+					return m.findNextEntry()
+				}
+				// The top.span keys might have changed; fall through to the full slab
+				// rebuild below. Note that m.seekGE might unnecessarily re-seek <top>
+				// but it will be a cheap no-op thanks to TrySeekUsingNext (since top is
+				// now at >= key).
+				// TODO(radu): consider a skipReseek per-level flag.
+			}
 		}
 	}
 	m.err = nil
 	m.prefix = nil
 	m.seekGE(key, flags)
 	return m.findNextEntry()
+}
+
+// seekGEAfterBatchRefresh handles the BatchJustRefreshed case for
+// SeekGE(TrySeekUsingNext).
+//
+// The batch iterator may now expose new keys that require the merging iterator
+// to move backward; for example:
+//   - batch keys: a, d
+//   - SeekGE(b) -> d
+//   - refresh the batch; new batch keys: a, c, d
+//   - SeekGE(c, TrySeekUsingNext|BatchJustRefreshed). The iterator must move
+//     back to c, and lower levels could have boundaries between c and d that
+//     also need to be re-seeked.
+//
+// We pre-seek the batch level to determine whether the merging iterator's
+// position must move back. Returns earlyExit=true when no further work is
+// needed: either the batch level errored, or the iterator was exhausted before
+// the seek and the batch is also exhausted now. Otherwise, returns the updated
+// flags to use for the fall-through to m.seekGE: TrySeekUsingNext is cleared if
+// a backward move is required, and BatchJustRefreshed is always cleared
+// (the batch level was just seeked).
+func (m *mergingIterV2) seekGEAfterBatchRefresh(
+	key []byte, flags base.SeekGEFlags,
+) (newFlags base.SeekGEFlags, earlyExit bool) {
+	newFlags = flags.DisableBatchJustRefreshed()
+	if invariants.Enabled && m.slab.batchSnapshot == 0 {
+		panic(errors.AssertionFailedf("BatchJustRefreshed with no batch iterator"))
+	}
+	level := &m.levels[m.slab.batchLevelIdx]
+	var prevTopKey []byte
+	// Whether the heap is empty or non-empty, we need to seek the batch level to
+	// see if it causes the mergingIter to move back. If the heap is non-empty, we
+	// record the position in prevTopKey.
+	if m.heap.Len() > 0 {
+		top := m.heap.Top()
+		prevTopKey = top.iterKV.K.UserKey
+		if top == level {
+			// The batch level is the top; the seek below would invalidate the
+			// reference, so make a copy.
+			m.keyBuf = append(m.keyBuf[:0], prevTopKey...)
+			prevTopKey = m.keyBuf
+		}
+	}
+	m.prepareForLevelOp(level)
+	level.iterKV = level.iter.SeekGE(key, flags)
+	switch {
+	case level.iterKV == nil:
+		// The entire operation is done if there was an error or the merging
+		// iterator is still exhausted.
+		if m.levelHasError(level) || prevTopKey == nil {
+			return newFlags, true
+		}
+		// The heap is not moving back, we can use TrySeekUsingNext on other levels.
+	case prevTopKey == nil || m.heap.cmp(level.iterKV.K.UserKey, prevTopKey) < 0:
+		// Either the heap was empty (so other levels are exhausted and need
+		// absolute re-seeks) or the slab moves back. Fall back to the general
+		// seek path.
+		newFlags = newFlags.DisableTrySeekUsingNext()
+	default:
+		// The heap is not moving back, we can use TrySeekUsingNext on other levels.
+	}
+	return newFlags, false
 }
 
 // Next implements base.InternalIterator.

--- a/merging_iter_v2_slab.go
+++ b/merging_iter_v2_slab.go
@@ -26,8 +26,8 @@ type slabState struct {
 	snapshot base.SeqNum
 	// batchSnapshot is non-zero if and only if a level is the indexed batch.
 	batchSnapshot base.SeqNum
-	// batchLevelIdx is the index of the batch level; only meaningful when
-	// batchSnapshot != 0. Defaults to 0.
+	// batchLevelIdx is the index of the batch level; -1 when there is no batch
+	// (batchSnapshot == 0).
 	batchLevelIdx int
 
 	// levels aliases m.levels, sharing the same backing array. Indexed by


### PR DESCRIPTION
Previously, when a batch was refreshed via `SetOptions` while a
`pebble.Iterator` was using `mergingIterV2`, the point iterator stack
was torn down and rebuilt. This change instead propagates the
`BatchJustRefreshed` flag through `mergingIterV2` and `InterleavingIter`,
so the existing iterator can be reused across batch refreshes.

This case needs special handling in the SeekGE(TrySeekUsingNext) case:
the merging iterator needs to determine if it requires "rewinding"
lower levels. Note that this is not a concern for `SeekPrefixGE`
because it requires a new prefix, so all levels always move forward.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>