### PR TITLE
crl-release-25.2: db, sstable: clear pooled iterator fields with typed stores

### DIFF
--- a/external_iterator.go
+++ b/external_iterator.go
@@ -90,7 +90,6 @@ func NewExternalIterWithContext(
 			// of readers indexed by *fileMetadata.
 			panic("unreachable")
 		},
-		seqNum: base.SeqNumMax,
 	}
 	dbi.externalIter.bufferPool.Init(2)
 

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -40,6 +40,32 @@ import (
 // pattern is taken from the Go generics proposal:
 // https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#pointer-method-example
 type singleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIterator[D]] struct {
+	// singleLevelIterClearedState holds the fields that are cleared when the
+	// iterator is reset for reuse.
+	singleLevelIterClearedState
+
+	index I
+	data  D
+	// inPool is set to true before putting the iterator in the reusable pool;
+	// used to detect double-close.
+	inPool bool
+	// pool is the pool from which the iterator was allocated and to which the
+	// iterator should be returned on Close. Because the iterator is
+	// parameterized by the type of the data block iterator, pools must be
+	// specific to the type of the data block iterator.
+	//
+	// If the iterator is embedded within a twoLevelIterator, pool is nil and
+	// the twoLevelIterator.pool field may be non-nil.
+	pool *sync.Pool
+
+	// NOTE: any new fields should be added to singleLevelIterClearedState,
+	// unless they need to be retained when resetting the iterator.
+}
+
+// singleLevelIterClearedState holds the singleLevelIterator fields that are
+// cleared when the iterator is reset for reuse, by assigning the zero value of
+// this struct.
+type singleLevelIterClearedState struct {
 	ctx context.Context
 	cmp Compare
 	// Global lower/upper bound for the iterator.
@@ -168,26 +194,6 @@ type singleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIte
 	lastBloomFilterMatched bool
 
 	transforms IterTransforms
-
-	// All fields above this field are cleared when resetting the iterator for reuse.
-	clearForResetBoundary struct{}
-
-	index I
-	data  D
-	// inPool is set to true before putting the iterator in the reusable pool;
-	// used to detect double-close.
-	inPool bool
-	// pool is the pool from which the iterator was allocated and to which the
-	// iterator should be returned on Close. Because the iterator is
-	// parameterized by the type of the data block iterator, pools must be
-	// specific to the type of the data block iterator.
-	//
-	// If the iterator is embedded within a twoLevelIterator, pool is nil and
-	// the twoLevelIterator.pool field may be non-nil.
-	pool *sync.Pool
-
-	// NOTE: any new fields should be added above the clearForResetBoundary field,
-	// unless they need to be retained when resetting the iterator.
 }
 
 // singleLevelIterator implements the base.InternalIterator interface.
@@ -317,15 +323,8 @@ func (i *singleLevelIterator[I, PI, D, PD]) SetupForCompaction() {
 	}
 }
 
-const clearLen = unsafe.Offsetof(singleLevelIteratorRowBlocks{}.clearForResetBoundary)
-
-// Assert that clearLen is consistent betwen the row and columnar implementations.
-const clearLenColBlocks = unsafe.Offsetof(singleLevelIteratorColumnBlocks{}.clearForResetBoundary)
-const _ uintptr = clearLen - clearLenColBlocks
-const _ uintptr = clearLenColBlocks - clearLen
-
 func (i *singleLevelIterator[I, PI, D, PD]) resetForReuse() {
-	*(*[clearLen]byte)(unsafe.Pointer(i)) = [clearLen]byte{}
+	i.singleLevelIterClearedState = singleLevelIterClearedState{}
 	i.inPool = true
 }
 


### PR DESCRIPTION
`Iterator.clearForReuse` and `singleLevelIterator.resetForReuse` zeroed a
pointer-rich region of their structs through a raw `[N]byte` store. An
untyped clear compiles to `memclrNoHeapPointers`, deleting heap pointers
without GC write barriers. If a concurrent GC mark phase is running, an
object referenced only by such a field and by an already-scanned goroutine
stack can be missed by the mark phase and swept while still referenced,
later producing rare "runtime: marked free object in span" failures (seen
very rarely in metamorphic test runs).

Move the cleared fields into embedded sub-structs (`iterClearedState` and
`singleLevelIterClearedState`) and clear them by assigning the zero value:
a typed store for which the compiler emits the required write barriers.

The write-barrier code is only taken when a GC mark phase is actually
active; there should be no perf impact in practice:
```
name                 old time/op  new time/op  delta
NewIterClose/1-10     882ns ± 5%   855ns ± 1%  -3.08%  (p=0.008 n=9+8)
NewIterClose/10-10   5.45µs ± 2%  5.50µs ± 5%    ~     (p=0.203 n=8+10)
NewIterClose/100-10  85.4µs ± 5%  86.3µs ± 7%    ~     (p=0.604 n=9+10)
```

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>