### PR TITLE
crl-release-25.4: pebble: log per-table/blob output sizes for flushes and compactions

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -155,6 +155,9 @@ const (
 	compactionKindRewrite
 	compactionKindIngestedFlushable
 	compactionKindBlobFileRewrite
+	// compactionKindVirtualRewrite must be the last compactionKind.
+	// If a new kind has to be added after VirtualRewrite,
+	// update AllCompactionKindStrings() accordingly.
 	compactionKindVirtualRewrite
 )
 
@@ -195,6 +198,20 @@ func (k compactionKind) compactingOrFlushing() string {
 		return "flushing"
 	}
 	return "compacting"
+}
+
+// AllCompactionKindStrings returns all compaction kind string representations
+// for testing purposes. Used by tool/logs/compaction_test.go to verify the
+// compaction summary tool stays in sync with new compaction types.
+//
+// NOTE: This function iterates up to compactionKindVirtualRewrite. If a new
+// compactionKind is added after VirtualRewrite, update this function accordingly.
+func AllCompactionKindStrings() map[string]bool {
+	kinds := make(map[string]bool)
+	for k := compactionKindDefault; k <= compactionKindVirtualRewrite; k++ {
+		kinds[k.String()] = true
+	}
+	return kinds
 }
 
 type compaction interface {

--- a/event.go
+++ b/event.go
@@ -58,6 +58,41 @@ func formatFileNums(tables []TableInfo) string {
 	return buf.String()
 }
 
+// FormatTablesWithSizes formats a list of tables, showing each table's file
+// number, its size, and (if non-zero) its estimated blob reference size. For
+// example: "000123(1.0MB+4.0MB) 000124(2.0MB)".
+func FormatTablesWithSizes(tables []TableInfo) string {
+	var buf strings.Builder
+	for i := range tables {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString(tables[i].FileNum.String())
+		buf.WriteByte('(')
+		buf.WriteString(humanize.Bytes.Uint64(tables[i].Size).String())
+		if refSize := tables[i].EstimatedReferenceSize(); refSize > 0 {
+			buf.WriteByte('+')
+			buf.WriteString(humanize.Bytes.Uint64(refSize).String())
+		}
+		buf.WriteByte(')')
+	}
+	return buf.String()
+}
+
+// formatTotalSize formats a total table size and (if non-zero) total reference
+// size as "size+refSize" (e.g. "3.0MB+4.0MB"). The no-space form is
+// intentional: it mirrors the per-file form produced by FormatTablesWithSizes
+// (e.g. "000123(7.0MB+2.0MB)"). The log parser in tool/logs/compaction.go
+// accepts both this and the spaced "size + refSize" form that
+// LevelInfo.SafeFormat uses for input levels.
+func formatTotalSize(size, refSize uint64) string {
+	s := humanize.Bytes.Uint64(size).String()
+	if refSize > 0 {
+		s += "+" + humanize.Bytes.Uint64(refSize).String()
+	}
+	return s
+}
+
 // DataCorruptionInfo contains the information for a DataCorruption event.
 type DataCorruptionInfo struct {
 	// Path of the file that is corrupted. For remote files the path starts with
@@ -288,6 +323,41 @@ func formatBlobFileNums(blobs []BlobFileInfo) string {
 	return buf.String()
 }
 
+// FormatBlobsWithSizes formats a list of blob files, showing each blob file's
+// disk file number and size (and the MVCC garbage percentage, if present). For
+// example: "000125(5.0MB) 000126(2.0MB, MVCCGarbage: 12%)".
+func FormatBlobsWithSizes(blobs []BlobFileInfo) string {
+	var buf strings.Builder
+	for i := range blobs {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString(blobs[i].DiskFileNum.String())
+		buf.WriteByte('(')
+		buf.WriteString(humanize.Bytes.Uint64(blobs[i].Size).String())
+		if blobs[i].MVCCGarbageSize > 0 {
+			fmt.Fprintf(&buf, ", MVCCGarbage: %s",
+				crhumanize.Percent(blobs[i].MVCCGarbageSize, blobs[i].ValueSize))
+		}
+		buf.WriteByte(')')
+	}
+	return buf.String()
+}
+
+// formatOutputBlobs returns the " blob(s) [...] (...)" log segment for a list of
+// output blob files, or an empty string if there are none.
+func formatOutputBlobs(blobs []BlobFileInfo) redact.SafeString {
+	if len(blobs) == 0 {
+		return ""
+	}
+	pluralBlob := redact.SafeString("s")
+	if len(blobs) == 1 {
+		pluralBlob = ""
+	}
+	return redact.SafeString(fmt.Sprintf(" blob%s [%s] (%s)",
+		pluralBlob, FormatBlobsWithSizes(blobs), humanize.Bytes.Uint64(blobsTotalSize(blobs))))
+}
+
 // CompactionInfo contains the info for a compaction event.
 type CompactionInfo struct {
 	// JobID is the ID of the compaction job.
@@ -362,11 +432,13 @@ func (i CompactionInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	if len(i.Annotations) > 0 {
 		w.Printf("%s ", i.Annotations)
 	}
+	blobInfo := formatOutputBlobs(i.Output.Blobs)
 	w.Print(levelInfos(i.Input))
-	w.Printf(" -> L%d [%s] (%s), in %.1fs (%.1fs total), output rate %s/s",
+	w.Printf(" -> L%d [%s] (%s)%s, in %.1fs (%.1fs total), output rate %s/s",
 		redact.Safe(i.Output.Level),
-		redact.Safe(formatFileNums(i.Output.Tables)),
-		redact.Safe(humanize.Bytes.Uint64(outputSize)),
+		redact.Safe(FormatTablesWithSizes(i.Output.Tables)),
+		redact.Safe(formatTotalSize(outputSize, tablesTotalReferenceSize(i.Output.Tables))),
+		blobInfo,
 		redact.Safe(i.Duration.Seconds()),
 		redact.Safe(i.TotalDuration.Seconds()),
 		redact.Safe(humanize.Bytes.Uint64(uint64(float64(outputSize)/i.Duration.Seconds()))))
@@ -435,15 +507,7 @@ func (i FlushInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 	if i.Input == 1 {
 		plural = ""
 	}
-	blobInfo := redact.SafeString("")
-	if len(i.OutputBlobs) > 0 {
-		pluralBlob := redact.SafeString("s")
-		if len(i.OutputBlobs) == 1 {
-			pluralBlob = ""
-		}
-		blobInfo = redact.SafeString(fmt.Sprintf(" blob%s [%s] (%s)",
-			pluralBlob, formatBlobFileNums(i.OutputBlobs), humanize.Bytes.Uint64(blobsTotalSize(i.OutputBlobs))))
-	}
+	blobInfo := formatOutputBlobs(i.OutputBlobs)
 	if !i.Done {
 		w.Printf("[JOB %d] ", redact.Safe(i.JobID))
 		if !i.Ingest {
@@ -464,8 +528,8 @@ func (i FlushInfo) SafeFormat(w redact.SafePrinter, _ rune) {
 		w.Printf("[JOB %d] flushed %d memtable%s (%s) to L0 [%s] (%s)%s, in %.1fs (%.1fs total), output rate %s/s",
 			redact.Safe(i.JobID), redact.Safe(i.Input), plural,
 			redact.Safe(humanize.Bytes.Uint64(i.InputBytes)),
-			redact.Safe(formatFileNums(i.OutputTables)),
-			redact.Safe(humanize.Bytes.Uint64(outputSize)),
+			redact.Safe(FormatTablesWithSizes(i.OutputTables)),
+			redact.Safe(formatTotalSize(outputSize, tablesTotalReferenceSize(i.OutputTables))),
 			blobInfo,
 			redact.Safe(i.Duration.Seconds()),
 			redact.Safe(i.TotalDuration.Seconds()),

--- a/event_test.go
+++ b/event_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/internal/base"
@@ -68,4 +69,63 @@ func TestLevelInfoSafeFormat(t *testing.T) {
 		}
 		require.Equal(t, "L0 [000001 000002] (4.0KB + 1.2MB) Score=1.31", li.String())
 	})
+}
+
+func TestFormatTablesWithSizes(t *testing.T) {
+	require.Equal(t, "", FormatTablesWithSizes(nil))
+	require.Equal(t, "000001(3.0KB)",
+		FormatTablesWithSizes([]TableInfo{tableInfoWithRefSize(1, 3<<10, 0)}))
+	require.Equal(t, "000001(3.0KB+1.0MB)",
+		FormatTablesWithSizes([]TableInfo{tableInfoWithRefSize(1, 3<<10, 1<<20)}))
+	// Multiple tables exercise the separator and the per-table refSize omission.
+	require.Equal(t, "000001(3.0KB+1.0MB) 000002(1.0KB)",
+		FormatTablesWithSizes([]TableInfo{
+			tableInfoWithRefSize(1, 3<<10, 1<<20),
+			tableInfoWithRefSize(2, 1<<10, 0),
+		}))
+}
+
+func TestFormatBlobsWithSizes(t *testing.T) {
+	require.Equal(t, "", FormatBlobsWithSizes(nil))
+	require.Equal(t, "000006(5.0MB)",
+		FormatBlobsWithSizes([]BlobFileInfo{{DiskFileNum: base.DiskFileNum(6), Size: 5 << 20}}))
+	// Multiple blobs; the second carries MVCC garbage (1/4 of its values).
+	require.Equal(t, "000006(5.0MB) 000007(2.0MB, MVCCGarbage: 25%)",
+		FormatBlobsWithSizes([]BlobFileInfo{
+			{DiskFileNum: base.DiskFileNum(6), Size: 5 << 20},
+			{DiskFileNum: base.DiskFileNum(7), Size: 2 << 20, ValueSize: 4 << 20, MVCCGarbageSize: 1 << 20},
+		}))
+}
+
+func TestFormatTotalSize(t *testing.T) {
+	require.Equal(t, "3.0KB", formatTotalSize(3<<10, 0))
+	require.Equal(t, "3.0KB+1.0MB", formatTotalSize(3<<10, 1<<20))
+}
+
+// TestCompactionInfoSafeFormatBlobs verifies the compaction "done" line renders
+// per-table output sizes and the output-blob segment. This is the only direct
+// coverage of the compaction output-blob branch; golden testdata flushes blobs
+// but never compacts them.
+func TestCompactionInfoSafeFormatBlobs(t *testing.T) {
+	ci := CompactionInfo{
+		JobID:  1,
+		Reason: "default",
+		Input:  []LevelInfo{{Level: 0, Tables: []TableInfo{tableInfoWithRefSize(1, 1<<20, 0)}}},
+		Output: LevelInfo{
+			Level: 6,
+			Tables: []TableInfo{
+				tableInfoWithRefSize(10, 8<<20, 2<<20),
+				tableInfoWithRefSize(11, 2<<20, 0),
+			},
+			Blobs: []BlobFileInfo{
+				{DiskFileNum: base.DiskFileNum(12), Size: 3 << 20},
+				{DiskFileNum: base.DiskFileNum(13), Size: 1 << 20},
+			},
+		},
+		Duration:      time.Second,
+		TotalDuration: time.Second,
+		Done:          true,
+	}
+	require.Contains(t, ci.String(),
+		"-> L6 [000010(8.0MB+2.0MB) 000011(2.0MB)] (10MB+2.0MB) blobs [000012(3.0MB) 000013(1.0MB)] (4.0MB)")
 }

--- a/replay/testdata/collect/clean_before_copy
+++ b/replay/testdata/collect/clean_before_copy
@@ -13,7 +13,7 @@ flush
 000002
 ----
 created src/000002.sst
-[JOB 0] flushed 1 memtable (100B) to L0 [000002] (10KB), in 0.1s (0.1s total), output rate 100KB/s
+[JOB 0] flushed 1 memtable (100B) to L0 [000002(10KB)] (10KB), in 0.1s (0.1s total), output rate 100KB/s
 
 clean
 src/000002.sst

--- a/replay/testdata/collect/copy_before_clean
+++ b/replay/testdata/collect/copy_before_clean
@@ -8,7 +8,7 @@ flush
 000002
 ----
 created src/000002.sst
-[JOB 0] flushed 1 memtable (100B) to L0 [000002] (10KB), in 0.1s (0.1s total), output rate 100KB/s
+[JOB 0] flushed 1 memtable (100B) to L0 [000002(10KB)] (10KB), in 0.1s (0.1s total), output rate 100KB/s
 
 # Wait for 000002.sst to be copied.
 

--- a/replay/testdata/collect/manifest_copying
+++ b/replay/testdata/collect/manifest_copying
@@ -30,7 +30,7 @@ flush
 000003
 ----
 created src/000003.sst
-[JOB 0] flushed 1 memtable (100B) to L0 [000003] (10KB), in 0.1s (0.1s total), output rate 100KB/s
+[JOB 0] flushed 1 memtable (100B) to L0 [000003(10KB)] (10KB), in 0.1s (0.1s total), output rate 100KB/s
 
 wait
 ----
@@ -62,7 +62,7 @@ flush
 ----
 created src/000005.sst
 created src/000006.sst
-[JOB 0] flushed 1 memtable (100B) to L0 [000005 000006] (20KB), in 0.1s (0.1s total), output rate 200KB/s
+[JOB 0] flushed 1 memtable (100B) to L0 [000005(10KB) 000006(10KB)] (20KB), in 0.1s (0.1s total), output rate 200KB/s
 
 wait
 ----

--- a/replay/testdata/collect/start_stop
+++ b/replay/testdata/collect/start_stop
@@ -38,7 +38,7 @@ flush
 ----
 created src/000005.sst
 created src/000006.sst
-[JOB 0] flushed 1 memtable (100B) to L0 [000005 000006] (20KB), in 0.1s (0.1s total), output rate 200KB/s
+[JOB 0] flushed 1 memtable (100B) to L0 [000005(10KB) 000006(10KB)] (20KB), in 0.1s (0.1s total), output rate 200KB/s
 
 # dst/ should now have the original insgested files (00000{2-4}.sst) and the
 # manifest, but not the more-recently flushed files (00000{5-6}.sst). src/
@@ -82,7 +82,7 @@ flush
 ----
 created src/000007.sst
 created src/000008.sst
-[JOB 0] flushed 1 memtable (100B) to L0 [000007 000008] (20KB), in 0.1s (0.1s total), output rate 200KB/s
+[JOB 0] flushed 1 memtable (100B) to L0 [000007(10KB) 000008(10KB)] (20KB), in 0.1s (0.1s total), output rate 200KB/s
 
 wait
 ----

--- a/testdata/compaction/compaction_cancellation
+++ b/testdata/compaction/compaction_cancellation
@@ -34,7 +34,7 @@ manual compaction cancelled: context canceled, current queued compactions: 0
 # One compaction was done.
 compaction-log
 ----
-[JOB 1] compacted(move) L2 [000004] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L2 [000004] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000004(680B)] (680B), in 1.0s (1.0s total), output rate 680B/s
 
 compact a-z L2 parallel
 ----
@@ -45,8 +45,8 @@ L3:
 
 compaction-log sort
 ----
-[JOB 1] compacted(move) L2 [000005] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000005] (680B), in 1.0s (1.0s total), output rate 680B/s
-[JOB 1] compacted(move) L2 [000006] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000006] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L2 [000005] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000005(680B)] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L2 [000006] (680B) Score=0.00 + L3 [] (0B) Score=0.00 -> L3 [000006(680B)] (680B), in 1.0s (1.0s total), output rate 680B/s
 
 # Repeat with only blocking the last of the three manual compactions.
 add-ongoing-compaction startLevel=3 outputLevel=4 start=g end=h
@@ -59,5 +59,5 @@ manual compaction cancelled: context canceled, current queued compactions: 0
 # Two compactions were done.
 compaction-log
 ----
-[JOB 1] compacted(move) L3 [000004] (680B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
-[JOB 1] compacted(move) L3 [000005] (680B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000005] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L3 [000004] (680B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000004(680B)] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L3 [000005] (680B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000005(680B)] (680B), in 1.0s (1.0s total), output rate 680B/s

--- a/testdata/compaction/mvcc_garbage_blob
+++ b/testdata/compaction/mvcc_garbage_blob
@@ -39,8 +39,8 @@ Blob files:
 
 flush-log
 ----
-[JOB 1] flushed 1 memtable (100B) to L0 [000005] (827B) blob [000006 (MVCCGarbage: 100%)] (102B), in 1.0s (1.0s total), output rate 827B/s
-[JOB 1] flushed 1 memtable (100B) to L0 [000008] (707B), in 1.0s (1.0s total), output rate 707B/s
+[JOB 1] flushed 1 memtable (100B) to L0 [000005(827B+102B)] (827B+102B) blob [000006(102B, MVCCGarbage: 100%)] (102B), in 1.0s (1.0s total), output rate 827B/s
+[JOB 1] flushed 1 memtable (100B) to L0 [000008(707B)] (707B), in 1.0s (1.0s total), output rate 707B/s
 
 batch
 set yay@3 a
@@ -62,4 +62,4 @@ Blob files:
 
 flush-log
 ----
-[JOB 1] flushed 1 memtable (100B) to L0 [000010] (795B) blob [000011 (MVCCGarbage: 17%)] (102B), in 1.0s (1.0s total), output rate 795B/s
+[JOB 1] flushed 1 memtable (100B) to L0 [000010(795B+102B)] (795B+102B) blob [000011(102B, MVCCGarbage: 17%)] (102B), in 1.0s (1.0s total), output rate 795B/s

--- a/testdata/compaction/score_compaction_picked_before_manual
+++ b/testdata/compaction/score_compaction_picked_before_manual
@@ -15,7 +15,7 @@ L6:
 # compaction.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (680B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L5 [000004] (680B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000004(680B)] (680B), in 1.0s (1.0s total), output rate 680B/s
 
 # Do an auto score-based compaction with the same LSM as the previous test.
 define disable-multi-level lbase-max-bytes=1 auto-compactions=off
@@ -33,7 +33,7 @@ L6:
 # Note the score is > 1.0 since these is a score-based compaction.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (680B) Score=944.44 + L6 [] (0B) Score=0.00 -> L6 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L5 [000004] (680B) Score=944.44 + L6 [] (0B) Score=0.00 -> L6 [000004(680B)] (680B), in 1.0s (1.0s total), output rate 680B/s
 
 # With the same LSM as the previous test, try to do both a manual and
 # score-based compaction. The score-based compaction runs first.
@@ -64,4 +64,4 @@ set-disable-auto-compact v=true
 # The score-based compaction ran first.
 compaction-log
 ----
-[JOB 1] compacted(move) L5 [000004] (680B) Score=944.44 + L6 [] (0B) Score=0.00 -> L6 [000004] (680B), in 1.0s (1.0s total), output rate 680B/s
+[JOB 1] compacted(move) L5 [000004] (680B) Score=944.44 + L6 [] (0B) Score=0.00 -> L6 [000004(680B)] (680B), in 1.0s (1.0s total), output rate 680B/s

--- a/testdata/compaction_delete_only_hints
+++ b/testdata/compaction_delete_only_hints
@@ -127,8 +127,8 @@ maybe-compact
 Deletion hints:
   L1.000005 b-r seqnums(tombstone=200-230, file-smallest=30, type=point-key-only)
 Compactions:
-  [JOB 100] compacted(delete-only) (excised: 000005) L1 [000005] (649B) Score=0.00 + L2 [000006] (666B) Score=0.00 -> L6 [000009] (1B), in 1.0s (2.0s total), output rate 1B/s
-[JOB 100] compacted(virtual-sst-rewrite) L1 [000009] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000010] (643B), in 1.0s (2.0s total), output rate 643B/s
+  [JOB 100] compacted(delete-only) (excised: 000005) L1 [000005] (649B) Score=0.00 + L2 [000006] (666B) Score=0.00 -> L6 [000009(1B)] (1B), in 1.0s (2.0s total), output rate 1B/s
+[JOB 100] compacted(virtual-sst-rewrite) L1 [000009] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000010(643B)] (643B), in 1.0s (2.0s total), output rate 643B/s
 
 # Test a range tombstone that is already compacted into L6.
 
@@ -207,8 +207,8 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (666B) Score=0.00 + L3 [000006] (666B) Score=0.00 + L4 [000007] (666B) Score=0.00 -> L6 [000009] (94B), in 1.0s (2.0s total), output rate 94B/s
-[JOB 100] compacted(virtual-sst-rewrite) L4 [000009] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000010] (655B), in 1.0s (2.0s total), output rate 655B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000007) L2 [000005] (666B) Score=0.00 + L3 [000006] (666B) Score=0.00 + L4 [000007] (666B) Score=0.00 -> L6 [000009(94B)] (94B), in 1.0s (2.0s total), output rate 94B/s
+[JOB 100] compacted(virtual-sst-rewrite) L4 [000009] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000010(655B)] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 # A deletion hint present on an sstable in a higher level should NOT result in a
 # deletion-only compaction incorrectly removing an sstable in L6 following an
