### PR TITLE
*: various comment fixes

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -334,7 +334,7 @@ type batchInternal struct {
 	// requested. The cache is invalidated whenever a new range key
 	// (RangeKey{Set,Unset,Del}) is added to the batch. This cache can only be
 	// used when opening an iterator to read at a batch sequence number >=
-	// tombstonesSeqNum. This is the case for all new iterators created over a
+	// rangeKeysSeqNum. This is the case for all new iterators created over a
 	// batch but it's not the case for all cloned iterators.
 	rangeKeys       []keyspan.Span
 	rangeKeysSeqNum base.SeqNum

--- a/db.go
+++ b/db.go
@@ -2840,7 +2840,7 @@ func firstError(err0, err1 error) error {
 // Remote object usage is disabled until this method is called the first time.
 // Once set, the Creator ID is persisted and cannot change.
 //
-// Does nothing if SharedStorage was not set in the options when the DB was
+// Does nothing if RemoteStorage was not set in the options when the DB was
 // opened or if the DB is in read-only mode.
 func (d *DB) SetCreatorID(creatorID uint64) error {
 	if d.opts.RemoteStorage == nil || d.opts.ReadOnly {

--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -179,7 +179,6 @@ func (s *Skiplist) Add(key base.InternalKey, value []byte) error {
 
 func (s *Skiplist) addInternal(key base.InternalKey, value []byte, ins *Inserter) error {
 	if s.findSplice(key, ins) {
-		// Found a matching node, but handle case where it's been deleted.
 		return ErrRecordExists
 	}
 

--- a/internal/compact/snapshots.go
+++ b/internal/compact/snapshots.go
@@ -45,7 +45,7 @@ import (
 //	a.PUT.5
 type Snapshots []base.SeqNum
 
-// Index returns the index of the first snapshot sequence number which is >= seq
+// Index returns the index of the first snapshot sequence number which is > seq
 // or len(s) if there is no such sequence number.
 func (s Snapshots) Index(seq base.SeqNum) int {
 	return sort.Search(len(s), func(i int) bool {
@@ -54,8 +54,8 @@ func (s Snapshots) Index(seq base.SeqNum) int {
 }
 
 // IndexAndSeqNum returns the index of the first snapshot sequence number which
-// is >= seq and that sequence number, or len(s) and InternalKeySeqNumMax if
-// there is no such sequence number.
+// is > seq and that sequence number, or len(s) and SeqNumMax if there is no
+// such sequence number.
 func (s Snapshots) IndexAndSeqNum(seq base.SeqNum) (int, base.SeqNum) {
 	index := s.Index(seq)
 	if index == len(s) {

--- a/internal/iterv2/interleaving_iter.go
+++ b/internal/iterv2/interleaving_iter.go
@@ -56,7 +56,7 @@ type InterleavingIter struct {
 	// dir is +1 for forward, -1 for backward (and 0 for unpositioned).
 	dir int8
 	// inSpan indicates whether the current position is inside span. When inSpan is true,
-	// the presentedSpan Boundary matches span.End (forward iteration) or span.End
+	// the presentedSpan Boundary matches span.End (forward iteration) or span.Start
 	// (backward iteration).
 	inSpan bool
 	// atBoundary indicates if the last returned key was a boundary key.

--- a/internal/iterv2/trigger_iter.go
+++ b/internal/iterv2/trigger_iter.go
@@ -32,9 +32,9 @@ type BoundaryTrigger interface {
 // top-level child of the merging iterator to detect when point iteration
 // reaches a region that may contain range key sets.
 //
-// When bounds are set, the TriggerIter will check the entire region and elide
-// any work during iterator operations if there are no possible range key sets
-// within the bounds.
+// On Init, the TriggerIter checks the [lower, upper) region (using regiontree
+// sentinels when a bound is nil) and elides any work during iterator operations
+// if there are no possible range key sets within those bounds.
 type TriggerIter struct {
 	cmp     base.Compare
 	tree    *regiontree.T[[]byte, int]
@@ -54,8 +54,8 @@ type TriggerIter struct {
 
 var _ Iter = (*TriggerIter)(nil)
 
-// checkNoRegions sets noRegions to true if both bounds are set and there are no
-// regions with non-zero count within [lower, upper).
+// checkNoRegions sets noRegions to true if there are no regions with non-zero
+// count within [lower, upper). Either bound may be nil.
 func (t *TriggerIter) checkNoRegions() {
 	if t.trigger == nil {
 		t.noRegions = true

--- a/internal/keyspan/defragment.go
+++ b/internal/keyspan/defragment.go
@@ -502,8 +502,8 @@ func (i *DefragmentingIter) defragmentForward() (*Span, error) {
 func (i *DefragmentingIter) defragmentBackward() (*Span, error) {
 	if i.iterSpan.Empty() {
 		// An empty span will never be equal to another span; see checkEqual for
-		// why. To avoid loading non-empty range keys further ahead by calling Next,
-		// return early.
+		// why. To avoid loading non-empty range keys further behind by calling
+		// Prev, return early.
 		i.iterPos = iterPosCurr
 		return i.iterSpan, nil
 	}

--- a/internal/keyspan/get.go
+++ b/internal/keyspan/get.go
@@ -7,8 +7,8 @@ package keyspan
 import "github.com/cockroachdb/pebble/internal/base"
 
 // Get returns the newest span that contains the target key. If no span contains
-// the target key, an empty span is returned. The iterator must contain
-// fragmented spans: no span may overlap another.
+// the target key, nil is returned. The iterator must contain fragmented spans:
+// no span may overlap another.
 //
 // If an error occurs while seeking iter, a nil span and non-nil error is
 // returned.

--- a/internal/keyspan/iter.go
+++ b/internal/keyspan/iter.go
@@ -49,7 +49,7 @@ type FragmentIterator interface {
 	// It is valid to call Next when the iterator is positioned before the first
 	// key/value pair due to either a prior call to SeekLT or Prev which
 	// returned an invalid span. It is not allowed to call Next when the
-	// previous call to SeekGE, SeekPrefixGE or Next returned an invalid span.
+	// previous call to SeekGE or Next returned an invalid span.
 	Next() (*Span, error)
 
 	// Prev moves the iterator to the previous span.

--- a/internal/keyspan/keyspanimpl/level_iter.go
+++ b/internal/keyspan/keyspanimpl/level_iter.go
@@ -472,7 +472,7 @@ func (l *LevelIter) setPosAtFile(f *manifest.TableMetadata) error {
 	return nil
 }
 
-// setPos sets l.file and l.pos (and closes the iteris for the new file).
+// setPosInternal sets l.file and l.pos.
 func (l *LevelIter) setPosInternal(f *manifest.TableMetadata, pos levelIterPos) {
 	l.file = f
 	l.fileIter = nil

--- a/internal/keyspan/keyspanimpl/merging_iter.go
+++ b/internal/keyspan/keyspanimpl/merging_iter.go
@@ -1126,7 +1126,7 @@ func (m *MergingIter) TreeStepsNode() treesteps.NodeInfo {
 }
 
 type mergingIterItem struct {
-	// boundKey points to the corresponding mergingIterLevel's `iterKey`.
+	// boundKey points to the corresponding mergingIterLevel's `heapKey`.
 	*boundKey
 	// index is the index of this level within the MergingIter's levels field.
 	index int

--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -773,13 +773,13 @@ func (l *VersionList) Empty() bool {
 }
 
 // Front returns the oldest version in the list. Note that this version is only
-// valid if Empty() returns true.
+// valid if Empty() returns false.
 func (l *VersionList) Front() *Version {
 	return l.root.next
 }
 
 // Back returns the newest version in the list. Note that this version is only
-// valid if Empty() returns true.
+// valid if Empty() returns false.
 func (l *VersionList) Back() *Version {
 	return l.root.prev
 }

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -1335,8 +1335,6 @@ func (b *BulkVersionEdit) Accumulate(ve *VersionEdit) error {
 // Apply updates the backing refcounts (Ref/Unref) as files are installed into
 // the levels.
 //
-// curr may be nil, which is equivalent to a pointer to a zero version.
-//
 // Not that L0SublevelFiles is not initialized in the returned version; it is
 // the caller's responsibility to set it using L0Organizer.PerformUpdate().
 func (b *BulkVersionEdit) Apply(curr *Version, readCompactionRate int64) (*Version, error) {

--- a/objstorage/objstorageprovider/remote_backing.go
+++ b/objstorage/objstorageprovider/remote_backing.go
@@ -29,8 +29,8 @@ const (
 	// tagLocator encodes the remote.Locator; if absent the locator is "". It is
 	// followed by the locator string length and the locator string.
 	tagLocator = 5
-	// tagLocator encodes a custom object name (if present). It is followed by the
-	// custom name string length and the string.
+	// tagCustomObjectName encodes a custom object name (if present). It is
+	// followed by the custom name string length and the string.
 	tagCustomObjectName = 6
 
 	// Any new tags that don't have the tagNotSafeToIgnoreMask bit set must be

--- a/objstorage/objstorageprovider/remoteobjcat/version_edit.go
+++ b/objstorage/objstorageprovider/remoteobjcat/version_edit.go
@@ -28,8 +28,9 @@ type VersionEdit struct {
 }
 
 const (
-	// tagNewObject is followed by the FileNum, creator ID, creator FileNum,
-	// cleanup method, optional new object tags, and ending with a 0 byte.
+	// tagNewObject is followed by the FileNum, object type, creator ID, creator
+	// FileNum, cleanup method, optional new object tags, and ending with a 0
+	// byte.
 	tagNewObject = 1
 	// tagDeletedObject is followed by the FileNum.
 	tagDeletedObject = 2

--- a/objstorage/objstorageprovider/vfs.go
+++ b/objstorage/objstorageprovider/vfs.go
@@ -26,7 +26,7 @@ type localSubsystem struct {
 
 type localLockedState struct {
 	hotTier struct {
-		// objChangeCounter is incremented whenever objects are created.
+		// objChangeCounter is incremented whenever objects are created or deleted.
 		// The purpose of this counter is to avoid syncing the local filesystem when
 		// only remote objects are changed.
 		objChangeCounter uint64
@@ -35,7 +35,7 @@ type localLockedState struct {
 		objChangeCounterLastSync uint64
 	}
 	coldTier struct {
-		// objChangeCounter is incremented whenever objects are created.
+		// objChangeCounter is incremented whenever objects are created or deleted.
 		// The purpose of this counter is to avoid syncing the local filesystem when
 		// only remote objects are changed.
 		objChangeCounter uint64

--- a/record/log_writer.go
+++ b/record/log_writer.go
@@ -414,7 +414,7 @@ type syncTimer interface {
 // LogWriter writes records to an underlying io.Writer. In order to support WAL
 // file reuse, a LogWriter's records are tagged with the WAL's file
 // number. When reading a log file a record from a previous incarnation of the
-// file will return the error ErrInvalidLogNum.
+// file will return the error ErrInvalidChunk.
 type LogWriter struct {
 	// w is the underlying writer.
 	w io.Writer

--- a/record/record.go
+++ b/record/record.go
@@ -295,8 +295,8 @@ func NewReader(r io.Reader, logNum base.DiskFileNum) *Reader {
 	}
 }
 
-// nextChunk sets r.buf[r.i:r.j] to hold the next chunk's payload, reading the
-// next block into the buffer if necessary.
+// nextChunk sets r.buf[r.begin:r.end] to hold the next chunk's payload,
+// reading the next block into the buffer if necessary.
 func (r *Reader) nextChunk(wantFirst bool) error {
 	for {
 		if r.end+legacyHeaderSize <= r.n {

--- a/replay/sampled_metric.go
+++ b/replay/sampled_metric.go
@@ -117,7 +117,7 @@ func (m *SampledMetric) values(buckets int) (bucketDur time.Duration, values []f
 	bucketDur = totalDur / time.Duration(buckets)
 
 	for i, b := 0, 0; i < len(m.samples); i++ {
-		// Fill any buckets that precede this value with the previous value.
+		// Fill any buckets that precede this value with the next recorded value.
 		bi := int(m.samples[i].since / bucketDur)
 		if bi == buckets {
 			bi = buckets - 1

--- a/sstable/colblk/bitmap.go
+++ b/sstable/colblk/bitmap.go
@@ -201,9 +201,9 @@ func (b Bitmap) SeekUnsetBitGE(i int) int {
 	return wordIdx<<6 + bits.TrailingZeros64(^word)
 }
 
-// SeekUnsetBitLE returns the previous bit less than or equal to i set in the
-// bitmap. The i parameter must be in [0, bitCount). Returns -1 if no previous
-// bit is unset.
+// SeekUnsetBitLE returns the index of the previous unset bit less than or
+// equal to i in the bitmap. The i parameter must be in [0, bitCount). Returns
+// -1 if no previous bit is unset.
 func (b Bitmap) SeekUnsetBitLE(i int) int {
 	invariants.CheckBounds(i, b.bitCount)
 	if b.data.ptr == nil {

--- a/sstable/colblk/key_value_block.go
+++ b/sstable/colblk/key_value_block.go
@@ -44,7 +44,6 @@ func (w *KeyValueBlockWriter) Rows() int {
 }
 
 // AddKV adds a new key and value of a block to the key value block.
-// Add returns the index of the row.
 func (w *KeyValueBlockWriter) AddKV(key []byte, value []byte) {
 	w.keys.Put(key)
 	w.values.Put(value)

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -1361,10 +1361,9 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekLT(
 	return i.maybeVerifyKey(i.skipBackward())
 }
 
-// First implements internalIterator.First, as documented in the pebble
-// package. Note that First only checks the upper bound. It is up to the caller
-// to ensure that key is greater than or equal to the lower bound (e.g. via a
-// call to SeekGE(lower)).
+// First implements internalIterator.First, as documented in the pebble package.
+// First must not be called when a lower bound is configured on the iterator;
+// callers should use SeekGE(lower) instead.
 func (i *singleLevelIterator[I, PI, D, PD]) First() (kv *base.InternalKV) {
 	if treesteps.Enabled && treesteps.IsRecording(i) {
 		op := treesteps.StartOpf(i, "First()")
@@ -1493,10 +1492,9 @@ func (i *singleLevelIterator[I, PI, D, PD]) firstInternal(
 	return i.skipForward(shouldReturnMeta)
 }
 
-// Last implements internalIterator.Last, as documented in the pebble
-// package. Note that Last only checks the lower bound. It is up to the caller
-// to ensure that key is less than the upper bound (e.g. via a call to
-// SeekLT(upper))
+// Last implements internalIterator.Last, as documented in the pebble package.
+// Last must not be called when an upper bound is configured on the iterator;
+// callers should use SeekLT(upper) instead.
 func (i *singleLevelIterator[I, PI, D, PD]) Last() (kv *base.InternalKV) {
 	if treesteps.Enabled && treesteps.IsRecording(i) {
 		op := treesteps.StartOpf(i, "Last()")

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -873,10 +873,9 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekLT(
 	return i.skipBackward()
 }
 
-// First implements internalIterator.First, as documented in the pebble
-// package. Note that First only checks the upper bound. It is up to the caller
-// to ensure that key is greater than or equal to the lower bound (e.g. via a
-// call to SeekGE(lower)).
+// First implements internalIterator.First, as documented in the pebble package.
+// First must not be called when a lower bound is configured on the iterator;
+// callers should use SeekGE(lower) instead.
 func (i *twoLevelIterator[I, PI, D, PD]) First() (kv *base.InternalKV) {
 	kv, _ = i.firstInternal(false /* shouldReturnMeta */)
 	return kv
@@ -960,10 +959,9 @@ func (i *twoLevelIterator[I, PI, D, PD]) NextWithMeta() (*base.InternalKV, base.
 	return i.nextInternal(true /* shouldReturnMeta */)
 }
 
-// Last implements internalIterator.Last, as documented in the pebble
-// package. Note that Last only checks the lower bound. It is up to the caller
-// to ensure that key is less than the upper bound (e.g. via a call to
-// SeekLT(upper))
+// Last implements internalIterator.Last, as documented in the pebble package.
+// Last must not be called when an upper bound is configured on the iterator;
+// callers should use SeekLT(upper) instead.
 func (i *twoLevelIterator[I, PI, D, PD]) Last() (kv *base.InternalKV) {
 	if treesteps.Enabled && treesteps.IsRecording(i) {
 		op := treesteps.StartOpf(i, "Last()")

--- a/sstable/rowblk/rowblk_iter.go
+++ b/sstable/rowblk/rowblk_iter.go
@@ -630,7 +630,7 @@ func (i *Iter) SeekGE(key []byte, flags base.SeekGEFlags) *base.InternalKV {
 	}
 
 	i.clearCache()
-	// Find the index of the smallest restart point whose key is > the key
+	// Find the index of the smallest restart point whose key is >= the key
 	// sought; index will be numRestarts if there is no such restart point.
 	i.offset = 0
 	var index int32

--- a/sstable/suffix_rewriter.go
+++ b/sstable/suffix_rewriter.go
@@ -38,7 +38,7 @@ import (
 // re-computation of properties (is there any loss of fidelity?).
 //
 // Any block property collectors configured in the WriterOptions must implement
-// AddCollectedWithSuffixChange.
+// AddCollectedWithSuffixReplacement.
 //
 // The WriterOptions.TableFormat is ignored, and the output sstable has the same
 // TableFormat as the input, which is returned in case the caller wants to do

--- a/sstable/tablefilters/binaryfuse/binary_fuse.go
+++ b/sstable/tablefilters/binaryfuse/binary_fuse.go
@@ -22,8 +22,8 @@ const Family base.TableFilterFamily = "binaryfuse"
 var SupportedBitsPerFingerprint = bitpacking.SupportedBitsPerValue
 
 // FilterPolicy returns a base.TableFilterPolicy that creates binary fuse
-// filters with the given number of bits per fingerprint. Only 4, 8, 12, and 16
-// bits per fingerprint are supported.
+// filters with the given number of bits per fingerprint. Only 4, 8, 10, 12,
+// and 16 bits per fingerprint are supported.
 //
 // A binary fuse filter has false positive rate 1/2^bitsPerFingerprint and
 // overhead ~13% (i.e. contains ~1.13 fingerprints per key):

--- a/sstable/tablefilters/bloom/adaptive_policy.go
+++ b/sstable/tablefilters/bloom/adaptive_policy.go
@@ -104,7 +104,7 @@ func MaxBitsPerKey(numKeys uint, maxFilterSize uint64) uint32 {
 		return 0
 	}
 	// The filter always uses an odd number of cache lines (nLines |= 1 in
-	// filterNumLines). If maxLines is even, we can only use maxLines-1 lines.
+	// calculateNumLines). If maxLines is even, we can only use maxLines-1 lines.
 	if maxLines&1 == 0 {
 		maxLines--
 	}

--- a/sstable/tieredmeta/histogram.go
+++ b/sstable/tieredmeta/histogram.go
@@ -79,7 +79,7 @@ func (s *StatsHistogram) BytesAboveThreshold(threshold base.TieringAttribute) ui
 
 // encode serializes the histogram to bytes. The encoding format is:
 //
-//	<total bytes> <total count> <zero count> <digest size> <digest data>
+//	<total bytes> <total count> <zero bytes> <digest size> <digest data>
 func (s *StatsHistogram) encode() []byte {
 	// Calculate the size needed for the t-digest.
 	digestSize := s.digest.SerializedSize()

--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -1162,7 +1162,8 @@ func (a *aggregator) aggregate() []windowSummary {
 
 		}
 		// Add "long-running" events. Those that start in this window
-		// that have duration longer than the window interval.
+		// that have duration longer than a.longRunningLimit (configurable via
+		// --long-running-limit).
 		if e.timeEnd.Sub(e.timeStart) > a.longRunningLimit {
 			curWindow.longRunning = append(curWindow.longRunning, e)
 		}

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -150,8 +150,9 @@ func WithDBExciseSpanFn(fn DBExciseSpanFn) Option {
 // gs://foo/bar).
 type DBRemoteStorageFn func(uri string) (remote.Storage, error)
 
-// WithDBRemoteStorageFn specifies a function that returns the excise span for the
-// `db excise` command.
+// WithDBRemoteStorageFn specifies a function that resolves a cloud-storage URI
+// (e.g. gs://foo/bar) to a remote.Storage, used by commands that support such
+// URIs.
 func WithDBRemoteStorageFn(fn DBRemoteStorageFn) Option {
 	return func(t *T) {
 		t.remoteStorageFn = fn


### PR DESCRIPTION
This commit fixes various incorrect comments found by the
`doc-catcher` skill (only the subset that are straightforward).