### PR TITLE
db: fix TestIteratorErrors flake with iterv2

### DIFF
--- a/level_iter_v2.go
+++ b/level_iter_v2.go
@@ -332,10 +332,8 @@ func (l *levelIterV2) loadFile(file *manifest.TableMetadata) loadFileReturnIndic
 		return fileAlreadyLoaded
 	}
 
-	// Close the current iter.
-	if err := l.closeFileIter(); err != nil {
-		return noFileLoaded
-	}
+	// Close the current iter, ignoring any error.
+	_ = l.closeFileIter()
 
 	l.initTableBounds(file)
 	iterKinds := iterPointKeys
@@ -401,7 +399,7 @@ func (l *levelIterV2) SeekGE(key []byte, flags base.SeekGEFlags) (kv *base.Inter
 	atSyntheticBoundary := l.atSyntheticBoundary
 	if flags.TrySeekUsingNext() {
 		if invariants.Enabled && (l.err != nil || l.dir != +1 || l.prefix != nil) {
-			panic(errors.AssertionFailedf("invalid use of TrySeekUsingNext"))
+			panic(errors.AssertionFailedf("invalid use of TrySeekUsingNext (err:%v dir:%d prefix:%q)", l.err, l.dir, l.prefix))
 		}
 		if !l.currentSpan.Valid() {
 			// Iterator exhausted.
@@ -882,15 +880,14 @@ func (l *levelIterV2) Error() error {
 
 func (l *levelIterV2) closeFileIter() error {
 	if l.iterFile != nil {
-		if err := l.iter.Close(); err != nil && l.err == nil {
-			l.err = err
-		}
 		l.iterFile = nil
+		return l.iter.Close()
 	}
-	return l.err
+	return nil
 }
+
 func (l *levelIterV2) Close() error {
-	_ = l.closeFileIter()
+	l.err = firstError(l.err, l.closeFileIter())
 	l.invalidateSpan()
 	return l.err
 }
@@ -900,9 +897,10 @@ func (l *levelIterV2) SetBounds(lower, upper []byte) {
 	l.lower = lower
 	l.upper = upper
 
-	// TODO(radu): if the file is still covered by the iterator, keep it open and
-	// call SetBounds with the new bounds.
-	// closeFileIter() will set levelIterV2.err if an error occurs.
+	// Close any open iterator, ignoring any error. This is necessary because the
+	// existing iterator might not have the correct bounds.
+	// TODO(radu): if the file is still covered by the new bounds, keep it open
+	// and call SetBounds with the new bounds.
 	_ = l.closeFileIter()
 }
 

--- a/merging_iter_v2.go
+++ b/merging_iter_v2.go
@@ -1426,13 +1426,13 @@ func (m *mergingIterV2) shouldTrySingleLevelAdvance(
 func (m *mergingIterV2) finishSingleLevelAdvance(
 	top *mergingIterV2Level, spanKeysDetector *spanKeysChangeDetector,
 ) bool {
+	if top.iterKV == nil && m.levelHasError(top) {
+		return true
+	}
 	if spanKeysDetector.MayHaveChanged(top.span.Keys) {
 		return false
 	}
 	if top.iterKV == nil {
-		if m.levelHasError(top) {
-			return true
-		}
 		if invariants.Enabled && len(top.span.Keys) != 0 {
 			panic(errors.AssertionFailedf("span keys with nil KV"))
 		}
@@ -1458,6 +1458,8 @@ func (m *mergingIterV2) levelHasError(level *mergingIterV2Level) bool {
 		m.err = err
 		for i := range m.levels {
 			m.levels[i].atBoundary = false
+			m.levels[i].onlyFwdSinceParked = false
+			m.levels[i].iterKV = nil
 		}
 		m.heap.Reset()
 		return true


### PR DESCRIPTION
 - Fix an error path in mergingIterV2 where we weren't calling
   `m.levelHasError`.
 - Improve `levelHasError` to clear all `onlyFwdSinceParked` and
   `iterKV` values.
 - Improve `levelIterV2` to ignore iterator close errors when opening
   a new file.