@@ -257,7 +257,7 @@ L0.000001 a-z seqnums(tombstone=5-27, file-smallest=0, type=point-key-only)
 close-snapshot
 10
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (739B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (655B), in 1.0s (2.0s total), output rate 655B/s
+[JOB 100] compacted(elision-only) L6 [000004] (739B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005(655B)] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 # In previous versions of the code, the deletion hint was removed by the
 # elision-only compaction because it zeroed sequence numbers of keys with
@@ -476,9 +476,9 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (649B) Score=0.00 + L2 [000006] (666B) Score=0.00 + L3 [000007] (666B) Score=0.00 + L4 [000008] (666B) Score=0.00 -> L6 [000009 000010] (95B), in 1.0s (2.0s total), output rate 95B/s
+  [JOB 100] compacted(delete-only) multilevel (excised: 000005) (excised: 000008) L1 [000005] (649B) Score=0.00 + L2 [000006] (666B) Score=0.00 + L3 [000007] (666B) Score=0.00 + L4 [000008] (666B) Score=0.00 -> L6 [000009(1B) 000010(94B)] (95B), in 1.0s (2.0s total), output rate 95B/s
 [JOB 100] compacted(virtual-sst-rewrite) L1 [000009] (1B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [] (0B), in 1.0s (2.0s total), output rate 0B/s
-[JOB 100] compacted(virtual-sst-rewrite) L4 [000010] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000011] (655B), in 1.0s (2.0s total), output rate 655B/s
+[JOB 100] compacted(virtual-sst-rewrite) L4 [000010] (94B) Score=0.00 + L4 [] (0B) Score=0.00 -> L4 [000011(655B)] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 describe-lsm
 ----
@@ -610,9 +610,9 @@ maybe-compact
 Deletion hints:
   (none)
 Compactions:
-  [JOB 100] compacted(delete-only) (excised: 000004) L6 [000004] (810B) Score=0.00 -> L6 [000007 000008] (186B), in 1.0s (2.0s total), output rate 186B/s
-[JOB 100] compacted(virtual-sst-rewrite) L6 [000007] (93B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000009] (788B), in 1.0s (2.0s total), output rate 788B/s
-[JOB 100] compacted(virtual-sst-rewrite) L6 [000008] (93B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (792B), in 1.0s (2.0s total), output rate 792B/s
+  [JOB 100] compacted(delete-only) (excised: 000004) L6 [000004] (810B) Score=0.00 -> L6 [000007(93B) 000008(93B)] (186B), in 1.0s (2.0s total), output rate 186B/s
+[JOB 100] compacted(virtual-sst-rewrite) L6 [000007] (93B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000009(788B)] (788B), in 1.0s (2.0s total), output rate 788B/s
+[JOB 100] compacted(virtual-sst-rewrite) L6 [000008] (93B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010(792B)] (792B), in 1.0s (2.0s total), output rate 792B/s
 
 describe-lsm
 ----

--- a/testdata/compaction_read_triggered
+++ b/testdata/compaction_read_triggered
@@ -20,7 +20,7 @@ show-read-compactions
 
 maybe-compact
 ----
-[JOB 100] compacted(read) L5 [000004] (469B) Score=0.00 + L6 [000005] (469B) Score=0.00 -> L6 [000006] (463B), in 1.0s (2.0s total), output rate 463B/s
+[JOB 100] compacted(read) L5 [000004] (469B) Score=0.00 + L6 [000005] (469B) Score=0.00 -> L6 [000006(463B)] (463B), in 1.0s (2.0s total), output rate 463B/s
 
 show-read-compactions
 ----
@@ -81,7 +81,7 @@ show-read-compactions
 
 maybe-compact
 ----
-[JOB 100] compacted(read) L5 [000004] (469B) Score=0.00 + L6 [000005] (469B) Score=0.00 -> L6 [000006] (463B), in 1.0s (2.0s total), output rate 463B/s
+[JOB 100] compacted(read) L5 [000004] (469B) Score=0.00 + L6 [000005] (469B) Score=0.00 -> L6 [000006(463B)] (463B), in 1.0s (2.0s total), output rate 463B/s
 
 show-read-compactions
 ----

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -89,7 +89,7 @@ compression: None:124
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (700B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (655B), in 1.0s (2.0s total), output rate 655B/s
+[JOB 100] compacted(elision-only) L6 [000004] (700B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005(655B)] (655B), in 1.0s (2.0s total), output rate 655B/s
 
 version
 ----
@@ -215,7 +215,7 @@ compression: None:16929
 
 maybe-compact
 ----
-[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=88.39 + L6 [000007] (17KB) Score=0.00 -> L6 [000009] (25KB), in 1.0s (2.0s total), output rate 25KB/s
+[JOB 100] compacted(default) L5 [000004 000005] (26KB) Score=88.39 + L6 [000007] (17KB) Score=0.00 -> L6 [000009(25KB)] (25KB), in 1.0s (2.0s total), output rate 25KB/s
 
 define level-max-bytes=(L5 : 1000) auto-compactions=off
 L5
@@ -335,7 +335,7 @@ compression: None:227
 
 maybe-compact
 ----
-[JOB 100] compacted(elision-only) L6 [000004] (859B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005] (661B), in 1.0s (2.0s total), output rate 661B/s
+[JOB 100] compacted(elision-only) L6 [000004] (859B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000005(661B)] (661B), in 1.0s (2.0s total), output rate 661B/s
 
 # Close the DB, asserting that the reference counts balance.
 close
@@ -389,9 +389,9 @@ compression: None:87,Snappy:73/84
 # numbers, so the test overwrites them to 0.
 maybe-compact
 ----
-[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
-[JOB 101] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 102] compacted(default) L5 [000004] (696B) Score=2.72 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000(8.7KB)] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
+[JOB 101] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000(8.2KB)] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
+[JOB 102] compacted(default) L5 [000004] (696B) Score=2.72 + L6 [000006] (13KB) Score=0.00 -> L6 [000000(4.7KB)] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 # The same LSM as above. However, this time, with point tombstone weighting at
 # 2x, the table with the point tombstone (000004) will be selected as the
@@ -438,9 +438,9 @@ compression: None:87,Snappy:73/84
 # numbers, so the test overwrites them to 0.
 maybe-compact
 ----
-[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
-[JOB 101] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
-[JOB 102] compacted(default) L5 [000004] (696B) Score=2.72 + L6 [000006] (13KB) Score=0.00 -> L6 [000000] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
+[JOB 100] compacted(virtual-sst-rewrite) L6 [000000] (8.2KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000(8.7KB)] (8.7KB), in 1.0s (2.0s total), output rate 8.7KB/s
+[JOB 101] compacted(delete-only) (excised: 000007) L6 [000007] (13KB) Score=0.00 -> L6 [000000(8.2KB)] (8.2KB), in 1.0s (2.0s total), output rate 8.2KB/s
+[JOB 102] compacted(default) L5 [000004] (696B) Score=2.72 + L6 [000006] (13KB) Score=0.00 -> L6 [000000(4.7KB)] (4.7KB), in 1.0s (2.0s total), output rate 4.7KB/s
 
 
 # These tests demonstrate the behavior of the tombstone density compaction feature
@@ -518,8 +518,8 @@ compression: None:36,Snappy:95/108
 # should indicate "move" as the compaction type.
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L5 [000004] (716B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000] (661B), in 1.0s (2.0s total), output rate 661B/s
-[JOB 101] compacted(move) L4 [000004] (716B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000] (716B), in 1.0s (2.0s total), output rate 716B/s
+[JOB 100] compacted(tombstone-density) L5 [000004] (716B) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000000(661B)] (661B), in 1.0s (2.0s total), output rate 661B/s
+[JOB 101] compacted(move) L4 [000004] (716B) Score=0.00 + L5 [] (0B) Score=0.00 -> L5 [000000(716B)] (716B), in 1.0s (2.0s total), output rate 716B/s
 
 # Verify the result - the file should now be in L5
 # The file should maintain its original content since it was just moved rather than recompacted
@@ -579,7 +579,7 @@ compression: None:36,Snappy:95/108
 # because there are overlapping files in L5 that prevent the optimization
 maybe-compact
 ----
-[JOB 100] compacted(tombstone-density) L4 [000004] (716B) Score=0.00 + L5 [000005] (666B) Score=0.00 -> L5 [000007] (661B), in 1.0s (2.0s total), output rate 661B/s
+[JOB 100] compacted(tombstone-density) L4 [000004] (716B) Score=0.00 + L5 [000005] (666B) Score=0.00 -> L5 [000007(661B)] (661B), in 1.0s (2.0s total), output rate 661B/s
 
 # Verify the result - the file was recompacted with the overlapping L5 file
 # The output file should be different from the input files

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -149,7 +149,7 @@ close: db/marker.manifest.000002.MANIFEST-000006
 remove: db/marker.manifest.000001.MANIFEST-000001
 sync: db
 [JOB 3] MANIFEST created 000006
-[JOB 3] flushed 1 memtable (100B) to L0 [000005] (657B), in 1.0s (2.0s total), output rate 657B/s
+[JOB 3] flushed 1 memtable (100B) to L0 [000005(657B)] (657B), in 1.0s (2.0s total), output rate 657B/s
 
 compact
 ----
@@ -175,7 +175,7 @@ close: db/marker.manifest.000003.MANIFEST-000009
 remove: db/marker.manifest.000002.MANIFEST-000006
 sync: db
 [JOB 5] MANIFEST created 000009
-[JOB 5] flushed 1 memtable (100B) to L0 [000008] (657B), in 1.0s (2.0s total), output rate 657B/s
+[JOB 5] flushed 1 memtable (100B) to L0 [000008(657B)] (657B), in 1.0s (2.0s total), output rate 657B/s
 remove: db/MANIFEST-000001
 [JOB 5] MANIFEST deleted 000001
 [JOB 6] compacting(default) L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00; OverlappingRatio: Single 0.00, Multi 0.00
@@ -210,7 +210,7 @@ close: db/marker.manifest.000004.MANIFEST-000011
 remove: db/marker.manifest.000003.MANIFEST-000009
 sync: db
 [JOB 6] MANIFEST created 000011
-[JOB 6] compacted(default) L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010] (652B), in 1.0s (3.0s total), output rate 652B/s
+[JOB 6] compacted(default) L0 [000005 000008] (1.3KB) Score=0.00 + L6 [] (0B) Score=0.00 -> L6 [000010(652B)] (652B), in 1.0s (3.0s total), output rate 652B/s
 close: db/000005.sst
 close: db/000008.sst
 remove: db/MANIFEST-000006
@@ -247,7 +247,7 @@ close: db/marker.manifest.000005.MANIFEST-000014
 remove: db/marker.manifest.000004.MANIFEST-000011
 sync: db
 [JOB 8] MANIFEST created 000014
-[JOB 8] flushed 1 memtable (100B) to L0 [000013] (657B), in 1.0s (2.0s total), output rate 657B/s
+[JOB 8] flushed 1 memtable (100B) to L0 [000013(657B)] (657B), in 1.0s (2.0s total), output rate 657B/s
 
 enable-file-deletions
 ----
@@ -407,7 +407,7 @@ sync-data: db/000022.sst
 close: db/000022.sst
 sync: db
 sync: db/MANIFEST-000016
-[JOB 15] flushed 1 memtable (100B) to L0 [000022] (657B), in 1.0s (2.0s total), output rate 657B/s
+[JOB 15] flushed 1 memtable (100B) to L0 [000022(657B)] (657B), in 1.0s (2.0s total), output rate 657B/s
 [JOB 16] flushing 2 ingested tables
 create: db/MANIFEST-000023
 close: db/MANIFEST-000016

--- a/testdata/marked_for_compaction
+++ b/testdata/marked_for_compaction
@@ -20,8 +20,8 @@ marked L0.000004
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000005] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006] (665B), in 1.0s (2.0s total), output rate 665B/s
-[JOB 100] compacted(rewrite) L0 [000004] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007] (654B), in 1.0s (2.0s total), output rate 654B/s
+[JOB 100] compacted(rewrite) L1 [000005] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000006(665B)] (665B), in 1.0s (2.0s total), output rate 665B/s
+[JOB 100] compacted(rewrite) L0 [000004] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000007(654B)] (654B), in 1.0s (2.0s total), output rate 654B/s
 L0.0:
   000007:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:654
 L1:
