### PR TITLE
crl-release-25.4: blob: fix the unreferenced-virtual-block guard in the cached reader

### DIFF
--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -307,7 +307,7 @@ func (cr *cachedReader) GetUnsafeValue(
 		var valueIDOffset BlockValueID
 		if cr.indexBlock.dec.virtualBlockCount > 0 {
 			physicalBlockIndex, valueIDOffset = cr.indexBlock.dec.RemapVirtualBlockID(vh.BlockID)
-			if valueIDOffset == virtualBlockIndexMask {
+			if physicalBlockIndex == virtualBlockIndexMask {
 				return nil, errors.AssertionFailedf("blob file indicates virtual block ID %d in %s should be unreferenced",
 					vh.BlockID, vh.BlobFileID)
 			}

--- a/sstable/blob/fetcher_test.go
+++ b/sstable/blob/fetcher_test.go
@@ -354,3 +354,41 @@ func makeMockReaderProvider(
 	}
 	return rp
 }
+
+// TestValueFetcherUnreferencedVirtualBlock verifies that fetching a handle
+// pointing at a virtual block that the rewrite left unreferenced fails cleanly,
+// rather than reading past the end of the index block's offsets column.
+func TestValueFetcherUnreferencedVirtualBlock(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	// Write a file with virtual block IDs 0 and 2, leaving a gap at ID 1. The
+	// index block records the sentinel for the gap.
+	obj := &objstorage.MemObj{}
+	w := NewFileWriter(base.DiskFileNum(1), obj, FileWriterOptions{})
+	w.beginNewVirtualBlock(BlockID(0))
+	w.AddValue([]byte("hello"), false /* isLikelyMVCCGarbage */)
+	w.beginNewVirtualBlock(BlockID(2))
+	w.AddValue([]byte("world"), false /* isLikelyMVCCGarbage */)
+	_, err := w.Close()
+	require.NoError(t, err)
+
+	r, err := NewFileReader(ctx, obj, FileReaderOptions{
+		ReaderOptions: block.ReaderOptions{
+			CacheOpts: sstableinternal.CacheOptions{FileNum: base.DiskFileNum(1)},
+		},
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, r.Close()) }()
+
+	rp := &mockReaderProvider{readers: map[base.DiskFileNum]*FileReader{1: r}}
+	var f ValueFetcher
+	f.Init(identityFileMapping{}, rp, block.ReadEnv{}, 5 /* maxCachedReaders */)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	var handleBuf [MaxInlineHandleLength]byte
+	n := HandleSuffix{BlockID: BlockID(1), ValueID: BlockValueID(0)}.Encode(handleBuf[:])
+	_, _, err = f.FetchHandle(ctx, handleBuf[:n], base.BlobFileID(1), 5 /* valLen */, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unreferenced")
+}


### PR DESCRIPTION
A rewritten blob file records the sentinel `virtualBlockIndexMask` in the
low 32 bits of a virtual block's packed mapping to mark a block that the
rewrite left unreferenced. `GetUnsafeValue` compared the sentinel against
`valueIDOffset`, which unpacks the high 32 bits and is always 0 for the
sentinel, so the guard could never fire.

With the guard dead, a handle naming an unreferenced virtual block reached
`BlockHandle` with a block index of `0xffffffff`. In invariant builds the
bounds check caught it; in production builds it read past the end of the
index block's offsets column and crashed.

Compare the physical block index instead, and add a test covering a fetch
of a handle in a gap of the virtual block mapping.