### PR TITLE
event: annotate remote-backed files in ingest log line

### DIFF
--- a/event.go
+++ b/event.go
@@ -616,7 +616,8 @@ type TableIngestInfo struct {
 	JobID  int
 	Tables []struct {
 		TableInfo
-		Level int
+		Level    int
+		IsRemote bool
 	}
 	// GlobalSeqNum is the sequence number that was assigned to all entries in
 	// the ingested table.
@@ -666,8 +667,12 @@ func (i TableIngestInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 		if !i.flushable {
 			levelStr = fmt.Sprintf("L%d:", t.Level)
 		}
-		w.Printf(" %s%s (%s)", redact.Safe(levelStr), t.FileNum,
-			redact.Safe(humanize.Bytes.Uint64(t.Size)))
+		remoteStr := ""
+		if t.IsRemote {
+			remoteStr = "(remote)"
+		}
+		w.Printf(" %s%s%s (%s)", redact.Safe(levelStr), t.FileNum,
+			redact.Safe(remoteStr), redact.Safe(humanize.Bytes.Uint64(t.Size)))
 	}
 	w.Printf("; manifest update took %.1fs; block reads took %.1fs with %s block bytes read",
 		redact.Safe(i.ManifestUpdateDuration.Seconds()), redact.Safe(i.BlockReadDuration.Seconds()),

--- a/ingest.go
+++ b/ingest.go
@@ -2102,14 +2102,23 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 			info.GlobalSeqNum = loadResult.external[0].SeqNums.Low
 		}
 		if ve != nil {
+			remoteFiles := make(map[base.TableNum]bool, len(loadResult.shared)+len(loadResult.external))
+			for i := range loadResult.shared {
+				remoteFiles[loadResult.shared[i].TableNum] = true
+			}
+			for i := range loadResult.external {
+				remoteFiles[loadResult.external[i].TableNum] = true
+			}
 			info.Tables = make([]struct {
 				TableInfo
-				Level int
+				Level    int
+				IsRemote bool
 			}, len(ve.NewTables))
 			for i := range ve.NewTables {
 				e := &ve.NewTables[i]
 				info.Tables[i].Level = e.Level
 				info.Tables[i].TableInfo = e.Meta.TableInfo()
+				info.Tables[i].IsRemote = remoteFiles[e.Meta.TableNum]
 				stats.Bytes += e.Meta.Size
 				stats.LevelBytes[e.Level] += e.Meta.Size
 				stats.LevelFiles[e.Level]++
@@ -2124,7 +2133,8 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 			// NB: If asFlushable == true, there are no shared sstables.
 			info.Tables = make([]struct {
 				TableInfo
-				Level int
+				Level    int
+				IsRemote bool
 			}, len(loadResult.local))
 			for i, f := range loadResult.local {
 				info.Tables[i].Level = -1

--- a/replay/workload_capture_test.go
+++ b/replay/workload_capture_test.go
@@ -117,7 +117,8 @@ func TestWorkloadCollector(t *testing.T) {
 					fmt.Fprintf(&buf, "created %s\n", p)
 					ingestInfo.Tables = append(ingestInfo.Tables, struct {
 						pebble.TableInfo
-						Level int
+						Level    int
+						IsRemote bool
 					}{Level: 0, TableInfo: tableInfo})
 
 					// Simulate a version edit applied to the current manifest.

--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -244,7 +244,8 @@ var (
 	ingestedFilePattern   = regexp.MustCompile(
 		`L` +
 			/* Level       */ `(?P<level>\d):` +
-			/* File number */ `(?P<file>\d+)\s` +
+			/* File number */ `(?P<file>\d+)` +
+			/* Remote      */ `(?:\(remote\))?\s` +
 			/* Bytes       */ `\((?P<bytes>[0-9.]+( [BKMGTPE]|[KMGTPE]?B))\)`)
 	ingestedFilePatternLevelIdx = ingestedFilePattern.SubexpIndex("level")
 	ingestedFilePatternFileIdx  = ingestedFilePattern.SubexpIndex("file")


### PR DESCRIPTION
Add `IsRemote` to `TableIngestInfo` per-table entries and print `(remote)` after
the file number for files backed by remote storage (shared or external), e.g.:

```
[JOB 8] ingested L6:000008(remote) (13MB); ...
```

This makes it possible to distinguish restore ingestions from local ones in log
output without cross-referencing vmodule logs.

The log parser regex in `tool/logs/compaction.go` is updated to tolerate the new
marker.