### PR TITLE
treesteps: return *url.URL from Steps.URL

### DIFF
--- a/internal/treesteps/data.go
+++ b/internal/treesteps/data.go
@@ -87,7 +87,7 @@ func (t *TreeNode) print(parent treeprinter.Node) {
 
 // URL for a visualization of the steps. The URL contains the encoded and
 // compressed data as the URL fragment.
-func (s Steps) URL() url.URL {
+func (s Steps) URL() *url.URL {
 	// TODO(radu): ideally we would encode Steps and have a graphical
 	// visualization. For now, we generate and encode the ASCII trees.
 	var output struct {
@@ -122,7 +122,7 @@ func (s Steps) URL() url.URL {
 	if err := encoder.Close(); err != nil {
 		panic(err)
 	}
-	return url.URL{
+	return &url.URL{
 		Scheme:   "https",
 		Host:     "raduberinde.github.io",
 		Path:     "treesteps/decode.html",

--- a/internal/treesteps/tree_steps_test.go
+++ b/internal/treesteps/tree_steps_test.go
@@ -170,8 +170,7 @@ func TestSegmentTree(t *testing.T) {
 		if r != nil {
 			steps := r.Finish()
 			if td.HasArg("url") {
-				url := steps.URL()
-				return url.String()
+				return steps.URL().String()
 			}
 			return steps.String()
 		}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1472,8 +1472,7 @@ func TestSetOptionsBatchRefreshRand(t *testing.T) {
 		if mismatch {
 			t.Logf("seed: %d", seed)
 			if rec != nil {
-				u := recSteps.URL()
-				t.Logf("treesteps recording:\n%s", u.String())
+				t.Logf("treesteps recording:\n%s", recSteps.URL())
 			}
 			t.Fatalf("iter %d: op=%s seekKey=%q newSeekKey=%q\n got valid=%v keys=%q vals=%q\nwant valid=%v keys=%q vals=%q",
 				it, opName[op], seekKey, newSeekKey, gotValid, gotKeys, gotVals, wantValid, wantKeys, wantVals)

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -451,8 +451,7 @@ func (t *Test) runOp(idx int, h historyRecorder) {
 			rec := treesteps.StartRecording(node, op.formattedString(t.testOpts.KeyFormat))
 			defer func() {
 				steps := rec.Finish()
-				u := steps.URL()
-				fmt.Fprintf(os.Stderr, "#%d %s treesteps: %s\n", idx, op.formattedString(t.testOpts.KeyFormat), u.String())
+				fmt.Fprintf(os.Stderr, "#%d %s treesteps: %s\n", idx, op.formattedString(t.testOpts.KeyFormat), steps.URL())
 			}()
 		}
 	}

--- a/sstable/reader_iter_treesteps_test.go
+++ b/sstable/reader_iter_treesteps_test.go
@@ -76,6 +76,5 @@ func runIterTreeStepsCmd(t *testing.T, r *Reader, td *datadriven.TestData) strin
 	runIterCmd(td, iter, false)
 
 	steps := rec.Finish()
-	url := steps.URL()
-	return url.String()
+	return steps.URL().String()
 }


### PR DESCRIPTION
`Steps.URL` previously returned `url.URL` by value, forcing every
caller to use a temporary variable before calling `(*URL).String`.
Return a `*URL` to make this more ergonomic, matching the convention
used by `net/url` (e.g. `url.Parse`).

This also lets callers pass the result directly to `fmt`/`t.Logf`,
since `*url.URL` has a `String()` method.