@@ -41,8 +41,8 @@ reopen
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000006] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000012] (665B), in 1.0s (2.0s total), output rate 665B/s
-[JOB 100] compacted(rewrite) L0 [000007] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000013] (654B), in 1.0s (2.0s total), output rate 654B/s
+[JOB 100] compacted(rewrite) L1 [000006] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000012(665B)] (665B), in 1.0s (2.0s total), output rate 665B/s
+[JOB 100] compacted(rewrite) L0 [000007] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000013(654B)] (654B), in 1.0s (2.0s total), output rate 654B/s
 L0.0:
   000013:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:654
 L1:
@@ -66,8 +66,8 @@ reopen
 
 maybe-compact
 ----
-[JOB 100] compacted(rewrite) L1 [000012] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000019] (665B), in 1.0s (2.0s total), output rate 665B/s
-[JOB 100] compacted(rewrite) L0 [000013] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000020] (654B), in 1.0s (2.0s total), output rate 654B/s
+[JOB 100] compacted(rewrite) L1 [000012] (665B) Score=0.00 + L1 [] (0B) Score=0.00 -> L1 [000019(665B)] (665B), in 1.0s (2.0s total), output rate 665B/s
+[JOB 100] compacted(rewrite) L0 [000013] (654B) Score=0.00 + L0 [] (0B) Score=0.00 -> L0 [000020(654B)] (654B), in 1.0s (2.0s total), output rate 654B/s
 L0.0:
   000020:[c#11,SET-c#11,SET] seqnums:[11-11] points:[c#11,SET-c#11,SET] size:654
 L1:

--- a/tool/logs/compaction.go
+++ b/tool/logs/compaction.go
@@ -77,8 +77,15 @@ var (
 
 			/* Start / end level */
 			`(?P<levels>L(?P<from>\d).*?(?:.*(?:\+|->)\sL(?P<to>\d))?` +
-			/* Bytes (optionally "table + blob references", e.g. "(4.0KB + 1.2MB)") */
-			`(?:.*?\((?P<bytes>[0-9.]+( [BKMGTPE]|[KMGTPE]?B)( \+ [0-9.]+( [BKMGTPE]|[KMGTPE]?B))*)\))` +
+			/* Bytes: the aggregate size in parens following the first ']'-terminated
+			   file list after the (last) matched level, optionally
+			   "table + blob references" (e.g. "(4.0KB + 1.2MB)" or "(4.0KB+1.2MB)").
+			   For an "ed" (end) line the greedy '.*' above consumes the input levels
+			   so this captures the output size; for an "ing" (start) line it captures
+			   an input size (not asserted). The capture is anchored on the closing
+			   ']' so we skip the per-file sizes now embedded in the list itself, e.g.
+			   "[445883(7.0MB+2.0MB) 445887(6.0MB+1.0MB)] (13MB+3.0MB)". */
+			`(?:.*?]\s*\((?P<bytes>[0-9.]+( [BKMGTPE]|[KMGTPE]?B)(\s*\+\s*[0-9.]+( [BKMGTPE]|[KMGTPE]?B))*)\))` +
 			/* Score */
 			`?(\s*(Score=\d+(\.\d+)))?)`,
 	)
@@ -107,7 +114,10 @@ var (
 			/* Job ID                       */ `\[JOB (?P<job>\d+)]\s` +
 			/* Compaction type              */ `flush(?P<suffix>ed|ing)\s` +
 			/* Memtable count; size (23.2+) */ `\d+ memtables? (\([^)]+\))?` +
-			/* SSTable Bytes                */ `(?:.*?\((?P<bytes>[0-9.]+( [BKMGTPE]|[KMGTPE]?B))\))?`,
+			/* SSTable bytes: aggregate output size in parens following the output
+			   file list, anchored on the closing ']' so we skip the per-file sizes
+			   now embedded in the list. Optionally "table + blob references". */
+			`(?:.*?]\s*\((?P<bytes>[0-9.]+( [BKMGTPE]|[KMGTPE]?B)(\s*\+\s*[0-9.]+( [BKMGTPE]|[KMGTPE]?B))*)\))?`,
 	)
 	flushPatternSuffixIdx = flushPattern.SubexpIndex("suffix")
 	flushPatternJobIdx    = flushPattern.SubexpIndex("job")
@@ -374,9 +384,10 @@ func parseFlushEnd(matches []string) (compactionEnd, error) {
 	}
 	end = compactionEnd{jobID: jobID}
 
-	// Optionally, if we have flushed bytes.
+	// Optionally, if we have flushed bytes. The captured size may be a
+	// "table + blob references" sum (e.g. "859B+102B"), so use unHumanizeSum.
 	if matches[flushPatternBytesIdx] != "" {
-		end.writtenBytes = unHumanize(matches[flushPatternBytesIdx])
+		end.writtenBytes = unHumanizeSum(matches[flushPatternBytesIdx])
 	}
 
 	return end, nil

--- a/tool/logs/compaction_test.go
+++ b/tool/logs/compaction_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +48,12 @@ const (
 	// Lines with blob reference sizes, rendered as "(table + blob)".
 	compactionStartLineBlob = `I211215 14:26:56.012382 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1845 ⋮ [n5,pebble,s6] 1216510  [JOB 284925] compacting(default) L2 [442555] (4.2MB + 1.0MB) Score=1.01 + L3 [445853] (8.4MB + 2.0MB) Score=0.99;  OverlappingRatio: Single 8.03, Multi 25.05;`
 	compactionEndLineBlob   = `I211215 14:26:56.318543 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n5,pebble,s6] 1216554  [JOB 284925] compacted(default) L2 [442555] (4.2MB) Score=1.01 + L3 [445853] (8.4MB) Score=1.01 -> L3 [445883 445887] (13MB + 3.0MB), in 0.3s, output rate 42MB/s`
+
+	// Output lines with per-file sizes embedded in the file list and an output
+	// blob segment, e.g. "[445883(7.0MB+2.0MB) 445887(6.0MB+1.0MB)] (13MB+3.0MB)".
+	// The aggregate output size still follows the closing ']' of the table list.
+	compactionEndLinePerFileSizes = `I211215 14:26:56.318543 51831533 3@vendor/github.com/cockroachdb/pebble/compaction.go:1886 ⋮ [n5,pebble,s6] 1216554  [JOB 284925] compacted(default) L2 [442555] (4.2MB) Score=1.01 + L3 [445853] (8.4MB) Score=1.01 -> L3 [445883(7.0MB+2.0MB) 445887(6.0MB+1.0MB)] (13MB+3.0MB) blob [445890(3.0MB) 445891(1.5MB)] (4.5MB), in 0.3s, output rate 42MB/s`
+	flushEndLinePerFileSizes      = `I211213 16:23:49.134464 21136 3@vendor/github.com/cockroachdb/pebble/event.go:603 ⋮ [n9,pebble,s8] 26 [JOB 10] flushed 1 memtable (100B) to L0 [000005(859B+102B)] (859B+102B) blob [000006(102B, MVCCGarbage: 100%)] (102B), in 1.0s (1.0s total), output rate 859B/s`
 )
 
 func TestCompactionLogs_Regex(t *testing.T) {
@@ -223,6 +230,21 @@ func TestCompactionLogs_Regex(t *testing.T) {
 			},
 		},
 		{
+			name: "compaction end with per-file sizes and output blobs",
+			re:   compactionPattern,
+			line: compactionEndLinePerFileSizes,
+			matches: map[int]string{
+				compactionPatternJobIdx:    "284925",
+				compactionPatternSuffixIdx: "ed",
+				compactionPatternTypeIdx:   "default",
+				compactionPatternFromIdx:   "2",
+				compactionPatternToIdx:     "3",
+				// The aggregate table size is captured, not a per-file size or the
+				// output blob size.
+				compactionPatternBytesIdx: "13MB+3.0MB",
+			},
+		},
+		{
 			name: "flush start",
 			re:   flushPattern,
 			line: flushStartLine,
@@ -250,6 +272,18 @@ func TestCompactionLogs_Regex(t *testing.T) {
 				flushPatternJobIdx:    "10",
 				flushPatternSuffixIdx: "ed",
 				flushPatternBytesIdx:  "1.3MB",
+			},
+		},
+		{
+			name: "flush end with per-file sizes and output blobs",
+			re:   flushPattern,
+			line: flushEndLinePerFileSizes,
+			matches: map[int]string{
+				flushPatternJobIdx:    "10",
+				flushPatternSuffixIdx: "ed",
+				// The aggregate table size is captured, not a per-file size or the
+				// output blob size.
+				flushPatternBytesIdx: "859B+102B",
 			},
 		},
 		{
@@ -503,5 +537,118 @@ func TestParseInputBytes(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
 		})
+	}
+}
+
+// TestParseEndWrittenBytes exercises the full match -> parse path for compaction
+// and flush end lines, including the new per-file-size output format whose
+// aggregate is a "table + blob" sum. This guards against the parser mishandling
+// the summed size (e.g. feeding it to unHumanize instead of unHumanizeSum).
+func TestParseEndWrittenBytes(t *testing.T) {
+	testCases := []struct {
+		name  string
+		flush bool
+		line  string
+		want  uint64
+	}{
+		{name: "compaction end", line: compactionEndLine, want: 13 << 20},
+		{name: "compaction end with blob references", line: compactionEndLineBlob, want: 16 << 20},
+		{name: "compaction end with per-file sizes", line: compactionEndLinePerFileSizes, want: 16 << 20},
+		// unHumanize("1.3MB") = uint64(1.3 * 2^20) = 1363148.
+		{name: "flush end", flush: true, line: flushEndLine, want: 1363148},
+		{name: "flush end with per-file sizes", flush: true, line: flushEndLinePerFileSizes, want: 859 + 102},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.flush {
+				matches := flushPattern.FindStringSubmatch(tc.line)
+				require.NotNil(t, matches)
+				end, err := parseFlushEnd(matches)
+				require.NoError(t, err)
+				require.Equal(t, tc.want, end.writtenBytes)
+			} else {
+				matches := compactionPattern.FindStringSubmatch(tc.line)
+				require.NotNil(t, matches)
+				end, err := parseCompactionEnd(matches)
+				require.NoError(t, err)
+				require.Equal(t, tc.want, end.writtenBytes)
+			}
+		})
+	}
+}
+
+// TestCompactionKindToolSupport verifies that the tool's compactionType enum
+// stays in sync with the main compactionKind enum in compaction.go.
+// This test will fail if a new compaction type is added to compaction.go
+// but not to this tool, preventing the tool from becoming out of date.
+func TestCompactionKindToolSupport(t *testing.T) {
+	// Get all compaction kinds from compaction.go via the helper function
+	allKinds := pebble.AllCompactionKindStrings()
+
+	// These kinds use flush logging format, not compaction logging format.
+	// They are handled separately and should NOT be in the compactionType enum.
+	flushLoggedKinds := map[string]string{
+		"flush":              "logged via FlushInfo, not CompactionInfo",
+		"ingested-flushable": "logged as 'flushed N ingested flushables' via FlushInfo (see parseIngestDuringFlush)",
+	}
+
+	// These kinds are not yet parsed by the tool on this branch. On master the
+	// tool handles them; they are excluded here so the sync check still covers
+	// the kinds this branch's tool does support.
+	unsupportedKinds := map[string]string{
+		"copy":              "not yet parsed by the tool on this branch",
+		"tombstone-density": "not yet parsed by the tool on this branch",
+		"rewrite":           "not yet parsed by the tool on this branch",
+	}
+
+	var missingTypes []string
+	handledCount := 0
+
+	// Verify each non-flush kind is supported by the tool
+	for kindStr := range allKinds {
+		if reason, excluded := flushLoggedKinds[kindStr]; excluded {
+			t.Logf("Skipping %q: %s", kindStr, reason)
+			continue
+		}
+		if reason, excluded := unsupportedKinds[kindStr]; excluded {
+			t.Logf("Skipping %q: %s", kindStr, reason)
+			continue
+		}
+
+		// Special case: blob-file-rewrite logs as "blob-rewrite" in practice
+		testStr := kindStr
+		if kindStr == "blob-file-rewrite" {
+			testStr = "blob-rewrite"
+		}
+
+		_, err := parseCompactionType(testStr)
+		if err != nil {
+			missingTypes = append(missingTypes, kindStr)
+			t.Errorf("SYNC ERROR: compaction kind %q from compaction.go is not supported by tool/logs/compaction.go", kindStr)
+		} else {
+			handledCount++
+		}
+	}
+
+	if len(missingTypes) > 0 {
+		t.Errorf("\n"+
+			"═══════════════════════════════════════════════════════════════════════════\n"+
+			"  COMPACTION TOOL OUT OF SYNC\n"+
+			"═══════════════════════════════════════════════════════════════════════════\n"+
+			"\n"+
+			"A new compaction type was added to compaction.go but the compaction summary\n"+
+			"tool (tool/logs/compaction.go) was not updated.\n"+
+			"\n"+
+			"Missing types: %v\n"+
+			"═══════════════════════════════════════════════════════════════════════════\n",
+			missingTypes)
+	}
+
+	// Verify we're handling the expected number of types
+	expectedHandled := len(allKinds) - len(flushLoggedKinds) - len(unsupportedKinds)
+	if handledCount != expectedHandled {
+		t.Errorf("Expected to handle %d compaction types but only handle %d", expectedHandled, handledCount)
+	} else {
+		t.Logf("Successfully verified %d compaction types are supported", handledCount)
 	}
 }


