### PR TITLE
ci: declare workflow-level `contents: read` on ci + nightlies workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ on:
       - crl-release-*
       - pebble-release-*
 
+permissions:
+  contents: read
+
 jobs:
 
   # This check is required to merge PRs.

--- a/.github/workflows/nightlies-25.2.yaml
+++ b/.github/workflows/nightlies-25.2.yaml
@@ -8,6 +8,9 @@ on:
 env:
   BRANCH: crl-release-25.2
 
+permissions:
+  contents: read
+
 jobs:
   resolve-sha:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightlies-25.4.yaml
+++ b/.github/workflows/nightlies-25.4.yaml
@@ -8,6 +8,9 @@ on:
 env:
   BRANCH: crl-release-25.4
 
+permissions:
+  contents: read
+
 jobs:
   resolve-sha:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightlies-26.1.yaml
+++ b/.github/workflows/nightlies-26.1.yaml
@@ -8,6 +8,9 @@ on:
 env:
   BRANCH: crl-release-26.1
 
+permissions:
+  contents: read
+
 jobs:
   resolve-sha:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightlies-26.2.yaml
+++ b/.github/workflows/nightlies-26.2.yaml
@@ -8,6 +8,9 @@ on:
 env:
   BRANCH: crl-release-26.2
 
+permissions:
+  contents: read
+
 jobs:
   resolve-sha:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '00 10 * * * ' # 10am UTC daily
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 6 workflows in `.github/workflows/` that don't actually need any write scope:

- `ci.yaml`: PR/push CI suite.
- `nightlies.yaml`: master nightlies entry point.
- `nightlies-25.2.yaml`, `nightlies-25.4.yaml`, `nightlies-26.1.yaml`, `nightlies-26.2.yaml`: per-release nightly stress runs.

None call a GitHub API beyond the initial checkout, so `contents: read` is sufficient.

Left implicit on purpose:

- `code-cover-gen.yaml` uses `gh pr view` (needs `pull-requests: read`).
- `nightly-code-cover.yaml` passes `github.token` to a gh-cli step.
- `code-cover-publish.yaml` writes coverage results.

Those three are best declared by a maintainer who knows whether to put the extra scope at workflow or job level.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.