### PR TITLE
db: propagate minimumFormatMajorVersion in Batch.Apply

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -614,6 +614,7 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 	b.data = append(b.data, batch.data[batchrepr.HeaderLen:]...)
 
 	b.setCount(b.Count() + batch.Count())
+	b.minimumFormatMajorVersion = max(b.minimumFormatMajorVersion, batch.minimumFormatMajorVersion)
 
 	if b.db != nil || b.index != nil {
 		// Only iterate over the new entries if we need to track memTableSize or in

--- a/batch.go
+++ b/batch.go
@@ -49,6 +49,47 @@ var ErrInvalidBatch = batchrepr.ErrInvalidBatch
 // ErrBatchTooLarge indicates that the size of this batch is over the limit of 4GB.
 var ErrBatchTooLarge = base.MarkCorruptionError(errors.Newf("pebble: batch too large: >= %s", humanize.Bytes.Uint64(maxBatchSize)))
 
+// batchKindCategory groups InternalKeyKinds by how the batch record walkers
+// should handle them. The zero value (batchKindInvalid) marks kinds that are
+// not legal inside a batch record stream.
+type batchKindCategory uint8
+
+const (
+	batchKindInvalid        batchKindCategory = iota
+	batchKindPoint                            // SET / DEL / MERGE / SINGLEDEL / SETWITHDEL / DELSIZED
+	batchKindRangeDel                         // RANGEDEL
+	batchKindRangeKey                         // RANGEKEY{SET,UNSET,DEL}
+	batchKindLogData                          // LOGDATA — no counters, no memtable size, no index
+	batchKindIngestOrExcise                   // INGESTSST{,WithBlobs} / EXCISE — no memtable size; not legal in Batch.Apply
+)
+
+// batchKindInfo encodes per-kind facts the batch record walkers need.
+type batchKindInfo struct {
+	minFMV   FormatMajorVersion
+	category batchKindCategory
+}
+
+// batchKinds is indexed by InternalKeyKind. Entries left at the zero value
+// (category batchKindInvalid) are kinds that cannot appear in a batch
+// (e.g. Separator, SyntheticKey, SpanBoundary, or unused values in the
+// range [0, InternalKeyKindMax]).
+var batchKinds = [base.InternalKeyKindMax + 1]batchKindInfo{
+	InternalKeyKindSet:                {category: batchKindPoint},
+	InternalKeyKindDelete:             {category: batchKindPoint},
+	InternalKeyKindMerge:              {category: batchKindPoint},
+	InternalKeyKindSingleDelete:       {category: batchKindPoint},
+	InternalKeyKindSetWithDelete:      {category: batchKindPoint},
+	InternalKeyKindDeleteSized:        {category: batchKindPoint, minFMV: FormatDeleteSizedAndObsolete},
+	InternalKeyKindRangeDelete:        {category: batchKindRangeDel},
+	InternalKeyKindRangeKeySet:        {category: batchKindRangeKey},
+	InternalKeyKindRangeKeyUnset:      {category: batchKindRangeKey},
+	InternalKeyKindRangeKeyDelete:     {category: batchKindRangeKey},
+	InternalKeyKindLogData:            {category: batchKindLogData},
+	InternalKeyKindIngestSST:          {category: batchKindIngestOrExcise, minFMV: FormatFlushableIngest},
+	InternalKeyKindIngestSSTWithBlobs: {category: batchKindIngestOrExcise, minFMV: FormatIngestBlobFiles},
+	InternalKeyKindExcise:             {category: batchKindIngestOrExcise, minFMV: FormatFlushableIngestExcises},
+}
+
 // DeferredBatchOp represents a batch operation (eg. set, merge, delete) that is
 // being inserted into the batch. Indexing is not performed on the specified key
 // until Finish is called, hence the name deferred. This struct lets the caller
@@ -544,45 +585,28 @@ func (b *Batch) refreshMemTableSize() error {
 			}
 			break
 		}
