### PR TITLE
tool: sort L0 by seqnum in `lsm` buildEdits

### DIFF
--- a/internal/manifest/version.go
+++ b/internal/manifest/version.go
@@ -80,6 +80,37 @@ func NewInitialVersion(comparer *base.Comparer) *Version {
 	return v
 }
 
+// NewVersionWithFiles constructs a new Version with the provided files. The
+// per-level B-Trees are built using the canonical comparators
+// (`btreeCmpSeqNum` for L0, `btreeCmpSmallestKey` for L1+); tree iteration
+// reflects that order regardless of the order of `files`. The L0Organizer
+// should be freshly created.
+func NewVersionWithFiles(
+	comparer *base.Comparer, l0Organizer *L0Organizer, files [7][]*TableMetadata,
+) *Version {
+	v := &Version{
+		cmp:                comparer,
+		BlobFiles:          MakeBlobFileSet(nil),
+		RangeKeySetRegions: makeRangeKeySetRegions(comparer),
+	}
+	for l := range files {
+		v.Levels[l] = MakeLevelMetadata(comparer.Compare, l, files[l])
+		v.RangeKeyLevels[l] = MakeLevelMetadata(comparer.Compare, l, nil)
+		for _, f := range files[l] {
+			if f.HasRangeKeys {
+				if err := v.RangeKeyLevels[l].insert(f); err != nil {
+					panic(err)
+				}
+				if f.RangeKeyKinds == AnyRangeKeys {
+					addToRangeKeySetRegions(&v.RangeKeySetRegions, f)
+				}
+			}
+		}
+	}
+	l0Organizer.ResetForTesting(v)
+	return v
+}
+
 // NewVersionForTesting constructs a new Version with the provided files. It
 // requires the provided files are already well-ordered. The L0Organizer should
 // be freshly created.

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -323,7 +323,7 @@ func (l *lsmT) buildEdits(edits []*manifest.VersionEdit) error {
 		}
 
 		l0Organizer := manifest.NewL0Organizer(l.cmp, 0 /* flushSplitBytes */)
-		v := manifest.NewVersionForTesting(l.cmp, l0Organizer, currentFiles)
+		v := manifest.NewVersionWithFiles(l.cmp, l0Organizer, currentFiles)
 		edit.Sublevels = make(map[base.FileNum]int)
 		for sublevel, files := range v.L0SublevelFiles {
 			for f := range files.All() {

--- a/tool/lsm_test.go
+++ b/tool/lsm_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package tool
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildEditsL0OutOfSeqNumOrder exercises buildEdits with a sequence of
+// version edits that add L0 files out of largest-sequence-number order. The
+// L0Organizer requires successive overlapping L0 files to have non-decreasing
+// largest sequence numbers, so buildEdits must construct the per-edit Version
+// via a path that orders L0 by seqnum. NewVersionWithFiles satisfies that by
+// building the L0 B-Tree with btreeCmpSeqNum; previously buildEdits used
+// NewVersionForTesting, which preserved slice order and would panic in
+// addFileToSublevels on the second edit.
+func TestBuildEditsL0OutOfSeqNumOrder(t *testing.T) {
+	cmp := base.DefaultComparer
+
+	newL0Table := func(num base.FileNum, smallestSeq, largestSeq base.SeqNum) *manifest.TableMetadata {
+		m := (&manifest.TableMetadata{TableNum: num}).ExtendPointKeyBounds(
+			cmp.Compare,
+			base.MakeInternalKey([]byte("a"), largestSeq, base.InternalKeyKindSet),
+			base.MakeInternalKey([]byte("z"), smallestSeq, base.InternalKeyKindSet),
+		)
+		m.SeqNums.Low = smallestSeq
+		m.SeqNums.High = largestSeq
+		m.LargestSeqNumAbsolute = largestSeq
+		m.Size = 1
+		m.InitPhysicalBacking()
+		return m
+	}
+
+	// VE 0 introduces an L0 file with a larger SeqNums.High than VE 1's L0
+	// file. They share the same user-key interval, so the L0Organizer will see
+	// both in the same fileInterval. If buildEdits handed them to a Version
+	// constructor that preserved slice order, the second file's smaller
+	// SeqNums.High would trip the addFileToSublevels precondition.
+	high := newL0Table(1, 200, 200)
+	low := newL0Table(2, 100, 100)
+
+	edits := []*manifest.VersionEdit{
+		{NewTables: []manifest.NewTableEntry{{Level: 0, Meta: high}}},
+		{NewTables: []manifest.NewTableEntry{{Level: 0, Meta: low}}},
+	}
+
+	l := newLSM(&pebble.Options{}, sstable.Comparers{cmp.Name: cmp})
+	l.cmp = cmp
+	require.NotPanics(t, func() {
+		require.NoError(t, l.buildEdits(edits))
+	})
+	require.Len(t, l.state.Edits, 2)
+}


### PR DESCRIPTION
## Summary

`tool/lsm`'s `buildEdits` replays a manifest's version edits to reconstruct intermediate `Version`s for visualization. It accumulates files per level in arrival order — for each VE it appends `NewTables` to `currentFiles[level]` and stable-copies-down on `DeletedTables` — and then hands `currentFiles` to `manifest.NewVersionForTesting`, which builds the L0 B-Tree with `btreeCmpSpecificOrder(files[0])` so iteration order mirrors slice order. `L0Organizer.ResetForTesting` → `newL0Sublevels` then walks that tree calling `addFileToSublevels`, which requires successive files in the same key interval to have non-decreasing `SeqNums.High` and panics with `addFileToSublevels found existing newer file` otherwise.

Production code builds the L0 tree via `btreeCmpSeqNum`, which satisfies that precondition by construction. `buildEdits` was relying on VE arrival order to coincide with seqnum order; two single-file VEs whose L0 files share a key interval and arrive out of largest-seqnum order are sufficient to trip the assertion.

This patch sorts `currentFiles[0]` by `(SeqNums.High, SeqNums.Low, TableNum)` — the ordering `btreeCmpSeqNum` uses — immediately before the `NewVersionForTesting` call, and adds `TestBuildEditsL0OutOfSeqNumOrder` which panics without the sort.