### PR TITLE
wal: stop mutating failover monitor state after switch limit

### DIFF
--- a/wal/failover_manager.go
+++ b/wal/failover_manager.go
@@ -400,6 +400,11 @@ type lastWriterInfo struct {
 	numSwitches            int
 	ongoingLatencyAtSwitch time.Duration
 	errorCounts            [numDirIndices]int
+	// switchLimitReached is set when switchToNewDir returns a non-nil error
+	// (the only such error is "exceeded switching limit"). Further switch
+	// attempts for this writer are skipped so monitor bookkeeping stays
+	// aligned with the writer's last successful directory.
+	switchLimitReached bool
 }
 
 func (m *failoverMonitor) monitorLoop(shouldQuiesce <-chan struct{}) {
@@ -470,30 +475,42 @@ func (m *failoverMonitor) monitorLoop(shouldQuiesce <-chan struct{}) {
 					}
 				}
 			}
+			if lastWriter.switchLimitReached {
+				switchDir = false
+			}
 			if switchDir {
-				lastWriter.numSwitches++
+				nextDirIndex := secondaryDirIndex
 				if dirIndex == secondaryDirIndex {
-					// Switching back to primary, so don't need to probe to see if
-					// primary is healthy.
-					m.prober.disableProbing()
-					dirIndex = primaryDirIndex
-				} else {
-					m.prober.enableProbing()
-					dirIndex = secondaryDirIndex
+					nextDirIndex = primaryDirIndex
 				}
-				dir := m.opts.dirs[dirIndex]
+				dir := m.opts.dirs[nextDirIndex]
 				m.mu.Lock()
-				now := m.opts.timeSource.now()
-				m.accumulateDurationLocked(now)
-				m.mu.dirIndex = dirIndex
-				m.mu.dirSwitchCount++
-				if dirIndex == primaryDirIndex {
-					m.mu.lastFailBackTime = now
-				}
+				var switchErr error
 				if m.mu.writer != nil {
-					_ = m.mu.writer.switchToNewDir(dir)
+					switchErr = m.mu.writer.switchToNewDir(dir)
 				}
-				m.mu.Unlock()
+				if switchErr != nil {
+					lastWriter.switchLimitReached = true
+					m.mu.Unlock()
+				} else {
+					lastWriter.numSwitches++
+					now := m.opts.timeSource.now()
+					m.accumulateDurationLocked(now)
+					m.mu.dirIndex = nextDirIndex
+					m.mu.dirSwitchCount++
+					if nextDirIndex == primaryDirIndex {
+						m.mu.lastFailBackTime = now
+					}
+					m.mu.Unlock()
+					if nextDirIndex == primaryDirIndex {
+						// Switching back to primary, so don't need to probe to see if
+						// primary is healthy.
+						m.prober.disableProbing()
+					} else {
+						m.prober.enableProbing()
+					}
+					dirIndex = nextDirIndex
+				}
 			}
 		}
 		if m.opts.monitorStateForTesting != nil {

--- a/wal/failover_manager_test.go
+++ b/wal/failover_manager_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/crlib/testutils/leaktest"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/testutils"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/pebble/vfs/errorfs"
@@ -607,6 +608,119 @@ func TestFailoverManager_Quiesce(t *testing.T) {
 		}
 		require.NoError(t, m.Close())
 	})
