### PR TITLE
crl-release-26.2: sstable/blob: return an error for unreferenced virtual blocks

### DIFF
--- a/sstable/blob/blob.go
+++ b/sstable/blob/blob.go
@@ -612,7 +612,11 @@ func (r *FileReader) Layout() (string, error) {
 	if indexDecoder.virtualBlockCount > 0 {
 		fmt.Fprintf(&buf, "virtual blocks mapping:\n")
 		for i := range indexDecoder.virtualBlockCount {
-			blockIndex, valueIDOffset := indexDecoder.RemapVirtualBlockID(BlockID(i))
+			blockIndex, valueIDOffset, err := indexDecoder.RemapVirtualBlockID(BlockID(i))
+			if err != nil {
+				fmt.Fprintf(&buf, "virtual block %d -> unreferenced\n", i)
+				continue
+			}
 			fmt.Fprintf(&buf, "virtual block %d -> physical block %d (valueID offset: %d)\n",
 				i, blockIndex, valueIDOffset)
 		}

--- a/sstable/blob/blocks.go
+++ b/sstable/blob/blocks.go
@@ -186,15 +186,20 @@ func (d *indexBlockDecoder) BlockHandle(blockIndex int) block.Handle {
 // with a non-empty virtual blocks column (i.e., index blocks for rewritten blob
 // files).
 //
+// An error is returned if the virtual block is unreferenced, i.e. it has no
+// corresponding physical block.
+//
 // REQUIRES: d.virtualBlockCount > 0
 func (d *indexBlockDecoder) RemapVirtualBlockID(
 	blockID BlockID,
-) (blockIndex int, valueIDOffset BlockValueID) {
+) (blockIndex int, valueIDOffset BlockValueID, err error) {
 	invariants.CheckBounds(int(blockID), d.virtualBlockCount)
 	v := d.virtualBlocks.At(int(blockID))
-	blockIndex = int(v & virtualBlockIndexMask)
-	valueIDOffset = BlockValueID(v >> 32)
-	return blockIndex, valueIDOffset
+	idx := v & virtualBlockIndexMask
+	if idx == virtualBlockIndexMask {
+		return 0, 0, errors.AssertionFailedf("virtual block ID %d is unreferenced", errors.Safe(blockID))
+	}
+	return int(idx), BlockValueID(v >> 32), nil
 }
 
 // BlockCount returns the number of physical blocks encoded in the index block.

--- a/sstable/blob/blocks_test.go
+++ b/sstable/blob/blocks_test.go
@@ -76,7 +76,11 @@ func TestIndexBlockEncoding(t *testing.T) {
 			for _, arg := range d.CmdArgs {
 				blockID, err := strconv.ParseInt(arg.Key, 10, 64)
 				require.NoError(t, err)
-				blockIndex, valueIDOffset := decoder.RemapVirtualBlockID(BlockID(blockID))
+				blockIndex, valueIDOffset, err := decoder.RemapVirtualBlockID(BlockID(blockID))
+				if err != nil {
+					fmt.Fprintf(&buf, "%d -> %v\n", blockID, err)
+					continue
+				}
 				fmt.Fprintf(&buf, "%d -> block %d, with valueID offset %d\n", blockID, blockIndex, valueIDOffset)
 			}
 			return buf.String()

--- a/sstable/blob/fetcher.go
+++ b/sstable/blob/fetcher.go
@@ -306,10 +306,10 @@ func (cr *cachedReader) GetUnsafeValue(
 		var physicalBlockIndex int = int(vh.BlockID)
 		var valueIDOffset BlockValueID
 		if cr.indexBlock.dec.virtualBlockCount > 0 {
-			physicalBlockIndex, valueIDOffset = cr.indexBlock.dec.RemapVirtualBlockID(vh.BlockID)
-			if physicalBlockIndex == virtualBlockIndexMask {
-				return nil, errors.AssertionFailedf("blob file indicates virtual block ID %d in %s should be unreferenced",
-					errors.Safe(vh.BlockID), vh.BlobFileID)
+			var err error
+			physicalBlockIndex, valueIDOffset, err = cr.indexBlock.dec.RemapVirtualBlockID(vh.BlockID)
+			if err != nil {
+				return nil, errors.Wrapf(err, "blob file %s", vh.BlobFileID)
 			}
 		}
 		invariants.CheckBounds(physicalBlockIndex, cr.indexBlock.dec.BlockCount())

--- a/sstable/blob/testdata/index_block
+++ b/sstable/blob/testdata/index_block
@@ -95,3 +95,47 @@ remap-virtual-blockid 0 1 2 3 4
 2 -> block 1, with valueID offset 2
 3 -> block 1, with valueID offset 3
 4 -> block 2, with valueID offset 4
+
+# Build an index block with a gap in the virtual block IDs; the blocks within
+# the gap are unreferenced.
+
+build
+10 20
+35 100
+140 10
+virtual-block-mappings
+0 0 0
+3 1 2
+----
+index-block-decoder
+ └── index block header
+      ├── columnar block header
+      │    ├── 00-04: x 04000000 # virtual block count: 4
+      │    ├── 04-05: x 01       # version 1
+      │    ├── 05-07: x 0200     # 2 columns
+      │    ├── 07-11: x 03000000 # 3 rows
+      │    ├── 11-12: b 00000010 # col 0: uint
+      │    ├── 12-16: x 15000000 # col 0: page start 21
+      │    ├── 16-17: b 00000010 # col 1: uint
+      │    └── 17-21: x 38000000 # col 1: page start 56
+      ├── data for column 0 (uint)
+      │    ├── 21-22: x 08               # encoding: 8b
+      │    ├── 22-24: x 0000             # padding (aligning to 64-bit boundary)
+      │    ├── 24-32: x 0000000000000000 # data[0] = 0
+      │    ├── 32-40: x ffffffff00000000 # data[1] = 4294967295
+      │    ├── 40-48: x ffffffff00000000 # data[2] = 4294967295
+      │    └── 48-56: x 0100000002000000 # data[3] = 8589934593
+      ├── data for column 1 (uint)
+      │    ├── 56-57: x 01 # encoding: 1b
+      │    ├── 57-58: x 0a # data[0] = 10
+      │    ├── 58-59: x 23 # data[1] = 35
+      │    ├── 59-60: x 8c # data[2] = 140
+      │    └── 60-61: x 9b # data[3] = 155
+      └── 61-62: x 00 # block padding byte
+
+remap-virtual-blockid 0 1 2 3
+----
+0 -> block 0, with valueID offset 0
+1 -> virtual block ID 1 is unreferenced
+2 -> virtual block ID 2 is unreferenced
+3 -> block 1, with valueID offset 2


### PR DESCRIPTION
A recent (backported) assertion breaks 32-bit builds (which we still
tolerate on the older branches).

`RemapVirtualBlockID` now performs the check itself on the untruncated
value and returns an error.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>