### PR TITLE
db: back off after flush errors

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -134,6 +134,9 @@ func (c *compactionWritable) Write(p []byte) error {
 
 type compactionKind int
 
+// Flush retries start quickly to recover from transient errors, but eventually
+// settle at one attempt every five seconds to bound CPU and BackgroundError
+// callback churn during persistent failures.
 const (
 	compactionKindDefault compactionKind = iota
 	compactionKindFlush
@@ -1370,11 +1373,26 @@ func (d *DB) calculateDiskAvailableBytes() uint64 {
 	return space.AvailBytes
 }
 
+const (
+	flushRetryInitialBackoff = 100 * time.Millisecond
+	flushRetryMaxBackoff     = 5 * time.Second
+)
+
+func nextFlushRetryBackoff(previous time.Duration) time.Duration {
+	if previous == 0 {
+		return flushRetryInitialBackoff
+	}
+	if previous >= flushRetryMaxBackoff/2 {
+		return flushRetryMaxBackoff
+	}
+	return 2 * previous
+}
+
 // maybeScheduleFlush schedules a flush if necessary.
 //
 // d.mu must be held when calling this.
 func (d *DB) maybeScheduleFlush() {
-	if d.mu.compact.flushing || d.closed.Load() != nil || d.opts.ReadOnly {
+	if d.mu.compact.flushing || d.mu.compact.flushRetrying || d.closed.Load() != nil || d.opts.ReadOnly {
 		return
 	}
 	if len(d.mu.mem.queue) <= 1 {
@@ -1387,6 +1405,33 @@ func (d *DB) maybeScheduleFlush() {
 
 	d.mu.compact.flushing = true
 	go d.flush()
+}
+
+// scheduleFlushRetry schedules another flush attempt after delay. It prevents
+// other callers from scheduling a flush in the meantime. d.mu must be held
+// when calling this.
+func (d *DB) scheduleFlushRetry(delay time.Duration) {
+	d.mu.compact.flushRetrying = true
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+
+		select {
+		case <-d.closedCh:
+		case <-timer.C:
+		}
+
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		d.mu.compact.flushRetrying = false
+		d.maybeScheduleFlush()
+		if !d.mu.compact.flushing {
+			// There is no longer any flush work to retry. Treat a future error
+			// as the beginning of a new sequence.
+			d.mu.compact.flushRetryBackoff = 0
+		}
+		d.mu.compact.cond.Broadcast()
+	}()
 }
 
 func (d *DB) passedFlushThreshold() bool {
@@ -1477,9 +1522,13 @@ func (d *DB) flush() {
 		idleDuration := flushingWorkStart.Sub(d.mu.compact.noOngoingFlushStartTime)
 		var bytesFlushed uint64
 		var err error
+		var retryDelay time.Duration
 		if bytesFlushed, err = d.flush1(); err != nil {
-			// TODO(peter): count consecutive flush errors and backoff.
+			d.mu.compact.flushRetryBackoff = nextFlushRetryBackoff(d.mu.compact.flushRetryBackoff)
+			retryDelay = d.mu.compact.flushRetryBackoff
 			d.opts.EventListener.BackgroundError(err)
+		} else {
+			d.mu.compact.flushRetryBackoff = 0
 		}
 		d.mu.compact.flushing = false
 		d.mu.compact.noOngoingFlushStartTime = crtime.NowMono()
@@ -1487,9 +1536,15 @@ func (d *DB) flush() {
 		d.mu.compact.flushWriteThroughput.Bytes += int64(bytesFlushed)
 		d.mu.compact.flushWriteThroughput.WorkDuration += workDuration
 		d.mu.compact.flushWriteThroughput.IdleDuration += idleDuration
-		// More flush work may have arrived while we were flushing, so schedule
-		// another flush if needed.
-		d.maybeScheduleFlush()
+		if retryDelay > 0 {
+			// A failed flush leaves the same work queued. Delay its retry rather
+			// than immediately starting another failing flush.
+			d.scheduleFlushRetry(retryDelay)
+		} else {
+			// More flush work may have arrived while we were flushing, so schedule
+			// another flush if needed.
+			d.maybeScheduleFlush()
+		}
 		// Let the CompactionScheduler know, so that it can react immediately to
 		// an increase in DB.GetAllowedWithoutPermission.
 		d.compactionScheduler.UpdateGetAllowedWithoutPermission()

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2583,9 +2583,13 @@ func TestCompactFlushQueuedLargeBatch(t *testing.T) {
 func TestFlushError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Error the first five times we try to write a sstable.
+	// Error the first three times we try to write a sstable.
 	var errorOps atomic.Int32
 	errorOps.Store(3)
+	var errorTimes struct {
+		sync.Mutex
+		times []time.Time
+	}
 	fs := errorfs.Wrap(vfs.NewMem(), errorfs.InjectorFunc(func(op errorfs.Op) error {
 		if op.Kind == errorfs.OpCreate && filepath.Ext(op.Path) == ".sst" && errorOps.Add(-1) >= 0 {
 			return errorfs.ErrInjected
@@ -2596,6 +2600,9 @@ func TestFlushError(t *testing.T) {
 		FS: fs,
 		EventListener: &EventListener{
 			BackgroundError: func(err error) {
+				errorTimes.Lock()
+				errorTimes.times = append(errorTimes.times, time.Now())
+				errorTimes.Unlock()
 				t.Log(err)
 			},
 		},
@@ -2606,7 +2613,89 @@ func TestFlushError(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, d.Set([]byte("a"), []byte("foo"), NoSync))
 	require.NoError(t, d.Flush())
+	flushDoneAt := time.Now()
+
+	errorTimes.Lock()
+	times := append([]time.Time(nil), errorTimes.times...)
+	errorTimes.Unlock()
+	require.Len(t, times, 3)
+	require.GreaterOrEqual(t, times[1].Sub(times[0]), flushRetryInitialBackoff)
+	require.GreaterOrEqual(t, times[2].Sub(times[1]), 2*flushRetryInitialBackoff)
+	require.GreaterOrEqual(t, flushDoneAt.Sub(times[2]), 4*flushRetryInitialBackoff)
+
+	d.mu.Lock()
+	require.Zero(t, d.mu.compact.flushRetryBackoff)
+	require.False(t, d.mu.compact.flushRetrying)
+	d.mu.Unlock()
 	require.NoError(t, d.Close())
+}
+
+func TestFlushRetryBackoff(t *testing.T) {
+	backoff := time.Duration(0)
+	for _, expected := range []time.Duration{
+		flushRetryInitialBackoff,
+		2 * flushRetryInitialBackoff,
+		4 * flushRetryInitialBackoff,
+		8 * flushRetryInitialBackoff,
+		16 * flushRetryInitialBackoff,
+		32 * flushRetryInitialBackoff,
+		flushRetryMaxBackoff,
+		flushRetryMaxBackoff,
+	} {
+		backoff = nextFlushRetryBackoff(backoff)
+		require.Equal(t, expected, backoff)
+	}
+}
+
+func TestFlushRetryCancelledOnClose(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	backgroundErr := make(chan struct{}, 1)
+	fs := errorfs.Wrap(vfs.NewMem(), errorfs.InjectorFunc(func(op errorfs.Op) error {
+		if op.Kind == errorfs.OpCreate && filepath.Ext(op.Path) == ".sst" {
+			return errorfs.ErrInjected
+		}
+		return nil
+	}))
+	opts := &Options{
+		FS: fs,
+		EventListener: &EventListener{
+			BackgroundError: func(error) {
+				select {
+				case backgroundErr <- struct{}{}:
+				default:
+				}
+			},
+		},
+		Logger: testutils.Logger{T: t},
+	}
+	opts.WithFSDefaults()
+	d, err := Open("", opts)
+	require.NoError(t, err)
+	defer func() {
+		if d != nil {
+			_ = d.Close()
+		}
+	}()
+
+	require.NoError(t, d.Set([]byte("a"), []byte("foo"), NoSync))
+	d.mu.Lock()
+	d.mu.compact.flushRetryBackoff = flushRetryMaxBackoff / 2
+	d.mu.Unlock()
+	_, err = d.AsyncFlush()
+	require.NoError(t, err)
+
+	select {
+	case <-backgroundErr:
+	case <-time.After(10 * time.Second):
+		t.Fatal("flush did not report its background error")
+	}
+
+	closeStart := time.Now()
+	closeErr := d.Close()
+	d = nil
+	require.NoError(t, closeErr)
+	require.Less(t, time.Since(closeStart), flushRetryMaxBackoff/2)
 }
 
 func TestAdjustGrandparentOverlapBytesForFlush(t *testing.T) {

--- a/db.go
+++ b/db.go
@@ -420,6 +420,11 @@ type DB struct {
 			cond sync.Cond
 			// True when a flush is in progress.
 			flushing bool
+			// True while a retry is delayed after a flush error. flushing and
+			// flushRetrying are mutually exclusive.
+			flushRetrying bool
+			// The current backoff between consecutive flush errors.
+			flushRetryBackoff time.Duration
 			// The number of ongoing non-download compactions.
 			compactingCount int
 			// The number of calls to compact that have not yet finished. This is different
@@ -1866,7 +1871,8 @@ func (d *DB) Close() error {
 
 	defer d.cacheHandle.Close()
 
-	for d.mu.compact.compactingCount > 0 || d.mu.compact.downloadingCount > 0 || d.mu.compact.flushing {
+	for d.mu.compact.compactingCount > 0 || d.mu.compact.downloadingCount > 0 ||
+		d.mu.compact.flushing || d.mu.compact.flushRetrying {
 		d.mu.compact.cond.Wait()
 	}
 	for d.mu.tableStats.loading {

--- a/open.go
+++ b/open.go
@@ -447,7 +447,7 @@ func Open(dirname string, opts *Options) (db *DB, err error) {
 	compactionSchedulerRegistered = true
 	if !d.opts.ReadOnly {
 		d.maybeScheduleFlush()
-		for d.mu.compact.flushing {
+		for d.mu.compact.flushing || d.mu.compact.flushRetrying {
 			d.mu.compact.cond.Wait()
 		}
 


### PR DESCRIPTION
A failed flush leaves its memtable queued. The current completion path clears `flushing` and immediately calls `maybeScheduleFlush`, so persistent I/O errors can spin a CPU and flood `BackgroundError` callbacks.

This change applies exponential retry backoff from 100 ms to 5 seconds across consecutive failures. A pending retry blocks competing flush schedules, resets after a successful flush or when the work disappears, and is cancelled during `Close`. Recovery-time flushes in `Open` continue waiting across the delayed retries.

Fixes #6139