### PR TITLE
options: return an error for a malformed key_schema value

### DIFF
--- a/options.go
+++ b/options.go
@@ -2273,7 +2273,12 @@ func (o *Options) Parse(s string, hooks *ParseHooks) error {
 						})
 						var comparer *base.Comparer
 						var bundleSize int
-						comparer, err = parseComparer(args[0])
+						if len(args) != 2 {
+							err = errors.Newf("key_schema %q: require 2 arguments", errors.Safe(value))
+						}
+						if err == nil {
+							comparer, err = parseComparer(args[0])
+						}
 						if err == nil {
 							bundleSize, err = strconv.Atoi(args[1])
 						}

--- a/options_test.go
+++ b/options_test.go
@@ -601,6 +601,37 @@ comparer=unrecognized`, nil)
 	require.Equal(t, testkeys.Comparer, o.Comparer)
 }
 
+func TestOptionsParseKeySchema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// A malformed DefaultKeySchema(...) value must be reported as an error
+	// rather than panicking while indexing the argument list.
+	for _, value := range []string{
+		"DefaultKeySchema()",
+		"DefaultKeySchema( )",
+		"DefaultKeySchema(,,)",
+		"DefaultKeySchema(leveldb.BytewiseComparator)",
+		"DefaultKeySchema(leveldb.BytewiseComparator,16,32)",
+		"DefaultKeySchema(leveldb.BytewiseComparator,sixteen)",
+	} {
+		t.Run(value, func(t *testing.T) {
+			o := &Options{}
+			require.Error(t, o.Parse("[Options]\n  key_schema="+value+"\n", nil))
+		})
+	}
+
+	// A well-formed value still parses both arguments.
+	o := &Options{}
+	require.NoError(t, o.Parse("[Options]\n  key_schema=DefaultKeySchema(leveldb.BytewiseComparator,32)\n", nil))
+	require.Equal(t, "DefaultKeySchema(leveldb.BytewiseComparator,32)", o.KeySchema)
+	require.Contains(t, o.KeySchemas, o.KeySchema)
+
+	// A key schema that is not spelled DefaultKeySchema(...) is still tolerated
+	// when there are no hooks to resolve it.
+	o = &Options{}
+	require.NoError(t, o.Parse("[Options]\n  key_schema=some-other-schema\n", nil))
+	require.Equal(t, "some-other-schema", o.KeySchema)
+}
+
 func TestOptionsValidate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testCases := []struct {


### PR DESCRIPTION
`Options.Parse` panics with `index out of range` on a malformed `key_schema`
value, in a function that is documented to return an error and that tolerates
malformed input everywhere else.

In the `key_schema` case, a `DefaultKeySchema( ... )` value is split with
`strings.FieldsFunc` and then indexed at `args[0]` and `args[1]` with no length
check. `DefaultKeySchema()`, `DefaultKeySchema( )` and
`DefaultKeySchema(leveldb.BytewiseComparator)` all reach it. The sibling
`multilevel_compaction_heuristic` case in the same switch already counts its
fields and returns `require 2 arguments`; this does the same.

It is reachable from the shipped tool. `tool/db.go` calls `Parse` on the
OPTIONS file it finds on disk, and the `DefaultKeySchema(` branch is tried
before the `NewKeySchema` hook is consulted, so the hook does not protect it.
On a store whose OPTIONS carries `key_schema=DefaultKeySchema()`:

    before:  panic: runtime error: index out of range [0] with length 0
    after:   error loading options: key_schema "DefaultKeySchema()": require 2 arguments

`TestOptionsParseKeySchema` covers six malformed spellings, and asserts that
`DefaultKeySchema(leveldb.BytewiseComparator,32)` still produces that exact
`KeySchema` with its matching `KeySchemas` entry, and that an unrecognised
`key_schema` value stays tolerated. It panics on master.

Adjacent and deliberately not fixed here: with no `NewKeySchema` hook,
`DefaultKeySchema(no.SuchComparator,16)` still nil-derefs, because the comparer
lookup can fail after the argument count is right.
