### PR TITLE
Reduce VersionEdit.Decode allocations

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -808,6 +808,7 @@ func (ikr *InternalKeyBounds) Contains(cmp Compare, key []byte) bool {
 	return cmp(key, ikr.SmallestUserKey()) >= 0 && ikr.Largest().IsUpperBoundFor(cmp, key)
 }
 
+// SetInternalKeyBounds copies input keys rather than retaining aliases.
 func (ikr *InternalKeyBounds) SetInternalKeyBounds(smallest, largest InternalKey) {
 	ikr.userKeyData = string(smallest.UserKey) + string(largest.UserKey)
 	ikr.smallestTrailer = smallest.Trailer

--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -242,7 +242,14 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 		br = bufio.NewReader(r)
 	}
 	d := versionEditDecoder{br}
+
+	// A scratch buffer is reused across iterations to reduce allocations.
+	// Scratch slices should not be passed to code that may retain or alias
+	// them beyond the current iteration.
+	var sb scratchBuffer
 	for {
+		sb.Reset()
+
 		tag, err := binary.ReadUvarint(br)
 		if err == io.EOF {
 			break
@@ -252,7 +259,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 		}
 		switch tag {
 		case tagComparator:
-			s, err := d.readBytes()
+			s, err := d.readBytesInto(&sb)
 			if err != nil {
 				return err
 			}
@@ -283,7 +290,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			if _, err := d.readLevel(); err != nil {
 				return err
 			}
-			if _, err := d.readBytes(); err != nil {
+			if _, err := d.readBytesInto(&sb); err != nil {
 				return err
 			}
 			// NB: RocksDB does not use compaction pointers anymore.
@@ -348,6 +355,9 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			// whether we have point, range or both types of keys present in the
 			// table.
 			var (
+				// Safe to use scratch buffer even though DecodeInternalKey
+				// aliases the slice because SetInternalKeyBounds ultimately
+				// copies key bytes.
 				smallestPointKey, largestPointKey []byte
 				smallestRangeKey, largestRangeKey []byte
 				parsedPointBounds                 bool
@@ -355,11 +365,11 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 			)
 			if tag != tagNewFile5 {
 				// Range keys not present in the table. Parse the point key bounds.
-				smallestPointKey, err = d.readBytes()
+				smallestPointKey, err = d.readBytesInto(&sb)
 				if err != nil {
 					return err
 				}
-				largestPointKey, err = d.readBytes()
+				largestPointKey, err = d.readBytesInto(&sb)
 				if err != nil {
 					return err
 				}
@@ -372,11 +382,11 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				}
 				// Parse point key bounds, if present.
 				if boundsMarker&maskContainsPointKeys > 0 {
-					smallestPointKey, err = d.readBytes()
+					smallestPointKey, err = d.readBytesInto(&sb)
 					if err != nil {
 						return err
 					}
-					largestPointKey, err = d.readBytes()
+					largestPointKey, err = d.readBytesInto(&sb)
 					if err != nil {
 						return err
 					}
@@ -392,11 +402,11 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 					}
 				}
 				// Parse range key bounds.
-				smallestRangeKey, err = d.readBytes()
+				smallestRangeKey, err = d.readBytesInto(&sb)
 				if err != nil {
 					return err
 				}
-				largestRangeKey, err = d.readBytes()
+				largestRangeKey, err = d.readBytesInto(&sb)
 				if err != nil {
 					return err
 				}
@@ -421,8 +431,10 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 				backingFileNum uint64
 			}{}
 			var noRangeKeySets bool
-			var syntheticPrefix sstable.SyntheticPrefix
-			var syntheticSuffix sstable.SyntheticSuffix
+			// Safe to use scratch buffer because MakeSyntheticPrefixAndSuffix
+			// copies prefix/suffix bytes.
+			var syntheticPrefix []byte
+			var syntheticSuffix []byte
 			var blobReferences BlobReferences
 			var blobReferenceDepth BlobReferenceDepth
 			if tag == tagNewFile4 || tag == tagNewFile5 {
@@ -452,7 +464,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 						}
 
 					case customTagCreationTime:
-						field, err := d.readBytes()
+						field, err := d.readBytesInto(&sb)
 						if err != nil {
 							return err
 						}
@@ -463,7 +475,7 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 						}
 
 					case customTagNoRangeKeySets:
-						field, err := d.readBytes()
+						field, err := d.readBytesInto(&sb)
 						if err != nil {
 							return err
 						}
@@ -482,14 +494,13 @@ func (v *VersionEdit) Decode(r io.Reader) error {
 						}
 
 					case customTagSyntheticPrefix:
