### PR TITLE
crl-release-26.1: pebble: show blob reference size in compaction events

### DIFF
--- a/event.go
+++ b/event.go
@@ -146,16 +146,14 @@ func (i LevelInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 		blobInfo = redact.SafeString(fmt.Sprintf(" blob%s [%s] (%s)",
 			pluralBlob, formatBlobFileNums(i.Blobs), humanize.Bytes.Uint64(blobsTotalSize(i.Blobs))))
 	}
-	sizeStr := redact.Safe(humanize.Bytes.Uint64(tablesTotalSize(i.Tables)))
+	sizeStr := humanize.Bytes.Uint64(tablesTotalSize(i.Tables)).String()
 	if refSize := tablesTotalReferenceSize(i.Tables); refSize > 0 {
-		sizeStr = redact.Safe(fmt.Sprintf("%s + %s",
-			humanize.Bytes.Uint64(tablesTotalSize(i.Tables)),
-			humanize.Bytes.Uint64(refSize)))
+		sizeStr = fmt.Sprintf("%s + %s", sizeStr, humanize.Bytes.Uint64(refSize))
 	}
 	w.Printf("L%d [%s] (%s)%s Score=%.2f",
 		redact.Safe(i.Level),
 		redact.Safe(formatFileNums(i.Tables)),
-		sizeStr,
+		redact.Safe(sizeStr),
 		blobInfo,
 		redact.Safe(i.Score))
 }

--- a/event.go
+++ b/event.go
@@ -39,6 +39,14 @@ func tablesTotalSize(tables []TableInfo) uint64 {
 	return size
 }
 
+func tablesTotalReferenceSize(tables []TableInfo) uint64 {
+	var size uint64
+	for i := range tables {
+		size += tables[i].EstimatedReferenceSize()
+	}
+	return size
+}
+
 func formatFileNums(tables []TableInfo) string {
 	var buf strings.Builder
 	for i := range tables {
@@ -138,10 +146,16 @@ func (i LevelInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 		blobInfo = redact.SafeString(fmt.Sprintf(" blob%s [%s] (%s)",
 			pluralBlob, formatBlobFileNums(i.Blobs), humanize.Bytes.Uint64(blobsTotalSize(i.Blobs))))
 	}
+	sizeStr := redact.Safe(humanize.Bytes.Uint64(tablesTotalSize(i.Tables)))
+	if refSize := tablesTotalReferenceSize(i.Tables); refSize > 0 {
+		sizeStr = redact.Safe(fmt.Sprintf("%s + %s",
+			humanize.Bytes.Uint64(tablesTotalSize(i.Tables)),
+			humanize.Bytes.Uint64(refSize)))
+	}
 	w.Printf("L%d [%s] (%s)%s Score=%.2f",
 		redact.Safe(i.Level),
 		redact.Safe(formatFileNums(i.Tables)),
-		redact.Safe(humanize.Bytes.Uint64(tablesTotalSize(i.Tables))),
+		sizeStr,
 		blobInfo,
 		redact.Safe(i.Score))
 }

--- a/event_test.go
+++ b/event_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/internal/manifest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatBlockDataAsHex(t *testing.T) {
@@ -29,5 +32,40 @@ func TestFormatBlockDataAsHex(t *testing.T) {
 			t.Fatalf("unknown command: %s", td.Cmd)
 			return ""
 		}
+	})
+}
+
+// tableInfoWithRefSize builds a TableInfo carrying a single blob reference with
+// the given estimated physical size.
+func tableInfoWithRefSize(num base.FileNum, size, refSize uint64) TableInfo {
+	m := &manifest.TableMetadata{TableNum: num, Size: size}
+	if refSize > 0 {
+		m.BlobReferences = manifest.BlobReferences{
+			{FileID: base.BlobFileID(num), EstimatedPhysicalSize: refSize},
+		}
+	}
+	return m.TableInfo()
+}
+
+func TestLevelInfoSafeFormat(t *testing.T) {
+	t.Run("no blob references", func(t *testing.T) {
+		li := LevelInfo{
+			Level:  1,
+			Tables: []TableInfo{tableInfoWithRefSize(1, 3<<10, 0)},
+			Score:  1.31,
+		}
+		require.Equal(t, "L1 [000001] (3.0KB) Score=1.31", li.String())
+	})
+
+	t.Run("with blob references", func(t *testing.T) {
+		li := LevelInfo{
+			Level: 0,
+			Tables: []TableInfo{
+				tableInfoWithRefSize(1, 3<<10, 1<<20),
+				tableInfoWithRefSize(2, 1<<10, 200<<10),
+			},
+			Score: 1.31,
+		}
+		require.Equal(t, "L0 [000001 000002] (4.0KB + 1.2MB) Score=1.31", li.String())
 	})
 }

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -1213,6 +1213,16 @@ func (t *TableInfo) GetBlobReferenceFiles() []base.BlobFileID {
 	return files
 }
 