### PR DESCRIPTION
Flush and compaction event log lines previously printed the output sstable
file numbers and a single aggregate size, e.g. `-> L6 [000123 000124]
(3.0MB)`. Compaction lines did not print output blob files at all, even
though `CompactionInfo.Output.Blobs` was already populated.

This change prints size details for each output table and each output blob
file, which is cheap information that helps with debugging. Three helpers are
added in `event.go`:

- `FormatTablesWithSizes` renders each table as `filenum(size+refsize)`,
  omitting `+refsize` when the blob reference size is zero.
- `FormatBlobsWithSizes` renders each blob file as `filenum(size)`, plus the
  MVCC garbage percentage when present.
- `formatOutputBlobs` builds the shared ` blob(s) [...] (...)` segment used by
  both the flush and compaction log lines.

Both `FlushInfo.SafeFormat` and `CompactionInfo.SafeFormat` now use these
helpers; the aggregate total is also shown as `size+refsize`, and compaction
lines now include the output blob segment.

The `tool/logs` compaction/flush log parser extracts the aggregate output
size from these lines. Its regexes are updated to anchor the byte capture on
the closing `]` of the file list, so they skip the per-file sizes now
embedded in the list (and the trailing blob segment), and to accept `+`
without surrounding spaces. Both the compaction and flush end-line parsers
now use `unHumanizeSum` to handle the `table + blob` sum. This is backward
compatible with older log formats; new tests cover the new format and the
match-to-parse path.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>