### PR TITLE
cockroachkvs: fix off-by-one in `MaxMVCCTimestampProperty.Extract`

### DIFF
--- a/cockroachkvs/blockproperties.go
+++ b/cockroachkvs/blockproperties.go
@@ -168,7 +168,9 @@ func (MaxMVCCTimestampProperty) Extract(
 		return nil, false, nil
 	}
 	dst = append(dst, make([]byte, suffixLenWithWall)...)
-	binary.BigEndian.PutUint64(dst[len(dst)-suffixLenWithWall:], interval.Upper)
+	// BlockInterval is a half-open interval [Lower, Upper). The largest wall
+	// time present in the block is therefore Upper-1.
+	binary.BigEndian.PutUint64(dst[len(dst)-suffixLenWithWall:], interval.Upper-1)
 	dst[len(dst)-1] = suffixLenWithWall
 	return dst, true, nil
 }

--- a/cockroachkvs/blockproperties_test.go
+++ b/cockroachkvs/blockproperties_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cockroachkvs
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMaxMVCCTimestampPropertyExtract verifies that
+// MaxMVCCTimestampProperty.Extract returns a suffix that encodes the largest
+// wall time actually present in the block, not Upper of the half-open
+// BlockInterval. The returned suffix powers the sstable iterator's
+// synthetic-key optimization, so it must sort no later (under MVCC's
+// descending suffix order) than the largest real key's suffix; otherwise the
+// synthetic key sorts ahead of keys it is meant to stand in for.
+func TestMaxMVCCTimestampPropertyExtract(t *testing.T) {
+	collector := BlockPropertyCollectors[0]()
+
+	// Add a few MVCC keys with distinct wall times to a single data block.
+	walls := []uint64{100, 250, 175, 300, 50}
+	var maxWall uint64
+	for _, w := range walls {
+		key := EncodeMVCCKey(nil, []byte("roach"), w, 0)
+		ik := base.MakeInternalKey(key, base.SeqNumMax, base.InternalKeyKindSet)
+		require.NoError(t, collector.AddPointKey(ik, nil))
+		if w > maxWall {
+			maxWall = w
+		}
+	}
+
+	encodedInterval, err := collector.FinishDataBlock(nil)
+	require.NoError(t, err)
+
+	// Extract skips the first byte (shortID prefix added by the block-property
+	// framework in real sstables), so prepend a placeholder.
+	encoded := append([]byte{0x00}, encodedInterval...)
+
+	suffix, ok, err := MaxMVCCTimestampProperty{}.Extract(nil, encoded)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	wall, logical, err := DecodeMVCCTimestampSuffix(suffix)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), logical)
+	require.Equal(t, maxWall, wall,
+		"extracted wall time should match the largest wall time in the block")
+
+	// Stronger ordering check: the synthetic suffix must sort no later than
+	// the real largest suffix (ComparePointSuffixes <= 0).
+	realMax := NewTimestampSuffix(maxWall, 0)
+	require.LessOrEqual(t, ComparePointSuffixes(suffix, realMax), 0,
+		"extracted suffix must not sort after the largest real suffix")
+}


### PR DESCRIPTION
Found by bug catcher. This code is part of the "synthetic key optimization" which is not enabled by default.

`MaxMVCCTimestampProperty.Extract` encoded `interval.Upper` as the wall
time of the returned "max" suffix. `BlockInterval` is a half-open
interval `[Lower, Upper)`, and `mapSuffixToInterval` emits
`Upper = ts + 1` per key, so the suffix encoded a wall time one
nanosecond larger than any key actually present in the block.

Because CockroachDB MVCC suffixes sort descending by walltime, this
synthetic suffix was bytewise smaller than every real suffix in the
block — i.e., it sorted strictly *before* the key the deferred seek
would materialize. This breaks the ordering invariant the
synthetic-key optimization in `sstable/reader_iter_single_lvl.go`
relies on, and can produce wrong results when the merging iterator
contains other sstables.

Fix the encoding to write `interval.Upper - 1` (matching the analogous
testkeys implementation in `sstable/block_property_test_utils.go`) and
add a test that drives the production collector and asserts both the
decoded wall time and the ordering relationship against the real max
suffix via `ComparePointSuffixes`.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>