### PR TITLE
ci: add nightly stressmeta-iterv2 job

### DIFF
--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -99,3 +99,31 @@ jobs:
           title: "master: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ github.sha }} (go${{ matrix.go }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
           labels: "C-test-failure"
+
+  linux-stressmeta-iterv2:
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [ '1.26' ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 270
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Run stressmeta-iterv2 for 4 hours
+        run: |
+          go install github.com/cockroachdb/stress@latest
+          make stressmeta-iterv2 STRESSFLAGS="-maxtime 4h"
+
+      - name: Post issue on failure
+        if: failure()
+        uses: ./.github/actions/post-issue
+        with:
+          title: "master: nightly ${{ github.job }} failed"
+          body: "The nightly ${{ github.job }} test run failed on ${{ github.sha }} (go${{ matrix.go }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          labels: "C-test-failure"


### PR DESCRIPTION
Adds a new `linux-stressmeta-iterv2` job to the master nightlies
workflow that runs `make stressmeta-iterv2` under `stress` for 4 hours
(via `STRESSFLAGS="-maxtime 4h"`). The job has a 270-minute timeout to
allow for setup and reporting overhead, and files an issue on failure
following the existing nightly pattern.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>