### PR TITLE
crl-release-26.2: db, sstable: clear pooled iterator fields with typed stores

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -69,29 +69,31 @@ func NewExternalIterWithContext(
 	buf := iterAllocPool.Get().(*iterAlloc)
 	dbi := &buf.dbi
 	*dbi = Iterator{
-		ctx:                 ctx,
-		alloc:               buf,
-		merge:               o.Merger.Merge,
-		comparer:            o.Comparer,
-		readState:           nil,
-		keyBuf:              buf.keyBuf,
-		prefixOrFullSeekKey: buf.prefixOrFullSeekKey,
-		boundsBuf:           buf.boundsBuf,
-		batch:               nil,
-		// Add the external iter state to the Iterator so that Close closes it,
-		// and SetOptions can re-construct iterators using its state.
-		externalIter: &externalIterState{readers: readers},
-		newIters: func(context.Context, *manifest.TableMetadata, *IterOptions,
-			internalIterOpts, iterKinds) (iterSet, error) {
-			// NB: External iterators are currently constructed without any
-			// `levelIters`. newIters should never be called. When we support
-			// organizing multiple non-overlapping files into a single level
-			// (see TODO below), we'll need to adjust this tableNewIters
-			// implementation to open iterators by looking up f in a map
-			// of readers indexed by *fileMetadata.
-			panic("unreachable")
+		iterClearedState: iterClearedState{
+			ctx:                 ctx,
+			alloc:               buf,
+			merge:               o.Merger.Merge,
+			comparer:            o.Comparer,
+			readState:           nil,
+			keyBuf:              buf.keyBuf,
+			prefixOrFullSeekKey: buf.prefixOrFullSeekKey,
+			boundsBuf:           buf.boundsBuf,
+			batch:               nil,
+			// Add the external iter state to the Iterator so that Close closes it,
+			// and SetOptions can re-construct iterators using its state.
+			externalIter: &externalIterState{readers: readers},
+			newIters: func(context.Context, *manifest.TableMetadata, *IterOptions,
+				internalIterOpts, iterKinds) (iterSet, error) {
+				// NB: External iterators are currently constructed without any
+				// `levelIters`. newIters should never be called. When we support
+				// organizing multiple non-overlapping files into a single level
+				// (see TODO below), we'll need to adjust this tableNewIters
+				// implementation to open iterators by looking up f in a map
+				// of readers indexed by *fileMetadata.
+				panic("unreachable")
+			},
+			seqNum: base.SeqNumMax,
 		},
-		seqNum: base.SeqNumMax,
 	}
 	dbi.externalIter.bufferPool.Init(2, block.ForExternalIter)
 

--- a/get.go
+++ b/get.go
@@ -112,13 +112,15 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, io.Closer, 
 	i := &buf.dbi
 	pointIter := get
 	*i = Iterator{
-		ctx:       context.Background(),
-		iter:      pointIter,
-		pointIter: pointIter,
-		merge:     d.merge,
-		comparer:  d.opts.Comparer,
-		readState: readState,
-		keyBuf:    buf.keyBuf,
+		iterClearedState: iterClearedState{
+			ctx:       context.Background(),
+			iter:      pointIter,
+			pointIter: pointIter,
+			merge:     d.merge,
+			comparer:  d.opts.Comparer,
+			readState: readState,
+			keyBuf:    buf.keyBuf,
+		},
 	}
 
 	// Set up a blob value fetcher to use for retrieving values from blob files.

--- a/iterator.go
+++ b/iterator.go
@@ -207,13 +207,18 @@ type Iterator struct {
 	// version's BlobFileSet or flushable ingests.
 	combinedBlobMapping combinedBlobFileMapping
 
-	// All fields below this field are cleared during Iterator.Close before
-	// returning the Iterator to the pool. Any fields above this field must also
-	// be cleared, but may be cleared as a part of the body of Iterator.Close
-	// (eg, if these types have their own Close method that zeroes their
-	// fields).
-	clearForReuseBoundary struct{}
+	// iterClearedState holds all remaining Iterator fields; it is cleared
+	// during Iterator.Close before returning the Iterator to the pool. Any
+	// fields declared directly on Iterator (above) must also be cleared, but
+	// may be cleared as a part of the body of Iterator.Close (eg, if these
+	// types have their own Close method that zeroes their fields).
+	iterClearedState
+}
 
+// iterClearedState holds the Iterator fields that are cleared when the
+// Iterator is closed and returned to its pool, by assigning the zero value of
+// this struct.
+type iterClearedState struct {
 	// The context is stored here since (a) Iterators are expected to be
 	// short-lived (since they pin memtables and sstables), (b) plumbing a
 	// context into every method is very painful, (c) they do not (yet) respect
@@ -349,11 +354,8 @@ type Iterator struct {
 	nextPrefixNotPermittedByUpperBound bool
 }
 
-const clearOff = unsafe.Offsetof(Iterator{}.clearForReuseBoundary)
-const clearLen = unsafe.Sizeof(Iterator{}) - clearOff
-
 func (i *Iterator) clearForReuse() {
-	*(*[clearLen]byte)(unsafe.Add(unsafe.Pointer(i), clearOff)) = [clearLen]byte{}
+	i.iterClearedState = iterClearedState{}
 }
 
 // cmp is a convenience shorthand for the i.comparer.Compare function.
@@ -3037,22 +3039,24 @@ func (i *Iterator) CloneWithContext(ctx context.Context, opts CloneOptions) (*It
 	buf := newIterAlloc()
 	dbi := &buf.dbi
 	*dbi = Iterator{
-		ctx:                   ctx,
-		opts:                  *opts.IterOptions,
-		alloc:                 buf,
-		merge:                 i.merge,
-		comparer:              i.comparer,
-		readState:             readState,
-		version:               vers,
-		keyBuf:                buf.keyBuf,
-		prefixOrFullSeekKey:   buf.prefixOrFullSeekKey,
-		boundsBuf:             buf.boundsBuf,
-		fc:                    i.fc,
-		newIters:              i.newIters,
-		newIterRangeKey:       i.newIterRangeKey,
-		valueRetrievalProfile: i.valueRetrievalProfile,
-		seqNum:                i.seqNum,
-		tracker:               i.tracker,
+		iterClearedState: iterClearedState{
+			ctx:                   ctx,
+			opts:                  *opts.IterOptions,
+			alloc:                 buf,
+			merge:                 i.merge,
+			comparer:              i.comparer,
+			readState:             readState,
+			version:               vers,
+			keyBuf:                buf.keyBuf,
+			prefixOrFullSeekKey:   buf.prefixOrFullSeekKey,
+			boundsBuf:             buf.boundsBuf,
+			fc:                    i.fc,
+			newIters:              i.newIters,
+			newIterRangeKey:       i.newIterRangeKey,
+			valueRetrievalProfile: i.valueRetrievalProfile,
+			seqNum:                i.seqNum,
+			tracker:               i.tracker,
+		},
 	}
 	if i.tracker != nil && !dbi.opts.ExemptFromTracking {
 		dbi.trackerHandle = i.tracker.Start()

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -184,9 +184,11 @@ func TestIterator(t *testing.T) {
 			return merge(key, value)
 		}
 		it := &Iterator{
-			opts:     opts,
-			comparer: testkeys.Comparer,
-			merge:    wrappedMerge,
+			iterClearedState: iterClearedState{
+				opts:     opts,
+				comparer: testkeys.Comparer,
+				merge:    wrappedMerge,
+			},
 		}
 		// NB: Use a mergingIter to filter entries newer than seqNum.
 		fakeIter := base.NewFakeIter(kvs)
@@ -861,10 +863,12 @@ func TestIteratorSeekOptErrors(t *testing.T) {
 		// NB: This Iterator cannot be cloned since it is not constructed
 		// with a readState. It suffices for this test.
 		return &Iterator{
-			opts:     opts,
-			comparer: testkeys.Comparer,
-			merge:    DefaultMerger.Merge,
-			iter:     &errorIter,
+			iterClearedState: iterClearedState{
+				opts:     opts,
+				comparer: testkeys.Comparer,
+				merge:    DefaultMerger.Merge,
+				iter:     &errorIter,
+			},
 		}
 	}
 
@@ -1694,8 +1698,10 @@ func newPointTestkeysDatabase(t *testing.T, ks testkeys.Keyspace) *DB {
 func BenchmarkIteratorSeekGE(b *testing.B) {
 	m, keys := buildMemTable(b)
 	iter := &Iterator{
-		comparer: DefaultComparer,
-		iter:     m.newIter(nil),
+		iterClearedState: iterClearedState{
+			comparer: DefaultComparer,
+			iter:     m.newIter(nil),
+		},
 	}
 	rng := rand.New(rand.NewPCG(0, uint64(time.Now().UnixNano())))
 
@@ -1709,8 +1715,10 @@ func BenchmarkIteratorSeekGE(b *testing.B) {
 func BenchmarkIteratorNext(b *testing.B) {
 	m, _ := buildMemTable(b)
 	iter := &Iterator{
-		comparer: DefaultComparer,
-		iter:     m.newIter(nil),
+		iterClearedState: iterClearedState{
+			comparer: DefaultComparer,
+			iter:     m.newIter(nil),
+		},
 	}
 
 	b.ResetTimer()
@@ -1725,8 +1733,10 @@ func BenchmarkIteratorNext(b *testing.B) {
 func BenchmarkIteratorPrev(b *testing.B) {
 	m, _ := buildMemTable(b)
 	iter := &Iterator{
-		comparer: DefaultComparer,
-		iter:     m.newIter(nil),
+		iterClearedState: iterClearedState{
+			comparer: DefaultComparer,
+			iter:     m.newIter(nil),
+		},
 	}
 
 	b.ResetTimer()
@@ -1843,9 +1853,11 @@ func BenchmarkIteratorSeqSeekPrefixGENotFound(b *testing.B) {
 							levelSlices := levelSlices[index]
 							m := buildMergingIter(readers, levelSlices)
 							iter := Iterator{
-								comparer: testkeys.Comparer,
-								merge:    DefaultMerger.Merge,
-								iter:     m,
+								iterClearedState: iterClearedState{
+									comparer: testkeys.Comparer,
+									merge:    DefaultMerger.Merge,
+									iter:     m,
+								},
 							}
 							pos := 0
 							b.ResetTimer()
@@ -1908,9 +1920,11 @@ func BenchmarkIteratorSeqSeekPrefixGEFound(b *testing.B) {
 							levelSlices := levelSlices[index]
 							m := buildMergingIter(readers, levelSlices)
 							iter := Iterator{
-								comparer: testkeys.Comparer,
-								merge:    DefaultMerger.Merge,
-								iter:     m,
+								iterClearedState: iterClearedState{
+									comparer: testkeys.Comparer,
+									merge:    DefaultMerger.Merge,
+									iter:     m,
+								},
 							}
 							pos := 0
 							b.ResetTimer()
@@ -1961,9 +1975,11 @@ func BenchmarkIteratorSeqSeekGEWithBounds(b *testing.B) {
 					false, false, twoLevelIndex)
 				m := buildMergingIter(readers, levelSlices)
 				iter := Iterator{
-					comparer: testkeys.Comparer,
-					merge:    DefaultMerger.Merge,
-					iter:     m,
+					iterClearedState: iterClearedState{
+						comparer: testkeys.Comparer,
+						merge:    DefaultMerger.Merge,
+						iter:     m,
+					},
 				}
 				keyCount := len(keys)
 				b.ResetTimer()
@@ -2009,9 +2025,11 @@ func BenchmarkIteratorSeekGENoop(b *testing.B) {
 		b.Run(fmt.Sprintf("withLimit=%t", withLimit), func(b *testing.B) {
 			m := buildMergingIter(readers, levelSlices)
 			iter := Iterator{
-				comparer: testkeys.Comparer,
-				merge:    DefaultMerger.Merge,
-				iter:     m,
+				iterClearedState: iterClearedState{
+					comparer: testkeys.Comparer,
+					merge:    DefaultMerger.Merge,
+					iter:     m,
+				},
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -41,6 +41,38 @@ import (
 // pattern is taken from the Go generics proposal:
 // https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#pointer-method-example
 type singleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIterator[D]] struct {
+	// singleLevelIterClearedState holds the fields that are cleared when the
+	// iterator is reset for reuse.
+	singleLevelIterClearedState
+
+	// maximumSuffixProperty is used to store the maximum suffix property
+	// which extracts the suffix used by the synthetic key optimization.
+	maximumSuffixProperty MaximumSuffixProperty
+	// synthetic is used to store the synthetic key and the seek key.
+	synthetic syntheticKey
+
+	index I
+	data  D
+	// inPool is set to true before putting the iterator in the reusable pool;
+	// used to detect double-close.
+	inPool bool
+	// pool is the pool from which the iterator was allocated and to which the
+	// iterator should be returned on Close. Because the iterator is
+	// parameterized by the type of the data block iterator, pools must be
+	// specific to the type of the data block iterator.
+	//
+	// If the iterator is embedded within a twoLevelIterator, pool is nil and
+	// the twoLevelIterator.pool field may be non-nil.
+	pool *sync.Pool
+
+	// NOTE: any new fields should be added to singleLevelIterClearedState,
+	// unless they need to be retained when resetting the iterator.
+}
+
+// singleLevelIterClearedState holds the singleLevelIterator fields that are
+// cleared when the iterator is reset for reuse, by assigning the zero value of
+// this struct.
+type singleLevelIterClearedState struct {
 	ctx context.Context
 	cmp Compare
 	// Global lower/upper bound for the iterator.
@@ -175,32 +207,6 @@ type singleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIte
 	indexLoaded bool
 
 	transforms IterTransforms
-
-	// All fields above this field are cleared when resetting the iterator for reuse.
-	clearForResetBoundary struct{}
-
-	// maximumSuffixProperty is used to store the maximum suffix property
-	// which extracts the suffix used by the synthetic key optimization.
-	maximumSuffixProperty MaximumSuffixProperty
-	// synthetic is used to store the synthetic key and the seek key.
-	synthetic syntheticKey
-
-	index I
-	data  D
-	// inPool is set to true before putting the iterator in the reusable pool;
-	// used to detect double-close.
-	inPool bool
-	// pool is the pool from which the iterator was allocated and to which the
-	// iterator should be returned on Close. Because the iterator is
-	// parameterized by the type of the data block iterator, pools must be
-	// specific to the type of the data block iterator.
-	//
-	// If the iterator is embedded within a twoLevelIterator, pool is nil and
-	// the twoLevelIterator.pool field may be non-nil.
-	pool *sync.Pool
-
-	// NOTE: any new fields should be added above the clearForResetBoundary field,
-	// unless they need to be retained when resetting the iterator.
 }
 
 // singleLevelIterator implements the base.InternalIterator interface.
@@ -314,15 +320,8 @@ func (i *singleLevelIterator[I, PI, D, PD]) SetupForCompaction() {
 	}
 }
 
-const clearLen = unsafe.Offsetof(singleLevelIteratorRowBlocks{}.clearForResetBoundary)
-
-// Assert that clearLen is consistent between the row and columnar implementations.
-const clearLenColBlocks = unsafe.Offsetof(singleLevelIteratorColumnBlocks{}.clearForResetBoundary)
-const _ uintptr = clearLen - clearLenColBlocks
-const _ uintptr = clearLenColBlocks - clearLen
-
 func (i *singleLevelIterator[I, PI, D, PD]) resetForReuse() {
-	*(*[clearLen]byte)(unsafe.Pointer(i)) = [clearLen]byte{}
+	i.singleLevelIterClearedState = singleLevelIterClearedState{}
 	i.inPool = true
 	// Clear the synthetic key fields.
 	clear(i.synthetic.seekKey[:cap(i.synthetic.seekKey)])


### PR DESCRIPTION
`Iterator.clearForReuse` and `singleLevelIterator.resetForReuse` zeroed a
pointer-rich region of their structs through a raw `[N]byte` store. An
untyped clear compiles to `memclrNoHeapPointers`, deleting heap pointers
without GC write barriers. If a concurrent GC mark phase is running, an
object referenced only by such a field and by an already-scanned goroutine
stack can be missed by the mark phase and swept while still referenced,
later producing rare "runtime: marked free object in span" failures (seen
very rarely in metamorphic test runs).

Move the cleared fields into embedded sub-structs (`iterClearedState` and
`singleLevelIterClearedState`) and clear them by assigning the zero value:
a typed store for which the compiler emits the required write barriers.

The write-barrier code is only taken when a GC mark phase is actually
active; there should be no perf impact in practice:
```
name                 old time/op  new time/op  delta
NewIterClose/1-10     882ns ± 5%   855ns ± 1%  -3.08%  (p=0.008 n=9+8)
NewIterClose/10-10   5.45µs ± 2%  5.50µs ± 5%    ~     (p=0.203 n=8+10)
NewIterClose/100-10  85.4µs ± 5%  86.3µs ± 7%    ~     (p=0.604 n=9+10)
```

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>