### PR TITLE
crl-release-26.1: db: account for blob references in compaction code, sstable info API

### DIFF
--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1179,7 +1179,6 @@ func pickCompactionSeedFile(
 
 		skip := false
 		for outputFile != nil && sstableKeyCompare(cmp, outputFile.Smallest(), f.Largest()) <= 0 {
-			overlappingBytes += outputFile.Size
 			if outputFile.IsCompacting() {
 				// If one of the overlapping files is compacting, we're not going to be
 				// able to compact f anyway, so skip it.
@@ -1192,19 +1191,27 @@ func pickCompactionSeedFile(
 				break
 			}
 
+			sizeContribution := outputFile.EstimatedDataSize()
 			// For files in the bottommost level of the LSM, the
-			// Stats.RangeDeletionsBytesEstimate field is set to the estimate
-			// of bytes /within/ the file itself that may be dropped by
-			// recompacting the file. These bytes from obsolete keys would not
-			// need to be rewritten if we compacted `f` into `outputFile`, so
-			// they don't contribute to write amplification. Subtracting them
-			// out of the overlapping bytes helps prioritize these compactions
-			// that are cheaper than their file sizes suggest.
+			// Stats.RangeDeletionsBytesEstimate field is set to the estimate of bytes
+			// /within/ the file itself that may be dropped by recompacting the file.
+			// These bytes from obsolete keys would not need to be rewritten if we
+			// compacted `f` into `outputFile`, so they don't contribute to write
+			// amplification. Subtracting them out of the overlapping bytes
+			// contribution helps prioritize these compactions that are cheaper than
+			// their file sizes suggest.
 			if outputLevel == numLevels-1 && outputFile.LargestSeqNum < earliestSnapshotSeqNum {
 				if stats, ok := outputFile.Stats(); ok {
-					overlappingBytes -= stats.RangeDeletionsBytesEstimate
+					// There are no hard guarantees about the estimate, so guard against
+					// underflow.
+					if stats.RangeDeletionsBytesEstimate < sizeContribution {
+						sizeContribution -= stats.RangeDeletionsBytesEstimate
+					} else {
+						sizeContribution = 0
+					}
 				}
 			}
+			overlappingBytes += sizeContribution
 
 			// If the file in the next level extends beyond f's largest key,
 			// break out and don't advance outputIter because f's successor

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -547,7 +547,7 @@ func (pc *pickedTableCompaction) maybeGrowL0ForBase(cmp base.Compare, maxExpande
 	for j, f := 0, iter.First(); f != nil; j, f = j+1, iter.Next() {
 		if pc.lcf.FilesIncluded[f.L0Index] {
 			newStartLevelFiles = append(newStartLevelFiles, f)
-			sizeSum += f.Size
+			sizeSum += f.EstimatedDataSize()
 		}
 	}
 

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -1604,7 +1604,7 @@ var elisionOnlyAnnotator = manifest.MakePickFileAnnotator(
 			// `NumEntries` and `RangeDeletionsBytesEstimate` are both zero) are excluded
 			// from elision-only compactions.
 			// TODO(travers): Consider an alternative heuristic for elision of range-keys.
-			eligible = stats.RangeDeletionsBytesEstimate*10 >= f.Size || backingProps.NumDeletions*10 > backingProps.NumEntries
+			eligible = stats.RangeDeletionsBytesEstimate*10 >= f.EstimatedDataSize() || backingProps.NumDeletions*10 > backingProps.NumEntries
 			return eligible, true
 		},
 		Compare: func(f1 *manifest.TableMetadata, f2 *manifest.TableMetadata) bool {

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -602,7 +602,6 @@ func TestCompactionPickerL0(t *testing.T) {
 		if m.SmallestSeqNum > m.LargestSeqNum {
 			m.SmallestSeqNum, m.LargestSeqNum = m.LargestSeqNum, m.SmallestSeqNum
 		}
-		}
 		m.LargestSeqNumAbsolute = m.LargestSeqNum
 		m.InitPhysicalBacking()
 		return m, nil

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -571,10 +571,37 @@ func TestCompactionPickerL0(t *testing.T) {
 			base.ParseInternalKey(strings.TrimSpace(parts[0])),
 			base.ParseInternalKey(strings.TrimSpace(parts[1])),
 		)
+		// Optional space-separated fields after the key bounds, e.g.
+		//   000100:a#1,SET-b#2,SET size=1000 blob-ref-size=5000:
+		for _, f := range fields[1:] {
+			switch {
+			case strings.HasPrefix(f, "size="):
+				v, err := strconv.ParseUint(strings.TrimPrefix(f, "size="), 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				m.Size = v
+			case strings.HasPrefix(f, "blob-ref-size="):
+				v, err := strconv.ParseUint(strings.TrimPrefix(f, "blob-ref-size="), 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				m.BlobReferenceDepth = 1
+				m.BlobReferences = manifest.BlobReferences{{
+					FileID:                base.BlobFileID(tableNum),
+					ValueSize:             v,
+					BackingValueSize:      v,
+					EstimatedPhysicalSize: v,
+				}}
+			default:
+				return nil, errors.Errorf("unknown field %q in table spec %q", f, s)
+			}
+		}
 		m.SmallestSeqNum = m.Smallest().SeqNum()
 		m.LargestSeqNum = m.Largest().SeqNum()
 		if m.SmallestSeqNum > m.LargestSeqNum {
 			m.SmallestSeqNum, m.LargestSeqNum = m.LargestSeqNum, m.SmallestSeqNum
+		}
 		}
 		m.LargestSeqNumAbsolute = m.LargestSeqNum
 		m.InitPhysicalBacking()

--- a/db.go
+++ b/db.go
@@ -2237,13 +2237,15 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 
 			if opt.withApproximateSpanBytes {
 				if m.ContainedWithinSpan(d.opts.Comparer.Compare, opt.start, opt.end) {
-					destTables[j].ApproximateSpanBytes = m.Size
+					destTables[j].ApproximateSpanBytes = m.EstimatedDataSize()
 				} else {
 					size, err := d.fileCache.estimateSize(m, opt.start, opt.end)
 					if err != nil {
 						return nil, err
 					}
-					destTables[j].ApproximateSpanBytes = size
+					// We use the size/m.Size ratio to scale the overall data size.
+					ratio := float64(size) / float64(max(m.Size, 1))
+					destTables[j].ApproximateSpanBytes = uint64(ratio * float64(m.EstimatedDataSize()))
 				}
 			}
 			j++

--- a/db_test.go
+++ b/db_test.go
@@ -1340,15 +1340,19 @@ func TestSSTablesWithApproximateSpanBytes(t *testing.T) {
 		}
 	}()
 
+	// Values are large enough to be separated into blob files, depending on the
+	// random options.
+	largeValue := bytes.Repeat([]byte("x"), 2000)
+
 	// Create two sstables.
-	// sstable is contained within keyspan (fileNum = 5).
-	require.NoError(t, d.Set([]byte("c"), nil, nil))
-	require.NoError(t, d.Set([]byte("d"), nil, nil))
+	// This sstable is contained within the [a, e) keyspan.
+	require.NoError(t, d.Set([]byte("c"), largeValue, nil))
+	require.NoError(t, d.Set([]byte("d"), largeValue, nil))
 	require.NoError(t, d.Flush())
 
-	// sstable partially overlaps keyspan (fileNum = 7).
-	require.NoError(t, d.Set([]byte("d"), nil, nil))
-	require.NoError(t, d.Set([]byte("g"), nil, nil))
+	// This sstable partially overlaps the [a, e) keyspan.
+	require.NoError(t, d.Set([]byte("d"), largeValue, nil))
+	require.NoError(t, d.Set([]byte("g"), largeValue, nil))
 	require.NoError(t, d.Flush())
 
 	// cannot use WithApproximateSpanBytes without WithKeyRangeFilter.
@@ -1358,13 +1362,19 @@ func TestSSTablesWithApproximateSpanBytes(t *testing.T) {
 	tableInfos, err := d.SSTables(WithProperties(), WithKeyRangeFilter([]byte("a"), []byte("e")), WithApproximateSpanBytes())
 	require.NoError(t, err)
 
+	cmp := d.opts.Comparer.Compare
 	for _, levelTables := range tableInfos {
 		for _, table := range levelTables {
-			if table.FileNum == 5 {
-				require.Equal(t, table.ApproximateSpanBytes, table.Size)
-			}
-			if table.FileNum == 7 {
-				require.Less(t, table.ApproximateSpanBytes, table.Size)
+			// EstimatedDataSize includes the size of values stored in blob files.
+			estimatedDataSize := table.Size + table.EstimatedReferenceSize()
+			if cmp(table.Largest.UserKey, []byte("e")) < 0 {
+				// The sstable is contained within the span, so all of its data
+				// (including referenced blob data) is within the span.
+				require.Equal(t, estimatedDataSize, table.ApproximateSpanBytes)
+			} else {
+				// The sstable partially overlaps the span, so only part of its
+				// data is within the span.
+				require.Less(t, table.ApproximateSpanBytes, estimatedDataSize)
 			}
 		}
 	}

--- a/internal/compact/run.go
+++ b/internal/compact/run.go
@@ -381,11 +381,11 @@ func (r *Runner) TableSplitLimit(startKey []byte) []byte {
 	f := iter.SeekGE(r.cmp, startKey)
 	// Handle an overlapping table.
 	if f != nil && r.cmp(f.Smallest().UserKey, startKey) <= 0 {
-		overlappedBytes += f.Size
+		overlappedBytes += f.EstimatedDataSize()
 		f = iter.Next()
 	}
 	for ; f != nil; f = iter.Next() {
-		overlappedBytes += f.Size
+		overlappedBytes += f.EstimatedDataSize()
 		if overlappedBytes > r.cfg.MaxGrandparentOverlapBytes {
 			limitKey = f.Smallest().UserKey
 			break

--- a/internal/compact/run_test.go
+++ b/internal/compact/run_test.go
@@ -26,6 +26,18 @@ func TestTableSplitLimit(t *testing.T) {
 			d.MaybeScanArgs(t, "flush-split-bytes", &flushSplitBytes)
 			l0Organizer = manifest.NewL0Organizer(base.DefaultComparer, flushSplitBytes)
 			v = testutils.CheckErr(manifest.ParseVersionDebug(base.DefaultComparer, l0Organizer, d.Input))
+			// The debug format records each blob reference's value size but not
+			// its estimated physical size, which is what EstimatedDataSize() (and
+			// thus the grandparent overlap accounting) uses. Approximate the
+			// physical size as the value size so blobrefs in the input affect the
+			// computed split limits.
+			for _, lm := range v.Levels {
+				for f := range lm.All() {
+					for i := range f.BlobReferences {
+						f.BlobReferences[i].EstimatedPhysicalSize = f.BlobReferences[i].ValueSize
+					}
+				}
+			}
 			buf.WriteString(v.String())
 			if v.Levels[0].Len() != 0 {
 				buf.WriteString("flush split keys:\n")

--- a/internal/compact/testdata/table_split_limit
+++ b/internal/compact/testdata/table_split_limit
@@ -224,3 +224,30 @@ o: w
 s: w
 u: w
 x: no limit
+
+# A grandparent that references a large value in a blob file contributes that
+# blob data to the grandparent overlap, forcing an earlier split. Here each
+# grandparent sstable is tiny (size 1), but 000002 references 100 bytes of blob
+# data.
+#
+# With the fix, the overlap accounting uses EstimatedDataSize (sstable size plus
+# blob reference size), so the blob-heavy 000002 trips the max-overlap limit and
+# forces a split. Before the fix, only the sstable size was counted (~1 byte per
+# grandparent), so no split limit was imposed at all.
+define
+L1:
+  1:[a#0,SET-b#0,SET] size:1
+  2:[c#0,SET-d#0,SET] size:1 blobrefs:[(B000007: 100); depth:1]
+  3:[e#0,SET-f#0,SET] size:1
+----
+L1:
+  000001:[a#0,SET-b#0,SET]
+  000002:[c#0,SET-d#0,SET]
+  000003:[e#0,SET-f#0,SET]
+
+split-limit max-overlap=10
+a c e
+----
+a: c
+c: e
+e: no limit

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -98,7 +98,7 @@ type TableMetadata struct {
 	// virtual sstables.
 	//
 	// Value separation: Size does NOT include the size of separated values in
-	// blob files; add EstimatedReferenceSize() if needed.
+	// blob files; EstimatedDataSize() does.
 	//
 	// INVARIANTS:
 	// - When !TableMetadata.Virtual, Size == TableBacking.Size.

--- a/internal/manifest/table_metadata.go
+++ b/internal/manifest/table_metadata.go
@@ -97,6 +97,9 @@ type TableMetadata struct {
 	// Size is the size of the file, in bytes. Size is an approximate value for
 	// virtual sstables.
 	//
+	// Value separation: Size does NOT include the size of separated values in
+	// blob files; add EstimatedReferenceSize() if needed.
+	//
 	// INVARIANTS:
 	// - When !TableMetadata.Virtual, Size == TableBacking.Size.
 	// - Size should be non-zero. Size 0 virtual sstables must not be created.
@@ -294,9 +297,16 @@ func (m *TableMetadata) VirtualMeta() *TableMetadata {
 	return m
 }
 
-// EstimatedReferenceSize returns the estimated physical size of all the file's
-// blob references in the table. This sum, added to the sstable's size, yields
-// an approximation of the overall size of the data represented by the table.
+// EstimatedDataSize returns the approximate overall size of the data
+// represented by the table. It is the physical size of the table plus the
+// estimated physical size of all the table's blob references.
+func (m *TableMetadata) EstimatedDataSize() uint64 {
+	return m.Size + m.EstimatedReferenceSize()
+}
+
+// EstimatedReferenceSize returns the estimated physical size of all the table's
+// blob references. This sum, added to the sstable's size, yields an
+// approximation of the overall size of the data represented by the table.
 //
 // EstimatedReferenceSize is an estimate, but it's guaranteed to be stable over
 // the lifetime of the table. This is necessary to correctly maintain

--- a/testdata/compaction_picker_L0
+++ b/testdata/compaction_picker_L0
@@ -438,3 +438,40 @@ pick-auto non-score l0_compaction_threshold=1000
 L0 -> L0
 L0: 000049
 grandparents: 000045
+
+# Regression test for blob references being accounted for when deciding whether
+# to grow an L0->Lbase compaction (maybeGrowL0ForBase).
+#
+# The seed compaction is the two-file stack over key "a" (000110, 000120),
+# overlapping the Lbase file 000200. When growing the compaction to span the rest
+# of 000200's key range, the picker would pull in 000100 (over key "c"). 000100
+# is a tiny sstable but references ~2GB of data in a blob file. Growing the
+# compaction to include it would blow past the expansion byte limit once that
+# referenced data is counted, so 000100 must NOT be pulled in.
+#
+# Before the fix, the expansion budget used the sstable size alone (~1KB), so
+# 000100 was (incorrectly) included. With the fix, EstimatedDataSize() is used,
+# which counts the blob reference, so the grow is reverted and only the seed
+# files are compacted.
+
+define
+L0
+   000100:c#10,SET-c#10,SET size=1000 blob-ref-size=2000000000:
+   000110:a#20,SET-a#20,SET size=1000:
+   000120:a#30,SET-a#30,SET size=1000:
+L1
+   000200:a#1,SET-c#2,SET size=1000:
+----
+L0.1:
+  000120:[a#30,SET-a#30,SET]
+L0.0:
+  000110:[a#20,SET-a#20,SET]
+  000100:[c#10,SET-c#10,SET]
+L1:
+  000200:[a#1,SET-c#2,SET]
+
+pick-auto l0_compaction_threshold=1
+----
+L0 -> L1
+L0: 000110,000120
+L1: 000200

--- a/testdata/compaction_picker_pick_file
+++ b/testdata/compaction_picker_pick_file
@@ -298,3 +298,46 @@ L1 [b1, b2]
 pick-file L1
 ----
 000005:[d#11,SET-e#11,SET]
+
+# Test that a file's blob references count toward the overlapping bytes used to
+# compute write amplification when picking a seed file.
+#
+# Two L5 files each overlap exactly one L6 file. The L6 file overlapping "a" is a
+# tiny sstable (~786 bytes) with a large (100000-byte) blob reference; the L6
+# file overlapping "c" is a ~50000-byte sstable with no blob reference. Counting
+# only sstable size, the "a" file overlaps far fewer bytes (~786 vs ~50000) and
+# would be picked. Counting blob-referenced bytes too, the "a" file overlaps
+# ~100786 bytes versus ~50000 for the "c" file, so the "c" file is picked
+# instead. No range-deletion estimates are involved, so this exercises the
+# EstimatedReferenceSize accounting, not the bottommost range-del subtraction.
+define
+L5
+  a#11,SET:<rand-bytes=1000>
+L5
+  c#11,SET:<rand-bytes=1000>
+L6
+  a#0,SET:blob{fileNum=000020 valueLen=100000}
+L6
+  c#0,SET:<rand-bytes=50000>
+----
+L5:
+  000004:[a#11,SET-a#11,SET]
+  000005:[c#11,SET-c#11,SET]
+L6:
+  000006:[a#0,SET-a#0,SET]
+  000007:[c#0,SET-c#0,SET]
+Blob files:
+  B000020 physical:{000020 size:[172 (172B)] vals:[0 (0B)]}
+
+file-sizes
+----
+L5:
+  000004:[a#11,SET-a#11,SET]: 1671 bytes (1.6KB)
+  000005:[c#11,SET-c#11,SET]: 1671 bytes (1.6KB)
+L6:
+  000006:[a#0,SET-a#0,SET]: 753 bytes (753B)
+  000007:[c#0,SET-c#0,SET]: 50667 bytes (50KB)
+
+pick-file L5
+----
+000005:[c#11,SET-c#11,SET]

--- a/testdata/compaction_tombstones
+++ b/testdata/compaction_tombstones
@@ -651,3 +651,63 @@ L4:
   000004:[a#101,DEL-e#105,SET]
 L6:
   000005:[a#1,SET-e#2,SET]
+
+# Regression test for the elision-only eligibility heuristic accounting for blob
+# references. The bottommost file 000004 references a large value (100KB) in a
+# blob file, so the data it represents (EstimatedDataSize = sstable size +
+# estimated blob reference size ~= 103KB) is far larger than its sstable size
+# (~3KB). A range deletion covers only a single key, so the range deletion
+# reclaims well under 10% of the file's overall data.
+#
+# The range-deletions-bytes-estimate (~2.5KB) is more than 10% of the sstable
+# size but far less than 10% of the overall data size, so the file should NOT be
+# eligible for an elision-only compaction.
+#
+# Before the fix, eligibility compared range-deletions-bytes-estimate*10 against
+# the sstable size alone, which excludes blob references. The estimate cleared
+# that bar and the file was (incorrectly) compacted. With the fix, the comparison
+# is against the overall EstimatedDataSize, so the small range deletion no longer
+# makes the file eligible.
+
+define auto-compactions=off block-size=1 value-separation=(enabled, min-size=10, max-ref-depth=10)
+L6
+  a#1,SET:a
+  b#2,SET:b
+  c#3,SET:c
+  d#4,SET:d
+  e#5,SET:e
+  f#6,SET:f
+  g#7,SET:g
+  h#8,SET:h
+  i#9,SET:i
+  j#10,SET:j
+  k#11,SET:k
+  l#12,SET:l
+  m#13,SET:m
+  n#14,SET:n
+  o#15,SET:o
+  p#16,SET:p
+  q#17,SET:q
+  r#18,SET:r
+  s#19,SET:s
+  t#20,SET:blob{fileNum=000020 valueLen=100000}
+  a#100,RANGEDEL:b
+----
+L6:
+  000004:[a#100,RANGEDEL-t#20,SET]
+Blob files:
+  B000020 physical:{000020 size:[172 (172B)] vals:[0 (0B)]}
+
+wait-pending-table-stats
+000004
+----
+num-entries: 20
+num-deletions: 1
+num-range-key-sets: 0
+point-deletions-bytes-estimate: 0
+range-deletions-bytes-estimate: 2562
+compression: None:918,Snappy:1452/1680
+
+maybe-compact
+----
+(none)


### PR DESCRIPTION
#### db: account for blob references in seed file write-amp heuristic

`pickCompactionSeedFile` chooses the file to compact by minimizing write
amplification, estimated as the ratio of overlapping bytes in the output
level to the file's compensated size. Previously the overlapping bytes
summed only each output file's `Size`, which excludes values stored
out-of-line in blob files. For output files with separated values this
undercounted the bytes that a compaction would have to rewrite, biasing
the heuristic toward picking such files.

Worse, in L6 we were subtracting `RangeDeletionBytesEstimate` which
does include separated values, leading to a real chance of uint64
underflow.

Include each overlapping output file's `EstimatedReferenceSize()` (the
estimated physical size of its blob references) in the overlapping-bytes
total so the write-amp estimate reflects the separated values that would
be rewritten. Add a guard for underflow.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### db: account for blob references in elision-only compaction heuristic

The elision-only compaction picker considers a bottommost file eligible
only if its range deletions delete at least 10% of its data. Previously,
this threshold was compared against `TableMetadata.Size`, which is the
sstable's physical size and excludes values stored in blob files. For a
file that separates most of its data into blob files, `Size` is tiny
relative to the data the file actually represents, so a small range
deletion could clear the bar and trigger a wasteful elision-only
compaction.

Compare against `EstimatedDataSize()` instead, which adds the estimated
physical size of the file's blob references to `Size`. The
`range-deletions-bytes-estimate` already accounts for the proportional
share of blob references, so this makes both sides of the comparison
consistent.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### db: account for blob references when growing L0->Lbase compactions

When an L0->Lbase compaction is picked, `maybeGrowL0ForBase` tries to pull
in additional L0 files within the output level's key range, as long as the
expanded compaction stays under a byte limit. Previously, the expanded
size was summed using `TableMetadata.Size`, which is the sstable's
physical size and excludes values stored in blob files. A tiny sstable
referencing a large amount of blob-separated data would be treated as
cheap to include, so the compaction could grow far past the intended byte
limit.

Sum `EstimatedDataSize()` instead, which adds the estimated physical size
of each file's blob references to `Size`, so the expansion limit reflects
the data the compaction would actually rewrite.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### compact: account for blob references in grandparent overlap split limit

When writing a compaction's output tables, `TableSplitLimit` caps how far
an output table can extend by summing the sizes of the grandparent-level
tables it overlaps, splitting the output once that sum exceeds
`MaxGrandparentOverlapBytes`. Previously this sum used
`TableMetadata.Size`, the sstable's physical size, which excludes values
stored in blob files. A grandparent that references a large amount of
blob-separated data was therefore undercounted, so an output table could
overlap far more real data than intended before being split.

Sum `EstimatedDataSize()` instead, which adds the estimated physical size
of each grandparent's blob references to its sstable size.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### db: account for blob references in SSTables ApproximateSpanBytes

`DB.SSTables` with the `WithApproximateSpanBytes` option estimates how
many bytes of each sstable fall within the requested key span. Previously
this used `TableMetadata.Size`, the sstable's physical size, which excludes
values stored in blob files. For a table that separates values into blob
files, this undercounts the data the table actually represents within the
span.

For a table fully contained in the span, report `EstimatedDataSize()`
(sstable size plus estimated blob reference size). For a table that only
partially overlaps the span, scale `EstimatedDataSize()` by the same
in-sstable fraction (`size / Size`) used for the existing estimate.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>