### PR TITLE
sstable: unify initBounds for single-level iterator

### DIFF
--- a/sstable/colblk/data_block.go
+++ b/sstable/colblk/data_block.go
@@ -368,7 +368,7 @@ func (ks *defaultKeySeeker) init(d *DataBlockDecoder, bd *BlockDecoder) {
 // IsLowerBound is part of the KeySeeker interface.
 func (ks *defaultKeySeeker) IsLowerBound(k []byte, syntheticSuffix []byte) bool {
 	si := ks.comparer.Split(k)
-	if v := ks.comparer.Compare(ks.prefixes.UnsafeFirstSlice(), k[:si]); v != 0 {
+	if v := bytes.Compare(ks.prefixes.UnsafeFirstSlice(), k[:si]); v != 0 {
 		return v > 0
 	}
 	suffix := syntheticSuffix

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -358,48 +358,27 @@ func (i *singleLevelIterator[I, PI, D, PD]) resetForReuse() {
 	i.synthetic.kv.K.Trailer = 0
 }
 
+// initBounds sets the iteration bounds for the current block (blockLower,blockUpper).
 func (i *singleLevelIterator[I, PI, D, PD]) initBounds() {
-	// Trim the iteration bounds for the current block. We don't have to check
-	// the bounds on each iteration if the block is entirely contained within the
-	// iteration bounds.
-	i.blockLower = i.lower
-	if i.blockLower != nil {
-		kv := PD(&i.data).First()
-		// TODO(radu): this should be <= 0
-		if kv != nil && i.cmp(i.blockLower, kv.K.UserKey) < 0 {
-			// The lower-bound is less than the first key in the block. No need
-			// to check the lower-bound again for this block.
-			i.blockLower = nil
-		}
+	// Trim the iteration bounds for the current block: we don't have to check
+	// a bounds on each key if the bound applies to the entire block.
+	i.blockLower = nil
+	if i.lower != nil && !PD(&i.data).IsLowerBound(i.lower) {
+		i.blockLower = i.lower
 	}
-	i.blockUpper = i.upper
-	// TODO(radu): this should be >= 0 if blockUpper is inclusive.
-	if i.blockUpper != nil && PI(&i.index).SeparatorLT(i.blockUpper) {
-		// The upper-bound is greater than the index key which itself is greater
-		// than or equal to every key in the block. No need to check the
-		// upper-bound again for this block. Even if blockUpper is inclusive
-		// because of upper being inclusive, we can still safely set blockUpper
-		// to nil here.
-		i.blockUpper = nil
-	}
-}
 
-func (i *singleLevelIterator[I, PI, D, PD]) initBoundsForAlreadyLoadedBlock() {
-	// TODO(radu): determine automatically if we need to call First or not and
-	// unify this function with initBounds().
-	i.blockLower = i.lower
-	if i.blockLower != nil && PD(&i.data).IsLowerBound(i.blockLower) {
-		// The lower-bound is less than the first key in the block. No need
-		// to check the lower-bound again for this block.
-		i.blockLower = nil
-	}
-	i.blockUpper = i.upper
-	// TODO(radu): this should be >= 0 if blockUpper is inclusive.
-	if i.blockUpper != nil && PI(&i.index).SeparatorLT(i.blockUpper) {
-		// The upper-bound is greater than the index key which itself is greater
-		// than or equal to every key in the block. No need to check the
-		// upper-bound again for this block.
-		i.blockUpper = nil
+	i.blockUpper = nil
+	// For all k in the block, sep >= k.
+	//
+	// We are required to use the upper bound when:
+	// Case 1 (i.upper is inclusive): the block contains some k > i.upper (k has to be omitted)
+	// Case 2 (i.upper is exclusive): the block contains some k >= i.upper (k has to be omitted)
+	//
+	// We can weaken these expressions by substituting sep for k.
+	if i.upper != nil && PI(&i.index).SeparatorGT(i.upper, !i.endKeyInclusive) {
+		// The bound does not apply to sep:
+		//   sep > i.upper || (sep == i.upper && !i.endKeyInclusive)
+		i.blockUpper = i.upper
 	}
 }
 
@@ -784,7 +763,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) seekGEHelper(
 		// use Next() on the block is only applied when we are already at the
 		// block that the slow-path (the else-clause) would load -- this is the
 		// motivation for the IsSeparatorUpperBound(key, true) predicate.
-		i.initBoundsForAlreadyLoadedBlock()
+		i.initBounds()
 		kv, done := i.trySeekGEUsingNextWithinBlock(key)
 		if done {
 			return kv, base.KVMeta{}
@@ -1239,7 +1218,8 @@ func (i *singleLevelIterator[I, PI, D, PD]) virtualLastSeekLE() *base.InternalKV
 
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package. Note that SeekLT only checks the lower bound. It is up to the
-// caller to ensure that key is less than or equal to the upper bound.
+// caller to ensure that key is less than the upper bound (virtual sstable
+// iterators additionally tolerate key == upper).
 func (i *singleLevelIterator[I, PI, D, PD]) SeekLT(
 	key []byte, flags base.SeekLTFlags,
 ) (kv *base.InternalKV) {
@@ -1298,7 +1278,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekLT(
 		// use Prev() on the block is only applied when we are already at the
 		// block that can satisfy this seek -- this is the motivation for the
 		// the i.cmp(i.data.firstKey.UserKey, key) < 0 predicate.
-		i.initBoundsForAlreadyLoadedBlock()
+		i.initBounds()
 		ikv, done := i.trySeekLTUsingPrevWithinBlock(key)
 		if done {
 			return ikv


### PR DESCRIPTION
First commit is #6069

#### sstable: unify initBounds for single-level iterator

Previously there were two variants of bounds initialization: `initBounds`,
which called `First()` on the data block to find the first key, and
`initBoundsForAlreadyLoadedBlock`, which used `IsLowerBound` on the
already-loaded block. The two were nearly identical apart from how the
block lower bound check was performed, and both contained TODOs noting
imprecise comparisons against the iteration bounds.

This change collapses them into a single `initBounds` that uses
`IsLowerBound` (which works regardless of iterator position) for the
lower bound, and `SeparatorGT` with `endKeyInclusive` for the upper
bound, correctly handling the inclusive case. The remaining call sites
of `initBoundsForAlreadyLoadedBlock` are switched to the unified
`initBounds`.

Also:
 - `defaultKeySeeker.IsLowerBound` now uses `bytes.Compare` for the
   prefix comparison; prefixes do not need the user comparer.
 - The `SeekLT` comment is updated to note that virtual sstable
   iterators tolerate `key == upper`.