### PR TITLE
sstable/block: record incompressible blocks under the None setting

### DIFF
--- a/sstable/block/compressor.go
+++ b/sstable/block/compressor.go
@@ -87,7 +87,10 @@ func (c *Compressor) Compress(dst, src []byte, kind Kind) (CompressionIndicator,
 	//      before
 	if setting.Algorithm != compression.NoAlgorithm &&
 		int64(len(out))*100 > int64(len(src))*int64(100-c.minReductionPercent) {
-		setting.Algorithm = compression.NoAlgorithm
+		// Reset the whole setting, not just the algorithm: the level that was
+		// attempted is not part of how the block is stored, and a setting like
+		// {NoAlgorithm, 1} is not a setting we can name.
+		setting = compression.NoCompression
 		out = append(out[:0], src...)
 	}
 	c.stats.addOne(setting, CompressionStatsForSetting{

--- a/sstable/block/compressor_test.go
+++ b/sstable/block/compressor_test.go
@@ -5,6 +5,7 @@
 package block
 
 import (
+	"fmt"
 	"math/rand/v2"
 	"testing"
 
@@ -48,5 +49,44 @@ func TestCompressor(t *testing.T) {
 		require.Equal(t, compressionIndicatorFromAlgorithm(profile.OtherBlocks.Algorithm), ci)
 
 		compressor.Close()
+	}
+}
+
+// TestCompressorIncompressibleBlockStats verifies that a block which is stored
+// uncompressed because it did not compress well enough is attributed to the
+// no-compression setting, whatever setting was attempted.
+func TestCompressorIncompressibleBlockStats(t *testing.T) {
+	// Random data does not compress, so each compressor produces an output at
+	// least as large as its input and the block is stored uncompressed.
+	rng := rand.New(rand.NewPCG(1, 2))
+	src := make([]byte, 4096)
+	for i := range src {
+		src[i] = byte(rng.Uint32())
+	}
+
+	for _, setting := range []compression.Setting{
+		compression.NoCompression,
+		compression.SnappySetting,
+		compression.MinLZFastest,
+		compression.MinLZBalanced,
+		compression.ZstdLevel1,
+		compression.ZstdLevel3,
+	} {
+		t.Run(setting.String(), func(t *testing.T) {
+			profile := &CompressionProfile{
+				Name:                setting.String(),
+				DataBlocks:          SimpleCompressionSetting(setting),
+				ValueBlocks:         SimpleCompressionSetting(setting),
+				OtherBlocks:         setting,
+				MinReductionPercent: 12,
+			}
+			compressor := MakeCompressor(profile)
+			defer compressor.Close()
+
+			ci, out := compressor.Compress(nil, src, blockkind.SSTableData)
+			require.Equal(t, NoCompressionIndicator, ci)
+			require.Equal(t, src, out)
+			require.Equal(t, fmt.Sprintf("None:%d", len(src)), compressor.Stats().String())
+		})
 	}
 }


### PR DESCRIPTION
`Compressor.Compress` stores a block uncompressed when compression did not shrink it by at least `MinReductionPercent`. It signalled that by clearing only the algorithm of the setting the underlying compressor returned, `setting.Algorithm = compression.NoAlgorithm` in `sstable/block/compressor.go`. The level was left in place, so for any setting with a non-zero level the result was a setting like `{NoAlgorithm, 1}`, which is not `compression.NoCompression` (`{NoAlgorithm, 0}`).

`CompressionStats.addOne` therefore matched neither its `NoCompression` case nor its `fastestCompression` case, and filed the bytes in the `others` map keyed by a setting whose `String()` is `None1`. That string reaches disk: it is what `CompressionStats.String()` writes into the `pebble.compression_stats` sstable property and into the blob file property of the same name, and `compression.ParseSetting` reads `None1` back as `{NoAlgorithm, 1}` on the next read.

Every compression setting Pebble uses by default has a non-zero level: MinLZ1 for the `Fastest`, `Fast` and `Balanced` profiles, and Zstd1 or Zstd3 for `Good` and `ZSTD`. Only Snappy, whose level is 0, was unaffected, which is why the existing testdata never showed this. A table written with any other profile that held a block too incompressible to keep reported `pebble.compression_stats: None1:4096/4096` instead of `None:4096`, its `noCompressionBytes` field stayed at zero, and the `others` map was allocated for stats the inlined fields exist to hold. The `invariants` assertion in `addOne` that no-compression stats have equal compressed and uncompressed sizes never ran for those blocks either.

The fix assigns `compression.NoCompression` to the whole setting instead of clearing its algorithm. `compressionIndicatorFromAlgorithm` and `CompressionMetrics.Add` read only the algorithm, so the block encoding and the aggregate `NoCompressionBytes` metric are unchanged, and no testdata file moves.

`TestCompressorIncompressibleBlockStats` compresses 4KiB of PRNG output under each of `NoCompression`, `SnappySetting`, `MinLZFastest`, `MinLZBalanced`, `ZstdLevel1` and `ZstdLevel3`, and asserts the block comes back uncompressed with stats `None:4096`. Without the one-line change it fails for the four leveled settings with `None1:4096/4096`, `None2:4096/4096`, `None1:4096/4096` and `None3:4096/4096`; with it, all six pass. Also green: `go test -tags invariants ./sstable/... ./internal/compression/...`, the same packages with `TAGS=` and with `CGO_ENABLED=0`, `go test -race ./sstable/block/`, `-count=200` on the new test, and `go test -tags invariants ./internal/lint` (crlfmt, staticcheck, gcassert, roachvet).
