### PR TITLE
ci: cap `GITHUB_TOKEN` to `contents: read` on the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ on:
       - crl-release-*
       - pebble-release-*
 
+permissions:
+  contents: read
+
 jobs:
 
   # This check is required to merge PRs.


### PR DESCRIPTION
The CI workflow runs the pebble test suite. No GitHub API writes from the workflow, so a workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.