### PR TITLE
pebble: detect double Iterator.Close in invariants builds

### DIFF
--- a/db.go
+++ b/db.go
@@ -1168,6 +1168,7 @@ func (d *DB) newIter(
 		buf = &a.iterAllocCommon
 	}
 	dbi := &buf.dbi
+	dbi.closeChecker = invariants.CloseChecker{}
 	dbi.ctx = ctx
 	dbi.merge = d.merge
 	dbi.comparer = d.opts.Comparer

--- a/iterator.go
+++ b/iterator.go
@@ -208,6 +208,15 @@ type Iterator struct {
 	// version's BlobFileSet or flushable ingests.
 	combinedBlobMapping combinedBlobFileMapping
 
+	// closeChecker detects double Close. It is intentionally above
+	// clearForReuseBoundary so the "closed" bit survives clearForReuse and
+	// catches a second Close on the same Iterator pointer. It is reset to the
+	// zero value when an Iterator is re-initialized for a new caller (the
+	// pool-allocation sites all use a `*dbi = Iterator{...}` literal or
+	// explicitly reset it). The `invariants:"reused"` tag exempts it from
+	// iterAlloc.assertZeroed.
+	closeChecker invariants.CloseChecker `invariants:"reused"`
+
 	// All fields below this field are cleared during Iterator.Close before
 	// returning the Iterator to the pool. Any fields above this field must also
 	// be cleared, but may be cleared as a part of the body of Iterator.Close
@@ -2481,6 +2490,7 @@ func maybeReuseKeyBuf(save *[]byte, buf []byte) {
 // It is not valid to call any method, including Close, after the iterator
 // has been closed.
 func (i *Iterator) Close() error {
+	i.closeChecker.Close()
 	if i.trackerHandle.IsValid() {
 		i.tracker.Stop(i.trackerHandle)
 		i.trackerHandle = 0

--- a/iterator_histories_test.go
+++ b/iterator_histories_test.go
@@ -51,7 +51,11 @@ func TestIterHistories(t *testing.T) {
 			// SetOptions/seek calls; opt out of invariant-only randomization that
 			// suppresses seek-using-next or forces SetOptions reconstruction.
 			it.forceEnableSeekOpt = true
-			iters[name] = it
+			// Only track named iterators; unnamed ones are closed inline by
+			// runIterCmd and would otherwise be double-closed by cleanup.
+			if name != "" {
+				iters[name] = it
+			}
 			return it
 		}
 		var opts *Options

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -339,11 +339,13 @@ func TestReadSampling(t *testing.T) {
 				if err := iter.Close(); err != nil {
 					return err.Error()
 				}
+				iter = nil
 			}
 			if d != nil {
 				if err := d.Close(); err != nil {
 					return err.Error()
 				}
+				d = nil
 			}
 
 			opts := &Options{}
@@ -472,6 +474,7 @@ func TestReadSampling(t *testing.T) {
 				if err := iter.Close(); err != nil {
 					return err.Error()
 				}
+				iter = nil
 			}
 			return ""
 


### PR DESCRIPTION
#### pebble: detect double Iterator.Close in invariants builds

`Iterator.Close` documents that it is not valid to call any method
(including `Close`) after the iterator has been closed, but the
implementation does not enforce this. A second `Close` on a
pool-allocated `Iterator` is very fragile: the underlying allocation
is returned to its `sync.Pool` at the end of the first `Close`, so a
second call can touch state that now belongs to a different iterator.

Add an `invariants.CloseChecker` field to `Iterator` and call
`closeChecker.Close()` at the top of `Iterator.Close()`. In
`invariants`/`race` builds this panics with `"double close"` on a
second call; in production builds the field is zero-sized and the call
compiles to nothing.

The field is placed above `clearForReuseBoundary` so the `closed` bit
survives `clearForReuse` and catches double-close on the same
`*Iterator`. It is reset when the underlying allocation is re-used.

Enabling the check surfaced two pre-existing double-close bugs in test
code, which are fixed in this commit:

- `iterator_histories_test.go`: `newIter` stored every iterator in the
  `iters` map keyed by name, including unnamed iterators that
  `runIterCmd` closes inline. `cleanup` then closed them again. Only
  insert into the map when a name is provided.
- `iterator_test.go` (`TestReadSampling`): the `define` and
  `close-iter` directives closed `iter`/`d` without nil'ing the
  variables, so the test-level deferred close ran a second time. Set
  the variables to `nil` after closing.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>
