### PR TITLE
batchrepr: harden DecodeStr and DecodeBlobFileIDs against corrupt input

### DIFF
--- a/batchrepr/reader.go
+++ b/batchrepr/reader.go
@@ -112,11 +112,18 @@ func (r *Reader) Next() (kind base.InternalKeyKind, ukey []byte, value []byte, o
 // TODO(jackson): This should be unexported once pebble package callers have
 // been updated to use appropriate abstractions.
 func DecodeStr(data []byte) (odata []byte, s []byte, ok bool) {
-	// TODO(jackson): This will index out of bounds if there's no varint or an
-	// invalid varint (eg, a single 0xff byte). Correcting will add a bit of
-	// overhead. We could avoid that overhead whenever len(data) >=
-	// binary.MaxVarint32?
-
+	if len(data) <= 128 {
+		// Any valid varint here must be a single byte: a multi-byte varint
+		// encodes a value v >= 128, which would require at least 130 bytes of
+		// input (2 varint bytes + 128 string bytes).
+		if len(data) == 0 || data[0] >= byte(len(data)) {
+			return nil, nil, false
+		}
+		n := int(data[0])
+		return data[1+n:], data[1 : 1+n], true
+	}
+	// The unsafe loads below read up to 5 bytes; safe because
+	// len(data) > 128 >= binary.MaxVarintLen32.
 	var v uint32
 	var n int
 	ptr := unsafe.Pointer(&data[0])
@@ -152,8 +159,17 @@ func DecodeBlobFileIDs(value []byte) (blobIDs []base.BlobFileID, ok bool) {
 	if n <= 0 {
 		return nil, false
 	}
+	// Each blob file ID is a varint of at least one byte, so blobCount cannot
+	// exceed the number of remaining bytes. This bounds the allocation against
+	// corrupt input.
+	if blobCount > uint64(len(value)-n) {
+		return nil, false
+	}
 	blobIDs = make([]base.BlobFileID, 0, blobCount)
 	for i := uint64(0); i < blobCount; i++ {
+		if n >= len(value) {
+			return nil, false
+		}
 		blobID, m := binary.Uvarint(value[n:])
 		if m <= 0 {
 			return nil, false

--- a/batchrepr/reader_test.go
+++ b/batchrepr/reader_test.go
@@ -6,6 +6,7 @@ package batchrepr
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -14,6 +15,8 @@ import (
 
 	"github.com/cockroachdb/crlib/crstrings"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReader(t *testing.T) {
@@ -70,4 +73,123 @@ func readRepr(t testing.TB, str string) []byte {
 		reprBuf.Write(b)
 	}
 	return reprBuf.Bytes()
+}
+
+func TestDecodeStr(t *testing.T) {
+	t.Run("truncated", func(t *testing.T) {
+		// Each of these inputs must not panic and must report ok=false.
+		cases := [][]byte{
+			nil,
+			{},
+			{0x01},                                 // length byte says 1, but no payload
+			{0x7f},                                 // length byte says 127, but no payload
+			{0xff},                                 // partial multi-byte varint
+			{0xff, 0xff, 0xff, 0xff},               // longer partial multi-byte varint
+			append([]byte{0x05}, []byte("abc")...), // says 5, only 3 bytes
+		}
+		for i, data := range cases {
+			t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+				_, _, ok := DecodeStr(data)
+				require.False(t, ok)
+			})
+		}
+	})
+
+	t.Run("valid-fast-path", func(t *testing.T) {
+		// Single-byte varint, len(data) <= 128.
+		payload := bytes.Repeat([]byte("x"), 127)
+		data := append([]byte{0x7f}, payload...)
+		require.Equal(t, 128, len(data))
+		odata, s, ok := DecodeStr(data)
+		require.True(t, ok)
+		require.Equal(t, payload, s)
+		require.Empty(t, odata)
+	})
+
+	t.Run("valid-slow-path", func(t *testing.T) {
+		// Force len(data) > 128 with both single- and multi-byte varints.
+		for _, strLen := range []int{0, 1, 127, 128, 200, 16384} {
+			payload := bytes.Repeat([]byte("y"), strLen)
+			var buf [binary.MaxVarintLen32]byte
+			n := binary.PutUvarint(buf[:], uint64(strLen))
+			data := append([]byte{}, buf[:n]...)
+			data = append(data, payload...)
+			// Append trailing bytes so len(data) > 128 and we exercise the
+			// slow path.
+			tail := bytes.Repeat([]byte("z"), 200)
+			data = append(data, tail...)
+			odata, s, ok := DecodeStr(data)
+			require.True(t, ok, "strLen=%d", strLen)
+			require.Equal(t, payload, s, "strLen=%d", strLen)
+			require.Equal(t, tail, odata, "strLen=%d", strLen)
+		}
+	})
+}
+
+func TestDecodeBlobFileIDs(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		_, ok := DecodeBlobFileIDs(nil)
+		require.False(t, ok)
+		_, ok = DecodeBlobFileIDs([]byte{})
+		require.False(t, ok)
+	})
+
+	t.Run("count-too-large", func(t *testing.T) {
+		// Varint encoding of a huge count; this would previously panic in
+		// make() with "cap out of range".
+		var buf [binary.MaxVarintLen64]byte
+		n := binary.PutUvarint(buf[:], ^uint64(0))
+		_, ok := DecodeBlobFileIDs(buf[:n])
+		require.False(t, ok)
+	})
+
+	t.Run("count-exceeds-remaining", func(t *testing.T) {
+		// Count says 5 but only 2 trailing bytes are present.
+		data := []byte{0x05, 0x01, 0x02}
+		_, ok := DecodeBlobFileIDs(data)
+		require.False(t, ok)
+	})
+
+	t.Run("truncated-body", func(t *testing.T) {
+		// Count=3, but only one valid varint follows.
+		data := []byte{0x03, 0x01}
+		_, ok := DecodeBlobFileIDs(data)
+		require.False(t, ok)
+	})
+
+	t.Run("round-trip", func(t *testing.T) {
+		ids := []base.BlobFileID{1, 7, 128, 65535}
+		var buf []byte
+		var tmp [binary.MaxVarintLen64]byte
+		n := binary.PutUvarint(tmp[:], uint64(len(ids)))
+		buf = append(buf, tmp[:n]...)
+		for _, id := range ids {
+			n := binary.PutUvarint(tmp[:], uint64(id))
+			buf = append(buf, tmp[:n]...)
+		}
+		got, ok := DecodeBlobFileIDs(buf)
+		require.True(t, ok)
+		require.Equal(t, ids, got)
+	})
+}
+
+func TestReaderNextTruncated(t *testing.T) {
+	// Each of these is a corrupt or truncated batch payload (header stripped).
+	// Reader.Next must return ok=false with a non-nil error and not panic.
+	kindSet := byte(base.InternalKeyKindSet)
+	cases := [][]byte{
+		{kindSet},                       // kind only, no key
+		{kindSet, 0xff},                 // partial varint
+		{kindSet, 0x05, 'a', 'b'},       // key length says 5, only 2 bytes
+		{kindSet, 0x01, 'k'},            // key ok, missing value
+		{kindSet, 0x01, 'k', 0x05, 'v'}, // key ok, value length says 5, only 1 byte
+	}
+	for i, data := range cases {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			r := Reader(append([]byte(nil), data...))
+			_, _, _, ok, err := r.Next()
+			require.False(t, ok)
+			require.Error(t, err)
+		})
+	}
 }


### PR DESCRIPTION
`DecodeStr` previously dereferenced `&data[0]` via `unsafe.Pointer`
without first checking `len(data) > 0`, and could read past the end of
`data` for partial multi-byte varints. A truncated batch repr therefore
panicked with an out-of-bounds index instead of returning `ok=false`,
which crashed the process during WAL replay.

`DecodeBlobFileIDs` read an untrusted `uint64` count from the value and
fed it directly into `make([]base.BlobFileID, 0, blobCount)`, panicking
with `makeslice: cap out of range` (or OOMing) on corrupt input.

This change:

- Adds a safe fast path to `DecodeStr` for `len(data) <= 128`. In that
  regime any valid varint must be a single byte, since a multi-byte
  varint encodes `v >= 128` and would require at least 130 bytes total.
  The remaining unsafe path is now provably safe because
  `len(data) > 128 >= binary.MaxVarintLen32`.
- Bounds `blobCount` by the number of remaining bytes in
  `DecodeBlobFileIDs` before `make`, and guards the loop against running
  past the end of `value`.
- Adds unit tests for truncated and corrupt inputs to both decoders, as
  well as `Reader.Next`.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>