### PR TITLE
manifest: improve SeekGE with KeyTypePoint

### DIFF
--- a/internal/manifest/level_metadata.go
+++ b/internal/manifest/level_metadata.go
@@ -677,28 +677,29 @@ func (i *LevelIterator) SeekGE(cmp Compare, userKey []byte) *TableMetadata {
 		}
 		i.iter.descend(i.iter.n, i.iter.pos)
 	}
-
-	// If the iterator is filtered or has bounds, we fall into a slow path that
-	// filters based on the current table and constraints the iterator's position
-	// according to the configured bounds.
-	if i.filter != KeyTypePointAndRange || i.start != nil || i.end != nil {
-		m := i.constrainToIteratorBounds()
-		if i.filter != KeyTypePointAndRange && m != nil {
-			b, ok := m.LargestBound(i.filter)
-			if !ok || !b.IsUpperBoundFor(cmp, userKey) {
-				// The table does not contain any keys of desired key types
-				// that are >= userKey.
-				return i.Next()
-			}
-		}
-		return i.skipFilteredForward(m)
-	}
-	// If the iterator is not filtered and has no bounds, we fall into a fast
-	// path that returns the current table.
 	if !i.iter.valid() {
 		return nil
 	}
-	return i.iter.cur()
+	if i.start == nil && i.end == nil {
+		// Fast path.
+		if m := i.iter.cur(); i.filter == KeyTypePointAndRange || (i.filter == KeyTypePoint && !m.HasRangeKeys) {
+			return m
+		}
+	}
+
+	// If the iterator has bounds, we fall into a slow path that
+	// filters based on the current table and constraints the iterator's position
+	// according to the configured bounds.
+	m := i.constrainToIteratorBounds()
+	if i.filter != KeyTypePointAndRange && m != nil {
+		b, ok := m.LargestBound(i.filter)
+		if !ok || !b.IsUpperBoundFor(cmp, userKey) {
+			// The table does not contain any keys of desired key types
+			// that are >= userKey.
+			return i.Next()
+		}
+	}
+	return i.skipFilteredForward(m)
 }
 
 // SeekLT seeks to the last table with a smallest key (of the desired type) that


### PR DESCRIPTION
Optimize `LevelIterator.SeekGE` when we have a `KeyTypePoint` filter
and no bounds and the file we found has no range keys (which should be
the common case). This is the code path used by iterv2 and the extra
function calls in the slow path show up (modestly) in profiles.