### PR TITLE
crl-release-26.2: blob: flush a block immediately after a value that fills it

### DIFF
--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -201,12 +201,24 @@ func (w *FileWriter) AddValue(v []byte, isLikelyMVCCGarbage bool) Handle {
 		w.stats.MVCCGarbageBytes += uint64(len(v))
 	}
 	w.valuesEncoder.AddValue(v)
-	return Handle{
+	h := Handle{
 		BlobFileID: base.BlobFileID(w.fileNum),
 		ValueLen:   uint32(len(v)),
 		BlockID:    BlockID(w.stats.BlockCount),
 		ValueID:    BlockValueID(valuesInBlock),
 	}
+	// If the value fills a block on its own, flush it now instead of carrying it
+	// in the pending (uncompressed) block. Otherwise EstimatedSize would account
+	// for this value at its uncompressed size until the next AddValue triggers a
+	// flush, overestimating the file size (and causing premature output splits in
+	// compactions/flushes). We use len(v) rather than valuesEncoder.size() to
+	// avoid recomputing the block size on every call; a small unfinished block is
+	// negligible for the estimate. Note h must be captured before flush(), which
+	// increments BlockCount.
+	if len(v) >= w.flushGov.HighWatermark() {
+		w.flush()
+	}
+	return h
 }
 
 // beginNewVirtualBlock adds a virtual block mapping to the current physical

--- a/sstable/blob/blob_test.go
+++ b/sstable/blob/blob_test.go
@@ -30,11 +30,18 @@ func TestBlobWriter(t *testing.T) {
 		switch td.Cmd {
 		case "build":
 			opts := scanFileWriterOptions(t, td)
+			// If estimated-size is set, print the writer's EstimatedSize after each
+			// added value.
+			showEstimatedSize := td.HasArg("estimated-size")
 			obj = &objstorage.MemObj{}
 			w := NewFileWriter(000001, obj, opts)
 			for l := range crstrings.LinesSeq(td.Input) {
 				h := w.AddValue([]byte(l), false /* isLikelyMVCCGarbage */)
-				fmt.Fprintf(&buf, "%-25s: %q\n", h, l)
+				fmt.Fprintf(&buf, "%-25s: %q", h, l)
+				if showEstimatedSize {
+					fmt.Fprintf(&buf, "  (estimated size: %d)", w.EstimatedSize())
+				}
+				buf.WriteByte('\n')
 			}
 			stats, err := w.Close()
 			if err != nil {

--- a/sstable/blob/testdata/writer
+++ b/sstable/blob/testdata/writer
@@ -135,6 +135,40 @@ PropsHandle: (348, 49)
 Properties:
   compression_stats: None:318
 
+# A value at least the high watermark (target block size) fills a block on its
+# own and is flushed immediately, instead of lingering in the pending
+# (uncompressed) block until the next AddValue. The estimated size reported right
+# after the large (compressible) value reflects its compressed block size; if the
+# value were left pending uncompressed, the estimate would instead jump by its
+# full uncompressed length.
+
+build target-block-size=64 block-size-threshold=90 compression=snappy estimated-size
+apple
+orange
+blueberry
+tangerine
+pomegranate
+watermelon
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+fig
+plum
+----
+(B000001,blk0,id0,len5)  : "apple"  (estimated size: 73)
+(B000001,blk0,id1,len6)  : "orange"  (estimated size: 80)
+(B000001,blk0,id2,len9)  : "blueberry"  (estimated size: 90)
+(B000001,blk0,id3,len9)  : "tangerine"  (estimated size: 100)
+(B000001,blk0,id4,len11) : "pomegranate"  (estimated size: 112)
+(B000001,blk1,id0,len10) : "watermelon"  (estimated size: 147)
+(B000001,blk1,id1,len82) : "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  (estimated size: 167)
+(B000001,blk2,id0,len3)  : "fig"  (estimated size: 186)
+(B000001,blk2,id1,len4)  : "plum"  (estimated size: 191)
+Stats:
+  BlockCount: 3
+  ValueCount: 9
+  UncompressedValueBytes: 139B
+  FileLen: 206B
+Compression counters: value: 0B  other: 0B
+
 # Build a sparse table containing a subset of the previous block's values.
 
 build-sparse

--- a/sstable/block/flush_governor.go
+++ b/sstable/block/flush_governor.go
@@ -117,6 +117,14 @@ func (fg *FlushGovernor) LowWatermark() int {
 	return fg.lowWatermark
 }
 
+// HighWatermark returns the size at or above which a block will always be
+// flushed before another KV is added to it. A value whose own size is at least
+// the high watermark fills a block on its own, so its block can be flushed
+// immediately rather than waiting for the next KV.
+func (fg *FlushGovernor) HighWatermark() int {
+	return fg.highWatermark
+}
+
 // ShouldFlush returns true if we should flush the current block of sizeBefore
 // instead of adding another KV that would increase the block to sizeAfter.
 func (fg *FlushGovernor) ShouldFlush(sizeBefore int, sizeAfter int) bool {


### PR DESCRIPTION
`FileWriter.EstimatedSize` counts completed blocks at their compressed size
but the pending block at its uncompressed size. The pending block was only
flushed on the *next* `AddValue` (when the flush governor decided it was
full), so a value large enough to fill a block on its own lingered
uncompressed in the estimate until the following value arrived.

During flushes and value-separating compactions, `EstimatedSize` feeds the
output splitter's size accounting (via `EstimatedReferenceSize`). The
transient uncompressed overstatement after a large value could push the
estimate over the split threshold and cause premature output splits,
producing many small files.

`AddValue` now flushes the block immediately when the just-added value is at
least the flush governor's high watermark, so it is compressed before the
next `EstimatedSize` query.

A small unfinished block of normal-sized values is still carried
uncompressed, but that is negligible relative to the file size.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>