### PR TITLE
github: fix issue posting from actions

### DIFF
--- a/.github/actions/post-issue/action.yaml
+++ b/.github/actions/post-issue/action.yaml
@@ -15,7 +15,7 @@ inputs:
     description: "The unique title to search for in the repository; if found, a comment will be posted. Defaults to title"
     required: false
   labels:
-    description: "Labels to use when creating an issue"
+    description: "Comma-separated labels to use when creating an issue"
     required: false
 
 outputs:
@@ -26,56 +26,39 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Find issue
-      id: find-issue
-      uses: actions-cool/issues-helper@v3
-      with:
-        token: ${{ inputs.token }}
-        actions: "find-issues"
-        title-includes: ${{ inputs.unique-title-includes || inputs.title}}
-
-    - name: Get issue number
-      shell: bash
-      id: get-issue-number
-      run: |
-        if num=$(jq -re '.[0].number' <<'EOF'
-        ${{ steps.find-issue.outputs.issues }}
-        EOF
-        ); then
-          echo "Found existing issue #$num"
-          echo "issue-number=$num" >> $GITHUB_OUTPUT
-        else
-          echo "No existing issue found"
-        fi
-
-    - name: Create issue
-      if: steps.get-issue-number.outputs.issue-number == ''
-      id: create-issue
-      uses: actions-cool/issues-helper@v3
-      with:
-        token: ${{ inputs.token }}
-        actions: "create-issue"
-        title: ${{ inputs.title }}
-        body: ${{ inputs.body }}
-        labels: ${{ inputs.labels }}
-
-    - name: Comment on existing issue
-      if: steps.get-issue-number.outputs.issue-number != ''
-      id: comment-on-issue
-      uses: actions-cool/issues-helper@v3
-      with:
-        token: ${{ inputs.token }}
-        actions: "create-comment"
-        issue-number: ${{ steps.get-issue-number.outputs.issue-number }}
-        title: ${{ inputs.title }}
-        body: ${{ inputs.body }}
-
-    - name: Result
-      shell: bash
+    - name: Create or comment on issue
       id: result
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ github.repository }}
+        TITLE: ${{ inputs.title }}
+        BODY: ${{ inputs.body }}
+        LABELS: ${{ inputs.labels }}
+        SEARCH: ${{ inputs.unique-title-includes || inputs.title }}
       run: |
-        if [ -n "${{ steps.get-issue-number.outputs.issue-number }}" ]; then
-          echo "issue-number=${{ steps.get-issue-number.outputs.issue-number }}" >> $GITHUB_OUTPUT
-        elif [ -n "${{ steps.create-issue.outputs.issue-number }}" ]; then
-          echo "issue-number=${{ steps.create-issue.outputs.issue-number }}" >> $GITHUB_OUTPUT
+        set -euo pipefail
+
+        # Find an open issue whose title contains the (unique) search string.
+        # --search narrows server-side; the jq `contains` filter makes the
+        # match exact (search is fuzzy and may return unrelated issues).
+        num=$(gh issue list --state open --limit 100 \
+          --search "in:title \"$SEARCH\"" \
+          --json number,title \
+          --jq "map(select(.title | contains(\"$SEARCH\"))) | .[0].number // empty")
+
+        if [ -n "$num" ]; then
+          echo "Commenting on existing issue #$num"
+          gh issue comment "$num" --body "$BODY"
+        else
+          echo "Creating new issue"
+          label_args=()
+          if [ -n "$LABELS" ]; then
+            label_args=(--label "$LABELS")
+          fi
+          url=$(gh issue create --title "$TITLE" --body "$BODY" "${label_args[@]}")
+          echo "Created $url"
+          num=${url##*/}
         fi
+
+        echo "issue-number=$num" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cockroach-go.yaml
+++ b/.github/workflows/cockroach-go.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }}. Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/crossversion.yaml
+++ b/.github/workflows/crossversion.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/instrumented.yaml
+++ b/.github/workflows/instrumented.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -77,7 +77,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -101,7 +101,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Post issue on failure
         if: failure()
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "master: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ github.sha }} (go${{ matrix.go }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/s390x.yaml
+++ b/.github/workflows/s390x.yaml
@@ -32,9 +32,6 @@ on:
         default: '1.26'
         type: string
 
-permissions:
-  issues: write
-
 jobs:
   linux-qemu-s390x:
     runs-on: ubuntu-latest

--- a/.github/workflows/s390x.yaml
+++ b/.github/workflows/s390x.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} test failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/stress.yaml
+++ b/.github/workflows/stress.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} tests failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -77,7 +77,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly linux-32bit test failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -101,7 +101,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly linux-arm test failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -128,7 +128,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly crossversion test failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -152,7 +152,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -176,7 +176,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -200,7 +200,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -224,7 +224,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -251,7 +251,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} test failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
@@ -282,7 +282,7 @@ jobs:
       - name: Post issue on failure
         if: failure() && inputs.file_issue_branch != ''
         id: create-or-update-unique-issue
-        uses: ./.github/actions/post-issue
+        uses: $/.github/actions/post-issue
         with:
           title: "${{ inputs.file_issue_branch }}: nightly ${{ github.job }} failed"
           body: "The nightly ${{ github.job }} test run failed on ${{ inputs.sha }} (go${{ inputs.go_version }}). Please review the run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."


### PR DESCRIPTION
#### github: post nightly failure issues with the gh CLI

The `post-issue` composite action drove issue creation and commenting
through `actions-cool/issues-helper`, which has since been disabled. Every
nightly failure on the release branches therefore ran to completion without
filing anything.

Reimplement the action on top of the `gh` CLI, which is preinstalled on all
GitHub-hosted runners and needs no third-party dependency. Issue lookup now
narrows server-side with a `in:title` search and then filters the results
with an exact `contains` check, since the search index is fuzzy and can
return unrelated issues.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### github: reference post-issue with self-repository syntax

The nightly workflows for the release branches live on the default branch,
but the jobs they call check out the release branch SHA. A `uses: ./...`
reference resolves against `$GITHUB_WORKSPACE`, so `./.github/actions/post-issue`
loaded the *release branch's* copy of the action rather than the one next to
the workflow. Fixing the action on the default branch alone would have had no
effect on any of the release-branch nightlies.

Switch all 18 call sites to the `$/` self-repository syntax, which resolves
to the repository at the commit the workflow is running from and requires no
checkout. One fix on the default branch now covers `crl-release-26.2` and
older, plus every future release branch, with no per-branch backport.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### github: drop the permissions block on the s390x workflow

The s390x workflow was the only one of the nightly workflows to declare a
`permissions` block. Because such a block drops every unlisted scope to
`none`, its job ran with just `Issues: write` and `Metadata: read`, while
every sibling workflow inherits the caller's token untouched.

Remove the block so all the nightly workflows behave alike. The narrowing
bought nothing — the job is reached only from the nightly workflows on the
default branch — and it was the one place where the `post-issue` action
could have been denied a scope it needs.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>
