### PR TITLE
crl-release-25.2: go.mod: require go 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,4 +53,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.23
+go 1.23.6


### PR DESCRIPTION
The branch declares `go 1.23`, which resolves to the 1.23.0 toolchain when using the backport script. Some development tooling needs a newer patch release and fails under 1.23.0. This bumps the `go` directive to 1.23.6 so the minimum required toolchain includes those fixes.