-		switch kind {
-		case InternalKeyKindRangeDelete:
-			b.countRangeDels++
-		case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
-			b.countRangeKeys++
-		case InternalKeyKindSet, InternalKeyKindDelete, InternalKeyKindMerge, InternalKeyKindSingleDelete, InternalKeyKindSetWithDelete:
-			// fallthrough
-		case InternalKeyKindDeleteSized:
-			if b.minimumFormatMajorVersion < FormatDeleteSizedAndObsolete {
-				b.minimumFormatMajorVersion = FormatDeleteSizedAndObsolete
-			}
-		case InternalKeyKindLogData:
-			// LogData does not contribute to memtable size.
-			continue
-		case InternalKeyKindIngestSST:
-			if b.minimumFormatMajorVersion < FormatFlushableIngest {
-				b.minimumFormatMajorVersion = FormatFlushableIngest
-			}
-			// This key kind doesn't contribute to the memtable size.
-			continue
-		case InternalKeyKindIngestSSTWithBlobs:
-			if b.minimumFormatMajorVersion < FormatIngestBlobFiles {
-				b.minimumFormatMajorVersion = FormatIngestBlobFiles
-			}
-			// This key kind doesn't contribute to the memtable size.
-			continue
-		case InternalKeyKindExcise:
-			if b.minimumFormatMajorVersion < FormatFlushableIngestExcises {
-				b.minimumFormatMajorVersion = FormatFlushableIngestExcises
-			}
-			// This key kind doesn't contribute to the memtable size.
-			continue
-		default:
+		if kind > InternalKeyKindMax {
 			// Note In some circumstances this might be temporary memory
 			// corruption that can be recovered by discarding the batch and
 			// trying again. In other cases, the batch repr might've been
 			// already persisted elsewhere, and we'll loop continuously trying
 			// to commit the same corrupted batch. The caller is responsible for
 			// distinguishing.
+			return errors.Wrapf(ErrInvalidBatch, "unrecognized kind %v", kind)
+		}
+		info := batchKinds[kind]
+		b.minimumFormatMajorVersion = max(b.minimumFormatMajorVersion, info.minFMV)
+		switch info.category {
+		case batchKindPoint:
+			// Contributes to memtable size below.
+		case batchKindRangeDel:
+			b.countRangeDels++
+		case batchKindRangeKey:
+			b.countRangeKeys++
+		case batchKindLogData, batchKindIngestOrExcise:
+			// These kinds do not contribute to memtable size.
+			continue
+		default: // batchKindInvalid
 			return errors.Wrapf(ErrInvalidBatch, "unrecognized kind %v", kind)
 		}
 		b.memTableSize += memTableEntrySize(len(key), len(value))
@@ -628,20 +652,7 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 				}
 				break
 			}
