### PR TITLE
vfs: allow sync_file_range on XFS

### DIFF
--- a/vfs/default_linux.go
+++ b/vfs/default_linux.go
@@ -130,11 +130,10 @@ func isSyncRangeSupported(fd uintptr) bool {
 	// Allowlist which filesystems we allow using sync_file_range with as some
 	// filesystems treat that syscall as a noop (notably ZFS). A allowlist is
 	// used instead of a denylist in order to have a more graceful failure mode
-	// in case a filesystem we haven't tested is encountered. Currently only
-	// ext2/3/4 are known to work properly.
-	const extMagic = 0xef53
+	// in case a filesystem we haven't tested is encountered. Currently ext2/3/4
+	// and XFS are known to work properly.
 	switch stat.Type {
-	case extMagic:
+	case unix.EXT4_SUPER_MAGIC, unix.XFS_SUPER_MAGIC:
 		return syncRangeSmokeTest(fd, unix.SyncFileRange)
 	}
 	return false


### PR DESCRIPTION
Pebble uses sync_file_range for periodic, non-durable syncing to limit dirty data accumulation while writing files. Previously this path was only enabled on ext2/3/4, so XFS fell back to blocking fdatasync calls at each BytesPerSync interval.

Allow XFS through the existing filesystem allowlist and keep the existing runtime smoke test. XFS is one of CockroachDB's recommended filesystems, and RocksDB's POSIX environment allows sync_file_range on XFS while only excluding filesystems known to misbehave, notably ZFS.

This preserves durability semantics: full fdatasync calls are still used for Sync and close-time persistence.

Given that [XFS is a recommended production filesystem for CockroachDB](https://www.cockroachlabs.com/docs/stable/recommended-production-settings#storage) and [is supported by RocksDB](https://github.com/facebook/rocksdb/blob/0f15da1c2db1d5583d0c7200208b6465357f95fc/env/io_posix.cc#L172), there is no underlying reason to restrict its use. The original logic introduced in https://github.com/cockroachdb/pebble/pull/71#pullrequestreview-226221728 restricted support to EXT filesystems primarily to limit the testing scope early in Pebble's development, not due to any technical incompatibility with XFS.