-						synthetic, err := d.readBytes()
+						syntheticPrefix, err = d.readBytesInto(&sb)
 						if err != nil {
 							return err
 						}
-						syntheticPrefix = synthetic
 
 					case customTagSyntheticSuffix:
-						if syntheticSuffix, err = d.readBytes(); err != nil {
+						if syntheticSuffix, err = d.readBytesInto(&sb); err != nil {
 							return err
 						}
 
@@ -1042,6 +1053,21 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 	return err
 }
 
+// scratchBuffer is a reusable temp buffer that minimizes allocations across
+// decode iterations.
+type scratchBuffer []byte
+
+// New returns n bytes of scratch space.
+func (sc *scratchBuffer) New(n int) []byte {
+	*sc = slices.Grow(*sc, n)[:len(*sc)+n]
+	return (*sc)[len(*sc)-n:]
+}
+
+// Reset buffer between iterations.
+func (sc *scratchBuffer) Reset() {
+	(*sc) = (*sc)[:0]
+}
+
 // versionEditDecoder should be used to decode version edits.
 type versionEditDecoder struct {
 	byteReader
@@ -1053,7 +1079,7 @@ func (d versionEditDecoder) readBytes() ([]byte, error) {
 		return nil, err
 	}
 	s := make([]byte, n)
-	_, err = io.ReadFull(d, s)
+	_, err = io.ReadFull(d.byteReader, s)
 	if err != nil {
 		if err == io.ErrUnexpectedEOF {
 			return nil, base.CorruptionErrorf("pebble: corrupt manifest: failed to read %d bytes", n)
@@ -1061,6 +1087,23 @@ func (d versionEditDecoder) readBytes() ([]byte, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+// readBytesInto reads the next n bytes into the scratch buffer and returns a
+// slice that is valid until the buffer is reset.
+func (d versionEditDecoder) readBytesInto(sb *scratchBuffer) ([]byte, error) {
+	n, err := d.readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	buf := sb.New(int(n))
+	if _, err := io.ReadFull(d.byteReader, buf); err != nil {
+		if err == io.ErrUnexpectedEOF {
+			return nil, base.CorruptionErrorf("pebble: corrupt manifest: failed to read %d bytes", n)
+		}
+		return nil, err
+	}
+	return buf, nil
 }
 
 func (d versionEditDecoder) readLevel() (int, error) {
@@ -1083,7 +1126,7 @@ func (d versionEditDecoder) readFileNum() (base.FileNum, error) {
 }
 
 func (d versionEditDecoder) readUvarint() (uint64, error) {
-	u, err := binary.ReadUvarint(d)
+	u, err := binary.ReadUvarint(d.byteReader)
 	if err != nil {
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return 0, base.CorruptionErrorf("pebble: corrupt manifest: failed to read uvarint")

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -35,11 +35,24 @@ func checkRoundTrip(e0 VersionEdit) error {
 	}
 	diff := pretty.Diff(e0, e1)
 	// SyntheticPrefixAndSuffix can't be correctly compared with pretty.Diff.
+	// Compared separately below.
 	diff = slices.DeleteFunc(diff, func(s string) bool {
 		return strings.Contains(s, "SyntheticPrefixAndSuffix")
 	})
 	if len(diff) > 0 {
 		return errors.Errorf("%s", strings.Join(diff, "\n"))
+	}
+	if len(e0.NewTables) != len(e1.NewTables) {
+		return errors.Errorf("NewTables length mismatch: %d vs %d", len(e0.NewTables), len(e1.NewTables))
+	}
+	for i := range e0.NewTables {
+		a := e0.NewTables[i].Meta.SyntheticPrefixAndSuffix
+		b := e1.NewTables[i].Meta.SyntheticPrefixAndSuffix
+		if !bytes.Equal(a.Prefix(), b.Prefix()) || !bytes.Equal(a.Suffix(), b.Suffix()) {
+			return errors.Errorf("NewTables[%d].SyntheticPrefixAndSuffix mismatch: "+
+				"prefix %q vs %q, suffix %q vs %q",
+				i, a.Prefix(), b.Prefix(), a.Suffix(), b.Suffix())
+		}
 	}
 	return nil
 }
@@ -321,6 +334,35 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	)
 	m8.InitPhysicalBacking()
 
+	// Tables m9 and m10 ensure that synthetic prefix/suffix doesn't leak
+	// across `NewTables` entries.
+	m9 := (&TableMetadata{
+		TableNum:                 814,
+		Size:                     8140,
+		CreationTime:             814090,
+		SeqNums:                  base.SeqNumRange{Low: 15, High: 17},
+		LargestSeqNumAbsolute:    17,
+		SyntheticPrefixAndSuffix: sstable.MakeSyntheticPrefixAndSuffix([]byte("pre"), []byte("suf")),
+	}).ExtendPointKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("c"), 0, base.InternalKeyKindSet),
+		base.MakeInternalKey([]byte("k"), 0, base.InternalKeyKindSet),
+	)
+	m9.InitPhysicalBacking()
+
+	m10 := (&TableMetadata{
+		TableNum:              815,
+		Size:                  8150,
+		CreationTime:          815100,
+		SeqNums:               base.SeqNumRange{Low: 18, High: 20},
+		LargestSeqNumAbsolute: 20,
+	}).ExtendPointKeyBounds(
+		cmp,
+		base.MakeInternalKey([]byte("d"), 0, base.InternalKeyKindSet),
+		base.MakeInternalKey([]byte("l"), 0, base.InternalKeyKindSet),
+	)
+	m10.InitPhysicalBacking()
+
 	testCases := []VersionEdit{
 		// An empty version edit.
 		{},
@@ -367,6 +409,14 @@ func TestVersionEditRoundTrip(t *testing.T) {
 				{
 					Level: 6,
 					Meta:  m8,
+				},
+				{
+					Level: 6,
+					Meta:  m9,
+				},
+				{
+					Level: 6,
+					Meta:  m10,
 				},
 			},
 		},

--- a/recovery.go
+++ b/recovery.go
@@ -5,6 +5,7 @@
 package pebble
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/binary"
@@ -326,6 +327,7 @@ func recoverVersion(
 	}
 	defer manifestFile.Close()
 	rr := record.NewReader(manifestFile, 0 /* logNum */)
+	br := bufio.NewReader(nil) // wrap io.Reader in a io.ByteReader
 	for {
 		r, err := rr.Next()
 		if err == io.EOF || record.IsInvalidRecord(err) {
@@ -335,8 +337,9 @@ func recoverVersion(
 			return nil, errors.Wrapf(err, "pebble: error when loading manifest file %q",
 				errors.Safe(manifestFilename))
 		}
+		br.Reset(r)
 		var ve manifest.VersionEdit
-		err = ve.Decode(r)
+		err = ve.Decode(br)
 		if err != nil {
 			// Break instead of returning an error if the record is corrupted
 			// or invalid.

--- a/sstable/blockiter/transforms.go
+++ b/sstable/blockiter/transforms.go
@@ -176,7 +176,7 @@ type SyntheticPrefixAndSuffix struct {
 }
 
 // MakeSyntheticPrefixAndSuffix returns a SyntheticPrefixAndSuffix with the
-// given prefix and suffix.
+// given prefix and suffix. Copies input rather than retaining aliases.
 func MakeSyntheticPrefixAndSuffix(
 	prefix SyntheticPrefix, suffix SyntheticSuffix,
 ) SyntheticPrefixAndSuffix {

--- a/sstable/reader_common.go
+++ b/sstable/reader_common.go
@@ -47,7 +47,7 @@ var NoTransforms = blockiter.NoTransforms
 var NoFragmentTransforms = blockiter.NoFragmentTransforms
 
 // MakeSyntheticPrefixAndSuffix returns a SyntheticPrefixAndSuffix with the
-// given prefix and suffix.
+// given prefix and suffix. Copies input rather than retaining aliases.
 func MakeSyntheticPrefixAndSuffix(
 	prefix SyntheticPrefix, suffix SyntheticSuffix,
 ) SyntheticPrefixAndSuffix {


### PR DESCRIPTION
Optimizes `VersionEdit.Decode` to reduce allocations. 

- Passes the embedded `versionEditDecoder.byteReader` to avoid interface boxing allocs through `binary.ReadUvarint` and `io.ReadFull`. 
- Reuses `[]byte` vars across loop iterations to avoid alloc per tag. 
- Updates `recoverVersion` to pass `Decode` a `io.ByteReader` to avoid allocating a new `bufio.NewReader` per decode. 

Performance comparison from an 18MB manifest pulled from a prod DB: ~80% reduction in allocs and ~1.7x speedup. 
```
# Before
VersionEdit/Decode     31	 102814368 ns/op	 179.28 MB/s	194293147 B/op	 3055756 allocs/op
# After
VersionEdit/Decode     58	  58038384 ns/op	 317.59 MB/s	91613244 B/op	  596126 allocs/op
```