+}
+
+// limitSwitchWriter is a switchableWriter that succeeds switchToNewDir a
+// bounded number of times, then returns the same error failoverWriter
+// returns when maxPhysicalLogs is exhausted. Latency grows faster than
+// the monitor's 2x decay gate so switches continue until the cap.
+type limitSwitchWriter struct {
+	mu            sync.Mutex
+	calls         int
+	samples       int
+	maxSuccessful int
+}
+
+func (w *limitSwitchWriter) switchToNewDir(dirAndFileHandle) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.calls++
+	if w.calls > w.maxSuccessful {
+		return errors.Errorf("exceeded switching limit")
+	}
+	return nil
+}
+
+func (w *limitSwitchWriter) ongoingLatencyOrErrorForCurDir() (time.Duration, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.samples++
+	// 100ms * 3^samples exceeds the 2x-of-last-switch latency heuristic.
+	lat := 100 * time.Millisecond
+	for i := 1; i < w.samples; i++ {
+		lat *= 3
+	}
+	return lat, nil
+}
+
+func (w *limitSwitchWriter) switchCalls() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.calls
+}
+
+// TestFailoverMonitor_SwitchLimitPreservesDirState checks that once
+// switchToNewDir hits the physical-log cap, the monitor does not keep
+// flipping dirIndex, dirSwitchCount, or lastFailBackTime.
+func TestFailoverMonitor_SwitchLimitPreservesDirState(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	memFS := vfs.NewMem()
+	require.NoError(t, memFS.MkdirAll("pri", os.ModePerm))
+	require.NoError(t, memFS.MkdirAll("sec", os.ModePerm))
+	pri, err := memFS.OpenDir("pri")
+	require.NoError(t, err)
+	defer pri.Close()
+	sec, err := memFS.OpenDir("sec")
+	require.NoError(t, err)
+	defer sec.Close()
+
+	ts := newManualTime(time.UnixMilli(0))
+	monitorCh := make(chan struct{}, 1000)
+	stopper := newStopper()
+	defer stopper.stop()
+
+	w := &limitSwitchWriter{maxSuccessful: maxPhysicalLogs}
+	m := newFailoverMonitor(failoverMonitorOptions{
+		dirs: [numDirIndices]dirAndFileHandle{
+			{Dir: Dir{FS: memFS, Dirname: "pri"}, File: pri},
+			{Dir: Dir{FS: memFS, Dirname: "sec"}, File: sec},
+		},
+		FailoverOptions: FailoverOptions{
+			PrimaryDirProbeInterval:      time.Second,
+			HealthyProbeLatencyThreshold: 50 * time.Millisecond,
+			HealthyInterval:              200 * time.Millisecond,
+			UnhealthySamplingInterval:    75 * time.Millisecond,
+			UnhealthyOperationLatencyThreshold: func() (time.Duration, bool) {
+				return 50 * time.Millisecond, true
+			},
+			timeSource:                 ts,
+			monitorIterationForTesting: monitorCh,
+		},
+		stopper: stopper,
+	})
+	// Wait for the monitor goroutine to start.
+	<-monitorCh
+
+	m.newWriter(func(dirAndFileHandle) switchableWriter { return w })
+
+	// Each sample sees an injected writer error, so the monitor attempts a
+	// switch. After maxPhysicalLogs successes the next attempt must fail
+	// without further bookkeeping. Extra samples would previously keep
+	// flipping dirIndex and incrementing dirSwitchCount.
+	const extraSamples = 5
+	for range maxPhysicalLogs + extraSamples {
+		ts.advance(75 * time.Millisecond)
+		<-monitorCh
+	}
+
+	stats := m.stats()
+	require.Equal(t, int64(maxPhysicalLogs), stats.DirSwitchCount)
+	require.Equal(t, maxPhysicalLogs+1, w.switchCalls())
+	m.mu.Lock()
+	dirIdx := m.mu.dirIndex
+	m.mu.Unlock()
+	// An even number of successful switches returns the monitor to primary.
+	require.Equal(t, primaryDirIndex, dirIdx)
+
+	// A new writer must be allowed to switch again.
+	w2 := &limitSwitchWriter{maxSuccessful: 1}
+	m.noWriter()
+	m.newWriter(func(dirAndFileHandle) switchableWriter { return w2 })
+	ts.advance(75 * time.Millisecond)
+	<-monitorCh
+	require.Equal(t, 1, w2.switchCalls())
+	require.Equal(t, int64(maxPhysicalLogs+1), m.stats().DirSwitchCount)
 }
 
 func TestFailoverManager_SecondaryIsWritable(t *testing.T) {


### PR DESCRIPTION
## Summary

Stop the WAL failover monitor from flipping directory bookkeeping after `switchToNewDir` hits the per-WAL physical-log cap.

## Problem

`failoverMonitor.monitorLoop` decided a switch, updated `dirIndex`, probe enable/disable, `dirSwitchCount`, and `lastFailBackTime`, then called `switchToNewDir` and ignored the result.

`switchToNewDir` is documented as returning a non-nil error only when the switching limit is exceeded (`maxPhysicalLogs = 10`). That failure is synchronous: no new writer is created.

After the cap, every later unhealthy sample (default `UnhealthySamplingInterval` is 100ms) flipped monitor state while the writer stayed on the last physical log. Duration metrics, `dirSwitchCount`, `lastFailBackTime`, and primary probing then described the wrong directory. Fail-back and elevated write-stall heuristics read that state.

This is not a record-loss path. The writer keeps using the last physical log.

A flapping or dual-error disk can hit 10 switches quickly (an error triggers an immediate switch).

## Change

- Call `switchToNewDir` before committing monitor state.
- On error, set `lastWriter.switchLimitReached` and skip further switches for that writer.
- On success, then update `dirIndex`, probe state, `dirSwitchCount`, and `lastFailBackTime`.
- A new writer still starts with a clean `lastWriterInfo`, so the next logical WAL can switch again.

## Validation

`TestFailoverMonitor_SwitchLimitPreservesDirState` drives the monitor with a writer that succeeds `maxPhysicalLogs` times, then returns `"exceeded switching limit"`.

- Before: `DirSwitchCount` was 15 after 10 successes plus 5 extra samples.
- After: `DirSwitchCount` stays 10, `switchToNewDir` is called once more (the failing attempt), then stops. A replacement writer can switch again.

Also ran `go test -tags invariants -race ./wal` and `go test -tags invariants ./internal/lint -run TestLint/TestFmtErrorf`.

## Origin

Introduced in [#3224](https://github.com/cockroachdb/pebble/pull/3224) ([`2154c3729`](https://github.com/cockroachdb/pebble/commit/2154c3729), 2024-01-13). The `_ =` discard was added in the errcheck sweep [`d8b52a2b3`](https://github.com/cockroachdb/pebble/commit/d8b52a2b3) (2025-04-08).

Closes #6173
