### PR TITLE
db: fix visibleSeqNum publish-window race via NotYetPublished state

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -141,6 +141,12 @@ type commitEnv struct {
 	// the memtable the batch should be applied to. Serial execution enforced by
 	// commitPipeline.mu.
 	write func(b *Batch, wg *sync.WaitGroup, err *error) (*memTable, error)
+
+	// testingBeforePublish, if non-nil, is invoked at the top of
+	// commitPipeline.publish, before visibleSeqNum is bumped. It fires for
+	// both regular commits and ingests (both route through publish). Used
+	// by tests to widen the apply->publish race window.
+	testingBeforePublish func()
 }
 
 // A commitPipeline manages the stages of committing a set of mutations
@@ -474,6 +480,10 @@ func (p *commitPipeline) prepare(b *Batch, syncWAL bool, noSyncWait bool) (*memT
 }
 
 func (p *commitPipeline) publish(b *Batch) {
+	if p.env.testingBeforePublish != nil {
+		p.env.testingBeforePublish()
+	}
+
 	// Mark the batch as applied.
 	b.applied.Store(true)
 

--- a/commit.go
+++ b/commit.go
@@ -147,6 +147,12 @@ type commitEnv struct {
 	// both regular commits and ingests (both route through publish). Used
 	// by tests to widen the apply->publish race window.
 	testingBeforePublish func()
+
+	// afterPublish, if non-nil, is invoked at the end of publish, after
+	// visibleSeqNum has been bumped. The handler is expected to perform an
+	// atomic fast-path check and only acquire DB.mu when there is work to do
+	// (transitioning tables out of CompactionStateNotYetPublished).
+	afterPublish func()
 }
 
 // A commitPipeline manages the stages of committing a set of mutations
@@ -526,5 +532,9 @@ func (p *commitPipeline) publish(b *Batch) {
 		}
 
 		t.commit.Done()
+	}
+
+	if p.env.afterPublish != nil {
+		p.env.afterPublish()
 	}
 }

