### PR TITLE
crl-release-26.1: sstable: improve checksum mismatch error

### DIFF
--- a/sstable/block/block.go
+++ b/sstable/block/block.go
@@ -190,9 +190,9 @@ func ValidateChecksum(checksumType ChecksumType, b []byte, bh Handle) error {
 			}
 		}
 		found, indexFound, bitFound := bitflip.CheckSliceForBitFlip(data, checksumFunction, expectedChecksum)
-		err := base.CorruptionErrorf("block %d/%d: %s checksum mismatch %x != %x",
-			errors.Safe(bh.Offset), errors.Safe(bh.Length), checksumType,
-			expectedChecksum, computedChecksum)
+		err := base.CorruptionErrorf("block %d/%d: %s checksum mismatch: expected 0x%08x, got 0x%08x",
+			errors.Safe(bh.Offset), errors.Safe(bh.Length), errors.Safe(checksumType),
+			errors.Safe(expectedChecksum), errors.Safe(computedChecksum))
 		if found {
 			err = errors.WithSafeDetails(err, ". bit flip found: byte index %d. got: 0x%x. want: 0x%x.",
 				errors.Safe(indexFound), errors.Safe(data[indexFound]), errors.Safe(data[indexFound]^(1<<bitFound)))

--- a/tool/testdata/sstable_check
+++ b/tool/testdata/sstable_check
@@ -44,7 +44,7 @@ WARNING: OUT OF ORDER KEYS!
 sstable check
 testdata/corrupted-sst/000003.sst
 ----
-000003.sst: pebble: file 000003: block 87/465: crc32c checksum mismatch c8539ba5 != b972e324
+000003.sst: pebble: file 000003: block 87/465: crc32c checksum mismatch: expected 0xc8539ba5, got 0xb972e324
 
 sstable check
 testdata/bad-magic-sst/000015.sst


### PR DESCRIPTION
Don't redact the checksum type; always show all hex digits; and
mention which is which.