+// EstimatedReferenceSize returns the estimated physical size of all the table's
+// blob references.
+func (t *TableInfo) EstimatedReferenceSize() uint64 {
+	var size uint64
+	for i := range t.blobReferences {
+		size += t.blobReferences[i].EstimatedPhysicalSize
+	}
+	return size
+}
+
 // TableStats contains statistics on a table used for compaction heuristics,
 // and export via Metrics.
 type TableStats struct {

--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -194,8 +194,8 @@ var (
 
 			/* Start / end level */
 			`(?P<levels>L(?P<from>\d).*?(?:.*(?:\+|->)\sL(?P<to>\d))?` +
-			/* Bytes             */
-			`(?:.*?\((?P<bytes>[0-9.]+( [BKMGTPE]|[KMGTPE]?B))\))` +
+			/* Bytes (optionally "table + blob references", e.g. "(4.0KB + 1.2MB)") */
+			`(?:.*?\((?P<bytes>[0-9.]+( [BKMGTPE]|[KMGTPE]?B)( \+ [0-9.]+( [BKMGTPE]|[KMGTPE]?B))*)\))` +
 			/* Score */
 			`?(\s*(Score=\d+(\.\d+)))?)`,
 	)
@@ -470,7 +470,7 @@ func parseCompactionEnd(matches []string) (compactionEnd, error) {
 
 	// Optionally, if we have compacted bytes.
 	if matches[compactionPatternBytesIdx] != "" {
-		end.writtenBytes = unHumanize(matches[compactionPatternBytesIdx])
+		end.writtenBytes = unHumanizeSum(matches[compactionPatternBytesIdx])
 	}
 
 	return end, nil
@@ -1563,6 +1563,17 @@ func unHumanize(s string) uint64 {
 	return uint64(val * float64(multiplier))
 }
 
+// unHumanizeSum parses a parenthesized size value, which may be a single size
+// (e.g. "4.0KB") or a sum of a table size and its blob reference size (e.g.
+// "4.0KB + 1.2MB"), returning the total number of bytes.
+func unHumanizeSum(s string) uint64 {
+	var total uint64
+	for _, part := range strings.Split(s, "+") {
+		total += unHumanize(strings.TrimSpace(part))
+	}
+	return total
+}
+
 // sumInputBytes takes a string as input and returns the sum of the
 // human-readable sizes, as an integer number of bytes.
 func sumInputBytes(s string) (total uint64, _ error) {
@@ -1575,7 +1586,7 @@ func sumInputBytes(s string) (total uint64, _ error) {
 		case '(':
 			open = true
 		case ')':
-			total += unHumanize(b.String())
+			total += unHumanizeSum(b.String())
 			b.Reset()
 			open = false
 		default:

--- a/tool/logs/compaction_test.go
+++ b/tool/logs/compaction_test.go
@@ -44,6 +44,10 @@ const (
 
 	flushableIngestionLine23_1 = `I230831 04:13:28.824280 3780 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 365  [JOB 226] flushed 6 ingested flushables L0:024334 (1.5 K) + L0:024339 (1.0 K) + L0:024335 (1.9 K) + L0:024336 (1.1 K) + L0:024337 (1.1 K) + L0:024338 (12 K) in 0.0s (0.0s total), output rate 67 M/s`
 	flushableIngestionLine     = `I230831 04:13:28.824280 3780 3@pebble/event.go:685 ⋮ [n10,s10,pebble] 365  [JOB 226] flushed 6 ingested flushables L0:024334 (1.5KB) + L0:024339 (1.0KB) + L0:024335 (1.9KB) + L0:024336 (1.1KB) + L0:024337 (1.1KB) + L0:024338 (12KB) in 0.0s (0.0s total), output rate 67MB/s`
+
+	// Lines with blob reference sizes, rendered as "(table + blob)".
+	compactionStartLineBlob = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n5,pebble,s6] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2MB + 1.0MB) Score=1.01 + L3 [445853] (8.4MB + 2.0MB) Score=0.99;  OverlappingRatio: Single 8.03, Multi 25.05;`
+	compactionEndLineBlob   = `I211215 14:26:56.318543 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n5,pebble,s6] 1216554  [JOB 284925] compacted(default) L2 [442555] (4.2MB) Score=1.01 + L3 [445853] (8.4MB) Score=1.01 -> L3 [445883 445887] (13MB + 3.0MB), in 0.3s, output rate 42MB/s`
 )
 
 func TestCompactionLogs_Regex(t *testing.T) {
@@ -191,6 +195,32 @@ func TestCompactionLogs_Regex(t *testing.T) {
 				compactionPatternFromIdx:   "2",
 				compactionPatternToIdx:     "4",
 				compactionPatternBytesIdx:  "46MB",
+			},
+		},
+		{
+			name: "compaction start with blob references",
+			re:   compactionPattern,
+			line: compactionStartLineBlob,
+			matches: map[int]string{
+				compactionPatternJobIdx:    "284925",
+				compactionPatternSuffixIdx: "ing",
+				compactionPatternTypeIdx:   "default",
+				compactionPatternFromIdx:   "2",
+				compactionPatternToIdx:     "3",
+				compactionPatternLevels:    "L2 [442555] (4.2MB + 1.0MB) Score=1.01 + L3 [445853] (8.4MB + 2.0MB) Score=0.99",
+			},
+		},
+		{
+			name: "compaction end with blob references",
+			re:   compactionPattern,
+			line: compactionEndLineBlob,
+			matches: map[int]string{
+				compactionPatternJobIdx:    "284925",
+				compactionPatternSuffixIdx: "ed",
+				compactionPatternTypeIdx:   "default",
+				compactionPatternFromIdx:   "2",
+				compactionPatternToIdx:     "3",
+				compactionPatternBytesIdx:  "13MB + 3.0MB",
 			},
 		},
 		{
@@ -452,6 +482,16 @@ func TestParseInputBytes(t *testing.T) {
 		{
 			"(10MB) + (20MB) + (30MB)",
 			60 << 20,
+		},
+		// Blob reference sizes are rendered within a single set of parentheses as
+		// "table + blob"; both are summed.
+		{
+			"(10MB + 5MB)",
+			15 << 20,
+		},
+		{
+			"(10MB + 5MB) + (20MB + 1MB)",
+			36 << 20,
 		},
 		{
 			"foo",


### PR DESCRIPTION
#### pebble: show blob reference size in compaction events

Previously, the per-level size in compaction event log lines reflected
only the sum of the input tables' sizes, e.g.:

    L0 [31152773 31152772] (747KB) Score=1.31

This omitted the physical size of any blob references, so the reported
size understated the amount of data the tables actually represent when
value separation is in use.

This change sums the `EstimatedPhysicalSize` of each table's blob
references and, when non-zero, renders the level size as `(x + y)`,
where `x` is the table size and `y` is the blob reference size, e.g.:

    L0 [31152773 31152772] (747KB + 1.2MB) Score=1.31

A new `TableInfo.EstimatedReferenceSize` method is added (mirroring the
existing `TableMetadata.EstimatedReferenceSize`) since the underlying
`blobReferences` field is package-private to `manifest`. Levels without
blob references are unchanged.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### tool/logs: parse blob reference size in compaction log lines

Compaction event log lines now render a level's size as `(table + blob)`
(e.g. `(4.2MB + 1.0MB)`) when the input tables reference blob files. The
log parser previously assumed a single size value inside the parentheses:

- The `compactionPattern` regexp required the closing paren immediately
  after the first size, so the `bytes` capture (used for the output size
  of an `compacted` line) matched nothing for the new format.
- `sumInputBytes` passed the entire parenthesized contents to
  `unHumanize`, which only understands a single size token.

This change teaches the parser about the optional `+ <size>` suffix. The
regexp now accepts one or more `+`-separated sizes within the
parentheses, and a new `unHumanizeSum` helper splits on `+` and sums the
parts. Both the input-byte and output-byte parsing paths use it, so the
reported sizes include the estimated physical size of blob references.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>