### PR TITLE
crl-release-26.1: vfs: allow sync_file_range on XFS

### DIFF
--- a/vfs/default_linux.go
+++ b/vfs/default_linux.go
@@ -130,11 +130,10 @@ func isSyncRangeSupported(fd uintptr) bool {
 	// Allowlist which filesystems we allow using sync_file_range with as some
 	// filesystems treat that syscall as a noop (notably ZFS). A allowlist is
 	// used instead of a denylist in order to have a more graceful failure mode
-	// in case a filesystem we haven't tested is encountered. Currently only
-	// ext2/3/4 are known to work properly.
-	const extMagic = 0xef53
+	// in case a filesystem we haven't tested is encountered. Currently ext2/3/4
+	// and XFS are known to work properly.
 	switch stat.Type {
-	case extMagic:
+	case unix.EXT4_SUPER_MAGIC, unix.XFS_SUPER_MAGIC:
 		return syncRangeSmokeTest(fd, unix.SyncFileRange)
 	}
 	return false


### PR DESCRIPTION
Pebble uses sync_file_range for periodic, non-durable syncing to
limit dirty data accumulation while writing files. Previously this path was
only enabled on ext2/3/4, so XFS fell back to blocking fdatasync calls at
each BytesPerSync interval.

Allow XFS through the existing filesystem allowlist and keep the existing
runtime smoke test. XFS is one of CockroachDB's recommended filesystems, and
RocksDB's POSIX environment allows sync_file_range on XFS while only
excluding filesystems known to misbehave, notably ZFS.

This preserves durability semantics: full fdatasync calls are still used for
Sync and close-time persistence.