--- a/compaction.go
+++ b/compaction.go
@@ -373,8 +373,9 @@ func (c *tableCompaction) AddInProgressLocked(d *DB) {
 	var isBase, isIntraL0 bool
 	for _, cl := range c.inputs {
 		for f := range cl.files.All() {
-			if f.IsCompacting() {
-				d.opts.Logger.Fatalf("L%d->L%d: %s already being compacted", c.startLevel.level, c.outputLevel.level, f.TableNum)
+			if !f.IsAvailableForCompaction() {
+				d.opts.Logger.Fatalf("L%d->L%d: %s not available for compaction (state %s)",
+					c.startLevel.level, c.outputLevel.level, f.TableNum, f.CompactionState)
 			}
 			f.SetCompactionState(manifest.CompactionStateCompacting)
 			if c.startLevel != nil && c.outputLevel != nil && c.startLevel.level == 0 {
@@ -1948,6 +1949,48 @@ func (d *DB) maybeTransitionSnapshotsToFileOnlyLocked() {
 		_ = s.efos.transitionToFileOnlySnapshot(currentVersion)
 		s = next
 	}
+}
+
+// maybePublishTables transitions tables out of CompactionStateNotYetPublished
+// once visibleSeqNum has advanced past their SeqNums.High, then schedules a
+// compaction if any tables transitioned. Called from commitPipeline.publish
+// without DB.mu held; the atomic fast-path check keeps the common case (no
+// unpublished tables) cheap.
+func (d *DB) maybePublishTables() {
+	if !d.mu.versions.hasUnpublishedTables.Load() {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	list := d.mu.versions.unpublishedTables
+	if len(list) == 0 {
+		return
+	}
+	visible := d.mu.versions.visibleSeqNum.Load()
+	// Walk in FIFO order, stopping at the first entry that is not yet
+	// publishable. Any entries past the stopping point will be handled on a
+	// subsequent publish (visibleSeqNum is monotonically increasing, so they
+	// remain queued and eventually drain). In the typical case, all entries
+	// from a single flush/ingest become publishable at the same time.
+	i := 0
+	for i < len(list) && list[i].SeqNums.High < visible {
+		list[i].SetCompactionState(manifest.CompactionStateNotCompacting)
+		list[i] = nil
+		i++
+	}
+	if i == 0 {
+		return
+	}
+	if i == len(list) {
+		d.mu.versions.unpublishedTables = list[:0]
+		// Disarm the fast path. Safe under DB.mu: any concurrent
+		// UpdateVersionLocked also holds DB.mu and will re-arm the flag
+		// after appending its own entries.
+		d.mu.versions.hasUnpublishedTables.Store(false)
+	} else {
+		d.mu.versions.unpublishedTables = append(list[:0], list[i:]...)
+	}
+	d.maybeScheduleCompaction()
 }
 
 // maybeScheduleCompactionAsync should be used when

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -608,13 +608,14 @@ func (pc *pickedTableCompaction) setupMultiLevelCandidate(opts *Options, env com
 	return pc.setupInputs(opts, env.diskAvailBytes, env.inProgressCompactions, &pc.inputs[1], nil /* TODO(radu) */)
 }
 
-// canCompactTables returns true if the tables in the level slice are not
-// compacting already and don't intersect any problem spans.
+// canCompactTables returns true if the tables in the level slice are
+// available for compaction (not already compacting and have published
+// seqnums) and don't intersect any problem spans.
 func canCompactTables(
 	inputs manifest.LevelSlice, level int, problemSpans *problemspans.ByLevel,
 ) bool {
 	for f := range inputs.All() {
-		if f.IsCompacting() {
+		if !f.IsAvailableForCompaction() {
 			return false
 		}
 		if problemSpans != nil && problemSpans.Overlaps(level, f.UserKeyBounds()) {
@@ -1191,10 +1192,11 @@ func pickCompactionSeedFile(
 
 	for f := startIter.First(); f != nil; f = startIter.Next() {
 		var overlappingBytes uint64
-		if f.IsCompacting() {
-			// Move on if this file is already being compacted. We'll likely
-			// still need to move past the overlapping output files regardless,
-			// but in cases where all start-level files are compacting we won't.
+		if !f.IsAvailableForCompaction() {
+			// Move on if this file is not available for compaction (already
+			// being compacted, or has unpublished seqnums). We'll likely still
+			// need to move past the overlapping output files regardless, but
+			// in cases where all start-level files are unavailable we won't.
 			continue
 		}
 		if problemSpans != nil && problemSpans.Overlaps(level, f.UserKeyBounds()) {
@@ -1210,9 +1212,9 @@ func pickCompactionSeedFile(
 		skip := false
 		for outputFile != nil && sstableKeyCompare(cmp, outputFile.Smallest(), f.Largest()) <= 0 {
 			overlappingBytes += outputFile.Size
-			if outputFile.IsCompacting() {
-				// If one of the overlapping files is compacting, we're not going to be
-				// able to compact f anyway, so skip it.
+			if !outputFile.IsAvailableForCompaction() {
+				// If one of the overlapping files is unavailable, we're not
+				// going to be able to compact f anyway, so skip it.
 				skip = true
 				break
 			}
@@ -1603,7 +1605,7 @@ var elisionOnlyAnnotator = manifest.MakePickFileAnnotator(
 	manifest.NewTableAnnotationIdx(),
 	manifest.PickFileAnnotatorFuncs{
 		Filter: func(f *manifest.TableMetadata) (eligible bool, cacheOK bool) {
-			if f.IsCompacting() {
+			if !f.IsAvailableForCompaction() {
 				return false, true
 			}
 
@@ -1646,7 +1648,7 @@ func (p *compactionPickerByScore) pickedCompactionFromCandidateFile(
 	outputLevel int,
 	kind compactionKind,
 ) *pickedTableCompaction {
-	if candidate == nil || candidate.IsCompacting() {
+	if candidate == nil || !candidate.IsAvailableForCompaction() {
 		return nil
 	}
 
@@ -1742,7 +1744,7 @@ func (p *compactionPickerByScore) pickVirtualRewriteCompaction(
 
 	for level, tables := range vtablesByLevel {
 		for _, vt := range tables {
-			if vt.IsCompacting() {
+			if !vt.IsAvailableForCompaction() {
 				continue
 			}
 			if pc := p.pickedCompactionFromCandidateFile(vt, env, level, level, compactionKindVirtualRewrite); pc != nil {
@@ -1865,7 +1867,7 @@ func (p *compactionPickerByScore) pickTombstoneDensityCompaction(
 	for l := numLevels - 2; l >= 0; l-- {
 		iter := p.vers.Levels[l].Iter()
 		for f := iter.First(); f != nil; f = iter.Next() {
-			if f.IsCompacting() || f.Size == 0 {
+			if !f.IsAvailableForCompaction() || f.Size == 0 {
 				continue
 			}
 			props, propsValid := f.TableBacking.Properties()
@@ -2197,8 +2199,8 @@ func pickDownloadCompaction(
 	level int,
 	file *manifest.TableMetadata,
 ) (pc *pickedTableCompaction) {
-	// Check if the file is compacting already.
-	if file.CompactionState == manifest.CompactionStateCompacting {
+	// Check if the file is available for compaction.
+	if !file.IsAvailableForCompaction() {
 		return nil
 	}
 	if kind != compactionKindCopy && kind != compactionKindRewrite {

--- a/download.go
+++ b/download.go
@@ -286,7 +286,7 @@ func (d *DB) tryLaunchDownloadForFile(
 	level int,
 	f *manifest.TableMetadata,
 ) (doneCh chan error, ok bool) {
-	if f.IsCompacting() {
+	if !f.IsAvailableForCompaction() {
 		return nil, false
 	}
 	if download.testing.launchDownloadCompaction != nil {

--- a/internal/manifest/l0_sublevels.go
+++ b/internal/manifest/l0_sublevels.go
@@ -1454,11 +1454,18 @@ func (s *l0Sublevels) PickBaseCompaction(
 		for j := fs.minIntervalIndex; j <= fs.maxIntervalIndex; j++ {
 			consideredIntervals[j] = true
 		}
-		if f.IsCompacting() {
+		if !f.IsAvailableForCompaction() {
 			if f.IsIntraL0Compacting {
 				// If we're picking a base compaction and we came across a seed
 				// file candidate that's being intra-L0 compacted, skip the
 				// interval instead of emitting an error.
+				continue
+			}
+			if f.CompactionState == CompactionStateNotYetPublished {
+				// The file's seqnums haven't been published yet; it must be
+				// skipped from compaction picking. The seed-file iteration
+				// could have selected it because L0Sublevels does not track
+				// the not-yet-published bit in fileStateMap.
 				continue
 			}
 			// We chose a compaction seed file that should not be compacting; this
@@ -1607,7 +1614,7 @@ func (s *l0Sublevels) extendFiles(
 		if s.state(f).minIntervalIndex > cFiles.maxIntervalIndex {
 			break
 		}
-		if f.IsCompacting() {
+		if !f.IsAvailableForCompaction() {
 			return false
 		}
 		// Skip over files that are newer than earliestUnflushedSeqNum. This is
@@ -1666,8 +1673,9 @@ func (s *l0Sublevels) PickIntraL0Compaction(
 			stackDepthReduction := scoredInterval.score
 			for i := len(interval.files) - 1; i >= 0; i-- {
 				f := interval.files[i]
-				if f.IsCompacting() {
-					// This file could be in a concurrent intra-L0 or base compaction; we
+				if !f.IsAvailableForCompaction() {
+					// This file could be in a concurrent intra-L0 or base
+					// compaction, or its seqnums haven't been published; we
 					// can't use this interval.
 					return nil
 				}
@@ -1741,7 +1749,7 @@ func (s *l0Sublevels) intraL0CompactionUsingSeed(
 		f2 := interval.files[slIndex]
 		f2s := s.state(f2)
 		sl := f2s.subLevel
-		if f2.IsCompacting() {
+		if !f2.IsAvailableForCompaction() {
 			break
 		}
 		c.seedIntervalStackDepthReduction++
@@ -2011,7 +2019,7 @@ func (s *l0Sublevels) extendCandidateToRectangle(
 		candidateHasAlreadyPickedFiles := false
 		for index = firstIndex; index <= lastIndex; index++ {
 			f := files[index]
-			if f.IsCompacting() {
+			if !f.IsAvailableForCompaction() {
 				if nonCompactingFirst != -1 {
 					last := index - 1
 					// Prioritize runs of consecutive non-compacting files that
@@ -2063,10 +2071,10 @@ func (s *l0Sublevels) extendCandidateToRectangle(
 		}
 		for index := candidateNonCompactingFirst; index <= candidateNonCompactingLast; index++ {
 			f := files[index]
-			if f.IsCompacting() {
+			if !f.IsAvailableForCompaction() {
 				// TODO(bilal): Do a logger.Fatalf instead of a panic, for
 				// cleaner unwinding and error messages.
-				panic(errors.AssertionFailedf("expected %s to not be compacting", f.TableNum))
+				panic(errors.AssertionFailedf("expected %s to be available for compaction", f.TableNum))
 			}
 			if candidate.isIntraL0 && f.SeqNums.High >= candidate.earliestUnflushedSeqNum {
 				continue

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -606,6 +606,10 @@ func (m *TableMetadata) SetCompactionState(to CompactionState) {
 			}
 		case CompactionStateCompacted:
 			panic(transitionErr())
+		case CompactionStateNotYetPublished:
+			if to != CompactionStateNotCompacting {
+				panic(transitionErr())
+			}
 		default:
 			panic(errors.AssertionFailedf("pebble: unknown compaction state: %d", m.CompactionState))
 		}
@@ -617,6 +621,14 @@ func (m *TableMetadata) SetCompactionState(to CompactionState) {
 // CompactionStateCompacting. Protected by DB.mu.
 func (m *TableMetadata) IsCompacting() bool {
 	return m.CompactionState == CompactionStateCompacting
+}
+
+// IsAvailableForCompaction returns true iff the file is eligible to be picked
+// as input to a new compaction (CompactionState == CompactionStateNotCompacting).
+// Returns false for tables that are already being compacted, have been
+// compacted, or whose seqnums have not yet been published. Protected by DB.mu.
+func (m *TableMetadata) IsAvailableForCompaction() bool {
+	return m.CompactionState == CompactionStateNotCompacting
 }
 
 // Stats returns the table statistics if they have been populated, or nil and
@@ -1306,10 +1318,16 @@ type TableStats struct {
 //
 // The following shows the valid state transitions:
 //
-//	NotCompacting --> Compacting --> Compacted
-//	      ^               |
-//	      |               |
-//	      +-------<-------+
+//	NotYetPublished --> NotCompacting --> Compacting --> Compacted
+//	                         ^               |
+//	                         |               |
+//	                         +-------<-------+
+//
+// A table produced by a flush or an ingest enters the LSM in the
+// NotYetPublished state if its highest sequence number has not yet been
+// published (i.e. is >= visibleSeqNum). NotYetPublished tables must not be
+// selected as inputs to a compaction. Once visibleSeqNum advances past the
+// table's SeqNums.High, the table transitions to NotCompacting.
 //
 // Input files to a compaction transition to Compacting when a compaction is
 // picked. A file that has finished compacting typically transitions into the
@@ -1328,6 +1346,7 @@ const (
 	CompactionStateNotCompacting CompactionState = iota
 	CompactionStateCompacting
 	CompactionStateCompacted
+	CompactionStateNotYetPublished
 )
 
 // SafeFormat implements redact.SafeFormatter.
@@ -1344,6 +1363,8 @@ func (s CompactionState) String() string {
 		return "Compacting"
 	case CompactionStateCompacted:
 		return "Compacted"
+	case CompactionStateNotYetPublished:
+		return "NotYetPublished"
 	default:
 		panic(errors.AssertionFailedf("pebble: unknown compaction state %d", s))
 	}

--- a/internal/tombspan/tombspan.go
+++ b/internal/tombspan/tombspan.go
@@ -447,8 +447,9 @@ func (ts *Set) PickCompaction(
 					continue
 				}
 
-				// Skip any currently compacting tables.
-				if m.IsCompacting() {
+				// Skip any tables that are not available for compaction
+				// (already compacting, or seqnums not yet published).
+				if !m.IsAvailableForCompaction() {
 					skippedDueToCompacting = true
 					continue
 				}

--- a/open.go
+++ b/open.go
@@ -222,10 +222,11 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	}()
 
 	d.commit = newCommitPipeline(commitEnv{
-		logSeqNum:     &d.mu.versions.logSeqNum,
-		visibleSeqNum: &d.mu.versions.visibleSeqNum,
-		apply:         d.commitApply,
-		write:         d.commitWrite,
+		logSeqNum:            &d.mu.versions.logSeqNum,
+		visibleSeqNum:        &d.mu.versions.visibleSeqNum,
+		apply:                d.commitApply,
+		write:                d.commitWrite,
+		testingBeforePublish: opts.private.testingBeforePublishFunc,
 	})
 	d.mu.nextJobID = 1
 	d.mu.mem.nextSize = min(opts.MemTableSize, initialMemTableSize)

--- a/open.go
+++ b/open.go
@@ -227,6 +227,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		apply:                d.commitApply,
 		write:                d.commitWrite,
 		testingBeforePublish: opts.private.testingBeforePublishFunc,
+		afterPublish:         d.maybePublishTables,
 	})
 	d.mu.nextJobID = 1
 	d.mu.mem.nextSize = min(opts.MemTableSize, initialMemTableSize)

--- a/options.go
+++ b/options.go
@@ -1274,6 +1274,15 @@ type Options struct {
 		// before calling DB.ingestApply.
 		testingBeforeIngestApplyFunc func()
 
+		// testingBeforePublishFunc when non-nil, is called at the top of
+		// commitPipeline.publish, before visibleSeqNum is bumped. It fires
+		// for both regular commits and ingests (since both publish through
+		// commitPipeline.publish). Used by tests to widen the apply->publish
+		// race window in which a batch's data is already in the memtable /
+		// the ingested sstables are already in the version, but visibleSeqNum
+		// has not yet been advanced.
+		testingBeforePublishFunc func()
+
 		// timeNow returns the current time. It defaults to time.Now. It's
 		// configurable here so that tests can mock the current time.
 		timeNow func() time.Time

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -8,11 +8,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"reflect"
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,6 +24,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/testutils"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -448,4 +452,296 @@ func TestEFOSAndExciseRace(t *testing.T) {
 	waitForCh <- struct{}{}
 	// Wait for the snapshot checking to finish.
 	<-snapDone
+}
+
+// TestNewSnapshotIngestRace, TestEFOSIngestRace, and TestNewSnapshotCommitFlushRace
+// exercise the race window between commitPipeline.publish (which bumps
+// visibleSeqNum) and the apply step that already installed the batch's data
+// into the LSM (commitApply for regular commits, ingestApply for ingests).
+// In that window:
+//
+//   - For commits: the batch's entries are already in the memtable, and the
+//     batch's writer ref on the memtable has been dropped (writerUnref runs
+//     inside commitApply). visibleSeqNum is still N.
+//   - For ingests: the ingested sstables are already installed in the current
+//     version. visibleSeqNum is still N.
+//
+// In either case, a concurrent compaction running while visibleSeqNum is
+// still N captures a snapshot list that lacks any snapshot registered at
+// S=N (because no snapshot has been registered yet at that moment), so a
+// later-created snapshot at S=N is invisible to the compaction. If the
+// compaction merges away an older entry e@old (because the stripe (old, N]
+// looks unprotected), a subsequent read from the snapshot sees the post-
+// edit version with the older entry gone — and the surviving entry at
+// seqnum N is filtered out (N < N is false). Result: ErrNotFound, which is
+// the data-loss bug.
+//
+// All three tests use a single test hook on the publish path
+// (testingBeforePublishFunc) that blocks the committing/ingesting goroutine
+// before it bumps visibleSeqNum. While that goroutine is held, the test:
+//   1. Drives a manual compaction with a context timeout. On master the
+//      compaction picks the freshly-installed sstable, captures a snapshot
+//      list that does not yet include S=N, drops e@old, and returns. With
+//      the CompactionStateNotYetPublished fix, the sstable is NotYetPublished
+//      and the compaction is deferred until publish runs; the context
+//      timeout fires and Compact returns DeadlineExceeded.
+//   2. Creates the snapshot at S=N.
+//   3. Releases the publish hook.
+//
+// On master, snap.Get returns ErrNotFound (the data-loss bug): the
+// compaction's edit has already dropped e@old and e@N is filtered out by
+// the snapshot's seqnum (N < N is false). With the fix, the compaction
+// never ran during the race window, so e@old is still present and
+// snap.Get returns it.
+func TestNewSnapshotIngestRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	runIngestSnapshotRace(t, false /* useEFOS */)
+}
+
+func TestEFOSIngestRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	runIngestSnapshotRace(t, true /* useEFOS */)
+}
+
+// snapshotReader is the common subset of *Snapshot and *EventuallyFileOnlySnapshot.
+type snapshotReader interface {
+	Get(key []byte) ([]byte, io.Closer, error)
+}
+
+// publishBlocker installs a testingBeforePublishFunc that fires exactly once
+// (after enable() has been called): it signals on entered and then blocks on
+// release. Callers use enable() to arm the hook after setup writes are done,
+// then wait on entered, and finally close release to let publish proceed.
+type publishBlocker struct {
+	enabled atomic.Bool
+	fired   atomic.Bool
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newPublishBlocker() *publishBlocker {
+	return &publishBlocker{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (b *publishBlocker) hook() func() {
+	return func() {
+		if !b.enabled.Load() {
+			return
+		}
+		if b.fired.CompareAndSwap(false, true) {
+			close(b.entered)
+			<-b.release
+		}
+	}
+}
+
+func (b *publishBlocker) enable()  { b.enabled.Store(true) }
+func (b *publishBlocker) unblock() { close(b.release) }
+
+func runIngestSnapshotRace(t *testing.T, useEFOS bool) {
+	blocker := newPublishBlocker()
+	o := &Options{
+		FS:                          vfs.NewMem(),
+		DisableAutomaticCompactions: true,
+		FormatMajorVersion:          FormatNewest,
+	}
+	o.private.testingBeforePublishFunc = blocker.hook()
+
+	d, err := Open("", o)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, d.Close()) }()
+
+	// Hold a long-lived "barrier" snapshot taken before any writes. This
+	// disables the last-stripe SeqNumZero rewrite in the compaction iterator
+	// so the surviving "k"@new keeps its original seqnum N. Without this,
+	// the racing snapshot at S=N would still see "k"@new (because its
+	// seqnum was rewritten to 0), masking the bug as a benign "saw the
+	// newer write" outcome instead of the actual data loss (NotFound).
+	barrier := d.NewSnapshot()
+	defer func() { require.NoError(t, barrier.Close()) }()
+
+	// Set "k"="old" and push it down to L6 via a manual compaction so that
+	// the value lives in a stable sstable below where the ingest will land.
+	require.NoError(t, d.Set([]byte("k"), []byte("old"), nil))
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Compact(context.Background(), []byte("a"), []byte("z"), false))
+
+	// Arm the publish hook now that setup is done.
+	blocker.enable()
+
+	// Build an sstable containing "k"="new" for ingestion. Because "k"
+	// overlaps the L6 sstable, the ingest will land at L5.
+	f, err := o.FS.Create("ext", vfs.WriteCategoryUnspecified)
+	require.NoError(t, err)
+	w := sstable.NewWriter(objstorageprovider.NewFileWritable(f),
+		d.opts.MakeWriterOptions(0, d.TableFormat()))
+	require.NoError(t, w.Set([]byte("k"), []byte("new")))
+	require.NoError(t, w.Close())
+
+	// Start the ingest. It blocks in commitPipeline.publish once
+	// ingestApply has installed the new sstable into the current version
+	// but before visibleSeqNum has been bumped past N.
+	ingestDone := make(chan struct{})
+	go func() {
+		defer close(ingestDone)
+		require.NoError(t, d.Ingest(context.Background(), []string{"ext"}))
+	}()
+	<-blocker.entered
+
+	// We are now in the race window. The current version contains the
+	// freshly-ingested L5 sstable at seqnum N (along with the original L6
+	// sstable at some seqnum < N), but visibleSeqNum is still N (publish
+	// hasn't run).
+
+	// Drive the L5 -> L6 compaction. On master, the compaction picks the
+	// L5 file immediately, captures a snapshot list that does not yet
+	// include S=N (we have not created that snapshot yet), drops "k"@old,
+	// and returns nil. With the CompactionStateNotYetPublished fix, the
+	// L5 file is ineligible for picking until publish runs; the manual
+	// compaction is deferred and the context timeout fires
+	// (DeadlineExceeded). Either outcome is acceptable for the test setup;
+	// what matters is the snap.Get assertion below.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := d.Compact(ctx, []byte("a"), []byte("z"), false); err != nil &&
+		!errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("unexpected Compact error: %v", err)
+	}
+
+	// Create the snapshot/EFOS AFTER attempting the compaction. On master
+	// this races with the compaction's already-captured snapshot list —
+	// the compaction has already dropped "k"@old and the current version
+	// lacks it, so snap.Get below returns ErrNotFound (data loss). With
+	// the fix, the compaction never ran (it timed out, deferred); the
+	// current version still contains "k"@old, so snap.Get returns "old".
+	var snap snapshotReader
+	var closeSnap func() error
+	if useEFOS {
+		efos := d.NewEventuallyFileOnlySnapshot([]KeyRange{
+			{Start: []byte("a"), End: []byte("z")},
+		})
+		snap = efos
+		closeSnap = efos.Close
+	} else {
+		s := d.NewSnapshot()
+		snap = s
+		closeSnap = s.Close
+	}
+
+	// Release the ingest so publish runs and visibleSeqNum is bumped.
+	blocker.unblock()
+	<-ingestDone
+
+	// Snapshot must still observe a value for "k": at the moment the
+	// snapshot was created, visibleSeqNum was N and "k"@old (seqnum < N)
+	// was visible. The ingest is concurrent, so either "old" or "new" is
+	// an acceptable answer — but observing NotFound is data loss.
+	v, closer, getErr := snap.Get([]byte("k"))
+	var observed string
+	if getErr == nil {
+		observed = string(v)
+		_ = closer.Close()
+	}
+	require.NoError(t, closeSnap())
+
+	require.NoError(t, getErr, "snapshot should still see the key (saw NotFound — data loss)")
+	require.Contains(t, []string{"old", "new"}, observed,
+		"snapshot should observe either pre- or post-ingest value")
+}
+
+// TestNewSnapshotCommitFlushRace is the commit+flush variant: it exploits
+// the same publish-side window but for a regular commit (not an ingest).
+// While the committing goroutine is held in publish:
+//
+//  1. d.Flush() rotates the active memtable. The committing batch's writer
+//     ref was dropped inside commitApply, so the rotated memtable can flush
+//     immediately, producing an L0 sstable containing a@N. With the fix,
+//     the new L0 sstable is in CompactionStateNotYetPublished.
+//  2. The snapshot is created at S=N (visibleSeqNum is still N).
+//  3. The L0->L6 manual compaction is started in a goroutine. With the fix
+//     it is queued but deferred; on master it would run immediately and
+//     drop a@old.
+//  4. Releasing the publish hook transitions the L0 sstable to
+//     NotCompacting and re-triggers scheduling; the deferred compaction
+//     then runs with S=N in its snapshot list and preserves a@old.
+func TestNewSnapshotCommitFlushRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	blocker := newPublishBlocker()
+	o := &Options{
+		FS:                          vfs.NewMem(),
+		DisableAutomaticCompactions: true,
+		FormatMajorVersion:          FormatNewest,
+	}
+	o.private.testingBeforePublishFunc = blocker.hook()
+
+	d, err := Open("", o)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, d.Close()) }()
+
+	// Barrier snapshot (see runIngestSnapshotRace).
+	barrier := d.NewSnapshot()
+	defer func() { require.NoError(t, barrier.Close()) }()
+
+	require.NoError(t, d.Set([]byte("a"), []byte("old"), nil))
+	require.NoError(t, d.Flush())
+	require.NoError(t, d.Compact(context.Background(), []byte("a"), []byte("z"), false))
+
+	blocker.enable()
+
+	// Commit B writing a="new". Blocks in publish: env.apply has installed
+	// a@N into the memtable and dropped B's writer ref, but visibleSeqNum
+	// is still N.
+	commitDone := make(chan struct{})
+	go func() {
+		defer close(commitDone)
+		require.NoError(t, d.Set([]byte("a"), []byte("new"), nil))
+	}()
+	<-blocker.entered
+
+	// Force the memtable to flush. The rotated memtable's writerRefs reach
+	// zero once the queue's ref is dropped (B's writer ref was already
+	// dropped inside commitApply), so the flush produces an L0 sstable
+	// containing a@N. With the fix, that L0 sstable is marked
+	// CompactionStateNotYetPublished.
+	require.NoError(t, d.Flush())
+
+	// Drive the L0 -> L6 compaction. On master, the compaction picks the
+	// L0 file immediately, captures a snapshot list lacking S=N (we have
+	// not created that snapshot yet), drops a@old, and returns nil. With
+	// the fix, the L0 file is in CompactionStateNotYetPublished; the
+	// manual compaction is deferred and the context timeout fires.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := d.Compact(ctx, []byte("a"), []byte("z"), false); err != nil &&
+		!errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("unexpected Compact error: %v", err)
+	}
+
+	// Create the snapshot at S=N. On master, the compaction has already
+	// applied its edit and the current version no longer contains a@old,
+	// so snap.Get returns ErrNotFound. With the fix, the compaction never
+	// ran (deferred until publish); the version still contains a@old.
+	snap := d.NewSnapshot()
+
+	// Release B's publish.
+	blocker.unblock()
+	<-commitDone
+
+	// snap.Get loads the post-edit version: a@old is gone; a@N is filtered
+	// out by snap.seqNum == N (N < N is false). Result: ErrNotFound.
+	v, closer, getErr := snap.Get([]byte("a"))
+	var observed string
+	if getErr == nil {
+		observed = string(v)
+		_ = closer.Close()
+	}
+	require.NoError(t, snap.Close())
+
+	require.NoError(t, getErr, "snapshot should still see the key (saw NotFound — data loss)")
+	require.Contains(t, []string{"old", "new"}, observed,
+		"snapshot should observe either pre- or post-commit value")
 }

--- a/version_set.go
+++ b/version_set.go
@@ -122,6 +122,20 @@ type versionSet struct {
 	rotationHelper record.RotationHelper
 
 	pickedCompactionCache pickedCompactionCache
+
+	// unpublishedTables is the FIFO queue of tables in
+	// CompactionStateNotYetPublished. A table is appended when added by a
+	// flush or ingest whose seqnums have not yet been published, and drained
+	// from the front by DB.maybePublishTables once visibleSeqNum has advanced
+	// past the table's SeqNums.High. Protected by DB.mu.
+	unpublishedTables []*manifest.TableMetadata
+
+	// hasUnpublishedTables is a fast-path flag for DB.maybePublishTables that
+	// lets the (hot) publish path skip acquiring DB.mu when there is no work
+	// to do. Set to true (under DB.mu) inside UpdateVersionLocked whenever a
+	// new entry is appended to unpublishedTables; cleared (under DB.mu) by
+	// DB.maybePublishTables when the queue drains to empty.
+	hasUnpublishedTables atomic.Bool
 }
 
 // latestVersionState maintains mutable state describing only the most recent
@@ -374,6 +388,30 @@ func (vs *versionSet) UpdateVersionLocked(
 
 	updateManifestStart := crtime.NowMono()
 	ve := vu.VE
+
+	// Mark any newly-added tables whose seqnums have not yet been published
+	// (i.e. SeqNums.High >= visibleSeqNum) as NotYetPublished. The compaction
+	// picker will skip these tables until DB.maybePublishTables transitions
+	// them to NotCompacting once visibleSeqNum has advanced past their
+	// SeqNums.High. This prevents the publish-window race in which a
+	// compaction could drop an older entry shadowed by an entry whose seqnum
+	// is not yet visible to concurrently-created snapshots. Compaction-output
+	// tables always have SeqNums.High < visibleSeqNum, so this is a no-op for
+	// them; the only callers that produce unpublished tables are flush and
+	// ingest.
+	visible := vs.visibleSeqNum.Load()
+	for i := range ve.NewTables {
+		meta := ve.NewTables[i].Meta
+		if meta.SeqNums.High >= visible {
+			meta.CompactionState = manifest.CompactionStateNotYetPublished
+			vs.unpublishedTables = append(vs.unpublishedTables, meta)
+			// Arm the publish-side fast path. Stored before publish() runs,
+			// so a publish observing visibleSeqNum past these tables also
+			// observes the flag and runs DB.maybePublishTables.
+			vs.hasUnpublishedTables.Store(true)
+		}
+	}
+
 	if ve.MinUnflushedLogNum != 0 {
 		if ve.MinUnflushedLogNum < vs.minUnflushedLogNum ||
 			vs.nextFileNum.Load() <= uint64(ve.MinUnflushedLogNum) {


### PR DESCRIPTION
#### db: add tests for visibleSeqNum publish-window race

These tests reproduce a data-loss race between `commitPipeline.publish`
(which bumps `visibleSeqNum`) and concurrent compactions / snapshot
creation. During the apply→publish window the batch's data is already
in the LSM (in the memtable for commits, or installed as sstables for
ingests) but `visibleSeqNum` is still `N`. A compaction running in this
window captures a snapshot list that lacks any snapshot at `S=N`; a
snapshot created at `S=N` after the compaction has dropped an older
entry `e@old` then sees the post-edit version with only `e@N`, which is
filtered out (`N < N` is false) — producing `ErrNotFound`.

The tests introduce a single test hook, `testingBeforePublishFunc`,
invoked at the top of `commitPipeline.publish` (covering both `Commit`
and `AllocateSeqNum`). With the publish window held open, the test
drives the compaction (using a context with a short timeout so the
call returns either on completion or DeadlineExceeded) and then
creates the snapshot. The bug reproduces deterministically because
creating the snapshot after the compaction has applied its version
edit guarantees that `S=N` is missing from the compaction's snapshot
list and that the current version no longer contains `e@old`.

Three tests:
 - `TestNewSnapshotIngestRace`: ingest variant, regular `Snapshot`.
 - `TestEFOSIngestRace`: ingest variant, `EventuallyFileOnlySnapshot`.
 - `TestNewSnapshotCommitFlushRace`: commit+flush variant (no ingest).

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### db: fix visibleSeqNum publish-window race via NotYetPublished state

Previously, the apply->publish window of `commitPipeline.publish` allowed
a compaction to drop an older entry shadowed by a write whose seqnum was
not yet visible. A snapshot subsequently created at `S=N` (still possible
because `visibleSeqNum` was `N`) would load the post-edit version with
the older entry gone and the surviving entry at seqnum `N` filtered out
(`N < N` is false), returning `ErrNotFound` -- data loss.

This change introduces a new `CompactionStateNotYetPublished`. Tables
added by a flush or ingest enter the LSM in this state if their
`SeqNums.High >= visibleSeqNum`, and remain ineligible for compaction
picking until the publish bumps `visibleSeqNum` past their highest
seqnum. A new `IsAvailableForCompaction` helper centralizes the picker's
"eligible for new compaction" semantic, replacing direct
`IsCompacting()` checks throughout the picker, L0 sublevels, download,
and tombspan analysis. The fatal assertion at compaction start is
tightened to catch picker bugs for either `Compacting` or
`NotYetPublished` inputs.

`versionSet` gains an `unpublishedTables` FIFO queue (populated inside
`UpdateVersionLocked`) and an `atomic.Bool` fast-path flag. A new
`afterPublish` hook on `commitPipeline.publish` invokes
`DB.maybePublishTables`, which is a single atomic load on the hot path
and only acquires `DB.mu` when there is work to do. When tables
transition out of `NotYetPublished`, `maybeScheduleCompaction` is called
so any deferred manual or automatic compaction can retry.

The three publish-window race tests added in the previous commit now
pass: with the fix, the manual compaction is deferred and the test's
context timeout fires; the snapshot is then created at `S=N` and reads
the pre-edit version, returning the older entry. On master (without
this fix) the same tests fail with `ErrNotFound`.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>