### PR TITLE
ci: disable nightly scheduling on master

### DIFF
--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -1,8 +1,6 @@
 name: Nightlies (master)
 
 on:
-  schedule:
-    - cron: '00 10 * * * ' # 10am UTC daily
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nightly-code-cover.yaml
+++ b/.github/workflows/nightly-code-cover.yaml
@@ -1,8 +1,6 @@
 name: Nightly code coverage
 
 on:
-  schedule:
-    - cron: '00 08 * * * '
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove the `schedule` trigger from both workflows while keeping `workflow_dispatch`, so they can still be triggered manually.