### PR TITLE
crl-release-26.1: options: make the WAL preallocation size configurable

### DIFF
--- a/db.go
+++ b/db.go
@@ -2257,20 +2257,6 @@ func (d *DB) SSTables(opts ...SSTablesOption) ([][]SSTableInfo, error) {
 	return destLevels, nil
 }
 
-func (d *DB) walPreallocateSize() int {
-	// Set the WAL preallocate size to 110% of the memtable size. Note that there
-	// is a bit of apples and oranges in units here as the memtabls size
-	// corresponds to the memory usage of the memtable while the WAL size is the
-	// size of the batches (plus overhead) stored in the WAL.
-	//
-	// TODO(peter): 110% of the memtable size is quite hefty for a block
-	// size. This logic is taken from GetWalPreallocateBlockSize in
-	// RocksDB. Could a smaller preallocation block size be used?
-	size := d.opts.MemTableSize
-	size = (size / 10) + size
-	return int(size)
-}
-
 func (d *DB) newMemTable(
 	logNum base.DiskFileNum, logSeqNum base.SeqNum, minSize uint64,
 ) (*memTable, *flushableEntry) {

--- a/metamorphic/options.go
+++ b/metamorphic/options.go
@@ -702,6 +702,15 @@ func RandomOptions(rng *rand.Rand, kf KeyFormat, cfg RandomOptionsCfg) *TestOpti
 	if rng.IntN(2) == 0 {
 		opts.WALDir = pebble.MakeStoreRelativePath(opts.FS, "wal")
 	}
+	if rng.IntN(4) == 0 {
+		// Occasionally override the WAL preallocation size; a quarter of the time
+		// use 0, which disables preallocation entirely.
+		var walPreallocateSize int
+		if rng.IntN(4) > 0 {
+			walPreallocateSize = int(randPowerOf2(rng, 10, 20)) // 1KB - 1MB
+		}
+		opts.WALPreallocateSize = func() int { return walPreallocateSize }
+	}
 
 	// Half the time enable WAL failover.
 	if !cfg.NoWALFailover && rng.IntN(2) == 0 {

--- a/metamorphic/options_test.go
+++ b/metamorphic/options_test.go
@@ -88,6 +88,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		"Experimental.EnableDeleteOnlyCompactionExcises:",
 		"Experimental.TombstoneDenseCompactionThreshold:",
 		"Experimental.ValueSeparationPolicy:",
+		"WALPreallocateSize:",
 		"Levels[0].Compression:",
 		"Levels[1].Compression:",
 		"Levels[2].Compression:",
@@ -121,6 +122,7 @@ func TestOptionsRoundtrip(t *testing.T) {
 		expectEqualFn(t, o.Opts.Experimental.TombstoneDenseCompactionThreshold, parsed.Opts.Experimental.TombstoneDenseCompactionThreshold)
 		expectEqualFn(t, o.Opts.Experimental.ValueSeparationPolicy, parsed.Opts.Experimental.ValueSeparationPolicy)
 		expectEqualFn(t, o.Opts.DeletionPacing.BaselineRate, parsed.Opts.DeletionPacing.BaselineRate)
+		expectEqualFn(t, o.Opts.WALPreallocateSize, parsed.Opts.WALPreallocateSize)
 
 		expBaseline, expUpper := o.Opts.CompactionConcurrencyRange()
 		parsedBaseline, parsedUpper := parsed.Opts.CompactionConcurrencyRange()

--- a/open.go
+++ b/open.go
@@ -292,7 +292,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 		MaxNumRecyclableLogs: opts.MemTableStopWritesThreshold + 1,
 		NoSyncOnClose:        opts.NoSyncOnClose,
 		BytesPerSync:         opts.WALBytesPerSync,
-		PreallocateSize:      d.walPreallocateSize,
+		PreallocateSize:      opts.WALPreallocateSize,
 		MinSyncInterval:      opts.WALMinSyncInterval,
 		QueueSemChan:         d.commit.logSyncQSem,
 		Logger:               opts.Logger,

--- a/options.go
+++ b/options.go
@@ -1137,6 +1137,16 @@ type Options struct {
 	// changing options dynamically?
 	WALMinSyncInterval func() time.Duration
 
+	// WALPreallocateSize is the size in bytes to which WAL files are
+	// preallocated when they are created. Preallocation reduces filesystem
+	// metadata updates and file fragmentation as the WAL grows. A value of 0
+	// disables preallocation. This option is supplied as a closure in order to
+	// allow the value to be changed dynamically; it is consulted each time a WAL
+	// file is created.
+	//
+	// The default is 110% of MemTableSize.
+	WALPreallocateSize func() int
+
 	// DeletionPacing manage deletion pacing, which slows down deletions when
 	// compactions finish or when readers close and obsolete files must be cleaned
 	// up. Rapid deletion of many files simultaneously can increase disk latency
@@ -1583,6 +1593,18 @@ func (o *Options) EnsureDefaults() {
 	if o.WALFailover != nil {
 		o.WALFailover.FailoverOptions.EnsureDefaults()
 	}
+	if o.WALPreallocateSize == nil {
+		// Default the WAL preallocate size to 110% of the memtable size. Note that
+		// there is a bit of apples and oranges in units here as the memtable size
+		// corresponds to the memory usage of the memtable while the WAL size is the
+		// size of the batches (plus overhead) stored in the WAL.
+		//
+		// TODO(peter): 110% of the memtable size is quite hefty for a block
+		// size. This logic is taken from GetWalPreallocateBlockSize in
+		// RocksDB. Could a smaller preallocation block size be used?
+		size := int(o.MemTableSize + o.MemTableSize/10)
+		o.WALPreallocateSize = func() int { return size }
+	}
 	if o.Experimental.UseDeprecatedCompensatedScore == nil {
 		o.Experimental.UseDeprecatedCompensatedScore = func() bool { return false }
 	}
@@ -1757,6 +1779,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  validate_on_ingest=%t\n", o.Experimental.ValidateOnIngest)
 	fmt.Fprintf(&buf, "  wal_dir=%s\n", o.WALDir)
 	fmt.Fprintf(&buf, "  wal_bytes_per_sync=%d\n", o.WALBytesPerSync)
+	fmt.Fprintf(&buf, "  wal_preallocate_size=%d\n", o.WALPreallocateSize())
 	fmt.Fprintf(&buf, "  secondary_cache_size_bytes=%d\n", o.Experimental.SecondaryCacheSizeBytes)
 	fmt.Fprintf(&buf, "  create_on_shared=%d\n", o.Experimental.CreateOnShared)
 
@@ -2209,6 +2232,12 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 				o.WALDir = value
 			case "wal_bytes_per_sync":
 				o.WALBytesPerSync, err = strconv.Atoi(value)
+			case "wal_preallocate_size":
+				var walPreallocateSize int
+				walPreallocateSize, err = strconv.Atoi(value)
+				if err == nil {
+					o.WALPreallocateSize = func() int { return walPreallocateSize }
+				}
 			case "secondary_cache_size_bytes":
 				o.Experimental.SecondaryCacheSizeBytes, err = strconv.ParseInt(value, 10, 64)
 			case "create_on_shared":

--- a/options_test.go
+++ b/options_test.go
@@ -141,6 +141,7 @@ func TestDefaultOptionsString(t *testing.T) {
   validate_on_ingest=false
   wal_dir=
   wal_bytes_per_sync=0
+  wal_preallocate_size=4613734
   secondary_cache_size_bytes=0
   create_on_shared=0
 

--- a/replay/testdata/replay
+++ b/replay/testdata/replay
@@ -11,7 +11,7 @@ tree
      508      000007.sst
        0      LOCK
      133      MANIFEST-000001
-    2733      OPTIONS-000002
+    2764      OPTIONS-000002
        0      marker.format-version.000001.013
        0      marker.manifest.000001.MANIFEST-000001
             simple/
@@ -21,7 +21,7 @@ tree
       11        000004.log
      480        000005.sst
       85        MANIFEST-000001
-    2733        OPTIONS-000002
+    2764        OPTIONS-000002
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -72,6 +72,7 @@ cat build/OPTIONS-000002
   validate_on_ingest=false
   wal_dir=
   wal_bytes_per_sync=0
+  wal_preallocate_size=4613734
   secondary_cache_size_bytes=0
   create_on_shared=0
 

--- a/replay/testdata/replay_ingest
+++ b/replay/testdata/replay_ingest
@@ -12,7 +12,7 @@ tree
        0      LOCK
      172      MANIFEST-000001
      209      MANIFEST-000008
-    2734      OPTIONS-000002
+    2765      OPTIONS-000002
        0      marker.format-version.000012.025
        0      marker.manifest.000002.MANIFEST-000008
             simple_ingest/
@@ -25,7 +25,7 @@ tree
      678        000004.sst
      661        000005.sst
      172        MANIFEST-000001
-    2734        OPTIONS-000002
+    2765        OPTIONS-000002
        0        marker.format-version.000001.025
        0        marker.manifest.000001.MANIFEST-000001
 
@@ -76,6 +76,7 @@ cat build/OPTIONS-000002
   validate_on_ingest=false
   wal_dir=
   wal_bytes_per_sync=0
+  wal_preallocate_size=4613734
   secondary_cache_size_bytes=0
   create_on_shared=0
 

--- a/replay/testdata/replay_paced
+++ b/replay/testdata/replay_paced
@@ -14,7 +14,7 @@ tree
        0      LOCK
      133      MANIFEST-000001
      205      MANIFEST-000010
-    2733      OPTIONS-000002
+    2764      OPTIONS-000002
        0      marker.format-version.000001.013
        0      marker.manifest.000002.MANIFEST-000010
             high_read_amp/
@@ -26,7 +26,7 @@ tree
       11        000008.log
      454        000009.sst
      157        MANIFEST-000010
-    2733        OPTIONS-000002
+    2764        OPTIONS-000002
        0        marker.format-version.000001.013
        0        marker.manifest.000001.MANIFEST-000010
 

--- a/replay/testdata/replay_val_sep
+++ b/replay/testdata/replay_val_sep
@@ -17,7 +17,7 @@ tree
        0      LOCK
      152      MANIFEST-000010
      250      MANIFEST-000013
-    2942      OPTIONS-000002
+    2973      OPTIONS-000002
        0      marker.format-version.000011.024
        0      marker.manifest.000003.MANIFEST-000013
             simple_val_sep/
@@ -32,7 +32,7 @@ tree
       11        000011.log
      687        000012.sst
      187        MANIFEST-000013
-    2942        OPTIONS-000002
+    2973        OPTIONS-000002
        0        marker.format-version.000001.024
        0        marker.manifest.000001.MANIFEST-000013
 
@@ -86,6 +86,7 @@ cat build/OPTIONS-000002
   validate_on_ingest=false
   wal_dir=
   wal_bytes_per_sync=0
+  wal_preallocate_size=4613734
   secondary_cache_size_bytes=0
   create_on_shared=0
 

--- a/testdata/metrics
+++ b/testdata/metrics
@@ -236,7 +236,7 @@ Iter category stats:
 
 disk-usage
 ----
-3,684B
+3,715B
 
 batch
 set b 2
@@ -365,7 +365,7 @@ Iter category stats:
 
 disk-usage
 ----
-5,917B
+5,948B
 
 # Closing iter a will release one of the zombie memtables.
 
@@ -584,7 +584,7 @@ Iter category stats:
 
 disk-usage
 ----
-5,230B
+5,261B
 
 # Closing iter b will release the last zombie sstable and the last zombie memtable.
 
@@ -695,7 +695,7 @@ Iter category stats:
 
 disk-usage
 ----
-4,543B
+4,574B
 
 additional-metrics
 ----
@@ -2600,7 +2600,7 @@ Blob files:
 
 disk-usage
 ----
-7,605B
+7,636B
 
 init reopen
 ----
@@ -2608,4 +2608,4 @@ init reopen
 # The disk usage is expected to go down a bit because we remove the WALs.
 disk-usage
 ----
-7,088B
+7,119B


### PR DESCRIPTION
The WAL preallocation size was hardcoded to 110% of `MemTableSize`. This
adds an `Options.WALPreallocateSize func() int` so that it can be tuned by
embedders; it is supplied as a closure so that CockroachDB can drive it
from a cluster setting, and it is consulted each time a WAL file is
created. A value of 0 disables preallocation.

When left unset, `EnsureDefaults` populates it with the previous 110% of
`MemTableSize` value. The option is serialized to the OPTIONS file as
`wal_preallocate_size`, and the metamorphic test occasionally overrides it.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>