### PR TITLE
crl-release-26.2: ingest: limit flushable queue size during failover

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -1914,23 +1914,30 @@ func (d *DB) ingest(ctx context.Context, args ingestArgs) (IngestOperationStats,
 		// TODO(aaditya): We should make flushableIngest compatible with remote
 		// files.
 		hasRemoteFiles := len(shared) > 0 || len(external) > 0
-		// TODO(xinhaoz): Allow blob files as flushable ingests.
 		canIngestFlushable := d.FormatMajorVersion() >= FormatFlushableIngest &&
-			// We require that either the queue of flushables is below the
-			// stop-writes threshold (note that this is typically a conservative
-			// check, since not every element of this queue will contribute the full
-			// memtable memory size that could result in a write stall), or WAL
-			// failover is permitting an unlimited queue without causing a write
-			// stall. The latter condition is important to avoid delays in
-			// visibility of concurrent writes that happen to get a sequence number
-			// after this ingest and then must wait for this ingest that is itself
-			// waiting on a large flush. See
-			// https://github.com/cockroachdb/pebble/issues/4944 for an illustration
-			// of this problem.
-			(len(d.mu.mem.queue) < d.opts.MemTableStopWritesThreshold ||
-				d.mu.log.manager.ElevateWriteStallThresholdForFailover()) &&
-			!d.opts.Experimental.DisableIngestAsFlushable() && !hasRemoteFiles &&
+			!d.opts.Experimental.DisableIngestAsFlushable() &&
+			!hasRemoteFiles &&
 			(!args.ExciseSpan.Valid() || d.FormatMajorVersion() >= FormatFlushableIngestExcises)
+
+		if canIngestFlushable {
+			// We require that the queue of flushables is below the stop-writes
+			// threshold (note that this is typically a conservative check, since not
+			// every element of this queue will contribute the full memtable memory
+			// size that could result in a write stall).
+			//
+			// During WAL failover we permit a longer queue without causing a write
+			// stall. The latter condition is important to avoid delays in visibility
+			// of concurrent writes that happen to get a sequence number after this
+			// ingest and then must wait for this ingest that is itself waiting on a
+			// large flush. See https://github.com/cockroachdb/pebble/issues/4944 for
+			// an illustration of this problem.
+			queueLimit := d.opts.MemTableStopWritesThreshold
+			if d.mu.log.manager.ElevateWriteStallThresholdForFailover() {
+				queueLimit *= d.opts.FlushableIngestLimitMultiplierDuringFailover()
+			}
+			canIngestFlushable = len(d.mu.mem.queue) < queueLimit
+		}
+
 		if !canIngestFlushable {
 			// We're not able to ingest as a flushable,
 			// so we must synchronously flush.

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/internal/base"
 	"github.com/cockroachdb/pebble/internal/blobtest"
+	"github.com/cockroachdb/pebble/internal/buildtags"
 	"github.com/cockroachdb/pebble/internal/keyspan"
 	"github.com/cockroachdb/pebble/internal/manifest"
 	"github.com/cockroachdb/pebble/internal/rangekey"
@@ -2753,6 +2754,92 @@ func TestIngestFlushQueuedMemTable(t *testing.T) {
 
 	ingest("a")
 
+	require.NoError(t, d.Close())
+}
+
+// TestIngestFlushableLimitDuringFailover verifies that the flushable queue does
+// not grow without bound when WAL failover elevates the write stall threshold
+// and ingests keep getting added to the queue as flushables.
+func TestIngestFlushableLimitDuringFailover(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const stopWritesThreshold = 2
+	const multiplier = 3
+	const queueLimit = stopWritesThreshold * multiplier
+	const numIngests = 4 * queueLimit
+
+	mem := vfs.NewMem()
+	// Block all sstable creation, so that flushes cannot make progress and the
+	// flushable queue can only grow.
+	blockingFS := newBlockingFS(mem, false /* blockWAL */, true /* blockSST */)
+	o := &Options{
+		FS:                          blockingFS,
+		FormatMajorVersion:          internalFormatNewest,
+		MemTableStopWritesThreshold: stopWritesThreshold,
+		FlushableIngestLimitMultiplierDuringFailover: func() int { return multiplier },
+		Logger: testutils.Logger{T: t},
+	}
+	o.DisableAutomaticCompactions = true
+	d, err := Open("", o)
+	require.NoError(t, err)
+
+	// Pretend we are failed over to the secondary WAL location; writes no longer
+	// stall on the length of the flushable queue.
+	d.mu.Lock()
+	testWALManager := &testLogManager{Manager: d.mu.log.manager}
+	testWALManager.elevateWriteStallThreshold.Store(true)
+	d.mu.log.manager = testWALManager
+	d.mu.Unlock()
+
+	// Add "a" to the memtable so that every ingest below overlaps something in
+	// the flushable queue and is thus eligible to be ingested as a flushable.
+	require.NoError(t, d.Set([]byte("a"), nil, nil))
+
+	var numIngested atomic.Int32
+	ingestsDone := make(chan struct{})
+	go func() {
+		defer close(ingestsDone)
+		for i := 0; i < numIngests; i++ {
+			path := fmt.Sprintf("ext%d", i)
+			f, err := mem.Create(path, vfs.WriteCategoryUnspecified)
+			require.NoError(t, err)
+			w := sstable.NewWriter(objstorageprovider.NewFileWritable(f), sstable.WriterOptions{
+				TableFormat: o.FormatMajorVersion.MinTableFormat(),
+			})
+			require.NoError(t, w.Set([]byte("a"), nil))
+			require.NoError(t, w.Close())
+			require.NoError(t, d.Ingest(context.Background(), []string{path}))
+			numIngested.Add(1)
+		}
+	}()
+
+	// Once the queue reaches the limit, ingests can no longer be added as
+	// flushables; the next ingest blocks waiting for a flush which cannot
+	// complete while sstable writes are blocked.
+	timeout := time.Second
+	if buildtags.SlowBuild {
+		timeout = 10 * time.Second
+	}
+	select {
+	case <-ingestsDone:
+		t.Fatalf("all %d ingests completed without any flush", numIngests)
+	case <-time.After(timeout):
+	}
+	d.mu.Lock()
+	queueLen := len(d.mu.mem.queue)
+	d.mu.Unlock()
+	// Each flushable ingest adds the ingest itself plus a new mutable memtable to
+	// the queue, so the queue can exceed the limit by one entry.
+	require.LessOrEqual(t, queueLen, queueLimit+1)
+	require.Less(t, int(numIngested.Load()), numIngests)
+
+	// Unblock flushes; all remaining ingests should now complete.
+	blockingFS.unblock()
+	select {
+	case <-ingestsDone:
+	case <-time.After(time.Minute):
+		t.Fatalf("ingests did not complete; %d out of %d done", numIngested.Load(), numIngests)
+	}
 	require.NoError(t, d.Close())
 }
 

--- a/options.go
+++ b/options.go
@@ -976,6 +976,16 @@ type Options struct {
 	// The default value is 2.
 	MemTableStopWritesThreshold int
 
+	// FlushableIngestLimitMultiplierDuringFailover limits the eligibility of
+	// flushable ingest during failover to a flushable queue length of
+	// FlushableIngestLimitMultiplierDuringFailover * MemTableStopWritesThreshold.
+	//
+	// A higher limit allows for longer periods without the primary disk being
+	// available, but allows more WALs to accumulate in the secondary location.
+	//
+	// The default value is 4.
+	FlushableIngestLimitMultiplierDuringFailover func() int
+
 	// Merger defines the associative merge operation to use for merging values
 	// written with {Batch,DB}.Merge.
 	//
@@ -1700,6 +1710,9 @@ func (o *Options) EnsureDefaults() {
 	}
 	if o.MemTableStopWritesThreshold <= 0 {
 		o.MemTableStopWritesThreshold = 2
+	}
+	if o.FlushableIngestLimitMultiplierDuringFailover == nil {
+		o.FlushableIngestLimitMultiplierDuringFailover = func() int { return 4 }
 	}
 	if o.Merger == nil {
 		o.Merger = DefaultMerger


### PR DESCRIPTION
github.com/cockroachdb/pebble/pull/4946 made the change to remove the
flushable queue limit during failover. This can result in arbitrarily
high number of WAL files on the secondary, filling up the disk.

This change adds back a limit that is configurable (as a multiplier on
the normal limit).