-			switch kind {
-			case InternalKeyKindRangeDelete:
-				b.countRangeDels++
-			case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
-				b.countRangeKeys++
-			case InternalKeyKindIngestSST, InternalKeyKindIngestSSTWithBlobs, InternalKeyKindExcise:
-				panic(errors.AssertionFailedf("pebble: invalid key kind for batch"))
-			case InternalKeyKindLogData:
-				// LogData does not contribute to memtable size.
-				continue
-			case InternalKeyKindSet, InternalKeyKindDelete, InternalKeyKindMerge,
-				InternalKeyKindSingleDelete, InternalKeyKindSetWithDelete, InternalKeyKindDeleteSized:
-				// fallthrough
-			default:
+			if kind > InternalKeyKindMax {
 				// Note In some circumstances this might be temporary memory
 				// corruption that can be recovered by discarding the batch and
 				// trying again. In other cases, the batch repr might've been
@@ -650,17 +661,38 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 				// responsible for distinguishing.
 				return errors.Wrapf(ErrInvalidBatch, "unrecognized kind %v", kind)
 			}
+			info := batchKinds[kind]
+			if invariants.Enabled && batch.minimumFormatMajorVersion < info.minFMV {
+				panic(errors.AssertionFailedf(
+					"source batch FMV %d < required %d for kind %s",
+					batch.minimumFormatMajorVersion, info.minFMV, kind))
+			}
+			switch info.category {
+			case batchKindPoint:
+				// Contributes to index/memtable size below.
+			case batchKindRangeDel:
+				b.countRangeDels++
+			case batchKindRangeKey:
+				b.countRangeKeys++
+			case batchKindLogData:
+				// LogData does not contribute to memtable size.
+				continue
+			case batchKindIngestOrExcise:
+				panic(errors.AssertionFailedf("pebble: invalid key kind for batch.Apply: %s", kind))
+			default: // batchKindInvalid
+				return errors.Wrapf(ErrInvalidBatch, "unrecognized kind %v", kind)
+			}
 			if b.index != nil {
 				var err error
-				switch kind {
-				case InternalKeyKindRangeDelete:
+				switch info.category {
+				case batchKindRangeDel:
 					b.tombstones = nil
 					b.tombstonesSeqNum = 0
 					if b.rangeDelIndex == nil {
 						b.rangeDelIndex = batchskl.NewSkiplist(&b.data, b.comparer.Compare, b.comparer.AbbreviatedKey)
 					}
 					err = b.rangeDelIndex.Add(uint32(offset))
-				case InternalKeyKindRangeKeySet, InternalKeyKindRangeKeyUnset, InternalKeyKindRangeKeyDelete:
+				case batchKindRangeKey:
 					b.rangeKeys = nil
 					b.rangeKeysSeqNum = 0
 					if b.rangeKeyIndex == nil {
@@ -703,6 +735,7 @@ func (b *Batch) prepareDeferredKeyValueRecord(keyLen, valueLen int, kind Interna
 	}
 	b.count++
 	b.memTableSize += memTableEntrySize(keyLen, valueLen)
+	b.minimumFormatMajorVersion = max(b.minimumFormatMajorVersion, batchKinds[kind].minFMV)
 
 	pos := len(b.data)
 	b.deferredOp.offset = uint32(pos)
@@ -755,6 +788,7 @@ func (b *Batch) prepareDeferredKeyRecord(keyLen int, kind InternalKeyKind) {
 	}
 	b.count++
 	b.memTableSize += memTableEntrySize(keyLen, 0)
+	b.minimumFormatMajorVersion = max(b.minimumFormatMajorVersion, batchKinds[kind].minFMV)
 
 	pos := len(b.data)
 	b.deferredOp.offset = uint32(pos)
@@ -938,10 +972,6 @@ func (b *Batch) DeleteSized(key []byte, deletedValueSize uint32, _ *WriteOptions
 // complete key slice, letting the caller encode into the DeferredBatchOp.Key
 // slice and then call Finish() on the returned object.
 func (b *Batch) DeleteSizedDeferred(keyLen int, deletedValueSize uint32) *DeferredBatchOp {
-	if b.minimumFormatMajorVersion < FormatDeleteSizedAndObsolete {
-		b.minimumFormatMajorVersion = FormatDeleteSizedAndObsolete
-	}
-
 	// Encode the sum of the key length and the value in the value.
 	v := uint64(deletedValueSize) + uint64(keyLen)
 
@@ -1229,11 +1259,9 @@ func (b *Batch) ingestSST(tableNum base.TableNum, blobFileIDs []base.BlobFileID)
 		}
 		valueBuf = valueBuf[:countLen]
 		b.prepareDeferredKeyValueRecord(keyLen, len(valueBuf), InternalKeyKindIngestSSTWithBlobs)
-		b.minimumFormatMajorVersion = max(b.minimumFormatMajorVersion, FormatIngestBlobFiles)
 	} else {
 		// Use InternalKeyKindIngestSST when no blob files.
 		b.prepareDeferredKeyRecord(keyLen, InternalKeyKindIngestSST)
-		b.minimumFormatMajorVersion = max(b.minimumFormatMajorVersion, FormatFlushableIngest)
 	}
 
 	copy(b.deferredOp.Key, keyBuf[:keyLen])
@@ -1266,7 +1294,6 @@ func (b *Batch) excise(start, end []byte) {
 	// is not reset because for the InternalKeyKindIngestSST/Excise the count
 	// is the number of sstable paths which have been added to the batch.
 	b.memTableSize = origMemTableSize
-	b.minimumFormatMajorVersion = FormatFlushableIngestExcises
 }
 
 // Empty returns true if the batch is empty, and false otherwise.

--- a/batch_test.go
+++ b/batch_test.go
@@ -311,6 +311,37 @@ func TestBatchIngestSSTWithBlobs(t *testing.T) {
 	})
 }
 
+func TestBatchApplyPropagatesMinimumFormatMajorVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// A DeleteSized in the source batch should ratchet the destination batch's
+	// minimumFormatMajorVersion when merged via Batch.Apply. Without this, the
+	// FMV gate in (*DB).Apply can be bypassed by chaining batches.
+	t.Run("ratchets from source", func(t *testing.T) {
+		var b1 Batch
+		require.NoError(t, b1.DeleteSized([]byte("k"), 100, nil))
+		require.Equal(t, FormatDeleteSizedAndObsolete, b1.minimumFormatMajorVersion)
+
+		var b2 Batch
+		require.Equal(t, FormatMajorVersion(0), b2.minimumFormatMajorVersion)
+		require.NoError(t, b2.Apply(&b1, nil))
+		require.Equal(t, FormatDeleteSizedAndObsolete, b2.minimumFormatMajorVersion)
+	})
+
+	// Apply must take the max: if the destination already requires a higher
+	// FMV than the source, it must not be lowered.
+	t.Run("does not lower existing", func(t *testing.T) {
+		var b1 Batch
+		require.NoError(t, b1.Set([]byte("k"), []byte("v"), nil))
+		require.Equal(t, FormatMajorVersion(0), b1.minimumFormatMajorVersion)
+
+		var b2 Batch
+		b2.minimumFormatMajorVersion = FormatFlushableIngestExcises
+		require.NoError(t, b2.Apply(&b1, nil))
+		require.Equal(t, FormatFlushableIngestExcises, b2.minimumFormatMajorVersion)
+	})
+}
+
 func TestBatchLen(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var b Batch


### PR DESCRIPTION
#### db: propagate minimumFormatMajorVersion in Batch.Apply

Previously, `Batch.Apply` merged the source batch's records into the
receiver but did not propagate `minimumFormatMajorVersion`. The
per-record kind switch lumped `InternalKeyKindDeleteSized` (and any
future FMV-gated point op) into a fallthrough group with no FMV
bookkeeping, while `refreshMemTableSize` does ratchet the field. Since
`applyInternal` skips `refreshMemTableSize` when `batch.db \!= nil`,
chaining batches could bypass the FMV gate in `(*DB).Apply`:

```
b1 := db.NewBatch(); b1.DeleteSized(k, sz, nil)
b2 := db.NewBatch(); b2.Apply(b1, nil)
db.Apply(b2, nil) // proceeds even if FMV < FormatDeleteSizedAndObsolete
```

`Batch.Apply` now ratchets the receiver's `minimumFormatMajorVersion`
from the source. This avoids duplicating the kind switch in
`refreshMemTableSize` and works for any current or future FMV-gated
kind.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### db: centralize per-kind batch metadata in a lookup table

Cleanup, intended to be a functional no-op.

Previously, FMV requirements for FMV-gated record kinds were tracked
by manual ratchets at each typed setter and re-derived by a duplicate
kind switch in `refreshMemTableSize`; `Batch.Apply` had a third
per-kind switch. The duplication was the root cause of a recent FMV
bypass bug.

This commit introduces `batchKinds`, an array indexed by
`InternalKeyKind` whose entries encode the kind's category and minimum
required `FormatMajorVersion`. The `prepareDeferred*` helpers ratchet
the FMV from the table, removing the per-setter ratchets. The per-kind
switches in `refreshMemTableSize` and `Batch.Apply` collapse into an
out-of-range guard plus a small category switch. `Batch.Apply` also
gains an `invariants.Enabled` assertion that the source batch's
`minimumFormatMajorVersion` is at least the table value for each
record observed.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>