### PR TITLE
db: fix TestBatchPreAlloc flake

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -217,8 +217,8 @@ func TestBatchPreAlloc(t *testing.T) {
 	for _, c := range cases {
 		b := newBatchWithSize(nil, c.size)
 		b.Set([]byte{0x1}, []byte{0x2}, nil)
-		if cap(b.data) != c.exp {
-			t.Errorf("Unexpected memory space, required: %d, got: %d", c.exp, cap(b.data))
+		if cap(b.data) < c.exp {
+			t.Errorf("Unexpected memory space, required: %d+, got: %d", c.exp, cap(b.data))
 		}
 	}
 }


### PR DESCRIPTION
I saw this test failing when I ran all package test with `--count 4`.
The test uses a pool, and it can get a reused buffer (from code that
ran in a different test) with larger capacity. Relax the check.