### PR TITLE
manifest: always terminate tagNewFile5 custom fields

### DIFF
--- a/internal/manifest/version_edit.go
+++ b/internal/manifest/version_edit.go
@@ -973,7 +973,7 @@ func (v *VersionEdit) Encode(w io.Writer) error {
 		}
 		e.writeUvarint(uint64(x.Meta.SeqNums.Low))
 		e.writeUvarint(uint64(x.Meta.SeqNums.High))
-		if customFields {
+		if tag == tagNewFile4 || tag == tagNewFile5 {
 			if x.Meta.CreationTime != 0 {
 				e.writeUvarint(customTagCreationTime)
 				var buf [binary.MaxVarintLen64]byte

--- a/internal/manifest/version_edit_test.go
+++ b/internal/manifest/version_edit_test.go
@@ -428,6 +428,80 @@ func TestVersionEditRoundTrip(t *testing.T) {
 	}
 }
 
+func TestVersionEditRoundTripRangeKeysWithoutCustomFields(t *testing.T) {
+	makeRangeKeyTable := func(fileNum base.FileNum, creationTime int64) *TableMetadata {
+		m := (&TableMetadata{
+			TableNum:              fileNum,
+			Size:                  100,
+			CreationTime:          creationTime,
+			SeqNums:               base.SeqNumRange{Low: 1, High: 2},
+			LargestSeqNumAbsolute: 2,
+		}).ExtendRangeKeyBounds(
+			base.DefaultComparer.Compare,
+			AnyRangeKeys,
+			base.MakeInternalKey([]byte("a"), 1, base.InternalKeyKindRangeKeySet),
+			base.MakeExclusiveSentinelKey(base.InternalKeyKindRangeKeyDelete, []byte("z")),
+		)
+		m.InitPhysicalBacking()
+		return m
+	}
+	makePointKeyTable := func(fileNum base.FileNum) *TableMetadata {
+		m := (&TableMetadata{
+			TableNum: fileNum,
+			Size:     100,
+		}).ExtendPointKeyBounds(
+			base.DefaultComparer.Compare,
+			base.MakeInternalKey([]byte("a"), 1, base.InternalKeyKindSet),
+			base.MakeInternalKey([]byte("z"), 1, base.InternalKeyKindSet),
+		)
+		m.InitPhysicalBacking()
+		return m
+	}
+
+	testCases := []struct {
+		name string
+		edit VersionEdit
+	}{
+		{
+			name: "single range-key table",
+			edit: VersionEdit{NewTables: []NewTableEntry{
+				{Level: 6, Meta: makeRangeKeyTable(1, 0)},
+			}},
+		},
+		{
+			name: "multiple range-key tables",
+			edit: VersionEdit{NewTables: []NewTableEntry{
+				{Level: 6, Meta: makeRangeKeyTable(1, 0)},
+				{Level: 6, Meta: makeRangeKeyTable(2, 0)},
+			}},
+		},
+		{
+			name: "range-key table followed by point-key table",
+			edit: VersionEdit{NewTables: []NewTableEntry{
+				{Level: 6, Meta: makeRangeKeyTable(1, 0)},
+				{Level: 6, Meta: makePointKeyTable(2)},
+			}},
+		},
+		{
+			name: "range-key table with creation time",
+			edit: VersionEdit{NewTables: []NewTableEntry{
+				{Level: 6, Meta: makeRangeKeyTable(1, 1234)},
+			}},
+		},
+		{
+			name: "point-key table without custom fields",
+			edit: VersionEdit{NewTables: []NewTableEntry{
+				{Level: 6, Meta: makePointKeyTable(1)},
+			}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, checkRoundTrip(tc.edit))
+		})
+	}
+}
+
 func TestVersionEditDecode(t *testing.T) {
 	var inputBuf, outputBuf bytes.Buffer
 	datadriven.RunTest(t, "testdata/version_edit_decode",


### PR DESCRIPTION
### PR Description

`VersionEdit.Encode` selects `tagNewFile5` for tables containing range keys. However, it previously emitted the custom-tag section only when another custom field was present.

`VersionEdit.Decode` always expects `tagNewFile5` to contain a custom-tag section terminated by `customTagTerminate`. As a result, a range-key table without other custom fields could cause decoding to consume the next entry or fail at EOF, leaving the MANIFEST undecodable.

Make custom-section emission depend on the selected wire tag, ensuring that both `tagNewFile4` and `tagNewFile5` always include the required terminator.

Add regression coverage for:

* A single affected range-key table.
* Multiple affected range-key tables.
* An affected table followed by a point-key table.
* A range-key table with a creation time.
* A point-key table without custom fields.

Tests:

* `go test -tags invariants ./internal/manifest -count=1`
* `go test ./internal/manifest -count=1`

Fixes #6182