### PR TITLE
ingest: add per-level byte and file count fields to IngestOperationStats

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1361,11 +1361,22 @@ type IngestOperationStats struct {
 	// into L0. This value is approximate when flushable ingests are active and
 	// an ingest overlaps an entry in the flushable queue. Currently, this
 	// approximation is very rough, only including tables that overlapped the
-	// memtable. This estimate may be improved with #2112.
+	// memtable. This estimate may be improved with #2112. This value is equal
+	// to LevelBytes[0].
 	ApproxIngestedIntoL0Bytes uint64
 	// MemtableOverlappingFiles is the count of ingested sstables
 	// that overlapped keys in the memtables.
 	MemtableOverlappingFiles int
+	// LevelBytes is the number of bytes ingested into each level of the LSM.
+	// Like ApproxIngestedIntoL0Bytes, the L0 entry is approximate when
+	// flushable ingests are active and an ingest overlaps an entry in the
+	// flushable queue; it currently only includes tables that overlapped the
+	// memtable.
+	LevelBytes [manifest.NumLevels]uint64
+	// LevelFiles is the number of files ingested into each level of the LSM.
+	// Like MemtableOverlappingFiles, the L0 entry is approximate under
+	// flushable ingests, only counting tables that overlapped the memtable.
+	LevelFiles [manifest.NumLevels]int
 }
 
 // ExternalFile are external sstables that can be referenced through
@@ -2100,6 +2111,8 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 				info.Tables[i].Level = e.Level
 				info.Tables[i].TableInfo = e.Meta.TableInfo()
 				stats.Bytes += e.Meta.Size
+				stats.LevelBytes[e.Level] += e.Meta.Size
+				stats.LevelFiles[e.Level]++
 				if e.Level == 0 {
 					stats.ApproxIngestedIntoL0Bytes += e.Meta.Size
 				}


### PR DESCRIPTION
Add LevelBytes and LevelFiles array fields to IngestOperationStats to provide per-level granularity on where ingested files land in the LSM. These are populated from ve.NewTables entries alongside the existing aggregate Bytes counter, using each entry's Level and Meta.Size.

Existing fields (Bytes, ApproxIngestedIntoL0Bytes, MemtableOverlappingFiles) are unchanged for backwards compatibility.