### PR TITLE
pebble: introduce iterV2Alloc pool

### DIFF
--- a/db.go
+++ b/db.go
@@ -8,6 +8,7 @@ package pebble // import "github.com/cockroachdb/pebble"
 import (
 	"context"
 	"io"
+	"math/rand/v2"
 	"reflect"
 	"slices"
 	"sync"
@@ -956,27 +957,31 @@ func (d *DB) commitWrite(b *Batch, syncWG *sync.WaitGroup, syncErr *error) (*mem
 	return mem, err
 }
 
-type iterAlloc struct {
+// iterAllocCommon contains the iterator-allocation state shared between the
+// V1 (iterAlloc) and V2 (iterV2Alloc) pool entries.
+type iterAllocCommon struct {
 	keyBuf              []byte    `invariants:"reused"`
 	boundsBuf           [2][]byte `invariants:"reused"`
 	prefixOrFullSeekKey []byte    `invariants:"reused"`
 	batchState          iteratorBatchState
 	dbi                 Iterator
-	merging             mergingIter
-	mlevels             [3 + numLevels]mergingIterLevel
-	levels              [3 + numLevels]levelIter
-	levelsPositioned    [3 + numLevels]bool
 }
 
-// maybeAssertZeroed asserts that i is a "zeroed" value. See assertZeroed for
-// the definition of "zeroed". It's used to ensure we're properly zeroing out
-// memory before returning the iterAlloc to the shared pool.
-func (i *iterAlloc) maybeAssertZeroed() {
-	if invariants.Enabled {
-		v := reflect.ValueOf(i).Elem()
-		if err := assertZeroed(v); err != nil {
-			panic(err)
-		}
+type iterAlloc struct {
+	iterAllocCommon
+	merging          mergingIter
+	mlevels          [3 + numLevels]mergingIterLevel
+	levels           [3 + numLevels]levelIter
+	levelsPositioned [3 + numLevels]bool
+}
+
+// assertZeroed asserts that i is a "zeroed" value. See assertZeroed for the
+// definition of "zeroed". It's used to ensure we're properly zeroing out memory
+// before returning the iterAlloc to the shared pool.
+func (i *iterAlloc) assertZeroed() {
+	v := reflect.ValueOf(i).Elem()
+	if err := assertZeroed(v); err != nil {
+		panic(err)
 	}
 }
 
@@ -1023,13 +1028,48 @@ func assertZeroed(v reflect.Value) error {
 
 func newIterAlloc() *iterAlloc {
 	buf := iterAllocPool.Get().(*iterAlloc)
-	buf.maybeAssertZeroed()
+	if invariants.Enabled {
+		buf.assertZeroed()
+	}
 	return buf
 }
 
 var iterAllocPool = sync.Pool{
 	New: func() interface{} {
 		return &iterAlloc{}
+	},
+}
+
+// iterV2Alloc is the pool entry for V2 iterator stacks. It mirrors iterAlloc
+// but holds the V2-specific buffers (mergingIterV2 plus pre-allocated arrays
+// for the level/heap-item/InterleavingIter/levelIterV2 children).
+type iterV2Alloc struct {
+	iterAllocCommon
+	merging mergingIterV2
+	// We need InterleavingIters for the memtable iterators.
+	interleavingIters [2]iterv2.InterleavingIter
+	// Preallocate enough level iterators for 4 L0 sublevels.
+	levelIters [3 + numLevels]levelIterV2
+}
+
+func (i *iterV2Alloc) assertZeroed() {
+	v := reflect.ValueOf(i).Elem()
+	if err := assertZeroed(v); err != nil {
+		panic(err)
+	}
+}
+
+func newIterV2Alloc() *iterV2Alloc {
+	buf := iterV2AllocPool.Get().(*iterV2Alloc)
+	if invariants.Enabled {
+		buf.assertZeroed()
+	}
+	return buf
+}
+
+var iterV2AllocPool = sync.Pool{
+	New: func() interface{} {
+		return &iterV2Alloc{}
 	},
 }
 
@@ -1117,10 +1157,18 @@ func (d *DB) newIter(
 
 	// Bundle various structures under a single umbrella in order to allocate
 	// them together.
-	buf := newIterAlloc()
+	var buf *iterAllocCommon
+	if iterv2.Enabled {
+		a := newIterV2Alloc()
+		a.dbi.allocV2 = a
+		buf = &a.iterAllocCommon
+	} else {
+		a := newIterAlloc()
+		a.dbi.alloc = a
+		buf = &a.iterAllocCommon
+	}
 	dbi := &buf.dbi
 	dbi.ctx = ctx
-	dbi.alloc = buf
 	dbi.merge = d.merge
 	dbi.comparer = d.opts.Comparer
 	dbi.readState = readState
@@ -1151,17 +1199,15 @@ func (d *DB) newIter(
 	if !dbi.batchOnlyIter && d.iterTracker != nil && !dbi.opts.ExemptFromTracking {
 		dbi.trackerHandle = d.iterTracker.Start()
 	}
-	return finishInitializingIter(ctx, buf)
+	dbi.finishInitializingIter(ctx)
+	return dbi
 }
 
-// finishInitializingIter is a helper for doing the non-trivial initialization
-// of an Iterator. It's invoked to perform the initial initialization of an
-// Iterator during NewIter or Clone, and to perform reinitialization due to a
-// change in IterOptions by a call to Iterator.SetOptions.
-func finishInitializingIter(ctx context.Context, buf *iterAlloc) *Iterator {
-	// Short-hand.
-	dbi := &buf.dbi
-
+// finishInitializingIter does the non-trivial initialization of an Iterator.
+// It's invoked to perform the initial initialization of an Iterator during
+// NewIter or Clone, and to perform reinitialization due to a change in
+// IterOptions by a call to Iterator.SetOptions.
+func (dbi *Iterator) finishInitializingIter(ctx context.Context) {
 	var memtables flushableList
 	if dbi.readState != nil {
 		memtables = dbi.readState.memtables
@@ -1185,7 +1231,12 @@ func finishInitializingIter(ctx context.Context, buf *iterAlloc) *Iterator {
 		// Iterator has already initialized dbi.merging, constructPointIter is a
 		// noop and an initialized pointIter already exists in dbi.pointIter.
 		if dbi.pointIter == nil {
-			dbi.constructPointIter(ctx, memtables, buf)
+			internalOpts := dbi.makeInternalIterOpts(memtables)
+			if dbi.allocV2 != nil {
+				dbi.constructPointIterV2(ctx, memtables, internalOpts)
+			} else {
+				dbi.constructPointIter(ctx, memtables, internalOpts)
+			}
 		}
 		dbi.iter = dbi.pointIter
 	} else {
@@ -1280,12 +1331,12 @@ func finishInitializingIter(ctx context.Context, buf *iterAlloc) *Iterator {
 			dbi.triggerIter.Reset(nil)
 		}
 	}
-	return dbi
 }
 
-func (i *Iterator) constructPointIter(
-	ctx context.Context, memtables flushableList, buf *iterAlloc,
-) {
+// makeInternalIterOpts builds the internalIterOpts for the point iterator
+// stack and initializes the iterator's blob value fetcher when a blob mapping
+// exists. Shared by V1 and V2 construction paths.
+func (i *Iterator) makeInternalIterOpts(memtables flushableList) internalIterOpts {
 	readEnv := block.ReadEnv{
 		Stats: &i.stats.InternalStats,
 		// If the file cache has a sstable stats collector, ask it for an
@@ -1324,12 +1375,13 @@ func (i *Iterator) constructPointIter(
 	if i.opts.RangeKeyMasking.Filter != nil {
 		internalOpts.boundLimitedFilter = &i.rangeKeyMasking
 	}
+	return internalOpts
+}
 
-	if iterv2.Enabled {
-		i.constructPointIterV2(ctx, memtables, buf, internalOpts)
-		return
-	}
-
+func (i *Iterator) constructPointIter(
+	ctx context.Context, memtables flushableList, internalOpts internalIterOpts,
+) {
+	buf := i.alloc
 	// Merging levels and levels from iterAlloc.
 	mlevels := buf.mlevels[:0]
 	levels := buf.levels[:0]
@@ -1453,19 +1505,54 @@ func (i *Iterator) constructPointIter(
 // constructPointIterV2 builds the point iterator stack using mergingIterV2 and
 // levelIterV2/InterleavingIter children.
 func (i *Iterator) constructPointIterV2(
-	ctx context.Context, memtables flushableList, buf *iterAlloc, internalOpts internalIterOpts,
+	ctx context.Context, memtables flushableList, internalOpts internalIterOpts,
 ) {
-	var v2iters []iterv2.Iter
+	buf := i.allocV2
 
+	// Compute an upper bound on the number of merging-iterator children so we
+	// can size buffers ahead of time. Per-source counts (in order of
+	// appearance):
+	//   * TriggerIter             : 1 if !batchOnlyIter
+	//   * Batch                   : 1 if i.batch != nil
+	//   * Memtables               : len(memtables) when !batchOnlyIter
+	//                               (ingestedFlushable may contribute one extra
+	//                               iter for the range-del side; we pad below)
+	//   * L0 sublevels + L1+      : current.MaxReadAmp() levelIterV2s
+	numMergingLevels := 0
+	// We create the trigger level even if KeyTypes == IterKeyTypePointsOnly, to
+	// allow reusing the iterator stack in more cases (see iterator.SetOptions).
+	hasTriggerIter := !i.batchOnlyIter
+	if hasTriggerIter {
+		numMergingLevels++ // TriggerIter
+	}
+	if i.batch != nil {
+		numMergingLevels++
+	}
 	var current *manifest.Version
 	if !i.batchOnlyIter {
-		if i.version != nil {
-			current = i.version
-		} else {
+		// Memtables.
+		numMergingLevels += len(memtables)
+		for _, mem := range memtables {
+			if f, ok := mem.flushable.(*ingestedFlushable); ok {
+				if f.exciseSpan.Valid() {
+					// See ingestedFlushable.newItersV2().
+					numMergingLevels++
+				}
+			}
+		}
+		current = i.version
+		if current == nil {
 			current = i.readState.current
 		}
-		// Always include the TriggerIter as the first level. It's a no-op
-		// unless armed; finishInitializingIter and SetOptions arm it via
+		// Levels.
+		maxReadAmp := current.MaxReadAmp()
+		numMergingLevels += maxReadAmp
+	}
+	bld := makePointIterV2Builder(i.allocV2, numMergingLevels, i.comparer, i.opts.LowerBound, i.opts.UpperBound)
+
+	if hasTriggerIter {
+		// When the TriggerIter is used, it is always the first level. It does
+		// nothing unless armed; finishInitializingIter and SetOptions arm it via
 		// Reset() when lazy combined iteration is desired.
 		i.triggerIter.Init(
 			i.comparer.Compare,
@@ -1473,7 +1560,7 @@ func (i *Iterator) constructPointIterV2(
 			nil, /* trigger */
 			i.opts.LowerBound, i.opts.UpperBound,
 		)
-		v2iters = append(v2iters, &i.triggerIter)
+		bld.AddLevel(&i.triggerIter)
 	}
 
 	// 1. Batch iterator (if any).
@@ -1492,39 +1579,39 @@ func (i *Iterator) constructPointIterV2(
 			rangeDelIter,
 			nil, nil, // startKey, endKey: unbounded
 			i.opts.LowerBound, i.opts.UpperBound)
-		v2iters = append(v2iters, &i.batch.pointInterleavingIter)
+		bld.AddLevel(&i.batch.pointInterleavingIter)
 	}
 
 	if !i.batchOnlyIter {
 		// 2. Memtable iterators (newest to oldest).
-		for j := len(memtables) - 1; j >= 0; j-- {
-			mem := memtables[j]
+		for _, mem := range slices.Backward(memtables) {
 			if fi, ok := mem.flushable.(*ingestedFlushable); ok {
 				flushableLevelIter, flushableRangeDelIter := fi.newItersV2(&i.opts, internalOpts)
-				v2iters = append(v2iters, flushableLevelIter)
+				bld.AddLevel(flushableLevelIter)
 				if flushableRangeDelIter != nil {
-					v2iters = append(v2iters, flushableRangeDelIter)
+					bld.AddLevel(flushableRangeDelIter)
 				}
 				continue
 			}
 			pointIter := mem.newIter(&i.opts)
 			rangeDelIter := mem.newRangeDelIter(&i.opts)
-			iiter := new(iterv2.InterleavingIter)
+			iiter := bld.InterleavingIter()
 			iiter.Init(i.comparer, pointIter, rangeDelIter,
 				nil, nil, // startKey, endKey: unbounded
 				i.opts.LowerBound, i.opts.UpperBound)
-			v2iters = append(v2iters, iiter)
+			bld.AddLevel(iiter)
 		}
 
 		// 3. Level iterators: L0 sublevels followed by L1+.
-		i.opts.snapshotForHideObsoletePoints = buf.dbi.seqNum
+		i.opts.snapshotForHideObsoletePoints = i.seqNum
 
 		addLevelIterV2 := func(files manifest.LevelIterator, layer manifest.Layer) {
 			// Filter to point-key files only; range-key-only files are handled
 			// by the separate range key iterator.
 			files = files.Filter(manifest.KeyTypePoint)
-			li := newLevelIterV2(ctx, i.opts, i.comparer, i.newIters, files, layer, internalOpts)
-			v2iters = append(v2iters, li)
+			li := bld.LevelIter()
+			li.init(ctx, i.opts, i.comparer, i.newIters, files, layer, internalOpts)
+			bld.AddLevel(li)
 		}
 
 		// L0 sublevels, newest to oldest.
@@ -1539,27 +1626,99 @@ func (i *Iterator) constructPointIterV2(
 			addLevelIterV2(current.Levels[level].Iter(), manifest.Level(level))
 		}
 	}
-	for j := range v2iters {
-		v2iters[j] = iterv2.MaybeWrapInInvalidating(v2iters[j])
-	}
 
-	m := newMergingIterV2(i.comparer.Compare, i.comparer.Split, i.seqNum, v2iters...)
-	m.lower = i.opts.LowerBound
-	m.upper = i.opts.UpperBound
-	m.logger = i.opts.getLogger()
-	m.stats = &i.stats.InternalStats
+	var batchSnapshot base.SeqNum
+	batchLevelIdx := -1
 	if i.batch != nil {
-		m.slab.batchSnapshot = i.batch.batchSeqNum
-		// The batch follows the TriggerIter if one was inserted (i.e. when
-		// !batchOnlyIter); otherwise the batch is the first level.
-		if i.batchOnlyIter {
-			m.slab.batchLevelIdx = 0
-		} else {
-			m.slab.batchLevelIdx = 1
+		batchSnapshot = i.batch.batchSeqNum
+		// The batch follows the TriggerIter if one was inserted; otherwise the
+		// batch is the first level.
+		batchLevelIdx = 0
+		if hasTriggerIter {
+			batchLevelIdx = 1
 		}
 	}
-	i.pointIter = invalidating.MaybeWrapIfInvariants(m).(topLevelIterator)
+
+	m := &buf.merging
+	m.Init(
+		i.comparer, i.opts.getLogger(),
+		i.opts.LowerBound, i.opts.UpperBound,
+		&i.stats.InternalStats,
+		i.seqNum,
+		batchSnapshot, batchLevelIdx,
+		bld.Levels(),
+	)
 	i.mergingV2 = m
+	i.pointIter = m
+	if invariants.Enabled && invariants.Sometimes(10) {
+		i.pointIter = invalidating.NewIter(m)
+	}
+}
+
+type pointIterV2Builder struct {
+	levels            []mergingIterV2Level
+	interleavingIters []iterv2.InterleavingIter
+	levelIters        []levelIterV2
+
+	// cmp, lower, upper are used in invariants builds to randomly wrap each
+	// added level's iter with iterv2.NewOpCheckIter.
+	cmp   invariants.Value[*base.Comparer]
+	lower invariants.Value[[]byte]
+	upper invariants.Value[[]byte]
+}
+
+func makePointIterV2Builder(
+	buf *iterV2Alloc, numLevels int, cmp *base.Comparer, lower, upper []byte,
+) pointIterV2Builder {
+	bld := pointIterV2Builder{
+		levels:            slices.Grow(buf.merging.levels[:0], numLevels),
+		interleavingIters: buf.interleavingIters[:],
+		levelIters:        buf.levelIters[:],
+		cmp:               invariants.MakeValue(cmp),
+		lower:             invariants.MakeValue(lower),
+		upper:             invariants.MakeValue(upper),
+	}
+	return bld
+}
+
+func (bld *pointIterV2Builder) AddLevel(iter iterv2.Iter) {
+	if invariants.Enabled {
+		switch rand.IntN(10) {
+		case 0:
+			iter = iterv2.NewInvalidating(iter)
+		case 1:
+			iter = iterv2.NewOpCheckIter(iter, bld.cmp.Get(), bld.lower.Get(), bld.upper.Get())
+		}
+	}
+	index := len(bld.levels)
+	bld.levels = bld.levels[:index+1]
+	bld.levels[index].Init(index, iter)
+}
+
+func (bld *pointIterV2Builder) Levels() []mergingIterV2Level {
+	return bld.levels
+}
+
+// InterleavingIter produces a blank iterv2.InterleavingIter, using pre-allocated
+// space when possible.
+func (bld *pointIterV2Builder) InterleavingIter() *iterv2.InterleavingIter {
+	if len(bld.interleavingIters) > 0 {
+		iter := &bld.interleavingIters[0]
+		bld.interleavingIters = bld.interleavingIters[1:]
+		return iter
+	}
+	return &iterv2.InterleavingIter{}
+}
+
+// LevelIter produces a blank levelIterV2, using pre-allocated space when
+// possible.
+func (bld *pointIterV2Builder) LevelIter() *levelIterV2 {
+	if len(bld.levelIters) > 0 {
+		iter := &bld.levelIters[0]
+		bld.levelIters = bld.levelIters[1:]
+		return iter
+	}
+	return &levelIterV2{}
 }
 
 // NewBatch returns a new empty write-only batch. Any reads on the batch will

--- a/internal/invariants/off.go
+++ b/internal/invariants/off.go
@@ -43,6 +43,10 @@ func (d *CloseChecker) AssertNotClosed() {}
 // allow getting a valid pointer address of the field).
 type Value[V any] struct{}
 
+func MakeValue[V any](v V) Value[V] {
+	return Value[V]{}
+}
+
 // Get the current value, or the zero value if invariants are disabled.
 func (*Value[V]) Get() V {
 	var v V // zero value

--- a/internal/invariants/on.go
+++ b/internal/invariants/on.go
@@ -68,9 +68,18 @@ type Value[V any] struct {
 	v V
 }
 
+func MakeValue[V any](v V) Value[V] {
+	return Value[V]{v: v}
+}
+
 // Get the current value, or the zero-value if invariants are disabled.
 func (v *Value[V]) Get() V {
 	return v.v
+}
+
+// Set the value; no-op in non-invariant builds.
+func (v *Value[V]) Set(inner V) {
+	v.v = inner
 }
 
 // MaybeMangle mangles a byte slice sometimes in invariant builds.
@@ -106,11 +115,6 @@ func (bm *BufMangler) MaybeMangleLater(buf []byte) []byte {
 		return bm.lastReturnedBuf
 	}
 	return buf
-}
-
-// Set the value; no-op in non-invariant builds.
-func (v *Value[V]) Set(inner V) {
-	v.v = inner
 }
 
 // CheckBounds panics if the index is not in the range [0, n). No-op in

--- a/internal/keyspan/keyspanimpl/merging_iter.go
+++ b/internal/keyspan/keyspanimpl/merging_iter.go
@@ -690,7 +690,7 @@ func (m *MergingIter) Close() {
 	for i := range m.levels {
 		m.levels[i].iter.Close()
 	}
-	m.levels = nil
+	m.levels = m.levels[:0]
 	m.heap.items = m.heap.items[:0]
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -261,8 +261,12 @@ type Iterator struct {
 	boundsBufIdx int
 	// iterKV reflects the latest position of iter, except when SetBounds is
 	// called. In that case, it is explicitly set to nil.
-	iterKV              *base.InternalKV
-	alloc               *iterAlloc
+	iterKV *base.InternalKV
+	// alloc is set when this Iterator was allocated from the V1 iterAllocPool.
+	alloc *iterAlloc
+	// allocV2 is set when this Iterator was allocated from the V2
+	// iterV2AllocPool. Exactly one of alloc and allocV2 is non-nil.
+	allocV2             *iterV2Alloc
 	prefixOrFullSeekKey []byte
 	readSampling        readSampling
 	stats               IteratorStats
@@ -2464,6 +2468,14 @@ func (i *Iterator) Error() error {
 
 const maxKeyBufCacheSize = 4 << 10 // 4 KB
 
+// maybeReuseKeyBuf saves buf into *save when buf is below the maximum cache
+// size. Used when returning iterAlloc/iterV2Alloc state to a pool.
+func maybeReuseKeyBuf(save *[]byte, buf []byte) {
+	if cap(buf) < maxKeyBufCacheSize {
+		*save = buf
+	}
+}
+
 // Close closes the iterator and returns any accumulated error. Exhausting
 // all the key/value pairs in a table is not considered to be an error.
 // It is not valid to call any method, including Close, after the iterator
@@ -2544,8 +2556,15 @@ func (i *Iterator) Close() error {
 		i.rangeKey = nil
 	}
 
-	alloc := i.alloc
-	if alloc == nil {
+	allocV1 := i.alloc
+	allocV2 := i.allocV2
+	var alloc *iterAllocCommon
+	switch {
+	case allocV1 != nil:
+		alloc = &allocV1.iterAllocCommon
+	case allocV2 != nil:
+		alloc = &allocV2.iterAllocCommon
+	default:
 		// NB: When the Iterator is used as a part of a Get(), Close() is called by
 		// getIterAlloc.Close which handles recycling the appropriate structure and
 		// fields.
@@ -2554,21 +2573,11 @@ func (i *Iterator) Close() error {
 
 	// Reset the alloc struct, retaining any buffers within their maximum
 	// bounds, and return the iterAlloc struct to the pool.
-
-	// Avoid caching the key buf if it is overly large. The constant is fairly
-	// arbitrary.
-	if cap(i.keyBuf) < maxKeyBufCacheSize {
-		alloc.keyBuf = i.keyBuf
-	}
-	if cap(i.prefixOrFullSeekKey) < maxKeyBufCacheSize {
-		alloc.prefixOrFullSeekKey = i.prefixOrFullSeekKey
-	}
+	maybeReuseKeyBuf(&alloc.keyBuf, i.keyBuf)
+	maybeReuseKeyBuf(&alloc.prefixOrFullSeekKey, i.prefixOrFullSeekKey)
 	for j := range i.boundsBuf {
-		if cap(i.boundsBuf[j]) < maxKeyBufCacheSize {
-			alloc.boundsBuf[j] = i.boundsBuf[j]
-		}
+		maybeReuseKeyBuf(&alloc.boundsBuf[j], i.boundsBuf[j])
 	}
-	mergingIterHeapItems := alloc.merging.heap.items
 
 	// We zero each field piecemeal in part to avoid the use of a stack
 	// allocated autotmp iterAlloc variable, and in part to make it easier
@@ -2580,14 +2589,22 @@ func (i *Iterator) Close() error {
 		alloc.batchState = iteratorBatchState{}
 	}
 	alloc.dbi.clearForReuse()
-	alloc.merging = mergingIter{}
-	clear(mergingIterHeapItems[:cap(mergingIterHeapItems)])
-	alloc.merging.heap.items = mergingIterHeapItems
-	clear(alloc.mlevels[:])
-	clear(alloc.levels[:])
-	clear(alloc.levelsPositioned[:])
 
-	iterAllocPool.Put(alloc)
+	if allocV1 != nil {
+		mergingIterHeapItems := allocV1.merging.heap.items
+		allocV1.merging = mergingIter{}
+		clear(mergingIterHeapItems[:cap(mergingIterHeapItems)])
+		allocV1.merging.heap.items = mergingIterHeapItems
+		clear(allocV1.mlevels[:])
+		clear(allocV1.levels[:])
+		clear(allocV1.levelsPositioned[:])
+		iterAllocPool.Put(allocV1)
+	} else {
+		allocV2.merging.PrepareForReuse()
+		clear(allocV2.interleavingIters[:])
+		clear(allocV2.levelIters[:])
+		iterV2AllocPool.Put(allocV2)
+	}
 	return err
 }
 
@@ -2882,7 +2899,7 @@ func (i *Iterator) SetOptions(o *IterOptions) {
 		}
 		return
 	}
-	finishInitializingIter(i.ctx, i.alloc)
+	i.finishInitializingIter(i.ctx)
 }
 
 func (i *Iterator) invalidate() {
@@ -2992,12 +3009,22 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 	}
 	// Bundle various structures under a single umbrella in order to allocate
 	// them together.
-	buf := newIterAlloc()
+	var buf *iterAllocCommon
+	var allocV1 *iterAlloc
+	var allocV2 *iterV2Alloc
+	if iterv2.Enabled {
+		allocV2 = newIterV2Alloc()
+		buf = &allocV2.iterAllocCommon
+	} else {
+		allocV1 = newIterAlloc()
+		buf = &allocV1.iterAllocCommon
+	}
 	dbi := &buf.dbi
 	*dbi = Iterator{
 		ctx:                   ctx,
 		opts:                  *opts.IterOptions,
-		alloc:                 buf,
+		alloc:                 allocV1,
+		allocV2:               allocV2,
 		merge:                 i.merge,
 		comparer:              i.comparer,
 		readState:             readState,
@@ -3026,7 +3053,8 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 		}
 	}
 	dbi.processBounds(dbi.opts.LowerBound, dbi.opts.UpperBound)
-	return finishInitializingIter(ctx, buf), nil
+	dbi.finishInitializingIter(ctx)
+	return dbi, nil
 }
 
 // Merge adds all of the argument's statistics to the receiver. It may be used

--- a/merging_iter_v2.go
+++ b/merging_iter_v2.go
@@ -256,6 +256,16 @@ type mergingIterV2Level struct {
 	atBoundary bool
 }
 
+// Init initializes a level with its index and iter. The level's span pointer is
+// stashed from iter.Span() so we don't have to keep calling Span().
+func (level *mergingIterV2Level) Init(index int, iter iterv2.Iter) {
+	*level = mergingIterV2Level{
+		index: index,
+		iter:  iter,
+		span:  iter.Span(),
+	}
+}
+
 func (level *mergingIterV2Level) Name() string {
 	return string('A' + byte(level.index))
 }
@@ -264,28 +274,56 @@ func (level *mergingIterV2Level) Compare(cmp base.Compare, other *mergingIterV2L
 	return base.InternalCompare(cmp, level.iterKV.K, other.iterKV.K)
 }
 
-// newMergingIterV2 creates a new merging iterator V2 over the given level
-// iterators. The iterators must implement iterv2.Iter.
-func newMergingIterV2(
-	cmp base.Compare, split Split, snapshot base.SeqNum, iters ...iterv2.Iter,
-) *mergingIterV2 {
-	m := &mergingIterV2{}
-	m.levels = make([]mergingIterV2Level, len(iters))
-	for i, iter := range iters {
-		m.levels[i] = mergingIterV2Level{
-			index: i,
-			iter:  iter,
-			// We stash the pointer so we don't have to keep calling Span().
-			span: iter.Span(),
-		}
+// Init initializes a mergingIterV2 in place from caller-provided buffers. The
+// levels slice must be pre-populated with initialized mergingIterV2Levels
+// (typically via mergingIterV2Level.Init). batchLevelIdx is the index of the
+// indexed-batch level, or -1 if there is no batch (in which case batchSnapshot
+// must be 0).
+func (m *mergingIterV2) Init(
+	cmp *base.Comparer,
+	logger Logger,
+	lower, upper []byte,
+	stats *InternalIteratorStats,
+	snapshot, batchSnapshot base.SeqNum,
+	batchLevelIdx int,
+	levels []mergingIterV2Level,
+) {
+	// Reuse any existing items; see PrepareForReuse().
+	items := slices.Grow(m.heap.items[:0], len(levels))
+	*m = mergingIterV2{
+		logger: logger,
+		split:  cmp.Split,
+		levels: levels,
+		heap: mergingIterV2Heap{
+			cmp:   cmp.Compare,
+			items: items,
+		},
+		slab: slabState{
+			cmp:           cmp.Compare,
+			snapshot:      snapshot,
+			batchSnapshot: batchSnapshot,
+			batchLevelIdx: batchLevelIdx,
+			levels:        levels,
+		},
+		lower: lower,
+		upper: upper,
+		stats: stats,
 	}
-	m.split = split
-	m.heap.cmp = cmp
-	m.heap.items = make([]mergingIterV2HeapItem, 0, len(iters))
-	m.slab.cmp = cmp
-	m.slab.snapshot = snapshot
-	m.slab.batchLevelIdx = -1
-	m.slab.levels = m.levels
+}
+
+// newMergingIterV2 creates a new merging iterator V2 over the given level
+// iterators. The iterators must implement iterv2.Iter. This constructor is
+// used by tests; production code calls mergingIterV2.Init directly with
+// caller-provided buffers.
+func newMergingIterV2(
+	cmp *base.Comparer, snapshot base.SeqNum, iters ...iterv2.Iter,
+) *mergingIterV2 {
+	levels := make([]mergingIterV2Level, len(iters))
+	for i, iter := range iters {
+		levels[i].Init(i, iter)
+	}
+	m := &mergingIterV2{}
+	m.Init(cmp, nil, nil, nil, nil, snapshot, 0, -1, levels)
 	return m
 }
 
@@ -1220,14 +1258,23 @@ func (m *mergingIterV2) Error() error {
 // Close implements base.InternalIterator.
 func (m *mergingIterV2) Close() error {
 	m.heap.Reset()
+	clear(m.heap.items[:cap(m.heap.items)])
 	for i := range m.levels {
-		m.levels[i].iterKV = nil
 		if err := m.levels[i].iter.Close(); err != nil && m.err == nil {
 			m.err = err
 		}
 	}
-	m.levels = nil
+	clear(m.levels)
+	m.levels = m.levels[:0]
 	return m.err
+}
+
+func (m *mergingIterV2) PrepareForReuse() {
+	levels := m.levels
+	items := m.heap.items
+	*m = mergingIterV2{}
+	m.levels = levels[:0]
+	m.heap.items = items[:0]
 }
 
 // SetBounds implements base.InternalIterator.

--- a/merging_iter_v2_test.go
+++ b/merging_iter_v2_test.go
@@ -93,7 +93,7 @@ func newMergingIterV2FromLevels(
 			iters[i] = iterv2.NewOpCheckIter(iters[i], cmp, nil, nil)
 		}
 	}
-	return newMergingIterV2(cmp.Compare, cmp.Split, snapshot, iters...)
+	return newMergingIterV2(cmp, snapshot, iters...)
 }
 
 // parseMergingTestLevels parses a define block. Each level starts with an "L"

--- a/treesteps_test.go
+++ b/treesteps_test.go
@@ -119,7 +119,7 @@ func TestTreeSteps(t *testing.T) {
 						v.Levels[l].Iter(), manifest.Level(l), internalIterOpts{})
 					levelIters = append(levelIters, li)
 				}
-				miter := newMergingIterV2(d.cmp, d.split, base.SeqNumMax, levelIters...)
+				miter := newMergingIterV2(d.opts.Comparer, base.SeqNumMax, levelIters...)
 				defer miter.Close()
 				rec := treeStepsStartRecording(t, td, miter)
 				out := itertest.RunInternalIterCmd(t, td, miter, itertest.Verbose)


### PR DESCRIPTION
Iterators built on the V2 stack (`mergingIterV2`, `levelIterV2`,
`InterleavingIter`) previously allocated their per-iterator structures
on the heap on every `NewIter`/`Clone`, while the V1 stack was already
served by the `iterAlloc` `sync.Pool`. This commit gives the V2 stack
the same pooling treatment.

Changes:

- Split `iterAlloc` into `iterAllocCommon` (the fields shared with the
  V2 path: `keyBuf`, `boundsBuf`, `prefixOrFullSeekKey`, `batchState`,
  `dbi`) and a V1-specific tail (`merging`, `mlevels`, `levels`,
  `levelsPositioned`).
- Add `iterV2Alloc` (embedding `iterAllocCommon`) with its own backing
  arrays for `mergingIterV2Level`, `mergingIterV2HeapItem`,
  `iterv2.InterleavingIter`, and `levelIterV2`, plus an embedded
  `mergingIterV2`. Add `iterV2AllocPool` and `newIterV2Alloc()`.
- Add `Iterator.allocV2 *iterV2Alloc` alongside `alloc *iterAlloc`;
  exactly one is non-nil.
- Add `mergingIterV2.Init` and `mergingIterV2Level.Init` so the v2
  merging iterator can be constructed in place from caller-provided
  buffers (the slab `batchLevelIdx` is now part of the `Init`
  signature).
- Reduce `newMergingIterV2` to a test helper, taking `*base.Comparer`
  and delegating to `Init` after allocating fresh buffers.
- Convert `finishInitializingIter` from a free function taking
  `*iterAlloc` to a method on `*Iterator`, so it can dispatch to
  either `constructPointIter` or `constructPointIterV2` based on
  which allocation path was taken. Extract `makeInternalIterOpts` so
  it can be shared between the two construction paths.
- Update `Iterator.Close` to recycle either pool, share buffer-reuse
  via a small `maybeReuseKeyBuf` helper.
- Update `(d *DB).newIter` and `Iterator.CloneWithContext` to pick the
  right pool via `iterv2.Enabled` and call `finishInitializingIter` as
  a method.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>