### PR TITLE
internal/compact: fix iterator state corruption on deletable merges

### DIFF
--- a/compaction_deletable_merger_test.go
+++ b/compaction_deletable_merger_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+// deletableSumMerger wires base.NewDeletableSumValueMerger (a
+// DeletableValueMerger whose merges resolving to zero report delete=true)
+// into a *pebble.Merger usable by a DB.
+var deletableSumMerger = &Merger{
+	Name:  "deletable-sum-merger",
+	Merge: base.NewDeletableSumValueMerger,
+}
+
+// TestCompactionDeletableMergerStress exercises DeletableValueMerger results
+// under compaction with randomized-but-deterministic sequences of
+// Set/Merge/Flush/Snapshot/Compact. Open snapshots split key histories into
+// snapshot stripes, reaching the compaction iterator's needDelete handling in
+// a variety of iterator states.
+//
+// Regression test: the needDelete path used to elide the merge result via
+// `continue` without the skip/position bookkeeping the returned-key path
+// performs, tripping the "compaction iterator has skip=true, but iterator is
+// at iterPosNext" assertion (a panic on the compaction goroutine).
+func TestCompactionDeletableMergerStress(t *testing.T) {
+	ctx := context.Background()
+	for seed := uint64(0); seed < 100; seed++ {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			rng := rand.New(rand.NewPCG(0, seed))
+			db, err := Open("", &Options{
+				FS:     vfs.NewMem(),
+				Merger: deletableSumMerger,
+			})
+			require.NoError(t, err)
+			var snaps []*Snapshot
+			defer func() {
+				for _, s := range snaps {
+					require.NoError(t, s.Close())
+				}
+				require.NoError(t, db.Close())
+			}()
+
+			keys := [][]byte{[]byte("a"), []byte("b"), []byte("c")}
+			for op := 0; op < 400; op++ {
+				key := keys[rng.IntN(len(keys))]
+				switch rng.IntN(10) {
+				case 0, 1:
+					require.NoError(t, db.Set(key, []byte("1"), NoSync))
+				case 2, 3, 4:
+					require.NoError(t, db.Merge(key, []byte("2"), NoSync))
+				case 5, 6:
+					// Drives merges toward sums of zero, which the deletable
+					// merger reports as delete=true.
+					require.NoError(t, db.Merge(key, []byte("-2"), NoSync))
+				case 7:
+					require.NoError(t, db.Flush())
+				case 8:
+					if len(snaps) < 4 {
+						snaps = append(snaps, db.NewSnapshot())
+					} else {
+						require.NoError(t, snaps[0].Close())
+						snaps = snaps[1:]
+					}
+				case 9:
+					require.NoError(t, db.Compact(ctx, []byte("a"), []byte("d"), false))
+				}
+			}
+			for _, s := range snaps {
+				require.NoError(t, s.Close())
+			}
+			snaps = nil
+			require.NoError(t, db.Flush())
+			require.NoError(t, db.Compact(ctx, []byte("a"), []byte("d"), false))
+		})
+	}
+}

--- a/internal/compact/iterator.go
+++ b/internal/compact/iterator.go
@@ -683,7 +683,22 @@ func (i *Iter) Next() *base.InternalKV {
 					if i.closeValueCloser() != nil {
 						return nil
 					}
-					continue
+					// The merged result is non-existent. Eliding it inline via
+					// `continue` would re-enter the iteration loop without the
+					// skip/position bookkeeping the returned-key path performs:
+					// if mergeNext consumed a base SET/DEL in this stripe it
+					// set skip=true, and continuing with that state pending
+					// re-processes entries the merge already consumed and trips
+					// the "compaction iterator has skip=true, but iterator is
+					// at iterPosNext" assertion on a later Next (see
+					// TestCompactionDeletableMergerStress). Instead, surface
+					// the non-existent result as a DELETE tombstone through
+					// the normal return path, which maintains the iterator
+					// invariants; the tombstone is elided by the usual means
+					// on a later bottommost compaction.
+					i.kv.K.SetKind(base.InternalKeyKindDelete)
+					i.kv.V = base.MakeInPlaceValue(nil)
+					return &i.kv
 				}
 				return &i.kv
 			}

--- a/internal/compact/testdata/iter
+++ b/internal/compact/testdata/iter
@@ -1066,7 +1066,9 @@ a#inf,RANGEDEL:; Span() = a-c:{(#3,RANGEDEL)}
 b#5,MERGE:5
 b#1,MERGE:1
 
-# NB: Zero values are skipped by deletable merger.
+# NB: Merges resolving to zero under the deletable merger surface as DELETE
+# tombstones (elided later by the usual means at the bottommost level);
+# eliding them inline would corrupt the iterator's skip state.
 define merger=deletable
 a#4,MERGE:-2
 a#3,MERGE:-1
@@ -1083,8 +1085,8 @@ first
 next
 next
 ----
-.
-.
+a#4,DEL:
+b#4,DEL:
 .
 
 # Test that range keys are interleaved and exposed by the iterator.


### PR DESCRIPTION
When a DeletableValueMerger reports that a merge result is non-existent (needDelete), the compaction iterator elided the record inline via continue, re-entering the iteration loop without the skip/position bookkeeping the returned-key path performs. If mergeNext had consumed a base SET/DEL in the same snapshot stripe (setting skip=true), the loop re-processed entries the merge had already consumed, and a later Next tripped the assertion:

    compaction iterator has skip=true, but iterator is at iterPosNext

panicking the compaction goroutine. Reachable with any DeletableValueMerger whose merges can resolve to non-existence over a SET base; observed in production, and reproduced by the new TestCompactionDeletableMergerStress using base.NewDeletableSumValueMerger (randomized Set/Merge/Flush/Snapshot/Compact sequences; open snapshots split key histories into stripes, reaching needDelete in varied iterator states).

Fix by surfacing the non-existent result as a DELETE tombstone through the normal key-return path, which maintains the iterator invariants by construction; the tombstone is elided by the usual means on a later bottommost compaction. This changes the observable compaction output for such merges (a DEL where previously nothing was emitted, reflected in testdata/iter) but preserves the user-visible semantics one compaction later, and removes the possibility of re-processing consumed entries.

Fixes https://github.com/cockroachdb/pebble/issues/6168