### PR TITLE
db: derive minimumFormatMajorVersion from contents in Batch.Apply

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -662,11 +662,12 @@ func (b *Batch) Apply(batch *Batch, _ *WriteOptions) error {
 				return errors.Wrapf(ErrInvalidBatch, "unrecognized kind %v", kind)
 			}
 			info := batchKinds[kind]
-			if invariants.Enabled && batch.minimumFormatMajorVersion < info.minFMV {
-				panic(errors.AssertionFailedf(
-					"source batch FMV %d < required %d for kind %s",
-					batch.minimumFormatMajorVersion, info.minFMV, kind))
-			}
+			// Ratchet the receiver's minimumFormatMajorVersion from the record's
+			// kind. Not all paths that populate a batch set
+			// minimumFormatMajorVersion (e.g. SetRepr on a batch with a nil db
+			// skips refreshMemTableSize); so, the source batch's value may be
+			// stale.
+			b.minimumFormatMajorVersion = max(b.minimumFormatMajorVersion, info.minFMV)
 			switch info.category {
 			case batchKindPoint:
 				// Contributes to index/memtable size below.


### PR DESCRIPTION
Previously, Batch.Apply asserted (under invariants) that the source batch's minimumFormatMajorVersion was at least the minimum required by each record kind. Not all batch construction paths populate the field; for example, SetRepr on a batch with a nil db skips refreshMemTableSize and leaves minimumFormatMajorVersion at zero

Replace the assertion with a ratchet of the receiver's minimumFormatMajorVersion from the per-kind lookup table. The receiver ends up with the correct floor regardless of how the source batch was constructed.