### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -480,7 +480,7 @@ var _ Reader = (*Batch)(nil)
 var _ Writer = (*Batch)(nil)
 
 var batchPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Batch{}
 	},
 }
@@ -491,7 +491,7 @@ type indexedBatch struct {
 }
 
 var indexedBatchPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &indexedBatch{}
 	},
 }
@@ -2584,7 +2584,7 @@ func WithMaxRetainedSizeBytes(s int) BatchOption {
 // intended for testing use only. The batch.Sort dance is done to prevent
 // exposing this method in the public pebble interface.
 func batchSort(
-	i interface{},
+	i any,
 ) (
 	points internalIterator,
 	rangeDels keyspan.FragmentIterator,

--- a/batch_test.go
+++ b/batch_test.go
@@ -1339,7 +1339,7 @@ func TestBatchRangeOps(t *testing.T) {
 func TestBatchTooLarge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var b Batch
-	var result interface{}
+	var result any
 	func() {
 		defer func() {
 			if r := recover(); r != nil {

--- a/bench/fsbench.go
+++ b/bench/fsbench.go
@@ -219,7 +219,7 @@ func (e *fsEnv) removeAllFiles(filepath string) {
 	}
 }
 
-func (e *fsEnv) verbosef(fmtstr string, args ...interface{}) {
+func (e *fsEnv) verbosef(fmtstr string, args ...any) {
 	if e.verbose {
 		fmt.Printf(fmtstr, args...)
 	}

--- a/blob_rewrite_test.go
+++ b/blob_rewrite_test.go
@@ -47,7 +47,7 @@ func TestBlobRewrite(t *testing.T) {
 		// the test. When testing a value separation policy that writes new blob
 		// files, this demonstrates the creation of new blob files and that
 		// they're created lazily, the first time a value is actually separated.
-		fs = vfs.WithLogging(vfs.NewMem(), func(format string, args ...interface{}) {
+		fs = vfs.WithLogging(vfs.NewMem(), func(format string, args ...any) {
 			fmt.Fprint(&buf, "# ")
 			fmt.Fprintf(&buf, format, args...)
 			fmt.Fprintln(&buf)

--- a/data_test.go
+++ b/data_test.go
@@ -1587,7 +1587,7 @@ func runIngestExternalCmd(
 ) error {
 	var external []ExternalFile
 	for line := range crstrings.LinesSeq(td.Input) {
-		usageErr := func(info interface{}) {
+		usageErr := func(info any) {
 			t.Helper()
 			td.Fatalf(t, "error parsing %q: %v; "+
 				"usage: obj bounds=(smallest,largest) [size=x] [synthetic-prefix=prefix] [synthetic-suffix=suffix] [no-point-keys] [has-range-keys]",

--- a/db.go
+++ b/db.go
@@ -1035,7 +1035,7 @@ func newIterAlloc() *iterAlloc {
 }
 
 var iterAllocPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &iterAlloc{}
 	},
 }
@@ -1068,7 +1068,7 @@ func newIterV2Alloc() *iterV2Alloc {
 }
 
 var iterV2AllocPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &iterV2Alloc{}
 	},
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1506,11 +1506,11 @@ type testTracer struct {
 	buf                                strings.Builder
 }
 
-func (t *testTracer) Infof(format string, args ...interface{})  {}
-func (t *testTracer) Errorf(format string, args ...interface{}) {}
-func (t *testTracer) Fatalf(format string, args ...interface{}) {}
+func (t *testTracer) Infof(format string, args ...any)  {}
+func (t *testTracer) Errorf(format string, args ...any) {}
+func (t *testTracer) Fatalf(format string, args ...any) {}
 
-func (t *testTracer) Eventf(ctx context.Context, format string, args ...interface{}) {
+func (t *testTracer) Eventf(ctx context.Context, format string, args ...any) {
 	if t.enabledOnlyForNonBackgroundContext && ctx == context.Background() {
 		return
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -28,10 +28,10 @@ import (
 
 type panicLogger struct{}
 
-func (l panicLogger) Infof(format string, args ...interface{})  {}
-func (l panicLogger) Errorf(format string, args ...interface{}) {}
+func (l panicLogger) Infof(format string, args ...any)  {}
+func (l panicLogger) Errorf(format string, args ...any) {}
 
-func (l panicLogger) Fatalf(format string, args ...interface{}) {
+func (l panicLogger) Fatalf(format string, args ...any) {
 	panic(errors.Errorf("fatal: "+format, args...))
 }
 

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -333,17 +333,17 @@ type redactLogger struct {
 }
 
 // Infof implements the Logger.Infof interface.
-func (l redactLogger) Infof(format string, args ...interface{}) {
+func (l redactLogger) Infof(format string, args ...any) {
 	l.logger.Infof("%s", redact.Sprintf(format, args...).Redact())
 }
 
 // Errorf implements the Logger.Errorf interface.
-func (l redactLogger) Errorf(format string, args ...interface{}) {
+func (l redactLogger) Errorf(format string, args ...any) {
 	l.logger.Errorf("%s", redact.Sprintf(format, args...).Redact())
 }
 
 // Fatalf implements the Logger.Fatalf interface.
-func (l redactLogger) Fatalf(format string, args ...interface{}) {
+func (l redactLogger) Fatalf(format string, args ...any) {
 	l.logger.Fatalf("%s", redact.Sprintf(format, args...).Redact())
 }
 
@@ -376,24 +376,24 @@ func TestMakeLoggingEventListenerSetsAllCallbacks(t *testing.T) {
 }
 
 type mockLogger struct {
-	infoFunc  func(format string, args ...interface{})
-	errorFunc func(format string, args ...interface{})
-	fatalFunc func(format string, args ...interface{})
+	infoFunc  func(format string, args ...any)
+	errorFunc func(format string, args ...any)
+	fatalFunc func(format string, args ...any)
 }
 
-func (l *mockLogger) Infof(format string, args ...interface{}) {
+func (l *mockLogger) Infof(format string, args ...any) {
 	if l.infoFunc != nil {
 		l.infoFunc(format, args...)
 	}
 }
 
-func (l *mockLogger) Errorf(format string, args ...interface{}) {
+func (l *mockLogger) Errorf(format string, args ...any) {
 	if l.errorFunc != nil {
 		l.errorFunc(format, args...)
 	}
 }
 
-func (l *mockLogger) Fatalf(format string, args ...interface{}) {
+func (l *mockLogger) Fatalf(format string, args ...any) {
 	if l.fatalFunc != nil {
 		l.fatalFunc(format, args...)
 	}
@@ -402,13 +402,13 @@ func (l *mockLogger) Fatalf(format string, args ...interface{}) {
 func newCountingMockLogger(t *testing.T) (*mockLogger, *int, *int) {
 	var infoCount, errorCount int
 	return &mockLogger{
-		infoFunc: func(format string, args ...interface{}) {
+		infoFunc: func(format string, args ...any) {
 			infoCount++
 		},
-		errorFunc: func(format string, args ...interface{}) {
+		errorFunc: func(format string, args ...any) {
 			errorCount++
 		},
-		fatalFunc: func(format string, args ...interface{}) {
+		fatalFunc: func(format string, args ...any) {
 			t.Fatal("Unexpected call to Fatalf")
 		},
 	}, &infoCount, &errorCount

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -1442,10 +1442,10 @@ type catchFatalLogger struct {
 
 var _ Logger = (*catchFatalLogger)(nil)
 
-func (tl *catchFatalLogger) Infof(format string, args ...interface{})  {}
-func (tl *catchFatalLogger) Errorf(format string, args ...interface{}) {}
+func (tl *catchFatalLogger) Infof(format string, args ...any)  {}
+func (tl *catchFatalLogger) Errorf(format string, args ...any) {}
 
-func (tl *catchFatalLogger) Fatalf(format string, args ...interface{}) {
+func (tl *catchFatalLogger) Fatalf(format string, args ...any) {
 	tl.fatalMsgs = append(tl.fatalMsgs, fmt.Sprintf(format, args...))
 }
 

--- a/filenames_test.go
+++ b/filenames_test.go
@@ -101,15 +101,15 @@ type noFatalLogger struct {
 	t *testing.T
 }
 
-func (l noFatalLogger) Infof(format string, args ...interface{}) {
+func (l noFatalLogger) Infof(format string, args ...any) {
 	l.t.Logf(format, args...)
 }
 
-func (l noFatalLogger) Errorf(format string, args ...interface{}) {
+func (l noFatalLogger) Errorf(format string, args ...any) {
 	l.t.Logf(format, args...)
 }
 
-func (l noFatalLogger) Fatalf(format string, args ...interface{}) {
+func (l noFatalLogger) Fatalf(format string, args ...any) {
 	l.t.Logf(format, args...)
 }
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1009,7 +1009,7 @@ func TestOverlappingIngestedSSTs(t *testing.T) {
 
 		require.NoError(t, mem.MkdirAll("ext", 0755))
 		opts = &Options{
-			FS: vfs.WithLogging(mem, func(format string, args ...interface{}) {
+			FS: vfs.WithLogging(mem, func(format string, args ...any) {
 				fsLog.Lock()
 				defer fsLog.Unlock()
 				fmt.Fprintf(&fsLog.buf, format+"\n", args...)
@@ -3428,17 +3428,17 @@ type fatalCapturingLogger struct {
 }
 
 // Infof implements the Logger interface.
-func (l *fatalCapturingLogger) Infof(fmt string, args ...interface{}) {
+func (l *fatalCapturingLogger) Infof(fmt string, args ...any) {
 	l.t.Logf(fmt, args...)
 }
 
 // Errorf implements the Logger interface.
-func (l *fatalCapturingLogger) Errorf(fmt string, args ...interface{}) {
+func (l *fatalCapturingLogger) Errorf(fmt string, args ...any) {
 	l.t.Logf(fmt, args...)
 }
 
 // Fatalf implements the Logger interface.
-func (l *fatalCapturingLogger) Fatalf(_ string, args ...interface{}) {
+func (l *fatalCapturingLogger) Fatalf(_ string, args ...any) {
 	l.err = args[0].(error)
 }
 

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -74,7 +74,7 @@ type Iterator struct {
 var _ base.InternalIterator = (*Iterator)(nil)
 
 var iterPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Iterator{}
 	},
 }

--- a/internal/ascii/whiteboard.go
+++ b/internal/ascii/whiteboard.go
@@ -178,7 +178,7 @@ func (c Cursor) SetColumn(col int) Cursor {
 
 // Printf writes the formatted string to cursor, returning a cursor where the
 // written text ends.
-func (c Cursor) Printf(format string, args ...interface{}) Cursor {
+func (c Cursor) Printf(format string, args ...any) Cursor {
 	return c.WriteString(fmt.Sprintf(format, args...))
 }
 

--- a/internal/base/directory_lock.go
+++ b/internal/base/directory_lock.go
@@ -85,7 +85,7 @@ func LockDirectory(dirname string, fs vfs.FS) (*DirLock, error) {
 	}
 	l := &DirLock{dirname: dirname, fileLock: fileLock}
 	l.refs.Store(1)
-	invariants.SetFinalizer(l, func(obj interface{}) {
+	invariants.SetFinalizer(l, func(obj any) {
 		if refs := obj.(*DirLock).refs.Load(); refs > 0 {
 			panic(errors.AssertionFailedf("lock for %q finalized with %d refs", errors.Safe(dirname), errors.Safe(refs)))
 		}

--- a/internal/base/error.go
+++ b/internal/base/error.go
@@ -33,7 +33,7 @@ func IsCorruptionError(err error) bool {
 
 // CorruptionErrorf formats according to a format specifier and returns
 // the string as an error value that is marked as a corruption error.
-func CorruptionErrorf(format string, args ...interface{}) error {
+func CorruptionErrorf(format string, args ...any) error {
 	return errors.Mark(errors.Newf(format, args...), ErrCorruption)
 }
 
@@ -67,7 +67,7 @@ func ExtractCorruptBlockData(err error) []byte {
 
 // AssertionFailedf creates an assertion error and panics in invariants.Enabled
 // builds. It should only be used when it indicates a bug.
-func AssertionFailedf(format string, args ...interface{}) error {
+func AssertionFailedf(format string, args ...any) error {
 	err := errors.AssertionFailedf(format, args...)
 	if invariants.Enabled {
 		panic(err)

--- a/internal/base/filenames.go
+++ b/internal/base/filenames.go
@@ -287,7 +287,7 @@ func ParseDiskFileNum(s string) (dfn DiskFileNum, ok bool) {
 
 // A Fataler fatals a process with a message when called.
 type Fataler interface {
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 }
 
 // MustExist checks if err is an error indicating a file does not exist.

--- a/internal/base/filenames_test.go
+++ b/internal/base/filenames_test.go
@@ -112,7 +112,7 @@ type bufferFataler struct {
 	buf bytes.Buffer
 }
 
-func (b *bufferFataler) Fatalf(msg string, args ...interface{}) {
+func (b *bufferFataler) Fatalf(msg string, args ...any) {
 	fmt.Fprintf(&b.buf, msg, args...)
 }
 

--- a/internal/base/logger.go
+++ b/internal/base/logger.go
@@ -18,9 +18,9 @@ import (
 
 // Logger defines an interface for writing log messages.
 type Logger interface {
-	Infof(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
+	Infof(format string, args ...any)
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
 }
 type defaultLogger struct{}
 
@@ -30,17 +30,17 @@ var DefaultLogger defaultLogger
 var _ Logger = DefaultLogger
 
 // Infof implements the Logger.Infof interface.
-func (defaultLogger) Infof(format string, args ...interface{}) {
+func (defaultLogger) Infof(format string, args ...any) {
 	_ = log.Output(2, fmt.Sprintf(format, args...))
 }
 
 // Errorf implements the Logger.Errorf interface.
-func (defaultLogger) Errorf(format string, args ...interface{}) {
+func (defaultLogger) Errorf(format string, args ...any) {
 	_ = log.Output(2, fmt.Sprintf(format, args...))
 }
 
 // Fatalf implements the Logger.Fatalf interface.
-func (defaultLogger) Fatalf(format string, args ...interface{}) {
+func (defaultLogger) Fatalf(format string, args ...any) {
 	_ = log.Output(2, fmt.Sprintf(format, args...))
 	os.Exit(1)
 }
@@ -71,7 +71,7 @@ func (b *InMemLogger) String() string {
 }
 
 // Infof is part of the Logger interface.
-func (b *InMemLogger) Infof(format string, args ...interface{}) {
+func (b *InMemLogger) Infof(format string, args ...any) {
 	s := fmt.Sprintf(format, args...)
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -82,12 +82,12 @@ func (b *InMemLogger) Infof(format string, args ...interface{}) {
 }
 
 // Errorf is part of the Logger interface.
-func (b *InMemLogger) Errorf(format string, args ...interface{}) {
+func (b *InMemLogger) Errorf(format string, args ...any) {
 	b.Infof(format, args...)
 }
 
 // Fatalf is part of the Logger interface.
-func (b *InMemLogger) Fatalf(format string, args ...interface{}) {
+func (b *InMemLogger) Fatalf(format string, args ...any) {
 	b.Infof("FATAL: "+format, args...)
 }
 
@@ -97,7 +97,7 @@ type LoggerAndTracer interface {
 	// Eventf formats and emits a tracing log, if tracing is enabled in the
 	// current context. It can also emit to a regular log, if expensive
 	// logging is enabled.
-	Eventf(ctx context.Context, format string, args ...interface{})
+	Eventf(ctx context.Context, format string, args ...any)
 	// IsTracingEnabled returns true if tracing is enabled for this context,
 	// or expensive logging is enabled. It can be used as an optimization to
 	// avoid calling Eventf (which will be a noop when tracing or expensive
@@ -113,7 +113,7 @@ type LoggerWithNoopTracer struct {
 var _ LoggerAndTracer = &LoggerWithNoopTracer{}
 
 // Eventf implements LoggerAndTracer.
-func (*LoggerWithNoopTracer) Eventf(ctx context.Context, format string, args ...interface{}) {
+func (*LoggerWithNoopTracer) Eventf(ctx context.Context, format string, args ...any) {
 	if invariants.Enabled && ctx == nil {
 		panic(errors.AssertionFailedf("Eventf context is nil"))
 	}
@@ -135,16 +135,16 @@ type NoopLoggerAndTracer struct{}
 var _ LoggerAndTracer = NoopLoggerAndTracer{}
 
 // Infof implements LoggerAndTracer.
-func (l NoopLoggerAndTracer) Infof(format string, args ...interface{}) {}
+func (l NoopLoggerAndTracer) Infof(format string, args ...any) {}
 
 // Errorf implements LoggerAndTracer.
-func (l NoopLoggerAndTracer) Errorf(format string, args ...interface{}) {}
+func (l NoopLoggerAndTracer) Errorf(format string, args ...any) {}
 
 // Fatalf implements LoggerAndTracer.
-func (l NoopLoggerAndTracer) Fatalf(format string, args ...interface{}) {}
+func (l NoopLoggerAndTracer) Fatalf(format string, args ...any) {}
 
 // Eventf implements LoggerAndTracer.
-func (l NoopLoggerAndTracer) Eventf(ctx context.Context, format string, args ...interface{}) {
+func (l NoopLoggerAndTracer) Eventf(ctx context.Context, format string, args ...any) {
 	if invariants.Enabled && ctx == nil {
 		panic(errors.AssertionFailedf("Eventf context is nil"))
 	}

--- a/internal/binfmt/binfmt.go
+++ b/internal/binfmt/binfmt.go
@@ -110,7 +110,7 @@ func (f *Formatter) PeekUint(w int) uint64 {
 
 // Byte formats a single byte in binary format, displaying each bit as a zero or
 // one.
-func (f *Formatter) Byte(format string, args ...interface{}) int {
+func (f *Formatter) Byte(format string, args ...any) int {
 	f.printOffsets(1)
 	f.printf("b %08b", f.data[f.off])
 	f.off++
@@ -120,7 +120,7 @@ func (f *Formatter) Byte(format string, args ...interface{}) int {
 
 // HexBytesln formats the next n bytes in hexadecimal format, appending the
 // formatted comment string to each line and ending on a newline.
-func (f *Formatter) HexBytesln(n int, format string, args ...interface{}) int {
+func (f *Formatter) HexBytesln(n int, format string, args ...any) int {
 	commentLine := strings.TrimSpace(fmt.Sprintf(format, args...))
 	printLine := func() {
 		bytesInLine := min(f.lineWidth/2, n)
@@ -164,7 +164,7 @@ func (f *Formatter) HexTextln(n int) int {
 
 // Uvarint decodes the bytes at the current offset as a uvarint, formatting them
 // in hexadecimal and prefixing the comment with the encoded decimal value.
-func (f *Formatter) Uvarint(format string, args ...interface{}) {
+func (f *Formatter) Uvarint(format string, args ...any) {
 	comment := fmt.Sprintf(format, args...)
 	v, n := binary.Uvarint(f.data[f.off:])
 	f.HexBytesln(n, "uvarint(%d): %s", v, comment)
@@ -239,7 +239,7 @@ func (f *Formatter) printOffsets(n int) {
 	f.printf(f.offsetFormatStr, f.off, f.off+n)
 }
 
-func (f *Formatter) printf(format string, args ...interface{}) {
+func (f *Formatter) printf(format string, args ...any) {
 	fmt.Fprintf(&f.buf, format, args...)
 }
 
@@ -280,7 +280,7 @@ func (l Line) HexBytes(n int) Line {
 }
 
 // Done finishes the line, appending the provided comment if any.
-func (l Line) Done(format string, args ...interface{}) int {
+func (l Line) Done(format string, args ...any) int {
 	if l.n != l.i {
 		panic(errors.AssertionFailedf("unconsumed data in line"))
 	}

--- a/internal/cache/block_map.go
+++ b/internal/cache/block_map.go
@@ -54,7 +54,7 @@ func newBlockMap(initialCapacity int) *blockMap {
 	m.Init(initialCapacity)
 
 	// Note: this is a no-op if invariants are disabled or race is enabled.
-	invariants.SetFinalizer(m, func(obj interface{}) {
+	invariants.SetFinalizer(m, func(obj any) {
 		m := obj.(*blockMap)
 		if !m.closed {
 			fmt.Fprintf(os.Stderr, "%p: block-map not closed\n", m)

--- a/internal/cache/entry.go
+++ b/internal/cache/entry.go
@@ -182,7 +182,7 @@ func entryAllocNew() *entry {
 		// We want to allocate each entry independently to check that it has been
 		// properly cleaned up.
 		e := &entry{}
-		invariants.SetFinalizer(e, func(obj interface{}) {
+		invariants.SetFinalizer(e, func(obj any) {
 			e := obj.(*entry)
 			if *e != (entry{}) {
 				fmt.Fprintf(os.Stderr, "%p: entry was not freed", e)
@@ -209,7 +209,7 @@ func entryAllocFree(e *entry) {
 }
 
 var entryAllocPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return newEntryAllocCache()
 	},
 }
@@ -236,7 +236,7 @@ func newEntryAllocCache() *entryAllocCache {
 	return c
 }
 
-func freeEntryAllocCache(obj interface{}) {
+func freeEntryAllocCache(obj any) {
 	c := obj.(*entryAllocCache)
 	for i, e := range c.entries {
 		c.dealloc(e)

--- a/internal/cache/read_shard.go
+++ b/internal/cache/read_shard.go
@@ -157,7 +157,7 @@ type readEntry struct {
 }
 
 var readEntryPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &readEntry{}
 	},
 }

--- a/internal/cache/value.go
+++ b/internal/cache/value.go
@@ -65,7 +65,7 @@ func Alloc(n int) *Value {
 		v.ref.init(1)
 		// Note: this is a no-op if invariants and tracing are disabled or race is
 		// enabled.
-		invariants.SetFinalizer(v, func(obj interface{}) {
+		invariants.SetFinalizer(v, func(obj any) {
 			v := obj.(*Value)
 			if v.buf != nil {
 				fmt.Fprintf(os.Stderr, "%p: cache value was not freed: refs=%d\n%s",

--- a/internal/devtools/roachvet/forbidden_imports.go
+++ b/internal/devtools/roachvet/forbidden_imports.go
@@ -96,7 +96,7 @@ func checkTransitiveImports(pass *analysis.Pass) {
 	}
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	// Only check allowed top-level packages
 	if !packagesToCheck[pass.Pkg.Path()] {
 		return nil, nil

--- a/internal/intern/intern.go
+++ b/internal/intern/intern.go
@@ -7,7 +7,7 @@ package intern
 import "sync"
 
 var pool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return make(map[string]string)
 	},
 }

--- a/internal/invariants/invariants.go
+++ b/internal/invariants/invariants.go
@@ -37,7 +37,7 @@ const UseFinalizers = !buildtags.Race && (buildtags.Invariants || buildtags.Trac
 // This function is a no-op if UseFinalizers is false and it should inline to
 // nothing. However, note that it might not inline so in very hot paths it's
 // best to check UseFinalizers first.
-func SetFinalizer(obj, finalizer interface{}) {
+func SetFinalizer(obj, finalizer any) {
 	if UseFinalizers {
 		runtime.SetFinalizer(obj, finalizer)
 	}

--- a/internal/iterv2/op_check_iter.go
+++ b/internal/iterv2/op_check_iter.go
@@ -33,7 +33,7 @@ type IllegalOpError struct {
 
 func (e *IllegalOpError) Error() string { return e.msg }
 
-func illegalOpf(format string, args ...interface{}) *IllegalOpError {
+func illegalOpf(format string, args ...any) *IllegalOpError {
 	return &IllegalOpError{msg: fmt.Sprintf(format, args...)}
 }
 

--- a/internal/iterv2/test_utils.go
+++ b/internal/iterv2/test_utils.go
@@ -25,8 +25,8 @@ import (
 // without a direct dependency on the testing package.
 type TB interface {
 	Helper()
-	Logf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
+	Logf(format string, args ...any)
+	Fatalf(format string, args ...any)
 	Failed() bool
 }
 

--- a/internal/keyspan/assert_iter.go
+++ b/internal/keyspan/assert_iter.go
@@ -81,7 +81,7 @@ type assertIter struct {
 
 var _ FragmentIterator = (*assertIter)(nil)
 
-func (i *assertIter) panicf(format string, args ...interface{}) {
+func (i *assertIter) panicf(format string, args ...any) {
 	str := fmt.Sprintf(format, args...)
 	panic(errors.AssertionFailedf("%s; wraps %T", str, i.iter))
 }

--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -399,7 +399,7 @@ func saveDirs(t testing.TB, d dirsToSave) {
 	}
 }
 
-func fatalf(t testing.TB, fatalOnce *sync.Once, dirs dirsToSave, msg string, args ...interface{}) {
+func fatalf(t testing.TB, fatalOnce *sync.Once, dirs dirsToSave, msg string, args ...any) {
 	fatalOnce.Do(func() {
 		saveDirs(t, dirs)
 		t.Fatalf(msg, args...)

--- a/internal/metamorphic/metarunner/main.go
+++ b/internal/metamorphic/metarunner/main.go
@@ -52,7 +52,7 @@ type mockT struct {
 
 var _ metamorphic.TestingT = (*mockT)(nil)
 
-func (t *mockT) Errorf(format string, args ...interface{}) {
+func (t *mockT) Errorf(format string, args ...any) {
 	t.failed = true
 	fmt.Fprintf(os.Stderr, format+"\n", args...)
 }

--- a/internal/mkbench/util.go
+++ b/internal/mkbench/util.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 )
 
-func prettyJSON(v interface{}) []byte {
+func prettyJSON(v any) []byte {
 	data, err := json.MarshalIndent(v, "", "\t")
 	if err != nil {
 		log.Fatal(err)

--- a/internal/private/batch.go
+++ b/internal/private/batch.go
@@ -12,7 +12,7 @@ import (
 // BatchSort is a hook for constructing iterators over the point and range
 // mutations contained in a batch in sorted order. It is intended for testing
 // use only.
-var BatchSort func(interface{}) (
+var BatchSort func(any) (
 	points base.InternalIterator,
 	rangeDels keyspan.FragmentIterator,
 	rangeKeys keyspan.FragmentIterator,

--- a/internal/rangedel/rangedel.go
+++ b/internal/rangedel/rangedel.go
@@ -90,7 +90,7 @@ func Interleave(
 }
 
 var interleavingIterPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &interleavingIter{}
 	},
 }

--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -11,15 +11,15 @@ type Logger struct {
 	T testing.TB
 }
 
-func (l Logger) Infof(format string, args ...interface{}) {
+func (l Logger) Infof(format string, args ...any) {
 	l.T.Logf(format, args...)
 }
 
-func (l Logger) Errorf(format string, args ...interface{}) {
+func (l Logger) Errorf(format string, args ...any) {
 	l.T.Logf(format, args...)
 }
 
-func (l Logger) Fatalf(format string, args ...interface{}) {
+func (l Logger) Fatalf(format string, args ...any) {
 	l.T.Helper()
 	l.T.Fatalf(format, args...)
 }

--- a/internal/treeprinter/tree_printer.go
+++ b/internal/treeprinter/tree_printer.go
@@ -235,7 +235,7 @@ func (t *tree) addRow(level int, text string) (rowIdx int) {
 }
 
 // Childf adds a node as a child of the given node.
-func (n Node) Childf(format string, args ...interface{}) Node {
+func (n Node) Childf(format string, args ...any) Node {
 	return n.Child(fmt.Sprintf(format, args...))
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -493,7 +493,7 @@ func (b *rangeKeyBuffers) PrepareForReuse() {
 }
 
 var iterRangeKeyStateAllocPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &iteratorRangeKeyState{}
 	},
 }

--- a/mem_table.go
+++ b/mem_table.go
@@ -110,7 +110,7 @@ type memTableOptions struct {
 	releaseAccountingReservation func()
 }
 
-func checkMemTable(obj interface{}) {
+func checkMemTable(obj any) {
 	m := obj.(*memTable)
 	if m.arenaBuf.Data() != nil {
 		fmt.Fprintf(os.Stderr, "%v: memTable buffer was not freed\n", m.arenaBuf)

--- a/metamorphic/history.go
+++ b/metamorphic/history.go
@@ -49,7 +49,7 @@ func (h *history) Close() {
 	h.mu.Unlock()
 }
 
-func (h *history) Recordf(op int, format string, args ...interface{}) {
+func (h *history) Recordf(op int, format string, args ...any) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.mu.closed {
@@ -83,7 +83,7 @@ func (h *history) Error() error {
 	return nil
 }
 
-func (h *history) format(typ, format string, args ...interface{}) string {
+func (h *history) format(typ, format string, args ...any) string {
 	var buf strings.Builder
 	orig := fmt.Sprintf(format, args...)
 	timestamp := time.Now().Format("15:04:05.000")
@@ -95,7 +95,7 @@ func (h *history) format(typ, format string, args ...interface{}) string {
 
 // Infof implements the pebble.Logger interface. Note that the output is
 // commented.
-func (h *history) Infof(format string, args ...interface{}) {
+func (h *history) Infof(format string, args ...any) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	// Suppress any messages that come after closing. This could happen if the
@@ -107,7 +107,7 @@ func (h *history) Infof(format string, args ...interface{}) {
 
 // Errorf implements the pebble.Logger interface. Note that the output is
 // commented.
-func (h *history) Errorf(format string, args ...interface{}) {
+func (h *history) Errorf(format string, args ...any) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	// Suppress any messages that come after closing. This could happen if the
@@ -119,7 +119,7 @@ func (h *history) Errorf(format string, args ...interface{}) {
 
 // Fatalf implements the pebble.Logger interface. Note that the output is
 // commented.
-func (h *history) Fatalf(format string, args ...interface{}) {
+func (h *history) Fatalf(format string, args ...any) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.mu.closed {
@@ -131,7 +131,7 @@ func (h *history) Fatalf(format string, args ...interface{}) {
 }
 
 func (h *history) recorder(
-	thread int, op int, optionalRecordf func(format string, args ...interface{}),
+	thread int, op int, optionalRecordf func(format string, args ...any),
 ) historyRecorder {
 	return historyRecorder{
 		history:         h,
@@ -145,11 +145,11 @@ func (h *history) recorder(
 type historyRecorder struct {
 	history         *history
 	op              int
-	optionalRecordf func(string, ...interface{})
+	optionalRecordf func(string, ...any)
 }
 
 // Recordf records the results of a single operation.
-func (h historyRecorder) Recordf(format string, args ...interface{}) {
+func (h historyRecorder) Recordf(format string, args ...any) {
 	// Check for assertion errors.
 	for _, a := range args {
 		if err, ok := a.(error); ok && errors.IsAssertionFailure(err) {

--- a/metamorphic/parser.go
+++ b/metamorphic/parser.go
@@ -23,7 +23,7 @@ type methodInfo struct {
 	validTags   uint32
 }
 
-func makeMethod(i interface{}, tags ...objTag) *methodInfo {
+func makeMethod(i any, tags ...objTag) *methodInfo {
 	var validTags uint32
 	for _, tag := range tags {
 		validTags |= 1 << tag
@@ -46,92 +46,92 @@ func makeMethod(i interface{}, tags ...objTag) *methodInfo {
 // The argument list returns pointers to operation fields that map to arguments
 // for the operation. The last argument can be a pointer to a slice,
 // corresponding to a variable number of arguments.
-func opArgs(op op) (receiverID *objID, targetID *objID, args []interface{}) {
+func opArgs(op op) (receiverID *objID, targetID *objID, args []any) {
 	switch t := op.(type) {
 	case *applyOp:
-		return &t.writerID, nil, []interface{}{&t.batchID}
+		return &t.writerID, nil, []any{&t.batchID}
 	case *checkpointOp:
-		return &t.dbID, nil, []interface{}{&t.spans}
+		return &t.dbID, nil, []any{&t.spans}
 	case *closeOp:
 		return &t.objID, nil, nil
 	case *compactOp:
-		return &t.dbID, nil, []interface{}{&t.start, &t.end, &t.parallelize}
+		return &t.dbID, nil, []any{&t.start, &t.end, &t.parallelize}
 	case *batchCommitOp:
 		return &t.batchID, nil, nil
 	case *dbRatchetFormatMajorVersionOp:
-		return &t.dbID, nil, []interface{}{&t.vers}
+		return &t.dbID, nil, []any{&t.vers}
 	case *dbRestartOp:
 		return &t.dbID, nil, nil
 	case *deleteOp:
-		return &t.writerID, nil, []interface{}{&t.key}
+		return &t.writerID, nil, []any{&t.key}
 	case *deleteRangeOp:
-		return &t.writerID, nil, []interface{}{&t.start, &t.end}
+		return &t.writerID, nil, []any{&t.start, &t.end}
 	case *downloadOp:
-		return &t.dbID, nil, []interface{}{&t.spans}
+		return &t.dbID, nil, []any{&t.spans}
 	case *iterFirstOp:
 		return &t.iterID, nil, nil
 	case *flushOp:
 		return &t.db, nil, nil
 	case *getOp:
-		return &t.readerID, nil, []interface{}{&t.key}
+		return &t.readerID, nil, []any{&t.key}
 	case *ingestOp:
-		return &t.dbID, nil, []interface{}{&t.batchIDs}
+		return &t.dbID, nil, []any{&t.batchIDs}
 	case *ingestAndExciseOp:
-		return &t.dbID, nil, []interface{}{&t.batchID, &t.exciseStart, &t.exciseEnd, ignoreExtraArgs{}}
+		return &t.dbID, nil, []any{&t.batchID, &t.exciseStart, &t.exciseEnd, ignoreExtraArgs{}}
 	case *ingestExternalFilesOp:
-		return &t.dbID, nil, []interface{}{&t.objs}
+		return &t.dbID, nil, []any{&t.objs}
 	case *initOp:
-		return nil, nil, []interface{}{&t.dbSlots, &t.batchSlots, &t.iterSlots, &t.snapshotSlots, &t.externalObjSlots}
+		return nil, nil, []any{&t.dbSlots, &t.batchSlots, &t.iterSlots, &t.snapshotSlots, &t.externalObjSlots}
 	case *iterLastOp:
 		return &t.iterID, nil, nil
 	case *logDataOp:
-		return &t.writerID, nil, []interface{}{&t.data}
+		return &t.writerID, nil, []any{&t.data}
 	case *mergeOp:
-		return &t.writerID, nil, []interface{}{&t.key, &t.value}
+		return &t.writerID, nil, []any{&t.key, &t.value}
 	case *newBatchOp:
 		return &t.dbID, &t.batchID, nil
 	case *newIndexedBatchOp:
 		return &t.dbID, &t.batchID, nil
 	case *newIterOp:
-		return &t.readerID, &t.iterID, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.flags}
+		return &t.readerID, &t.iterID, []any{&t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.flags}
 	case *newIterUsingCloneOp:
-		return &t.existingIterID, &t.iterID, []interface{}{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.flags}
+		return &t.existingIterID, &t.iterID, []any{&t.refreshBatch, &t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.flags}
 	case *newSnapshotOp:
-		return &t.dbID, &t.snapID, []interface{}{&t.bounds}
+		return &t.dbID, &t.snapID, []any{&t.bounds}
 	case *newExternalObjOp:
 		return &t.batchID, &t.externalObjID, nil
 	case *iterNextOp:
-		return &t.iterID, nil, []interface{}{&t.limit}
+		return &t.iterID, nil, []any{&t.limit}
 	case *iterNextPrefixOp:
 		return &t.iterID, nil, nil
 	case *iterCanSingleDelOp:
-		return &t.iterID, nil, []interface{}{}
+		return &t.iterID, nil, []any{}
 	case *iterPrevOp:
-		return &t.iterID, nil, []interface{}{&t.limit}
+		return &t.iterID, nil, []any{&t.limit}
 	case *iterSeekLTOp:
-		return &t.iterID, nil, []interface{}{&t.key, &t.limit}
+		return &t.iterID, nil, []any{&t.key, &t.limit}
 	case *iterSeekGEOp:
-		return &t.iterID, nil, []interface{}{&t.key, &t.limit}
+		return &t.iterID, nil, []any{&t.key, &t.limit}
 	case *iterSeekPrefixGEOp:
-		return &t.iterID, nil, []interface{}{&t.key}
+		return &t.iterID, nil, []any{&t.key}
 	case *setOp:
-		return &t.writerID, nil, []interface{}{&t.key, &t.value}
+		return &t.writerID, nil, []any{&t.key, &t.value}
 	case *iterSetBoundsOp:
-		return &t.iterID, nil, []interface{}{&t.lower, &t.upper}
+		return &t.iterID, nil, []any{&t.lower, &t.upper}
 	case *iterSetOptionsOp:
-		return &t.iterID, nil, []interface{}{&t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.flags}
+		return &t.iterID, nil, []any{&t.lower, &t.upper, &t.keyTypes, &t.filterMax, &t.filterMin, &t.useL6Filters, &t.maskSuffix, &t.flags}
 	case *singleDeleteOp:
-		return &t.writerID, nil, []interface{}{&t.key, &t.maybeReplaceDelete}
+		return &t.writerID, nil, []any{&t.key, &t.maybeReplaceDelete}
 	case *rangeKeyDeleteOp:
-		return &t.writerID, nil, []interface{}{&t.start, &t.end}
+		return &t.writerID, nil, []any{&t.start, &t.end}
 	case *rangeKeySetOp:
-		return &t.writerID, nil, []interface{}{&t.start, &t.end, &t.suffix, &t.value}
+		return &t.writerID, nil, []any{&t.start, &t.end, &t.suffix, &t.value}
 	case *rangeKeyUnsetOp:
-		return &t.writerID, nil, []interface{}{&t.start, &t.end, &t.suffix}
+		return &t.writerID, nil, []any{&t.start, &t.end, &t.suffix}
 	case *replicateOp:
-		return &t.source, nil, []interface{}{&t.dest, &t.start, &t.end}
+		return &t.source, nil, []any{&t.dest, &t.start, &t.end}
 	case *estimateDiskUsageOp:
-		return &t.dbID, nil, []interface{}{&t.start, &t.end}
+		return &t.dbID, nil, []any{&t.start, &t.end}
 	}
 	panic(errors.AssertionFailedf("unsupported op type: %T", op))
 }
@@ -330,12 +330,12 @@ func unquoteBytes(lit string) []byte {
 	return []byte(s)
 }
 
-func (p *parser) parseArgs(op op, methodName string, args []interface{}) {
+func (p *parser) parseArgs(op op, methodName string, args []any) {
 	pos, list := p.parseList()
 	p.scanToken(token.SEMICOLON)
 
 	// The last argument can have variable length.
-	var varArg interface{}
+	var varArg any
 	if len(args) > 0 {
 		switch args[len(args)-1].(type) {
 		case *iterFlags, *[]objID, *[]pebble.KeyRange, *[]pebble.CheckpointSpan, *[]pebble.DownloadSpan, *[]externalObjWithBounds, ignoreExtraArgs:
@@ -680,7 +680,7 @@ func (p *parser) tokenf(tok token.Token, lit string) string {
 	return tok.String()
 }
 
-func (p *parser) errorf(pos token.Pos, format string, args ...interface{}) error {
+func (p *parser) errorf(pos token.Pos, format string, args ...any) error {
 	return errors.New("metamorphic test internal error: " + p.fset.Position(pos).String() + ": " + fmt.Sprintf(format, args...))
 }
 

--- a/metamorphic/test.go
+++ b/metamorphic/test.go
@@ -410,14 +410,14 @@ func (t *Test) saveInMemoryData() {
 // Step may be used instead of Execute to advance a test one operation at a
 // time.
 func (t *Test) Step() (more bool, operationOutput string, err error) {
-	more = t.step(t.h, func(format string, args ...interface{}) {
+	more = t.step(t.h, func(format string, args ...any) {
 		operationOutput = fmt.Sprintf(format, args...)
 	})
 	err = t.h.Error()
 	return more, operationOutput, err
 }
 
-func (t *Test) step(h *history, optionalRecordf func(string, ...interface{})) bool {
+func (t *Test) step(h *history, optionalRecordf func(string, ...any)) bool {
 	if t.idx >= len(t.ops) {
 		return false
 	}

--- a/objstorage/objstorageprovider/provider_test.go
+++ b/objstorage/objstorageprovider/provider_test.go
@@ -36,10 +36,10 @@ import (
 func TestProvider(t *testing.T) {
 	datadriven.Walk(t, "testdata/provider", func(t *testing.T, path string) {
 		var log base.InMemLogger
-		fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...interface{}) {
+		fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...any) {
 			log.Infof("<local fs> "+fmt, args...)
 		})
-		sharedStore := remote.WithLogging(remote.NewInMem(), func(fmt string, args ...interface{}) {
+		sharedStore := remote.WithLogging(remote.NewInMem(), func(fmt string, args ...any) {
 			log.Infof("<remote> "+fmt, args...)
 		})
 		sharedFactory := remote.MakeSimpleFactory(map[remote.Locator]remote.Storage{

--- a/objstorage/objstorageprovider/remote_readable.go
+++ b/objstorage/objstorageprovider/remote_readable.go
@@ -174,7 +174,7 @@ type remoteReadHandle struct {
 var _ objstorage.ReadHandle = (*remoteReadHandle)(nil)
 
 var remoteReadHandlePool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &remoteReadHandle{}
 	},
 }

--- a/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
+++ b/objstorage/objstorageprovider/sharedcache/shared_cache_test.go
@@ -25,7 +25,7 @@ func TestSharedCache(t *testing.T) {
 
 	datadriven.Walk(t, "testdata/cache", func(t *testing.T, path string) {
 		var log base.InMemLogger
-		fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...interface{}) {
+		fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...any) {
 			log.Infof("<local fs> "+fmt, args...)
 		})
 
@@ -119,7 +119,7 @@ func TestSharedCacheRandomized(t *testing.T) {
 	ctx := context.Background()
 
 	var log base.InMemLogger
-	fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...interface{}) {
+	fs := vfs.WithLogging(vfs.NewMem(), func(fmt string, args ...any) {
 		log.Infof("<local fs> "+fmt, args...)
 	})
 

--- a/objstorage/objstorageprovider/vfs_readable.go
+++ b/objstorage/objstorageprovider/vfs_readable.go
@@ -53,7 +53,7 @@ func newFileReadable(
 	}
 	if invariants.UseFinalizers {
 		stack := debug.Stack()
-		invariants.SetFinalizer(r, func(obj interface{}) {
+		invariants.SetFinalizer(r, func(obj any) {
 			if obj.(*fileReadable).file != nil {
 				fmt.Fprintf(os.Stderr, "Readable %s was not closed\n%s", filename, stack)
 				os.Exit(1)
@@ -107,10 +107,10 @@ type vfsReadHandle struct {
 var _ objstorage.ReadHandle = (*vfsReadHandle)(nil)
 
 var readHandlePool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		i := &vfsReadHandle{}
 		if invariants.UseFinalizers {
-			invariants.SetFinalizer(i, func(obj interface{}) {
+			invariants.SetFinalizer(i, func(obj any) {
 				if obj.(*vfsReadHandle).r != nil {
 					fmt.Fprintf(os.Stderr, "ReadHandle was not closed")
 					os.Exit(1)

--- a/objstorage/remote/logging.go
+++ b/objstorage/remote/logging.go
@@ -13,7 +13,7 @@ import (
 
 // WithLogging wraps the given Storage implementation and emits logs for various
 // operations.
-func WithLogging(wrapped Storage, logf func(fmt string, args ...interface{})) Storage {
+func WithLogging(wrapped Storage, logf func(fmt string, args ...any)) Storage {
 	return &loggingStore{
 		logf:    logf,
 		wrapped: wrapped,
@@ -23,7 +23,7 @@ func WithLogging(wrapped Storage, logf func(fmt string, args ...interface{})) St
 // loggingStore wraps a remote.Storage implementation and emits logs of the
 // operations.
 type loggingStore struct {
-	logf    func(fmt string, args ...interface{})
+	logf    func(fmt string, args ...any)
 	wrapped Storage
 }
 
@@ -127,7 +127,7 @@ func (l *loggingStore) Size(objName string) (int64, error) {
 	return size, err
 }
 
-func errOrPrintf(err error, format string, args ...interface{}) string {
+func errOrPrintf(err error, format string, args ...any) string {
 	if err != nil {
 		return fmt.Sprintf("error: %v", err)
 	}

--- a/open.go
+++ b/open.go
@@ -517,7 +517,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	// finializer limitation by setting a finalizer on another object that is
 	// tied to the lifetime of DB: the DB.closed atomic.Value.
 	dPtr := fmt.Sprintf("%p", d)
-	invariants.SetFinalizer(d.closed, func(obj interface{}) {
+	invariants.SetFinalizer(d.closed, func(obj any) {
 		v := obj.(*atomic.Value)
 		if err := v.Load(); err == nil {
 			fmt.Fprintf(os.Stderr, "%s: unreferenced DB not closed\n", dPtr)

--- a/open_test.go
+++ b/open_test.go
@@ -1889,7 +1889,7 @@ func TestMkdirAllAndSyncParents(t *testing.T) {
 			if p, ok := rootPaths[fsName]; ok {
 				t.Chdir(p)
 			}
-			fs := vfs.WithLogging(filesystems[fsName], func(format string, args ...interface{}) {
+			fs := vfs.WithLogging(filesystems[fsName], func(format string, args ...any) {
 				fmt.Fprintf(&buf, format+"\n", args...)
 			})
 			f, err := mkdirAllAndSyncParents(fs, path)

--- a/record/record.go
+++ b/record/record.go
@@ -278,7 +278,7 @@ type Reader struct {
 }
 
 type loggerForTesting interface {
-	logf(format string, args ...interface{})
+	logf(format string, args ...any)
 }
 
 // NewReader returns a new reader. If the file contains records encoded using

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -903,7 +903,7 @@ func (l *readerLogger) getLog() string {
 	return l.builder.String()
 }
 
-func (l *readerLogger) logf(format string, args ...interface{}) {
+func (l *readerLogger) logf(format string, args ...any) {
 	fmt.Fprintf(&l.builder, format, args...)
 }
 

--- a/scan_internal.go
+++ b/scan_internal.go
@@ -1377,7 +1377,7 @@ type scanInternalIterAlloc struct {
 }
 
 var scanInternalIteratorIterAllocPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &scanInternalIterAlloc{}
 	},
 }

--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -184,7 +184,7 @@ func NewFileWriter(fn base.DiskFileNum, w objstorage.Writable, opts FileWriterOp
 }
 
 var writerPool = sync.Pool{
-	New: func() interface{} { return &FileWriter{} },
+	New: func() any { return &FileWriter{} },
 }
 
 // AddValue adds the provided value to the blob file, returning a Handle

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -58,7 +58,7 @@ func SuggestedCachedReaders(readAmp int) int {
 // retaining a recycled iterator's pool, because not all iterators need to
 // retrieve separated values.
 var cachedReaderPool sync.Pool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &cachedReaderSet{}
 	},
 }

--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -514,7 +514,7 @@ func (r *Reader) doRead(
 	}
 	readDuration := readStopwatch.Stop()
 	// Call IsTracingEnabled to avoid the allocations of boxing integers into an
-	// interface{}, unless necessary.
+	// any, unless necessary.
 	if (readDuration+waitBeforeReadDuration) >= base.SlowReadTracingThreshold &&
 		r.opts.LoggerAndTracer.IsTracingEnabled(ctx) {
 		_, file1, line1, _ := runtime.Caller(1)
@@ -636,7 +636,7 @@ func ReadRaw(
 	}
 	readDuration := readStopwatch.Stop()
 	// Call IsTracingEnabled to avoid the allocations of boxing integers into an
-	// interface{}, unless necessary.
+	// any, unless necessary.
 	if readDuration >= base.SlowReadTracingThreshold && logger.IsTracingEnabled(ctx) {
 		logger.Eventf(ctx, "reading footer of %d bytes took %v",
 			len(buf), readDuration)

--- a/sstable/block_property.go
+++ b/sstable/block_property.go
@@ -92,7 +92,7 @@ import (
 //     index block. It is included when AddPrevDataBlockToIndexBlock is called.
 //     An alternative would be to return an opaque handle from FinishDataBlock
 //     and pass it to a new AddToIndexBlock method, which requires more
-//     plumbing, and passing of an interface{} results in a undesirable heap
+//     plumbing, and passing of an any results in a undesirable heap
 //     allocation. AddPrevDataBlockToIndexBlock must be called before keys are
 //     added to the new data block.
 type BlockPropertyCollector interface {
@@ -668,7 +668,7 @@ type BlockPropertiesFilterer struct {
 }
 
 var blockPropertiesFiltererPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &BlockPropertiesFilterer{}
 	},
 }

--- a/sstable/colblk/block_test.go
+++ b/sstable/colblk/block_test.go
@@ -173,11 +173,11 @@ func dataTypeFromName(name string) DataType {
 }
 
 // randBlock generates a random block of n rows with the provided schema. It
-// returns the serialized raw block and a []interface{} slice containing the
+// returns the serialized raw block and a []any slice containing the
 // generated data. The type of each element of the slice is dependent on the
 // corresponding column's type.
-func randBlock(rng *rand.Rand, rows int, schema []testColumnSpec) ([]byte, []interface{}) {
-	data := make([]interface{}, len(schema))
+func randBlock(rng *rand.Rand, rows int, schema []testColumnSpec) ([]byte, []any) {
+	data := make([]any, len(schema))
 	for col := range data {
 		switch schema[col].DataType {
 		case DataTypeBool:
@@ -219,7 +219,7 @@ func randBlock(rng *rand.Rand, rows int, schema []testColumnSpec) ([]byte, []int
 	return buf, data
 }
 
-func buildBlock(schema []testColumnSpec, rows int, data []interface{}) []byte {
+func buildBlock(schema []testColumnSpec, rows int, data []any) []byte {
 	cw := make([]ColumnWriter, len(schema))
 	for col := range schema {
 		switch schema[col].DataType {
@@ -289,7 +289,7 @@ func testRandomBlock(t *testing.T, rng *rand.Rand, rows int, schema []testColumn
 
 		for col := range data {
 			spec := schema[col]
-			var got interface{}
+			var got any
 			switch spec.DataType {
 			case DataTypeBool:
 				got = Clone(d.Bitmap(col), rows)

--- a/sstable/colblk/keyspan.go
+++ b/sstable/colblk/keyspan.go
@@ -336,10 +336,10 @@ func NewKeyspanIter(
 }
 
 var keyspanIterPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		i := &KeyspanIter{}
 		if invariants.UseFinalizers {
-			invariants.SetFinalizer(i, func(obj interface{}) {
+			invariants.SetFinalizer(i, func(obj any) {
 				if i := obj.(*KeyspanIter); i.handle.Valid() {
 					fmt.Fprintf(os.Stderr, "KeyspanIter.handle is not nil: %#v\n", i.handle)
 					os.Exit(1)

--- a/sstable/reader_iter.go
+++ b/sstable/reader_iter.go
@@ -159,7 +159,7 @@ var (
 
 func init() {
 	singleLevelIterRowBlockPool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			i := &singleLevelIteratorRowBlocks{pool: &singleLevelIterRowBlockPool}
 			if invariants.UseFinalizers {
 				invariants.SetFinalizer(i, checkSingleLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
@@ -168,7 +168,7 @@ func init() {
 		},
 	}
 	twoLevelIterRowBlockPool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			i := &twoLevelIteratorRowBlocks{pool: &twoLevelIterRowBlockPool}
 			if invariants.UseFinalizers {
 				invariants.SetFinalizer(i, checkTwoLevelIterator[rowblk.IndexIter, *rowblk.IndexIter, rowblk.Iter, *rowblk.Iter])
@@ -177,7 +177,7 @@ func init() {
 		},
 	}
 	singleLevelIterColumnBlockPool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			i := &singleLevelIteratorColumnBlocks{
 				pool: &singleLevelIterColumnBlockPool,
 			}
@@ -188,7 +188,7 @@ func init() {
 		},
 	}
 	twoLevelIterColumnBlockPool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			i := &twoLevelIteratorColumnBlocks{
 				pool: &twoLevelIterColumnBlockPool,
 			}
@@ -201,7 +201,7 @@ func init() {
 }
 
 func checkSingleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIterator[D]](
-	obj interface{},
+	obj any,
 ) {
 	i := obj.(*singleLevelIterator[I, PI, D, PD])
 	if h := PD(&i.data).Handle(); h.Valid() {
@@ -215,7 +215,7 @@ func checkSingleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlo
 }
 
 func checkTwoLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIterator[D]](
-	obj interface{},
+	obj any,
 ) {
 	i := obj.(*twoLevelIterator[I, PI, D, PD])
 	if h := PD(&i.secondLevel.data).Handle(); h.Valid() {

--- a/sstable/reader_iter_two_lvl_benchmark_test.go
+++ b/sstable/reader_iter_two_lvl_benchmark_test.go
@@ -409,7 +409,7 @@ func BenchmarkTwoLevelLazyLoadingIteratorReuse(b *testing.B) {
 
 	// Create a pool for testing reuse
 	var pool sync.Pool
-	pool.New = func() interface{} {
+	pool.New = func() any {
 		return &twoLevelIteratorRowBlocks{pool: &pool}
 	}
 

--- a/sstable/rowblk/rowblk_fragment_iter.go
+++ b/sstable/rowblk/rowblk_fragment_iter.go
@@ -64,7 +64,7 @@ type fragmentIter struct {
 var _ keyspan.FragmentIterator = (*fragmentIter)(nil)
 
 var fragmentBlockIterPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		i := &fragmentIter{}
 		if invariants.UseFinalizers {
 			invariants.SetFinalizer(i, checkFragmentBlockIterator)
@@ -419,7 +419,7 @@ func (i *fragmentIter) TreeStepsNode() treesteps.NodeInfo {
 	return ni
 }
 
-func checkFragmentBlockIterator(obj interface{}) {
+func checkFragmentBlockIterator(obj any) {
 	i := obj.(*fragmentIter)
 	if h := i.blockIter.Handle(); h.Valid() {
 		fmt.Fprintf(os.Stderr, "fragmentBlockIter.blockIter.handle is not nil: %#v\n", h)

--- a/sstable/rowblk_writer.go
+++ b/sstable/rowblk_writer.go
@@ -303,7 +303,7 @@ func (i *indexBlockBuf) clear() {
 }
 
 var indexBlockBufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &indexBlockBuf{}
 	},
 }
@@ -393,7 +393,7 @@ func (d *dataBlockEstimates) addInflightDataBlock(size int) {
 }
 
 var writeTaskPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		t := &writeTask{}
 		t.compressionDone = make(chan bool, 1)
 		return t
@@ -467,7 +467,7 @@ func (d *dataBlockBuf) clear() {
 }
 
 var dataBlockBufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &dataBlockBuf{}
 	},
 }

--- a/sstable/tablefilters/binaryfuse/filter.go
+++ b/sstable/tablefilters/binaryfuse/filter.go
@@ -49,7 +49,7 @@ func ensureInitialized() {
 }
 
 var builderPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		// Preallocate enough size to avoid allocations while ramping up.
 		b := &builder{
 			hashes: make([]uint64, maxSizeForPool),

--- a/sstable/tablefilters/binaryfuse/hash_collector.go
+++ b/sstable/tablefilters/binaryfuse/hash_collector.go
@@ -27,7 +27,7 @@ const hashBlockLen = 8192
 type hashBlock [hashBlockLen]uint64
 
 var hashBlockPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &hashBlock{}
 	},
 }

--- a/sstable/tablefilters/bloom/hash_collector.go
+++ b/sstable/tablefilters/bloom/hash_collector.go
@@ -27,7 +27,7 @@ const hashBlockLen = 16384
 type hashBlock [hashBlockLen]uint32
 
 var hashBlockPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &hashBlock{}
 	},
 }

--- a/sstable/valblk/writer.go
+++ b/sstable/valblk/writer.go
@@ -37,7 +37,7 @@ type bufferedValueBlock struct {
 }
 
 var valueBlockWriterPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Writer{}
 	},
 }

--- a/tool/db.go
+++ b/tool/db.go
@@ -845,61 +845,61 @@ func (d *dbT) runProperties(cmd *cobra.Command, args []string) {
 		fmt.Fprintln(tw, "\tL0\tL1\tL2\tL3\tL4\tL5\tL6\tTOTAL")
 
 		fmt.Fprintf(tw, "count\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			propArgs(all, func(p *props) interface{} { return p.Count })...)
+			propArgs(all, func(p *props) any { return p.Count })...)
 
 		fmt.Fprintln(tw, "seq num\t\t\t\t\t\t\t\t")
 		fmt.Fprintf(tw, "  smallest\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			propArgs(all, func(p *props) interface{} { return p.SmallestSeqNum })...)
+			propArgs(all, func(p *props) any { return p.SmallestSeqNum })...)
 		fmt.Fprintf(tw, "  largest\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			propArgs(all, func(p *props) interface{} { return p.LargestSeqNum })...)
+			propArgs(all, func(p *props) any { return p.LargestSeqNum })...)
 
 		fmt.Fprintln(tw, "size\t\t\t\t\t\t\t\t")
 		fmt.Fprintf(tw, "  data\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.DataSize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.DataSize) })...)
 		fmt.Fprintf(tw, "    blocks\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			propArgs(all, func(p *props) interface{} { return p.NumDataBlocks })...)
+			propArgs(all, func(p *props) any { return p.NumDataBlocks })...)
 		fmt.Fprintf(tw, "  index\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.IndexSize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.IndexSize) })...)
 		fmt.Fprintf(tw, "    blocks\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			propArgs(all, func(p *props) interface{} { return p.NumIndexBlocks })...)
+			propArgs(all, func(p *props) any { return p.NumIndexBlocks })...)
 		fmt.Fprintf(tw, "    top-level\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.TopLevelIndexSize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.TopLevelIndexSize) })...)
 		fmt.Fprintf(tw, "  filter\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.FilterSize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.FilterSize) })...)
 		fmt.Fprintf(tw, "  raw-key\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.RawKeySize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.RawKeySize) })...)
 		fmt.Fprintf(tw, "  raw-value\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.RawValueSize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.RawValueSize) })...)
 		fmt.Fprintf(tw, "  pinned-key\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.SnapshotPinnedKeySize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.SnapshotPinnedKeySize) })...)
 		fmt.Fprintf(tw, "  pinned-value\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.SnapshotPinnedValueSize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.SnapshotPinnedValueSize) })...)
 		fmt.Fprintf(tw, "  point-del-key-size\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.RawPointTombstoneKeySize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.RawPointTombstoneKeySize) })...)
 		fmt.Fprintf(tw, "  point-del-value-size\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Bytes.Uint64(p.RawPointTombstoneValueSize) })...)
+			propArgs(all, func(p *props) any { return humanize.Bytes.Uint64(p.RawPointTombstoneValueSize) })...)
 
 		fmt.Fprintln(tw, "records\t\t\t\t\t\t\t\t")
 		fmt.Fprintf(tw, "  set\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} {
+			propArgs(all, func(p *props) any {
 				return humanize.Count.Uint64(p.NumEntries - p.NumDeletions - p.NumMergeOperands)
 			})...)
 		fmt.Fprintf(tw, "  delete\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Count.Uint64(p.NumDeletions - p.NumRangeDeletions) })...)
+			propArgs(all, func(p *props) any { return humanize.Count.Uint64(p.NumDeletions - p.NumRangeDeletions) })...)
 		fmt.Fprintf(tw, "  delete-sized\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Count.Uint64(p.NumSizedDeletions) })...)
+			propArgs(all, func(p *props) any { return humanize.Count.Uint64(p.NumSizedDeletions) })...)
 		fmt.Fprintf(tw, "  range-delete\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Count.Uint64(p.NumRangeDeletions) })...)
+			propArgs(all, func(p *props) any { return humanize.Count.Uint64(p.NumRangeDeletions) })...)
 		fmt.Fprintf(tw, "  range-key-sets\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Count.Uint64(p.NumRangeKeySets) })...)
+			propArgs(all, func(p *props) any { return humanize.Count.Uint64(p.NumRangeKeySets) })...)
 		fmt.Fprintf(tw, "  range-key-unsets\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Count.Uint64(p.NumRangeKeyUnSets) })...)
+			propArgs(all, func(p *props) any { return humanize.Count.Uint64(p.NumRangeKeyUnSets) })...)
 		fmt.Fprintf(tw, "  range-key-deletes\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Count.Uint64(p.NumRangeKeyDeletes) })...)
+			propArgs(all, func(p *props) any { return humanize.Count.Uint64(p.NumRangeKeyDeletes) })...)
 		fmt.Fprintf(tw, "  merge\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Count.Uint64(p.NumMergeOperands) })...)
+			propArgs(all, func(p *props) any { return humanize.Count.Uint64(p.NumMergeOperands) })...)
 		fmt.Fprintf(tw, "  pinned\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			propArgs(all, func(p *props) interface{} { return humanize.Count.Uint64(p.SnapshotPinnedKeys) })...)
+			propArgs(all, func(p *props) any { return humanize.Count.Uint64(p.SnapshotPinnedKeys) })...)
 
 		if err := tw.Flush(); err != nil {
 			return err
@@ -1027,8 +1027,8 @@ func (n nonReadOnly) Apply(dirname string, opts *pebble.Options) {
 	opts.L0CompactionThreshold = 10
 }
 
-func propArgs(props []props, getProp func(*props) interface{}) []interface{} {
-	args := make([]interface{}, 0, len(props))
+func propArgs(props []props, getProp func(*props) any) []any {
+	args := make([]any, 0, len(props))
 	for _, p := range props {
 		args = append(args, getProp(&p))
 	}

--- a/tool/lsm.go
+++ b/tool/lsm.go
@@ -417,14 +417,14 @@ func (l *lsmT) reason(ve *manifest.VersionEdit) string {
 	return "added"
 }
 
-func (l *lsmT) formatJSON(v interface{}) string {
+func (l *lsmT) formatJSON(v any) string {
 	if l.pretty {
 		return l.prettyJSON(v)
 	}
 	return l.uglyJSON(v)
 }
 
-func (l *lsmT) uglyJSON(v interface{}) string {
+func (l *lsmT) uglyJSON(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {
 		log.Fatal(err)
@@ -432,7 +432,7 @@ func (l *lsmT) uglyJSON(v interface{}) string {
 	return string(data)
 }
 
-func (l *lsmT) prettyJSON(v interface{}) string {
+func (l *lsmT) prettyJSON(v any) string {
 	data, err := json.MarshalIndent(v, "", "\t")
 	if err != nil {
 		log.Fatal(err)

--- a/valsep/value_separation_test.go
+++ b/valsep/value_separation_test.go
@@ -37,7 +37,7 @@ func TestValueSeparationPolicy(t *testing.T) {
 		// the test. When testing a value separation policy that writes new blob
 		// files, this demonstrates the creation of new blob files and that
 		// they're created lazily, the first time a value is actually separated.
-		fs = vfs.WithLogging(vfs.NewMem(), func(format string, args ...interface{}) {
+		fs = vfs.WithLogging(vfs.NewMem(), func(format string, args ...any) {
 			fmt.Fprint(&buf, "# ")
 			fmt.Fprintf(&buf, format, args...)
 			fmt.Fprintln(&buf)

--- a/version_set_test.go
+++ b/version_set_test.go
@@ -302,7 +302,7 @@ func TestVersionSetSeqNums(t *testing.T) {
 		sync.Mutex
 		bytes.Buffer
 	}
-	fs := vfs.WithLogging(vfs.NewMem(), func(format string, args ...interface{}) {
+	fs := vfs.WithLogging(vfs.NewMem(), func(format string, args ...any) {
 		buf.Mutex.Lock()
 		defer buf.Mutex.Unlock()
 		fmt.Fprintf(&buf.Buffer, format, args...)

--- a/vfs/atomicfs/marker_test.go
+++ b/vfs/atomicfs/marker_test.go
@@ -42,7 +42,7 @@ func TestMarker_FilenameRoundtrip(t *testing.T) {
 }
 
 func TestMarker_Parsefilename(t *testing.T) {
-	testCases := map[string]func(require.TestingT, error, ...interface{}){
+	testCases := map[string]func(require.TestingT, error, ...any){
 		"marker.current.000003.MANIFEST-000021":  require.NoError,
 		"marker.current.10.MANIFEST-000021":      require.NoError,
 		"marker.v.10.1.2.3.4":                    require.NoError,

--- a/vfs/logging_fs.go
+++ b/vfs/logging_fs.go
@@ -20,7 +20,7 @@ func WithLogging(fs FS, logFn LogFn) FS {
 }
 
 // LogFn is a function that is used to capture a log when WithLogging is used.
-type LogFn func(fmt string, args ...interface{})
+type LogFn func(fmt string, args ...any)
 
 type loggingFS struct {
 	FS

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -957,7 +957,7 @@ func (f *memFileInfo) IsDir() bool {
 	return f.isDir
 }
 
-func (f *memFileInfo) Sys() interface{} {
+func (f *memFileInfo) Sys() any {
 	return nil
 }
 

--- a/wal/reader_test.go
+++ b/wal/reader_test.go
@@ -109,7 +109,7 @@ func TestReader(t *testing.T) {
 	var memFS *vfs.MemFS
 	setFS := func(mem *vfs.MemFS) {
 		memFS = mem
-		fs = vfs.WithLogging(mem, func(format string, args ...interface{}) {
+		fs = vfs.WithLogging(mem, func(format string, args ...any) {
 			s := fmt.Sprintf("# "+format, args...)
 			fmt.Fprintln(&buf, strings.TrimRightFunc(s, unicode.IsSpace))
 		})


### PR DESCRIPTION
Mechanical refactor replacing `interface{}` with `any` across the codebase. This is the modern Go 1.18+ idiom for the empty interface type.

74 files updated, 216 insertions, 216 deletions.

Generated files (*.pb.go) skipped.